### PR TITLE
M2-A1: documents.normalized_content + documents.was_ocrd

### DIFF
--- a/api/alembic/versions/0024_normalized_content_and_was_ocrd.py
+++ b/api/alembic/versions/0024_normalized_content_and_was_ocrd.py
@@ -1,0 +1,61 @@
+"""add documents.normalized_content and documents.was_ocrd — M2-A1
+
+These two columns are the data substrate the M2 Citation Engine and
+tolerant-match step depend on:
+
+* ``normalized_content`` carries the full, canonical PyMuPDF text
+  stream. The fidelity invariant
+  ``normalized_content[chunk.char_offset_start:chunk.char_offset_end]
+  == chunk.content`` is what the verifier consumes when it re-reads
+  a citation against its source.
+* ``was_ocrd`` is a forward-looking flag: an M2 follow-on task adds
+  an OCR fallback for image-only PDFs, and tolerant-match toggles
+  OCR-artifact normalization on documents that went through OCR.
+  M1's parsers never OCR, so existing rows and new M1 ingests get
+  ``FALSE``; the column unblocks the later code path.
+
+Both columns are ``NOT NULL`` with a default so backfill on existing
+rows is the schema's job rather than the migration's. The one-time
+script ``scripts/backfill_normalized_content.py`` then reconstructs
+``normalized_content`` for pre-M2 documents from their chunks.
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-05-16
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0024"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "documents",
+        sa.Column(
+            "normalized_content",
+            sa.Text(),
+            nullable=False,
+            server_default="",
+        ),
+    )
+    op.add_column(
+        "documents",
+        sa.Column(
+            "was_ocrd",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("documents", "was_ocrd")
+    op.drop_column("documents", "normalized_content")

--- a/api/app/models/document.py
+++ b/api/app/models/document.py
@@ -33,6 +33,7 @@ from datetime import datetime
 from typing import Any
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     DateTime,
     ForeignKey,
@@ -82,6 +83,23 @@ class Document(Base):
     structured_content: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB,
         nullable=True,
+    )
+    # M2-A1: full canonical text from PyMuPDF, the source of truth the
+    # Citation Engine slices at chunk offsets when verifying citations.
+    # ``chunk.content == normalized_content[char_offset_start:char_offset_end]``
+    # is the load-bearing invariant.
+    normalized_content: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default="",
+    )
+    # M2-A1: True if the source document went through OCR — toggles
+    # OCR-artifact normalization in tolerant-match (M2-B1). False for
+    # every M1 ingest because M1's parsers do not OCR.
+    was_ocrd: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
     )
     processed_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/api/app/pipeline/ingest.py
+++ b/api/app/pipeline/ingest.py
@@ -315,6 +315,12 @@ async def _persist_document_and_chunks(
     existing_doc_stmt = select(Document).where(Document.file_id == file_row.id)
     existing_doc = (await db.execute(existing_doc_stmt)).scalar_one_or_none()
 
+    # M2-A1: ``normalized_content`` is exactly the PyMuPDF canonical text
+    # the chunker sliced — keeping them coupled at write time means the
+    # Citation Engine's re-read invariant
+    # ``chunk.content == normalized_content[char_offset_start:char_offset_end]``
+    # holds for every freshly ingested document. ``was_ocrd`` is False
+    # because M1's parsers never OCR.
     if existing_doc is None:
         doc = Document(
             file_id=file_row.id,
@@ -323,6 +329,8 @@ async def _persist_document_and_chunks(
             page_count=parsed.page_count,
             character_count=len(parsed.canonical_text),
             structured_content=parsed.structured_content,
+            normalized_content=parsed.canonical_text,
+            was_ocrd=False,
         )
         db.add(doc)
         await db.flush()  # populate doc.id
@@ -334,6 +342,8 @@ async def _persist_document_and_chunks(
         doc.page_count = parsed.page_count
         doc.character_count = len(parsed.canonical_text)
         doc.structured_content = parsed.structured_content
+        doc.normalized_content = parsed.canonical_text
+        doc.was_ocrd = False
         # Delete prior chunks so the re-insert doesn't violate the
         # (document_id, chunk_index) UNIQUE constraint.
         await db.execute(delete(DocumentChunk).where(DocumentChunk.document_id == doc.id))

--- a/api/app/pipeline/normalized_backfill.py
+++ b/api/app/pipeline/normalized_backfill.py
@@ -1,0 +1,195 @@
+"""Backfill ``documents.normalized_content`` from existing chunks — M2-A1.
+
+The M2-A1 migration adds ``normalized_content TEXT NOT NULL DEFAULT ''``
+to the ``documents`` table. New ingests populate it directly from the
+PyMuPDF canonical text. Pre-M2 rows land with the empty-string default
+and need backfilling — this module is what fills them.
+
+The reconstruction algorithm walks chunks in order of
+``char_offset_start`` and appends only the suffix that extends beyond
+the running end position. That handles the chunker's overlap (default
+200 chars) correctly: overlapping ranges represent the *same* bytes,
+and we only need each byte once. A gap between consecutive chunks is
+flagged rather than silently filled — corrupt reconstruction is a
+worse failure than skipped reconstruction, because the Citation Engine
+re-reads ``normalized_content`` at chunk offsets and would compare
+against wrong bytes.
+
+The module is split into two layers so the algorithm is unit-testable
+without touching a database:
+
+* :func:`reconstruct_from_chunks` — pure function, takes a list of
+  :class:`DocumentChunk` and returns ``(text, has_gap)``.
+* :func:`backfill_documents` — async DB walker that finds candidate
+  documents, loads their chunks, calls the pure function, and writes
+  the result back. Skips rows already populated unless ``force=True``.
+
+The thin CLI wrapper lives at ``scripts/backfill_normalized_content.py``
+at the repo root so the script appears where the M2 plan said it would.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.document import Document, DocumentChunk
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class BackfillReport:
+    """Summary of a backfill run.
+
+    ``processed`` rows had their ``normalized_content`` written.
+    ``skipped`` rows were already populated (and ``force`` was False).
+    ``gaps`` rows had a gap between consecutive chunks — they are
+    logged and left untouched so the operator can investigate; the
+    Citation Engine treats an empty ``normalized_content`` as "cannot
+    verify" rather than verifying against the wrong text.
+    """
+
+    processed: int = 0
+    skipped: int = 0
+    gaps: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Pure algorithm
+# ---------------------------------------------------------------------------
+
+
+def reconstruct_from_chunks(chunks: Iterable[DocumentChunk]) -> tuple[str, bool]:
+    """Reconstruct canonical text from a document's chunks.
+
+    Walks chunks in order of ``char_offset_start`` and appends only the
+    portion of each chunk that extends beyond the running end position.
+    Overlapping ranges (the chunker emits a configurable overlap) are
+    folded together — the overlap region is appended exactly once.
+
+    Args:
+        chunks: One document's :class:`DocumentChunk` rows, any order.
+
+    Returns:
+        ``(text, has_gap)``. ``has_gap`` is True if any chunk starts
+        beyond the running end position — i.e. there's a range of the
+        original document that no chunk covers. The reconstruction is
+        best-effort in that case; callers should skip writing rather
+        than persisting partial text.
+    """
+
+    sorted_chunks = sorted(chunks, key=lambda c: c.char_offset_start)
+    if not sorted_chunks:
+        return "", False
+
+    parts: list[str] = []
+    cur_end = 0
+    has_gap = False
+
+    for chunk in sorted_chunks:
+        start = chunk.char_offset_start
+        end = chunk.char_offset_end
+
+        if start > cur_end:
+            # Gap. Flag but continue assembling — the caller decides
+            # whether to persist or skip.
+            has_gap = True
+            parts.append(chunk.content)
+            cur_end = end
+        elif end <= cur_end:
+            # Fully contained in what we've already collected.
+            continue
+        else:
+            # Overlap or perfect adjacency.
+            overlap = cur_end - start
+            parts.append(chunk.content[overlap:])
+            cur_end = end
+
+    return "".join(parts), has_gap
+
+
+# ---------------------------------------------------------------------------
+# Async DB walker
+# ---------------------------------------------------------------------------
+
+
+async def backfill_documents(
+    db: AsyncSession,
+    *,
+    force: bool = False,
+) -> BackfillReport:
+    """Reconstruct ``normalized_content`` for every document that needs it.
+
+    Args:
+        db: An active :class:`AsyncSession`. The function commits per
+            document so a long-running backfill can be interrupted and
+            resumed without losing the rows already written.
+        force: When True, re-process rows whose ``normalized_content``
+            is already non-empty. The default is to skip them — the
+            common case is the one-time migration from pre-M2 state.
+
+    Returns:
+        :class:`BackfillReport` summarising the run.
+    """
+
+    report = BackfillReport()
+
+    # Load every document and decide per-row whether to process or
+    # skip. Backfills run rarely and the documents table is small
+    # relative to the chunks table — there's no efficiency win from
+    # filtering in SQL, and we lose the "skipped" count operators rely
+    # on to confirm the script saw the rows they expected.
+    rows = (await db.execute(select(Document))).scalars().all()
+
+    for doc in rows:
+        # ``normalized_content == ''`` is the canonical "needs backfill"
+        # marker; when ``force=True`` we re-process every row regardless.
+        if not force and doc.normalized_content != "":
+            report.skipped += 1
+            continue
+
+        chunk_rows = (
+            (await db.execute(select(DocumentChunk).where(DocumentChunk.document_id == doc.id)))
+            .scalars()
+            .all()
+        )
+
+        text, has_gap = reconstruct_from_chunks(chunk_rows)
+
+        if has_gap:
+            log.warning(
+                "backfill: gap detected in chunks; skipping document",
+                extra={
+                    "event": "backfill_gap_detected",
+                    "document_id": str(doc.id),
+                    "chunk_count": len(chunk_rows),
+                },
+            )
+            report.gaps += 1
+            continue
+
+        doc.normalized_content = text
+        await db.commit()
+        report.processed += 1
+
+        log.info(
+            "backfill: populated normalized_content",
+            extra={
+                "event": "backfill_document_populated",
+                "document_id": str(doc.id),
+                "chars": len(text),
+                "chunk_count": len(chunk_rows),
+            },
+        )
+
+    return report

