### PR TITLE
M2-A2: Citation Engine Stage 1 — exact-match verification

### DIFF
--- a/api/alembic/versions/0025_create_message_citations.py
+++ b/api/alembic/versions/0025_create_message_citations.py
@@ -1,0 +1,130 @@
+"""create message_citations table — M2-A2
+
+The Citation Engine (PRD §3.3) persists one row per model-emitted
+citation alongside the assistant message. Each row carries:
+
+* ``source_file_id`` + ``source_offset_start`` / ``source_offset_end``:
+  the byte-precise span in the source document the model claims to
+  be quoting. The verifier checks these against
+  ``documents.normalized_content`` (added in M2-A1, migration 0024).
+* ``source_text``: the exact text the model quoted.
+* ``verified`` + ``verification_method`` + ``verification_confidence``:
+  the verifier's verdict. ``verified=TRUE`` only when at least one
+  stage passed.
+
+The schema is built to carry every Stage's output the M2 plan
+specifies, not just Stage 1's. Stages 2-4 (tolerant-match, LLM judge,
+ensemble) land in later tasks but write into the same column shape;
+``verification_method`` distinguishes them. Pre-emptive plumbing now
+saves a follow-on migration.
+
+This migration **promotes the table** from the forward-looking sketch
+that has been in ``docs/db-schema.md`` since C3 — that sketch was
+explicitly flagged as "may or may not survive the M2 citation work"
+(the schema doc note at the head of the messages section). M2-A2
+chose the relational path; the JSONB ``messages.citations`` column
+remains in place at its ``'[]'`` default until M2-C2 (failed-citation
+UI rendering) decides whether to retire it.
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-05-16
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0025"
+down_revision = "0024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "message_citations",
+        sa.Column(
+            "id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "message_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "messages.id",
+                ondelete="CASCADE",
+                name="fk_message_citations_message_id",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "source_file_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "files.id",
+                ondelete="CASCADE",
+                name="fk_message_citations_source_file_id",
+            ),
+            nullable=False,
+        ),
+        sa.Column("source_offset_start", sa.Integer(), nullable=False),
+        sa.Column("source_offset_end", sa.Integer(), nullable=False),
+        sa.Column("source_page", sa.Integer(), nullable=True),
+        sa.Column("source_text", sa.Text(), nullable=False),
+        sa.Column(
+            "verified",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("verification_method", sa.Text(), nullable=True),
+        sa.Column("verification_confidence", sa.Numeric(3, 2), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "source_offset_start >= 0",
+            name="chk_message_citations_offset_start_nonneg",
+        ),
+        sa.CheckConstraint(
+            "source_offset_end > source_offset_start",
+            name="chk_message_citations_offset_end_gt_start",
+        ),
+        sa.CheckConstraint(
+            "verification_method IS NULL OR verification_method IN "
+            "('exact_match', 'tolerant_match', 'llm_judge', 'ensemble', 'failed')",
+            name="chk_message_citations_method_values",
+        ),
+        sa.CheckConstraint(
+            "verification_confidence IS NULL OR "
+            "(verification_confidence >= 0 AND verification_confidence <= 1)",
+            name="chk_message_citations_confidence_range",
+        ),
+        sa.CheckConstraint(
+            "(verified = false) OR (verification_method IS NOT NULL)",
+            name="chk_message_citations_verified_has_method",
+        ),
+    )
+    op.create_index(
+        "idx_message_citations_message",
+        "message_citations",
+        ["message_id"],
+    )
+    op.create_index(
+        "idx_message_citations_file",
+        "message_citations",
+        ["source_file_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_message_citations_file", table_name="message_citations")
+    op.drop_index("idx_message_citations_message", table_name="message_citations")
+    op.drop_table("message_citations")

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -69,12 +69,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies import ActiveUser
 from app.api.skills import _resolve_skill_for_user
 from app.audit import audit_action
+from app.citation import extract_citations, verify_exact_match
 from app.clients.gateway import GatewayClient, get_gateway_client
 from app.db.session import get_db
 from app.errors import LQAIError, NotFound, ValidationError
 from app.knowledge.embed import DEFAULT_EMBEDDING_MODEL, request_embedding_vector
 from app.knowledge.retrieval import HybridSearchResult, hybrid_search
-from app.models.chat import Chat, Message
+from app.models.chat import Chat, Message, MessageCitation
+from app.models.document import Document
 from app.models.inference import InferenceRoutingLog
 from app.models.knowledge import KnowledgeBase
 from app.models.project import Project
@@ -807,6 +809,16 @@ def _format_retrieval_context_block(
     gateway request as a ``system`` message so the LLM treats it as
     grounding rather than user turn content.
 
+    The header carries the M2 Citation Engine's citation contract: when
+    the model grounds a claim in a retrieved chunk, it must quote the
+    source verbatim in straight double quotes followed by
+    ``(Source: [N])`` where N matches the bracketed index of the chunk
+    below. The extractor (``app.citation.extraction``) parses that
+    shape; the Stage 1 verifier checks the quote byte-for-byte against
+    ``documents.normalized_content``. Paraphrases or smart-quoted
+    citations fail Stage 1 and fall through to later stages when those
+    ship (M2-B1 tolerant-match, M2-C1 LLM judge).
+
     Chunk text is included verbatim. We do not truncate at the
     character level (the LLM's tokenizer will window if the request is
     oversized); :data:`RAG_MAX_TOTAL_CHUNKS` upstream is the bound.
@@ -816,6 +828,14 @@ def _format_retrieval_context_block(
         "Retrieved context from your matter's knowledge bases. "
         "Cite these sources when they bear on the user's question; "
         "ignore them if they are not relevant.",
+        "",
+        "Citation format: when you ground a claim in a retrieved chunk, "
+        'quote the source passage VERBATIM in straight double quotes "..." '
+        "immediately followed by `(Source: [N])` where N is the bracketed "
+        "index of the chunk below. Quotes must be byte-for-byte exact - "
+        "do not paraphrase, summarize, or change punctuation, casing, or "
+        "whitespace inside quoted material. Use this format every time you "
+        "rely on a chunk; otherwise the citation will render as unverified.",
         "",
     ]
     for idx, chunk in enumerate(chunks, start=1):
@@ -1151,6 +1171,7 @@ async def send_message(
             assistant_message_id=assistant_message_id,
             user_message_id=user_message.id,
             request_id=request_id,
+            retrieved_chunks=retrieved_chunks,
             http_request=request,
             attached_skill_provenance=attached_skill_provenance,
         )
@@ -1163,6 +1184,7 @@ async def send_message(
         assistant_message_id=assistant_message_id,
         user_message_id=user_message.id,
         request_id=request_id,
+        retrieved_chunks=retrieved_chunks,
         http_request=request,
         attached_skill_names=attached_skill_names,
         slash_unresolved=slash_unresolved,
@@ -1172,7 +1194,7 @@ async def send_message(
 
 @router.get(
     "/{chat_id}/messages/{message_id}/citations",
-    summary="Get citations for a message (M2 — empty until citation engine ships)",
+    summary="Get citations for a message (M2-A2: relational message_citations rows)",
 )
 async def get_citations(
     chat_id: str,
@@ -1180,12 +1202,23 @@ async def get_citations(
     user: ActiveUser,
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[dict[str, Any]]:
-    """Return persisted citations on the message row.
+    """Return citations persisted for a message.
 
-    M1 stores ``[]``; M2 populates the structured shape. C3 returns
-    whatever the row carries so this endpoint is forward-compatible
-    without an additional task. The chat ownership check is enforced
-    so a cross-user request can't enumerate message ids.
+    M2-A2 (this version) reads from ``message_citations`` (one row per
+    citation) rather than the legacy ``messages.citations`` JSONB
+    column. Each citation in the response carries the verifier's
+    verdict (``verified``, ``verification_method``,
+    ``verification_confidence``) so the UI (M2-C2) can render unverified
+    citations distinctly.
+
+    The legacy JSONB column is kept at its ``'[]'`` default by the
+    chat-send path; readers should consume this endpoint, not the
+    column. The column itself remains for backward compatibility with
+    older clients and is slated for retirement by M2-C2.
+
+    Chat ownership is enforced so a cross-user request can't enumerate
+    message ids — the visibility check uses the same path as message
+    list reads.
     """
 
     cid = _validate_chat_id(chat_id)
