### PR TITLE
M2-A3: Anonymization Layer scaffold + PseudonymMapper

### DIFF
--- a/gateway/app/anonymization/__init__.py
+++ b/gateway/app/anonymization/__init__.py
@@ -1,0 +1,36 @@
+"""Anonymization Layer — gateway pre/post middleware (PRD §4.7).
+
+Pseudonymizes sensitive entities in outbound LLM requests and rehydrates
+the originals on the response path so:
+
+* The model provider only sees pseudonyms (``PERSON_0001``,
+  ``ORGANIZATION_0003``, etc.). Real names, account numbers, and other
+  PII never leave the deployment's security boundary.
+* The user's prose-level reading experience is unchanged — the
+  rehydration step on the way back substitutes originals back in
+  before the response is returned to the api/.
+
+Per decision M2-1 (locked at M2 kickoff): only chat/skill content is
+pseudonymized. Retrieved-document content stays un-pseudonymized so
+the existing retrieval surface continues to render real document text
+to the user. The alternative (Option A — pseudonymize the document
+corpus too) is filed as DE-269 for future consideration.
+
+Module layout:
+
+* :mod:`mapper` — :class:`PseudonymMapper`, the per-request mapping data
+  structure (M2-A3; this milestone task).
+* :mod:`engine` — :class:`Anonymizer`, the top-level façade that wires
+  Presidio's :class:`AnalyzerEngine` + custom legal recognizers + the
+  mapper (scaffolded in M2-A3; Presidio integration lands in M2-B3).
+* :mod:`recognizers` — custom legal recognizers populated in M2-B2
+  (contract numbers, party block patterns, court docket numbers, etc.).
+
+Heavy imports (presidio/spaCy) are deferred to the module that needs
+them so the gateway boots even before the spaCy model is downloaded.
+The mapper itself is dependency-free and is what M2-A3 ships.
+"""
+
+from app.anonymization.mapper import PseudonymMapper
+
+__all__ = ["PseudonymMapper"]

