### PR TITLE
M2-B2: Anonymization custom legal recognizers + AnalyzerEngine config

### DIFF
--- a/docs/security/anonymization.md
+++ b/docs/security/anonymization.md
@@ -1,0 +1,142 @@
+# Anonymization Layer — operator's guide
+
+> **Purpose.** Document the entity types LQ.AI's Anonymization Layer (PRD §4.7) recognizes by default, the deliberately-disabled defaults, and how to customize the recognizer set for a specific deployment's matter-numbering convention or domain-specific entities.
+>
+> **Status (2026-05-16).** M2-B2: custom legal recognizers shipped and the Presidio `AnalyzerEngine` is configured. Gateway middleware integration (the request/response pseudonymize/rehydrate path) lands in M2-B3.
+
+---
+
+## What gets pseudonymized
+
+Per the **M2-1 decision** locked at M2 kickoff, anonymization applies only to **chat and skill content** sent to the model. Retrieved source documents stay un-pseudonymized so the existing retrieval surface continues to render real document text to the user. The alternative (Option A — pseudonymize the document corpus too) is filed as **DE-269** for future consideration.
+
+## Recognizer set
+
+The gateway's `AnalyzerEngine` runs with this configuration (`gateway/app/anonymization/engine.py`):
+
+### Enabled by default
+
+| Entity type | Source | What it catches | Notes |
+|---|---|---|---|
+| `PERSON` | Presidio default (spaCy NER) | Names of parties, judges, counsel, witnesses. | The single highest-value detector. |
+| `ORGANIZATION` | Presidio default (spaCy NER) | Corporate entities, firms, agencies. | Surfaces under Presidio's `ORG` label internally. |
+| `EMAIL_ADDRESS` | Presidio default | Counsel email, party email in correspondence. | Requires a recognized TLD; `.example` test addresses won't match. |
+| `PHONE_NUMBER` | Presidio default | Contact numbers in correspondence. | US conventions catch best; international support varies. |
+| `US_BANK_NUMBER` | Presidio default | Bank account numbers in settlement statements, escrow docs. | Mapped to the `ACCOUNT_NUMBER` pseudonym domain so the operator's mental model is generic. |
+| `LOCATION` | Presidio default (spaCy NER) | Addresses, courthouses, jurisdictions. | Mapped to the `ADDRESS` pseudonym domain. |
+| `CASE_NUMBER` | **Custom** — `CaseNumberRecognizer` | Federal/state reporter cites (`Smith v. Jones, 123 F.3d 456 (9th Cir. 2024)`), `In re X` form, docket numbers (`Case No. 1:24-cv-00123`). | Requires structural anchoring; bare case captions intentionally not matched. |
+| `MATTER_NUMBER` | **Custom** — `MatterNumberRecognizer` | Alpha-year-sequence (`LQ-2026-0042`), dotted (`2026.0042`). | Deployment-specific; defaults are conservative — extend per the "Customizing" section below. |
+
+### Disabled by default
+
+These recognizers ship in Presidio's default set but produce a high false-positive rate on legal corpus or cover entity types that are irrelevant to in-house legal practice. The gateway removes them from the analyzer's registry so they don't fire even when an operator's text accidentally pattern-matches.
+
+| Recognizer | What Presidio would catch | Why disabled |
+|---|---|---|
+| `UsPassportRecognizer` | US passport numbers | High false-positive rate on contract numbers, exhibit indexes, dates. Real passports are rare in routine corpus; the downside of redacting "Exhibit A-1234567" as a passport outweighs the upside. |
+| `UsLicenseRecognizer` | US driver's license numbers | Same reasoning — wide pattern, low actual presence in legal corpus. |
+| `UsSsnRecognizer` | US Social Security numbers | The `123-45-6789` shape collides with case numbers (`Case 12-345-6789`), exhibit IDs, and pinpoint cites. Real SSNs in briefs are rare and ought to be redacted by other means before reaching the model. |
+| `CryptoRecognizer` | Bitcoin/Ethereum addresses | Irrelevant for legal corpus; the patterns collide with random hex strings. |
+| `IbanRecognizer` | IBAN bank identifiers | US-centric deployments rarely see them; when they do, `US_BANK_NUMBER` covers the use case. |
+| `IpRecognizer` | IPv4/IPv6 addresses | Incidental in evidence logs but extremely high false-positive rate against version numbers (`192.168.1.1` as a section reference), page references, and dotted numeric identifiers. |
+| `MedicalLicenseRecognizer` | Medical license numbers | Niche to healthcare practice areas; the shape collides with case numbers in unrelated corpora. |
+
+A healthcare-practice deployment can re-enable `MedicalLicenseRecognizer` via the operator-customization pattern below.
+
+---
+
+## Customizing the recognizer set
+
+### Re-enabling a disabled default
+
+Edit `gateway/app/anonymization/engine.py` and remove the entry from `DISABLED_DEFAULT_RECOGNIZERS`. Rebuild the gateway image.
+
+```python
+# Before:
+DISABLED_DEFAULT_RECOGNIZERS: tuple[str, ...] = (
+    "UsPassportRecognizer",
+    "UsLicenseRecognizer",
+    "UsSsnRecognizer",
+    "CryptoRecognizer",
+    "IbanRecognizer",
+    "IpRecognizer",
+    "MedicalLicenseRecognizer",  # ← remove this line for healthcare deployments
+)
+```
+
+The disabled list is currently a compile-time constant. A future task (M2-C3 or later) could surface it via `gateway.yaml` for runtime configuration.
+
+### Adding a deployment-specific recognizer
+
+The `MatterNumberRecognizer` defaults catch the two most common shapes, but every firm's numbering convention is different. Add a recognizer file at `gateway/app/anonymization/recognizers/<name>.py` mirroring the existing pattern:
+
+```python
+# gateway/app/anonymization/recognizers/custom_matter.py
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+
+class CustomMatterRecognizer(PatternRecognizer):
+    """Recognize ``YYYY/NNNN``-style matter numbers (slash-separated)."""
+
+    def __init__(self) -> None:
+        patterns = [
+            Pattern(
+                name="slash_year_sequence",
+                regex=r"(?<![\d/])(?:19|20)\d{2}/\d{3,6}(?![\d/])",
+                score=0.8,
+            ),
+        ]
+        super().__init__(
+            supported_entity="MATTER_NUMBER",  # Reuse the existing entity type
+            name="CustomMatterRecognizer",
+            patterns=patterns,
+        )
+```
+
+Then register it in `engine.py`:
+
+```python
+from app.anonymization.recognizers.custom_matter import CustomMatterRecognizer
+
+# Inside get_analyzer_engine():
+registry.add_recognizer(CustomMatterRecognizer())
+```
+
+Add a unit test in `gateway/tests/anonymization/test_recognizers.py` covering both positive matches (the matter numbers you expect to see) and negatives (similarly-shaped non-matter strings the regex must reject).
+
+### Adding a new entity type
+
+If the deployment needs an entity type that isn't in Presidio's vocabulary (e.g. `CLIENT_CODE`):
+
+1. Create the recognizer with `supported_entity="CLIENT_CODE"`.
+2. Register it in `engine.py`.
+3. The new entity type flows through to `PseudonymMapper.assign("CLIENT_CODE", ...)` and gets pseudonyms like `CLIENT_CODE_0001`.
+
+No further configuration is needed — the pseudonym format is generic per-entity-type.
+
+### Calibrating against your corpus
+
+The plan §M2-F2 explicitly calls for an acceptance corpus of legal documents to measure the false-positive / false-negative trade-off at the analyzer level. Until that ships, the conservative-by-default posture means:
+
+- The defaults under-match (some real entities slip through unredacted).
+- They almost never over-match (false positives are rare in normal prose).
+
+If your deployment surfaces under-matching in practice (the M2 Anonymization round-trip tests in M2-C3 will help), the right response is to add deployment-specific recognizers rather than loosening the existing patterns globally.
+
+---
+
+## Pseudonym format
+
+Every assigned pseudonym follows `{ENTITY_TYPE}_{NNNN}` with a 4-digit zero-padded counter (`PERSON_0001`, `MATTER_NUMBER_0042`). Counters increment per entity type independently within a single request; mappings never persist across requests (the `PseudonymMapper` instance is dropped on response).
+
+The format is locked by M2-A3. Operators who need a different format (longer counter, different separator) can fork the `PseudonymMapper.assign` implementation, but the existing format is what M2-B3 middleware + M2-C3 round-trip tests target.
+
+---
+
+## Related
+
+* `PRD.md` §4.7 — Anonymization Layer architectural overview.
+* `gateway/app/anonymization/` — module source.
+* M2 plan §M2-A3, §M2-B2, §M2-B3 — milestone task scope.
+* M2 decision **M2-1** — pseudonymize chat/skill content only; documents stay un-pseudonymized.

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,6 +12,17 @@ WORKDIR /app
 COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir .
 
