### PR TITLE
feat(api,gateway,m2-c1): Citation Engine Stage 3 — paraphrase judge

### DIFF
--- a/api/alembic/versions/0026_paraphrase_judge_and_partial.py
+++ b/api/alembic/versions/0026_paraphrase_judge_and_partial.py
@@ -1,0 +1,104 @@
+"""add paraphrase_judge method + partial column on message_citations — M2-C1
+
+Stage 3 of the Citation Engine cascade is the LLM paraphrase judge.
+Two schema changes land here:
+
+1. The ``verification_method`` CHECK constraint is widened from the
+   M2-A2 list to also accept ``'paraphrase_judge'``. M2-A2's enum
+   reserved ``'llm_judge'`` for this slot (more generic), but the M2
+   plan §M2-C1 names the method ``'paraphrase_judge'`` and that's the
+   semantically tighter label — only paraphrase judgments take this
+   code path. We add it as a new value rather than reusing the
+   generic name so future LLM-based verification stages (semantic
+   matching, claim decomposition) can take ``'llm_judge'`` without
+   conflating with the paraphrase verdict.
+
+2. A ``partial`` BOOLEAN NOT NULL DEFAULT FALSE column distinguishes
+   "judge says yes, this paraphrase captures the claim" from "judge
+   says the claim is *partially* supported — the source supports
+   part but not all of what the model cited." Both persist as
+   ``verified=true``; the partial flag drives the M2-C2 UI's
+   visually-distinct "verified with caveats" rendering.
+
+The CHECK constraint replacement uses DROP + ADD because Postgres
+doesn't support in-place ALTER on a named CHECK. Downgrade reverses
+both.
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-05-16
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0026"
+down_revision = "0025"
+branch_labels = None
+depends_on = None
+
+
+_NEW_METHOD_VALUES = (
+    "exact_match",
+    "tolerant_match",
+    "llm_judge",
+    "paraphrase_judge",
+    "ensemble",
+    "failed",
+)
+
+_OLD_METHOD_VALUES = (
+    "exact_match",
+    "tolerant_match",
+    "llm_judge",
+    "ensemble",
+    "failed",
+)
+
+
+def _method_check_sql(values: tuple[str, ...]) -> str:
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"verification_method IS NULL OR verification_method IN ({quoted})"
+
+
+def upgrade() -> None:
+    # Replace the method CHECK with the widened list.
+    op.drop_constraint(
+        "chk_message_citations_method_values",
+        "message_citations",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_message_citations_method_values",
+        "message_citations",
+        _method_check_sql(_NEW_METHOD_VALUES),
+    )
+
+    # ``partial`` defaults False — existing rows stay strictly verified
+    # or unverified; only Stage 3's 'partial' verdict sets this true.
+    op.add_column(
+        "message_citations",
+        sa.Column(
+            "partial",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("message_citations", "partial")
+
+    op.drop_constraint(
+        "chk_message_citations_method_values",
+        "message_citations",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_message_citations_method_values",
+        "message_citations",
+        _method_check_sql(_OLD_METHOD_VALUES),
+    )

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -1357,6 +1357,7 @@ async def _persist_message_citations(
     message_id: uuid.UUID,
     assistant_text: str,
     retrieved_chunks: list[HybridSearchResult],
+    gateway: GatewayClient | None = None,
 ) -> None:
     """Extract, verify, and persist citations from an assistant message — M2-A2.
 
@@ -1365,14 +1366,21 @@ async def _persist_message_citations(
     (no RAG context this turn → nothing to cite) or when extraction
     finds no ``"..." (Source: [N])`` pairs.
 
-    Stage 1 (exact-match) is the only verifier wired today. Candidates
-    that fail Stage 1 are NOT persisted in M2-A2 — they'd land here
-    once Stage 2 (M2-B1) ships and routes the verifier cascade. The
-    plan's "render as unverified" UI path (M2-C2) consumes either:
+    Verifier cascade (per the M2 plan):
 
-    * verified=true rows from Stage 1 (or later stages once they ship),
-      OR
-    * the absence of any row for a quote the model emitted.
+    * Stage 1 (exact-match) — M2-A2.
+    * Stage 2 (tolerant-match) — M2-B1.
+    * Stage 3 (paraphrase judge) — M2-C1, runs only when ``gateway``
+      is supplied. The judge model is resolved via
+      :meth:`GatewayClient.get_citation_engine_judge_model` (cached
+      for the process) so the operator configures it once in
+      ``gateway.yaml`` rather than on the api/ side.
+
+    Candidates that pass any stage persist with the stage's method
+    string and confidence. Stage 3 ``partial`` verdicts persist with
+    ``verified=true, partial=true`` — the M2-C2 UI renders these as
+    "verified with caveats". Candidates that miss every stage are NOT
+    persisted; their absence is the unverified signal the UI consumes.
     """
 
     if not retrieved_chunks:
@@ -1389,6 +1397,13 @@ async def _persist_message_citations(
     doc_rows = (await db.execute(select(Document).where(Document.id.in_(doc_ids)))).scalars().all()
     docs_by_id = {d.id: d for d in doc_rows}
 
+    # M2-C1: resolve the Stage 3 judge model once per persist call.
+    # The lookup is process-cached on the GatewayClient, so the per-
+    # request cost is one Python-dict read after the first call.
+    judge_model = "fast"
+    if gateway is not None:
+        judge_model = await gateway.get_citation_engine_judge_model()
+
     new_rows: list[MessageCitation] = []
     for cand in candidates:
         doc = docs_by_id.get(cand.source_document_id)
@@ -1398,12 +1413,12 @@ async def _persist_message_citations(
             # would reject anyway.
             continue
 
-        result = verify(cand, doc)
+        result = await verify(cand, doc, gateway=gateway, judge_model=judge_model)
         if not result.verified:
-            # Every wired stage (currently 1 + 2) rejected the
-            # candidate. Drop until Stages 3-4 (LLM judge / ensemble)
-            # land in M2-C1 / M2-D1; those plug into the same
-            # ``verify()`` cascade.
+            # Every wired stage rejected the candidate. M2-C2's UI
+            # consumes the *absence* of a row as the unverified
+            # signal — no DB row for an emitted quote means "we
+            # couldn't verify it; render as unverified."
             continue
 
         new_rows.append(
@@ -1417,6 +1432,7 @@ async def _persist_message_citations(
                 verified=True,
                 verification_method=result.method,
                 verification_confidence=result.confidence,
+                partial=result.partial,
             )
         )
 
@@ -1626,13 +1642,16 @@ async def _non_streaming_response(
         error_code=None,
     )
 
-    # M2-A2: extract + verify + persist citations from the assistant
-    # response. No-op when no chunks were retrieved this turn.
+    # M2-A2 / M2-B1 / M2-C1: extract + verify + persist citations from
+    # the assistant response. The verifier cascade is Stage 1
+    # (exact-match) → Stage 2 (tolerant-match) → Stage 3 (paraphrase
+    # judge through the gateway). No-op when no chunks were retrieved.
     await _persist_message_citations(
         db,
         message_id=assistant_message_id,
         assistant_text=assistant_text,
         retrieved_chunks=retrieved_chunks or [],
+        gateway=gateway,
     )
 
     await _audit_message_sent(
@@ -1794,6 +1813,7 @@ async def _stream_response(
                         message_id=assistant_message_id,
                         assistant_text="".join(accumulated),
                         retrieved_chunks=retrieved_chunks or [],
+                        gateway=gateway,
                     )
                 except Exception as cite_exc:
                     log.warning(

--- a/api/app/citation/judge_prompts.py
+++ b/api/app/citation/judge_prompts.py
@@ -1,0 +1,129 @@
+"""Stage 3 paraphrase-judge prompt construction — M2-C1.
+
+Builds the ``list[ChatCompletionMessage]`` the Citation Engine
+dispatches to the gateway as its Stage 3 judge call. The judge is an
+LLM asked to evaluate whether a model-emitted claim is faithfully
+supported by the cited source passage.
+
+The prompt is deliberately conservative: it biases the judge toward
+``no`` / ``partial`` on uncertainty, on the principle that
+false-positive verifications (calling an unsupported claim verified)
+do more harm in a legal-citation context than false-negative
+verifications (calling a borderline-supported claim unverified). The
+M2-F1 acceptance corpus will measure this trade-off empirically; the
+prompt's calibration is the lever to tune.
+
+Output contract: the judge returns a single JSON object with three
+fields — ``verdict`` (``yes`` / ``partial`` / ``no``), ``confidence``
+(``high`` / ``medium`` / ``low``), and ``justification`` (free text).
+:func:`app.citation.verification.verify_paraphrase` parses this shape;
+the parser falls through to MISS on malformed JSON so a misbehaving
+judge can't crash the pipeline.
+"""
+
+from __future__ import annotations
+
+from app.schemas.gateway import ChatCompletionMessage
+
+__all__ = ["build_judge_prompt"]
+
+
+_SYSTEM_PROMPT = """\
+You are a Citation Verification Judge for a legal AI assistant.
+
+Your job is to evaluate whether a claim — a passage another model
+quoted from a source document — is FAITHFULLY SUPPORTED by the
+SOURCE passages provided. You are NOT evaluating the legal merits
+of the claim; only whether the source actually says what the claim
+asserts.
+
+Respond with STRICTLY VALID JSON in this exact shape:
+
+  {"verdict": "yes" | "partial" | "no",
+   "confidence": "high" | "medium" | "low",
+   "justification": "<one or two sentences explaining your verdict>"}
+
+Verdict meanings:
+
+* "yes" — the source supports the ENTIRE substance of the claim.
+  The wording does not need to match verbatim, but every assertion
+  in the claim must follow from the source.
+* "partial" — the source supports SOME of the claim's assertions
+  but not all. A claim that adds qualifiers or details the source
+  doesn't contain is "partial", not "yes".
+* "no" — the source does not support the claim, or the source
+  contradicts it.
+
+Confidence meanings:
+
+* "high" — the verdict is unambiguous; another careful reader would
+  reach the same conclusion.
+* "medium" — the verdict is sound but reasonable readers could
+  weigh it differently.
+* "low" — the verdict is best-guess; the source is ambiguous or
+  the claim is vague enough to be hard to evaluate.
+
+CALIBRATION — IMPORTANT.
+
+When you are uncertain, prefer "no" or "partial" over "yes". A
+false-positive verification (declaring an unsupported claim
+verified) is worse than a false-negative (declaring a supported
+claim unverified) in this context. If the source is ambiguous, or
+the claim adds qualifiers the source doesn't contain, lean toward
+"partial". If the source is genuinely off-topic relative to the
+claim, lean toward "no".
+
+Output ONLY the JSON object. No preamble, no markdown fencing, no
+trailing commentary."""
+
+
+def build_judge_prompt(
+    *,
+    claim_text: str,
+    chunks: list[str],
+) -> list[ChatCompletionMessage]:
+    """Construct the two-message judge prompt.
+
+    Args:
+        claim_text: The text the citation-generating model quoted.
+            This is the ``source_text`` field on the citation
+            candidate — the model's literal claim, as it appears in
+            the assistant's response.
+        chunks: The source-document text chunks the citation points
+            at. The caller decides what to include (typically the
+            cited span plus a small window of surrounding context);
+            this function just embeds each chunk into the user message
+            verbatim with separators.
+
+    Returns:
+        A two-element list: ``[system_message, user_message]`` ready
+        to set as :attr:`ChatCompletionRequest.messages`.
+    """
+
+    user_message = _build_user_message(claim_text=claim_text, chunks=chunks)
+    return [
+        ChatCompletionMessage(role="system", content=_SYSTEM_PROMPT),
+        ChatCompletionMessage(role="user", content=user_message),
+    ]
+
+
+def _build_user_message(*, claim_text: str, chunks: list[str]) -> str:
+    """Format SOURCE chunks and CLAIM into a labeled user message body."""
+
+    # Degenerate empty-chunks case is well-formed — the judge will
+    # return "no" / "low" confidence (nothing to support a claim
+    # against) but the prompt is still parseable.
+    source_block = "\n---\n".join(chunks) if chunks else "(no source passages provided)"
+
+    return (
+        "SOURCE PASSAGES:\n"
+        '"""\n'
+        f"{source_block}\n"
+        '"""\n\n'
+        "CLAIM:\n"
+        '"""\n'
+        f"{claim_text}\n"
+        '"""\n\n'
+        "Does the SOURCE support the CLAIM? Respond with the JSON "
+        "object only — no preamble, no markdown fencing."
+    )