--- a/api/tests/test_normalized_backfill.py
+++ b/api/tests/test_normalized_backfill.py
@@ -1,0 +1,339 @@
+"""Tests for the M2-A1 backfill that reconstructs ``documents.normalized_content``
+from existing ``document_chunks`` rows.
+
+Reconstruction has to handle the chunker's overlap (default 200 chars);
+the algorithm walks chunks by ``char_offset_start`` and appends only the
+suffix that extends beyond ``cur_end``. The async backfill walks rows
+where ``normalized_content = ''`` (the schema default that landed in
+migration 0024) and writes the reconstructed text.
+
+Verification matches the M2 plan's stated criteria:
+
+* Re-extraction at chunk offsets reproduces ``chunk.content``
+  byte-for-byte (the load-bearing fidelity invariant).
+* The script is idempotent — a second run is a no-op on rows already
+  populated (and ``force=True`` re-runs everything).
+* ``was_ocrd`` is left at the schema default (False) — M1 has no OCR.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.document import Document, DocumentChunk
+from app.models.file import File as FileModel
+from app.models.user import User
+from app.pipeline.ingest import ingest_file
+from app.pipeline.normalized_backfill import (
+    BackfillReport,
+    backfill_documents,
+    reconstruct_from_chunks,
+)
+from app.security import hash_password
+from tests.test_storage_streaming import FakeS3Client
+
+fitz = pytest.importorskip("fitz", reason="PyMuPDF not installed")
+
+
+# ---------------------------------------------------------------------------
+# Reconstruction algorithm — pure-function tests (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+def _chunk(start: int, end: int, content: str) -> DocumentChunk:
+    """Build a transient DocumentChunk for algorithm tests; no DB write."""
+
+    return DocumentChunk(
+        document_id=uuid.uuid4(),
+        chunk_index=start,  # arbitrary; ordering driven by offset
+        content=content,
+        char_offset_start=start,
+        char_offset_end=end,
+    )
+
+
+@pytest.mark.unit
+def test_reconstruct_handles_disjoint_chunks() -> None:
+    """Two non-overlapping, adjacent chunks reconstruct trivially."""
+
+    chunks = [
+        _chunk(0, 5, "hello"),
+        _chunk(5, 11, " world"),
+    ]
+    text, gap = reconstruct_from_chunks(chunks)
+    assert text == "hello world"
+    assert gap is False
+
+
+@pytest.mark.unit
+def test_reconstruct_handles_overlap() -> None:
+    """Overlapping chunks (typical chunker output) reconstruct correctly."""
+
+    # canonical = "abcdefghij"
+    # chunk 0 covers [0,6) = "abcdef"
+    # chunk 1 covers [3,10) = "defghij" (overlaps chunk 0 by "def")
+    chunks = [
+        _chunk(0, 6, "abcdef"),
+        _chunk(3, 10, "defghij"),
+    ]
+    text, gap = reconstruct_from_chunks(chunks)
+    assert text == "abcdefghij"
+    assert gap is False
+
+
+@pytest.mark.unit
+def test_reconstruct_handles_unordered_input() -> None:
+    """Algorithm sorts by ``char_offset_start`` — order-agnostic."""
+
+    chunks = [
+        _chunk(3, 10, "defghij"),
+        _chunk(0, 6, "abcdef"),
+    ]
+    text, gap = reconstruct_from_chunks(chunks)
+    assert text == "abcdefghij"
+    assert gap is False
+
+
+@pytest.mark.unit
+def test_reconstruct_flags_gap() -> None:
+    """A missing range between chunks is flagged — never silently filled."""
+
+    chunks = [
+        _chunk(0, 5, "hello"),
+        _chunk(7, 12, "world"),  # gap at [5,7)
+    ]
+    _text, gap = reconstruct_from_chunks(chunks)
+    assert gap is True
+    # text may be best-effort or empty — the caller decides what to do
+    # with a gap (skip the document, log, etc.). The contract is just
+    # "tell me if there's a gap."
+
+
+@pytest.mark.unit
+def test_reconstruct_empty_chunks_returns_empty() -> None:
+    """No chunks → empty string, no gap (vacuously true)."""
+
+    text, gap = reconstruct_from_chunks([])
+    assert text == ""
+    assert gap is False
+
+
+# ---------------------------------------------------------------------------
+# Async backfill — integration against a real DB + ingest pipeline
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_pdf() -> bytes:
+    text = (
+        "Hello, world. " * 50
+        + "The quick brown fox jumps over the lazy dog. " * 50
+        + "Pack my box with five dozen liquor jugs. " * 50
+    )
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((50, 72), text, fontsize=11)
+    out = doc.tobytes()
+    doc.close()
+    return out
+
+
+@pytest_asyncio.fixture
+async def fake_s3() -> FakeS3Client:
+    return FakeS3Client()
+
+
+@pytest_asyncio.fixture
+async def patched_storage(fake_s3: FakeS3Client) -> AsyncIterator[FakeS3Client]:
+    @asynccontextmanager
+    async def _ctx() -> AsyncIterator[FakeS3Client]:
+        yield fake_s3
+
+    with patch("app.storage.s3_client", _ctx):
+        yield fake_s3
+
+
+@pytest_asyncio.fixture
+async def db_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"backfill-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Backfill Test User",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+async def _ingest_then_clear_normalized(
+    db: AsyncSession,
+    user: User,
+    fake_s3: FakeS3Client,
+    pdf: bytes,
+) -> uuid.UUID:
+    """Run the live ingest and then clear the normalized_content column so the
+    document looks like a pre-M2 row that needs backfilling."""
+
+    storage_key = f"{uuid.uuid4()}"
+    fake_s3.objects[storage_key] = pdf
+    fake_s3.content_types[storage_key] = "application/pdf"
+
+    file_row = FileModel(
+        owner_id=user.id,
+        filename="test.pdf",
+        mime_type="application/pdf",
+        size_bytes=len(pdf),
+        hash_sha256="0" * 64,
+        storage_path=storage_key,
+        ingestion_status="pending",
+    )
+    db.add(file_row)
+    await db.flush()
+
+    result = await ingest_file(db, file_row.id)
+    assert result.status == "ready"
+    assert result.document_id is not None
+
+    # Simulate pre-M2 state: the column existed (schema default '')
+    # but no canonical text was written.
+    await db.execute(
+        update(Document).where(Document.id == result.document_id).values(normalized_content="")
+    )
+    await db.commit()
+    return result.document_id
+
+
+@pytest.mark.integration
+async def test_backfill_populates_pre_m2_rows(
+    db_session: AsyncSession,
+    db_user: User,
+    fake_s3: FakeS3Client,
+    patched_storage: FakeS3Client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A document with empty normalized_content gets reconstructed from chunks."""
+
+    from app.config import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "lq_ai_docling_enabled", False)
+
+    doc_id = await _ingest_then_clear_normalized(db_session, db_user, fake_s3, _make_simple_pdf())
+
+    report = await backfill_documents(db_session)
+
+    assert report.processed == 1
+    assert report.skipped == 0
+    assert report.gaps == 0
+
+    # Reload and check fidelity: slicing at chunk offsets reproduces
+    # chunk content byte-for-byte.
+    doc = (await db_session.execute(select(Document).where(Document.id == doc_id))).scalar_one()
+    assert doc.normalized_content != ""
+    assert doc.was_ocrd is False  # backfill must not touch this column
+
+    chunks = (
+        (
+            await db_session.execute(
+                select(DocumentChunk)
+                .where(DocumentChunk.document_id == doc_id)
+                .order_by(DocumentChunk.chunk_index)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(chunks) > 0
+    for chunk in chunks:
+        slice_ = doc.normalized_content[chunk.char_offset_start : chunk.char_offset_end]
+        assert slice_ == chunk.content
+
+
+@pytest.mark.integration
+async def test_backfill_is_idempotent(
+    db_session: AsyncSession,
+    db_user: User,
+    fake_s3: FakeS3Client,
+    patched_storage: FakeS3Client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-running on already-populated rows is a no-op (skip semantics)."""
+
+    from app.config import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "lq_ai_docling_enabled", False)
+
+    await _ingest_then_clear_normalized(db_session, db_user, fake_s3, _make_simple_pdf())
+
+    first = await backfill_documents(db_session)
+    assert first.processed == 1
+
+    second = await backfill_documents(db_session)
+    assert second.processed == 0
+    assert second.skipped == 1
+
+
+@pytest.mark.integration
+async def test_backfill_force_rewrites_populated_rows(
+    db_session: AsyncSession,
+    db_user: User,
+    fake_s3: FakeS3Client,
+    patched_storage: FakeS3Client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``force=True`` re-processes rows whose normalized_content is non-empty."""
+
+    from app.config import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "lq_ai_docling_enabled", False)
+
+    doc_id = await _ingest_then_clear_normalized(db_session, db_user, fake_s3, _make_simple_pdf())
+
+    await backfill_documents(db_session)
+
+    # Sabotage the row to prove force actually recomputes.
+    await db_session.execute(
+        update(Document).where(Document.id == doc_id).values(normalized_content="bogus")
+    )
+    await db_session.commit()
+
+    report = await backfill_documents(db_session, force=True)
+    assert report.processed == 1
+
+    doc = (await db_session.execute(select(Document).where(Document.id == doc_id))).scalar_one()
+    assert doc.normalized_content != "bogus"
+    # Fidelity check after force re-run.
+    chunks = (
+        (await db_session.execute(select(DocumentChunk).where(DocumentChunk.document_id == doc_id)))
+        .scalars()
+        .all()
+    )
+    for chunk in chunks:
+        assert (
+            doc.normalized_content[chunk.char_offset_start : chunk.char_offset_end] == chunk.content
+        )
+
+
+@pytest.mark.integration
+async def test_backfill_report_shape(
+    db_session: AsyncSession,
+) -> None:
+    """Empty DB → report shows zero rows everywhere; type is BackfillReport."""
+
+    report = await backfill_documents(db_session)
+    assert isinstance(report, BackfillReport)
+    assert report.processed == 0
+    assert report.skipped == 0
+    assert report.gaps == 0

--- a/api/tests/test_pipeline_ingest.py
+++ b/api/tests/test_pipeline_ingest.py
@@ -435,3 +435,114 @@ async def test_ingest_missing_row(
     result = await ingest_file(db_session, uuid.uuid4())
     assert result.status == "missing"
     assert result.error == "row_not_found"
+
+
+# ---------------------------------------------------------------------------
+# M2-A1: normalized_content + was_ocrd
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_ingest_populates_normalized_content_and_was_ocrd(
+    db_session: AsyncSession,
+    db_user: User,
+    fake_s3: FakeS3Client,
+    patched_storage: FakeS3Client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """M2-A1: ingest writes the canonical text to ``normalized_content``
+    and sets ``was_ocrd=False`` (M1 has no OCR path).
+
+    The Citation Engine (M2-A2) re-reads from ``normalized_content`` at
+    chunk offsets — this test guards the load-bearing fidelity invariant
+    that ``normalized_content[start:end] == chunk.content`` for every
+    chunk in the document.
+    """
+
+    from app.config import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "lq_ai_docling_enabled", False)
+
+    pdf_bytes = _make_simple_pdf()
+    storage_key = f"{uuid.uuid4()}"
+    _put_in_fake_s3(fake_s3, storage_key, pdf_bytes)
+
+    file_row = await _create_file_row(
+        db_session, db_user, storage_path=storage_key, pdf_bytes=pdf_bytes
+    )
+
+    result = await ingest_file(db_session, file_row.id)
+    assert result.status == "ready"
+
+    doc = (
+        await db_session.execute(select(Document).where(Document.file_id == file_row.id))
+    ).scalar_one()
+
+    # New columns are populated and have the expected M1 values.
+    from app.pipeline.parsers import parse_pdf
+
+    parsed = parse_pdf(pdf_bytes, run_docling=False)
+    assert doc.normalized_content == parsed.canonical_text
+    assert doc.was_ocrd is False
+
+    # Fidelity: every chunk slices back byte-for-byte against the
+    # persisted normalized_content (not the re-parsed canonical text).
+    chunks = (
+        (
+            await db_session.execute(
+                select(DocumentChunk)
+                .where(DocumentChunk.document_id == doc.id)
+                .order_by(DocumentChunk.chunk_index)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(chunks) > 0
+    for chunk in chunks:
+        slice_ = doc.normalized_content[chunk.char_offset_start : chunk.char_offset_end]
+        assert slice_ == chunk.content, (
+            f"chunk {chunk.chunk_index} fidelity against normalized_content broken: "
+            f"len(slice)={len(slice_)}, len(content)={len(chunk.content)}"
+        )
+
+
+@pytest.mark.integration
+async def test_ingest_re_run_refreshes_normalized_content(
+    db_session: AsyncSession,
+    db_user: User,
+    fake_s3: FakeS3Client,
+    patched_storage: FakeS3Client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """M2-A1: idempotent re-ingest keeps normalized_content in sync with chunks."""
+
+    from app.config import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "lq_ai_docling_enabled", False)
+
+    pdf_bytes = _make_simple_pdf()
+    storage_key = f"{uuid.uuid4()}"
+    _put_in_fake_s3(fake_s3, storage_key, pdf_bytes)
+
+    file_row = await _create_file_row(
+        db_session, db_user, storage_path=storage_key, pdf_bytes=pdf_bytes
+    )
+
+    first = await ingest_file(db_session, file_row.id)
+    assert first.status == "ready"
+    second = await ingest_file(db_session, file_row.id)
+    assert second.status == "ready"
+    assert second.document_id == first.document_id  # same row, replaced chunks.
+
+    doc = (
+        await db_session.execute(select(Document).where(Document.file_id == file_row.id))
+    ).scalar_one()
+
+    from app.pipeline.parsers import parse_pdf
+
+    parsed = parse_pdf(pdf_bytes, run_docling=False)
+    assert doc.normalized_content == parsed.canonical_text
+    assert doc.was_ocrd is False

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -516,7 +516,9 @@ CREATE TABLE documents (
     parser_version      TEXT,            -- e.g. 'pymupdf=1.24.0; docling=1.16.0'
     page_count          INTEGER,
     character_count     INTEGER,
-    structured_content  JSONB,           -- Docling's structured representation; M2 reads
+    structured_content  JSONB,            -- Docling's structured representation; M2 reads
+    normalized_content  TEXT NOT NULL DEFAULT '',  -- M2-A1 (migration 0024); see below
+    was_ocrd            BOOLEAN NOT NULL DEFAULT FALSE,  -- M2-A1 (migration 0024); see below
     processed_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
@@ -527,6 +529,23 @@ Per ADR 0006, the `parser` column carries the cascade outcome:
 `docling+pymupdf` (both succeeded), `pymupdf` (Docling fell through),
 or `pymupdf-only` (Docling intentionally disabled via
 `LQ_AI_DOCLING_ENABLED=false`).
+
+Per M2-A1 (migration 0024), `normalized_content` carries the full,
+canonical PyMuPDF text stream — the source the M2 Citation Engine
+slices at chunk offsets when verifying that a citation appears in the
+source document. The fidelity invariant is
+`document_chunks.content == normalized_content[char_offset_start:char_offset_end]`,
+held at write time by `app.pipeline.ingest`. Pre-M2 rows landed with
+the empty-string default and were reconstructed from their chunks via
+the one-time script `scripts/backfill_normalized_content.py` (which
+remains idempotent and re-runnable should a future migration require
+it).
+
+`was_ocrd` is a forward-looking flag: a later M2 task adds an OCR
+fallback for image-only PDFs, and the tolerant-match verification stage
+(M2-B1) uses this flag to enable OCR-artifact normalization. Every M1
+ingest and every backfilled row sets `was_ocrd = FALSE` because M1's
+parsers never OCR (image-only PDFs are rejected with `parse_failed`).
 
 ### `document_chunks`
 

--- a/scripts/backfill_normalized_content.py
+++ b/scripts/backfill_normalized_content.py
@@ -1,0 +1,89 @@
+"""One-time backfill of ``documents.normalized_content`` from chunks — M2-A1.
+
+The M2-A1 migration adds ``normalized_content`` and ``was_ocrd`` to the
+``documents`` table with safe defaults so deploys don't block. Pre-M2
+documents land with the empty-string default; this script reconstructs
+their text from the existing chunks so the M2 Citation Engine has a
+canonical source to re-read at chunk offsets.
+
+Usage (from inside the API container):
+
+    docker compose exec api python /app/scripts/backfill_normalized_content.py
+    docker compose exec api python /app/scripts/backfill_normalized_content.py --force
+
+By default the script skips documents whose ``normalized_content`` is
+already non-empty. ``--force`` re-processes every row — only use it if
+you suspect a previous backfill produced wrong text and you've worked
+out why.
+
+The reconstruction is overlap-aware. If a document's chunks have a gap
+(no chunk covers some byte range of the original) the document is
+left untouched and the operator is asked to investigate. Corrupt
+``normalized_content`` is worse than missing ``normalized_content``:
+the Citation Engine compares against it byte-for-byte.
+
+Exit codes:
+    0  — success (any combination of processed/skipped/gaps reported).
+    1  — unrecoverable error (DB connection failure, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.config import get_settings
+from app.pipeline.normalized_backfill import backfill_documents
+
+log = logging.getLogger("backfill_normalized_content")
+
+
+async def _run(force: bool) -> int:
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with session_factory() as session:
+            report = await backfill_documents(session, force=force)
+    finally:
+        await engine.dispose()
+
+    log.info(
+        "backfill complete: processed=%d, skipped=%d, gaps=%d",
+        report.processed,
+        report.skipped,
+        report.gaps,
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill documents.normalized_content from existing chunks (M2-A1)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-process documents whose normalized_content is already populated.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        return asyncio.run(_run(force=args.force))
+    except Exception as exc:
+        log.error("backfill failed: %s", exc, exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

First task of M2: lays the data substrate the Citation Engine (M2-A2+) and tolerant-match (M2-B1) depend on. Adds two columns to `documents`, populates them on every ingest, and ships a one-time backfill script for pre-M2 rows.

- **`normalized_content TEXT NOT NULL DEFAULT ''`** — the full PyMuPDF canonical text. The Citation Engine re-reads this at chunk offsets when verifying citations. The fidelity invariant `chunk.content == normalized_content[start:end]` is held at write time by the ingest pipeline.
- **`was_ocrd BOOLEAN NOT NULL DEFAULT FALSE`** — forward-looking flag the tolerant-match stage uses to enable OCR-artifact normalization. Every M1 ingest and every backfilled row lands at FALSE because M1's parsers never OCR.

Per M2-A1 (`docs/M2-IMPLEMENTATION-PLAN.md`).

## What landed

| Layer | File | Change |
|---|---|---|
| Migration | `api/alembic/versions/0024_normalized_content_and_was_ocrd.py` | New |
| ORM | `api/app/models/document.py` | +18 lines |
| Pipeline | `api/app/pipeline/ingest.py` | +10 lines — both new and re-ingest paths refresh both columns |
| Backfill | `api/app/pipeline/normalized_backfill.py` | New (pure overlap-aware algorithm + async DB walker) |
| Backfill CLI | `scripts/backfill_normalized_content.py` | New (thin shim) |
| Tests | `api/tests/test_pipeline_ingest.py` | +2 tests for new columns + fidelity |
| Tests | `api/tests/test_normalized_backfill.py` | New — 5 unit + 4 integration tests |
| Docs | `docs/db-schema.md` | Documents both columns + the load-bearing invariant under §documents |

## Design notes

**Backfill reconstruction is overlap-aware.** The chunker emits overlapping chunks (default 200-char overlap). The algorithm sorts by `char_offset_start` and appends only the suffix beyond the running end position. Gaps between consecutive chunks are flagged explicitly rather than silently filled — corrupt `normalized_content` would mislead the Citation Engine byte-for-byte.

**Backfill is idempotent.** Skip-if-populated by default; `--force` re-processes. Operators see `processed`, `skipped`, `gaps` counters per run.

**No OCR detection in this task.** `was_ocrd` is False for every row in M1 (image-only PDFs are rejected with `parse_failed`). The flag exists so M2-B1 tolerant-match has a hook when a later task adds OCR fallback.

## Test plan

- [x] Migration applies cleanly on a fresh DB (covered by the per-test DB fixture running `alembic upgrade head`).
- [x] `test_ingest_populates_normalized_content_and_was_ocrd` — verifies both new columns are populated and chunks slice back byte-for-byte against `normalized_content`.
- [x] `test_ingest_re_run_refreshes_normalized_content` — idempotent re-ingest keeps `normalized_content` in sync.
- [x] 5 unit tests for `reconstruct_from_chunks`: disjoint, overlap, unordered input, gap detection, empty input.
- [x] 4 integration tests for `backfill_documents`: populates pre-M2 rows, idempotent skip, `--force` re-write, empty-DB report shape.
- [x] Full api suite: 873 passed, 1 skipped.
- [x] `mypy app` clean. `ruff check api scripts` clean. `ruff format --check` clean.
- [ ] **Operator-side:** after merge, run `docker compose exec api python /app/scripts/backfill_normalized_content.py` against the dev DB to backfill any pre-M2 documents that exist there.

## Verification against the M2 plan

The M2 plan §M2-A1 specifies three verification criteria:
1. psql query shows both columns populated on a sample document — covered by `test_ingest_populates_normalized_content_and_was_ocrd`.
2. Re-extraction at chunk offsets reproduces chunk.content byte-for-byte — same test, plus the backfill fidelity test.
3. Backfill script is idempotent — `test_backfill_is_idempotent` (skip-if-populated) + `test_backfill_force_rewrites_populated_rows`.

Refs: `docs/M2-IMPLEMENTATION-PLAN.md` §Task M2-A1, `docs/PRD.md` §3.3.