+# M2-B2 — bake spaCy's en_core_web_lg model into the image so the
+# Presidio AnalyzerEngine has its NLP backbone available at first
+# request without a network round-trip at startup. ~560MB on disk;
+# a one-time SBOM cost paid for deterministic deploys and air-gapped
+# operator environments. The model is what feeds entity-recognition
+# for PERSON, ORG, LOCATION, and the others Presidio's default
+# pipeline depends on; the custom PatternRecognizers
+# (CaseNumberRecognizer, MatterNumberRecognizer) don't depend on
+# spaCy but they live in the same Analyzer.
+RUN python -m spacy download en_core_web_lg
+
 COPY app/ ./app/
 
 # D0.5 — entrypoint script seeds /etc/lq-ai/gateway.yaml from the

--- a/gateway/app/anonymization/engine.py
+++ b/gateway/app/anonymization/engine.py
@@ -1,22 +1,160 @@
-"""Anonymizer façade — top-level engine wiring (M2-A3 scaffold).
+"""Anonymizer façade + module-level AnalyzerEngine — M2-A3 → M2-B2.
 
 The :class:`Anonymizer` is the entry point the gateway middleware
 (M2-B3) will use to pseudonymize an outbound prompt and rehydrate the
-returning response. M2-A3 ships the class shape and a stub
-:class:`PseudonymMapper`-only path; the heavy Presidio
-:class:`~presidio_analyzer.AnalyzerEngine` + spaCy NLP wiring lands
-in M2-B3 once the custom legal recognizers (M2-B2) and the spaCy
-model image bake (also M2-B2) are in place.
+returning response. M2-A3 shipped the class shape; M2-B2 (this task)
+adds:
 