--- a/api/app/citation/verification.py
+++ b/api/app/citation/verification.py
@@ -28,13 +28,19 @@ remapping.
 
 from __future__ import annotations
 
+import json
+import logging
 import uuid
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 from rapidfuzz import fuzz
 
+from app.citation.judge_prompts import build_judge_prompt
 from app.citation.normalization import normalize
+from app.schemas.gateway import ChatCompletionRequest
+
+logger = logging.getLogger(__name__)
 
 
 class _CandidateProtocol(Protocol):
@@ -75,15 +81,22 @@ class VerificationResult:
 
     The shape is symmetric with the ``message_citations`` columns so
     the persistence layer can copy fields without re-mapping.
+
+    M2-C1 added ``partial``: Stage 3 (paraphrase judge) can return
+    ``verified=True, partial=True`` when the source supports *some*
+    but not all of the claim. Stages 1 and 2 always emit
+    ``partial=False`` because they are exact-content stages — a
+    partial match is, by their definition, no match.
     """
 
     verified: bool
     method: str | None
     confidence: float | None
+    partial: bool = False
 
 
 # A sentinel result for misses, reused so callers don't allocate.
-_MISS = VerificationResult(verified=False, method=None, confidence=None)
+_MISS = VerificationResult(verified=False, method=None, confidence=None, partial=False)
 
 # Stage 2 acceptance threshold on the rapidfuzz ratio scale (0-100).
 # 95 catches normalization-only differences (smart quotes, whitespace
@@ -182,19 +195,201 @@ def verify_tolerant_match(
     )
 
 
-def verify(
+# --- Stage 3 — paraphrase judge (M2-C1) --------------------------------------
+
+
+# Map the judge's high/medium/low to a numeric confidence the
+# ``message_citations.verification_confidence`` column accepts. Stages 1
+# and 2 emit 1.0 / 0.95+; Stage 3 sits below — a paraphrase verdict
+# is genuinely less certain than a byte-or-normalization match.
+_CONFIDENCE_MAP: dict[str, float] = {
+    "high": 0.90,
+    "medium": 0.70,
+    "low": 0.50,
+}
+
+# Window of context characters to include around the cited span. A pure
+# slice can be too narrow ("the source span says X but the claim adds Y"
+# when Y appears in the same sentence). A small window picks up that
+# context without flooding the judge with the full document.
+_CONTEXT_WINDOW_CHARS = 200
+
+
+class _JudgeGatewayProtocol(Protocol):
+    """Subset of :class:`app.clients.gateway.GatewayClient` the judge needs.
+
+    Tests pass a stub that records the request and returns canned
+    responses; production passes the real client.
+    """
+
+    async def chat_completion(
+        self,
+        request: ChatCompletionRequest,
+        *,
+        request_id: str | None = ...,
+    ) -> Any: ...
+
+
+async def verify_paraphrase(
     candidate: _CandidateProtocol,
     document: _DocumentProtocol,
+    *,
+    gateway: _JudgeGatewayProtocol,
+    judge_model: str,
+) -> VerificationResult:
+    """Stage 3: ask an LLM judge whether the claim is supported by the source.
+
+    Dispatches a structured-JSON judge prompt to the gateway, parses
+    the verdict, and maps the high/medium/low confidence to numeric
+    confidence (0.90 / 0.70 / 0.50). A ``partial`` verdict persists as
+    ``verified=True, partial=True`` so the M2-C2 UI can render it
+    distinctly from a fully verified citation.
+
+    Failure modes are silent: gateway transport errors, malformed
+    JSON, unknown verdict / confidence values, and empty responses
+    all return :data:`_MISS`. Stage 3 is best-effort verification on
+    top of Stages 1 and 2; a failure here just means the citation
+    falls through to "unverified" without crashing the persistence
+    pipeline.
+    """
+
+    claim = candidate.source_text
+    if not claim:
+        return _MISS
+
+    chunk = _source_chunk_with_context(candidate, document)
+    if chunk is None:
+        return _MISS
+
+    messages = build_judge_prompt(claim_text=claim, chunks=[chunk])
+    request = ChatCompletionRequest(
+        model=judge_model,
+        messages=messages,
+        # The judge prompt asks for a short structured JSON; cap the
+        # token budget so a chatty model can't run away with the
+        # output. ~400 tokens is plenty for ``{"verdict": ..., ...}``
+        # plus a one-sentence justification.
+        max_tokens=400,
+        # We don't want creative paraphrases of the verdict; 0.0 keeps
+        # the judge deterministic.
+        temperature=0.0,
+        # Per-request opt-out from anonymization — the judge needs to
+        # see actual content to verify it. Anonymized text would
+        # destroy the semantics the judge is checking against.
+        anonymize=False,
+    )
+
+    try:
+        response = await gateway.chat_completion(request)
+    except Exception as exc:
+        logger.warning(
+            "paraphrase judge gateway call failed: %s",
+            exc,
+            extra={"event": "citation_judge_error", "error_type": type(exc).__name__},
+        )
+        return _MISS
+
+    return _parse_judge_response(response)
+
+
+def _source_chunk_with_context(
+    candidate: _CandidateProtocol,
+    document: _DocumentProtocol,
+) -> str | None:
+    """Return the cited span plus ``_CONTEXT_WINDOW_CHARS`` on each side."""
+
+    content = document.normalized_content
+    doc_len = len(content)
+    if not _slice_in_range(candidate.source_offset_start, candidate.source_offset_end, doc_len):
+        return None
+    start = max(0, candidate.source_offset_start - _CONTEXT_WINDOW_CHARS)
+    end = min(doc_len, candidate.source_offset_end + _CONTEXT_WINDOW_CHARS)
+    return content[start:end]
+
+
+def _parse_judge_response(response: Any) -> VerificationResult:
+    """Extract verdict + confidence + partial from the judge's chat completion."""
+
+    try:
+        choices = response.choices
+        if not choices:
+            return _MISS
+        content = choices[0].message.content
+    except AttributeError:
+        return _MISS
+
+    if not content:
+        return _MISS
+
+    try:
+        payload = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        logger.info(
+            "paraphrase judge produced non-JSON output",
+            extra={"event": "citation_judge_malformed"},
+        )
+        return _MISS
+
+    if not isinstance(payload, dict):
+        return _MISS
+
+    verdict = payload.get("verdict")
+    confidence_label = payload.get("confidence")
+
+    if verdict == "no":
+        # The judge rejected the claim — fall through to unverified.
+        return _MISS
+
+    if verdict not in ("yes", "partial"):
+        logger.info(
+            "paraphrase judge returned unknown verdict %r",
+            verdict,
+            extra={"event": "citation_judge_unknown_verdict"},
+        )
+        return _MISS
+
+    if confidence_label not in _CONFIDENCE_MAP:
+        logger.info(
+            "paraphrase judge returned unknown confidence %r",
+            confidence_label,
+            extra={"event": "citation_judge_unknown_confidence"},
+        )
+        return _MISS
+
+    return VerificationResult(
+        verified=True,
+        method="paraphrase_judge",
+        confidence=_CONFIDENCE_MAP[confidence_label],
+        partial=(verdict == "partial"),
+    )
+
+
+async def verify(
+    candidate: _CandidateProtocol,
+    document: _DocumentProtocol,
+    *,
+    gateway: _JudgeGatewayProtocol | None = None,
+    judge_model: str = "fast",
 ) -> VerificationResult:
     """Run the verification cascade and return the first hit.
 
-    Order: Stage 1 (exact-match) → Stage 2 (tolerant-match). Returns
-    :data:`_MISS` only when every stage has rejected the candidate.
-    Stages 3 and 4 (LLM judge, ensemble) land in M2-C1 / M2-D1 and
-    will plug in here.
+    Order: Stage 1 (exact-match) → Stage 2 (tolerant-match) → Stage 3
+    (paraphrase judge). Returns :data:`_MISS` only when every stage
+    has rejected the candidate.
 
-    The persistence layer in ``app.api.chats`` calls this rather than
-    a specific stage so the cascade is opaque to callers.
+    Stage 3 only runs when ``gateway`` is supplied. Callers without
+    an LLM (smoke tests, eval scripts that exercise only the
+    deterministic stages) pass ``gateway=None``; the cascade then
+    runs Stages 1+2 only and short-circuits to MISS if both miss.
+
+    ``judge_model`` is the alias the gateway resolves for the Stage 3
+    judge call. Default ``"fast"`` matches ``gateway.yaml.example``'s
+    ``citation_engine.judge_model``; the chat-send caller passes the
+    value it pulled from ``GatewayClient.get_citation_engine_judge_model``.
+
+    Made async in M2-C1: Stages 1 and 2 are still pure Python and run
+    synchronously inside the function; the ``async def`` is for
+    Stage 3's gateway call.
     """
 
     result = verify_exact_match(candidate, document)
