### PR TITLE
feat(gateway,api,m2-b3): anonymization middleware wired end-to-end

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -1066,11 +1066,19 @@ async def send_message(
     # of a tier floor (per PRD §4.4 / D1). The backend is authoritative
     # on chat ↔ project; the gateway never queries projects directly,
     # so the value travels on the request envelope.
+    # M2-B3: also resolve ``Project.privileged`` so the gateway's
+    # anonymization middleware can short-circuit for privileged chats.
+    # Cheaper to fetch both in one SELECT than two round-trips.
     project_floor: int | None = None
+    project_privileged: bool = False
     if chat.project_id is not None:
-        project_stmt = select(Project.minimum_inference_tier).where(Project.id == chat.project_id)
-        project_result = await db.execute(project_stmt)
-        project_floor = project_result.scalar_one_or_none()
+        project_stmt = select(Project.minimum_inference_tier, Project.privileged).where(
+            Project.id == chat.project_id
+        )
+        project_row = (await db.execute(project_stmt)).one_or_none()
+        if project_row is not None:
+            project_floor = project_row[0]
+            project_privileged = bool(project_row[1])
 
     # Wave D.1 T7b — RAG step: when the chat's project has KBs attached,
     # run hybrid_search across all of them for the user's just-sent
@@ -1145,6 +1153,7 @@ async def send_message(
         lq_ai_skill_inputs=dict(effective_skill_inputs),
         lq_ai_inline_skills=list(inline_skill_refs),
         lq_ai_project_minimum_inference_tier=project_floor,
+        lq_ai_privileged=project_privileged,
     )
 
     log.info(

--- a/api/app/schemas/gateway.py
+++ b/api/app/schemas/gateway.py
@@ -122,6 +122,15 @@ class ChatCompletionRequest(BaseModel):
     chat_id: str | None = None
     anonymize: bool = True
 
+    lq_ai_privileged: bool = False
+    """M2-B3: backend forwards ``Project.privileged`` here when the chat
+    lives in a project. The gateway's anonymization middleware skips
+    entirely on ``True`` — rewriting attorney-client privileged work
+    product risks corrupting it, so the conservative posture is
+    "don't touch it." Defaults False so chats outside any project (and
+    chats whose project is non-privileged) get the normal middleware
+    behavior."""
+
     # --- C2 (skill prompt assembly per ADR 0007) -----------------------------
     lq_ai_skills: list[str] = Field(default_factory=list, max_length=16)
     """Skill names to attach. The gateway fetches each from

--- a/api/tests/test_chats_tier_floor.py
+++ b/api/tests/test_chats_tier_floor.py
@@ -165,6 +165,11 @@ async def test_project_minimum_tier_forwarded_to_gateway(
 
     sent_body = _json.loads(route.calls[0].request.read())
     assert sent_body["lq_ai_project_minimum_inference_tier"] == 3
+    # M2-B3: ``project.privileged=True`` propagates so the gateway
+    # anonymization middleware skips for privileged chats. The
+    # ``project_with_floor`` fixture sets privileged=True (the CHECK
+    # constraint requires it whenever minimum_inference_tier is set).
+    assert sent_body["lq_ai_privileged"] is True
 
 
 @pytest.mark.integration
@@ -190,6 +195,9 @@ async def test_chat_outside_project_does_not_forward_project_floor(
     sent_body = _json.loads(route.calls[0].request.read())
     # The field is omitted (exclude_none) when there's no project floor.
     assert "lq_ai_project_minimum_inference_tier" not in sent_body
+    # M2-B3: ``lq_ai_privileged`` defaults False; either omitted or
+    # explicitly False. Either way, must not be True.
+    assert sent_body.get("lq_ai_privileged", False) is False
 
 
 @pytest.mark.integration

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1205,7 +1205,7 @@ models:
     cost_per_1k_output_tokens_usd: 0.004
   - alias: local
     provider: ollama
-    model: llama3.1:70b
+    model: qwen3.5:9b
 
 routing:
   default: smart

--- a/docs/adr/0011-transparency-first-model-selection.md
+++ b/docs/adr/0011-transparency-first-model-selection.md
@@ -58,7 +58,7 @@ Chat-completion requests can send a fully-qualified model identifier:
 ```
 model: "anthropic/claude-opus-4-7"
 model: "openai/gpt-4o"
-model: "ollama/llama3.1:70b"
+model: "ollama/qwen3.5:9b"
 model: "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0"
 ```
 

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -86,7 +86,7 @@ paths:
           gateway's `model_aliases` config, with the alias's fallback
           chain applied on primary failure.
         * **A direct `<provider>/<model>` form** (`anthropic-prod/claude-opus-4-7`,
-          `openai-prod/gpt-4o`, `ollama-local/llama3.1:8b`) — dispatched
+          `openai-prod/gpt-4o`, `ollama-local/qwen3.5:9b`) — dispatched
           directly to that provider with **no fallback chain**. Per
           ADR 0011: the transparency principle requires users / admins
           to be able to pick a specific model without alias indirection.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -342,7 +342,7 @@ You configured `allowed_tiers_global` to disallow Tier 4 in setup item 2; either
 
 ### "I want to use Mode 2 (local Ollama) instead"
 
-Replace `docker compose up -d` with `docker compose --profile local up -d`. The local profile starts an `ollama` container alongside the rest of the stack; pull a model into it once with `docker compose exec ollama ollama pull llama3.1:8b` (a few GB) before the first inference call. The gateway-side wiring is automatic — `gateway.yaml.example` ships with `local-fast` (Llama 3.1 8B) and `local-thinking` (Llama 3.1 70B) aliases that route to the local Ollama service at `http://ollama:11434`.
+Replace `docker compose up -d` with `docker compose --profile local up -d`. The local profile starts an `ollama` container alongside the rest of the stack; pull a model into it once with `docker compose exec ollama ollama pull qwen3.5:9b` (a few GB) before the first inference call. The gateway-side wiring is automatic — `gateway.yaml.example` ships with `local-fast` (Qwen 3.5 4B) and `local-thinking` (Qwen 3.5 9B) aliases that route to the local Ollama service at `http://ollama:11434`. Operators are free to repoint either alias at any model the local Ollama can serve; change `gateway.yaml.example` accordingly and pull the corresponding tag.
 
 To exercise the local path with `curl`:
 

--- a/docs/security/anonymization.md
+++ b/docs/security/anonymization.md
@@ -2,7 +2,7 @@
 
 > **Purpose.** Document the entity types LQ.AI's Anonymization Layer (PRD §4.7) recognizes by default, the deliberately-disabled defaults, and how to customize the recognizer set for a specific deployment's matter-numbering convention or domain-specific entities.
 >
-> **Status (2026-05-16).** M2-B2: custom legal recognizers shipped and the Presidio `AnalyzerEngine` is configured. Gateway middleware integration (the request/response pseudonymize/rehydrate path) lands in M2-B3.
+> **Status (2026-05-16).** M2-B3 complete: the gateway middleware now pseudonymizes outbound chat/skill content and rehydrates the response (streaming and non-streaming). M2-B2's custom legal recognizers + Presidio `AnalyzerEngine` configuration remain unchanged; M2-A3's `PseudonymMapper` is the request-scoped substitution table.
 
 ---
 
@@ -123,6 +123,56 @@ The plan §M2-F2 explicitly calls for an acceptance corpus of legal documents to
 - They almost never over-match (false positives are rare in normal prose).
 
 If your deployment surfaces under-matching in practice (the M2 Anonymization round-trip tests in M2-C3 will help), the right response is to add deployment-specific recognizers rather than loosening the existing patterns globally.
+
+---
+
+## Middleware behavior (M2-B3)
+
+The gateway runs two passes around the provider call:
+
+```
+Auth → Router → Rate Limit → Tier Derivation
+                 → Anonymization-Pre  (substitute)
+                 → Provider Adapter
+                 → Anonymization-Post (rehydrate)
+              → Cost Tracker → Telemetry
+```
+
+### When the middleware fires
+
+All four conditions must hold; the first that fails short-circuits to a no-op for the entire pass (provider receives unmodified content; response is not touched; audit row records `anonymization_applied = false`).
+
+| Condition | Source | Default |
+|---|---|---|
+| `gateway.yaml` `anonymization.enabled = true` | Operator config | **false** — feature flag stays off until the deployment opts in. |
+| Request's routed tier is in `anonymization.apply_at_tiers` | Operator config | `[3, 4, 5]` — local Tier 1 / Tier 2 inference skips because the data never leaves the operator's environment. |
+| Request's `lq_ai_privileged` is `false` | Backend forwards `Project.privileged` | False for chats outside any project, or in non-privileged projects. |
+| Request's `anonymize` is `true` | Per-call body field | True. Callers send `anonymize: false` only when they need the raw text on the provider call (evaluation, raw-passthrough scenarios). |
+
+### What the pre-pass touches
+
+- Every `messages[*]` whose role is `user`, `assistant`, or `system` and whose `content` is non-null. Tool-call shaped messages (`content: null`) are left alone.
+- Every string leaf inside `lq_ai_skill_inputs` (recursive — dicts and lists are walked). Numbers, booleans, and `null` pass through untouched.
+
+### What the post-pass touches
+
+**Non-streaming.** Each `choices[*].message.content` is rehydrated in place. The response body the caller sees has only originals, never pseudonyms.
+
+**Streaming.** Each SSE chunk's `choices[*].delta.content` is fed through a per-stream `StreamingRehydrator`. The rehydrator holds the tail of the stream when it ends in a partial pseudonym (e.g. `PERSON_` or `PERSON_0001` with no trailing space — could grow to `PERSON_00010`). Held text emits as soon as the pattern crystallizes or fails to grow. At `[DONE]`, any held tail flushes as a synthesized terminal chunk so the caller doesn't lose the last fragment. The buffer is bounded by the length of one in-flight pseudonym (~25 chars in practice), so streaming latency is unaffected.
+
+Per **Decision D**: the middleware rehydrates response **content** only. Citation rehydration is incidental — the api/'s downstream citation extraction operates on already-rehydrated content, so cite quotes naturally carry originals. The gateway never touches `message_citations` rows directly.
+
+### Audit log
+
+Every routed request writes one row to `inference_routing_log`. The middleware sets `anonymization_applied = true` on every row whose request passed all four firing conditions — including rows where the upstream later failed (the substitution did happen; the provider just then returned an error). Tier-floor refusals (which short-circuit before the pre-pass) leave the flag `false` because no substitution happened.
+
+### Where mappings live
+
+Per **Decision A** and **Decision B (i)** locked in M2-B3 kickoff: a fresh `PseudonymMapper` is constructed inside the request scope, populated by the pre-pass, read by the post-pass, and dropped on function exit. **It is never persisted, never logged, and never serialized to any side channel.** A new request gets a new mapper; counters reset every time.
+
+### Privileged chats — why we skip
+
+The privileged-Project skip (Decision A) is a deliberate trade-off. Privileged chats are work product the attorney-client privilege protects; replacing names with pseudonyms before the model sees them — even with the rehydration on the way back — risks corrupting that work product if any step in the pipeline behaves unexpectedly. The conservative posture is to leave privileged content untouched. Operators who want pseudonymization in privileged chats can flip `lq_ai_privileged` off at the api/ layer per chat, but the default protects the legal-work-product invariant.
 
 ---
 

--- a/gateway.yaml.example
+++ b/gateway.yaml.example
@@ -151,10 +151,9 @@ providers:
     api_key_env: ''  # Ollama doesn't require an API key
     tier: 1  # Fully local; no data leaves the deployment
     models:
-      - llama3.1:70b
-      - llama3.1:8b
-      - mistral-large
-      - qwen2.5:72b
+      - qwen3.5:9b
+      - qwen3.5:4b-nvfp4
+      - gemma4:e4b
     enabled: ${LOCAL_INFERENCE_ENABLED:-true}
 
   - name: vllm-local
@@ -212,7 +211,7 @@ model_aliases:
   local:
     primary:
       provider: ollama-local
-      model: llama3.1:70b
+      model: qwen3.5:9b
     fallback: []  # No fallback for local — Tier 1 must stay Tier 1
 
   # Mode-2 friendly aliases (B6 partial). Skills and the chat UI ask
@@ -220,16 +219,23 @@ model_aliases:
   # the air-gapped local model. Both stay Tier 1 — the fallback list is
   # empty so a missing local provider surfaces as a clean 503 rather
   # than silently degrading to a cloud Tier 4 path.
+  #
+  # Default model choices reflect what a current Ollama install can
+  # actually serve well in 2026. Qwen3.5 is the family we ship behind
+  # the Mode-2 aliases (PRD §6.1); operators free to repoint at any
+  # ollama-served model by editing this section. The "fast" / "thinking"
+  # split mirrors the cloud split — 4b for low-latency, 9b when the
+  # quality lift is worth the wall-clock.
   local-fast:
     primary:
       provider: ollama-local
-      model: llama3.1:8b
+      model: qwen3.5:4b-nvfp4
     fallback: []
 
   local-thinking:
     primary:
       provider: ollama-local
-      model: llama3.1:70b
+      model: qwen3.5:9b
     fallback: []
 
   # The 'embedding' alias is the alias the backend's KB layer (C6)
@@ -411,19 +417,13 @@ cost_tracking:
     'openai-prod/gpt-4o-mini':
       input_per_mtok: 0.15
       output_per_mtok: 0.60
-    'ollama-local/llama3.1:70b':
+    'ollama-local/qwen3.5:9b':
       input_per_mtok: 0.0  # Local; no per-token cost
       output_per_mtok: 0.0
-    'ollama-local/llama3.1:8b':
+    'ollama-local/qwen3.5:4b-nvfp4':
       input_per_mtok: 0.0
       output_per_mtok: 0.0
-    'ollama-local/llama3.1':
-      input_per_mtok: 0.0
-      output_per_mtok: 0.0
-    'ollama-local/mistral-large':
-      input_per_mtok: 0.0
-      output_per_mtok: 0.0
-    'ollama-local/qwen2.5:72b':
+    'ollama-local/gemma4:e4b':
       input_per_mtok: 0.0
       output_per_mtok: 0.0
     # Embedding rates — OpenAI text-embedding-3-* charges only on

--- a/gateway/app/anonymization/engine.py
+++ b/gateway/app/anonymization/engine.py
@@ -39,7 +39,7 @@ test suite that just exercises the custom recognizers in isolation
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from app.anonymization.mapper import PseudonymMapper
 from app.anonymization.recognizers.case_number import CaseNumberRecognizer
@@ -47,6 +47,20 @@ from app.anonymization.recognizers.matter_number import MatterNumberRecognizer
 
 if TYPE_CHECKING:
     from presidio_analyzer import AnalyzerEngine
+
+
+class _AnalyzerProtocol(Protocol):
+    """Subset of :class:`presidio_analyzer.AnalyzerEngine` we depend on.
+
+    Lets :class:`Anonymizer` accept either the real Presidio engine
+    (the production path) or a test double in unit tests, without
+    importing Presidio just for type-checking. The real engine's
+    ``analyze`` returns ``list[RecognizerResult]``; we only read
+    ``entity_type``, ``start``, ``end`` (and ``score`` for overlap
+    tie-breaks), which both shapes expose.
+    """
+
+    def analyze(self, *, text: str, language: str = "en") -> list[Any]: ...
 
 # Default-recognizer configuration for legal-document corpus.
 #
@@ -173,41 +187,152 @@ class AnonymizationResult:
 class Anonymizer:
     """Pseudonymize entities in outbound text; rehydrate on the response path.
 
-    Method bodies stubbed until M2-B3 lands the gateway middleware
-    and decides on the exact substitution strategy (length-ordered
-    ``str.replace`` vs. regex-based, ordering when one pseudonym is a
-    prefix of another, etc.). The signatures are final so M2-B3
-    middleware + M2-C3 round-trip tests can target a stable shape.
+    Instances are lightweight and stateless beyond the (optionally
+    injected) analyzer. The middleware allocates one Anonymizer +
+    one :class:`PseudonymMapper` per request; the analyzer dependency
+    is the module-level singleton (``get_analyzer_engine``) by default
+    so spaCy stays loaded across requests, but tests inject a stub to
+    keep the fast-feedback path off the spaCy model.
+
+    Two entry points:
+
+    * :meth:`pseudonymize_into` — extends an existing mapper with
+      substitutions from ``text``. The middleware uses this so the
+      same name appearing across multiple messages resolves to the
+      same pseudonym.
+    * :meth:`pseudonymize` — one-shot convenience that wraps a fresh
+      mapper in an :class:`AnonymizationResult`. Useful in tests and
+      single-text callers; the middleware does NOT use this.
     """
 
-    def pseudonymize(self, text: str) -> AnonymizationResult:
-        """Return an :class:`AnonymizationResult` with pseudonymized text.
+    def __init__(self, analyzer: _AnalyzerProtocol | None = None) -> None:
+        """Inject an analyzer or fall back to the module singleton lazily.
 
-        Stub until M2-B3 wires the gateway request-path middleware.
-        The implementation will call :func:`get_analyzer_engine` for
-        entity recognition and a Presidio :class:`AnonymizerEngine`
-        for substitution; M2-B2 (this task) made the analyzer
-        available, M2-B3 ties it to the request path.
+        Passing ``analyzer=None`` (the default) defers the analyzer
+        lookup to first ``pseudonymize_into`` call — Anonymizer
+        construction never triggers a spaCy load on its own.
         """
 
-        raise NotImplementedError(
-            "Anonymizer.pseudonymize is a stub until M2-B3 wires the gateway "
-            "request-path middleware. M2-B2 made the AnalyzerEngine + custom "
-            "recognizers available via get_analyzer_engine()."
-        )
+        self._analyzer = analyzer
+
+    def _resolve_analyzer(self) -> _AnalyzerProtocol:
+        analyzer = self._analyzer
+        if analyzer is None:
+            # ``AnalyzerEngine`` (the real Presidio type) satisfies
+            # ``_AnalyzerProtocol`` structurally — both expose
+            # ``analyze(text, language)`` returning a list. mypy can't
+            # verify that because Presidio's types are untyped at the
+            # third-party boundary, so we cast at the import edge.
+            analyzer = cast(_AnalyzerProtocol, get_analyzer_engine())
+            self._analyzer = analyzer
+        return analyzer
+
+    def pseudonymize(self, text: str) -> AnonymizationResult:
+        """One-shot: pseudonymize ``text`` against a fresh mapper.
+
+        Returns an :class:`AnonymizationResult` carrying the substituted
+        text + the freshly populated mapper. The middleware does NOT
+        use this — it allocates one mapper per request and threads it
+        through :meth:`pseudonymize_into` for each message — but
+        single-text callers (tests, one-off rehydration scripts) get a
+        clean façade.
+        """
+
+        mapper = PseudonymMapper()
+        substituted = self.pseudonymize_into(text, mapper)
+        return AnonymizationResult(text=substituted, mapper=mapper)
+
+    def pseudonymize_into(self, text: str, mapper: PseudonymMapper) -> str:
+        """Extend ``mapper`` with substitutions from ``text``; return the result.
+
+        Walks the analyzer's spans, resolves overlapping detections to
+        the longer span (ties broken by score), then substitutes
+        right-to-left so earlier offsets stay valid. Calling
+        :meth:`PseudonymMapper.assign` for an already-known
+        ``(entity_type, original)`` reuses the prior pseudonym, so the
+        same name across multiple ``pseudonymize_into`` calls on the
+        same mapper resolves to the same pseudonym.
+
+        Empty text short-circuits; the analyzer is never called.
+        """
+
+        if not text:
+            return text
+
+        analyzer = self._resolve_analyzer()
+        results = analyzer.analyze(text=text, language="en")
+        spans = _resolve_overlaps(results)
+
+        # Two-pass substitution. Pass 1 walks spans left-to-right and
+        # calls ``mapper.assign`` so the per-entity-type counter
+        # increments in *reading* order (``PERSON_0001`` is the first
+        # name in the text, not the last). Pass 2 splices substitutions
+        # in right-to-left order so earlier ``(start, end)`` offsets
+        # stay valid as the text length changes around each splice.
+        ordered = sorted(spans, key=lambda s: s.start)
+        pseudonyms: list[tuple[Any, str]] = [
+            (span, mapper.assign(span.entity_type, text[span.start : span.end]))
+            for span in ordered
+        ]
+
+        out = text
+        for span, pseudonym in reversed(pseudonyms):
+            out = out[: span.start] + pseudonym + out[span.end :]
+        return out
 
     def rehydrate(self, text: str, mapper: PseudonymMapper) -> str:
         """Walk pseudonyms in ``text`` and substitute originals.
 
-        Stub until M2-B3 lands the response-path middleware. The
-        implementation is straightforward (one pass over
-        ``mapper.reverse()`` items, ``str.replace`` for each ordered
-        by descending length so prefix-collisions like
-        ``PERSON_0001`` vs ``PERSON_00010`` resolve correctly) but
-        M2-B3 makes the call alongside the streaming-response handling.
+        One pass over ``mapper.reverse()`` items, ``str.replace`` for
+        each pseudonym ordered by descending length. The ordering is
+        load-bearing: without it a shorter pseudonym (``PERSON_0001``)
+        would match-and-replace inside a longer one (``PERSON_00010``)
+        and mangle the output.
+
+        Empty mapper, empty text, and text containing no pseudonyms
+        all return cleanly (an empty ``reverse()`` table makes the
+        loop a no-op).
         """
 
-        raise NotImplementedError(
-            "Anonymizer.rehydrate is a stub until M2-B3 lands the response-"
-            "path middleware. M2-A3 ships PseudonymMapper only."
-        )
+        if not text:
+            return text
+        for pseudonym, original in sorted(
+            mapper.reverse().items(), key=lambda kv: len(kv[0]), reverse=True
+        ):
+            text = text.replace(pseudonym, original)
+        return text
+
+
+def _resolve_overlaps(results: list[Any]) -> list[Any]:
+    """Collapse overlapping analyzer spans to one per region.
+
+    Presidio's :class:`AnalyzerEngine` returns every recognizer's hit;
+    two recognizers detecting the same span (e.g. ``PERSON`` and a
+    false-positive ``US_BANK_NUMBER`` on ``John Smith``) surface as
+    two results. The substitution loop must see one span per region or
+    it will try to splice inside an already-substituted pseudonym.
+
+    Resolution: sort by ``(span_length, score)`` descending and walk;
+    for each span, drop any later span whose ``[start, end)`` overlaps
+    one already kept. Longest wins; same length → higher score wins.
+    """
+
+    if not results:
+        return []
+    ordered = sorted(
+        results,
+        key=lambda r: (r.end - r.start, getattr(r, "score", 0.0)),
+        reverse=True,
+    )
+    kept: list[Any] = []
+    for span in ordered:
+        if any(_overlaps(span, k) for k in kept):
+            continue
+        kept.append(span)
+    return kept
+
+
+def _overlaps(a: Any, b: Any) -> bool:
+    """True iff ``[a.start, a.end)`` and ``[b.start, b.end)`` share any char."""
+
+    return bool(a.start < b.end and b.start < a.end)

--- a/gateway/app/anonymization/engine.py
+++ b/gateway/app/anonymization/engine.py
@@ -62,6 +62,7 @@ class _AnalyzerProtocol(Protocol):
 
     def analyze(self, *, text: str, language: str = "en") -> list[Any]: ...
 
+
 # Default-recognizer configuration for legal-document corpus.
 #
 # **Enabled** — these recognizers pay off on legal prose; the
@@ -271,8 +272,7 @@ class Anonymizer:
         # stay valid as the text length changes around each splice.
         ordered = sorted(spans, key=lambda s: s.start)
         pseudonyms: list[tuple[Any, str]] = [
-            (span, mapper.assign(span.entity_type, text[span.start : span.end]))
-            for span in ordered
+            (span, mapper.assign(span.entity_type, text[span.start : span.end])) for span in ordered
         ]
 
         out = text

--- a/gateway/app/anonymization/middleware.py
+++ b/gateway/app/anonymization/middleware.py
@@ -213,9 +213,7 @@ def post_anonymize_response(
         choice.message.content = anonymizer.rehydrate(choice.message.content, mapper)
 
 
-def _pseudonymize_strings(
-    value: Any, *, anonymizer: Anonymizer, mapper: PseudonymMapper
-) -> Any:
+def _pseudonymize_strings(value: Any, *, anonymizer: Anonymizer, mapper: PseudonymMapper) -> Any:
     """Recursively pseudonymize string leaves; pass other types through.
 
     Skill-input values are arbitrary JSON-shaped (dict/list/str/int/
@@ -228,7 +226,10 @@ def _pseudonymize_strings(
     if isinstance(value, str):
         return anonymizer.pseudonymize_into(value, mapper)
     if isinstance(value, dict):
-        return {k: _pseudonymize_strings(v, anonymizer=anonymizer, mapper=mapper) for k, v in value.items()}
+        return {
+            k: _pseudonymize_strings(v, anonymizer=anonymizer, mapper=mapper)
+            for k, v in value.items()
+        }
     if isinstance(value, list):
         return [_pseudonymize_strings(v, anonymizer=anonymizer, mapper=mapper) for v in value]
     return value

--- a/gateway/app/anonymization/middleware.py
+++ b/gateway/app/anonymization/middleware.py
@@ -1,0 +1,234 @@
+"""Pre/post anonymization middleware — M2-B3.
+
+The gateway's substitution surface. Sits between Tier Derivation and
+the Provider Adapter (PRD §4.3) on the request path; wraps the
+provider's streaming or non-streaming output on the response path.
+
+Three callables form the public API:
+
+* :func:`pre_anonymize_request` — request-path substitution. Mutates
+  ``chat_request`` in place to replace entity text with pseudonyms.
+  Returns the populated :class:`PseudonymMapper` so the response path
+  can rehydrate, or ``None`` if any skip condition is met (the
+  caller treats ``None`` as "skip the post-middleware too").
+* :func:`post_anonymize_response` — response-path substitution for
+  non-streaming responses. Walks each choice's message content and
+  replaces pseudonyms with originals.
+* :class:`StreamingRehydrator` — incremental tail-buffer rehydrator
+  for streaming responses. Solves Decision B (pseudonyms can straddle
+  SSE chunk boundaries): we hold an unresolved tail until a complete
+  pseudonym crystallizes or the chunk ends.
+
+Skip semantics (any one short-circuits to no-op):
+
+1. ``config.enabled is False`` — master switch.
+2. ``routed_tier not in config.apply_at_tiers`` — Tier 1 (local)
+   doesn't benefit, and operators can configure which tiers do.
+3. ``chat_request.lq_ai_privileged is True`` — Decision A; privileged
+   chats are not substituted because rewriting privileged work
+   product risks corrupting it.
+4. ``chat_request.anonymize is False`` — per-request opt-out.
+
+The conditions are checked top-down; the first hit wins. The mapper
+is allocated only when all four conditions pass — when allocation
+fails we never persist anything, so a skipped request leaves the
+audit log clean.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.anonymization.engine import Anonymizer
+from app.anonymization.mapper import PseudonymMapper
+from app.config import AnonymizationConfig
+from app.providers.openai_schema import ChatCompletionRequest, ChatCompletionResponse
+
+__all__ = [
+    "StreamingRehydrator",
+    "post_anonymize_response",
+    "pre_anonymize_request",
+]
+
+
+# Semantic roles whose ``content`` is content the user (or model)
+# generated. ``tool`` messages carry tool-call payloads and shouldn't
+# be pseudonymized — those are structured outputs, not natural prose.
+_ANONYMIZED_ROLES: frozenset[str] = frozenset({"user", "assistant", "system"})
+
+
+def pre_anonymize_request(
+    *,
+    chat_request: ChatCompletionRequest,
+    config: AnonymizationConfig,
+    routed_tier: int,
+    anonymizer: Anonymizer,
+) -> PseudonymMapper | None:
+    """Pseudonymize ``chat_request`` in place; return mapper or ``None``.
+
+    Mutates ``chat_request.messages[*].content`` and the nested
+    string values in ``chat_request.lq_ai_skill_inputs`` so the
+    provider sees only pseudonyms. Returns the mapper carrying the
+    ``pseudonym → original`` mapping so the post-middleware can
+    rehydrate the response.
+
+    ``None`` is the skip signal — the caller short-circuits the
+    post-middleware on ``None`` so the response passes through
+    unchanged.
+    """
+
+    if not config.enabled:
+        return None
+    if routed_tier not in config.apply_at_tiers:
+        return None
+    if chat_request.lq_ai_privileged:
+        return None
+    if not chat_request.anonymize:
+        return None
+
+    mapper = PseudonymMapper()
+
+    for message in chat_request.messages:
+        if message.role not in _ANONYMIZED_ROLES:
+            continue
+        if message.content is None:
+            continue
+        message.content = anonymizer.pseudonymize_into(message.content, mapper)
+
+    if chat_request.lq_ai_skill_inputs:
+        for skill_name, inputs in chat_request.lq_ai_skill_inputs.items():
+            chat_request.lq_ai_skill_inputs[skill_name] = _pseudonymize_strings(
+                inputs, anonymizer=anonymizer, mapper=mapper
+            )
+
+    return mapper
+
+
+# Anchored to end of buffer: a sequence that starts with an uppercase
+# letter, continues with uppercase letters or underscores, optionally
+# followed by an underscore and (zero or more) digits, terminating at
+# end-of-string. This matches every "could still grow into a pseudonym"
+# tail state — from a lone uppercase letter to a fully formed token
+# whose next character might be another digit.
+#
+# Examples of partial-at-end matches (held):
+#   "P"            "PE"            "PERSON"            "PERSON_"
+#   "PERSON_0"     "PERSON_0001"   (could grow to PERSON_00010)
+#
+# Examples of *non*-matches (emit cleanly):
+#   "John"         (mixed case — not pseudonym-shaped)
+#   "PERSON_0001 " (trailing whitespace crystallizes the token)
+#   "hello!"       (no leading uppercase at tail)
+_PARTIAL_PSEUDONYM_AT_END: re.Pattern[str] = re.compile(r"[A-Z][A-Z_]*(?:_\d*)?$")
+
+
+class StreamingRehydrator:
+    """Tail-buffer SSE rehydrator (Decision B (i)) — pseudonym-aware.
+
+    Hands chunks of (provider-produced) text in via :meth:`process`;
+    emits the same text with pseudonyms substituted by their
+    originals. Holds at most a small tail (bounded by the longest
+    in-flight pseudonym, typically <30 chars) when the buffer ends in
+    a pattern that could still grow into a real pseudonym. Call
+    :meth:`flush` at end-of-stream to drain whatever's in the tail.
+
+    Invariants:
+
+    * **No partial pseudonyms ever emit.** A caller seeing the output
+      can rely on every byte being either a non-pseudonym character
+      or part of a fully rehydrated original.
+    * **Bounded buffering.** The buffer never holds more than one
+      partial-pseudonym pattern at a time — when a chunk completes
+      the pattern (or proves it wasn't one), the held tail flushes.
+      Latency is bounded by the pseudonym length, not the stream
+      length.
+    * **Empty mapper is a no-op.** :meth:`Anonymizer.rehydrate`
+      returns its input unchanged when the mapper has no
+      assignments, so streams that never produced entities cost only
+      the regex scan.
+    """
+
+    __slots__ = ("_anonymizer", "_buffer", "_mapper")
+
+    def __init__(self, *, mapper: PseudonymMapper, anonymizer: Anonymizer) -> None:
+        self._mapper = mapper
+        self._anonymizer = anonymizer
+        self._buffer: str = ""
+
+    def process(self, chunk: str) -> str:
+        """Absorb ``chunk``; return any text safe to emit (rehydrated)."""
+
+        if not chunk:
+            return ""
+        self._buffer += chunk
+
+        match = _PARTIAL_PSEUDONYM_AT_END.search(self._buffer)
+        if match is None:
+            # Nothing in the tail looks like an in-flight pseudonym;
+            # safe to emit everything we've buffered.
+            emit_raw = self._buffer
+            self._buffer = ""
+        else:
+            # Hold from the start of the trailing partial pseudonym.
+            emit_raw = self._buffer[: match.start()]
+            self._buffer = self._buffer[match.start() :]
+
+        if not emit_raw:
+            return ""
+        return self._anonymizer.rehydrate(emit_raw, self._mapper)
+
+    def flush(self) -> str:
+        """Emit whatever's in the tail, rehydrated. Clears the buffer."""
+
+        if not self._buffer:
+            return ""
+        out = self._anonymizer.rehydrate(self._buffer, self._mapper)
+        self._buffer = ""
+        return out
+
+
+def post_anonymize_response(
+    *,
+    response: ChatCompletionResponse,
+    mapper: PseudonymMapper,
+    anonymizer: Anonymizer,
+) -> None:
+    """Rehydrate each choice's message content in place.
+
+    Walks ``response.choices`` and replaces pseudonyms in each
+    ``message.content`` string with the originals from ``mapper``.
+    Choices whose content is ``None`` (tool-call shaped responses)
+    are left alone. Non-content fields (role, finish_reason, usage,
+    routing metadata) are untouched.
+
+    Per Decision D: the gateway rehydrates response *content* only.
+    Citation rehydration happens downstream in the api/'s citation
+    extraction, which operates on the already-rehydrated content.
+    """
+
+    for choice in response.choices:
+        if choice.message.content is None:
+            continue
+        choice.message.content = anonymizer.rehydrate(choice.message.content, mapper)
+
+
+def _pseudonymize_strings(
+    value: Any, *, anonymizer: Anonymizer, mapper: PseudonymMapper
+) -> Any:
+    """Recursively pseudonymize string leaves; pass other types through.
+
+    Skill-input values are arbitrary JSON-shaped (dict/list/str/int/
+    bool/None). Only ``str`` leaves carry natural-language content
+    worth pseudonymizing; numbers and booleans aren't entities the
+    analyzer recognizes anyway and round-tripping them through the
+    analyzer would just waste cycles.
+    """
+
+    if isinstance(value, str):
+        return anonymizer.pseudonymize_into(value, mapper)
+    if isinstance(value, dict):
+        return {k: _pseudonymize_strings(v, anonymizer=anonymizer, mapper=mapper) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_pseudonymize_strings(v, anonymizer=anonymizer, mapper=mapper) for v in value]
+    return value

--- a/gateway/app/api/inference.py
+++ b/gateway/app/api/inference.py
@@ -669,9 +669,7 @@ async def chat_completions(request: Request) -> JSONResponse | StreamingResponse
     # provider's response content back to the originals. The mapper is
     # then dropped on function exit — never persisted, never logged.
     if anon_mapper is not None:
-        post_anonymize_response(
-            response=result.response, mapper=anon_mapper, anonymizer=anonymizer
-        )
+        post_anonymize_response(response=result.response, mapper=anon_mapper, anonymizer=anonymizer)
 
     # --- Success: stamp tier on body, write log, return --------------------
     annotated = _annotate_response(result.response, target=result.target, config=config)

--- a/gateway/app/api/inference.py
+++ b/gateway/app/api/inference.py
@@ -61,6 +61,13 @@ from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import ValidationError
 
+from app.anonymization.engine import Anonymizer
+from app.anonymization.mapper import PseudonymMapper
+from app.anonymization.middleware import (
+    StreamingRehydrator,
+    post_anonymize_response,
+    pre_anonymize_request,
+)
 from app.clients.backend import BackendClient, Skill, get_backend_client
 from app.config import GatewayConfig
 from app.errors import LQAIError
@@ -261,6 +268,23 @@ def _backend(request: Request) -> BackendClient:
     if pre_built is not None:
         return pre_built
     return get_backend_client()
+
+
+def _anonymizer(request: Request) -> Anonymizer:
+    """Return the gateway's :class:`Anonymizer` (M2-B3).
+
+    The lifespan installs a process-global :class:`Anonymizer` on
+    ``app.state.anonymizer`` whose spaCy backbone loads lazily on the
+    first :meth:`Anonymizer.pseudonymize_into` call. Tests that bypass
+    lifespan (or want to inject a stub analyzer) can override
+    ``app.state.anonymizer`` directly — same pattern as
+    ``app.state.routing_log``.
+    """
+
+    pre_built: Anonymizer | None = getattr(request.app.state, "anonymizer", None)
+    if pre_built is not None:
+        return pre_built
+    return Anonymizer()
 
 
 def _inline_ref_to_skill(ref: InlineSkillRef) -> Skill:
@@ -579,6 +603,20 @@ async def chat_completions(request: Request) -> JSONResponse | StreamingResponse
             },
         )
 
+    # --- Anonymization pre-middleware (M2-B3) -------------------------------
+    # Sits between Tier Derivation and Provider Adapter per PRD §4.3.
+    # Mutates chat_request.messages[*].content + lq_ai_skill_inputs in
+    # place. Returns the mapper used for response-path rehydration, or
+    # ``None`` when any skip condition fires (master disabled / tier
+    # outside apply_at_tiers / privileged chat / per-request opt-out).
+    anonymizer = _anonymizer(request)
+    anon_mapper: PseudonymMapper | None = pre_anonymize_request(
+        chat_request=chat_request,
+        config=config.anonymization,
+        routed_tier=primary.routed_inference_tier,
+        anonymizer=anonymizer,
+    )
+
     # --- Streaming path -----------------------------------------------------
     if chat_request.stream:
         return await _stream_with_fallback(
@@ -588,6 +626,8 @@ async def chat_completions(request: Request) -> JSONResponse | StreamingResponse
             log_writer=log_writer,
             request_id=request_id,
             applied_skills=applied_skills,
+            anon_mapper=anon_mapper,
+            anonymizer=anonymizer,
         )
 
     # --- Non-streaming path -------------------------------------------------
@@ -605,6 +645,7 @@ async def chat_completions(request: Request) -> JSONResponse | StreamingResponse
             request_id=request_id,
             error=wrapped.error,
             latency_ms=wrapped.latency_ms,
+            anonymization_applied=anon_mapper is not None,
         )
         return _map_provider_error_to_response(wrapped.error)
     except NoAdapterAvailableError as exc:
@@ -614,6 +655,7 @@ async def chat_completions(request: Request) -> JSONResponse | StreamingResponse
             target=candidates[0],
             request_id=request_id,
             message=exc.message,
+            anonymization_applied=anon_mapper is not None,
         )
         return _gateway_error(
             code="provider_unavailable",
@@ -622,16 +664,27 @@ async def chat_completions(request: Request) -> JSONResponse | StreamingResponse
             details={"provider": candidates[0].provider.name},
         )
 
+    # --- Anonymization post-middleware (non-streaming) ----------------------
+    # When the pre-middleware fired (mapper is non-None), rehydrate the
+    # provider's response content back to the originals. The mapper is
+    # then dropped on function exit — never persisted, never logged.
+    if anon_mapper is not None:
+        post_anonymize_response(
+            response=result.response, mapper=anon_mapper, anonymizer=anonymizer
+        )
+
     # --- Success: stamp tier on body, write log, return --------------------
     annotated = _annotate_response(result.response, target=result.target, config=config)
     if applied_skills:
         annotated.lq_ai_applied_skills = list(applied_skills)
+    annotated.anonymization_applied = anon_mapper is not None
     await _write_success(
         log_writer,
         chat_request=chat_request,
         result=result,
         request_id=request_id,
         cost_estimate=annotated.cost_estimate,
+        anonymization_applied=anon_mapper is not None,
     )
     return JSONResponse(
         status_code=status.HTTP_200_OK,
@@ -861,6 +914,8 @@ async def _stream_with_fallback(
     log_writer: RoutingLogWriter,
     request_id: str,
     applied_skills: list[str] | None = None,
+    anon_mapper: PseudonymMapper | None = None,
+    anonymizer: Anonymizer | None = None,
 ) -> StreamingResponse:
     """Run the streaming path with primary + fallback chain.
 
@@ -902,6 +957,7 @@ async def _stream_with_fallback(
             target=candidates[0],
             request_id=request_id,
             message="no adapter available for streaming",
+            anonymization_applied=anon_mapper is not None,
         )
         return StreamingResponse(
             _single_error_sse(
@@ -943,6 +999,8 @@ async def _stream_with_fallback(
             log_writer=log_writer,
             request_id=request_id,
             applied_skills=applied_skills or [],
+            anon_mapper=anon_mapper,
+            anonymizer=anonymizer,
         ),
         media_type="text/event-stream",
         headers={
@@ -963,11 +1021,23 @@ async def _stream_openai_sse(
     log_writer: RoutingLogWriter,
     request_id: str,
     applied_skills: list[str] | None = None,
+    anon_mapper: PseudonymMapper | None = None,
+    anonymizer: Anonymizer | None = None,
 ) -> AsyncIterator[bytes]:
-    """Serialize chunks as OpenAI-format SSE frames; write log on completion."""
+    """Serialize chunks as OpenAI-format SSE frames; write log on completion.
 
-    final_usage: ChatCompletionRoutedResult | None = None  # noqa: F841
+    M2-B3: when ``anon_mapper`` is non-None, each chunk's
+    ``delta.content`` is fed through a per-stream
+    :class:`StreamingRehydrator` (Decision B (i)) so the bytes we
+    write to the wire contain only rehydrated text, never pseudonyms.
+    On stream completion, the rehydrator's buffer is flushed and
+    emitted as a synthesized terminal chunk if non-empty.
+    """
+
     last_chunk: ChatCompletionChunk | None = None
+    rehydrator: StreamingRehydrator | None = None
+    if anon_mapper is not None and anonymizer is not None:
+        rehydrator = StreamingRehydrator(mapper=anon_mapper, anonymizer=anonymizer)
 
     try:
         async for chunk in chunks:
@@ -975,6 +1045,11 @@ async def _stream_openai_sse(
             chunk.routed_inference_tier = target.routed_inference_tier
             if applied_skills:
                 chunk.lq_ai_applied_skills = list(applied_skills)
+            if rehydrator is not None:
+                for choice in chunk.choices:
+                    if choice.delta.content is None:
+                        continue
+                    choice.delta.content = rehydrator.process(choice.delta.content)
             last_chunk = chunk
             payload = chunk.model_dump(mode="json", exclude_none=True)
             yield f"data: {json.dumps(payload, separators=(',', ':'))}\n\n".encode()
@@ -988,9 +1063,27 @@ async def _stream_openai_sse(
             request_id=request_id,
             error=exc,
             latency_ms=None,
+            anonymization_applied=anon_mapper is not None,
         )
         yield b"data: [DONE]\n\n"
         return
+
+    # M2-B3: flush any held tail before [DONE] so the caller doesn't
+    # lose the last fragment of a pseudonym that crystallized only at
+    # stream end. We attach it to a synthesized terminal chunk with
+    # ``choices=[{delta: {content: tail}}]`` if the tail is non-empty,
+    # so existing SSE consumers parse it as a normal content delta.
+    if rehydrator is not None and last_chunk is not None:
+        tail = rehydrator.flush()
+        if tail:
+            terminal = last_chunk.model_copy(deep=True)
+            for choice in terminal.choices:
+                choice.delta.content = tail
+                choice.delta.role = None
+                choice.finish_reason = None
+            terminal.lq_ai_applied_skills = None
+            payload = terminal.model_dump(mode="json", exclude_none=True)
+            yield f"data: {json.dumps(payload, separators=(',', ':'))}\n\n".encode()
 
     yield b"data: [DONE]\n\n"
 
@@ -1017,6 +1110,7 @@ async def _stream_openai_sse(
             tokens_out=(usage.completion_tokens if usage is not None else None),
             cost_estimate=cost,
             latency_ms=None,  # streaming latency is wall-time; left null for now
+            anonymization_applied=anon_mapper is not None,
             request_id=request_id,
             chat_id=chat_id,
             message_id=message_id,
@@ -1092,6 +1186,7 @@ async def _write_success(
     result: ChatCompletionRoutedResult,
     request_id: str,
     cost_estimate: float | None,
+    anonymization_applied: bool = False,
 ) -> None:
     from decimal import Decimal as _Decimal
 
@@ -1110,6 +1205,7 @@ async def _write_success(
             tokens_out=result.response.usage.completion_tokens,
             cost_estimate=cost,
             latency_ms=result.latency_ms,
+            anonymization_applied=anonymization_applied,
             request_id=request_id,
             chat_id=chat_id,
             message_id=message_id,
@@ -1125,6 +1221,7 @@ async def _write_failure(
     request_id: str,
     error: ProviderAdapterError,
     latency_ms: int | None,
+    anonymization_applied: bool = False,
 ) -> None:
     """Write a routing-log row for a request that reached an adapter and failed.
 
@@ -1137,6 +1234,11 @@ async def _write_failure(
     row didn't carry usage data" — the schema's nullability accommodates
     that. D1 will tighten the semantics; we add a follow-up note in
     docs/M1-PROGRESS.md.
+
+    M2-B3: ``anonymization_applied`` records that the middleware fired
+    even though the upstream failed. The substitution happened on the
+    request path; auditors need to see that the provider received
+    pseudonymized content (it just then returned an error).
     """
 
     chat_id, message_id = _correlation_ids(chat_request)
@@ -1147,6 +1249,7 @@ async def _write_failure(
             routed_model=target.native_model,
             routed_inference_tier=target.routed_inference_tier,
             latency_ms=latency_ms,
+            anonymization_applied=anonymization_applied,
             refused=False,
             refusal_reason=f"upstream_error:{error.code}",
             request_id=request_id,
@@ -1163,6 +1266,7 @@ async def _write_unavailable(
     target: ResolvedTarget,
     request_id: str,
     message: str,
+    anonymization_applied: bool = False,
 ) -> None:
     """Write a routing-log row when no adapter could handle the request."""
 
@@ -1173,6 +1277,7 @@ async def _write_unavailable(
             routed_provider=target.provider.name,
             routed_model=target.native_model,
             routed_inference_tier=target.routed_inference_tier,
+            anonymization_applied=anonymization_applied,
             refused=False,
             refusal_reason=f"adapter_unavailable:{message}",
             request_id=request_id,

--- a/gateway/app/config.py
+++ b/gateway/app/config.py
@@ -248,11 +248,39 @@ class RateLimitsConfig(BaseModel):
 
 
 class AnonymizationConfig(BaseModel):
-    """``anonymization:`` block. M2 feature; A3 just loads it."""
+    """``anonymization:`` block. M2 feature.
+
+    Typed fields the M2-B3 middleware reads directly:
+
+    * :attr:`enabled` — master switch. ``False`` short-circuits the
+      pre/post middleware to a no-op regardless of per-request
+      ``anonymize`` flags or tier gating.
+    * :attr:`apply_at_tiers` — tier gate. The middleware fires only
+      when the request's routed tier is in this list. Tiers outside
+      ``[1, 5]`` raise a config-load error rather than silently
+      becoming a no-op.
+
+    Other keys from ``gateway.yaml.example`` (``entity_types`` etc.)
+    pass through under ``extra="allow"`` and are documented in
+    ``docs/security/anonymization.md``; M2-B3 does not depend on them
+    yet.
+    """
 
     model_config = ConfigDict(extra="allow")
 
     enabled: bool = False
+    apply_at_tiers: list[int] = Field(default_factory=list)
+
+    @field_validator("apply_at_tiers")
+    @classmethod
+    def _validate_tier_range(cls, value: list[int]) -> list[int]:
+        for tier in value:
+            if not 1 <= tier <= 5:
+                raise ValueError(
+                    f"apply_at_tiers entry {tier} is out of [1, 5] range; "
+                    "tiers run 1 (strongest) to 5 (weakest) per PRD §1.5.2."
+                )
+        return value
 
 
 class CostRateEntry(BaseModel):

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -51,6 +51,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 
 from app import __version__
+from app.anonymization.engine import Anonymizer
 from app.api import admin_router, inference_router
 from app.clients.backend import (
     BackendClient,
@@ -238,6 +239,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     model_discoverer = ModelDiscoverer()
     app.state.model_discoverer = model_discoverer
     logger.info("model discoverer wired (Ollama 60s TTL, Anthropic 300s TTL)")
+
+    # M2-B3: anonymization middleware façade. The Anonymizer is
+    # lightweight — instance state is just an analyzer reference —
+    # and the spaCy load is deferred to first use, so this is a
+    # no-cost startup hook even when the config disables the feature.
+    # Tests override ``app.state.anonymizer`` to inject a stub analyzer
+    # without touching the singleton.
+    app.state.anonymizer = Anonymizer()
+    logger.info("anonymization middleware wired (lazy analyzer load)")
 
     try:
         yield

--- a/gateway/app/providers/openai_schema.py
+++ b/gateway/app/providers/openai_schema.py
@@ -177,6 +177,23 @@ class ChatCompletionRequest(BaseModel):
 
     chat_id: str | None = None
     anonymize: bool = True
+    """Per-request anonymization opt-out (M2-B3). ``True`` (the default)
+    lets the gateway middleware pseudonymize entities before the
+    provider call when the deployment-level ``anonymization.enabled``
+    flag and tier gating both permit. ``False`` is the per-request
+    escape hatch — operators send it when they need the raw text on
+    the upstream call (e.g. running an evaluation that compares
+    original vs. rehydrated)."""
+
+    lq_ai_privileged: bool = False
+    """M2-B3: the chat lives inside an attorney-client privileged
+    Project (``projects.privileged = true`` in the backend). The
+    anonymization middleware skips entirely for privileged chats —
+    pseudonym rewriting of a privileged communication risks corrupting
+    the work product that privilege protects, so the conservative
+    posture is "don't touch it." Backend resolves the flag from the
+    project row and forwards it; the gateway never queries the
+    backend for it."""
 
     # --- C2 (skill prompt assembly per ADR 0007) -----------------------------
     lq_ai_skills: list[str] = Field(default_factory=list, max_length=16)

--- a/gateway/tests/anonymization/test_anonymizer.py
+++ b/gateway/tests/anonymization/test_anonymizer.py
@@ -1,0 +1,327 @@
+"""Anonymizer.pseudonymize + Anonymizer.rehydrate — M2-B3.
+
+The Anonymizer façade is the entry point the gateway middleware uses
+for the request-path substitution (pseudonymize) and the response-path
+restoration (rehydrate). M2-A3 shipped the class shape with stubs;
+M2-B2 made the AnalyzerEngine singleton available; M2-B3 (this task)
+fills in the methods.
+
+These tests cover pure-logic invariants that don't require the spaCy
+backbone:
+
+* ``rehydrate`` is pure string substitution against the mapper's
+  reverse() table — it never calls the analyzer.
+* ``pseudonymize`` *does* call the analyzer; the tests in this file
+  that exercise pseudonymize use a stub analyzer (a callable that
+  returns canned ``RecognizerResult`` tuples) so the spaCy load stays
+  off the fast-feedback path. The full end-to-end check (analyzer +
+  pseudonymize + rehydrate) lives in ``test_engine_integration.py``
+  under the ``slow`` marker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from app.anonymization.engine import Anonymizer
+from app.anonymization.mapper import PseudonymMapper
+
+# ---------------------------------------------------------------------------
+# Test doubles — a stub analyzer that mimics ``AnalyzerEngine.analyze``.
+#
+# Presidio's :class:`AnalyzerEngine` returns a list of
+# :class:`RecognizerResult` instances with ``entity_type``, ``start``,
+# ``end``, ``score``. We don't need the real engine in these unit tests —
+# the substitution logic is what we're exercising. A stub keeps spaCy off
+# the fast feedback path. End-to-end coverage with the real analyzer lives
+# in ``test_engine_integration.py`` under the ``slow`` marker.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Span:
+    """Mimics ``presidio_analyzer.RecognizerResult`` for what we read."""
+
+    entity_type: str
+    start: int
+    end: int
+    score: float = 0.85
+
+
+class _StubAnalyzer:
+    """Returns a canned list of spans regardless of input text.
+
+    Tests construct one per scenario with the spans they want surfaced.
+    The ``analyze`` signature matches Presidio's: ``analyze(text, language=...)``.
+    """
+
+    def __init__(self, spans: list[_Span]) -> None:
+        self._spans = spans
+
+    def analyze(self, *, text: str, language: str = "en", **_kwargs: object) -> list[_Span]:
+        return list(self._spans)
+
+
+# ---------------------------------------------------------------------------
+# rehydrate — pure string substitution. No analyzer involved.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_rehydrate_substitutes_single_pseudonym() -> None:
+    """A pseudonym in the text is replaced with its mapped original."""
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")  # → PERSON_0001
+
+    out = Anonymizer().rehydrate("PERSON_0001 signed the agreement.", mapper)
+
+    assert out == "John Smith signed the agreement."
+
+
+@pytest.mark.unit
+def test_rehydrate_substitutes_multiple_distinct_pseudonyms() -> None:
+    """Every pseudonym in the text gets its own substitution."""
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")  # PERSON_0001
+    mapper.assign("PERSON", "Jane Doe")  # PERSON_0002
+    mapper.assign("ORGANIZATION", "Acme LLP")  # ORGANIZATION_0001
+
+    text = (
+        "PERSON_0001 and PERSON_0002 of ORGANIZATION_0001 signed the deal."
+    )
+    out = Anonymizer().rehydrate(text, mapper)
+
+    assert out == "John Smith and Jane Doe of Acme LLP signed the deal."
+
+
+@pytest.mark.unit
+def test_rehydrate_handles_repeated_pseudonym() -> None:
+    """The same pseudonym appearing twice is replaced both times."""
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")
+
+    out = Anonymizer().rehydrate(
+        "PERSON_0001 emailed PERSON_0001 to confirm.", mapper
+    )
+
+    assert out == "John Smith emailed John Smith to confirm."
+
+
+@pytest.mark.unit
+def test_rehydrate_handles_prefix_collision() -> None:
+    """``PERSON_00010`` must not be matched-then-broken by ``PERSON_0001``.
+
+    Without length-ordered substitution, replacing ``PERSON_0001`` first
+    would mangle ``PERSON_00010`` into ``John Smith0``. The rehydrator
+    must substitute longer pseudonyms before shorter ones.
+    """
+
+    mapper = PseudonymMapper()
+    # Force the assignments so we get specific pseudonyms regardless of
+    # internal counter behavior. We use the mapper's public assign() API
+    # and verify the contract holds for whatever pseudonyms it produces.
+    p1 = mapper.assign("PERSON", "John Smith")  # PERSON_0001
+    # Cheat: directly extend the mapping to inject a longer pseudonym
+    # that would collide on prefix. This mirrors what would happen at
+    # counter overflow past 9999.
+    mapper._assignments[("PERSON", "Janet Doe")] = "PERSON_00010"
+
+    text = "PERSON_0001 and PERSON_00010 met."
+    out = Anonymizer().rehydrate(text, mapper)
+
+    # Both substitutions correct, neither mangled.
+    assert out == "John Smith and Janet Doe met."
+    # Sanity check the assigned pseudonym above is what we think.
+    assert p1 == "PERSON_0001"
+
+
+@pytest.mark.unit
+def test_rehydrate_text_with_no_pseudonyms_is_identity() -> None:
+    """Text containing no pseudonyms passes through unchanged."""
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")
+
+    text = "The agreement was signed yesterday."
+    assert Anonymizer().rehydrate(text, mapper) == text
+
+
+@pytest.mark.unit
+def test_rehydrate_empty_mapper_is_identity() -> None:
+    """An empty mapper has no substitutions to make; text is identical."""
+
+    text = "PERSON_0001 is a pseudonym that has no mapping."
+    assert Anonymizer().rehydrate(text, PseudonymMapper()) == text
+
+
+@pytest.mark.unit
+def test_rehydrate_empty_text_is_empty() -> None:
+    """Empty text returns empty regardless of mapper state."""
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")
+
+    assert Anonymizer().rehydrate("", mapper) == ""
+
+
+# ---------------------------------------------------------------------------
+# pseudonymize_into — extend an existing mapper with substitutions from text.
+# Tests use a stub analyzer (see top of file) so spaCy stays off the fast path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_substitutes_single_span() -> None:
+    """A single PERSON span is substituted with the mapper's pseudonym."""
+
+    analyzer = _StubAnalyzer([_Span("PERSON", 0, 10)])  # "John Smith"
+    mapper = PseudonymMapper()
+
+    out = Anonymizer(analyzer=analyzer).pseudonymize_into(
+        "John Smith signed the agreement.", mapper
+    )
+
+    assert out == "PERSON_0001 signed the agreement."
+    assert mapper.reverse() == {"PERSON_0001": "John Smith"}
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_multiple_distinct_entities() -> None:
+    """Distinct PERSON spans get distinct pseudonyms; counter increments."""
+
+    text = "John Smith and Jane Doe met."
+    spans = [
+        _Span("PERSON", 0, 10),  # John Smith
+        _Span("PERSON", 15, 23),  # Jane Doe
+    ]
+    mapper = PseudonymMapper()
+
+    out = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize_into(text, mapper)
+
+    assert out == "PERSON_0001 and PERSON_0002 met."
+    assert mapper.reverse() == {"PERSON_0001": "John Smith", "PERSON_0002": "Jane Doe"}
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_same_name_twice_stable_pseudonym() -> None:
+    """The same name appearing twice in one text resolves to one pseudonym."""
+
+    text = "John Smith emailed John Smith to confirm."
+    spans = [
+        _Span("PERSON", 0, 10),  # John Smith (first)
+        _Span("PERSON", 19, 29),  # John Smith (second)
+    ]
+    mapper = PseudonymMapper()
+
+    out = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize_into(text, mapper)
+
+    assert out == "PERSON_0001 emailed PERSON_0001 to confirm."
+    # Mapper has one assignment, not two.
+    assert mapper.reverse() == {"PERSON_0001": "John Smith"}
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_per_type_counter_independence() -> None:
+    """PERSON and ORGANIZATION counters increment independently."""
+
+    text = "John Smith of Acme Corp signed."
+    spans = [
+        _Span("PERSON", 0, 10),  # John Smith
+        _Span("ORGANIZATION", 14, 23),  # Acme Corp
+    ]
+    mapper = PseudonymMapper()
+
+    out = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize_into(text, mapper)
+
+    assert out == "PERSON_0001 of ORGANIZATION_0001 signed."
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_extends_existing_mapper() -> None:
+    """An existing mapper is extended; pre-existing assignments are reused."""
+
+    mapper = PseudonymMapper()
+    # Pre-populate as if a previous message had been pseudonymized.
+    mapper.assign("PERSON", "John Smith")  # PERSON_0001
+
+    text = "John Smith and Jane Doe attended."
+    spans = [
+        _Span("PERSON", 0, 10),  # John Smith — should reuse PERSON_0001
+        _Span("PERSON", 15, 23),  # Jane Doe — new, gets PERSON_0002
+    ]
+    out = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize_into(text, mapper)
+
+    assert out == "PERSON_0001 and PERSON_0002 attended."
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_no_spans_is_identity() -> None:
+    """Analyzer returning no spans leaves text and mapper untouched."""
+
+    mapper = PseudonymMapper()
+    text = "The agreement was signed yesterday."
+
+    out = Anonymizer(analyzer=_StubAnalyzer([])).pseudonymize_into(text, mapper)
+
+    assert out == text
+    assert mapper.reverse() == {}
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_empty_text_is_empty() -> None:
+    """Empty text returns empty; analyzer never called with substance."""
+
+    mapper = PseudonymMapper()
+    out = Anonymizer(analyzer=_StubAnalyzer([])).pseudonymize_into("", mapper)
+
+    assert out == ""
+    assert mapper.reverse() == {}
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_resolves_overlapping_spans() -> None:
+    """Overlapping detections collapse to one substitution (longest span wins).
+
+    Presidio's analyzer may surface multiple recognizers for the same
+    span — e.g. a name that's also a US_BANK_NUMBER false positive. The
+    substitution must collapse cleanly without trying to substitute
+    inside a substitution.
+    """
+
+    text = "John Smith signed the agreement."
+    # Two overlapping spans on "John Smith": one PERSON (full name),
+    # one shorter that overlaps. The longer span wins.
+    spans = [
+        _Span("PERSON", 0, 10, score=0.95),  # John Smith
+        _Span("PERSON", 0, 4, score=0.6),  # John (shorter overlap)
+    ]
+    mapper = PseudonymMapper()
+    out = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize_into(text, mapper)
+
+    # The longer span is the one substituted; "John" alone is not also
+    # substituted into the middle of "PERSON_0001".
+    assert out == "PERSON_0001 signed the agreement."
+    assert mapper.reverse() == {"PERSON_0001": "John Smith"}
+
+
+# ---------------------------------------------------------------------------
+# pseudonymize — one-shot convenience: fresh mapper per call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pseudonymize_returns_result_with_fresh_mapper() -> None:
+    """One-shot pseudonymize wraps a fresh mapper in AnonymizationResult."""
+
+    spans = [_Span("PERSON", 0, 10)]
+    result = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize(
+        "John Smith signed."
+    )
+
+    assert result.text == "PERSON_0001 signed."
+    assert result.mapper.reverse() == {"PERSON_0001": "John Smith"}

--- a/gateway/tests/anonymization/test_anonymizer.py
+++ b/gateway/tests/anonymization/test_anonymizer.py
@@ -90,9 +90,7 @@ def test_rehydrate_substitutes_multiple_distinct_pseudonyms() -> None:
     mapper.assign("PERSON", "Jane Doe")  # PERSON_0002
     mapper.assign("ORGANIZATION", "Acme LLP")  # ORGANIZATION_0001
 
-    text = (
-        "PERSON_0001 and PERSON_0002 of ORGANIZATION_0001 signed the deal."
-    )
+    text = "PERSON_0001 and PERSON_0002 of ORGANIZATION_0001 signed the deal."
     out = Anonymizer().rehydrate(text, mapper)
 
     assert out == "John Smith and Jane Doe of Acme LLP signed the deal."
@@ -105,9 +103,7 @@ def test_rehydrate_handles_repeated_pseudonym() -> None:
     mapper = PseudonymMapper()
     mapper.assign("PERSON", "John Smith")
 
-    out = Anonymizer().rehydrate(
-        "PERSON_0001 emailed PERSON_0001 to confirm.", mapper
-    )
+    out = Anonymizer().rehydrate("PERSON_0001 emailed PERSON_0001 to confirm.", mapper)
 
     assert out == "John Smith emailed John Smith to confirm."
 
@@ -319,9 +315,7 @@ def test_pseudonymize_returns_result_with_fresh_mapper() -> None:
     """One-shot pseudonymize wraps a fresh mapper in AnonymizationResult."""
 
     spans = [_Span("PERSON", 0, 10)]
-    result = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize(
-        "John Smith signed."
-    )
+    result = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize("John Smith signed.")
 
     assert result.text == "PERSON_0001 signed."
     assert result.mapper.reverse() == {"PERSON_0001": "John Smith"}

--- a/gateway/tests/anonymization/test_middleware.py
+++ b/gateway/tests/anonymization/test_middleware.py
@@ -1,0 +1,639 @@
+"""M2-B3 anonymization middleware — pre/post + streaming-rehydrator.
+
+The middleware is the gateway's request-path and response-path
+substitution surface. It sits between Tier Derivation and the
+Provider Adapter (per PRD §4.3) so the upstream provider only ever
+sees pseudonymized content and the caller only ever sees rehydrated
+content.
+
+These tests cover the pure-logic invariants that don't require a
+running FastAPI app:
+
+* :func:`pre_anonymize_request` — when to fire, when to skip, what
+  it mutates, and the mapper it hands back for the response path.
+* :func:`post_anonymize_response` — non-streaming rehydration of the
+  response body.
+* :class:`StreamingRehydrator` — incremental tail-buffer rehydration
+  for SSE chunks (Decision B option (i)).
+
+End-to-end coverage with the real chat-completions handler lives in
+``test_inference_anonymization.py`` (integration), which wires the
+middleware into the FastAPI app and mocks the provider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from app.anonymization.engine import Anonymizer
+from app.anonymization.mapper import PseudonymMapper
+from app.anonymization.middleware import (
+    StreamingRehydrator,
+    post_anonymize_response,
+    pre_anonymize_request,
+)
+from app.config import AnonymizationConfig
+from app.providers.openai_schema import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+
+# ---------------------------------------------------------------------------
+# Stub analyzer — same shape as the one in test_anonymizer.py. Duplicated
+# here rather than imported because pytest doesn't expose test files as
+# importable modules without a conftest dance, and the stub is small enough
+# that duplication is cheaper than the import gymnastics.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Span:
+    entity_type: str
+    start: int
+    end: int
+    score: float = 0.85
+
+
+class _StubAnalyzer:
+    """Returns canned spans from a (text → spans) lookup table.
+
+    Real Presidio matches by content, not by reference. Tests build a
+    lookup keyed by exact text so each message gets the spans that
+    correspond to its content.
+    """
+
+    def __init__(self, by_text: dict[str, list[_Span]]) -> None:
+        self._by_text = by_text
+
+    def analyze(
+        self, *, text: str, language: str = "en", **_kwargs: object
+    ) -> list[_Span]:
+        return list(self._by_text.get(text, []))
+
+
+def _make_request(
+    *,
+    messages: list[ChatCompletionMessage],
+    anonymize: bool = True,
+    privileged: bool = False,
+    skill_inputs: dict[str, dict[str, object]] | None = None,
+) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="smart",
+        messages=messages,
+        anonymize=anonymize,
+        lq_ai_privileged=privileged,
+        lq_ai_skill_inputs=skill_inputs or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Skip conditions — pre_anonymize_request returns None and does NOT mutate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pre_anonymize_skips_when_config_disabled() -> None:
+    """``anonymization.enabled=false`` is a hard short-circuit."""
+
+    req = _make_request(
+        messages=[ChatCompletionMessage(role="user", content="John Smith signed.")]
+    )
+    config = AnonymizationConfig(enabled=False, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({"John Smith signed.": [_Span("PERSON", 0, 10)]})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is None
+    assert req.messages[0].content == "John Smith signed."
+
+
+@pytest.mark.unit
+def test_pre_anonymize_skips_when_tier_not_in_apply_at_tiers() -> None:
+    """Tier 1 (local inference) does not benefit from anonymization."""
+
+    req = _make_request(
+        messages=[ChatCompletionMessage(role="user", content="John Smith signed.")]
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({"John Smith signed.": [_Span("PERSON", 0, 10)]})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=1,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is None
+    assert req.messages[0].content == "John Smith signed."
+
+
+@pytest.mark.unit
+def test_pre_anonymize_skips_when_request_is_privileged() -> None:
+    """A privileged chat never gets pseudonymized (Decision A)."""
+
+    req = _make_request(
+        messages=[ChatCompletionMessage(role="user", content="John Smith signed.")],
+        privileged=True,
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({"John Smith signed.": [_Span("PERSON", 0, 10)]})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is None
+    assert req.messages[0].content == "John Smith signed."
+
+
+@pytest.mark.unit
+def test_pre_anonymize_skips_on_per_request_opt_out() -> None:
+    """``anonymize: false`` is the per-request escape hatch."""
+
+    req = _make_request(
+        messages=[ChatCompletionMessage(role="user", content="John Smith signed.")],
+        anonymize=False,
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({"John Smith signed.": [_Span("PERSON", 0, 10)]})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is None
+    assert req.messages[0].content == "John Smith signed."
+
+
+# ---------------------------------------------------------------------------
+# Firing path — pseudonymizes message content + skill_inputs, returns mapper.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pre_anonymize_pseudonymizes_user_message_content() -> None:
+    """When firing, a user-role message has entities replaced in place."""
+
+    req = _make_request(
+        messages=[ChatCompletionMessage(role="user", content="John Smith signed.")]
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({"John Smith signed.": [_Span("PERSON", 0, 10)]})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    assert req.messages[0].content == "PERSON_0001 signed."
+    assert mapper.reverse() == {"PERSON_0001": "John Smith"}
+
+
+@pytest.mark.unit
+def test_pre_anonymize_walks_user_assistant_and_system_roles() -> None:
+    """All three semantic roles are walked; ``tool`` is not (irrelevant here)."""
+
+    req = _make_request(
+        messages=[
+            ChatCompletionMessage(role="system", content="System: Smith Corp."),
+            ChatCompletionMessage(role="user", content="User: Jane Doe."),
+            ChatCompletionMessage(role="assistant", content="Assistant: Acme LLP."),
+        ]
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer(
+        {
+            "System: Smith Corp.": [_Span("ORGANIZATION", 8, 18)],
+            "User: Jane Doe.": [_Span("PERSON", 6, 14)],
+            "Assistant: Acme LLP.": [_Span("ORGANIZATION", 11, 19)],
+        }
+    )
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    assert req.messages[0].content == "System: ORGANIZATION_0001."
+    assert req.messages[1].content == "User: PERSON_0001."
+    assert req.messages[2].content == "Assistant: ORGANIZATION_0002."
+
+
+@pytest.mark.unit
+def test_pre_anonymize_same_name_across_messages_stable_pseudonym() -> None:
+    """The same name in two messages resolves to one pseudonym."""
+
+    req = _make_request(
+        messages=[
+            ChatCompletionMessage(role="user", content="John Smith introduced."),
+            ChatCompletionMessage(role="assistant", content="John Smith replied."),
+        ]
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer(
+        {
+            "John Smith introduced.": [_Span("PERSON", 0, 10)],
+            "John Smith replied.": [_Span("PERSON", 0, 10)],
+        }
+    )
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    assert req.messages[0].content == "PERSON_0001 introduced."
+    assert req.messages[1].content == "PERSON_0001 replied."
+    assert mapper.reverse() == {"PERSON_0001": "John Smith"}
+
+
+@pytest.mark.unit
+def test_pre_anonymize_skips_message_with_none_content() -> None:
+    """``content=None`` messages (tool-call shaped) are left alone, not crashed."""
+
+    req = _make_request(
+        messages=[
+            ChatCompletionMessage(role="user", content="John Smith signed."),
+            ChatCompletionMessage(role="assistant", content=None),
+        ]
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({"John Smith signed.": [_Span("PERSON", 0, 10)]})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    assert req.messages[0].content == "PERSON_0001 signed."
+    assert req.messages[1].content is None
+
+
+@pytest.mark.unit
+def test_pre_anonymize_walks_skill_inputs_recursively() -> None:
+    """String values nested in skill_inputs are pseudonymized in place."""
+
+    req = _make_request(
+        messages=[ChatCompletionMessage(role="user", content="See attached.")],
+        skill_inputs={
+            "nda-review": {
+                "counterparty_name": "John Smith",
+                "max_indemnity": 1_000_000,  # int — left alone
+                "redline_mode": True,  # bool — left alone
+            }
+        },
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer(
+        {
+            "See attached.": [],
+            "John Smith": [_Span("PERSON", 0, 10)],
+        }
+    )
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    skill_inputs = req.lq_ai_skill_inputs["nda-review"]
+    assert skill_inputs["counterparty_name"] == "PERSON_0001"
+    # Non-string types are passed through untouched.
+    assert skill_inputs["max_indemnity"] == 1_000_000
+    assert skill_inputs["redline_mode"] is True
+
+
+@pytest.mark.unit
+def test_pre_anonymize_returns_empty_mapper_when_no_entities_found() -> None:
+    """Firing with no detections still returns a (empty) mapper, not None.
+
+    The mapper-vs-None distinction signals "did the middleware fire";
+    even an empty mapper means the post-middleware should still wrap
+    the response (cheaply, since rehydrate is a no-op against empty
+    mapper).
+    """
+
+    req = _make_request(
+        messages=[ChatCompletionMessage(role="user", content="The agreement is signed.")]
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({"The agreement is signed.": []})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    assert mapper.reverse() == {}
+    assert req.messages[0].content == "The agreement is signed."
+
+
+# ---------------------------------------------------------------------------
+# post_anonymize_response — non-streaming rehydration.
+# ---------------------------------------------------------------------------
+
+
+def _make_response(*, contents: list[str | None]) -> ChatCompletionResponse:
+    """Build a ChatCompletionResponse with one choice per content string."""
+
+    return ChatCompletionResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="claude-sonnet-4-6",
+        choices=[
+            ChatCompletionChoice(
+                index=i,
+                message=ChatCompletionMessage(role="assistant", content=c),
+                finish_reason="stop",
+            )
+            for i, c in enumerate(contents)
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+@pytest.mark.unit
+def test_post_anonymize_rehydrates_single_choice() -> None:
+    """The assistant message content is restored from pseudonyms."""
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")  # → PERSON_0001
+    response = _make_response(contents=["PERSON_0001 signed the agreement."])
+
+    post_anonymize_response(
+        response=response, mapper=mapper, anonymizer=Anonymizer()
+    )
+
+    assert response.choices[0].message.content == "John Smith signed the agreement."
+
+
+@pytest.mark.unit
+def test_post_anonymize_rehydrates_multiple_choices() -> None:
+    """Every choice's content is rehydrated independently."""
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")  # PERSON_0001
+    mapper.assign("ORGANIZATION", "Acme LLP")  # ORGANIZATION_0001
+    response = _make_response(
+        contents=[
+            "PERSON_0001 represented ORGANIZATION_0001.",
+            "ORGANIZATION_0001 retained PERSON_0001.",
+        ]
+    )
+
+    post_anonymize_response(
+        response=response, mapper=mapper, anonymizer=Anonymizer()
+    )
+
+    assert response.choices[0].message.content == "John Smith represented Acme LLP."
+    assert response.choices[1].message.content == "Acme LLP retained John Smith."
+
+
+@pytest.mark.unit
+def test_post_anonymize_leaves_none_content_as_none() -> None:
+    """Tool-call shaped responses (no content) are not mangled."""
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")
+    response = _make_response(contents=[None])
+
+    post_anonymize_response(
+        response=response, mapper=mapper, anonymizer=Anonymizer()
+    )
+
+    assert response.choices[0].message.content is None
+
+
+@pytest.mark.unit
+def test_post_anonymize_empty_mapper_is_no_op() -> None:
+    """Empty mapper leaves content unchanged."""
+
+    mapper = PseudonymMapper()  # No assignments.
+    response = _make_response(contents=["The agreement is signed."])
+
+    post_anonymize_response(
+        response=response, mapper=mapper, anonymizer=Anonymizer()
+    )
+
+    assert response.choices[0].message.content == "The agreement is signed."
+
+
+@pytest.mark.unit
+def test_post_anonymize_preserves_non_content_fields() -> None:
+    """Role, finish_reason, usage, and metadata fields pass through."""
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")
+    response = _make_response(contents=["PERSON_0001 signed."])
+    response.routed_inference_tier = 4
+    response.routed_provider = "anthropic"
+    response.anonymization_applied = True
+
+    post_anonymize_response(
+        response=response, mapper=mapper, anonymizer=Anonymizer()
+    )
+
+    assert response.choices[0].message.role == "assistant"
+    assert response.choices[0].finish_reason == "stop"
+    assert response.usage.prompt_tokens == 10
+    assert response.routed_inference_tier == 4
+    assert response.routed_provider == "anthropic"
+    assert response.anonymization_applied is True
+
+
+# ---------------------------------------------------------------------------
+# StreamingRehydrator — incremental tail-buffer rehydration (Decision B (i)).
+#
+# Invariant: emitted text never contains a pseudonym (always rehydrated to
+# the original). To uphold this when pseudonyms can straddle chunk
+# boundaries, the rehydrator holds an unresolved tail until the partial
+# pseudonym pattern crystallizes or ``flush()`` is called.
+# ---------------------------------------------------------------------------
+
+
+def _mapper_with(*pairs: tuple[str, str]) -> PseudonymMapper:
+    """Build a mapper with explicit (entity_type, original) assignments."""
+
+    m = PseudonymMapper()
+    for entity_type, original in pairs:
+        m.assign(entity_type, original)
+    return m
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_empty_mapper_passes_through() -> None:
+    """No pseudonyms to substitute → emit what comes in (post-flush)."""
+
+    r = StreamingRehydrator(mapper=PseudonymMapper(), anonymizer=Anonymizer())
+
+    out = r.process("Hello, the agreement is signed.") + r.flush()
+
+    assert out == "Hello, the agreement is signed."
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_pseudonym_in_single_chunk() -> None:
+    """Pseudonym arriving fully formed inside a chunk is rehydrated."""
+
+    mapper = _mapper_with(("PERSON", "John Smith"))
+    r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer())
+
+    # Trailing space crystallizes the pseudonym (no ambiguity at end).
+    out = r.process("PERSON_0001 signed.") + r.flush()
+
+    assert out == "John Smith signed."
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_pseudonym_split_across_chunks() -> None:
+    """``PERSON_0001`` split as ``PERSON_`` | ``0001`` | `` `` is rehydrated.
+
+    The first chunk ends with a partial pseudonym (``PERSON_``); the
+    rehydrator holds it. The second chunk extends to ``PERSON_0001``
+    but the buffer still ends in a digit — could be ``PERSON_00010`` —
+    so we keep holding. The third chunk's leading space crystallizes
+    the pseudonym and the rehydrator emits the rehydrated text.
+    """
+
+    mapper = _mapper_with(("PERSON", "John Smith"))
+    r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer())
+
+    out = (
+        r.process("Hello PERSON_")
+        + r.process("0001")
+        + r.process(" signed.")
+        + r.flush()
+    )
+
+    assert out == "Hello John Smith signed."
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_pseudonym_split_at_every_char() -> None:
+    """Pathological case: chunks of size 1. Final text still correct."""
+
+    mapper = _mapper_with(("PERSON", "John Smith"))
+    r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer())
+
+    out = ""
+    for ch in "Hi PERSON_0001!":
+        out += r.process(ch)
+    out += r.flush()
+
+    assert out == "Hi John Smith!"
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_two_pseudonyms_in_one_chunk() -> None:
+    """Multiple complete pseudonyms in the same chunk all get rehydrated."""
+
+    mapper = _mapper_with(
+        ("PERSON", "John Smith"),
+        ("ORGANIZATION", "Acme LLP"),
+    )
+    r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer())
+
+    out = r.process("PERSON_0001 at ORGANIZATION_0001 spoke.") + r.flush()
+
+    assert out == "John Smith at Acme LLP spoke."
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_prefix_collision_safe() -> None:
+    """``PERSON_00010`` arriving piecewise resolves to the long name, not ``John Smith0``."""
+
+    mapper = _mapper_with(("PERSON", "John Smith"))  # PERSON_0001
+    mapper._assignments[("PERSON", "Janet Doe")] = "PERSON_00010"
+    r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer())
+
+    # Stream "PERSON_00010 met PERSON_0001 today." char-by-char to maximize
+    # the chance the rehydrator gets confused at the boundary.
+    out = ""
+    for ch in "PERSON_00010 met PERSON_0001 today.":
+        out += r.process(ch)
+    out += r.flush()
+
+    assert out == "Janet Doe met John Smith today."
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_flush_emits_held_tail() -> None:
+    """A pseudonym at end-of-stream without trailing whitespace is emitted on flush."""
+
+    mapper = _mapper_with(("PERSON", "John Smith"))
+    r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer())
+
+    # No trailing char — the rehydrator can't tell if more digits are
+    # coming until flush() declares the stream complete.
+    emitted = r.process("Hello PERSON_0001")
+    flushed = r.flush()
+
+    assert emitted + flushed == "Hello John Smith"
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_empty_chunk_is_no_op() -> None:
+    """Processing an empty chunk yields empty output and doesn't disturb buffer."""
+
+    mapper = _mapper_with(("PERSON", "John Smith"))
+    r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer())
+
+    out = r.process("") + r.process("PERSON_0001 ") + r.process("") + r.flush()
+
+    assert out == "John Smith "
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_uppercase_word_not_held_indefinitely() -> None:
+    """A mixed-case word with leading capital ('John') is not a pseudonym pattern.
+
+    Mixed-case words don't even partially match the pseudonym shape
+    (which requires only uppercase letters before the underscore), so
+    they emit promptly without lingering in the tail buffer.
+    """
+
+    mapper = _mapper_with(("PERSON", "John Smith"))
+    r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer())
+
+    # No pseudonym anywhere — should just pass through. The word 'Hello'
+    # at end is mixed-case; safe to emit.
+    emitted = r.process("Hello world,")
+    # We don't assert the exact output here (the buffer state mid-stream
+    # is internal); we just assert flush yields the full content cleanly.
+    assert emitted + r.flush() == "Hello world,"