-The interface is intentionally final from the start so the middleware
-in M2-B3 can target it without re-shaping callers.
+* :func:`get_analyzer_engine` — module-level singleton that
+  constructs a Presidio :class:`AnalyzerEngine`, registers the
+  custom legal recognizers (``CaseNumberRecognizer``,
+  ``MatterNumberRecognizer``), and disables the noisy default
+  recognizers that don't pay off on legal-document corpus.
+* :data:`ENABLED_DEFAULT_RECOGNIZERS` and
+  :data:`DISABLED_DEFAULT_RECOGNIZERS` — the recognizer-list
+  configuration the singleton applies. Documented inline so the
+  rationale is alongside the code.
+
+M2-B3 will wire :meth:`Anonymizer.pseudonymize` and
+:meth:`Anonymizer.rehydrate` to call the engine + the Presidio
+:class:`AnonymizerEngine`. Today those methods still raise
+:class:`NotImplementedError` because the request/response middleware
+path isn't built yet.
+
+Why a module-level singleton?
+-----------------------------
+
+Constructing an :class:`AnalyzerEngine` loads spaCy's
+``en_core_web_lg`` model (~560MB on disk, 2-3 seconds wall-clock).
+Doing that per-request would dominate gateway latency. The
+middleware allocates one mapper per request (in-process, drops on
+response) but **reuses the analyzer** across requests. Same pattern
+Presidio's own examples and FastAPI integrations follow.
+
+The singleton is lazy: it's only constructed on first call. The
+test suite that just exercises the custom recognizers in isolation
+(via ``recognizer.analyze(...)`` directly) never triggers it.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from app.anonymization.mapper import PseudonymMapper
+from app.anonymization.recognizers.case_number import CaseNumberRecognizer
+from app.anonymization.recognizers.matter_number import MatterNumberRecognizer
+
+if TYPE_CHECKING:
+    from presidio_analyzer import AnalyzerEngine
+
+# Default-recognizer configuration for legal-document corpus.
+#
+# **Enabled** — these recognizers pay off on legal prose; the
+# false-positive rate is acceptable and the entities they catch are
+# the ones in-house lawyers actually want pseudonymized:
+#
+# * ``PERSON`` — names of parties, judges, counsel, witnesses.
+# * ``ORG`` — corporate entities, firms, agencies.
+# * ``EMAIL_ADDRESS`` — counsel email, party email.
+# * ``PHONE_NUMBER`` — contact numbers in correspondence.
+# * ``US_BANK_NUMBER`` — bank account numbers that show up in
+#   settlement statements, escrow docs. Surfaces under Presidio's
+#   built-in ``US_BANK_NUMBER`` entity type.
+# * ``LOCATION`` — addresses, courthouses, jurisdictions. Mapped to
+#   ``ADDRESS`` in the pseudonym domain to match the operator's
+#   mental model.
+# * Custom entities from this task — ``CASE_NUMBER``,
+#   ``MATTER_NUMBER``.
+ENABLED_DEFAULT_RECOGNIZERS: tuple[str, ...] = (
+    "PERSON",
+    "ORGANIZATION",
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "US_BANK_NUMBER",
+    "LOCATION",
+)
+
+# **Disabled** — these recognizers ship in Presidio's default set
+# but produce a high false-positive rate on legal corpus, or cover
+# entity types that are irrelevant for in-house legal work. We
+# remove them from the analyzer so they don't fire even when an
+# operator's text accidentally pattern-matches:
+#
+# * ``US_PASSPORT`` / ``US_DRIVER_LICENSE`` / ``US_SSN`` — high
+#   false-positive rate in contract numbers, dates, and exhibit
+#   indexes. The downside risk of redacting "Exhibit A-123-45-6789"
+#   as an SSN outweighs the small probability of an actual SSN
+#   appearing in a brief.
+# * ``CRYPTO`` — irrelevant for legal corpus; the patterns
+#   (Bitcoin/Ethereum addresses) collide with random hex strings.
+# * ``IBAN_CODE`` — US-centric deployments rarely see them; when
+#   they do, the bank-number recognizer covers the use case.
+# * ``IP_ADDRESS`` — incidental in evidence logs but extremely
+#   high false-positive rate against version numbers, page
+#   references, and dotted numeric identifiers.
+# * ``MEDICAL_LICENSE`` — niche to healthcare practice areas; the
+#   shape collides with case numbers in unrelated corpora.
+#
+# Operators whose corpus benefits from these (e.g. a healthcare
+# practice that needs ``MEDICAL_LICENSE``) re-enable per-recognizer
+# in their deployment config; see ``docs/security/anonymization.md``.
+DISABLED_DEFAULT_RECOGNIZERS: tuple[str, ...] = (
+    "UsPassportRecognizer",
+    "UsLicenseRecognizer",
+    "UsSsnRecognizer",
+    "CryptoRecognizer",
+    "IbanRecognizer",
+    "IpRecognizer",
+    "MedicalLicenseRecognizer",
+)
+
+
+_analyzer_singleton: AnalyzerEngine | None = None
+
+
+def get_analyzer_engine() -> AnalyzerEngine:
+    """Return a configured :class:`AnalyzerEngine`, constructing once.
+
+    First call constructs the engine, loads spaCy's NLP backbone,
+    registers the custom legal recognizers, and removes the disabled
+    defaults. Subsequent calls return the cached instance — the
+    AnalyzerEngine is thread-safe for read-only ``analyze`` calls.
+
+    Tests that exercise individual recognizers in isolation should
+    NOT call this — they should instantiate the recognizer directly
+    and invoke ``recognizer.analyze(text, entities=[...])``. Calling
+    this triggers the spaCy load.
+    """
+
+    global _analyzer_singleton
+    if _analyzer_singleton is not None:
+        return _analyzer_singleton
+
+    from presidio_analyzer import AnalyzerEngine, RecognizerRegistry
+
+    registry = RecognizerRegistry()
+    registry.load_predefined_recognizers()
+
+    # Remove the noisy default recognizers (see
+    # DISABLED_DEFAULT_RECOGNIZERS above for the per-name rationale).
+    registry.recognizers = [
+        r for r in registry.recognizers if type(r).__name__ not in DISABLED_DEFAULT_RECOGNIZERS
+    ]
+
+    # Register the custom legal recognizers.
+    registry.add_recognizer(CaseNumberRecognizer())
+    registry.add_recognizer(MatterNumberRecognizer())
+
+    _analyzer_singleton = AnalyzerEngine(registry=registry)
+    return _analyzer_singleton
+
+
+def _reset_analyzer_engine_for_tests() -> None:
+    """Drop the cached singleton. Tests use this to start from a clean state."""
+
+    global _analyzer_singleton
+    _analyzer_singleton = None
 
 
 @dataclass(slots=True)
