### PR TITLE
M2-B1: Citation Engine Stage 2 — tolerant-match verification

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -69,7 +69,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies import ActiveUser
 from app.api.skills import _resolve_skill_for_user
 from app.audit import audit_action
-from app.citation import extract_citations, verify_exact_match
+from app.citation import extract_citations, verify
 from app.clients.gateway import GatewayClient, get_gateway_client
 from app.db.session import get_db
 from app.errors import LQAIError, NotFound, ValidationError
@@ -1389,10 +1389,12 @@ async def _persist_message_citations(
             # would reject anyway.
             continue
 
-        result = verify_exact_match(cand, doc)
+        result = verify(cand, doc)
         if not result.verified:
-            # Stage 1 missed — once Stages 2-4 land they fall through
-            # here. For M2-A2 we drop unverified candidates.
+            # Every wired stage (currently 1 + 2) rejected the
+            # candidate. Drop until Stages 3-4 (LLM judge / ensemble)
+            # land in M2-C1 / M2-D1; those plug into the same
+            # ``verify()`` cascade.
             continue
 
         new_rows.append(

--- a/api/app/citation/__init__.py
+++ b/api/app/citation/__init__.py
@@ -19,11 +19,18 @@ as "unverified" by the UI (M2-C2). The persistence shape is the
 """
 
 from app.citation.extraction import CitationCandidate, extract_citations
-from app.citation.verification import VerificationResult, verify_exact_match
+from app.citation.verification import (
+    VerificationResult,
+    verify,
+    verify_exact_match,
+    verify_tolerant_match,
+)
 
 __all__ = [
     "CitationCandidate",
     "VerificationResult",
     "extract_citations",
+    "verify",
     "verify_exact_match",
+    "verify_tolerant_match",
 ]

--- a/api/app/citation/extraction.py
+++ b/api/app/citation/extraction.py
@@ -1,30 +1,42 @@
-"""Citation extraction from assistant responses — Stage 1 (quote-then-locate).
+"""Citation extraction from assistant responses — quote-then-locate.
 
-The model is instructed (in the RAG context-block system message) to
-quote source passages verbatim in straight double-quotes followed by
-``(Source: [N])`` where ``N`` is the 1-based index of the retrieved
-chunk the quote came from. This module parses that shape and resolves
-each quote to a byte-precise span in the source document.
+The model is instructed (via the RAG context-block system message) to
+quote source passages in double quotes followed by ``(Source: [N])``
+where ``N`` is the 1-based index of the retrieved chunk the quote came
+from. This module parses that shape and resolves each quote to a
+byte-precise span in the source document.
 
 Resolution mechanics:
 
-1. Regex over the response text for ``"..."\\s*(Source: [N])``.
+1. Regex over the response text matches both straight ``"..."`` and
+   curly ``"..."`` quoted spans followed by ``(Source: [N])``.
 2. For each match, look up ``retrieved_chunks[N - 1]``.
-3. Locate the quote inside the chunk's content via ``str.find``.
-4. Derive the document offsets:
-   ``chunk.char_offset_start + match_pos`` … ``+ len(quote)``.
-5. Materialize a :class:`CitationCandidate` carrying everything the
-   verifier and the persistence layer need.
+3. Locate the quote inside the chunk's content:
 
-Quotes that can't be located (the model fabricated the quote or
-mis-cited the chunk index) are silently dropped — M2-A2 does not
-persist citations without valid offsets, and "the model claimed to
-quote but we can't find it" is a separate failure-mode to audit
-(future task).
+   * **Fast path:** byte-for-byte substring search via ``str.find``.
+   * **Fallback (M2-B1):** when byte-for-byte misses, use
+     :func:`rapidfuzz.fuzz.partial_ratio_alignment` to find the
+     best-aligned span. Threshold 85 gates extraction — looser than
+     the Stage 2 verifier's 95, so a candidate that survives
+     extraction may still get rejected by verification. Quotes with
+     no real overlap (an unrelated model fabrication) drop here.
+4. Materialize a :class:`CitationCandidate` carrying the source
+   document id + file id + byte-precise offsets + the model's quote
+   verbatim. The verifier cascade (``app.citation.verification.verify``)
+   then runs Stage 1 (byte-for-byte at offsets) and, on failure,
+   Stage 2 (normalized fuzzy ratio).
 
-Stage 1 is intentionally strict: smart quotes, whitespace
-differences, and paraphrases will not match. Those falls through to
-later stages once they ship (M2-B1 / M2-C1).
+Why a permissive extractor + strict verifier?
+---------------------------------------------
+
+Earlier M2-A2 extraction was strict (straight quotes + byte-for-byte
+only) and dropped smart-quoted or whitespace-divergent citations
+silently. With the M2-B1 Stage 2 verifier in place that policy hides
+real wins — the verifier was built to forgive exactly those
+normalization-only differences, but the candidates never reached it.
+M2-B1 loosens extraction so the verifier sees more candidates and
+ultimately the model's smart-quote citations land as
+``verified=True, method='tolerant_match'``.
 """
 
 from __future__ import annotations
@@ -34,6 +46,8 @@ import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
+
+from rapidfuzz import fuzz
 
 
 # A protocol so the extractor accepts any chunk-shaped object — the
@@ -64,21 +78,57 @@ class CitationCandidate:
     source_text: str
 
 
-# Straight double quote, lazy non-empty body, optional whitespace, then
-# ``(Source: [N])``. ``re.DOTALL`` lets the body span line breaks.
-# A negative-lookahead inside the body prevents the regex from
-# absorbing a closing quote that belongs to a later, different citation.
+# Regex: matches both straight (``"..."``) and curly (``"..."``)
+# double-quote pairs followed by ``(Source: [N])``. Alternation gives
+# two named groups; one is non-None per match.
+#
+# ``re.DOTALL`` lets the body span line breaks. The body uses a lazy
+# match (``+?``) so we don't gobble a closing quote that belongs to a
+# later, different citation.
 _CITATION_RE = re.compile(
-    r'"(?P<quote>[^"]+?)"\s*\(Source:\s*\[(?P<index>\d+)\]\)',
+    r'"(?P<sq>[^"]+?)"\s*\(Source:\s*\[(?P<sq_index>\d+)\]\)'
+    r"|"
+    r"“(?P<cq>[^”]+?)”\s*\(Source:\s*\[(?P<cq_index>\d+)\]\)",
     flags=re.DOTALL,
 )
+
+# Extraction-level fuzzy threshold. Below this, the quote is considered
+# unrelated to the chunk content (model fabricated or mis-cited).
+# Above, the candidate proceeds to the verifier cascade — Stage 1
+# expects a byte-for-byte hit (rare after fallback fired) and Stage 2
+# expects 95 on normalized text. Picking 85 here gives the Stage 2
+# verifier a 10-point cushion to absorb meaningful normalization
+# differences while filtering out obvious junk.
+_ALIGNMENT_THRESHOLD = 85.0
+
+
+def _locate_in_chunk(quote: str, chunk_content: str) -> tuple[int, int] | None:
+    """Find ``quote`` inside ``chunk_content`` — exact, then fuzzy.
+
+    Returns the (start, end) offsets *into the chunk's content string*
+    (not the document) when a credible match is found. ``None`` when
+    no match survives the fuzzy threshold.
+    """
+
+    exact = chunk_content.find(quote)
+    if exact >= 0:
+        return exact, exact + len(quote)
+
+    if not chunk_content or not quote:
+        return None
+
+    alignment = fuzz.partial_ratio_alignment(quote, chunk_content)
+    if alignment is None or alignment.score < _ALIGNMENT_THRESHOLD:
+        return None
+
+    return alignment.dest_start, alignment.dest_end
 
 
 def extract_citations(
     response_text: str,
     retrieved_chunks: Sequence[_RetrievedChunk],
 ) -> list[CitationCandidate]:
-    """Extract Stage-1-locatable citations from the assistant response.
+    """Extract citations from the assistant response.
 
     Args:
         response_text: The full assistant message content.
@@ -88,30 +138,36 @@ def extract_citations(
 
     Returns:
         One :class:`CitationCandidate` per ``"..." (Source: [N])``
-        pair whose quote could be located inside its cited chunk.
-        Pairs whose quote is unfindable or whose index is out of
-        range are dropped silently.
+        pair (straight or curly quotes) whose quote could be located
+        inside its cited chunk — exactly or via fuzzy alignment
+        above the extraction threshold. Pairs whose quote is
+        unfindable or whose index is out of range are dropped silently.
     """
 
     candidates: list[CitationCandidate] = []
 
     for match in _CITATION_RE.finditer(response_text):
-        quote = match.group("quote")
-        index_1based = int(match.group("index"))
+        # Exactly one of the two named branches is populated per match.
+        quote = match.group("sq") or match.group("cq")
+        index_str = match.group("sq_index") or match.group("cq_index")
+        if quote is None or index_str is None:
+            continue
 
+        index_1based = int(index_str)
         if not (1 <= index_1based <= len(retrieved_chunks)):
             continue
 
         chunk = retrieved_chunks[index_1based - 1]
-        match_pos = chunk.content.find(quote)
-        if match_pos < 0:
-            # Quote isn't byte-for-byte inside the chunk. Stage 2's
-            # tolerant-match will be the right place to handle this;
-            # Stage 1 drops it.
+        located = _locate_in_chunk(quote, chunk.content)
+        if located is None:
+            # Quote is neither a byte-for-byte substring nor a
+            # close-enough fuzzy match. The model either fabricated
+            # the quote or mis-cited the chunk index.
             continue
 
-        offset_start = chunk.char_offset_start + match_pos
-        offset_end = offset_start + len(quote)
+        in_chunk_start, in_chunk_end = located
+        offset_start = chunk.char_offset_start + in_chunk_start
+        offset_end = chunk.char_offset_start + in_chunk_end
 
         candidates.append(
             CitationCandidate(

--- a/api/app/citation/normalization.py
+++ b/api/app/citation/normalization.py
@@ -1,0 +1,141 @@
+# ruff: noqa: RUF001
+"""Comparison-time text normalization for Stage 2 tolerant-match.
+
+Both the source-at-offsets and the citation's quoted text run through
+:func:`normalize` before the Stage 2 verifier computes a fuzzy ratio.
+That isolates the kinds of differences Stage 2 is supposed to forgive
+(whitespace drift, smart vs. straight quotes, common OCR confusions)
+from the kinds it must reject (paraphrases, factual edits).
+
+The function has two layers:
+
+* **Always-on rules** apply to every document, regardless of OCR
+  provenance:
+
+  * Whitespace runs collapse to a single space (newlines treated as
+    whitespace).
+  * ``\\r\\n`` is canonicalised so we never leave a stray ``\\r``.
+  * Leading/trailing whitespace is stripped.
+  * Smart quotes (typographic single + double quotes,
+    ``\\u2018-\\u201d``) map to ASCII straight quotes.
+
+* **OCR-conditional rules** apply only when ``was_ocrd=True``
+  (i.e., the document's ``was_ocrd`` flag from M2-A1). These are
+  conservative substitutions for the most common OCR misreads:
+
+  * ``rn`` ↔ ``m`` collapses ``rn`` → ``m`` when mid-word
+    (most legible-PDF OCR engines fail this character pair).
+  * ``O`` ↔ ``0`` substitutes ``O`` → ``0`` only when adjacent to a
+    digit (so ``Office`` stays ``Office`` but ``O5`` becomes ``05``).
+  * ``l`` ↔ ``1`` substitutes ``l`` → ``1`` only when adjacent to a
+    digit (same pattern; ``liability`` stays).
+
+  We intentionally only canonicalise in one direction per pair —
+  the chunk content and the model's quote get the same normalization
+  applied, so collapsing variants down to the same target makes a
+  fuzzy ratio against an OCR'd source robust without injecting
+  false positives into clean text.
+
+The function is idempotent: ``normalize(normalize(t)) == normalize(t)``
+for every input. The verifier relies on this so the
+``rapidfuzz.fuzz.ratio`` comparison is symmetric in re-runs.
+
+OCR rule justification — why these three:
+
+* The pair ``m`` vs ``rn`` is the canonical Tesseract failure mode
+  for serif fonts at moderate DPI; rule ``rn`` → ``m`` mid-word
+  catches the common ``modem`` ↔ ``modern`` family.
+* ``O`` / ``0`` and ``l`` / ``1`` are the two most common
+  letter-vs-digit confusions in OCR'd legal text (Bates numbers,
+  section references, dates). Guarding the substitution on an
+  adjacent digit avoids re-typing ``Office`` as ``0ffice``.
+
+The conservative posture is intentional: every OCR rule is a chance
+to introduce a false positive against clean text. M2-B2 / M2-F1 (the
+acceptance corpus) will surface any additional rules that pay off
+empirically; this module is the place to add them.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Smart-quote → straight-quote translation table. Covers the four
+# Unicode codepoints (U+2018 LEFT SINGLE QUOTATION MARK, U+2019 RIGHT
+# SINGLE QUOTATION MARK, U+201C LEFT DOUBLE QUOTATION MARK, U+201D
+# RIGHT DOUBLE QUOTATION MARK).
+
+# smart-quote characters are the literal targets of the normalization
+# table, not typos for the ASCII apostrophe / grave accent.
+_SMART_QUOTE_TABLE = str.maketrans(
+    {
+        "‘": "'",  # LEFT SINGLE QUOTATION MARK
+        "’": "'",  # RIGHT SINGLE QUOTATION MARK
+        "“": '"',  # LEFT DOUBLE QUOTATION MARK
+        "”": '"',  # RIGHT DOUBLE QUOTATION MARK
+    }
+)
+
+# Whitespace-run collapse. Matches any sequence of one-or-more
+# whitespace characters (spaces, tabs, newlines, etc.) and collapses
+# them to a single ASCII space.
+_WS_RUN_RE = re.compile(r"\s+")
+
+# OCR rule: ``rn`` → ``m`` only when preceded by a word character.
+# The canonical OCR confusion (``m`` mis-OCR'd as ``rn``) most often
+# surfaces word-finally — ``modern`` ↔ ``modem``, ``barn`` ↔ ``bam``,
+# ``burn`` ↔ ``bum``. Guarding only on a preceding word char (not
+# also a following word char) catches those cases. The cost: some
+# false-positive word-final substitutions like ``turn`` → ``tum``.
+# Acceptable because the verifier threshold is 95: a single
+# false substitution in a long quote drops the fuzz ratio by ~1-2
+# points, well within the 5-point margin. Word-start ``rn`` is
+# preserved (``rnage`` stays ``rnage``) — no real OCR confusion
+# there, and the negative lookbehind keeps the rule conservative.
+_OCR_RN_RE = re.compile(r"(?<=\w)rn")
+
+# OCR rule: capital ``O`` → ``0`` when adjacent (immediately before or
+# after) to a digit. ``(?<=\d)O`` or ``O(?=\d)``.
+_OCR_O_RE = re.compile(r"(?<=\d)O|O(?=\d)")
+
+# OCR rule: lowercase ``l`` → ``1`` when adjacent to a digit. Symmetric
+# with the ``O``/``0`` rule.
+_OCR_L_RE = re.compile(r"(?<=\d)l|l(?=\d)")
+
+
+def normalize(text: str, *, was_ocrd: bool = False) -> str:
+    """Canonicalize text for Stage 2 fuzzy comparison.
+
+    The always-on layer is applied unconditionally; the OCR layer
+    runs only when ``was_ocrd`` is True.
+
+    Args:
+        text: The raw text to normalize. May contain smart quotes,
+            mixed line endings, runs of whitespace, etc.
+        was_ocrd: True when the source document went through OCR
+            (``documents.was_ocrd``). Enables OCR-confusion
+            substitutions.
+
+    Returns:
+        The normalized string. Idempotent — ``normalize(normalize(t))``
+        equals ``normalize(t)``.
+    """
+
+    # Always-on: smart quotes first so subsequent passes operate on
+    # ASCII quote characters only.
+    out = text.translate(_SMART_QUOTE_TABLE)
+
+    # Always-on: collapse whitespace runs (including CRLF, tabs,
+    # multiple spaces, newlines) to a single space.
+    out = _WS_RUN_RE.sub(" ", out)
+
+    # Always-on: strip leading/trailing whitespace introduced by the
+    # collapse step.
+    out = out.strip()
+
+    if was_ocrd:
+        out = _OCR_RN_RE.sub("m", out)
+        out = _OCR_O_RE.sub("0", out)
+        out = _OCR_L_RE.sub("1", out)
+
+    return out

--- a/api/app/citation/verification.py
+++ b/api/app/citation/verification.py
@@ -1,24 +1,29 @@
-"""Citation Engine — Stage 1: exact-match verification.
+"""Citation Engine — staged verification cascade.
 
-Given a :class:`CitationCandidate` produced by the extractor and the
-:class:`Document` it points at, this stage confirms that
-``document.normalized_content[source_offset_start:source_offset_end]``
-equals ``source_text`` byte-for-byte. If the extractor did its job
-the check passes trivially — the value here is twofold:
+Each stage takes a :class:`CitationCandidate` produced by the extractor
+and the :class:`Document` it points at and returns a
+:class:`VerificationResult`. :func:`verify` is the orchestrator the
+persistence layer calls; it tries stages in order and returns the
+first hit, falling through to a MISS only when every stage has
+rejected the candidate.
 
-* **Defense against drift.** If the chunker-vs-canonical-text
-  fidelity invariant breaks in a future change (e.g., a parser swap
-  that produces a different ``canonical_text``), Stage 1 will start
-  failing instead of silently rendering wrong text as "verified."
-* **Symmetry with later stages.** Stages 2-4 (tolerant-match, LLM
-  judge, ensemble) consume the same input shape and write the same
-  :class:`VerificationResult` shape. The persistence layer doesn't
-  need to know which stage produced the verdict.
+Stages live in canonical method-string order:
 
-This module is intentionally minimal — the Stage-2 normalization
-pipeline (M2-B1) lives in ``app.citation.normalization``; the LLM
-judge (M2-C1) lives in ``app.citation.llm_judge``; ensemble (M2-D1)
-in ``app.citation.ensemble``. Mirror the file naming.
+* :func:`verify_exact_match` — Stage 1 (M2-A2). Byte-for-byte equality
+  at the offsets the extractor produced. Trivially fast.
+* :func:`verify_tolerant_match` — Stage 2 (M2-B1; this task).
+  Normalizes both source-at-offsets and ``source_text`` via
+  :func:`app.citation.normalization.normalize` and compares with
+  ``rapidfuzz.fuzz.ratio`` at threshold 95. Catches smart-quote,
+  whitespace, and (when ``document.was_ocrd``) OCR-confusion
+  differences that Stage 1 rejects.
+* Stage 3 LLM judge (M2-C1) and Stage 4 ensemble (M2-D1) land in
+  later milestone tasks; :func:`verify` will route into them once
+  they ship.
+
+All stages share the :class:`VerificationResult` shape so the
+persistence layer can copy fields onto ``message_citations`` without
+remapping.
 """
 
 from __future__ import annotations
@@ -26,6 +31,10 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from typing import Protocol
+
+from rapidfuzz import fuzz
+
+from app.citation.normalization import normalize
 
 
 class _CandidateProtocol(Protocol):
@@ -50,6 +59,7 @@ class _DocumentProtocol(Protocol):
 
     id: uuid.UUID
     normalized_content: str
+    was_ocrd: bool
 
 
 @dataclass(slots=True)
@@ -75,6 +85,24 @@ class VerificationResult:
 # A sentinel result for misses, reused so callers don't allocate.
 _MISS = VerificationResult(verified=False, method=None, confidence=None)
 
+# Stage 2 acceptance threshold on the rapidfuzz ratio scale (0-100).
+# 95 catches normalization-only differences (smart quotes, whitespace
+# collapse, OCR-confusion substitutions on ``was_ocrd`` docs) while
+# rejecting genuine paraphrases — they live in the 70-90 range where
+# Stage 3's LLM judge belongs.
+#
+# Per M2-B1 the value is locked here; M2-E2 (ensemble calibration
+# against the M2-F1 acceptance corpus) revisits it with empirical
+# data and may move it. Keep the constant rather than inlining so
+# the calibration task changes one number.
+TOLERANT_MATCH_THRESHOLD = 95.0
+
+
+def _slice_in_range(start: int, end: int, document_len: int) -> bool:
+    """Whether the candidate's offsets describe a valid range inside the doc."""
+
+    return start >= 0 and end > start and end <= document_len
+
 
 def verify_exact_match(
     candidate: _CandidateProtocol,
@@ -88,18 +116,93 @@ def verify_exact_match(
     or case differences fall through to Stage 2.
     """
 
-    start = candidate.source_offset_start
-    end = candidate.source_offset_end
     quote = candidate.source_text
-
     if not quote:
         return _MISS
-    if start < 0 or end > len(document.normalized_content):
-        return _MISS
-    if end <= start:
+    if not _slice_in_range(
+        candidate.source_offset_start,
+        candidate.source_offset_end,
+        len(document.normalized_content),
+    ):
         return _MISS
 
-    if document.normalized_content[start:end] != quote:
+    if (
+        document.normalized_content[candidate.source_offset_start : candidate.source_offset_end]
+        != quote
+    ):
         return _MISS
 
     return VerificationResult(verified=True, method="exact_match", confidence=1.0)
+
+
+def verify_tolerant_match(
+    candidate: _CandidateProtocol,
+    document: _DocumentProtocol,
+) -> VerificationResult:
+    """Stage 2: fuzzy-match after normalization (M2-B1).
+
+    Normalizes both ``document.normalized_content[start:end]`` and
+    ``candidate.source_text`` via
+    :func:`app.citation.normalization.normalize` (passing the
+    document's ``was_ocrd`` flag so OCR-confusion rules fire only on
+    actually-OCR'd sources) and compares with
+    ``rapidfuzz.fuzz.ratio``. Returns verified=True when the ratio
+    is at or above :data:`TOLERANT_MATCH_THRESHOLD` (95.0).
+
+    The confidence on a pass is ``ratio / 100`` so the
+    ``verification_confidence`` column stays in the documented
+    ``[0, 1]`` range. A perfect match yields ``1.0`` (same as Stage 1).
+    """
+
+    quote = candidate.source_text
+    if not quote:
+        return _MISS
+    if not _slice_in_range(
+        candidate.source_offset_start,
+        candidate.source_offset_end,
+        len(document.normalized_content),
+    ):
+        return _MISS
+
+    source_slice = document.normalized_content[
+        candidate.source_offset_start : candidate.source_offset_end
+    ]
+    was_ocrd = bool(getattr(document, "was_ocrd", False))
+    normalized_source = normalize(source_slice, was_ocrd=was_ocrd)
+    normalized_quote = normalize(quote, was_ocrd=was_ocrd)
+
+    score = fuzz.ratio(normalized_source, normalized_quote)
+    if score < TOLERANT_MATCH_THRESHOLD:
+        return _MISS
+
+    return VerificationResult(
+        verified=True,
+        method="tolerant_match",
+        confidence=score / 100.0,
+    )
+
+
+def verify(
+    candidate: _CandidateProtocol,
+    document: _DocumentProtocol,
+) -> VerificationResult:
+    """Run the verification cascade and return the first hit.
+
+    Order: Stage 1 (exact-match) → Stage 2 (tolerant-match). Returns
+    :data:`_MISS` only when every stage has rejected the candidate.
+    Stages 3 and 4 (LLM judge, ensemble) land in M2-C1 / M2-D1 and
+    will plug in here.
+
+    The persistence layer in ``app.api.chats`` calls this rather than
+    a specific stage so the cascade is opaque to callers.
+    """
+
+    result = verify_exact_match(candidate, document)
+    if result.verified:
+        return result
+
+    result = verify_tolerant_match(candidate, document)
+    if result.verified:
+        return result
+
+    return _MISS

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -105,6 +105,13 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
     "opentelemetry-instrumentation-fastapi>=0.48b0,<1",
     "opentelemetry-instrumentation-httpx>=0.48b0,<1",
+    # M2-B1 — rapidfuzz powers Citation Engine Stage 2 (tolerant-match).
+    # Two uses: (1) extraction-time `partial_ratio_alignment` fallback
+    # when the model's quote isn't a byte-for-byte substring of the
+    # retrieved chunk (smart quotes, whitespace drift); (2) Stage 2
+    # verifier's `fuzz.ratio` against normalized text with threshold
+    # 95. MIT-licensed; C-extension backbone, no runtime config needed.
+    "rapidfuzz~=3.5",
 ]
 
 [project.optional-dependencies]

--- a/api/tests/citation/test_extraction.py
+++ b/api/tests/citation/test_extraction.py
@@ -168,13 +168,17 @@ def test_extract_tolerates_whitespace_around_source_marker() -> None:
 
 
 @pytest.mark.unit
-def test_extract_ignores_smart_quotes_for_stage_1() -> None:
-    """Stage 1 handles straight quotes only; smart quotes fall to Stage 2 (M2-B1)."""
+def test_extract_handles_smart_quotes() -> None:
+    """M2-B1: extractor accepts curly-quote pairs; Stage 2 verifier will pass them."""
 
     chunk = _chunk(content="Cited text.")
     response = "It says “Cited text.” (Source: [1]) here."
 
-    assert extract_citations(response, [chunk]) == []
+    candidates = extract_citations(response, [chunk])
+    assert len(candidates) == 1
+    # source_text preserves the model's quote shape (smart quotes); the
+    # verifier normalizes both sides before comparing.
+    assert candidates[0].source_text == "Cited text."
 
 
 @pytest.mark.unit
@@ -188,3 +192,57 @@ def test_extract_handles_multiline_quote() -> None:
     candidates = extract_citations(response, [chunk])
     assert len(candidates) == 1
     assert candidates[0].source_text == chunk_content
+
+
+# ---------------------------------------------------------------------------
+# M2-B1: rapidfuzz alignment fallback for quotes that aren't byte-for-byte
+# substrings of the cited chunk (smart quotes, whitespace drift).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_alignment_fallback_finds_whitespace_drift_quote() -> None:
+    """When byte-for-byte fails, partial_ratio_alignment locates the quote.
+
+    The candidate's offsets point at the best-aligned span in the chunk;
+    the verifier (Stage 2) re-checks at threshold 95 after normalizing.
+    """
+
+    chunk = _chunk(
+        content="The   agreement\nshall terminate.",
+        char_offset_start=100,
+    )
+    # Model emits the same text with normalized whitespace — byte-for-byte
+    # find will miss; alignment fallback locates it.
+    response = 'The model says "The agreement shall terminate." (Source: [1]).'
+
+    candidates = extract_citations(response, [chunk])
+    assert len(candidates) == 1
+    cite = candidates[0]
+    # The aligned span covers the whitespace-divergent region.
+    assert cite.source_offset_start >= 100
+    assert cite.source_offset_end <= 100 + len(chunk.content)
+    # source_text is the model's quote verbatim; verifier normalizes both sides.
+    assert cite.source_text == "The agreement shall terminate."
+
+
+@pytest.mark.unit
+def test_extract_alignment_fallback_rejects_unrelated_quote() -> None:
+    """A quote with no real overlap with the chunk falls below threshold."""
+
+    chunk = _chunk(content="The contract term is five years.")
+    response = 'The model wrote "completely unrelated subject matter." (Source: [1]).'
+
+    assert extract_citations(response, [chunk]) == []
+
+
+@pytest.mark.unit
+def test_extract_smart_quote_alignment_pairs() -> None:
+    """Mixed shapes: a smart-quoted citation whose text differs in whitespace."""
+
+    chunk = _chunk(content="The   agreement\nshall  terminate.")
+    response = "The model says “The agreement shall terminate.” (Source: [1])."
+
+    candidates = extract_citations(response, [chunk])
+    assert len(candidates) == 1
+    assert candidates[0].source_text == "The agreement shall terminate."

--- a/api/tests/citation/test_normalization.py
+++ b/api/tests/citation/test_normalization.py
@@ -1,0 +1,153 @@
+# ruff: noqa: RUF001
+"""Citation Engine — normalize() tests for Stage 2 tolerant-match.
+
+``normalize(text, *, was_ocrd=False)`` is the comparison-time
+normalization the Stage 2 verifier applies to both source-at-offsets
+and the model's quoted text before computing a fuzzy-ratio.
+
+Two layers:
+
+* **Always-on:** whitespace collapse, ``\\r\\n`` → ``\\n``, leading/
+  trailing strip, smart-quote → straight-quote (for both double and
+  single).
+* **OCR-conditional** (``was_ocrd=True`` only): replace common OCR
+  confusions (``rn`` → ``m`` mid-word, ``cl`` → ``d`` in word
+  contexts, ``O`` ↔ ``0`` / ``l`` ↔ ``1`` adjacent to digits).
+
+The OCR substitutions are conservative — applied only when the source
+went through OCR (``documents.was_ocrd``). Documents with reliable
+PyMuPDF extraction skip them so the function doesn't introduce
+false-positive matches against clean text.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.citation.normalization import normalize
+
+# ---------------------------------------------------------------------------
+# Always-on rules: whitespace + smart-quote normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_normalize_collapses_runs_of_whitespace() -> None:
+    assert normalize("the  quick   brown\tfox") == "the quick brown fox"
+
+
+@pytest.mark.unit
+def test_normalize_translates_crlf_to_lf() -> None:
+    # Newlines themselves are whitespace and collapse to a single space —
+    # the load-bearing claim is just that we don't double-substitute on
+    # CRLF (which would leave a stray ``\\r`` behind).
+    assert normalize("first line\r\nsecond line") == "first line second line"
+
+
+@pytest.mark.unit
+def test_normalize_strips_leading_and_trailing_whitespace() -> None:
+    assert normalize("   the agreement  ") == "the agreement"
+
+
+@pytest.mark.unit
+def test_normalize_translates_smart_double_quotes_to_straight() -> None:
+    # Both opening and closing curly double quotes map to ``"``.
+    assert normalize("“the agreement”") == '"the agreement"'
+
+
+@pytest.mark.unit
+def test_normalize_translates_smart_single_quotes_to_straight() -> None:
+    # Both opening and closing curly single quotes map to ``'``.
+    assert normalize("‘party A’") == "'party A'"
+
+
+@pytest.mark.unit
+def test_normalize_idempotent() -> None:
+    """Running twice yields the same string — the verifier relies on this."""
+
+    text = "the  quick “brown” fox  "
+    once = normalize(text)
+    twice = normalize(once)
+    assert once == twice
+
+
+# ---------------------------------------------------------------------------
+# OCR-conditional rules: applied only when was_ocrd=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_normalize_leaves_ocr_artefacts_when_was_ocrd_false() -> None:
+    """Clean-extraction documents never see OCR substitutions."""
+
+    # 'modern' is sometimes OCR'd as 'modem' or 'modern' → no substitution
+    # when the document didn't go through OCR.
+    assert normalize("the modern agreement", was_ocrd=False) == "the modern agreement"
+
+
+@pytest.mark.unit
+def test_normalize_rn_to_m_mid_word_when_was_ocrd_true() -> None:
+    """``rn`` is a known OCR confusion for ``m`` — collapse mid-word only."""
+
+    # mid-word: 'modem' OCR'd as 'modern'? Actual common confusion is the
+    # other direction (``m`` mis-OCR'd as ``rn``). We canonicalize ``rn``
+    # → ``m`` so the verifier matches either spelling against the chunk.
+    assert normalize("modern agreement", was_ocrd=True) == "modem agreement"
+
+
+@pytest.mark.unit
+def test_normalize_rn_to_m_skips_word_start() -> None:
+    """``rn`` at word START is preserved — no real OCR confusion there."""
+
+    assert normalize("rnage agreement", was_ocrd=True) == "rnage agreement"
+
+
+@pytest.mark.unit
+def test_normalize_rn_to_m_substitutes_word_final() -> None:
+    """Canonical OCR case: word-final ``rn`` (preceded by word char) → ``m``.
+
+    Accepts false positives like ``turn`` → ``tum`` to catch the common
+    ``modern`` ↔ ``modem`` family. The verifier's 95-threshold absorbs
+    single-token noise.
+    """
+
+    assert normalize("the burning ship turn", was_ocrd=True) == "the buming ship tum"
+
+
+@pytest.mark.unit
+def test_normalize_O_to_0_adjacent_to_digits_when_was_ocrd_true() -> None:
+    """``O`` ↔ ``0`` confusion: substitute only when adjacent to a digit."""
+
+    assert normalize("section O5", was_ocrd=True) == "section 05"
+    assert normalize("amount $1O0", was_ocrd=True) == "amount $100"
+
+
+@pytest.mark.unit
+def test_normalize_O_not_substituted_in_pure_text() -> None:
+    """Conservative: O in pure text (no adjacent digit) is preserved."""
+
+    assert normalize("Office of the Counsel", was_ocrd=True) == "Office of the Counsel"
+
+
+@pytest.mark.unit
+def test_normalize_l_to_1_adjacent_to_digits_when_was_ocrd_true() -> None:
+    """``l`` ↔ ``1`` confusion: substitute only when adjacent to a digit."""
+
+    assert normalize("section l5", was_ocrd=True) == "section 15"
+    assert normalize("section 5l", was_ocrd=True) == "section 51"
+
+
+@pytest.mark.unit
+def test_normalize_l_not_substituted_in_pure_text() -> None:
+    """Conservative: l in pure text (no adjacent digit) is preserved."""
+
+    assert normalize("clause of liability", was_ocrd=True) == "clause of liability"
+
+
+@pytest.mark.unit
+def test_normalize_combined_rules() -> None:
+    """A realistic citation with smart quotes + whitespace + OCR artefacts."""
+
+    raw = "  “The modern   provision” is in section l0  "
+    expected = '"The modem provision" is in section 10'
+    assert normalize(raw, was_ocrd=True) == expected

--- a/api/tests/citation/test_tolerant_match.py
+++ b/api/tests/citation/test_tolerant_match.py
@@ -1,0 +1,182 @@
+"""Citation Engine Stage 2 — tolerant-match verifier tests.
+
+``verify_tolerant_match(candidate, document)`` normalizes both
+``document.normalized_content[start:end]`` and ``candidate.source_text``
+via :func:`app.citation.normalization.normalize` and compares them
+with ``rapidfuzz.fuzz.ratio``. A ratio of 95 or above passes; the
+verdict carries ``method='tolerant_match'`` and
+``confidence=ratio/100``.
+
+The threshold ``95`` is locked at this stage (per M2 plan §M2-B1):
+
+* Below 95: paraphrases and meaningful edits start passing — that's
+  Stage 3's (LLM judge) job, not Stage 2's.
+* 95+: normalization-only diffs (smart quotes, whitespace, OCR
+  fixups under ``was_ocrd=True``) pass cleanly.
+
+M2-E2 (ensemble calibration) revisits this against the acceptance
+corpus and may surface a different number once we have empirical
+data; until then, 95 is the lock.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+from app.citation.verification import VerificationResult, verify_tolerant_match
+
+
+@dataclass(slots=True)
+class _StubDocument:
+    id: uuid.UUID
+    normalized_content: str
+    was_ocrd: bool = False
+
+
+@dataclass(slots=True)
+class _StubCandidate:
+    source_file_id: uuid.UUID
+    source_document_id: uuid.UUID
+    source_offset_start: int
+    source_offset_end: int
+    source_page: int | None
+    source_text: str
+
+
+def _doc(text: str, *, was_ocrd: bool = False) -> _StubDocument:
+    return _StubDocument(id=uuid.uuid4(), normalized_content=text, was_ocrd=was_ocrd)
+
+
+def _candidate(
+    doc: _StubDocument,
+    *,
+    offset_start: int,
+    offset_end: int,
+    source_text: str,
+) -> _StubCandidate:
+    return _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=offset_start,
+        source_offset_end=offset_end,
+        source_page=None,
+        source_text=source_text,
+    )
+
+
+@pytest.mark.unit
+def test_tolerant_match_smart_quotes_pass() -> None:
+    """Smart-vs-straight quote differences pass Stage 2."""
+
+    text = '"the agreement shall terminate after five years."'
+    doc = _doc(text)
+    smart_quoted = "“the agreement shall terminate after five years.”"
+    cand = _candidate(doc, offset_start=0, offset_end=len(text), source_text=smart_quoted)
+
+    result = verify_tolerant_match(cand, doc)
+
+    assert isinstance(result, VerificationResult)
+    assert result.verified is True
+    assert result.method == "tolerant_match"
+    assert result.confidence is not None
+    assert result.confidence >= 0.95
+
+
+@pytest.mark.unit
+def test_tolerant_match_whitespace_diff_passes() -> None:
+    """Whitespace differences (newlines, double spaces) pass Stage 2."""
+
+    text = "the agreement shall terminate after five years."
+    doc = _doc(text)
+    # Quote substitutes whitespace runs and adds newlines.
+    quote = "the agreement\nshall  terminate after five years."
+    cand = _candidate(doc, offset_start=0, offset_end=len(text), source_text=quote)
+
+    result = verify_tolerant_match(cand, doc)
+    assert result.verified is True
+    assert result.method == "tolerant_match"
+
+
+@pytest.mark.unit
+def test_tolerant_match_byte_for_byte_match_also_passes() -> None:
+    """Byte-for-byte matches pass at confidence 1.0 — Stage 2 doesn't need
+    Stage 1 to run first; it just happens to be slower."""
+
+    text = "the agreement shall terminate."
+    doc = _doc(text)
+    cand = _candidate(doc, offset_start=0, offset_end=len(text), source_text=text)
+
+    result = verify_tolerant_match(cand, doc)
+    assert result.verified is True
+    assert result.confidence == 1.0
+
+
+@pytest.mark.unit
+def test_tolerant_match_paraphrase_fails() -> None:
+    """Real paraphrases fall below threshold — Stage 3 (LLM judge) catches those."""
+
+    text = "the agreement shall terminate after five years."
+    doc = _doc(text)
+    # "may" instead of "shall", "ten" instead of "five" — paraphrase, not formatting.
+    paraphrase = "the agreement may end after ten years."
+    cand = _candidate(doc, offset_start=0, offset_end=len(text), source_text=paraphrase)
+
+    result = verify_tolerant_match(cand, doc)
+    assert result.verified is False
+    assert result.method is None
+    assert result.confidence is None
+
+
+@pytest.mark.unit
+def test_tolerant_match_ocr_substitution_passes_when_was_ocrd() -> None:
+    """``modern`` ↔ ``modem`` normalizes equal under was_ocrd=True."""
+
+    text = "in the modern provisions"
+    doc = _doc(text, was_ocrd=True)
+    quote = "in the modem provisions"
+    cand = _candidate(doc, offset_start=0, offset_end=len(text), source_text=quote)
+
+    result = verify_tolerant_match(cand, doc)
+    assert result.verified is True
+    assert result.method == "tolerant_match"
+
+
+@pytest.mark.unit
+def test_tolerant_match_ocr_rule_does_not_fire_without_was_ocrd() -> None:
+    """``modern`` vs ``modem`` fails Stage 2 when document is clean-extracted."""
+
+    text = "in the modern provisions"
+    doc = _doc(text, was_ocrd=False)
+    quote = "in the modem provisions"
+    cand = _candidate(doc, offset_start=0, offset_end=len(text), source_text=quote)
+
+    # Short enough that one differing character drops the ratio below 95.
+    result = verify_tolerant_match(cand, doc)
+    assert result.verified is False
+
+
+@pytest.mark.unit
+def test_tolerant_match_offset_out_of_range_returns_false() -> None:
+    """Defensive: offsets past the document end never claim verified."""
+
+    text = "Short text."
+    doc = _doc(text)
+    cand = _candidate(doc, offset_start=0, offset_end=1000, source_text="Short text.")
+
+    result = verify_tolerant_match(cand, doc)
+    assert result.verified is False
+
+
+@pytest.mark.unit
+def test_tolerant_match_empty_source_text_returns_false() -> None:
+    """Zero-length quote can't be meaningfully matched; reject."""
+
+    text = "Some text."
+    doc = _doc(text)
+    cand = _candidate(doc, offset_start=0, offset_end=0, source_text="")
+
+    result = verify_tolerant_match(cand, doc)
+    assert result.verified is False

--- a/api/tests/test_chat_citations.py
+++ b/api/tests/test_chat_citations.py
@@ -327,7 +327,104 @@ async def test_chat_send_persists_verified_citation_from_verbatim_quote(
 
 
 # ---------------------------------------------------------------------------
-# 2. Paraphrased quote → no citation row (Stage 1 strict; Stage 2 will catch)
+# M2-B1 — Stage 2 (tolerant-match) covers smart quotes + whitespace drift
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_chat_send_whitespace_drift_quote_passes_tolerant_match(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+) -> None:
+    """A model quote with whitespace drift passes Stage 2 (tolerant-match).
+
+    Source chunk has double spaces; model normalizes them to single
+    spaces when quoting. Stage 1 fails (byte-precise slice carries the
+    double space; model's source_text has the single-space version);
+    extraction's rapidfuzz alignment fallback still locates the span,
+    so Stage 2 runs and the normalized fuzz ratio passes.
+    """
+
+    body = "the employee  shall not  engage in any competing  business for two years."
+    drifted_quote = "the employee shall not engage in any competing business for two years."
+
+    # Fresh fixtures so the chunk content has the whitespace-drift body
+    # (avoids changing CHUNK_BODY used by other tests).
+    file_row = FileModel(
+        owner_id=owner_user.id,
+        filename="nda-template-double-space.pdf",
+        mime_type="application/pdf",
+        size_bytes=2048,
+        hash_sha256="c" * 64,
+        storage_path=f"cite-fixture/{uuid.uuid4()}",
+        ingestion_status="ready",
+    )
+    db_session.add(file_row)
+    await db_session.flush()
+
+    doc = Document(
+        file_id=file_row.id,
+        parser="pymupdf-only",
+        parser_version="pymupdf=1.27",
+        page_count=1,
+        character_count=len(body),
+        normalized_content=body,
+        was_ocrd=False,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+
+    chunk = DocumentChunk(
+        document_id=doc.id,
+        chunk_index=0,
+        content=body,
+        page_start=1,
+        page_end=1,
+        char_offset_start=0,
+        char_offset_end=len(body),
+    )
+    db_session.add(chunk)
+    await db_session.flush()
+
+    assistant_text = f'The agreement states "{drifted_quote}" (Source: [1]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text)),
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(return_value=[_hybrid_result_for(chunk, doc, file_row)]),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCitation).where(MessageCitation.source_file_id == file_row.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    cite = rows[0]
+    assert cite.verified is True
+    assert cite.verification_method == "tolerant_match"
+    assert cite.verification_confidence is not None
+    assert float(cite.verification_confidence) >= 0.95
+
+
+# ---------------------------------------------------------------------------
+# 2. Paraphrased quote → no citation row (Stages 1+2 reject; Stage 3 will catch)
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Fourth M2 task — Citation Engine Stage 2 (tolerant-match) shipped end-to-end on top of M2-A2's Stage 1. Citations that differ from their source only by **smart quotes**, **whitespace drift**, or (when the source is OCR'd) **common OCR confusions** now land verified instead of dropping silently.

The plan's M2-B1 bullet list said "normalize + verify_tolerant_match + cascade." The plan's stated Output said "smart quotes / whitespace / OCR variants pass Stage 2." Those weren't consistent — the M2-A2 extractor I shipped was strict (straight-quote regex + byte-for-byte chunk lookup), so smart-quoted candidates dropped at extraction and never reached the verification cascade. Kevin chose the "Faithful" path at task kickoff (B1-faithful): also loosen extraction so Stage 2's stated output is reachable. The literal-bullet-list interpretation would have shipped a Stage 2 that catches almost nothing in practice.

## What landed

| Layer | File | Change |
|---|---|---|
| Dep | `api/pyproject.toml` | + `rapidfuzz~=3.5` (MIT, C-extension). Two uses: extraction-time alignment fallback (`partial_ratio_alignment`) and Stage 2 verification ratio (`fuzz.ratio`). |
| Module | `api/app/citation/normalization.py` | `normalize(text, *, was_ocrd=False)`. Always-on: whitespace collapse, CRLF, smart-quote → straight. OCR-conditional: `rn` → `m` word-final, `O` ↔ `0` / `l` ↔ `1` adjacent to digits. Idempotent. Each OCR rule annotated with its false-positive trade-off and why it's safe at the 95-threshold. |
| Module | `api/app/citation/verification.py` | New `verify_tolerant_match(candidate, document)` (normalize both sides, rapidfuzz `ratio`, threshold 95 — locked here as a module constant, M2-E2 calibration may move it). New `verify(candidate, document)` cascade orchestrator: Stage 1 → Stage 2, returns first hit. Stages 3-4 plug into the same cascade. |
| Module | `api/app/citation/extraction.py` | Regex now matches both straight `"..."` and curly `"..."` double quotes. New `_locate_in_chunk` tries `str.find` first; on miss, falls back to `rapidfuzz.fuzz.partial_ratio_alignment` at threshold 85 (10 points below the verifier) to derive byte-precise in-chunk offsets. Fabricated quotes still drop below 85. |
| Cascade | `api/app/api/chats.py` | `_persist_message_citations` calls `verify()` instead of `verify_exact_match`. M2-C1 / M2-D1 plug into the same call site without further changes. |
| Tests | `api/tests/citation/test_normalization.py` | 15 unit: 6 always-on (whitespace, CRLF, strip, smart-double / smart-single → straight, idempotency) + 9 OCR-conditional (skip word-start `rn`, sub word-final `rn`, was_ocrd=False bypass, O↔0 adjacent / not-adjacent, l↔1 adjacent / not-adjacent, combined rules). |
| Tests | `api/tests/citation/test_tolerant_match.py` | 8 unit: smart-quote diff, whitespace drift, byte-for-byte at 1.0, paraphrase fail, OCR substitution under was_ocrd=True / fail under False, offset-out-of-range, empty source_text. |
| Tests | `api/tests/citation/test_extraction.py` (updated) | Smart-quote drop test → handles-smart-quotes (extractor now emits). +3 alignment-fallback tests: whitespace-drift located, unrelated rejected, mixed (smart + whitespace) shapes. |
| Tests | `api/tests/test_chat_citations.py` (updated) | New `test_chat_send_whitespace_drift_quote_passes_tolerant_match` end-to-end: chunk has double spaces, model emits single-space quote, citation lands as `method='tolerant_match'`, confidence ≥ 0.95. Existing tests (verbatim, paraphrase drop, unmarked drop, out-of-range drop, endpoint shape) unchanged. |

## Test plan

- [x] +27 new unit/integration tests (15 normalize + 8 tolerant_match + 3 extraction + 1 chat-citation E2E).
- [x] Full api suite: **921 passed, 1 skipped** (Δ = +27 from M2-A2 baseline of 894).
- [x] `mypy app` clean (84 source files).
- [x] `ruff check` + `ruff format --check` clean.
- [x] Smart-quote literals carry explicit `# ruff: noqa: RUF001` because the curly chars are load-bearing string-table targets, not typos.
- [ ] **Operator-side (recommended after merge):** run a chat with NDA Review where the model styles its quote typography (most modern models do); confirm citations land as `tolerant_match` with confidence ≥ 0.95.

## Architectural notes

**The cascade is now opaque to chat-send.** `chats.py` calls `verify()`; the function tries Stage 1, then Stage 2, returns the first hit. Adding Stage 3 (LLM judge, M2-C1) or Stage 4 (ensemble, M2-D1) is a single-function addition in `verification.py` plus an append in the cascade body — no change to the call site.

**Two thresholds, not one.** Extraction uses 85 for `partial_ratio_alignment` (gates "is this even close to something in the chunk"). Stage 2 verifier uses 95 for `fuzz.ratio` (gates "this is a normalization-only difference, not a paraphrase"). The 10-point gap lets the verifier have the final say without the extractor letting through obvious junk.

**OCR rules are conservative.** `rn` → `m` only when preceded by a word char (catches modem↔modern; accepts turn→tum as single-token noise that the 95 threshold absorbs over a longer quote). `O` ↔ `0` and `l` ↔ `1` only adjacent to a digit (so "Office" stays, "O5" becomes "05"; "liability" stays, "l5" becomes "15"). Every rule is annotated with its failure mode.

**Threshold calibration is deferred.** Both 85 and 95 are explicit constants in code with comments pointing at M2-E2 ensemble-calibration as the empirical re-tuning point. The M2-F1 acceptance corpus is the data source.

## Verification against the M2 plan

The plan §M2-B1 specifies four verification criteria:

1. **Unit tests for each normalization rule.** ✓ 15 tests in `test_normalization.py` (5 always-on + 9 OCR-conditional + 1 combined).
2. **Integration tests for end-to-end tolerant matching.** ✓ `test_chat_send_whitespace_drift_quote_passes_tolerant_match`.
3. **Test corpus with formatting variance.** ✓ Whitespace-drift fixture in `test_chat_citations.py`; smart-quote/OCR variants in unit tests.
4. **Threshold calibration documented.** ✓ Module constants `TOLERANT_MATCH_THRESHOLD = 95.0` and `_ALIGNMENT_THRESHOLD = 85.0` carry docstrings explaining the 10-point margin and the calibration deferral to M2-E2.

## PR ordering note

This PR was cut from `m2-development` at `3bff385` (M2-A2 merged). M2-A3 is on PR #24, awaiting separate review. **Zero file overlap** between this PR and M2-A3 — A3 is gateway/, B1 is api/. Whichever lands first, the other rebases cleanly.

Refs: `docs/M2-IMPLEMENTATION-PLAN.md` §M2-B1, `docs/PRD.md` §3.3.