--- a/gateway/app/anonymization/engine.py
+++ b/gateway/app/anonymization/engine.py
@@ -1,0 +1,72 @@
+"""Anonymizer façade — top-level engine wiring (M2-A3 scaffold).
+
+The :class:`Anonymizer` is the entry point the gateway middleware
+(M2-B3) will use to pseudonymize an outbound prompt and rehydrate the
+returning response. M2-A3 ships the class shape and a stub
+:class:`PseudonymMapper`-only path; the heavy Presidio
+:class:`~presidio_analyzer.AnalyzerEngine` + spaCy NLP wiring lands
+in M2-B3 once the custom legal recognizers (M2-B2) and the spaCy
+model image bake (also M2-B2) are in place.
+
+The interface is intentionally final from the start so the middleware
+in M2-B3 can target it without re-shaping callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.anonymization.mapper import PseudonymMapper
+
+
+@dataclass(slots=True)
+class AnonymizationResult:
+    """Outcome of a pseudonymization pass.
+
+    ``text`` is the substituted text the gateway forwards to the
+    provider. ``mapper`` carries the assignments so the response path
+    can rehydrate originals via :meth:`PseudonymMapper.reverse`.
+    """
+
+    text: str
+    mapper: PseudonymMapper
+
+
+class Anonymizer:
+    """Pseudonymize entities in outbound text; rehydrate on the response path.
+
+    M2-A3 ships the class signature only. :meth:`pseudonymize` raises
+    :class:`NotImplementedError` until M2-B3 wires Presidio's
+    :class:`AnalyzerEngine`, the custom legal recognizers (M2-B2), and
+    the spaCy NLP backbone. The middleware will allocate one instance
+    per request and discard it on response.
+    """
+
+    def pseudonymize(self, text: str) -> AnonymizationResult:
+        """Return an :class:`AnonymizationResult` with pseudonymized text.
+
+        Stub for M2-A3; the real Presidio-backed implementation lands
+        in M2-B3. Defined here so the middleware (M2-B3) and tests
+        (M2-C3 round-trip) target a stable signature from the start.
+        """
+
+        raise NotImplementedError(
+            "Anonymizer.pseudonymize is a stub until M2-B3 wires Presidio + "
+            "the spaCy NLP backbone. M2-A3 ships PseudonymMapper only."
+        )
+
+    def rehydrate(self, text: str, mapper: PseudonymMapper) -> str:
+        """Walk pseudonyms in ``text`` and substitute originals.
+
+        Stub for M2-A3; M2-B3 will implement the response-path
+        rehydration. The implementation is straightforward (one pass
+        over ``mapper.reverse()`` items, ``str.replace`` for each)
+        but the trade-offs between replacement strategies (length-
+        ordered to avoid prefix collisions, regex-based to handle word
+        boundaries, etc.) are M2-B3's decision.
+        """
+
+        raise NotImplementedError(
+            "Anonymizer.rehydrate is a stub until M2-B3 lands the response-"
+            "path middleware. M2-A3 ships PseudonymMapper only."
+        )

--- a/gateway/app/anonymization/mapper.py
+++ b/gateway/app/anonymization/mapper.py
@@ -1,0 +1,94 @@
+"""Request-scoped pseudonym assignment — M2-A3.
+
+The mapper sits between the gateway's middleware and the anonymizer
+engine: when Presidio (or a custom recognizer) flags an entity span,
+the middleware calls :meth:`PseudonymMapper.assign` to get a stable
+pseudonym to substitute into the outbound prompt. On the response
+path the middleware calls :meth:`PseudonymMapper.reverse` once and
+walks the response text replacing pseudonyms with their originals.
+
+Key invariants:
+
+* **Stable per (type, original).** ``assign("PERSON", "John Smith")``
+  always returns the same pseudonym within a single mapper instance.
+  Same name surfacing twice in one prompt only counts toward one
+  counter slot.
+* **Per-type counters.** ``PERSON`` and ``ORGANIZATION`` increment
+  independently so a transcript that mentions five people and three
+  companies reads cleanly: ``PERSON_0001..PERSON_0005`` /
+  ``ORGANIZATION_0001..ORGANIZATION_0003``.
+* **In-process only.** The mapping is held in plain Python dicts on
+  the instance. Never persisted, never logged, never serialized to
+  any side channel. A new request gets a new instance; the old one
+  is dropped on response.
+
+The format ``{ENTITY_TYPE}_{COUNTER:04d}`` is locked in by the M2
+plan's verification step ("returns ``PERSON_0001``"). Five-digit
+counter would also have worked; four is the plan's call.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+
+class PseudonymMapper:
+    """Stable, per-request, in-memory pseudonym assignment.
+
+    Holds two dicts: ``_assignments`` keyed by ``(entity_type,
+    original_text)`` → pseudonym for the stability invariant, and
+    ``_counters`` keyed by ``entity_type`` → next counter value for
+    the per-type independence invariant. Both are populated by
+    :meth:`assign` and read by :meth:`reverse`.
+    """
+
+    __slots__ = ("_assignments", "_counters")
+
+    def __init__(self) -> None:
+        self._assignments: dict[tuple[str, str], str] = {}
+        self._counters: defaultdict[str, int] = defaultdict(int)
+
+    def assign(self, entity_type: str, original: str) -> str:
+        """Return the stable pseudonym for ``(entity_type, original)``.
+
+        First call for a new ``(type, original)`` pair allocates the
+        next counter for ``entity_type``; subsequent calls return the
+        previously allocated pseudonym byte-for-byte.
+
+        Args:
+            entity_type: Canonical entity-type label, e.g. ``"PERSON"``,
+                ``"ORGANIZATION"``, ``"PHONE_NUMBER"``. Presidio's
+                vocabulary is what M2-B3 wires in; custom recognizers
+                (M2-B2) extend it.
+            original: The literal text of the entity as Presidio saw
+                it in the source prompt.
+
+        Returns:
+            The pseudonym, formatted ``{entity_type}_{NNNN}`` with a
+            zero-padded four-digit counter (``PERSON_0001``,
+            ``PERSON_0042``, etc.). Counter resets across instances
+            but not across calls within an instance.
+        """
+
+        key = (entity_type, original)
+        existing = self._assignments.get(key)
+        if existing is not None:
+            return existing
+
+        self._counters[entity_type] += 1
+        pseudonym = f"{entity_type}_{self._counters[entity_type]:04d}"
+        self._assignments[key] = pseudonym
+        return pseudonym
+
+    def reverse(self) -> dict[str, str]:
+        """Return a fresh ``pseudonym → original`` mapping for rehydration.
+
+        The middleware calls this once per response to rebuild the
+        post-substitution text. We return a copy rather than the live
+        internal dict so callers can mutate the result (or accidentally
+        drop it on the floor) without corrupting the mapper.
+
+        Empty mapper → empty dict; never raises.
+        """
+
+        return {pseudonym: original for (_, original), pseudonym in self._assignments.items()}