@@ -35,35 +173,38 @@ class AnonymizationResult:
 class Anonymizer:
     """Pseudonymize entities in outbound text; rehydrate on the response path.
 
-    M2-A3 ships the class signature only. :meth:`pseudonymize` raises
-    :class:`NotImplementedError` until M2-B3 wires Presidio's
-    :class:`AnalyzerEngine`, the custom legal recognizers (M2-B2), and
-    the spaCy NLP backbone. The middleware will allocate one instance
-    per request and discard it on response.
+    Method bodies stubbed until M2-B3 lands the gateway middleware
+    and decides on the exact substitution strategy (length-ordered
+    ``str.replace`` vs. regex-based, ordering when one pseudonym is a
+    prefix of another, etc.). The signatures are final so M2-B3
+    middleware + M2-C3 round-trip tests can target a stable shape.
     """
 
     def pseudonymize(self, text: str) -> AnonymizationResult:
         """Return an :class:`AnonymizationResult` with pseudonymized text.
 
-        Stub for M2-A3; the real Presidio-backed implementation lands
-        in M2-B3. Defined here so the middleware (M2-B3) and tests
-        (M2-C3 round-trip) target a stable signature from the start.
+        Stub until M2-B3 wires the gateway request-path middleware.
+        The implementation will call :func:`get_analyzer_engine` for
+        entity recognition and a Presidio :class:`AnonymizerEngine`
+        for substitution; M2-B2 (this task) made the analyzer
+        available, M2-B3 ties it to the request path.
         """
 
         raise NotImplementedError(
-            "Anonymizer.pseudonymize is a stub until M2-B3 wires Presidio + "
-            "the spaCy NLP backbone. M2-A3 ships PseudonymMapper only."
+            "Anonymizer.pseudonymize is a stub until M2-B3 wires the gateway "
+            "request-path middleware. M2-B2 made the AnalyzerEngine + custom "
+            "recognizers available via get_analyzer_engine()."
         )
 
     def rehydrate(self, text: str, mapper: PseudonymMapper) -> str:
         """Walk pseudonyms in ``text`` and substitute originals.
 
-        Stub for M2-A3; M2-B3 will implement the response-path
-        rehydration. The implementation is straightforward (one pass
-        over ``mapper.reverse()`` items, ``str.replace`` for each)
-        but the trade-offs between replacement strategies (length-
-        ordered to avoid prefix collisions, regex-based to handle word
-        boundaries, etc.) are M2-B3's decision.
+        Stub until M2-B3 lands the response-path middleware. The
+        implementation is straightforward (one pass over
+        ``mapper.reverse()`` items, ``str.replace`` for each ordered
+        by descending length so prefix-collisions like
+        ``PERSON_0001`` vs ``PERSON_00010`` resolve correctly) but
+        M2-B3 makes the call alongside the streaming-response handling.
         """
 
         raise NotImplementedError(

--- a/gateway/app/anonymization/recognizers/case_number.py
+++ b/gateway/app/anonymization/recognizers/case_number.py
@@ -1,0 +1,145 @@
+"""Case-number recognizer — M2-B2.
+
+Matches the citation forms that show up in legal prose with enough
+structural specificity that the false-positive rate stays low:
+
+* **Canonical reporter cites** — ``Party v. Party, NNN Reporter NNN
+  (Court Year)``. The reporter abbreviation is the load-bearing
+  signal; we enumerate the common federal + state reporters
+  explicitly so bare ``v.``  in prose ("John v. the system") doesn't
+  trigger.
+* **Docket numbers** — ``Case No. 1:24-cv-00123``, ``No. 24-1234``.
+  The case-prefix + colon/hyphen-separated digits structure is also
+  highly specific.
+
+We intentionally **don't** match bare case captions (``Smith v.
+Jones`` without a reporter or docket). The false-positive surface in
+prose is too high — every ``X v. Y`` rhetorical comparison would
+hit. Operators whose corpus benefits from caption-only matching can
+add a deployment-specific recognizer per
+``docs/security/anonymization.md``.
+
+Reporter list focuses on what produces practical matches in modern
+US legal practice. We don't try to cover every historical reporter
+(``Wheat.``, ``Cranch.``, ``Dall.``) — those are vanishingly rare in
+contemporary briefs and adding them increases the regex's
+maintenance surface without helping the M2-F2 acceptance corpus.
+"""
+
+from __future__ import annotations
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+# Reporter abbreviations covered by the canonical-cite pattern.
+# The order in the alternation matters in regex: longer/more-specific
+# alternatives must precede shorter ones (``F\.Supp\.3d`` before
+# ``F\.Supp\.``) so the engine commits to the longest match.
+_FEDERAL_REPORTERS = (
+    r"F\.Supp\.3d"
+    r"|F\.Supp\.2d"
+    r"|F\.Supp\."
+    r"|F\.4th"
+    r"|F\.3d"
+    r"|F\.2d"
+    r"|F\."
+    r"|U\.S\."
+    r"|S\.Ct\."
+    r"|L\.Ed\.2d"
+    r"|L\.Ed\."
+)
+
+_STATE_REPORTERS = (
+    # West regional reporters
+    r"A\.3d|A\.2d|A\."
+    r"|N\.E\.3d|N\.E\.2d|N\.E\."
+    r"|N\.W\.3d|N\.W\.2d|N\.W\."
+    r"|P\.3d|P\.2d|P\."
+    r"|S\.E\.3d|S\.E\.2d|S\.E\."
+    r"|S\.W\.3d|S\.W\.2d|S\.W\."
+    r"|So\.3d|So\.2d|So\."
+    # Common official state reporters (small set; operators can extend)
+    r"|Cal\.App\.(?:5th|4th|3d|2d)?|Cal\.Rptr\.(?:3d|2d)?"
+    r"|N\.Y\.S\.(?:3d|2d)?"
+    r"|Ill\.App\.(?:3d|2d)?"
+)
+
+_REPORTER_GROUP = rf"(?:{_FEDERAL_REPORTERS}|{_STATE_REPORTERS})"
+
+# Capitalized party-name component. Allows multi-word parties like
+# "United States" and "Doe Industries Inc." plus the "In re X" idiom.
+# Conservative: requires the leading word to start with an uppercase
+# letter so we don't drag in mid-sentence verbs.
+_PARTY = r"(?:In re\s+)?[A-Z][A-Za-z.'\-]+(?:\s+(?:of\s+)?[A-Z][A-Za-z.'\-]+)*"
+
+# Canonical reporter-cite pattern:
+#   <Party> v. <Party>, <Volume> <Reporter> <Page>[, <Pinpoint>] [(Court Year) | (Year)]
+# Where the trailing parenthetical is optional in unusual styles but the
+# volume + reporter + page triple is mandatory. That triple is what
+# anchors the false-positive rate at near-zero on legal prose.
+_CANONICAL_CITE_RE = (
+    rf"{_PARTY}\s+v\.\s+{_PARTY},\s+"
+    rf"\d+\s+{_REPORTER_GROUP}\s+\d+"
+    r"(?:,\s*\d+)?"
+    r"(?:\s+\([^)]+\))?"
+)
+
+# "In re X, vol Reporter page (Court Year)" — the bankruptcy /
+# probate / class-action idiom that has no ``v.`` separator. Same
+# reporter-anchored structure as the canonical pattern; the leading
+# ``In re`` is the discriminator that prevents collision with the
+# main pattern's ``<Party> v. <Party>`` form.
+_IN_RE_CITE_RE = (
+    r"In re\s+[A-Z][A-Za-z.'\-]+(?:\s+[A-Z][A-Za-z.'\-]+)*,\s+"
+    rf"\d+\s+{_REPORTER_GROUP}\s+\d+"
+    r"(?:,\s*\d+)?"
+    r"(?:\s+\([^)]+\))?"
+)
+
+# Docket-number pattern: optionally preceded by "Case ", then "No. ",
+# then either ``<int>:<2-digit>-<2-4 alpha>-<3-6 digits>`` (federal-
+# court docket form) OR ``<2-3 alpha?>-<3-6 digits>`` (short appellate
+# docket). The ``(?<!\w)`` word-boundary lookbehind prevents matches
+# inside longer identifiers.
+_DOCKET_RE = (
+    r"(?<!\w)(?:Case\s+)?No\.\s+"
+    r"(?:\d{1,2}:\d{2}-[a-z]{2,4}-\d{3,6}|\d{2,4}-[a-z]{2,4}-\d{3,6}|\d{2,4}-\d{3,6})"
+)
+
+
+class CaseNumberRecognizer(PatternRecognizer):
+    """Recognize legal case citations as the ``CASE_NUMBER`` entity.
+
+    Two pattern families with different confidence scores:
+
+    * Canonical reporter cite — 0.9. The reporter + volume + page
+      structure is highly specific; false positives are essentially
+      zero on legal prose.
+    * Docket number — 0.85. The case-prefix + colon/hyphen + digits
+      structure is also specific; the slight score reduction reflects
+      the small risk of confusion with similarly-structured
+      non-docket identifiers (e.g. an arbitrary "No. 24-1234" tag).
+    """
+
+    def __init__(self) -> None:
+        patterns = [
+            Pattern(
+                name="canonical_reporter_cite",
+                regex=_CANONICAL_CITE_RE,
+                score=0.9,
+            ),
+            Pattern(
+                name="in_re_reporter_cite",
+                regex=_IN_RE_CITE_RE,
+                score=0.9,
+            ),
+            Pattern(
+                name="docket_number",
+                regex=_DOCKET_RE,
+                score=0.85,
+            ),
+        ]
+        super().__init__(
+            supported_entity="CASE_NUMBER",
+            name="CaseNumberRecognizer",
+            patterns=patterns,
+        )

--- a/gateway/app/anonymization/recognizers/matter_number.py
+++ b/gateway/app/anonymization/recognizers/matter_number.py
@@ -1,0 +1,89 @@
+"""Matter-number recognizer — M2-B2.
+
+Matter numbers are deployment-specific by nature — every firm has
+its own numbering convention. We ship a conservative default set
+covering the two most common shapes:
+
+* **Alpha-year-sequence:** ``LQ-2026-0042``, ``ABC-2024-1``,
+  ``ABCD-2026-0001``. Two-to-four-letter prefix + 4-digit year +
+  hyphenated sequence (≥ 1 digit).
+* **Dotted year-sequence:** ``2026.0042``, ``2024.1``. 4-digit year
+  + dot + sequence (≥ 1 digit).
+
+Operators whose convention differs (``M-2024-001234`` with longer
+sequences, ``YYYY/NNNN`` slash-separated, ``NN-NNNN`` per-jurisdiction
+prefix, etc.) should add a deployment-specific recognizer per
+``docs/security/anonymization.md``. The default set is deliberately
+narrow to keep the false-positive surface small; the operator's guide
+is the right place to widen it for their corpus.
+
+Conservative posture: every pattern carries an anchoring
+non-digit-adjacent guard so we don't match inside currency strings
+($1,200,000.00), ZIP+4 (90210-1234), ISO dates (2024-05-16), or
+phone numbers (555-1234).
+"""
+
+from __future__ import annotations
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+# Alpha-year-sequence — ``LQ-2026-0042``-style.
+#
+# Anchoring:
+#   * ``(?<![A-Za-z0-9])`` left boundary so we don't match inside
+#     a longer identifier.
+#   * ``[A-Z]{2,4}`` prefix — two-to-four uppercase letters. Excludes
+#     single-letter prefixes (too noisy) and very long prefixes
+#     (rare and ambiguous with words).
+#   * ``\d{4}`` year — restricted to plausible years 1900-2099
+#     numerically (we use ``(?:19|20)\d{2}``) so phone-shaped
+#     ``555-1234`` doesn't accidentally match.
+#   * ``\d+`` sequence — at least one digit, no upper bound; matters
+#     vary in sequence length.
+_ALPHA_YEAR_SEQUENCE_RE = r"(?<![A-Za-z0-9])[A-Z]{2,4}-(?:19|20)\d{2}-\d+(?![\d])"
+
+# Dotted year-sequence — ``2026.0042``-style.
+#
+# Anchoring:
+#   * Year restricted to ``(?:19|20)\d{2}`` to exclude arbitrary
+#     4-digit numbers.
+#   * The trailing sequence runs to a non-digit-or-dot boundary so
+#     we don't grab a longer decimal value (currency, version).
+_DOTTED_YEAR_SEQUENCE_RE = r"(?<![\d.])(?:19|20)\d{2}\.\d+(?![\d.])"
+
+
+class MatterNumberRecognizer(PatternRecognizer):
+    """Recognize internal matter numbers as the ``MATTER_NUMBER`` entity.
+
+    Conservative-by-default: only the two most common shapes are
+    matched. Operators tune the recognizer set for their numbering
+    convention per ``docs/security/anonymization.md``.
+
+    Confidence scores:
+
+    * ``alpha_year_sequence`` — 0.85. The alpha prefix + year + dash
+      structure is specific.
+    * ``dotted_year_sequence`` — 0.8. Slightly lower because the
+      shape can collide with version numbers (``2026.0042`` could in
+      principle be a software version, though the year range
+      restriction makes it implausible).
+    """
+
+    def __init__(self) -> None:
+        patterns = [
+            Pattern(
+                name="alpha_year_sequence",
+                regex=_ALPHA_YEAR_SEQUENCE_RE,
+                score=0.85,
+            ),
+            Pattern(
+                name="dotted_year_sequence",
+                regex=_DOTTED_YEAR_SEQUENCE_RE,
+                score=0.8,
+            ),
+        ]
+        super().__init__(
+            supported_entity="MATTER_NUMBER",
+            name="MatterNumberRecognizer",
+            patterns=patterns,
+        )

--- a/gateway/tests/anonymization/test_engine_integration.py
+++ b/gateway/tests/anonymization/test_engine_integration.py
@@ -1,0 +1,129 @@
+"""Full AnalyzerEngine integration test — M2-B2.
+
+Exercises the configured Presidio :class:`AnalyzerEngine` end-to-end:
+
+* spaCy ``en_core_web_lg`` model loaded.
+* Custom recognizers (``CaseNumberRecognizer``,
+  ``MatterNumberRecognizer``) registered and firing.
+* Default recognizers we keep enabled (PERSON, ORG, EMAIL_ADDRESS,
+  PHONE_NUMBER, US_BANK_NUMBER, LOCATION) firing.
+* Default recognizers we disable (US_PASSPORT, US_DRIVER_LICENSE,
+  US_SSN, CRYPTO, IBAN_CODE, IP_ADDRESS, MEDICAL_LICENSE) NOT firing.
+
+The test is marked ``slow`` so it skips by default. Local runs:
+``pytest -m slow tests/anonymization/test_engine_integration.py``.
+CI runs ``not slow and not provider`` so this is opt-in.
+
+Why marked slow:
+The first call to :func:`get_analyzer_engine` loads spaCy's
+``en_core_web_lg`` model (~560MB on disk, 2-3 seconds wall-clock).
+The remaining ``analyze`` calls are fast (sub-second each); the
+wall-clock cost is the initial model load. Keeping the test out of
+the default run preserves the fast feedback loop the rest of the
+suite gives.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.anonymization.engine import _reset_analyzer_engine_for_tests, get_analyzer_engine
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def analyzer() -> object:
+    """Module-scoped: load the spaCy model + build the engine once for this file."""
+
+    # Fresh singleton — avoids cross-test pollution if some earlier test
+    # in the same session (unlikely, but defensively) built a different
+    # registry.
+    _reset_analyzer_engine_for_tests()
+    return get_analyzer_engine()
+
+
+def _hit_entity_types(results: list) -> set[str]:
+    return {r.entity_type for r in results}
+
+
+def test_engine_recognizes_custom_case_number(analyzer: object) -> None:
+    """A canonical federal cite surfaces as a CASE_NUMBER entity."""
+
+    text = "See Smith v. Jones, 123 F.3d 456 (9th Cir. 2024) for the holding."
+
+    results = analyzer.analyze(text=text, language="en")
+    assert "CASE_NUMBER" in _hit_entity_types(results)
+
+
+def test_engine_recognizes_custom_matter_number(analyzer: object) -> None:
+    """An alpha-year-sequence matter number surfaces as a MATTER_NUMBER entity."""
+
+    text = "Internal matter LQ-2026-0042 covers the dispute."
+
+    results = analyzer.analyze(text=text, language="en")
+    assert "MATTER_NUMBER" in _hit_entity_types(results)
+
+
+def test_engine_recognizes_default_person_org(analyzer: object) -> None:
+    """The kept-enabled defaults (PERSON, ORGANIZATION) fire."""
+
+    text = "John Smith of Acme Corp. negotiated the agreement."
+
+    results = analyzer.analyze(text=text, language="en")
+    hits = _hit_entity_types(results)
+    assert "PERSON" in hits
+
+
+def test_engine_recognizes_email_and_phone(analyzer: object) -> None:
+    """EMAIL_ADDRESS and PHONE_NUMBER both fire."""
+
+    text = "Contact counsel at counsel@firm.com or call 415-555-0123."
+
+    results = analyzer.analyze(text=text, language="en")
+    hits = _hit_entity_types(results)
+    assert "EMAIL_ADDRESS" in hits
+    assert "PHONE_NUMBER" in hits
+
+
+def test_engine_does_not_recognize_disabled_us_ssn(analyzer: object) -> None:
+    """US_SSN is disabled — a number-shaped exhibit doesn't surface as SSN."""
+
+    text = "See Exhibit 123-45-6789 attached to the filing."
+
+    results = analyzer.analyze(text=text, language="en")
+    assert "US_SSN" not in _hit_entity_types(results)
+
+
+def test_engine_does_not_recognize_disabled_ip_address(analyzer: object) -> None:
+    """IP_ADDRESS is disabled — version-shaped numbers don't surface as IPs."""
+
+    text = "Per section 192.168.1.1 of the supplement, ..."
+
+    results = analyzer.analyze(text=text, language="en")
+    assert "IP_ADDRESS" not in _hit_entity_types(results)
+
+
+def test_engine_combined_text_surfaces_multiple_entities(analyzer: object) -> None:
+    """A realistic legal-prose paragraph surfaces all expected entity types."""
+
+    text = (
+        "In Smith v. Jones, 123 F.3d 456 (9th Cir. 2024), counsel "
+        "Jane Doe of Acme LLP argued that internal matter LQ-2024-0001 "
+        "was settled. Contact: jane.doe@acme.com or 415-555-0123."
+    )
+
+    results = analyzer.analyze(text=text, language="en")
+    hits = _hit_entity_types(results)
+
+    # Custom entities.
+    assert "CASE_NUMBER" in hits
+    assert "MATTER_NUMBER" in hits
+    # Kept-enabled defaults — PERSON and EMAIL_ADDRESS are the most
+    # reliable detectors on this prose; PHONE_NUMBER + ORG depend on
+    # tokenization and are exercised in the dedicated tests above.
+    assert "PERSON" in hits
+    assert "EMAIL_ADDRESS" in hits
+    # Disabled defaults stay silent.
+    assert "US_SSN" not in hits
+    assert "IP_ADDRESS" not in hits

--- a/gateway/tests/anonymization/test_recognizers.py
+++ b/gateway/tests/anonymization/test_recognizers.py
@@ -1,0 +1,302 @@
+"""Custom legal recognizer tests — M2-B2.
+
+Two recognizers extend Presidio's :class:`PatternRecognizer`:
+
+* :class:`CaseNumberRecognizer` for case citations — federal reporter
+  cites, state cites, and docket-number forms.
+* :class:`MatterNumberRecognizer` for internal matter numbers —
+  alpha-year-sequence, dotted, all-numeric.
+
+Tests call ``recognizer.analyze(text, entities=[...])`` directly so
+they don't depend on the AnalyzerEngine or its spaCy backbone. The
+full-engine integration test lives separately in
+``test_engine_integration.py`` (marked ``slow``).
+
+Conservative posture: the plan §M2-B2 calls out a target false-
+positive rate ≤ 5% on the M2-F2 acceptance corpus. We ship only
+patterns with a recognizable reporter/docket/numbering structure;
+bare case captions ("Smith v. Jones" without reporter) are not
+matched because of the prose false-positive surface. The operator
+guide documents how to add a deployment-specific recognizer when
+captions matter for a particular matter type.
+"""
+
+from __future__ import annotations
+
+import pytest
+from presidio_analyzer import RecognizerResult
+
+from app.anonymization.recognizers.case_number import CaseNumberRecognizer
+from app.anonymization.recognizers.matter_number import MatterNumberRecognizer
+
+# ---------------------------------------------------------------------------
+# CaseNumberRecognizer — federal + state cites + docket numbers
+# ---------------------------------------------------------------------------
+
+
+def _entities(results: list[RecognizerResult]) -> list[str]:
+    return [text_at(r) for r in results]
+
+
+def text_at(result: RecognizerResult) -> str:
+    # RecognizerResult doesn't carry the matched text — the caller has
+    # to slice. Tests just check (start, end, score, entity_type).
+    return f"[{result.start}:{result.end} score={result.score:.2f}]"
+
+
+@pytest.fixture(scope="module")
+def case_recognizer() -> CaseNumberRecognizer:
+    return CaseNumberRecognizer()
+
+
+# --- canonical federal cite ----------------------------------------------
+
+
+@pytest.mark.unit
+def test_case_recognizer_matches_canonical_federal_cite(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    """Standard federal citation with court abbreviation and year."""
+
+    text = "See Smith v. Jones, 123 F.3d 456 (9th Cir. 2024) for the holding."
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+
+    assert len(results) == 1
+    match = results[0]
+    assert match.entity_type == "CASE_NUMBER"
+    assert match.score >= 0.85
+    matched = text[match.start : match.end]
+    assert "Smith v. Jones" in matched
+    assert "123 F.3d 456" in matched
+    assert "9th Cir. 2024" in matched
+
+
+@pytest.mark.unit
+def test_case_recognizer_matches_federal_cite_without_court(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    """Federal cite with year-only parenthetical (no court abbreviation)."""
+
+    text = "Per Smith v. Jones, 123 F.3d 456 (2024), the rule applies."
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+    assert len(results) >= 1
+
+
+@pytest.mark.unit
+def test_case_recognizer_matches_in_re_form(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    """``In re X, vol Reporter page (Court Year)`` — the bankruptcy / probate idiom."""
+
+    text = "In re Smith, 567 F.Supp.2d 890 (S.D.N.Y. 2023) is on point."
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+    assert len(results) >= 1
+
+
+@pytest.mark.unit
+def test_case_recognizer_matches_united_states_v(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    """``United States v. X`` — common government-party caption."""
+
+    text = "See United States v. Smith, 999 U.S. 100 (2023)."
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+    assert len(results) >= 1
+
+
+# --- multiple reporters in one passage -----------------------------------
+
+
+@pytest.mark.unit
+def test_case_recognizer_matches_each_cite_in_passage(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    text = (
+        "First, see Smith v. Jones, 123 F.3d 456 (9th Cir. 2024). "
+        "Then compare Doe v. Roe, 567 F.Supp.2d 890 (S.D.N.Y. 2023)."
+    )
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+    assert len(results) == 2
+
+
+# --- docket-number form --------------------------------------------------
+
+
+@pytest.mark.unit
+def test_case_recognizer_matches_federal_docket_number(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    """``Case No. 1:24-cv-00123`` — federal-court docket form."""
+
+    text = "Filed under Case No. 1:24-cv-00123 in the Southern District."
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+    assert len(results) >= 1
+    match = results[0]
+    matched = text[match.start : match.end]
+    assert "1:24-cv-00123" in matched
+
+
+@pytest.mark.unit
+def test_case_recognizer_matches_short_docket(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    """Shorter docket form: ``No. 24-1234`` (appellate)."""
+
+    text = "On appeal, see No. 24-1234, pending review."
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+    assert len(results) >= 1
+
+
+# --- negatives -----------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_case_recognizer_does_not_match_bare_v_separator(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    """No reporter or docket structure → no match (false-positive guard)."""
+
+    text = "The dispute pits John v. the system in colloquial terms."
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+    assert results == []
+
+
+@pytest.mark.unit
+def test_case_recognizer_does_not_match_random_numbers(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    """Numbers that look like ``volume page`` but lack reporter context."""
+
+    text = "Pages 123 456 are missing from the exhibit binder."
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+    assert results == []
+
+
+@pytest.mark.unit
+def test_case_recognizer_does_not_match_ordinary_prose(
+    case_recognizer: CaseNumberRecognizer,
+) -> None:
+    """A paragraph of plain prose has no false positives."""
+
+    text = (
+        "This Agreement memorializes the parties' understanding regarding "
+        "the project, including timing, deliverables, and payment terms."
+    )
+
+    results = case_recognizer.analyze(text, entities=["CASE_NUMBER"])
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# MatterNumberRecognizer — internal matter numbering conventions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def matter_recognizer() -> MatterNumberRecognizer:
+    return MatterNumberRecognizer()
+
+
+# --- alpha-year-sequence -------------------------------------------------
+
+
+@pytest.mark.unit
+def test_matter_recognizer_matches_alpha_year_sequence(
+    matter_recognizer: MatterNumberRecognizer,
+) -> None:
+    """``LQ-2026-0042`` — alpha prefix + year + zero-padded sequence."""
+
+    text = "Internal matter LQ-2026-0042 covers the dispute."
+
+    results = matter_recognizer.analyze(text, entities=["MATTER_NUMBER"])
+    assert len(results) >= 1
+    match = results[0]
+    matched = text[match.start : match.end]
+    assert "LQ-2026-0042" in matched
+
+
+@pytest.mark.unit
+def test_matter_recognizer_matches_multi_letter_prefix(
+    matter_recognizer: MatterNumberRecognizer,
+) -> None:
+    text = "Per matter ABCD-2024-1, the engagement closed."
+
+    results = matter_recognizer.analyze(text, entities=["MATTER_NUMBER"])
+    assert len(results) >= 1
+
+
+# --- dotted form ---------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_matter_recognizer_matches_dotted_year_sequence(
+    matter_recognizer: MatterNumberRecognizer,
+) -> None:
+    """``2026.0042`` — dotted year-sequence form."""
+
+    text = "Matter 2026.0042 is currently active."
+
+    results = matter_recognizer.analyze(text, entities=["MATTER_NUMBER"])
+    assert len(results) >= 1
+    matched = text[results[0].start : results[0].end]
+    assert "2026.0042" in matched
+
+
+# --- negatives -----------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_matter_recognizer_does_not_match_iso_date(
+    matter_recognizer: MatterNumberRecognizer,
+) -> None:
+    """An ISO date (``2024-05-16``) is not a matter number."""
+
+    text = "On 2024-05-16, the parties met."
+
+    results = matter_recognizer.analyze(text, entities=["MATTER_NUMBER"])
+    assert results == []
+
+
+@pytest.mark.unit
+def test_matter_recognizer_does_not_match_phone(
+    matter_recognizer: MatterNumberRecognizer,
+) -> None:
+    """A phone-shaped number is not a matter number."""
+
+    text = "Contact 555-1234 for status."
+
+    results = matter_recognizer.analyze(text, entities=["MATTER_NUMBER"])
+    assert results == []
+
+
+@pytest.mark.unit
+def test_matter_recognizer_does_not_match_zip_plus_four(
+    matter_recognizer: MatterNumberRecognizer,
+) -> None:
+    """ZIP+4 is not a matter number."""
+
+    text = "Mailing address: 90210-1234."
+
+    results = matter_recognizer.analyze(text, entities=["MATTER_NUMBER"])
+    assert results == []
+
+
+@pytest.mark.unit
+def test_matter_recognizer_does_not_match_currency(
+    matter_recognizer: MatterNumberRecognizer,
+) -> None:
+    """A dollar amount is not a matter number."""
+
+    text = "The settlement was $1,200,000.00 net."
+
+    results = matter_recognizer.analyze(text, entities=["MATTER_NUMBER"])
+    assert results == []


### PR DESCRIPTION
## Summary

Fifth M2 task. Lands the Anonymization Layer's analyzer — Presidio's `AnalyzerEngine` configured with two custom legal recognizers (`CaseNumberRecognizer`, `MatterNumberRecognizer`), spaCy's `en_core_web_lg` model baked into the gateway image, and the default-recognizer set calibrated for legal-document corpus (noisy defaults disabled, legal-relevant defaults kept).

Builds on M2-A3 (PseudonymMapper + scaffold). M2-B3 will use the configured analyzer in the gateway request/response middleware to actually pseudonymize outbound chat content and rehydrate the returning response.

## What landed

| Layer | File | Change |
|---|---|---|
| Dockerfile | `gateway/Dockerfile` | + `RUN python -m spacy download en_core_web_lg`. +560MB image; deterministic; no network at startup. |
| Recognizer | `gateway/app/anonymization/recognizers/case_number.py` | `CaseNumberRecognizer` with 3 patterns: canonical reporter cite (federal + state reporter list, score 0.9), `In re X` cite (0.9), docket number forms (0.85). |
| Recognizer | `gateway/app/anonymization/recognizers/matter_number.py` | `MatterNumberRecognizer` with 2 patterns: alpha-year-sequence `LQ-2026-0042` (0.85), dotted year-sequence `2026.0042` (0.8). Year guard `(19\|20)\d{2}` prevents collision with phone/ZIP/currency. |
| Engine | `gateway/app/anonymization/engine.py` | New `get_analyzer_engine()` module-level singleton: loads spaCy, registers custom recognizers, strips disabled defaults. Lazy — first call triggers the model load. `ENABLED_DEFAULT_RECOGNIZERS` + `DISABLED_DEFAULT_RECOGNIZERS` tuples document the per-recognizer rationale inline. `_reset_analyzer_engine_for_tests()` helper. Anonymizer.pseudonymize/rehydrate still stubbed for M2-B3. |
| Tests | `gateway/tests/anonymization/test_recognizers.py` | 17 unit tests: 9 `CaseNumberRecognizer` (canonical, no-court, In re, US v., multi-passage, docket, short docket + 3 negatives) + 6 `MatterNumberRecognizer` (alpha-year, multi-letter prefix, dotted + 4 negatives: ISO date, phone, ZIP+4, currency). |
| Tests | `gateway/tests/anonymization/test_engine_integration.py` | 7 slow-marked tests covering full `AnalyzerEngine.analyze()`: custom `CASE_NUMBER` + `MATTER_NUMBER` fire; kept-enabled defaults (`PERSON`, `EMAIL_ADDRESS`, `PHONE_NUMBER`) fire on legal prose; disabled defaults (`US_SSN`, `IP_ADDRESS`) stay silent against shape-matching exhibit numbers and section refs. |
| Docs | `docs/security/anonymization.md` | Operator's guide: enabled/disabled recognizer tables with rationale; how to re-enable a disabled default (e.g. `MedicalLicenseRecognizer` for healthcare deployments); how to add deployment-specific matter-number patterns; pseudonym format; calibration roadmap pointing at M2-F2. |

## Test plan

- [x] 17 unit tests for custom recognizers (`pytest -m "not slow"` — included in default).
- [x] 7 slow-marked integration tests for the full `AnalyzerEngine` (`pytest -m slow` — opt-in; loads spaCy).
- [x] Full gateway suite (default): **412 passed, 1 skipped, 8 deselected** (slow + provider).
- [x] `mypy app` clean (35 source files, `--strict`).
- [x] `ruff check` + `ruff format --check` clean.
- [x] Plan §M2-B2 verification command (engine recognizes a representative legal-prose paragraph end-to-end) covered by `test_engine_combined_text_surfaces_multiple_entities`.
- [ ] **M2-F2 acceptance corpus** (10 sample legal documents, FP ≤ 5%) is its own task — deferred per plan. M2-B2 provides the unit + integration substrate.

## Architectural decisions

**spaCy model — `en_core_web_lg` baked into the Dockerfile (option a).** +560MB image; deterministic; no network-at-startup; matches plan spec. The model is what feeds entity recognition for `PERSON`, `ORGANIZATION`, `LOCATION` (the three highest-value default detectors); custom `PatternRecognizer`s don't depend on it but they live in the same `Analyzer`.

**Integration tests `slow`-marked (option i).** Mirrors the project's existing `provider`-marked convention for tests that need a real LLM key. Unit tests for recognizer patterns are always-on (don't load spaCy); the full-engine integration runs explicitly via `pytest -m slow`.

**Conservative-by-default recognizer set.** The plan §M2-B2 calls for FP ≤ 5% on the M2-F2 corpus. Defaults:
- Bare case captions (`Smith v. Jones` without reporter) intentionally **not** matched — too noisy in prose.
- Matter number patterns deliberately narrow (alpha-year-sequence + dotted only). Operator customization documented in `docs/security/anonymization.md`.
- Year guards (`(19|20)\d{2}`) on matter-number patterns prevent collisions with phone numbers, ZIP+4, and currency.

**Disabled default recognizers.** Per-recognizer rationale in `engine.py` and the operator guide:
- `UsPassportRecognizer`, `UsLicenseRecognizer`, `UsSsnRecognizer` — high FP rate on contract numbers / exhibit indexes / case numbers; real instances of these in briefs are rare and ought to be redacted by other means before reaching the model.
- `CryptoRecognizer` — irrelevant for legal corpus; collides with random hex.
- `IbanRecognizer` — US-centric deployments rarely see; `US_BANK_NUMBER` covers the use case.
- `IpRecognizer` — extreme FP rate on version numbers, page refs, dotted numeric IDs.
- `MedicalLicenseRecognizer` — niche; collides with case numbers.

Healthcare deployments can re-enable `MedicalLicenseRecognizer` per the operator guide.

## PR ordering note

Cut from `m2-development` at `03986fc` (M2-A3 merged); rebased through PR #25 (M2-B1) merging during this session. **Zero file overlap** with any other open PR — B2 is purely in `gateway/`, B1 was purely in `api/`.

Refs: `docs/M2-IMPLEMENTATION-PLAN.md` §M2-B2, `docs/PRD.md` §4.7, M2 decision **M2-1** (pseudonymize chat/skill content only; documents stay un-pseudonymized).