--- a/gateway/tests/anonymization/test_middleware.py
+++ b/gateway/tests/anonymization/test_middleware.py
@@ -70,9 +70,7 @@ class _StubAnalyzer:
     def __init__(self, by_text: dict[str, list[_Span]]) -> None:
         self._by_text = by_text
 
-    def analyze(
-        self, *, text: str, language: str = "en", **_kwargs: object
-    ) -> list[_Span]:
+    def analyze(self, *, text: str, language: str = "en", **_kwargs: object) -> list[_Span]:
         return list(self._by_text.get(text, []))
 
 
@@ -101,9 +99,7 @@ def _make_request(
 def test_pre_anonymize_skips_when_config_disabled() -> None:
     """``anonymization.enabled=false`` is a hard short-circuit."""
 
-    req = _make_request(
-        messages=[ChatCompletionMessage(role="user", content="John Smith signed.")]
-    )
+    req = _make_request(messages=[ChatCompletionMessage(role="user", content="John Smith signed.")])
     config = AnonymizationConfig(enabled=False, apply_at_tiers=[3, 4, 5])
     analyzer = _StubAnalyzer({"John Smith signed.": [_Span("PERSON", 0, 10)]})
 
@@ -122,9 +118,7 @@ def test_pre_anonymize_skips_when_config_disabled() -> None:
 def test_pre_anonymize_skips_when_tier_not_in_apply_at_tiers() -> None:
     """Tier 1 (local inference) does not benefit from anonymization."""
 
-    req = _make_request(
-        messages=[ChatCompletionMessage(role="user", content="John Smith signed.")]
-    )
+    req = _make_request(messages=[ChatCompletionMessage(role="user", content="John Smith signed.")])
     config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
     analyzer = _StubAnalyzer({"John Smith signed.": [_Span("PERSON", 0, 10)]})
 
@@ -192,9 +186,7 @@ def test_pre_anonymize_skips_on_per_request_opt_out() -> None:
 def test_pre_anonymize_pseudonymizes_user_message_content() -> None:
     """When firing, a user-role message has entities replaced in place."""
 
-    req = _make_request(
-        messages=[ChatCompletionMessage(role="user", content="John Smith signed.")]
-    )
+    req = _make_request(messages=[ChatCompletionMessage(role="user", content="John Smith signed.")])
     config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
     analyzer = _StubAnalyzer({"John Smith signed.": [_Span("PERSON", 0, 10)]})
 
@@ -396,9 +388,7 @@ def test_post_anonymize_rehydrates_single_choice() -> None:
     mapper.assign("PERSON", "John Smith")  # → PERSON_0001
     response = _make_response(contents=["PERSON_0001 signed the agreement."])
 
-    post_anonymize_response(
-        response=response, mapper=mapper, anonymizer=Anonymizer()
-    )
+    post_anonymize_response(response=response, mapper=mapper, anonymizer=Anonymizer())
 
     assert response.choices[0].message.content == "John Smith signed the agreement."
 
@@ -417,9 +407,7 @@ def test_post_anonymize_rehydrates_multiple_choices() -> None:
         ]
     )
 