@@ -205,4 +400,7 @@ def verify(
     if result.verified:
         return result
 
-    return _MISS
+    if gateway is None:
+        return _MISS
+
+    return await verify_paraphrase(candidate, document, gateway=gateway, judge_model=judge_model)

--- a/api/app/clients/gateway.py
+++ b/api/app/clients/gateway.py
@@ -141,6 +141,98 @@ class GatewayClient:
 
         return self._client
 
+    # --- Citation engine config (M2-C1) -------------------------------------
+
+    _citation_engine_judge_model: str | None = None
+    """Process-cached judge model alias.
+
+    Populated on first :meth:`get_citation_engine_judge_model` call.
+    The gateway treats this config as immutable after startup
+    (``gateway.yaml`` is loaded once on lifespan); the api/ caches
+    the value for the same lifespan so we don't pay the round-trip
+    on every Stage 3 invocation. A gateway restart-then-api restart
+    is the deployment story for changing the alias.
+    """
+
+    async def get_citation_engine_judge_model(
+        self,
+        *,
+        fallback: str = "fast",
+    ) -> str:
+        """Fetch the configured judge model alias from the gateway.
+
+        Calls ``GET /v1/citation-engine/config`` once per process and
+        caches the result. On any failure (network, non-200, malformed
+        body) returns ``fallback`` — a missing config endpoint must not
+        crash the Citation Engine; Stage 3 silently degrades to the
+        default model.
+
+        Returns:
+            The configured ``judge_model`` (an alias the gateway can
+            resolve), or ``fallback`` when the lookup failed.
+        """
+
+        if self._citation_engine_judge_model is not None:
+            return self._citation_engine_judge_model
+
+        try:
+            response = await self._client.get(
+                "/v1/citation-engine/config",
+                timeout=5.0,
+            )
+        except Exception as exc:
+            # Catch broadly: the judge-model lookup is best-effort
+            # (the Stage 3 cascade still works with the fallback model).
+            # We don't want a transient gateway problem — or a respx
+            # test scenario that doesn't mock this endpoint — to crash
+            # the chat-send pipeline. Production callers see network,
+            # DNS, TLS, asyncio cancellation, etc. all in this slot.
+            log.warning(
+                "citation-engine config fetch failed: %s",
+                exc,
+                extra=_structured_log_extra(
+                    op="get_citation_engine_judge_model",
+                    error_type=type(exc).__name__,
+                ),
+            )
+            return fallback
+
+        if response.status_code != 200:
+            log.warning(
+                "citation-engine config endpoint returned %s",
+                response.status_code,
+                extra=_structured_log_extra(
+                    op="get_citation_engine_judge_model",
+                    status_code=response.status_code,
+                ),
+            )
+            return fallback
+
+        try:
+            payload = response.json()
+            judge_model = str(payload["judge_model"])
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            log.warning(
+                "citation-engine config response malformed: %s",
+                exc,
+                extra=_structured_log_extra(
+                    op="get_citation_engine_judge_model",
+                    error_type=type(exc).__name__,
+                ),
+            )
+            return fallback
+
+        if not judge_model:
+            return fallback
+
+        self._citation_engine_judge_model = judge_model
+        return judge_model
+
+    def _reset_citation_engine_cache_for_tests(self) -> None:
+        """Drop the cached judge model. Tests use this to test re-fetch."""
+
+        self._citation_engine_judge_model = None
+
     # --- Health probe --------------------------------------------------------
 
     async def health_check(self) -> bool:

--- a/api/app/models/chat.py
+++ b/api/app/models/chat.py
@@ -228,14 +228,23 @@ class MessageCitation(Base):
     * ``'exact_match'`` — Stage 1, byte-for-byte (M2-A2; lands here).
     * ``'tolerant_match'`` — Stage 2, normalized-whitespace + OCR
       artefacts (M2-B1).
-    * ``'llm_judge'`` — Stage 3, paraphrase judge (M2-C1).
+    * ``'paraphrase_judge'`` — Stage 3, paraphrase judge (M2-C1).
+    * ``'llm_judge'`` — reserved for future LLM-based verification
+      stages (semantic match, claim decomposition); ``'paraphrase_judge'``
+      is the tighter label for the M2-C1 paraphrase-only path.
     * ``'ensemble'`` — Stage 4, multi-model agreement (M2-D1).
     * ``'failed'`` — every stage rejected; rendered as unverified in
       the UI (M2-C2).
 
     ``verification_confidence`` is the stage's reported confidence in
     ``[0, 1]``; exact-match writes ``1.0``, tolerant-match writes a
-    similarity-based score, the LLM judge writes its own estimate.
+    similarity-based score, the paraphrase judge writes its own
+    high/medium/low → 0.90/0.70/0.50 mapping.
+
+    ``partial`` (M2-C1) distinguishes "judge says the source supports
+    the claim" from "judge says the source supports it *partially*".
+    Both persist with ``verified=true``; the partial flag drives the
+    M2-C2 UI's visually-distinct "verified with caveats" rendering.
     """
 
     __tablename__ = "message_citations"
@@ -250,7 +259,8 @@ class MessageCitation(Base):
         ),
         CheckConstraint(
             "verification_method IS NULL OR verification_method IN "
-            "('exact_match', 'tolerant_match', 'llm_judge', 'ensemble', 'failed')",
+            "('exact_match', 'tolerant_match', 'llm_judge', "
+            "'paraphrase_judge', 'ensemble', 'failed')",
             name="chk_message_citations_method_values",
         ),
         CheckConstraint(
@@ -300,6 +310,11 @@ class MessageCitation(Base):
     verification_confidence: Mapped[Decimal | None] = mapped_column(
         Numeric(3, 2),
         nullable=True,
+    )
+    partial: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/api/tests/citation/test_judge_prompts.py
+++ b/api/tests/citation/test_judge_prompts.py
@@ -1,0 +1,136 @@
+"""Tests for the Stage 3 paraphrase-judge prompt construction (M2-C1).
+
+The Stage 3 judge is an LLM call made through the gateway with a
+deterministic prompt: a system message that sets up the verification
+task and a user message carrying the candidate claim and the source
+context. The prompt's calibration (bias toward 'no'/'partial' on
+uncertainty) is load-bearing — it controls the false-positive rate
+that the M2-F1 acceptance corpus will measure.
+
+These tests pin the prompt's *invariants* — the exact wording is
+operator-tunable, but the structure (role split, JSON-only output
+instruction, conservative bias, claim and source both present) must
+hold.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.citation.judge_prompts import build_judge_prompt
+from app.schemas.gateway import ChatCompletionMessage
+
+
+@pytest.mark.unit
+def test_build_judge_prompt_returns_system_and_user_messages() -> None:
+    """The judge prompt is a two-message list: system then user."""
+
+    messages = build_judge_prompt(claim_text="hello", chunks=["world"])
+
+    assert len(messages) == 2
+    assert all(isinstance(m, ChatCompletionMessage) for m in messages)
+    assert messages[0].role == "system"
+    assert messages[1].role == "user"
+
+
+@pytest.mark.unit
+def test_build_judge_prompt_system_message_specifies_json_shape() -> None:
+    """System message tells the model the exact JSON output shape."""
+
+    messages = build_judge_prompt(claim_text="hello", chunks=["world"])
+    system_content = messages[0].content or ""
+
+    # Verdict + confidence + justification — the three keys the
+    # verify_paraphrase parser reads. Names must match.
+    assert "verdict" in system_content
+    assert "confidence" in system_content
+    assert "justification" in system_content
+    # Verdict and confidence enums.
+    assert '"yes"' in system_content
+    assert '"partial"' in system_content
+    assert '"no"' in system_content
+    assert '"high"' in system_content
+    assert '"medium"' in system_content
+    assert '"low"' in system_content
+
+
+@pytest.mark.unit
+def test_build_judge_prompt_system_message_has_conservative_bias() -> None:
+    """The prompt explicitly biases toward 'no' / 'partial' on uncertainty.
+
+    Calibration intent from M2-C1: false positives (calling an
+    unsupported claim verified) are more harmful than false negatives
+    in a legal-citation context. The prompt has to make this trade-off
+    explicit or the model defaults to charitable interpretation.
+    """
+
+    messages = build_judge_prompt(claim_text="hello", chunks=["world"])
+    system_content = (messages[0].content or "").lower()
+
+    # The wording is operator-tunable; the substance must hold —
+    # an explicit nudge toward "no" or "partial" when uncertain.
+    assert "uncertain" in system_content or "unsure" in system_content
+    assert "no" in system_content
+    assert "partial" in system_content
+
+
+@pytest.mark.unit
+def test_build_judge_prompt_user_message_contains_claim() -> None:
+    """The user message includes the model's quoted claim verbatim."""
+
+    claim = "The plaintiff prevailed on the breach claim."
+    messages = build_judge_prompt(claim_text=claim, chunks=["irrelevant"])
+    user_content = messages[1].content or ""
+
+    assert claim in user_content
+
+
+@pytest.mark.unit
+def test_build_judge_prompt_user_message_contains_all_chunks() -> None:
+    """Every chunk gets embedded in the user message."""
+
+    chunks = [
+        "Section 5.1 of the agreement defines breach.",
+        "Section 5.2 provides remedies for breach.",
+        "Section 5.3 is the integration clause.",
+    ]
+    messages = build_judge_prompt(claim_text="claim", chunks=chunks)
+    user_content = messages[1].content or ""
+
+    for chunk in chunks:
+        assert chunk in user_content
+
+
+@pytest.mark.unit
+def test_build_judge_prompt_user_message_labels_source_and_claim() -> None:
+    """User message labels the source vs. claim distinctly so the model parses correctly.
+
+    Without distinct labels (e.g. "SOURCE:" / "CLAIM:") the model can
+    conflate the claim into the source text and produce noisy
+    verdicts. The label format is internal but the existence is
+    load-bearing.
+    """
+
+    messages = build_judge_prompt(claim_text="claim", chunks=["source"])
+    user_content = (messages[1].content or "").lower()
+
+    assert "source" in user_content
+    assert "claim" in user_content
+
+
+@pytest.mark.unit
+def test_build_judge_prompt_handles_empty_chunks_list() -> None:
+    """Empty ``chunks`` is degenerate but must not crash.
+
+    The judge will likely return 'no' / 'low' confidence in this case
+    (no source to support the claim) but the prompt construction
+    itself stays well-formed.
+    """
+
+    messages = build_judge_prompt(claim_text="claim", chunks=[])
+
+    assert len(messages) == 2
+    assert messages[0].role == "system"
+    assert messages[1].role == "user"
+    user_content = messages[1].content or ""
+    assert "claim" in user_content