@@ -1199,16 +1232,40 @@ async def get_citations(
 
     await _load_visible_chat(db, cid, user.id, include_archived=True)
 
-    stmt = select(Message).where(Message.id == mid, Message.chat_id == cid)
-    result = await db.execute(stmt)
-    row = result.scalar_one_or_none()
-    if row is None:
+    # Confirm the message exists (and belongs to the chat) before
+    # returning an empty list — distinguishes "no citations" from
+    # "no message" for the caller.
+    msg_stmt = select(Message.id).where(Message.id == mid, Message.chat_id == cid)
+    if (await db.execute(msg_stmt)).scalar_one_or_none() is None:
         raise NotFound(
             f"Message {mid} not found.",
             details={"message_id": str(mid)},
         )
-    citations: list[dict[str, Any]] = list(row.citations or [])
-    return citations
+
+    cite_stmt = (
+        select(MessageCitation)
+        .where(MessageCitation.message_id == mid)
+        .order_by(MessageCitation.created_at, MessageCitation.id)
+    )
+    rows = (await db.execute(cite_stmt)).scalars().all()
+
+    return [
+        {
+            "id": str(c.id),
+            "source_file_id": str(c.source_file_id),
+            "source_offset_start": c.source_offset_start,
+            "source_offset_end": c.source_offset_end,
+            "source_page": c.source_page,
+            "source_text": c.source_text,
+            "verified": c.verified,
+            "verification_method": c.verification_method,
+            "verification_confidence": (
+                float(c.verification_confidence) if c.verification_confidence is not None else None
+            ),
+            "created_at": c.created_at.isoformat(),
+        }
+        for c in rows
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -1283,6 +1340,89 @@ async def _audit_message_sent(
         details=details,
     )
     await db.commit()
+
+
+async def _persist_message_citations(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    assistant_text: str,
+    retrieved_chunks: list[HybridSearchResult],
+) -> None:
+    """Extract, verify, and persist citations from an assistant message — M2-A2.
+
+    Runs after :func:`_persist_assistant_message` so ``message_id`` is
+    a real FK target. No-op when ``retrieved_chunks`` is empty
+    (no RAG context this turn → nothing to cite) or when extraction
+    finds no ``"..." (Source: [N])`` pairs.
+
+    Stage 1 (exact-match) is the only verifier wired today. Candidates
+    that fail Stage 1 are NOT persisted in M2-A2 — they'd land here
+    once Stage 2 (M2-B1) ships and routes the verifier cascade. The
+    plan's "render as unverified" UI path (M2-C2) consumes either:
+
+    * verified=true rows from Stage 1 (or later stages once they ship),
+      OR
+    * the absence of any row for a quote the model emitted.
+    """
+
+    if not retrieved_chunks:
+        return
+
+    candidates = extract_citations(assistant_text, retrieved_chunks)
+    if not candidates:
+        return
+
+    # Batch-load the documents the candidates point at so we don't
+    # round-trip the DB per citation. The verifier needs
+    # ``document.normalized_content`` to confirm the slice.
+    doc_ids = {c.source_document_id for c in candidates}
+    doc_rows = (await db.execute(select(Document).where(Document.id.in_(doc_ids)))).scalars().all()
+    docs_by_id = {d.id: d for d in doc_rows}
+
+    new_rows: list[MessageCitation] = []
+    for cand in candidates:
+        doc = docs_by_id.get(cand.source_document_id)
+        if doc is None:
+            # Defensive: chunk pointed at a document that was deleted
+            # between retrieval and persistence. Skip; the schema's FK
+            # would reject anyway.
+            continue
+
+        result = verify_exact_match(cand, doc)
+        if not result.verified:
+            # Stage 1 missed — once Stages 2-4 land they fall through
+            # here. For M2-A2 we drop unverified candidates.
+            continue
+
+        new_rows.append(
+            MessageCitation(
+                message_id=message_id,
+                source_file_id=cand.source_file_id,
+                source_offset_start=cand.source_offset_start,
+                source_offset_end=cand.source_offset_end,
+                source_page=cand.source_page,
+                source_text=cand.source_text,
+                verified=True,
+                verification_method=result.method,
+                verification_confidence=result.confidence,
+            )
+        )
+
+    if not new_rows:
+        return
+
+    db.add_all(new_rows)
+    await db.commit()
+
+    log.info(
+        "chat-send citations: persisted",
+        extra={
+            "event": "chat_message_citations_persisted",
+            "message_id": str(message_id),
+            "citation_count": len(new_rows),
+        },
+    )
 
 
 async def _persist_assistant_message(
@@ -1418,6 +1558,7 @@ async def _non_streaming_response(
     assistant_message_id: uuid.UUID,
     user_message_id: uuid.UUID,
     request_id: str,
+    retrieved_chunks: list[HybridSearchResult] | None = None,
     http_request: Request | None = None,
     attached_skill_names: list[str] | None = None,
     slash_unresolved: bool = False,
@@ -1474,6 +1615,15 @@ async def _non_streaming_response(
         error_code=None,
     )
 
+    # M2-A2: extract + verify + persist citations from the assistant
+    # response. No-op when no chunks were retrieved this turn.
+    await _persist_message_citations(
+        db,
+        message_id=assistant_message_id,
+        assistant_text=assistant_text,
+        retrieved_chunks=retrieved_chunks or [],
+    )
+
     await _audit_message_sent(
         db,
         user=user,
@@ -1522,6 +1672,7 @@ async def _stream_response(
     assistant_message_id: uuid.UUID,
     user_message_id: uuid.UUID,
     request_id: str,
+    retrieved_chunks: list[HybridSearchResult] | None = None,
     http_request: Request | None = None,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
 ) -> StreamingResponse:
@@ -1622,6 +1773,28 @@ async def _stream_response(
                 applied_skills=last_applied_skills or [],
                 error_code=error_code,
             )
+            # M2-A2: citations from the streamed assistant content.
+            # Skipped on error_code (no full artifact to cite). Failures
+            # here must not block the stream; log and continue.
+            if error_code is None:
+                try:
+                    await _persist_message_citations(
+                        db,
+                        message_id=assistant_message_id,
+                        assistant_text="".join(accumulated),
+                        retrieved_chunks=retrieved_chunks or [],
+                    )
+                except Exception as cite_exc:
+                    log.warning(
+                        "chat send_message: citation persistence failed",
+                        extra={
+                            "event": "chat_citation_persist_failed",
+                            "user_id": str(user.id),
+                            "chat_id": str(chat.id),
+                            "assistant_message_id": str(assistant_message_id),
+                            "error": str(cite_exc),
+                        },
+                    )
             # D3 audit row — best-effort, must not break the stream.
             try:
                 await _audit_message_sent(

--- a/api/app/citation/__init__.py
+++ b/api/app/citation/__init__.py
@@ -1,0 +1,29 @@
+"""Citation Engine — verifies every model-emitted citation before persistence.
+
+Per PRD §3.3 the engine is staged so high-confidence verdicts land
+cheaply and only difficult citations escalate to expensive checks:
+
+* **Stage 1 (M2-A2; this module)** — exact-match against the
+  retrieved chunk + the source document's
+  ``normalized_content``.
+* **Stage 2 (M2-B1)** — tolerant-match (whitespace + OCR
+  artefacts + smart-quote normalization).
+* **Stage 3 (M2-C1)** — LLM paraphrase judge.
+* **Stage 4 (M2-D1)** — ensemble verification for high-stakes
+  operations.
+
+A citation that fails Stage 1 falls through to Stage 2; one that
+fails every stage is persisted with ``verified=False`` and rendered
+as "unverified" by the UI (M2-C2). The persistence shape is the
+``message_citations`` table; see ``app.models.chat.MessageCitation``.
+"""
+
+from app.citation.extraction import CitationCandidate, extract_citations
+from app.citation.verification import VerificationResult, verify_exact_match
+
+__all__ = [
+    "CitationCandidate",
+    "VerificationResult",
+    "extract_citations",
+    "verify_exact_match",
+]

--- a/api/app/citation/extraction.py
+++ b/api/app/citation/extraction.py
@@ -1,0 +1,127 @@
+"""Citation extraction from assistant responses — Stage 1 (quote-then-locate).
+
+The model is instructed (in the RAG context-block system message) to
+quote source passages verbatim in straight double-quotes followed by
+``(Source: [N])`` where ``N`` is the 1-based index of the retrieved
+chunk the quote came from. This module parses that shape and resolves
+each quote to a byte-precise span in the source document.
+
+Resolution mechanics:
+
+1. Regex over the response text for ``"..."\\s*(Source: [N])``.
+2. For each match, look up ``retrieved_chunks[N - 1]``.
+3. Locate the quote inside the chunk's content via ``str.find``.
+4. Derive the document offsets:
+   ``chunk.char_offset_start + match_pos`` … ``+ len(quote)``.
+5. Materialize a :class:`CitationCandidate` carrying everything the
+   verifier and the persistence layer need.
+
+Quotes that can't be located (the model fabricated the quote or
+mis-cited the chunk index) are silently dropped — M2-A2 does not
+persist citations without valid offsets, and "the model claimed to
+quote but we can't find it" is a separate failure-mode to audit
+(future task).
+
+Stage 1 is intentionally strict: smart quotes, whitespace
+differences, and paraphrases will not match. Those falls through to
+later stages once they ship (M2-B1 / M2-C1).
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+
+# A protocol so the extractor accepts any chunk-shaped object — the
+# production caller passes ``HybridSearchResult``; tests pass a stub.
+class _RetrievedChunk(Protocol):
+    document_id: uuid.UUID
+    file_id: uuid.UUID
+    content: str
+    page_start: int | None
+    char_offset_start: int
+    char_offset_end: int
+
+
+@dataclass(slots=True)
+class CitationCandidate:
+    """One extracted citation with byte-precise offsets, awaiting verification.
+
+    All fields map 1-to-1 onto the ``message_citations`` row the
+    persistence step will create. The verifier runs against this
+    shape and stamps the ``verified`` / method / confidence flags.
+    """
+
+    source_file_id: uuid.UUID
+    source_document_id: uuid.UUID
+    source_offset_start: int
+    source_offset_end: int
+    source_page: int | None
+    source_text: str
+
+
+# Straight double quote, lazy non-empty body, optional whitespace, then
+# ``(Source: [N])``. ``re.DOTALL`` lets the body span line breaks.
+# A negative-lookahead inside the body prevents the regex from
+# absorbing a closing quote that belongs to a later, different citation.
+_CITATION_RE = re.compile(
+    r'"(?P<quote>[^"]+?)"\s*\(Source:\s*\[(?P<index>\d+)\]\)',
+    flags=re.DOTALL,
+)
+
+
+def extract_citations(
+    response_text: str,
+    retrieved_chunks: Sequence[_RetrievedChunk],
+) -> list[CitationCandidate]:
+    """Extract Stage-1-locatable citations from the assistant response.
+
+    Args:
+        response_text: The full assistant message content.
+        retrieved_chunks: The RAG-retrieved chunks delivered to the
+            model in this turn's prompt, in the same order they were
+            numbered ``[1], [2], …`` in the context block.
+
+    Returns:
+        One :class:`CitationCandidate` per ``"..." (Source: [N])``
+        pair whose quote could be located inside its cited chunk.
+        Pairs whose quote is unfindable or whose index is out of
+        range are dropped silently.
+    """
+
+    candidates: list[CitationCandidate] = []
+
+    for match in _CITATION_RE.finditer(response_text):
+        quote = match.group("quote")
+        index_1based = int(match.group("index"))
+
+        if not (1 <= index_1based <= len(retrieved_chunks)):
+            continue
+
+        chunk = retrieved_chunks[index_1based - 1]
+        match_pos = chunk.content.find(quote)
+        if match_pos < 0:
+            # Quote isn't byte-for-byte inside the chunk. Stage 2's
+            # tolerant-match will be the right place to handle this;
+            # Stage 1 drops it.
+            continue
+
+        offset_start = chunk.char_offset_start + match_pos
+        offset_end = offset_start + len(quote)
+
+        candidates.append(
+            CitationCandidate(
+                source_file_id=chunk.file_id,
+                source_document_id=chunk.document_id,
+                source_offset_start=offset_start,
+                source_offset_end=offset_end,
+                source_page=chunk.page_start,
+                source_text=quote,
+            )
+        )
+
+    return candidates

--- a/api/app/citation/verification.py
+++ b/api/app/citation/verification.py
@@ -1,0 +1,105 @@
+"""Citation Engine — Stage 1: exact-match verification.
+
+Given a :class:`CitationCandidate` produced by the extractor and the
+:class:`Document` it points at, this stage confirms that
+``document.normalized_content[source_offset_start:source_offset_end]``
+equals ``source_text`` byte-for-byte. If the extractor did its job
+the check passes trivially — the value here is twofold:
+
+* **Defense against drift.** If the chunker-vs-canonical-text
+  fidelity invariant breaks in a future change (e.g., a parser swap
+  that produces a different ``canonical_text``), Stage 1 will start
+  failing instead of silently rendering wrong text as "verified."
+* **Symmetry with later stages.** Stages 2-4 (tolerant-match, LLM
+  judge, ensemble) consume the same input shape and write the same
+  :class:`VerificationResult` shape. The persistence layer doesn't
+  need to know which stage produced the verdict.
+
+This module is intentionally minimal — the Stage-2 normalization
+pipeline (M2-B1) lives in ``app.citation.normalization``; the LLM
+judge (M2-C1) lives in ``app.citation.llm_judge``; ensemble (M2-D1)
+in ``app.citation.ensemble``. Mirror the file naming.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class _CandidateProtocol(Protocol):
+    """Shape the verifier reads from a citation candidate.
+
+    Production passes :class:`app.citation.extraction.CitationCandidate`;
+    tests pass an equivalent stub.
+    """
+
+    source_offset_start: int
+    source_offset_end: int
+    source_text: str
+    source_document_id: uuid.UUID
+
+
+class _DocumentProtocol(Protocol):
+    """Shape the verifier reads from a Document.
+
+    Production passes :class:`app.models.document.Document`; tests
+    pass a minimal stub.
+    """
+
+    id: uuid.UUID
+    normalized_content: str
+
+
+@dataclass(slots=True)
+class VerificationResult:
+    """Outcome of running one verification stage against one citation.
+
+    Either:
+
+    * ``verified=True``, ``method`` set to the canonical stage name
+      (e.g., ``'exact_match'``), and ``confidence`` populated; or
+    * ``verified=False``, ``method=None``, ``confidence=None``. The
+      caller routes the candidate to the next stage when False.
+
+    The shape is symmetric with the ``message_citations`` columns so
+    the persistence layer can copy fields without re-mapping.
+    """
+
+    verified: bool
+    method: str | None
+    confidence: float | None
+
+
+# A sentinel result for misses, reused so callers don't allocate.
+_MISS = VerificationResult(verified=False, method=None, confidence=None)
+
+
+def verify_exact_match(
+    candidate: _CandidateProtocol,
+    document: _DocumentProtocol,
+) -> VerificationResult:
+    """Return ``VerificationResult(verified=True)`` iff Stage 1 passes.
+
+    The contract is byte-for-byte equality between the candidate's
+    ``source_text`` and the document's ``normalized_content`` slice at
+    the candidate's offsets. No normalization is performed; whitespace
+    or case differences fall through to Stage 2.
+    """
+
+    start = candidate.source_offset_start
+    end = candidate.source_offset_end
+    quote = candidate.source_text
+
+    if not quote:
+        return _MISS
+    if start < 0 or end > len(document.normalized_content):
+        return _MISS
+    if end <= start:
+        return _MISS
+
+    if document.normalized_content[start:end] != quote:
+        return _MISS
+
+    return VerificationResult(verified=True, method="exact_match", confidence=1.0)

--- a/api/app/models/chat.py
+++ b/api/app/models/chat.py
@@ -30,14 +30,17 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from decimal import Decimal
 from typing import Any
 
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     CheckConstraint,
     DateTime,
     ForeignKey,
     Integer,
+    Numeric,
     SmallInteger,
     Text,
     text,
@@ -207,4 +210,107 @@ class Message(Base):
             f"<Message id={self.id} chat_id={self.chat_id} "
             f"role={self.role!r} tier={self.routed_inference_tier} "
             f"error={self.error_code!r}>"
+        )
+
+
+class MessageCitation(Base):
+    """One model-emitted citation, verified against its source document.
+
+    The M2 Citation Engine extracts citations from assistant responses
+    (M2-A2 ships Stage 1: exact-match against retrieved-chunk content)
+    and writes one row here per emitted citation. ``source_offset_start``
+    and ``source_offset_end`` are byte-precise into
+    ``documents.normalized_content`` — the same span the verifier
+    re-reads when checking that the model quoted the source verbatim.
+
+    ``verification_method`` enumerates which verification stage passed:
+
+    * ``'exact_match'`` — Stage 1, byte-for-byte (M2-A2; lands here).
+    * ``'tolerant_match'`` — Stage 2, normalized-whitespace + OCR
+      artefacts (M2-B1).
+    * ``'llm_judge'`` — Stage 3, paraphrase judge (M2-C1).
+    * ``'ensemble'`` — Stage 4, multi-model agreement (M2-D1).
+    * ``'failed'`` — every stage rejected; rendered as unverified in
+      the UI (M2-C2).
+
+    ``verification_confidence`` is the stage's reported confidence in
+    ``[0, 1]``; exact-match writes ``1.0``, tolerant-match writes a
+    similarity-based score, the LLM judge writes its own estimate.
+    """
+
+    __tablename__ = "message_citations"
+    __table_args__ = (
+        CheckConstraint(
+            "source_offset_start >= 0",
+            name="chk_message_citations_offset_start_nonneg",
+        ),
+        CheckConstraint(
+            "source_offset_end > source_offset_start",
+            name="chk_message_citations_offset_end_gt_start",
+        ),
+        CheckConstraint(
+            "verification_method IS NULL OR verification_method IN "
+            "('exact_match', 'tolerant_match', 'llm_judge', 'ensemble', 'failed')",
+            name="chk_message_citations_method_values",
+        ),
+        CheckConstraint(
+            "verification_confidence IS NULL OR "
+            "(verification_confidence >= 0 AND verification_confidence <= 1)",
+            name="chk_message_citations_confidence_range",
+        ),
+        CheckConstraint(
+            "(verified = false) OR (verification_method IS NOT NULL)",
+            name="chk_message_citations_verified_has_method",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    message_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "messages.id",
+            ondelete="CASCADE",
+            name="fk_message_citations_message_id",
+        ),
+        nullable=False,
+    )
+    source_file_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "files.id",
+            ondelete="CASCADE",
+            name="fk_message_citations_source_file_id",
+        ),
+        nullable=False,
+    )
+    source_offset_start: Mapped[int] = mapped_column(Integer, nullable=False)
+    source_offset_end: Mapped[int] = mapped_column(Integer, nullable=False)
+    source_page: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    source_text: Mapped[str] = mapped_column(Text, nullable=False)
+    verified: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
+    )
+    verification_method: Mapped[str | None] = mapped_column(Text, nullable=True)
+    verification_confidence: Mapped[Decimal | None] = mapped_column(
+        Numeric(3, 2),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<MessageCitation id={self.id} message_id={self.message_id} "
+            f"source_file={self.source_file_id} "
+            f"offsets=[{self.source_offset_start},{self.source_offset_end}) "
+            f"verified={self.verified} method={self.verification_method!r}>"
         )

--- a/api/tests/citation/test_exact_match.py
+++ b/api/tests/citation/test_exact_match.py
@@ -1,0 +1,170 @@
+"""Citation Engine — Stage 1 (exact-match) verifier tests.
+
+The Stage 1 verifier confirms that a citation candidate's
+``source_text`` appears byte-for-byte at the cited offsets in the
+document's ``normalized_content`` (the M2-A1 column).
+
+In production the extractor (``app.citation.extraction``) derives
+offsets from a substring search inside the retrieved chunk's content,
+so the verifier passes by construction unless the fidelity invariant
+``chunk.content == normalized_content[chunk_start:chunk_end]`` has
+broken. The verifier is still load-bearing for:
+
+* Defense against future drift (catches it loudly instead of
+  rendering wrong text as "verified").
+* The shared shape that later stages (tolerant-match, LLM judge,
+  ensemble) write into.
+* The handful of edge cases the M2 plan calls out: off-by-one
+  offsets, whitespace-modified quotes, casing-modified quotes —
+  these MUST return ``verified=False`` so they fall through to
+  Stage 2 later.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+from app.citation.verification import VerificationResult, verify_exact_match
+
+
+@dataclass(slots=True)
+class _StubDocument:
+    """Minimal Document-shaped stub for verifier tests — no DB needed."""
+
+    id: uuid.UUID
+    normalized_content: str
+    was_ocrd: bool = False
+
+
+@dataclass(slots=True)
+class _StubCandidate:
+    """Minimal CitationCandidate-shaped stub for verifier tests."""
+
+    source_file_id: uuid.UUID
+    source_document_id: uuid.UUID
+    source_offset_start: int
+    source_offset_end: int
+    source_page: int | None
+    source_text: str
+
+
+def _doc(text: str) -> _StubDocument:
+    return _StubDocument(id=uuid.uuid4(), normalized_content=text)
+
+
+def _candidate(
+    doc: _StubDocument,
+    *,
+    offset_start: int,
+    offset_end: int,
+    source_text: str,
+) -> _StubCandidate:
+    return _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=offset_start,
+        source_offset_end=offset_end,
+        source_page=None,
+        source_text=source_text,
+    )
+
+
+@pytest.mark.unit
+def test_exact_match_byte_for_byte_verified() -> None:
+    """Stage 1: quote matches normalized_content[start:end] byte-for-byte."""
+
+    text = "The agreement shall terminate after five years."
+    doc = _doc(text)
+    cand = _candidate(doc, offset_start=4, offset_end=13, source_text="agreement")
+
+    result = verify_exact_match(cand, doc)
+
+    assert isinstance(result, VerificationResult)
+    assert result.verified is True
+    assert result.method == "exact_match"
+    assert result.confidence == 1.0
+
+
+@pytest.mark.unit
+def test_exact_match_off_by_one_returns_false() -> None:
+    """Off-by-one offsets produce a different slice → unverified."""
+
+    text = "The agreement shall terminate after five years."
+    doc = _doc(text)
+    cand = _candidate(doc, offset_start=3, offset_end=13, source_text="agreement")
+
+    result = verify_exact_match(cand, doc)
+
+    assert result.verified is False
+    # method is left None — verifier doesn't claim a specific failure mode;
+    # Stage 2 will try tolerant-match next.
+    assert result.method is None
+    assert result.confidence is None
+
+
+@pytest.mark.unit
+def test_exact_match_whitespace_difference_returns_false() -> None:
+    """Modified whitespace fails Stage 1 (will be caught by Stage 2 M2-B1)."""
+
+    text = "The agreement\nshall  terminate."
+    doc = _doc(text)
+    # The quoted source_text collapses whitespace to single spaces — Stage 1
+    # rejects; Stage 2's normalize() will normalize whitespace and pass.
+    cand = _candidate(
+        doc,
+        offset_start=0,
+        offset_end=len(text),
+        source_text="The agreement shall terminate.",
+    )
+
+    result = verify_exact_match(cand, doc)
+    assert result.verified is False
+
+
+@pytest.mark.unit
+def test_exact_match_casing_difference_returns_false() -> None:
+    """Casing differences fail Stage 1 (paraphrase judge may catch later)."""
+
+    text = "The Agreement shall terminate."
+    doc = _doc(text)
+    cand = _candidate(
+        doc,
+        offset_start=0,
+        offset_end=len(text),
+        source_text="the agreement shall terminate.",
+    )
+
+    result = verify_exact_match(cand, doc)
+    assert result.verified is False
+
+
+@pytest.mark.unit
+def test_exact_match_offset_out_of_range_returns_false() -> None:
+    """Defensive: offsets past the document end never claim verified."""
+
+    text = "Short text."
+    doc = _doc(text)
+    cand = _candidate(
+        doc,
+        offset_start=0,
+        offset_end=1000,
+        source_text="Short text.",
+    )
+
+    result = verify_exact_match(cand, doc)
+    assert result.verified is False
+
+
+@pytest.mark.unit
+def test_exact_match_empty_source_text_returns_false() -> None:
+    """Zero-length source_text is meaningless; verifier rejects."""
+
+    text = "Some text."
+    doc = _doc(text)
+    cand = _candidate(doc, offset_start=0, offset_end=0, source_text="")
+
+    result = verify_exact_match(cand, doc)
+    assert result.verified is False

--- a/api/tests/citation/test_extraction.py
+++ b/api/tests/citation/test_extraction.py
@@ -1,0 +1,190 @@
+"""Citation Engine — extraction tests.
+
+The extractor parses the assistant response for quote-then-locate
+citations: a double-quoted passage immediately followed by a
+``(Source: [N])`` marker referring to a retrieved-chunk index.
+
+Each successfully located citation is materialized as a
+``CitationCandidate`` carrying the source_file_id / document_id /
+byte-precise offsets / source_text / page — everything the verifier
+and the persistence layer need.
+
+Quotes that can't be located inside their cited chunk are dropped
+silently for M2-A2. The schema requires file_id + offsets to be
+non-null, and we don't speculate where an unfindable quote came from.
+"Model claimed to cite but we can't find it" is a future failure-mode
+audit task (DE candidate).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+from app.citation.extraction import CitationCandidate, extract_citations
+
+
+@dataclass(slots=True)
+class _StubChunk:
+    """HybridSearchResult-shaped stub for extractor tests — no DB needed."""
+
+    document_id: uuid.UUID
+    file_id: uuid.UUID
+    content: str
+    page_start: int | None
+    char_offset_start: int
+    char_offset_end: int
+
+
+def _chunk(
+    *,
+    content: str,
+    char_offset_start: int = 0,
+    page_start: int | None = 1,
+) -> _StubChunk:
+    return _StubChunk(
+        document_id=uuid.uuid4(),
+        file_id=uuid.uuid4(),
+        content=content,
+        page_start=page_start,
+        char_offset_start=char_offset_start,
+        char_offset_end=char_offset_start + len(content),
+    )
+
+
+@pytest.mark.unit
+def test_extract_single_citation_byte_precise_offsets() -> None:
+    """A verbatim quote with (Source: [1]) becomes a candidate with derived offsets."""
+
+    chunk = _chunk(
+        content="The contract term shall be five years.",
+        char_offset_start=200,
+    )
+    response = 'The agreement says "The contract term shall be five years." (Source: [1]).'
+
+    candidates = extract_citations(response, [chunk])
+
+    assert len(candidates) == 1
+    cite = candidates[0]
+    assert isinstance(cite, CitationCandidate)
+    assert cite.source_file_id == chunk.file_id
+    assert cite.source_document_id == chunk.document_id
+    # Quote starts at the beginning of the chunk → offsets relative to the
+    # document begin at chunk.char_offset_start.
+    assert cite.source_offset_start == 200
+    assert cite.source_offset_end == 200 + len("The contract term shall be five years.")
+    assert cite.source_text == "The contract term shall be five years."
+    assert cite.source_page == 1
+
+
+@pytest.mark.unit
+def test_extract_handles_offset_within_chunk() -> None:
+    """Quote in the middle of a chunk → offsets account for the position inside."""
+
+    # The chunk text places the quote at character 4 within the chunk.
+    chunk = _chunk(content="==> The cited bit. ==>", char_offset_start=1000)
+    response = 'It says "The cited bit." (Source: [1]).'
+
+    candidates = extract_citations(response, [chunk])
+
+    assert len(candidates) == 1
+    cite = candidates[0]
+    assert cite.source_offset_start == 1000 + chunk.content.find("The cited bit.")
+    assert cite.source_offset_end == cite.source_offset_start + len("The cited bit.")
+    assert cite.source_text == "The cited bit."
+
+
+@pytest.mark.unit
+def test_extract_multiple_citations_resolve_independent_chunks() -> None:
+    """Two quotes citing two chunks produce two candidates."""
+
+    chunk1 = _chunk(content="First fact statement.", char_offset_start=0)
+    chunk2 = _chunk(content="Second fact assertion.", char_offset_start=500, page_start=3)
+    response = (
+        'He said "First fact statement." (Source: [1]) and '
+        'also "Second fact assertion." (Source: [2]).'
+    )
+
+    candidates = extract_citations(response, [chunk1, chunk2])
+
+    assert len(candidates) == 2
+    assert candidates[0].source_file_id == chunk1.file_id
+    assert candidates[1].source_file_id == chunk2.file_id
+    assert candidates[1].source_page == 3
+
+
+@pytest.mark.unit
+def test_extract_drops_quote_without_source_marker() -> None:
+    """A bare quote without `(Source: [N])` is not a citation; ignored."""
+
+    chunk = _chunk(content="Some text.")
+    response = 'He said "Some text." but cited nothing.'
+
+    assert extract_citations(response, [chunk]) == []
+
+
+@pytest.mark.unit
+def test_extract_drops_source_marker_without_quote() -> None:
+    """A standalone `(Source: [N])` with no preceding quote is ignored."""
+
+    chunk = _chunk(content="Some text.")
+    response = "Without quoting, the source is (Source: [1])."
+
+    assert extract_citations(response, [chunk]) == []
+
+
+@pytest.mark.unit
+def test_extract_drops_unfindable_quote() -> None:
+    """A quote not present in the cited chunk's content is dropped (M2-A2 policy)."""
+
+    chunk = _chunk(content="The actual chunk text.")
+    response = 'The model wrote "a fabricated quote." (Source: [1]).'
+
+    assert extract_citations(response, [chunk]) == []
+
+
+@pytest.mark.unit
+def test_extract_drops_out_of_range_source_index() -> None:
+    """`(Source: [99])` when only 2 chunks were retrieved is dropped."""
+
+    chunk = _chunk(content="Real content.")
+    response = 'He said "Real content." (Source: [99]).'
+
+    assert extract_citations(response, [chunk]) == []
+
+
+@pytest.mark.unit
+def test_extract_tolerates_whitespace_around_source_marker() -> None:
+    """Permissive: optional whitespace between quote and (Source: ...)."""
+
+    chunk = _chunk(content="Cited text.")
+    response = 'It says "Cited text."   (Source: [1]) here.'
+
+    candidates = extract_citations(response, [chunk])
+    assert len(candidates) == 1
+    assert candidates[0].source_text == "Cited text."
+
+
+@pytest.mark.unit
+def test_extract_ignores_smart_quotes_for_stage_1() -> None:
+    """Stage 1 handles straight quotes only; smart quotes fall to Stage 2 (M2-B1)."""
+
+    chunk = _chunk(content="Cited text.")
+    response = "It says “Cited text.” (Source: [1]) here."
+
+    assert extract_citations(response, [chunk]) == []
+
+
+@pytest.mark.unit
+def test_extract_handles_multiline_quote() -> None:
+    """Quotes spanning newlines are extracted (regex must cross line breaks)."""
+
+    chunk_content = "First line.\nSecond line of the same quote."
+    chunk = _chunk(content=chunk_content)
+    response = f'It says "{chunk_content}" (Source: [1]).'
+
+    candidates = extract_citations(response, [chunk])
+    assert len(candidates) == 1
+    assert candidates[0].source_text == chunk_content

--- a/api/tests/test_chat_citations.py
+++ b/api/tests/test_chat_citations.py
@@ -1,0 +1,510 @@
+"""Chat-send → message_citations end-to-end — M2-A2 Stage 1.
+
+Exercises the integration the M2 plan calls out in its M2-A2
+verification step: a chat with retrieved-chunk context, an assistant
+response that quotes a chunk verbatim followed by ``(Source: [N])``,
+and a ``message_citations`` row landing with ``verified=True``,
+``verification_method='exact_match'``, ``verification_confidence=1.0``.
+
+The fixture set mirrors ``test_chat_rag.py`` (same gateway-mock +
+hybrid_search-patch pattern) but adds real ``Document`` /
+``File`` / chunk rows so the citation's FK constraints resolve and
+the verifier has real ``normalized_content`` to slice against.
+
+Negative cases:
+
+* The model returns a paraphrase (not byte-for-byte): no row written
+  (Stage 1 drops; Stage 2 will catch when M2-B1 ships).
+* The model returns prose without any ``(Source: [N])`` marker:
+  no row written.
+* The model cites an out-of-range chunk index: no row written.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.clients.gateway import GatewayClient, set_gateway_client
+from app.db.session import get_db
+from app.main import app
+from app.models.chat import Chat, MessageCitation
+from app.models.document import Document, DocumentChunk
+from app.models.file import File as FileModel
+from app.models.knowledge import KnowledgeBase
+from app.models.project import Project
+from app.models.project_knowledge_base import ProjectKnowledgeBase
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+pytestmark = pytest.mark.integration
+
+GATEWAY_BASE = "http://test-gateway"
+GATEWAY_KEY = "test-gw-key"
+
+
+# ---------------------------------------------------------------------------
+# Boilerplate fixtures — match test_chat_rag.py's pattern
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    gw = GatewayClient(base_url=GATEWAY_BASE, gateway_key=GATEWAY_KEY)
+    set_gateway_client(gw)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    set_gateway_client(None)
+    await gw.aclose()
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def owner_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"cite-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Citation Test Owner",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def project_for_owner(db_session: AsyncSession, owner_user: User) -> Project:
+    project = Project(
+        owner_id=owner_user.id,
+        name="Citation matter",
+        slug=f"cite-matter-{uuid.uuid4().hex[:8]}",
+    )
+    db_session.add(project)
+    await db_session.flush()
+    return project
+
+
+@pytest_asyncio.fixture
+async def kb_for_owner(db_session: AsyncSession, owner_user: User) -> KnowledgeBase:
+    kb = KnowledgeBase(
+        owner_id=owner_user.id,
+        name="Citation KB",
+        description="Used for M2-A2 chat-citation tests",
+        hybrid_alpha=1.0,
+    )
+    db_session.add(kb)
+    await db_session.flush()
+    return kb
+
+
+@pytest_asyncio.fixture
+async def chat_with_kb_attached(
+    db_session: AsyncSession,
+    owner_user: User,
+    project_for_owner: Project,
+    kb_for_owner: KnowledgeBase,
+) -> Chat:
+    junction = ProjectKnowledgeBase(
+        project_id=project_for_owner.id,
+        knowledge_base_id=kb_for_owner.id,
+    )
+    db_session.add(junction)
+    chat = Chat(
+        owner_id=owner_user.id,
+        project_id=project_for_owner.id,
+        title="cite-chat-test",
+    )
+    db_session.add(chat)
+    await db_session.flush()
+    return chat
+
+
+# ---------------------------------------------------------------------------
+# Real File + Document + chunk so FKs resolve and the verifier has text
+# ---------------------------------------------------------------------------
+
+
+CHUNK_BODY = (
+    "The non-compete clause provides that the employee shall not engage "
+    "in any competing business for a period of two years following "
+    "termination of employment."
+)
+
+
+@pytest_asyncio.fixture
+async def source_file(db_session: AsyncSession, owner_user: User) -> FileModel:
+    f = FileModel(
+        owner_id=owner_user.id,
+        filename="nda-template.pdf",
+        mime_type="application/pdf",
+        size_bytes=1024,
+        hash_sha256="b" * 64,
+        storage_path=f"cite-fixture/{uuid.uuid4()}",
+        ingestion_status="ready",
+    )
+    db_session.add(f)
+    await db_session.flush()
+    return f
+
+
+@pytest_asyncio.fixture
+async def source_document(db_session: AsyncSession, source_file: FileModel) -> Document:
+    doc = Document(
+        file_id=source_file.id,
+        parser="pymupdf-only",
+        parser_version="pymupdf=1.27",
+        page_count=1,
+        character_count=len(CHUNK_BODY),
+        normalized_content=CHUNK_BODY,
+        was_ocrd=False,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+    return doc
+
+
+@pytest_asyncio.fixture
+async def source_chunk(db_session: AsyncSession, source_document: Document) -> DocumentChunk:
+    chunk = DocumentChunk(
+        document_id=source_document.id,
+        chunk_index=0,
+        content=CHUNK_BODY,
+        page_start=1,
+        page_end=1,
+        char_offset_start=0,
+        char_offset_end=len(CHUNK_BODY),
+    )
+    db_session.add(chunk)
+    await db_session.flush()
+    return chunk
+
+
+def _bearer(user: User) -> str:
+    return create_access_token(user.id, user.email, is_admin=user.is_admin)
+
+
+def _h(user: User) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_bearer(user)}"}
+
+
+def _success_payload(content: str) -> dict[str, Any]:
+    return {
+        "id": "chatcmpl-cite",
+        "object": "chat.completion",
+        "created": 1_700_000_000,
+        "model": "claude-sonnet-4-6",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 12, "total_tokens": 17},
+        "routed_inference_tier": 3,
+        "routed_provider": "anthropic-prod",
+        "cost_estimate": 0.0001,
+    }
+
+
+def _hybrid_result_for(
+    chunk: DocumentChunk,
+    document: Document,
+    file: FileModel,
+    *,
+    score: float = 0.9,
+) -> Any:
+    """Build a HybridSearchResult-shaped stand-in pointing at the real fixture rows."""
+
+    class _R:
+        def __init__(self) -> None:
+            self.chunk_id = chunk.id
+            self.document_id = document.id
+            self.file_id = file.id
+            self.file_name = file.filename
+            self.content = chunk.content
+            self.page_start = chunk.page_start
+            self.page_end = chunk.page_end
+            self.char_offset_start = chunk.char_offset_start
+            self.char_offset_end = chunk.char_offset_end
+            self.vector_score = score
+            self.fts_score = score
+            self.hybrid_score = score
+
+    return _R()
+
+
+# ---------------------------------------------------------------------------
+# 1. Verbatim quote with (Source: [1]) → message_citations row, verified=True
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_chat_send_persists_verified_citation_from_verbatim_quote(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """An assistant response with a verbatim quote + (Source: [1]) writes
+    a verified citation row pointing at the right file / offsets / page."""
+
+    quote = "the employee shall not engage in any competing business"
+    # Sanity: the quote is a real substring of the chunk we'll feed back.
+    assert quote in source_chunk.content
+
+    assistant_text = (
+        f'The agreement states "{quote}" (Source: [1]). This is a two-year non-compete.'
+    )
+
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text)),
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+    assert route.called
+
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCitation).where(MessageCitation.source_file_id == source_file.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(rows) == 1, f"expected exactly one citation, got {len(rows)}"
+    cite = rows[0]
+    assert cite.verified is True
+    assert cite.verification_method == "exact_match"
+    assert cite.verification_confidence is not None
+    assert float(cite.verification_confidence) == 1.0
+    assert cite.source_text == quote
+    assert cite.source_page == 1
+    # Offsets correspond to the position inside the chunk + the chunk's
+    # char_offset_start (which is 0 in this fixture).
+    expected_start = CHUNK_BODY.find(quote)
+    assert cite.source_offset_start == expected_start
+    assert cite.source_offset_end == expected_start + len(quote)
+
+
+# ---------------------------------------------------------------------------
+# 2. Paraphrased quote → no citation row (Stage 1 strict; Stage 2 will catch)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_chat_send_paraphrased_quote_writes_no_citation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """A paraphrased quote (not byte-for-byte) is dropped by Stage 1."""
+
+    # Note: the chunk body says "shall not engage" — this paraphrase
+    # changes it to "may not engage", so the byte-for-byte search fails.
+    paraphrase = "the employee may not engage in any competing business"
+    assert paraphrase not in source_chunk.content
+
+    assistant_text = f'The agreement says "{paraphrase}" (Source: [1]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text)),
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+
+    rows = (await db_session.execute(select(MessageCitation))).scalars().all()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# 3. No (Source: [N]) marker → no citation row
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_chat_send_unmarked_quote_writes_no_citation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """A quote without `(Source: [N])` is not a citation."""
+
+    quote = "the employee shall not engage in any competing business"
+    assistant_text = f'The agreement says "{quote}", but I cited nothing.'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text)),
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+
+    rows = (await db_session.execute(select(MessageCitation))).scalars().all()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Out-of-range source index → no citation row
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_citations_endpoint_returns_persisted_rows(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """`GET /chats/{id}/messages/{mid}/citations` returns the structured rows."""
+
+    quote = "the employee shall not engage in any competing business"
+    assistant_text = f'The agreement states "{quote}" (Source: [1]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text)),
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        send = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote it.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+    assert send.status_code == 200, send.text
+
+    message_id = send.json()["message"]["id"]
+
+    get_response = await client.get(
+        f"/api/v1/chats/{chat_with_kb_attached.id}/messages/{message_id}/citations",
+        headers=_h(owner_user),
+    )
+    assert get_response.status_code == 200, get_response.text
+    body = get_response.json()
+    assert isinstance(body, list)
+    assert len(body) == 1
+    cite = body[0]
+    assert cite["source_file_id"] == str(source_file.id)
+    assert cite["source_text"] == quote
+    assert cite["verified"] is True
+    assert cite["verification_method"] == "exact_match"
+    assert cite["verification_confidence"] == 1.0
+    assert cite["source_page"] == 1
+    expected_start = CHUNK_BODY.find(quote)
+    assert cite["source_offset_start"] == expected_start
+    assert cite["source_offset_end"] == expected_start + len(quote)
+
+
+@respx.mock
+async def test_chat_send_out_of_range_source_writes_no_citation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """`(Source: [99])` against one retrieved chunk is dropped."""
+
+    quote = "the employee shall not engage"
+    assistant_text = f'It says "{quote}" (Source: [99]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text)),
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+
+    rows = (await db_session.execute(select(MessageCitation))).scalars().all()
+    assert rows == []

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -276,11 +276,13 @@ the `project_files` join (the `files.project_id` column is the file's
 > 5. **`messages.error_code`** is a new column persisted when an
 >    assistant message fails mid-stream or the gateway raises. Carries
 >    the canonical `app.errors` code (e.g., `provider_unavailable`).
-> 6. **`messages.citations`** is `JSONB` with default `'[]'`. M1 stores
->    the empty list; M2's citation engine populates the structured
->    shape. The separate `message_citations` table (still listed below)
->    is a pre-existing PRD sketch that may or may not survive the M2
->    citation work — C3 doesn't create it.
+> 6. **`messages.citations`** is `JSONB` with default `'[]'`. M1 stored
+>    the empty list; M2-A2 chose the relational
+>    `message_citations` table (one row per citation, see below) over
+>    JSONB-on-message for queryability. The JSONB column stays at its
+>    `'[]'` default and the M2-A2 chat-send path leaves it alone — it
+>    is slated for retirement by M2-C2 (failed-citation UI rendering),
+>    which will read exclusively from `message_citations`.
 
 ### `chats`
 
@@ -385,9 +387,14 @@ ALTER TABLE inference_routing_log
 
 ### `message_citations`
 
+Per M2-A2 (migration `0025_create_message_citations.py`). One row per
+model-emitted citation, written by the chat-send path after the
+assistant message is persisted and the Citation Engine has run its
+verification cascade.
+
 ```sql
 CREATE TABLE message_citations (
-    id                        UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     message_id                UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
     source_file_id            UUID NOT NULL REFERENCES files(id) ON DELETE CASCADE,
     source_offset_start       INTEGER NOT NULL,
@@ -395,14 +402,58 @@ CREATE TABLE message_citations (
     source_page               INTEGER,
     source_text               TEXT NOT NULL,
     verified                  BOOLEAN NOT NULL DEFAULT FALSE,
-    verification_method       TEXT,  -- 'exact-match', 'llm-judge', 'failed'
+    verification_method       TEXT,  -- enum below
+    verification_confidence   NUMERIC(3,2),
     created_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
-    CONSTRAINT chk_offsets CHECK (source_offset_end > source_offset_start)
+
+    CONSTRAINT chk_message_citations_offset_start_nonneg
+        CHECK (source_offset_start >= 0),
+    CONSTRAINT chk_message_citations_offset_end_gt_start
+        CHECK (source_offset_end > source_offset_start),
+    CONSTRAINT chk_message_citations_method_values
+        CHECK (
+            verification_method IS NULL
+            OR verification_method IN (
+                'exact_match', 'tolerant_match', 'llm_judge', 'ensemble', 'failed'
+            )
+        ),
+    CONSTRAINT chk_message_citations_confidence_range
+        CHECK (
+            verification_confidence IS NULL
+            OR (verification_confidence >= 0 AND verification_confidence <= 1)
+        ),
+    CONSTRAINT chk_message_citations_verified_has_method
+        CHECK ((verified = false) OR (verification_method IS NOT NULL))
 );
 
 CREATE INDEX idx_message_citations_message ON message_citations(message_id);
 CREATE INDEX idx_message_citations_file ON message_citations(source_file_id);
 ```
+
+The `verification_method` enum carries the stage that produced the
+verdict — every stage writes into the same row shape so the
+persistence layer (and the UI) don't need to switch on stage:
+
+| Value | Stage | Confidence | Lands in |
+|---|---|---|---|
+| `'exact_match'` | Stage 1: byte-for-byte against `documents.normalized_content[start:end]` | always `1.0` | **M2-A2 (here)** |
+| `'tolerant_match'` | Stage 2: whitespace + OCR-artefact + smart-quote normalization | similarity-based | M2-B1 |
+| `'llm_judge'` | Stage 3: LLM paraphrase judge | judge-reported | M2-C1 |
+| `'ensemble'` | Stage 4: multi-model agreement for high-stakes ops | quorum-derived | M2-D1 |
+| `'failed'` | Every stage rejected; rendered as unverified | NULL | M2-C2 wiring |
+
+The `verified=true ⇒ verification_method IS NOT NULL` CHECK constraint
+prevents a row from claiming verification without naming which stage
+passed.
+
+M2-A2 ships Stage 1 only: extraction (`app.citation.extraction`) finds
+`"..." (Source: [N])` pairs in the assistant response, locates the
+quote inside the cited retrieved chunk's content, and derives byte-
+precise document offsets. The verifier (`app.citation.verification`)
+confirms `normalized_content[start:end] == source_text` byte-for-byte.
+Candidates that fail Stage 1 are dropped (not persisted) until later
+stages ship; the M2-C2 UI work decides what to render for "model
+emitted but we couldn't verify."
 
 ---
 


### PR DESCRIPTION
## Summary

Second M2 task. Lands the Citation Engine's Stage 1 (exact-match) verification end-to-end: extract model citations, verify them byte-for-byte against the source document, persist verified rows to a new `message_citations` table, surface them via the `/citations` endpoint.

Implements the full plan-as-written scope per the decisions locked at kickoff:
- **(B)** Relational `message_citations` table over JSONB-on-message.
- **(I)** Full model-emits-citations integration in this task (not deferred).
- **(a)** Quote-then-locate emission format (model quotes verbatim with `(Source: [N])`; we locate inside the retrieved chunk).

## What landed

Two atomic commits within the branch:

### `f98fcdf` — data + algorithm (slice 1)

| Layer | File | Change |
|---|---|---|
| Migration | `api/alembic/versions/0025_create_message_citations.py` | Creates the table with every Stage's column shape (so Stages 2-4 don't need their own migration). CHECK constraints on offsets, method enum, confidence range, and `verified=true ⇒ method IS NOT NULL`. |
| ORM | `api/app/models/chat.py` | `MessageCitation` model mirroring the schema 1-to-1. |
| Module | `api/app/citation/__init__.py`, `extraction.py`, `verification.py` | Pure functions: `extract_citations(response, chunks)` and `verify_exact_match(candidate, document)`. |
| Tests | `api/tests/citation/test_exact_match.py` (6), `test_extraction.py` (10) | Unit tests covering byte-for-byte / off-by-one / whitespace / casing / out-of-range / empty input for the verifier, and single / multi / mid-chunk / multiline / no-marker / no-quote / unfindable / out-of-range / smart-quote / whitespace-tolerance for the extractor. |

### `0c95363` — integration (slice 2)

| Layer | File | Change |
|---|---|---|
| Prompt | `api/app/api/chats.py:_format_retrieval_context_block` | Adds the citation-format instruction: verbatim quote + `(Source: [N])`. |
| Chat-send | `api/app/api/chats.py:_persist_message_citations` (new) | Extract → batch-load Documents → verify → bulk-insert verified rows. Wired into the non-streaming and streaming end-of-stream paths after `_persist_assistant_message`. Streaming path swallows citation errors so they can't break the SSE stream. |
| Endpoint | `api/app/api/chats.py:get_citations` | Now reads `message_citations` rows with the verifier's verdict attached. Legacy `messages.citations` JSONB column left at `'[]'`, slated for retirement by M2-C2. |
| Tests | `api/tests/test_chat_citations.py` (5) | End-to-end: verbatim quote → verified row; paraphrase → no row; no source marker → no row; out-of-range source → no row; GET endpoint returns the structured rows. |
| Docs | `docs/db-schema.md` | Promotes the table from forward-looking sketch to canonical. Documents the `verification_method` enum with the stage that owns each value. |

## Test plan

- [x] **Unit tests** (16 new): extractor + verifier pure-function coverage.
- [x] **Integration tests** (5 new): chat-send flow with real DB + mocked gateway + real File/Document/chunk so FK constraints resolve.
- [x] **Full api suite**: 894 passed, 1 skipped. mypy + ruff + format clean.
- [x] **Migration applies cleanly** via the existing per-test DB fixture's `alembic upgrade head`.
- [x] **Existing RAG tests** (`test_chat_rag.py`) pass unmodified — the prompt change is purely additive.
- [ ] **Operator verification (M2 plan §M2-A2 step 1):** run a chat with NDA Review against the sample NDA on a stack with a real provider key; inspect `message_citations` for the assistant message; verify each row has `verification_method = 'exact_match'` (where the model quoted verbatim) or no row (where it paraphrased — Stage 2 will pick those up when M2-B1 ships). Tracked separately; not blocking PR review since the automated tests cover the verifier + integration contract.

## Architectural notes

**Why `message_citations` instead of expanding `messages.citations` JSONB?** Three reasons, all addressed in the PR-side decision (option B at task kickoff):
1. The schema-doc author explicitly anticipated this in the C3 comment block ("the `message_citations` table... may or may not survive the M2 citation work — C3 doesn't create it") — picking the relational path is what they expected.
2. Audit analytics need `GROUP BY verification_method` and `JOIN files / documents` — costly with JSONB.
3. The full M2 plan (Stages 2-4) carries far more verifier metadata than a `citations` JSONB blob would comfortably hold.

**Why "quote-then-locate" emission format?** The model can't reliably know byte offsets — but it can quote verbatim. We instruct the model to do that, then locate the quote inside the retrieved chunk and derive offsets from the chunk's `char_offset_start`. The verifier then becomes a trivial defense against drift: if `chunk.content == normalized_content[chunk_start:chunk_end]` is intact, Stage 1 passes by construction.

**What about the model that fabricates a quote?** For M2-A2 we drop unfindable quotes silently — the schema forbids citations without valid offsets. A later task could surface "model claimed to cite but we can't find it" as its own failure mode (DE candidate); not blocking M2-A2.

## Verification against the M2 plan

The plan §M2-A2 specifies four verification criteria:

1. **Unit tests for byte-for-byte / off-by-one / whitespace / casing** — covered by `test_exact_match.py`.
2. **Migration adds `verification_method` and `verification_confidence`** — extended scope per the (B+I) decision: migration creates the whole table.
3. **Citations persisted to `message_citations` with `verified`, `verification_method`, `verification_confidence`** — covered by `test_chat_citations.py::test_chat_send_persists_verified_citation_from_verbatim_quote`.
4. **Run a chat with NDA Review** — operator-side, after merge, before kicking off M2-B1.

Refs: `docs/M2-IMPLEMENTATION-PLAN.md` §M2-A2, `docs/PRD.md` §3.3.