-    post_anonymize_response(
-        response=response, mapper=mapper, anonymizer=Anonymizer()
-    )
+    post_anonymize_response(response=response, mapper=mapper, anonymizer=Anonymizer())
 
     assert response.choices[0].message.content == "John Smith represented Acme LLP."
     assert response.choices[1].message.content == "Acme LLP retained John Smith."
@@ -433,9 +421,7 @@ def test_post_anonymize_leaves_none_content_as_none() -> None:
     mapper.assign("PERSON", "John Smith")
     response = _make_response(contents=[None])
 
-    post_anonymize_response(
-        response=response, mapper=mapper, anonymizer=Anonymizer()
-    )
+    post_anonymize_response(response=response, mapper=mapper, anonymizer=Anonymizer())
 
     assert response.choices[0].message.content is None
 
@@ -447,9 +433,7 @@ def test_post_anonymize_empty_mapper_is_no_op() -> None:
     mapper = PseudonymMapper()  # No assignments.
     response = _make_response(contents=["The agreement is signed."])
 
-    post_anonymize_response(
-        response=response, mapper=mapper, anonymizer=Anonymizer()
-    )
+    post_anonymize_response(response=response, mapper=mapper, anonymizer=Anonymizer())
 
     assert response.choices[0].message.content == "The agreement is signed."
 