--- a/api/tests/citation/test_paraphrase_judge.py
+++ b/api/tests/citation/test_paraphrase_judge.py
@@ -1,0 +1,392 @@
+"""Citation Engine Stage 3 — paraphrase judge tests (M2-C1).
+
+``verify_paraphrase(candidate, document, *, gateway, judge_model)``
+sends a structured JSON judge prompt to the gateway and parses the
+verdict. These tests cover:
+
+* The three pass verdicts (yes, partial) with all three confidence
+  levels mapping to 0.90 / 0.70 / 0.50.
+* The ``partial`` flag on the result.
+* The fail verdict ('no') → MISS regardless of confidence.
+* Failure modes that must not crash the pipeline: gateway raising,
+  malformed JSON output, unknown verdict / confidence values, empty
+  response content. All silently return MISS so the caller routes
+  the candidate to the next stage (or to "unverified" if Stage 3 was
+  the last stage).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+from app.citation.verification import (
+    VerificationResult,
+    verify_paraphrase,
+)
+from app.errors import GatewayUnreachable
+from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _StubDocument:
+    id: uuid.UUID
+    normalized_content: str
+    was_ocrd: bool = False
+
+
+@dataclass(slots=True)
+class _StubCandidate:
+    source_file_id: uuid.UUID
+    source_document_id: uuid.UUID
+    source_offset_start: int
+    source_offset_end: int
+    source_page: int | None
+    source_text: str
+
+
+class _StubGateway:
+    """Records the request and returns a canned chat-completion response."""
+
+    def __init__(
+        self,
+        *,
+        response_content: str | None = None,
+        raises: Exception | None = None,
+    ) -> None:
+        self._response_content = response_content
+        self._raises = raises
+        self.last_request: ChatCompletionRequest | None = None
+        self.call_count = 0
+
+    async def chat_completion(
+        self,
+        request: ChatCompletionRequest,
+        *,
+        request_id: str | None = None,
+    ) -> ChatCompletionResponse:
+        self.last_request = request
+        self.call_count += 1
+        if self._raises is not None:
+            raise self._raises
+        return ChatCompletionResponse(
+            id="chatcmpl-judge",
+            created=0,
+            model=request.model,
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=ChatCompletionMessage(
+                        role="assistant",
+                        content=self._response_content,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        )
+
+
+def _doc(text: str = "The agreement was signed on the third of June.") -> _StubDocument:
+    return _StubDocument(id=uuid.uuid4(), normalized_content=text)
+
+
+def _candidate(
+    doc: _StubDocument,
+    *,
+    source_text: str = "the agreement was signed",
+    offsets: tuple[int, int] | None = None,
+) -> _StubCandidate:
+    if offsets is None:
+        # Default: a slice that exists inside doc; the verifier reads
+        # the slice to build the judge prompt, but tests can override
+        # to exercise out-of-range offsets.
+        offsets = (0, min(40, len(doc.normalized_content)))
+    return _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=offsets[0],
+        source_offset_end=offsets[1],
+        source_page=None,
+        source_text=source_text,
+    )
+
+
+def _judge_json(
+    *,
+    verdict: str,
+    confidence: str = "high",
+    justification: str = "test",
+) -> str:
+    return json.dumps(
+        {"verdict": verdict, "confidence": confidence, "justification": justification}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — verdict + confidence mapping.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_yes_high_returns_verified_with_confidence_0_90() -> None:
+    """yes/high → verified=True, confidence=0.90, partial=False, method='paraphrase_judge'."""
+
+    gw = _StubGateway(response_content=_judge_json(verdict="yes", confidence="high"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result == VerificationResult(
+        verified=True,
+        method="paraphrase_judge",
+        confidence=pytest.approx(0.90),
+        partial=False,
+    )
+
+
+@pytest.mark.unit
+async def test_yes_medium_returns_confidence_0_70() -> None:
+    gw = _StubGateway(response_content=_judge_json(verdict="yes", confidence="medium"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is True
+    assert result.confidence == pytest.approx(0.70)
+    assert result.partial is False
+
+
+@pytest.mark.unit
+async def test_yes_low_returns_confidence_0_50() -> None:
+    gw = _StubGateway(response_content=_judge_json(verdict="yes", confidence="low"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is True
+    assert result.confidence == pytest.approx(0.50)
+
+
+@pytest.mark.unit
+async def test_partial_verdict_sets_partial_true() -> None:
+    """partial verdict → verified=True (rendered as verified-with-caveats), partial=True."""
+
+    gw = _StubGateway(response_content=_judge_json(verdict="partial", confidence="high"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is True
+    assert result.partial is True
+    assert result.confidence == pytest.approx(0.90)
+    assert result.method == "paraphrase_judge"
+
+
+@pytest.mark.unit
+async def test_partial_with_medium_confidence_maps_to_0_70() -> None:
+    gw = _StubGateway(response_content=_judge_json(verdict="partial", confidence="medium"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is True
+    assert result.partial is True
+    assert result.confidence == pytest.approx(0.70)
+
+
+# ---------------------------------------------------------------------------
+# 'no' verdict → MISS (caller can render as unverified).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_no_verdict_returns_miss() -> None:
+    """no verdict → verified=False, regardless of confidence level."""
+
+    gw = _StubGateway(response_content=_judge_json(verdict="no", confidence="high"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is False
+    assert result.method is None
+    assert result.partial is False
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — none must raise; all return MISS.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_gateway_raises_returns_miss() -> None:
+    """Gateway transport failure (timeout, unreachable) → silent MISS."""
+
+    gw = _StubGateway(raises=GatewayUnreachable("gateway down"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is False
+
+
+@pytest.mark.unit
+async def test_malformed_json_returns_miss() -> None:
+    """Judge produces non-JSON output → silent MISS."""
+
+    gw = _StubGateway(response_content="not json at all")
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is False
+
+
+@pytest.mark.unit
+async def test_empty_response_content_returns_miss() -> None:
+    """Judge returns empty content → MISS."""
+
+    gw = _StubGateway(response_content="")
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is False
+
+
+@pytest.mark.unit
+async def test_none_response_content_returns_miss() -> None:
+    """Judge returns null content (tool-call shape) → MISS."""
+
+    gw = _StubGateway(response_content=None)
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is False
+
+
+@pytest.mark.unit
+async def test_unknown_verdict_returns_miss() -> None:
+    """Verdict outside the documented enum → MISS."""
+
+    gw = _StubGateway(response_content=_judge_json(verdict="maybe", confidence="high"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is False
+
+
+@pytest.mark.unit
+async def test_unknown_confidence_returns_miss() -> None:
+    """Confidence outside the documented enum → MISS."""
+
+    gw = _StubGateway(response_content=_judge_json(verdict="yes", confidence="extreme"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is False
+
+
+@pytest.mark.unit
+async def test_missing_verdict_field_returns_miss() -> None:
+    """JSON missing the verdict key → MISS."""
+
+    gw = _StubGateway(response_content=json.dumps({"confidence": "high", "justification": "x"}))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is False
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction — verify the right alias and shape go to the gateway.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_dispatches_with_configured_judge_model() -> None:
+    """The ChatCompletionRequest sent to the gateway uses the passed judge_model."""
+
+    gw = _StubGateway(response_content=_judge_json(verdict="yes"))
+    doc = _doc()
+    cand = _candidate(doc)
+
+    await verify_paraphrase(cand, doc, gateway=gw, judge_model="budget")
+
+    assert gw.last_request is not None
+    assert gw.last_request.model == "budget"
+    # Sanity: the prompt has system + user messages (Stage 3 prompt shape).
+    assert len(gw.last_request.messages) >= 2
+    roles = [m.role for m in gw.last_request.messages]
+    assert "system" in roles
+    assert "user" in roles
+
+
+@pytest.mark.unit
+async def test_dispatches_with_claim_text_in_user_message() -> None:
+    """The candidate's source_text appears in the user prompt."""
+
+    claim = "The plaintiff prevailed on the breach claim."
+    gw = _StubGateway(response_content=_judge_json(verdict="yes"))
+    doc = _doc()
+    cand = _candidate(doc, source_text=claim)
+
+    await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert gw.last_request is not None
+    user_msg = next(m for m in gw.last_request.messages if m.role == "user")
+    assert claim in (user_msg.content or "")
+
+
+@pytest.mark.unit
+async def test_dispatches_with_source_slice_in_user_message() -> None:
+    """The cited document slice appears in the user prompt as context."""
+
+    doc_text = "Header. Section 5.1: The plaintiff prevailed. Section 5.2: ..."
+    doc = _doc(text=doc_text)
+    cited_span = "The plaintiff prevailed"
+    start = doc_text.index(cited_span)
+    cand = _candidate(
+        doc,
+        source_text=cited_span,
+        offsets=(start, start + len(cited_span)),
+    )
+
+    gw = _StubGateway(response_content=_judge_json(verdict="yes"))
+    await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
+
+    assert gw.last_request is not None
+    user_msg = next(m for m in gw.last_request.messages if m.role == "user")
+    # The cited span (and the surrounding context) is included.
+    assert cited_span in (user_msg.content or "")

