### PR TITLE
fix(web): enable 4 GiB Node heap for vite build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -32,8 +32,9 @@ ARG BUILD_HASH
 # `args:` from .env's PUBLIC_LQ_AI_API_BASE_URL=http://localhost:8000/api/v1.
 ARG PUBLIC_LQ_AI_API_BASE_URL=/api/v1
 
-# Set Node.js options (heap limit Allocation failed - JavaScript heap out of memory)
-# ENV NODE_OPTIONS="--max-old-space-size=4096"
+# Set Node.js options (heap limit Allocation failed - JavaScript heap out of memory).
+# Required for OpenWebUI's large bundle build; 4 GiB has been adequate in practice.
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Uncomments `ENV NODE_OPTIONS="--max-old-space-size=4096"` in `web/Dockerfile`.
- Caught by the Phase E pre-tag dry-run (run [25779995676](https://github.com/LegalQuants/lq-ai/actions/runs/25779995676)): api + gateway built cleanly, web failed with JS heap-OOM during `vite build`.

## Why
OpenWebUI's bundle exceeds Node's default ~2 GiB heap. The 4 GiB setting is already validated locally on `kk/main/Frontend_Design`; this PR brings it forward to main so the release matrix can build all three images.

## Test plan
- [ ] After merge, re-run `gh workflow run release.yml -f dry_run=true`
- [ ] Verify all 3 `build-and-push` matrix legs succeed (api ✓, gateway ✓, **web ✓** this time)
- [ ] Verify sbom + cosign legs still SKIPPED
- [ ] Final status: success, <5 min wall time

🤖 Generated with [Claude Code](https://claude.com/claude-code)