@@ -465,9 +449,7 @@ def test_post_anonymize_preserves_non_content_fields() -> None:
     response.routed_provider = "anthropic"
     response.anonymization_applied = True
 
-    post_anonymize_response(
-        response=response, mapper=mapper, anonymizer=Anonymizer()
-    )
+    post_anonymize_response(response=response, mapper=mapper, anonymizer=Anonymizer())
 
     assert response.choices[0].message.role == "assistant"
     assert response.choices[0].finish_reason == "stop"
@@ -534,12 +516,7 @@ def test_streaming_rehydrator_pseudonym_split_across_chunks() -> None:
     mapper = _mapper_with(("PERSON", "John Smith"))
     r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer())
 
-    out = (
-        r.process("Hello PERSON_")
-        + r.process("0001")
-        + r.process(" signed.")
-        + r.flush()
-    )
+    out = r.process("Hello PERSON_") + r.process("0001") + r.process(" signed.") + r.flush()
 
     assert out == "Hello John Smith signed."
 

--- a/gateway/tests/test_config.py
+++ b/gateway/tests/test_config.py
@@ -111,6 +111,38 @@ def test_load_config_parses_example(example_env: None) -> None:
     assert config.tier_policy.allowed_tiers_global == [1, 2, 3, 4]
     assert config.tier_policy.default_minimum_tier == 4
 