--- a/api/tests/citation/test_verify_cascade.py
+++ b/api/tests/citation/test_verify_cascade.py
@@ -1,0 +1,243 @@
+"""Tests for the async :func:`verify` cascade with Stage 3 wired in (M2-C1).
+
+``verify()`` was a sync function in M2-A2 / M2-B1 because Stages 1
+and 2 are pure-Python. M2-C1 makes it async because Stage 3 dispatches
+to the LLM judge through the gateway. The cascade order:
+
+1. Stage 1 (exact-match) — fast, byte-for-byte.
+2. Stage 2 (tolerant-match) — normalized fuzzy ratio at threshold 95.
+3. Stage 3 (paraphrase judge) — LLM call, only runs when a gateway is
+   supplied AND Stages 1+2 missed.
+
+The cascade short-circuits on the first hit. The gateway parameter is
+optional so callers without an LLM (smoke tests, eval scripts) can
+still run Stages 1+2 without scaffolding a gateway client.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+from app.citation.verification import VerificationResult, verify
+from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+
+
+@dataclass(slots=True)
+class _StubDocument:
+    id: uuid.UUID
+    normalized_content: str
+    was_ocrd: bool = False
+
+
+@dataclass(slots=True)
+class _StubCandidate:
+    source_file_id: uuid.UUID
+    source_document_id: uuid.UUID
+    source_offset_start: int
+    source_offset_end: int
+    source_page: int | None
+    source_text: str
+
+
+class _StubGateway:
+    def __init__(self, response_content: str) -> None:
+        self._content = response_content
+        self.call_count = 0
+
+    async def chat_completion(
+        self,
+        request: ChatCompletionRequest,
+        *,
+        request_id: str | None = None,
+    ) -> ChatCompletionResponse:
+        self.call_count += 1
+        return ChatCompletionResponse(
+            id="chatcmpl-test",
+            created=0,
+            model=request.model,
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content=self._content),
+                    finish_reason="stop",
+                )
+            ],
+            usage=ChatCompletionUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+
+def _doc(text: str) -> _StubDocument:
+    return _StubDocument(id=uuid.uuid4(), normalized_content=text)
+
+
+def _cand(
+    doc: _StubDocument,
+    *,
+    start: int,
+    end: int,
+    source_text: str,
+) -> _StubCandidate:
+    return _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=start,
+        source_offset_end=end,
+        source_page=None,
+        source_text=source_text,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 short-circuit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_stage_1_hit_short_circuits_cascade() -> None:
+    """Exact match returns immediately without touching Stages 2 or 3."""
+
+    text = "the agreement was signed on June 3rd."
+    doc = _doc(text)
+    cand = _cand(doc, start=0, end=len(text), source_text=text)
+
+    gw = _StubGateway('{"verdict": "no"}')  # Would fail if reached.
+    result = await verify(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result == VerificationResult(
+        verified=True,
+        method="exact_match",
+        confidence=1.0,
+        partial=False,
+    )
+    assert gw.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 short-circuit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_stage_2_hit_short_circuits_stage_3() -> None:
+    """Tolerant match (smart vs straight quotes) doesn't trigger Stage 3."""
+
+    text = '"the agreement was signed on June 3rd."'
+    doc = _doc(text)
+    smart = "“the agreement was signed on June 3rd.”"
+    cand = _cand(doc, start=0, end=len(text), source_text=smart)
+
+    gw = _StubGateway('{"verdict": "no"}')
+    result = await verify(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is True
+    assert result.method == "tolerant_match"
+    assert gw.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Stage 3 — fires when 1+2 miss.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_stage_3_runs_when_1_and_2_miss() -> None:
+    """Paraphrased citation passes Stage 3 after Stages 1+2 miss."""
+
+    text = "The plaintiff prevailed on the breach claim after extensive discovery."
+    doc = _doc(text)
+    # Paraphrase that doesn't byte-match and is below the 95 fuzz
+    # ratio threshold (Stage 2 also misses).
+    paraphrase = "The plaintiff won their breach case."
+    cand = _cand(doc, start=0, end=len(text), source_text=paraphrase)
+
+    gw = _StubGateway(
+        json.dumps({"verdict": "yes", "confidence": "high", "justification": "supports"})
+    )
+    result = await verify(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is True
+    assert result.method == "paraphrase_judge"
+    assert result.confidence == pytest.approx(0.90)
+    assert result.partial is False
+    assert gw.call_count == 1
+
+
+@pytest.mark.unit
+async def test_stage_3_partial_verdict_propagates() -> None:
+    """Stage 3 'partial' verdict surfaces with partial=True."""
+
+    text = "The plaintiff prevailed on the breach claim after extensive discovery."
+    doc = _doc(text)
+    paraphrase = "The plaintiff won their case on all counts."
+    cand = _cand(doc, start=0, end=len(text), source_text=paraphrase)
+
+    gw = _StubGateway(
+        json.dumps({"verdict": "partial", "confidence": "medium", "justification": "y"})
+    )
+    result = await verify(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is True
+    assert result.partial is True
+    assert result.method == "paraphrase_judge"
+    assert result.confidence == pytest.approx(0.70)
+
+
+@pytest.mark.unit
+async def test_stage_3_no_verdict_returns_miss() -> None:
+    """All stages miss → cascade returns the MISS sentinel."""
+
+    text = "The plaintiff prevailed on the breach claim."
+    doc = _doc(text)
+    cand = _cand(doc, start=0, end=len(text), source_text="An unrelated statement.")
+
+    gw = _StubGateway(json.dumps({"verdict": "no", "confidence": "high"}))
+    result = await verify(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is False
+    assert result.method is None
+    assert result.partial is False
+    assert gw.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Stage 3 — skipped when no gateway is provided.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_stage_3_skipped_when_no_gateway() -> None:
+    """Without a gateway, Stages 1+2 miss → MISS; no judge call attempted."""
+
+    text = "The plaintiff prevailed on the breach claim."
+    doc = _doc(text)
+    cand = _cand(doc, start=0, end=len(text), source_text="paraphrased claim")
+
+    result = await verify(cand, doc, gateway=None, judge_model="fast")
+
+    assert result.verified is False
+    assert result.method is None
+
+
+@pytest.mark.unit
+async def test_existing_callers_can_omit_gateway_kwargs() -> None:
+    """``await verify(cand, doc)`` is still valid — gateway/judge_model default."""
+
+    text = "the agreement was signed."
+    doc = _doc(text)
+    cand = _cand(doc, start=0, end=len(text), source_text=text)
+
+    result = await verify(cand, doc)
+
+    # Stage 1 hits — gateway never needed.
+    assert result.verified is True
+    assert result.method == "exact_match"

--- a/api/tests/test_chat_citations.py
+++ b/api/tests/test_chat_citations.py
@@ -605,3 +605,176 @@ async def test_chat_send_out_of_range_source_writes_no_citation(
 
     rows = (await db_session.execute(select(MessageCitation))).scalars().all()
     assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# M2-C1 — Stage 3 (paraphrase judge) catches paraphrases Stages 1+2 miss
+# ---------------------------------------------------------------------------
+
+
+def _judge_response_payload(*, verdict: str, confidence: str) -> dict[str, Any]:
+    """A chat.completion payload whose content is a judge JSON verdict."""
+
+    import json as _json
+
+    judge_content = _json.dumps(
+        {
+            "verdict": verdict,
+            "confidence": confidence,
+            "justification": "test justification",
+        }
+    )
+    return _success_payload(judge_content)
+
+
+@respx.mock
+async def test_chat_send_paraphrased_quote_verified_by_stage_3_judge(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """Paraphrased quote misses Stages 1+2; Stage 3 judge says 'yes/high' → verified.
+
+    Wire path: the gateway client makes two calls per message —
+    (a) the assistant chat completion, then
+    (b) the Stage 3 judge chat completion when Stages 1+2 miss.
+    Both hit ``/v1/chat/completions``; we sequence the responses with
+    respx ``side_effect``.
+    """
+
+    paraphrase = "the employee may not engage in any competing business"
+    assert paraphrase not in source_chunk.content  # genuine paraphrase
+
+    assistant_text = f'The agreement says "{paraphrase}" (Source: [1]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        side_effect=[
+            httpx.Response(200, json=_success_payload(assistant_text)),
+            httpx.Response(200, json=_judge_response_payload(verdict="yes", confidence="high")),
+        ]
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCitation).where(MessageCitation.source_file_id == source_file.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(rows) == 1
+    cite = rows[0]
+    assert cite.verified is True
+    assert cite.verification_method == "paraphrase_judge"
+    assert cite.verification_confidence is not None
+    assert float(cite.verification_confidence) == pytest.approx(0.90)
+    assert cite.partial is False
+    assert cite.source_text == paraphrase
+
+
+@respx.mock
+async def test_chat_send_partial_verdict_persists_with_partial_true(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """'partial' verdict persists as verified=True, partial=True (M2-C2 UI flag)."""
+
+    paraphrase = "the employee may not engage in any competing business"
+    assistant_text = f'The agreement says "{paraphrase}" (Source: [1]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        side_effect=[
+            httpx.Response(200, json=_success_payload(assistant_text)),
+            httpx.Response(
+                200,
+                json=_judge_response_payload(verdict="partial", confidence="medium"),
+            ),
+        ]
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+
+    rows = (await db_session.execute(select(MessageCitation))).scalars().all()
+    assert len(rows) == 1
+    cite = rows[0]
+    assert cite.verified is True
+    assert cite.partial is True
+    assert cite.verification_method == "paraphrase_judge"
+    assert float(cite.verification_confidence or 0) == pytest.approx(0.70)
+
+
+@respx.mock
+async def test_chat_send_judge_says_no_writes_no_citation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """'no' verdict → no citation row (rendered as unverified by M2-C2)."""
+
+    paraphrase = "the employee may not engage in any competing business"
+    assistant_text = f'The agreement says "{paraphrase}" (Source: [1]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        side_effect=[
+            httpx.Response(200, json=_success_payload(assistant_text)),
+            httpx.Response(200, json=_judge_response_payload(verdict="no", confidence="high")),
+        ]
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+
+    rows = (await db_session.execute(select(MessageCitation))).scalars().all()
+    assert rows == []

--- a/api/tests/test_gateway_client.py
+++ b/api/tests/test_gateway_client.py
@@ -697,6 +697,111 @@ async def test_list_models_sends_gateway_key_header(client: GatewayClient) -> No
     assert request.headers.get(GATEWAY_KEY_HEADER) == GATEWAY_KEY
 
 
+# ---------------------------------------------------------------------------
+# Citation Engine judge-model fetch (M2-C1).
+#
+# The api/ pulls the judge-model alias from the gateway over
+# GET /v1/citation-engine/config once per process and caches it.
+# Failure modes (network, non-200, malformed body) fall back silently
+# to the configured default — a missing config endpoint must not crash
+# the Citation Engine; Stage 3 just runs against the fallback model.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_judge_model_fetched_from_gateway(client: GatewayClient) -> None:
+    """Happy path: the gateway-configured alias propagates back."""
+
+    respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(200, json={"judge_model": "fast"})
+    )
+
+    judge = await client.get_citation_engine_judge_model()
+
+    assert judge == "fast"
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_judge_model_caches_for_process(client: GatewayClient) -> None:
+    """Second call doesn't re-hit the gateway."""
+
+    route = respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(200, json={"judge_model": "smart"})
+    )
+
+    first = await client.get_citation_engine_judge_model()
+    second = await client.get_citation_engine_judge_model()
+
+    assert first == "smart"
+    assert second == "smart"
+    assert route.call_count == 1
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_judge_model_falls_back_on_network_error(client: GatewayClient) -> None:
+    """A transport failure returns the fallback, not an exception."""
+
+    respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+
+    judge = await client.get_citation_engine_judge_model(fallback="budget")
+
+    assert judge == "budget"
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_judge_model_falls_back_on_500(client: GatewayClient) -> None:
+    """Gateway 500 returns the fallback (the Citation Engine must keep working)."""
+
+    respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(500, text="oops")
+    )
+
+    judge = await client.get_citation_engine_judge_model(fallback="fast")
+
+    assert judge == "fast"
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_judge_model_falls_back_on_malformed_body(client: GatewayClient) -> None:
+    """A 200 with a missing ``judge_model`` key returns the fallback."""
+
+    respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(200, json={"other_field": "value"})
+    )
+
+    judge = await client.get_citation_engine_judge_model(fallback="fast")
+
+    assert judge == "fast"
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_judge_model_failed_fetch_not_cached(client: GatewayClient) -> None:
+    """A failed fetch doesn't poison the cache — the next call retries."""
+
+    # First call fails.
+    route_failed = respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(500, text="oops")
+    )
+    judge1 = await client.get_citation_engine_judge_model(fallback="fast")
+    assert judge1 == "fast"
+    assert route_failed.call_count == 1
+
+    # Replace with a 200 and call again — should retry, not return cached fallback.
+    respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(200, json={"judge_model": "smart"})
+    )
+    judge2 = await client.get_citation_engine_judge_model(fallback="fast")
+    assert judge2 == "smart"
+
+
 # Suppress the "task pending" warning that respx can emit on cancellation.
 @pytest.fixture(autouse=True)
 def _suppress_pending_task_warnings() -> None:

--- a/api/tests/test_migrations.py
+++ b/api/tests/test_migrations.py
@@ -743,3 +743,142 @@ async def test_messages_applied_skills_default_empty_array(db_session: AsyncSess
     value = rows.scalar_one()
     # Postgres returns the text[] as a Python list.
     assert value == []
+
+
+# ---------------------------------------------------------------------------
+# 0026 — paraphrase_judge enum + partial column on message_citations (M2-C1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_message_citations_accepts_paraphrase_judge_method(
+    db_session: AsyncSession,
+) -> None:
+    """The widened enum accepts the new ``'paraphrase_judge'`` method value.
+
+    The 0026 migration replaces the M2-A2 CHECK constraint to add
+    ``'paraphrase_judge'``. Without the migration the INSERT below
+    would fail the constraint.
+    """
+
+    # Need a real chat + message + file to satisfy the FKs.
+    user_id = uuid.uuid4()
+    chat_id = uuid.uuid4()
+    message_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO users (id, email, display_name, hashed_password) "
+            "VALUES (:uid, :email, 'M2-C1 Test', 'x')"
+        ),
+        {"uid": user_id, "email": f"c1-{uuid.uuid4().hex[:6]}@example.com"},
+    )
+    await db_session.execute(
+        text("INSERT INTO chats (id, owner_id, title) VALUES (:cid, :uid, 't')"),
+        {"cid": chat_id, "uid": user_id},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO messages (id, chat_id, role, content) "
+            "VALUES (:mid, :cid, 'assistant', 'x')"
+        ),
+        {"mid": message_id, "cid": chat_id},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO files (id, owner_id, filename, mime_type, size_bytes, "
+            "hash_sha256, storage_path) VALUES "
+            "(:fid, :uid, 'f.pdf', 'application/pdf', 1, "
+            "'a' || repeat('0', 63), 's3://k')"
+        ),
+        {"fid": file_id, "uid": user_id},
+    )
+    await db_session.flush()
+
+    await db_session.execute(
+        text(
+            "INSERT INTO message_citations "
+            "(message_id, source_file_id, source_offset_start, source_offset_end, "
+            "source_text, verified, verification_method, verification_confidence, "
+            "partial) "
+            "VALUES (:mid, :fid, 0, 5, 'hello', true, 'paraphrase_judge', "
+            "0.90, true)"
+        ),
+        {"mid": message_id, "fid": file_id},
+    )
+    await db_session.flush()
+
+    row = (
+        await db_session.execute(
+            text(
+                "SELECT verification_method, partial FROM message_citations WHERE message_id = :mid"
+            ),
+            {"mid": message_id},
+        )
+    ).one()
+    assert row[0] == "paraphrase_judge"
+    assert row[1] is True
+
+
+@pytest.mark.integration
+async def test_message_citations_partial_default_false(
+    db_session: AsyncSession,
+) -> None:
+    """``partial`` defaults to ``false`` so M2-A2 / M2-B1 callers stay correct.
+
+    The Stage 1 / Stage 2 verifiers don't write ``partial`` explicitly;
+    the default keeps their rows readable as fully-verified.
+    """
+
+    user_id = uuid.uuid4()
+    chat_id = uuid.uuid4()
+    message_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO users (id, email, display_name, hashed_password) "
+            "VALUES (:uid, :email, 'C1 Default', 'x')"
+        ),
+        {"uid": user_id, "email": f"c1-{uuid.uuid4().hex[:6]}@example.com"},
+    )
+    await db_session.execute(
+        text("INSERT INTO chats (id, owner_id, title) VALUES (:cid, :uid, 't')"),
+        {"cid": chat_id, "uid": user_id},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO messages (id, chat_id, role, content) "
+            "VALUES (:mid, :cid, 'assistant', 'x')"
+        ),
+        {"mid": message_id, "cid": chat_id},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO files (id, owner_id, filename, mime_type, size_bytes, "
+            "hash_sha256, storage_path) VALUES "
+            "(:fid, :uid, 'f.pdf', 'application/pdf', 1, "
+            "'a' || repeat('0', 63), 's3://k')"
+        ),
+        {"fid": file_id, "uid": user_id},
+    )
+    await db_session.flush()
+
+    # Omit ``partial`` — the column default should populate it.
+    await db_session.execute(
+        text(
+            "INSERT INTO message_citations "
+            "(message_id, source_file_id, source_offset_start, source_offset_end, "
+            "source_text, verified, verification_method, verification_confidence) "
+            "VALUES (:mid, :fid, 0, 5, 'hello', true, 'exact_match', 1.0)"
+        ),
+        {"mid": message_id, "fid": file_id},
+    )
+    await db_session.flush()
+
+    row = (
+        await db_session.execute(
+            text("SELECT partial FROM message_citations WHERE message_id = :mid"),
+            {"mid": message_id},
+        )
+    ).one()
+    assert row[0] is False