--- a/gateway/app/anonymization/recognizers/__init__.py
+++ b/gateway/app/anonymization/recognizers/__init__.py
@@ -1,0 +1,20 @@
+"""Custom legal recognizers — populated in M2-B2.
+
+Presidio ships with a default recognizer set (US-centric PII like SSN,
+phone, email, credit card, etc.). The legal domain needs more:
+
+* **Contract numbers.** Per-firm or industry-specific patterns
+  (``CONTRACT-2025-001``, ``Agreement No. 7-A-238``, etc.).
+* **Party block patterns.** The "Party A / Party B" or
+  ``[Buyer] / [Seller]`` placeholder shapes used in template
+  contracts.
+* **Court docket numbers.** ``Case No. 1:24-cv-00123`` and the
+  federal/state variants.
+* **Bates numbers.** Standard production-set identifiers
+  (``ABC000123``).
+* Anything else surfaced by the M2-F2 acceptance corpus.
+
+This package is intentionally empty in M2-A3 — the structure is
+created so M2-B2 can drop recognizer modules in without a follow-on
+scaffold task.
+"""

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -55,6 +55,17 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
     "opentelemetry-instrumentation-fastapi>=0.48b0,<1",
     "opentelemetry-instrumentation-httpx>=0.48b0,<1",
+    # M2-A3 (PRD §4.7) — Anonymization Layer. Presidio is Microsoft's PII
+    # detection/redaction framework; we use it for entity recognition
+    # (analyzer) and pseudonym substitution (anonymizer). spaCy is the
+    # NLP backbone presidio-analyzer ships with by default; we pull
+    # ``en_core_web_lg`` in M2-B2 when custom legal recognizers land.
+    # M2-A3 itself only loads the PseudonymMapper (in-process counter,
+    # no spaCy/presidio runtime use); the heavy import path is deferred
+    # to M2-B3 middleware integration.
+    "presidio-analyzer~=2.2",
+    "presidio-anonymizer~=2.2",
+    "spacy~=3.7",
 ]
 
 [project.optional-dependencies]