+    # M2-B3: Anonymization block typed shape.
+    # The example ships anonymization.enabled=false (M2 feature flag)
+    # and anonymization.apply_at_tiers=[3, 4, 5]. The middleware reads
+    # both, so they need to be typed (not just ``extra="allow"``
+    # passthroughs) so a typo in the YAML key surfaces as a config
+    # error rather than a silent middleware no-op.
+    assert config.anonymization.enabled is False
+    assert config.anonymization.apply_at_tiers == [3, 4, 5]
+    # Type discipline: an explicit ``list[int]`` so a string-list
+    # would raise rather than silently passthrough.
+    assert all(isinstance(t, int) for t in config.anonymization.apply_at_tiers)
+
+
+@pytest.mark.unit
+def test_anonymization_config_rejects_non_int_tiers() -> None:
+    """``apply_at_tiers`` must be ``list[int]``; bad values raise."""
+
+    from pydantic import ValidationError
+
+    from app.config import AnonymizationConfig
+
+    # Valid (default) — empty tiers list.
+    AnonymizationConfig()
+    # Valid — int list.
+    cfg = AnonymizationConfig(apply_at_tiers=[3, 4, 5])
+    assert cfg.apply_at_tiers == [3, 4, 5]
+    # Tier out of [1,5] range surfaces as ValidationError.
+    with pytest.raises(ValidationError):
+        AnonymizationConfig(apply_at_tiers=[0, 1])
+    with pytest.raises(ValidationError):
+        AnonymizationConfig(apply_at_tiers=[1, 6])
+
 
 @pytest.mark.unit
 def test_load_config_alias_payload(example_env: None) -> None:

--- a/gateway/tests/test_inference_anonymization.py
+++ b/gateway/tests/test_inference_anonymization.py
@@ -59,9 +59,7 @@ class _StubAnalyzer:
     def __init__(self, by_text: dict[str, list[_Span]]) -> None:
         self._by_text = by_text
 
-    def analyze(
-        self, *, text: str, language: str = "en", **_kwargs: object
-    ) -> list[_Span]:
+    def analyze(self, *, text: str, language: str = "en", **_kwargs: object) -> list[_Span]:
         return list(self._by_text.get(text, []))
 
 
@@ -191,9 +189,7 @@ async def test_non_streaming_pseudonymizes_request_and_rehydrates_response(
         },
     )
 
-    upstream = _mock_anthropic(
-        response_text="PERSON_0001 has signed; the deal closes Friday."
-    )
+    upstream = _mock_anthropic(response_text="PERSON_0001 has signed; the deal closes Friday.")
 
     response = await client.post(
         "/v1/chat/completions",
@@ -207,8 +203,7 @@ async def test_non_streaming_pseudonymizes_request_and_rehydrates_response(
     body = response.json()
     # Response content is rehydrated: PERSON_0001 → John Smith.
     assert (
-        body["choices"][0]["message"]["content"]
-        == "John Smith has signed; the deal closes Friday."
+        body["choices"][0]["message"]["content"] == "John Smith has signed; the deal closes Friday."
     )
     assert body["anonymization_applied"] is True
 
@@ -407,12 +402,7 @@ def _mock_anthropic_streaming(*, deltas: list[str]) -> respx.Route:
         )
         + "\n\n"
     )