--- a/gateway.yaml.example
+++ b/gateway.yaml.example
@@ -388,6 +388,25 @@ anonymization:
   # before sending back to backend.
 
 # ============================================================
+# CITATION ENGINE (PRD §3.3 / M2-C1)
+# ============================================================
+# The api/ side runs the Citation Engine cascade (exact-match →
+# tolerant-match → LLM paraphrase judge → ensemble). Stage 3
+# dispatches a judge call through this gateway; ``judge_model`` is
+# the alias the gateway resolves for that call.
+#
+# Defaults to ``fast`` so the judge runs on a smaller, cheaper
+# model than whatever generated the citation. Operators who want a
+# different judge model should pick one weaker than the
+# citation-generating model (the plan's calibration intuition: the
+# judge shouldn't be smarter than the author, only different).
+# Accepts either an alias from ``model_aliases:`` above or a fully-
+# qualified ``provider-name/model-name`` form.
+
+citation_engine:
+  judge_model: fast
+
+# ============================================================
 # COST TRACKING
 # ============================================================
 # Per-model cost rates for the cost tracker. Updated as

--- a/gateway/app/api/inference.py
+++ b/gateway/app/api/inference.py
@@ -901,6 +901,31 @@ async def list_models(request: Request) -> dict[str, Any]:
     }
 
 
+@router.get("/citation-engine/config")
+async def citation_engine_config(request: Request) -> dict[str, str]:
+    """Expose the citation_engine block for the api/'s Citation Engine (M2-C1).
+
+    The api/ runs Stage 3 (LLM paraphrase judge) of the Citation
+    Engine cascade and reads the judge-model alias from this endpoint
+    at startup so the operator configures model choices in one place
+    (``gateway.yaml``) rather than mirroring them on the api/ side.
+
+    Response shape:
+
+    .. code-block:: json
+
+       {"judge_model": "fast"}
+
+    The api/ caches the value for the process lifetime; restarting the
+    gateway after an alias change is the deployment story for now.
+    Hot-reload of this value lands when M2 needs it; today the alias
+    rarely changes outside scheduled maintenance.
+    """
+
+    config = _config(request)
+    return {"judge_model": config.citation_engine.judge_model}
+
+
 # --- Streaming helpers --------------------------------------------------------
 
 

--- a/gateway/app/config.py
+++ b/gateway/app/config.py
@@ -335,6 +335,28 @@ class DevModeConfig(BaseModel):
     enabled: bool = False
 
 