--- a/gateway/tests/anonymization/test_mapper.py
+++ b/gateway/tests/anonymization/test_mapper.py
@@ -1,0 +1,118 @@
+"""PseudonymMapper smoke tests — M2-A3 scaffold.
+
+The mapper is a request-scoped, in-process dictionary that assigns a
+stable pseudonym to every entity it sees and exposes the reverse
+mapping for rehydration on the response path. The middleware wires
+the mapper into the gateway lifecycle in M2-B3; M2-A3 only ships
+the data structure + its invariants.
+
+Verifies the four contracts from the M2 plan §M2-A3:
+
+* Same original → same pseudonym across calls (stable assignment).
+* Different originals → different pseudonyms.
+* Counter increments per entity type independently.
+* ``reverse()`` returns the pseudonym → original mapping for the
+  rehydration step.
+
+The mapper holds nothing persistent: a new instance starts empty,
+and there is no read path that escapes its memory. The middleware
+allocates one mapper per request and drops it at response time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.anonymization.mapper import PseudonymMapper
+
+
+@pytest.mark.unit
+def test_same_original_returns_same_pseudonym() -> None:
+    """Calling ``assign`` twice with the same (type, original) is stable."""
+
+    m = PseudonymMapper()
+    first = m.assign("PERSON", "John Smith")
+    second = m.assign("PERSON", "John Smith")
+
+    assert first == second
+
+
+@pytest.mark.unit
+def test_first_assignment_uses_one_indexed_zero_padded_counter() -> None:
+    """First assigned PERSON → ``PERSON_0001`` per the plan's verification check."""
+
+    m = PseudonymMapper()
+    assert m.assign("PERSON", "John Smith") == "PERSON_0001"
+
+
+@pytest.mark.unit
+def test_counter_increments_for_distinct_originals_same_type() -> None:
+    """Second distinct original gets a fresh counter under the same type."""
+
+    m = PseudonymMapper()
+    first = m.assign("PERSON", "John Smith")
+    second = m.assign("PERSON", "Jane Doe")
+
+    assert first == "PERSON_0001"
+    assert second == "PERSON_0002"
+
+
+@pytest.mark.unit
+def test_counter_is_per_entity_type() -> None:
+    """PERSON and ORGANIZATION each have their own counter starting at 1."""
+
+    m = PseudonymMapper()
+    person = m.assign("PERSON", "John Smith")
+    org = m.assign("ORGANIZATION", "Acme Corp.")
+
+    assert person == "PERSON_0001"
+    assert org == "ORGANIZATION_0001"
+
+
+@pytest.mark.unit
+def test_reverse_returns_pseudonym_to_original_mapping() -> None:
+    """``reverse()`` is what the response-path middleware consumes."""
+
+    m = PseudonymMapper()
+    m.assign("PERSON", "John Smith")
+    m.assign("PERSON", "Jane Doe")
+    m.assign("ORGANIZATION", "Acme Corp.")
+
+    rev = m.reverse()
+
+    assert rev == {
+        "PERSON_0001": "John Smith",
+        "PERSON_0002": "Jane Doe",
+        "ORGANIZATION_0001": "Acme Corp.",
+    }
+
+
+@pytest.mark.unit
+def test_new_instance_starts_empty() -> None:
+    """Mapper state is per-instance — no shared / persistent state."""
+
+    first = PseudonymMapper()
+    first.assign("PERSON", "John Smith")
+
+    second = PseudonymMapper()
+    rev = second.reverse()
+
+    assert rev == {}
+    # Sanity: second instance also assigns starting at 0001.
+    assert second.assign("PERSON", "Someone Else") == "PERSON_0001"
+
+
+@pytest.mark.unit
+def test_reverse_returned_dict_is_a_copy() -> None:
+    """Mutating the reverse-mapping return value must not affect the mapper."""
+
+    m = PseudonymMapper()
+    m.assign("PERSON", "John Smith")
+
+    rev = m.reverse()
+    rev["PERSON_9999"] = "tampered"
+
+    # Original assignment is preserved.
+    assert m.assign("PERSON", "John Smith") == "PERSON_0001"
+    # And re-fetching reverse() shows no taint.
+    assert m.reverse() == {"PERSON_0001": "John Smith"}


### PR DESCRIPTION
## Summary