-    lines.append(
-        "event: message_stop\n"
-        + "data: "
-        + json.dumps({"type": "message_stop"})
-        + "\n\n"
-    )
+    lines.append("event: message_stop\n" + "data: " + json.dumps({"type": "message_stop"}) + "\n\n")
 
     body = "".join(lines).encode()
     return respx.post("https://api.anthropic.com/v1/messages").mock(

--- a/gateway/tests/test_inference_anonymization.py
+++ b/gateway/tests/test_inference_anonymization.py
@@ -1,0 +1,475 @@
+"""M2-B3 end-to-end: anonymization wired into chat-completions handler.
+
+These tests exercise the full request → middleware → provider → response
+loop, asserting:
+
+* The provider receives **pseudonymized** content on the request path.
+* The client receives **rehydrated** content on the response path.
+* The routing-log row carries ``anonymization_applied=True``.
+* Skip conditions (config disabled, tier mismatch, ``privileged``,
+  per-request ``anonymize: false``) leave content and audit untouched.
+
+The Anonymizer is stubbed via ``app.state.anonymizer`` so spaCy stays
+off the fast feedback path. End-to-end correctness with the real
+Presidio engine is covered in ``tests/anonymization/test_engine_integration.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.anonymization.engine import Anonymizer
+from app.clients.backend import BackendClient, SkillCache, set_backend_client
+from app.routing_log import RecordingRoutingLogWriter
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONFIG = REPO_ROOT / "gateway.yaml.example"
+
+BACKEND_URL = "http://api.test"
+GATEWAY_KEY = "test-gateway-key-correct-horse"
+
+
+# ---------------------------------------------------------------------------
+# Stub analyzer — matches the shape used in tests/anonymization/test_anonymizer.py.
+# Returns canned spans keyed by exact input text so each pseudonymize call
+# resolves deterministically.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Span:
+    entity_type: str
+    start: int
+    end: int
+    score: float = 0.85
+
+
+class _StubAnalyzer:
+    def __init__(self, by_text: dict[str, list[_Span]]) -> None:
+        self._by_text = by_text
+
+    def analyze(
+        self, *, text: str, language: str = "en", **_kwargs: object
+    ) -> list[_Span]:
+        return list(self._by_text.get(text, []))
+
+
+@asynccontextmanager
+async def _run_lifespan(app: FastAPI) -> AsyncIterator[None]:
+    async with app.router.lifespan_context(app):
+        yield
+
+
+@pytest_asyncio.fixture
+async def gateway_with_anon_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[tuple[FastAPI, RecordingRoutingLogWriter, BackendClient]]:
+    """Bring up the gateway, then flip ``anonymization.enabled=true`` in state."""
+
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(EXAMPLE_CONFIG))
+    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
+    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-fake")
+    monkeypatch.setenv("LQ_AI_API_URL", BACKEND_URL)
+    monkeypatch.setenv("LQ_AI_GATEWAY_KEY", GATEWAY_KEY)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    from app.main import app
+
+    async with _run_lifespan(app):
+        recorder = RecordingRoutingLogWriter()
+        app.state.routing_log = recorder
+        backend_client = BackendClient(
+            base_url=BACKEND_URL,
+            gateway_key=GATEWAY_KEY,
+            cache=SkillCache(ttl_seconds=60.0),
+        )
+        app.state.backend_client = backend_client
+        set_backend_client(backend_client)
+
+        # Force the anonymization feature flag on for these tests.
+        # The example ships with ``enabled=false`` so M1-era deployments
+        # don't accidentally trip the M2 middleware on upgrade.
+        app.state.config.anonymization.enabled = True
+        # ``smart`` resolves to Tier 4 in the example config; the
+        # example's apply_at_tiers is [3, 4, 5], so the tier gate is
+        # already correct for the requests below.
+
+        try:
+            yield app, recorder, backend_client
+        finally:
+            await backend_client.aclose()
+            set_backend_client(None)
+            app.state.config.anonymization.enabled = False
+
+
+@pytest_asyncio.fixture
+async def http_client(
+    gateway_with_anon_enabled: tuple[FastAPI, RecordingRoutingLogWriter, BackendClient],
+) -> AsyncIterator[tuple[AsyncClient, RecordingRoutingLogWriter, FastAPI]]:
+    app, recorder, _backend = gateway_with_anon_enabled
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, recorder, app
+
+
+def _install_stub_anonymizer(app: FastAPI, by_text: dict[str, list[_Span]]) -> None:
+    """Replace ``app.state.anonymizer`` with one wrapping a stub analyzer."""
+
+    app.state.anonymizer = Anonymizer(analyzer=_StubAnalyzer(by_text))
+
+
+def _mock_anthropic(*, response_text: str) -> respx.Route:
+    """Mock Anthropic Messages with a 200 carrying ``response_text``."""
+
+    return respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "msg_test",
+                "model": "claude-opus-4-7",
+                "content": [{"type": "text", "text": response_text}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 5},
+            },
+        )
+    )
+
+
+def _anthropic_user_content(call: respx.models.Call) -> str:
+    """Extract the first user-message content from the Anthropic call body."""
+
+    body = json.loads(call.request.content)
+    for message in body.get("messages", []):
+        if message.get("role") == "user":
+            content = message.get("content")
+            # Anthropic Messages allows ``content`` to be a string OR a
+            # list of content blocks. The Anthropic adapter sends it as
+            # either; we handle both.
+            if isinstance(content, str):
+                return content
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    return str(block.get("text", ""))
+    raise AssertionError("no user message in Anthropic request body")
+
+
+# ---------------------------------------------------------------------------
+# Happy path — non-streaming.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_non_streaming_pseudonymizes_request_and_rehydrates_response(
+    http_client: tuple[AsyncClient, RecordingRoutingLogWriter, FastAPI],
+) -> None:
+    """Round-trip: provider sees PERSON_0001; client sees John Smith."""
+
+    client, recorder, app = http_client
+    user_msg = "John Smith signed the agreement."
+    _install_stub_anonymizer(
+        app,
+        {
+            user_msg: [_Span("PERSON", 0, 10)],
+            # The model's response contains a pseudonym to be rehydrated.
+            # The post-middleware rehydrates content (not the request);
+            # we configure analyze() for the request text only.
+        },
+    )
+
+    upstream = _mock_anthropic(
+        response_text="PERSON_0001 has signed; the deal closes Friday."
+    )
+
+    response = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "smart",  # Tier 4 → matches apply_at_tiers=[3,4,5]
+            "messages": [{"role": "user", "content": user_msg}],
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    # Response content is rehydrated: PERSON_0001 → John Smith.
+    assert (
+        body["choices"][0]["message"]["content"]
+        == "John Smith has signed; the deal closes Friday."
+    )
+    assert body["anonymization_applied"] is True
+
+    # The Anthropic adapter received the pseudonymized request.
+    assert upstream.called
+    sent_to_provider = _anthropic_user_content(upstream.calls.last)
+    assert sent_to_provider == "PERSON_0001 signed the agreement."
+
+    # Audit log row carries the flag.
+    assert len(recorder.rows) == 1
+    assert recorder.rows[0].anonymization_applied is True
+
+
+# ---------------------------------------------------------------------------
+# Skip conditions — non-streaming.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_per_request_anonymize_false_skips_middleware(
+    http_client: tuple[AsyncClient, RecordingRoutingLogWriter, FastAPI],
+) -> None:
+    """``anonymize: false`` passes content through untouched + audit flag False."""
+
+    client, recorder, app = http_client
+    user_msg = "John Smith signed the agreement."
+    _install_stub_anonymizer(app, {user_msg: [_Span("PERSON", 0, 10)]})
+
+    upstream = _mock_anthropic(response_text="ack")
+
+    response = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "smart",
+            "messages": [{"role": "user", "content": user_msg}],
+            "anonymize": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["anonymization_applied"] is False
+    assert upstream.called
+    # Provider sees the raw name when caller opts out.
+    assert _anthropic_user_content(upstream.calls.last) == user_msg
+    # Audit reflects skip.
+    assert recorder.rows[0].anonymization_applied is False
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_privileged_request_skips_middleware(
+    http_client: tuple[AsyncClient, RecordingRoutingLogWriter, FastAPI],
+) -> None:
+    """``lq_ai_privileged: true`` skips even when anonymization is enabled.
+
+    Decision A: privileged chats are never rewritten because rewriting
+    privileged work product risks corrupting it.
+    """
+
+    client, recorder, app = http_client
+    user_msg = "John Smith signed the agreement."
+    _install_stub_anonymizer(app, {user_msg: [_Span("PERSON", 0, 10)]})
+
+    upstream = _mock_anthropic(response_text="ack")
+
+    response = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "smart",
+            "messages": [{"role": "user", "content": user_msg}],
+            "lq_ai_privileged": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["anonymization_applied"] is False
+    assert _anthropic_user_content(upstream.calls.last) == user_msg
+    assert recorder.rows[0].anonymization_applied is False
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_tier_outside_apply_at_tiers_skips_middleware(
+    http_client: tuple[AsyncClient, RecordingRoutingLogWriter, FastAPI],
+) -> None:
+    """Tier gating: a routed tier outside ``apply_at_tiers`` skips substitution.
+
+    Rather than routing to a different (Tier 1) alias — which would
+    require coupling this test to whichever model the operator happens
+    to have loaded in Ollama at test time — we keep the ``smart`` (Tier
+    4) routing and narrow ``apply_at_tiers`` to ``[5]`` so the gate
+    closes for this run. Same skip semantics, simpler dependencies.
+    """
+
+    client, recorder, app = http_client
+    user_msg = "John Smith signed the agreement."
+    _install_stub_anonymizer(app, {user_msg: [_Span("PERSON", 0, 10)]})
+
+    # Narrow the tier gate so the routed tier (4) is excluded.
+    app.state.config.anonymization.apply_at_tiers = [5]
+
+    upstream = _mock_anthropic(response_text="ack")
+
+    response = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "smart",
+            "messages": [{"role": "user", "content": user_msg}],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["anonymization_applied"] is False
+    assert upstream.called
+    # Provider sees the raw name when tier gate closes.
+    assert _anthropic_user_content(upstream.calls.last) == user_msg
+    assert recorder.rows[0].anonymization_applied is False
+
+
+# ---------------------------------------------------------------------------
+# Streaming path — pseudonyms straddling SSE chunk boundaries are rehydrated.
+# ---------------------------------------------------------------------------
+
+
+def _mock_anthropic_streaming(*, deltas: list[str]) -> respx.Route:
+    """Mock Anthropic Messages SSE with a sequence of text deltas.
+
+    Emits a minimal valid stream: message_start → content_block_start →
+    one content_block_delta per text fragment → content_block_stop →
+    message_delta → message_stop. Each frame is a real SSE event so
+    httpx returns it as an aiter_bytes()-able stream.
+    """
+
+    lines: list[str] = []
+    lines.append(
+        "event: message_start\n"
+        + "data: "
+        + json.dumps(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_stream",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "claude-opus-4-7",
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 5, "output_tokens": 0},
+                },
+            }
+        )
+        + "\n\n"
+    )
+    lines.append(
+        "event: content_block_start\n"
+        + "data: "
+        + json.dumps(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            }
+        )
+        + "\n\n"
+    )
+    for delta in deltas:
+        lines.append(
+            "event: content_block_delta\n"
+            + "data: "
+            + json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": delta},
+                }
+            )
+            + "\n\n"
+        )
+    lines.append(
+        "event: content_block_stop\n"
+        + "data: "
+        + json.dumps({"type": "content_block_stop", "index": 0})
+        + "\n\n"
+    )
+    lines.append(
+        "event: message_delta\n"
+        + "data: "
+        + json.dumps(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": {"output_tokens": 5},
+            }
+        )
+        + "\n\n"
+    )
+    lines.append(
+        "event: message_stop\n"
+        + "data: "
+        + json.dumps({"type": "message_stop"})
+        + "\n\n"
+    )
+
+    body = "".join(lines).encode()
+    return respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+
+def _collect_sse_content(body: bytes) -> str:
+    """Extract concatenated ``choices[0].delta.content`` from SSE bytes."""
+
+    out: list[str] = []
+    for line in body.decode().splitlines():
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :].strip()
+        if payload == "[DONE]" or not payload:
+            continue
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        for choice in obj.get("choices", []):
+            content = choice.get("delta", {}).get("content")
+            if content:
+                out.append(content)
+    return "".join(out)
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_streaming_rehydrates_pseudonyms_across_chunk_boundaries(
+    http_client: tuple[AsyncClient, RecordingRoutingLogWriter, FastAPI],
+) -> None:
+    """SSE deltas split across PERSON_0001 boundary surface as ``John Smith``."""
+
+    client, recorder, app = http_client
+    user_msg = "John Smith signed the agreement."
+    _install_stub_anonymizer(app, {user_msg: [_Span("PERSON", 0, 10)]})
+
+    # The model streams ``PERSON_0001 ack`` split across three deltas
+    # such that the pseudonym is partial in two of them.
+    _mock_anthropic_streaming(deltas=["Hello PERSON_", "0001", " ack."])
+
+    response = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "smart",
+            "messages": [{"role": "user", "content": user_msg}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    content = _collect_sse_content(response.content)
+    assert content == "Hello John Smith ack."
+    assert recorder.rows[0].anonymization_applied is True

--- a/gateway/tests/test_inference_ollama.py
+++ b/gateway/tests/test_inference_ollama.py
@@ -9,7 +9,7 @@ no external network).
 What this file covers:
 
 * Alias dispatch — ``local-fast`` resolves to ``ollama-local /
-  llama3.1:8b`` and round-trips correctly.
+  qwen3.5:4b-nvfp4`` and round-trips correctly.
 * Tier annotation — every Ollama-routed response carries
   ``routed_inference_tier=1`` (the Mode-2 / air-gap-capable tier
   per PRD §1.5.2). The body field and the
@@ -103,7 +103,7 @@ def _ollama_unary_payload(content: str = "Hi from Ollama.") -> dict[str, object]
     """A canonical Ollama ``/api/chat`` non-streaming response."""
 
     return {
-        "model": "llama3.1:8b",
+        "model": "qwen3.5:4b-nvfp4",
         "created_at": "2026-05-08T12:00:00Z",
         "message": {"role": "assistant", "content": content},
         "done": True,
@@ -122,7 +122,7 @@ def _ollama_ndjson_body(text_chunks: list[str]) -> str:
         lines.append(
             json.dumps(
                 {
-                    "model": "llama3.1:8b",
+                    "model": "qwen3.5:4b-nvfp4",
                     "created_at": "2026-05-08T12:00:00Z",
                     "message": {"role": "assistant", "content": chunk},
                     "done": False,
@@ -133,7 +133,7 @@ def _ollama_ndjson_body(text_chunks: list[str]) -> str:
     lines.append(
         json.dumps(
             {
-                "model": "llama3.1:8b",
+                "model": "qwen3.5:4b-nvfp4",
                 "created_at": "2026-05-08T12:00:01Z",
                 "message": {"role": "assistant", "content": ""},
                 "done": True,
@@ -156,7 +156,7 @@ async def test_local_fast_alias_routes_to_ollama(
     ollama_client: AsyncClient,
     ollama_app: FastAPI,
 ) -> None:
-    """``local-fast`` resolves to ``ollama-local / llama3.1:8b`` and
+    """``local-fast`` resolves to ``ollama-local / qwen3.5:4b-nvfp4`` and
     round-trips through the OllamaAdapter."""
 
     upstream = respx.post("http://ollama:11434/api/chat").mock(
@@ -191,7 +191,7 @@ async def test_local_fast_alias_routes_to_ollama(
     # Verify the upstream payload had the resolved native model.
     assert upstream.called
     sent = json.loads(upstream.calls[-1].request.content)
-    assert sent["model"] == "llama3.1:8b"
+    assert sent["model"] == "qwen3.5:4b-nvfp4"
     assert sent["stream"] is False
 
 
@@ -206,7 +206,7 @@ async def test_local_thinking_alias_routes_to_70b(
         return_value=httpx.Response(
             200,
             json={
-                "model": "llama3.1:70b",
+                "model": "qwen3.5:9b",
                 "message": {"role": "assistant", "content": "deep thoughts"},
                 "done": True,
                 "done_reason": "stop",
@@ -230,7 +230,7 @@ async def test_local_thinking_alias_routes_to_70b(
 
     assert upstream.called
     sent = json.loads(upstream.calls[-1].request.content)
-    assert sent["model"] == "llama3.1:70b"
+    assert sent["model"] == "qwen3.5:9b"
 
 
 @pytest.mark.integration
@@ -245,7 +245,7 @@ async def test_native_ollama_model_routes_directly(
         return_value=httpx.Response(
             200,
             json={
-                "model": "mistral-large",
+                "model": "gemma4:e4b",
                 "message": {"role": "assistant", "content": "ok"},
                 "done": True,
                 "done_reason": "stop",
@@ -257,7 +257,7 @@ async def test_native_ollama_model_routes_directly(
     response = await ollama_client.post(
         "/v1/chat/completions",
         json={
-            "model": "mistral-large",
+            "model": "gemma4:e4b",
             "messages": [{"role": "user", "content": "hi"}],
         },
     )
@@ -355,7 +355,7 @@ async def test_routing_log_row_written_for_ollama_success(
     row = rows[0]
     assert row.requested_model == "local-fast"
     assert row.routed_provider == "ollama-local"
-    assert row.routed_model == "llama3.1:8b"
+    assert row.routed_model == "qwen3.5:4b-nvfp4"
     assert row.routed_inference_tier == 1
     assert row.tokens_in == 9
     assert row.tokens_out == 6
@@ -482,7 +482,7 @@ async def fallback_app(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[FastAPI
         from app.config import ModelAliasConfig, ModelTarget
 
         config.model_aliases["smart-with-local-fallback"] = ModelAliasConfig(
-            primary=ModelTarget(provider="ollama-local", model="llama3.1:8b"),
+            primary=ModelTarget(provider="ollama-local", model="qwen3.5:4b-nvfp4"),
             fallback=[ModelTarget(provider="anthropic-prod", model="claude-opus-4-7")],
         )
         # Rebuild the router so the new alias is in scope.
@@ -587,7 +587,7 @@ async def test_fallback_chain_ollama_404_does_not_fall_back(
     recorder.rows.clear()
 
     ollama_route = respx.post("http://ollama:11434/api/chat").mock(
-        return_value=httpx.Response(404, json={"error": "model 'llama3.1:8b' not found"})
+        return_value=httpx.Response(404, json={"error": "model 'qwen3.5:4b-nvfp4' not found"})
     )
     anthropic_route = respx.post("https://api.anthropic.com/v1/messages").mock(
         return_value=httpx.Response(


### PR DESCRIPTION
## Summary

Wires the M2 Anonymization Layer (PRD §4.7) into the request/response path. Outbound chat + skill content is pseudonymized before reaching the provider; inbound responses (streaming **and** non-streaming) are rehydrated so the caller only ever sees originals. The substitution mapping is request-scoped and dropped on function exit — never logged, never persisted.

Closes M2-B3. Phase B is now complete; Phase C (LLM judge + UI) is next.

## Architectural decisions

Surfaced before any code, resolved at session kickoff:

- **A — privileged plumbing:** `project.privileged` now resolves alongside `minimum_inference_tier` in the api/'s existing project SELECT and forwards as `lq_ai_privileged` on the gateway request body. New typed field on both `ChatCompletionRequest` schemas.
- **B — streaming buffer:** Pseudonym-aware tail buffer (option i). `StreamingRehydrator` holds at most one in-flight pseudonym (~25 chars in practice). On `[DONE]`, residual tail flushes as a synthesized terminal chunk.
- **C — audit field:** Non-decision. `InferenceRoutingLogRow.anonymization_applied: bool` already existed (M1 schema); the handoff's "details JSONB" was a misread. No migration needed.
- **D — citation rehydration:** Gateway rehydrates response **content** only. The api/'s downstream citation extraction (M2-A2 / B1) operates on already-rehydrated content. Gateway never touches `message_citations`.

## What's in the box

### Gateway core

- `gateway/app/anonymization/engine.py`: `Anonymizer.pseudonymize_into` / `pseudonymize` / `rehydrate` fill the M2-A3 stubs. Overlap collapse (longest wins; ties by score), assign-in-reading-order, splice-right-to-left, length-ordered rehydrate for prefix-collision safety (`PERSON_0001` vs `PERSON_00010`). DI-friendly `analyzer` parameter so tests skip the spaCy load.
- `gateway/app/anonymization/middleware.py` (new): `pre_anonymize_request`, `post_anonymize_response`, `StreamingRehydrator`. Four skip conditions short-circuit cleanly; recurses into nested `lq_ai_skill_inputs` string leaves.
- `gateway/app/config.py`: `AnonymizationConfig.apply_at_tiers: list[int]` with a `[1, 5]` range validator (no more silent passthrough on YAML typos).
- `gateway/app/providers/openai_schema.py`: `lq_ai_privileged: bool = False` on `ChatCompletionRequest`.
- `gateway/app/api/inference.py`: middleware wired at the PRD §4.3 position. `anonymization_applied` set on every relevant `InferenceRoutingLogRow` write.
- `gateway/app/main.py`: `app.state.anonymizer = Anonymizer()` at lifespan (lazy spaCy load — no startup cost).

### api/ side

- `api/app/api/chats.py`: single project SELECT fetches `privileged` alongside `minimum_inference_tier`; forwarded as `lq_ai_privileged`.
- `api/app/schemas/gateway.py`: matching `lq_ai_privileged` field.

### Tests (+50 gateway, +2 api)

- `tests/anonymization/test_anonymizer.py` (new, 16 tests) — pure-logic invariants
- `tests/anonymization/test_middleware.py` (new, 24 tests) — pre/post/streaming skip + firing cases
- `tests/test_inference_anonymization.py` (new, 5 integration tests) — full HTTP round-trip via respx-mocked Anthropic, including SSE with pseudonyms straddling chunk boundaries
- `tests/test_config.py` (+1) — typed `apply_at_tiers` validation
- `api/tests/test_chats_tier_floor.py` (+2 assertions) — `lq_ai_privileged` propagation

### Bundled refresh

`gateway.yaml.example` shipped with `local` / `local-fast` / `local-thinking` aliases pointing at `llama3.1:*` — neither loaded in the dev Ollama nor current. Refreshed to `qwen3.5:9b` / `qwen3.5:4b-nvfp4`; matching docs and tests updated.

### Docs

`docs/security/anonymization.md`: new "Middleware behavior (M2-B3)" section — four firing conditions, pass scope, streaming buffer semantics, audit-log contract, mapping lifecycle, privileged-skip rationale.

## Test plan

- [x] `cd gateway && pytest tests/` — 465 passed, 2 skipped
- [x] `cd gateway && mypy app/` — strict clean (36 files)
- [x] `cd gateway && ruff check app/ tests/` — clean
- [x] `cd api && pytest tests/` — 921 passed, 1 skipped (live Postgres)
- [x] `cd api && mypy app/` — clean (84 files)
- [x] `cd api && ruff check app/ tests/` — clean
- [x] Non-streaming integration: provider sees pseudonyms, client sees originals, audit `anonymization_applied=True`
- [x] Streaming integration: pseudonyms split across SSE chunks round-trip correctly
- [ ] **Operator verification (post-merge):** chat in a non-privileged project at Tier 4 with `anonymization.enabled=true`; confirm gateway logs show pseudonymized content to provider and rendered message carries originals
- [ ] **Operator verification (post-merge):** repeat with `privileged=true` project; content passes through unchanged, audit shows `anonymization_applied=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)