+class CitationEngineConfig(BaseModel):
+    """``citation_engine:`` block — M2-C1.
+
+    The Citation Engine runs in the api/ but reads the *model name* it
+    should use for the Stage 3 (paraphrase) judge from the gateway's
+    config so the operator has one place to configure model choices.
+    The api/ pulls this over ``GET /v1/citation-engine/config`` at
+    startup (or on first need) and caches it for the process.
+
+    :attr:`judge_model` accepts any value the gateway's router can
+    resolve: an alias from ``model_aliases`` (``fast``, ``smart``,
+    ``budget``) or a fully-qualified provider/model form
+    (``anthropic-prod/claude-haiku-4-5``). Defaults to ``"fast"`` —
+    deliberately a smaller model than the typical citation-generating
+    model so the judge cost is bounded.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    judge_model: str = Field(default="fast", min_length=1)
+
+
 # --- Top-level config ---------------------------------------------------------
 
 
@@ -355,6 +377,7 @@ class GatewayConfig(BaseModel):
     tier_policy: TierPolicyConfig = Field(default_factory=TierPolicyConfig)
     rate_limits: RateLimitsConfig = Field(default_factory=RateLimitsConfig)
     anonymization: AnonymizationConfig = Field(default_factory=AnonymizationConfig)
+    citation_engine: CitationEngineConfig = Field(default_factory=CitationEngineConfig)
     cost_tracking: CostTrackingConfig = Field(default_factory=CostTrackingConfig)
     telemetry: TelemetryConfig = Field(default_factory=TelemetryConfig)
     circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig)

--- a/gateway/tests/test_config.py
+++ b/gateway/tests/test_config.py
@@ -123,6 +123,12 @@ def test_load_config_parses_example(example_env: None) -> None:
     # would raise rather than silently passthrough.
     assert all(isinstance(t, int) for t in config.anonymization.apply_at_tiers)
 
+    # M2-C1: Citation Engine block. ``judge_model`` defaults to ``fast``
+    # so Stage 3's paraphrase judge runs on a smaller model than the
+    # citation-generating model. The api/ pulls this value over the
+    # ``/v1/citation-engine/config`` endpoint at startup.
+    assert config.citation_engine.judge_model == "fast"
+
 
 @pytest.mark.unit
 def test_anonymization_config_rejects_non_int_tiers() -> None:
@@ -142,6 +148,28 @@ def test_anonymization_config_rejects_non_int_tiers() -> None:
         AnonymizationConfig(apply_at_tiers=[0, 1])
     with pytest.raises(ValidationError):
         AnonymizationConfig(apply_at_tiers=[1, 6])
+
+
+@pytest.mark.unit
+def test_citation_engine_config_default_is_fast() -> None:
+    """An omitted ``citation_engine:`` block still yields the sensible default."""
+
+    from app.config import CitationEngineConfig
+
+    assert CitationEngineConfig().judge_model == "fast"
+    assert CitationEngineConfig(judge_model="smart").judge_model == "smart"
+
+
+@pytest.mark.unit
+def test_citation_engine_config_rejects_empty_judge_model() -> None:
+    """``judge_model`` must be a non-empty string."""
+
+    from pydantic import ValidationError
+
+    from app.config import CitationEngineConfig
+
+    with pytest.raises(ValidationError):
+        CitationEngineConfig(judge_model="")
 
 
 @pytest.mark.unit

--- a/gateway/tests/test_inference.py
+++ b/gateway/tests/test_inference.py
@@ -147,6 +147,23 @@ async def test_models_returns_configured_aliases(client: AsyncClient) -> None:
 
 
 @pytest.mark.unit
+async def test_citation_engine_config_returns_judge_model(client: AsyncClient) -> None:
+    """``GET /v1/citation-engine/config`` exposes the loaded judge_model (M2-C1).
+
+    The api/'s Citation Engine pulls this at startup so the operator
+    configures the Stage 3 judge model in one place (``gateway.yaml``)
+    rather than mirroring it on the api/ side.
+    """
+
+    response = await client.get("/v1/citation-engine/config")
+
+    assert response.status_code == 200
+    body = response.json()
+    # The example config ships ``citation_engine.judge_model: fast``.
+    assert body == {"judge_model": "fast"}
+
+
+@pytest.mark.unit
 async def test_chat_completions_rejects_get(client: AsyncClient) -> None:
     """Sanity: only POST is registered on /v1/chat/completions."""
 


### PR DESCRIPTION
## Summary

Adds **Stage 3** of the Citation Engine cascade (PRD §3.3 / M2-C1): an LLM judge that evaluates whether the model's quoted citation is faithfully supported by the source passage.

The cascade is now complete through Stage 3:

```
Stage 1 (exact-match, M2-A2)
  → Stage 2 (tolerant-match, M2-B1)
    → Stage 3 (paraphrase judge, THIS TASK)
```

Stage 3 runs only when Stages 1+2 miss AND a gateway client is supplied. Failure modes (gateway transport error, malformed JSON, unknown verdict / confidence values, empty response) silently return MISS so a misbehaving judge can't crash the chat-send pipeline.

Closes M2-C1. Phase C is one task in; M2-C2 (failed-citation UI rendering) and M2-C3 (anonymization round-trip tests, needs M2-B3 first) remain.

## Architectural decisions

Surfaced and resolved before code (per `feedback_honest_framing`):

| Decision | Choice | Rationale |
|---|---|---|
| **A** — `verification_method` enum | (ii) Add `'paraphrase_judge'` value (migration 0026) | Preserves `'llm_judge'` for future LLM-based stages; tighter semantic label |
| **B** — `partial` representation | (a) New `partial: bool` column on `message_citations` | Single migration; cleaner than overloading the method enum; M2-C2 UI consumes it directly |
| **C** — Judge-model config location | (2) `gateway.yaml` + new `/v1/citation-engine/config` endpoint | Operator configures models in one place; api/ pulls + caches |
| **D** — Confidence mapping | `high`→0.90, `medium`→0.70, `low`→0.50 | Distinct from Stages 1 (1.0) and 2 (0.95+); paraphrase confidence is genuinely lower |
| **E** — `verify()` becomes async | Yes | Single caller in `chats.py` already in async context; one `await` ripple |

## What's in the box

### Schema (one migration)

`api/alembic/versions/0026_paraphrase_judge_and_partial.py`:
- Widens `message_citations.verification_method` CHECK to accept `'paraphrase_judge'`.
- Adds `partial BOOLEAN NOT NULL DEFAULT FALSE`. Existing rows default to false; only Stage 3's `partial` verdict sets it true.

### Gateway side

- `CitationEngineConfig` in `gateway/app/config.py` with typed `judge_model: str = "fast"`.
- `GET /v1/citation-engine/config` endpoint returning `{"judge_model": "..."}`.
- `gateway.yaml.example` ships a `citation_engine:` block with explanatory comments.

### api/ side

- `GatewayClient.get_citation_engine_judge_model()` — process-cached fetch with graceful fallback (network errors, respx assertions, asyncio cancellation — all silently fall back to the default).
- `app/citation/judge_prompts.py` — structured JSON prompt construction with a conservative-bias system message (bias toward `no`/`partial` on uncertainty per M2-C1 calibration intent).
- `app/citation/verification.py`:
  - `VerificationResult.partial: bool` field.
  - `verify_paraphrase()` — async, builds the prompt, dispatches via gateway, parses verdict + confidence, maps to `VerificationResult`.
  - `verify()` becomes async, chains Stage 3 when gateway supplied.
- `app/api/chats.py`:
  - `_persist_message_citations` takes optional `gateway` parameter.
  - `await verify(cand, doc, gateway=gateway, judge_model=judge_model)`.
  - Passes `result.partial` onto the `MessageCitation` row.

### Tests (+50 api, +5 gateway)

| File | Tests | Purpose |
|---|---|---|
| `tests/citation/test_judge_prompts.py` (new) | 7 | Prompt invariants: system+user roles, JSON shape instruction, conservative bias, claim and chunks present |
| `tests/citation/test_paraphrase_judge.py` (new) | 16 | Verdict + confidence mapping, partial flag, all failure modes |
| `tests/citation/test_verify_cascade.py` (new) | 7 | Async cascade order, Stage 3 short-circuit by earlier stages, optional gateway |
| `tests/test_chat_citations.py` (extended) | +3 | End-to-end: paraphrased quote + judge `yes/high` → verified; `partial/medium` → partial=true; `no` → no row |
| `tests/test_gateway_client.py` (extended) | +6 | Judge-model fetch + cache + fallback paths |
| `tests/test_migrations.py` (extended) | +2 | 0026 schema (paraphrase_judge enum, partial default) |
| `gateway/tests/test_config.py` (extended) | +3 | CitationEngineConfig defaults + validation |
| `gateway/tests/test_inference.py` (extended) | +1 | `/v1/citation-engine/config` endpoint |

## Test plan

- [x] `cd gateway && pytest tests/` — 422 passed, 2 skipped
- [x] `cd gateway && mypy app/` — strict clean (35 files)
- [x] `cd gateway && ruff format --check app/ tests/` — clean
- [x] `cd gateway && ruff check app/ tests/` — clean
- [x] `cd api && pytest tests/` — 962 passed, 1 skipped (live Postgres)
- [x] `cd api && mypy app/` — clean (85 files)
- [x] `cd api && ruff format --check app/ tests/` — clean
- [x] `cd api && ruff check app/ tests/` — clean
- [x] Migration 0026 applies cleanly against the live dev DB
- [x] Integration test exercises full chat-send → Stage 1+2 miss → judge mock returns `yes/high` → `message_citations` row with `partial=false, method='paraphrase_judge', confidence=0.90`
- [x] Same with `partial/medium` verdict → row with `partial=true, confidence=0.70`
- [x] Same with `no` verdict → no row written
- [ ] **Operator verification (post-merge):** chat against a real provider, ask for a quote that paraphrases the source (e.g. "may not engage" vs. source's "shall not engage"); confirm Stage 3 verdict surfaces correctly in the audit row

🤖 Generated with [Claude Code](https://claude.com/claude-code)