Third M2 task — the data-structure half of the Anonymization Layer (PRD §4.7). Adds Presidio + spaCy as dependencies, lays down the `gateway/app/anonymization/` package, and ships a fully-tested `PseudonymMapper`. The heavy bits (Presidio AnalyzerEngine wiring, spaCy NLP, custom legal recognizers, middleware integration) land in M2-B2 and M2-B3.

Scope was bounded ahead of writing code: nothing extra, no premature integration. The interfaces in `engine.py` are final from the start so M2-B3 middleware can target a stable shape; the implementations there raise `NotImplementedError` with a pointer to the milestone task that fills them.

## What landed

| Layer | File | Change |
|---|---|---|
| Deps | `gateway/pyproject.toml` | + `presidio-analyzer~=2.2`, `presidio-anonymizer~=2.2`, `spacy~=3.7`. |
| Module | `gateway/app/anonymization/__init__.py` | Exposes `PseudonymMapper`. |
| Module | `gateway/app/anonymization/mapper.py` | Full `PseudonymMapper` — stable per `(type, original)`, per-type counters, `{TYPE}_{NNNN}` 4-digit format, `reverse()` for response-path rehydration. |
| Module | `gateway/app/anonymization/engine.py` | `Anonymizer` façade with final method signatures; bodies stubbed for M2-B3. |
| Module | `gateway/app/anonymization/recognizers/__init__.py` | Empty package; M2-B2 populates with custom legal recognizers. |
| Tests | `gateway/tests/anonymization/test_mapper.py` (7) | Stability / distinct-originals / per-type counters / `reverse()` shape / fresh-instance isolation / copy-on-`reverse()` defensiveness / first-counter format `PERSON_0001`. |

## Test plan

- [x] Plan §M2-A3 verification cmd: `python -c "from app.anonymization.mapper import PseudonymMapper; m = PseudonymMapper(); print(m.assign('PERSON', 'John Smith'))"` → `PERSON_0001`.
- [x] 7 unit tests pass (covering the four contracts from the plan).
- [x] Full gateway suite: 395 passed, 1 skipped, 1 deselected.
- [x] `mypy --strict` clean (33 source files; gateway uses strict mode per `CONTRIBUTING.md`).
- [x] `ruff check` + `ruff format --check` clean.
- [x] Deps install on Python 3.12 (matches CI; gateway/.venv was rebuilt for this task).

## Design notes

**`PseudonymMapper` is dependency-free.** No Presidio, no spaCy imports — purely Python dicts. The mapper is what M2-A3 ships; everything heavy is deferred to M2-B3 where the middleware allocates one mapper per request and calls Presidio's `AnalyzerEngine` to populate it.

**`Anonymizer.pseudonymize` / `rehydrate` raise `NotImplementedError`.** Intentional. The interfaces are final from this task so callers (M2-B3 middleware, M2-C3 round-trip tests) can target a stable shape; bodies fill in when their dependencies (spaCy model bake, custom legal recognizers from M2-B2) land. The `NotImplementedError` message points at the milestone task that ships each.

**Why no spaCy model download in the Dockerfile?** `en_core_web_lg` is ~500MB and we don't exercise it in M2-A3. Folding it in now would bloat the image for a feature that doesn't run yet. M2-B2 (custom recognizers) is where the model first gets used; the Dockerfile change lands there.

## Verification against the M2 plan

Plan §M2-A3 specifies three verification criteria:

1. **Unit tests pass.** ✓ 7/7 covering stability, distinct originals, and per-type counter independence.
2. **`PseudonymMapper` returns `PERSON_0001` on first PERSON assign.** ✓ Verified by `test_first_assignment_uses_one_indexed_zero_padded_counter`.
3. **Module loadable.** ✓ `from app.anonymization.mapper import PseudonymMapper` works; CLI smoke command above.

Refs: `docs/M2-IMPLEMENTATION-PLAN.md` §M2-A3, `docs/PRD.md` §4.7, M2 architectural decision M2-1 (pseudonymize chat/skill content only — retrieved documents stay un-pseudonymized).