### PR TITLE
M2-C2: Citation Engine UI — 4-state hybrid (inline + sidecar)

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -1217,8 +1217,10 @@ async def get_citations(
     citation) rather than the legacy ``messages.citations`` JSONB
     column. Each citation in the response carries the verifier's
     verdict (``verified``, ``verification_method``,
-    ``verification_confidence``) so the UI (M2-C2) can render unverified
-    citations distinctly.
+    ``verification_confidence``, ``partial``) so the UI (M2-C2) can
+    render the five citation states distinctly — including the
+    paraphrase-judge "partial" verdict surfaced via the ``partial``
+    flag (M2-C1).
 
     The legacy JSONB column is kept at its ``'[]'`` default by the
     chat-send path; readers should consume this endpoint, not the
@@ -1271,6 +1273,7 @@ async def get_citations(
             "verification_confidence": (
                 float(c.verification_confidence) if c.verification_confidence is not None else None
             ),
+            "partial": c.partial,
             "created_at": c.created_at.isoformat(),
         }
         for c in rows

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -26,5 +26,16 @@ else
     echo "LQ.AI api: migrations complete."
 fi
 
-echo "LQ.AI api: starting uvicorn on 0.0.0.0:8000."
-exec uvicorn app.main:app --host 0.0.0.0 --port 8000
+# Respect the container's CMD when one is provided — the api service runs
+# without an override (and gets uvicorn) while the ingest-worker service
+# passes `arq app.workers.document_pipeline.WorkerSettings`. Hardcoding
+# `exec uvicorn` here silently turned the ingest-worker into a duplicate
+# api server (surfaced 2026-05-16 when KB ingestion stopped completing
+# after a worker image rebuild).
+if [ "$#" -eq 0 ]; then
+    echo "LQ.AI api: starting uvicorn on 0.0.0.0:8000."
+    exec uvicorn app.main:app --host 0.0.0.0 --port 8000
+else
+    echo "LQ.AI api: exec'ing container CMD: $*"
+    exec "$@"
+fi

--- a/api/tests/test_chat_citations.py
+++ b/api/tests/test_chat_citations.py
@@ -564,6 +564,7 @@ async def test_get_citations_endpoint_returns_persisted_rows(
     assert cite["verified"] is True
     assert cite["verification_method"] == "exact_match"
     assert cite["verification_confidence"] == 1.0
+    assert cite["partial"] is False
     assert cite["source_page"] == 1
     expected_start = CHUNK_BODY.find(quote)
     assert cite["source_offset_start"] == expected_start
@@ -738,6 +739,59 @@ async def test_chat_send_partial_verdict_persists_with_partial_true(
     assert cite.partial is True
     assert cite.verification_method == "paraphrase_judge"
     assert float(cite.verification_confidence or 0) == pytest.approx(0.70)
+
+
+@respx.mock
+async def test_get_citations_endpoint_exposes_partial_flag(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """`GET /messages/{id}/citations` surfaces `partial=True` for partial verdicts (M2-C2)."""
+
+    paraphrase = "the employee may not engage in any competing business"
+    assistant_text = f'The agreement says "{paraphrase}" (Source: [1]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        side_effect=[
+            httpx.Response(200, json=_success_payload(assistant_text)),
+            httpx.Response(
+                200,
+                json=_judge_response_payload(verdict="partial", confidence="medium"),
+            ),
+        ]
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        send = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+    assert send.status_code == 200, send.text
+    message_id = send.json()["message"]["id"]
+
+    get_response = await client.get(
+        f"/api/v1/chats/{chat_with_kb_attached.id}/messages/{message_id}/citations",
+        headers=_h(owner_user),
+    )
+    assert get_response.status_code == 200, get_response.text
+    body = get_response.json()
+    assert len(body) == 1
+    cite = body[0]
+    assert cite["verified"] is True
+    assert cite["partial"] is True
+    assert cite["verification_method"] == "paraphrase_judge"
+    assert cite["verification_confidence"] == pytest.approx(0.70)
 
 
 @respx.mock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,15 @@ services:
       LQ_AI_DOCLING_ENABLED: ${LQ_AI_DOCLING_ENABLED:-true}
       LQ_AI_CHUNK_TARGET_CHARS: ${LQ_AI_CHUNK_TARGET_CHARS:-2000}
       LQ_AI_CHUNK_OVERLAP_CHARS: ${LQ_AI_CHUNK_OVERLAP_CHARS:-200}
+      # Gateway endpoint + auth — required by `embed_chunks_for_file_job`
+      # which calls `POST {LQ_AI_GATEWAY_URL}/v1/embeddings` to vectorise
+      # each freshly-ingested chunk. Without these vars the embed step
+      # silently fails with `chunks_embedded: 0`, leaving chunks with
+      # NULL embeddings — KB hybrid_search then has no vector half to
+      # work with even on KBs configured for hybrid retrieval
+      # (`hybrid_alpha < 1.0`).
+      LQ_AI_GATEWAY_URL: ${LQ_AI_GATEWAY_URL:-http://gateway:8001}
+      LQ_AI_GATEWAY_KEY: ${LQ_AI_GATEWAY_KEY:?LQ_AI_GATEWAY_KEY is required}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     # Persist Docling's Hugging Face model cache and EasyOCR's detection
     # model cache across container restarts so the operator only pays

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2748,6 +2748,24 @@ The structural cost is a second request per message — more api/ load, more net
 
 **Acceptance criteria:** New assistant-message responses include a `citations` array reflecting the same data the GET endpoint returns; the frontend renders citations from the embedded data without an additional fetch when present; messages persisted before this lands continue to render correctly via the GET fallback; existing M2-C2 component tests pass with both data paths; `GET /messages/{id}/citations` is unchanged and remains the canonical source-of-truth endpoint.
 
+#### DE-276 — Ingest observability: surface silent embed/parse failures
+
+**Priority:** P2 · **Effort:** S-M
+
+**Context:** During M2-C2 manual verification on 2026-05-16, a KB-grounded chat returned "I don't have any NDA document in our conversation" despite the KB showing a successfully-attached document. Investigation found the document had been chunked correctly (16 chunks of real NDA text) but every chunk's `embedding` was NULL. Root cause: the ingest worker's `embed_chunks_for_file_job` was failing with `KeyError: 'LQ_AI_GATEWAY_URL'` because the worker container was missing the gateway env vars in `docker-compose.yml`. The worker reported `chunks_embedded: 0` and ARQ logged a one-line truncated error, but no surface in the product (admin UI, document status field, /admin/ingest-health endpoint) escalated this to operator-visible state — the document continued to render as "ready" and KB-attach UI showed it as if it were searchable. The immediate root cause was patched in a follow-on commit; this DE captures the broader observability gap.
+
+The failure mode is structurally bad: a deployment misconfiguration (missing env var, gateway unreachable, embedding-model permissions revoked) silently degrades KB hybrid retrieval to FTS-only across the entire deployment. Operators have no in-product signal until an end-user reports "the AI can't see my documents". The current `documents` table has no embed-state column, and the ingest worker's structured logs are not surfaced anywhere an admin reads.
+
+**Specific scope:** Three paths, ideally landed together:
+
+- **(a) Document-level embed status.** Add `documents.embedding_status` (enum: `pending`, `embedded`, `failed`) populated by `embed_chunks_for_file_job` per its return value. `failed` rows carry a `last_error` text field (the same string the worker already returns). Default `pending` for legacy rows; backfill from a one-time sweep that checks `EXISTS (SELECT 1 FROM document_chunks WHERE document_id = d.id AND embedding IS NULL)`.
+
+- **(b) Admin-visible state.** Surface the new status in the admin KB-detail UI and a new `GET /api/v1/admin/ingest-health` summary endpoint. Failed-embed rows show up with their error text; the admin can decide to re-trigger the embed job per-document or per-KB. Per `[[reference_lq_ai_dev_quirks]]` the operator-facing audit-health pattern (DE-257) is the right precedent.
+
+- **(c) CI guard against the specific regression.** Add a fresh-install validation step (per `[[feedback_dry_run_value]]`) that uploads a small fixture document, waits for `documents.embedding_status='embedded'`, then asserts at least one chunk has a non-NULL `embedding`. This is the canonical guard against the env-var class of failure — it would have caught the present bug at deploy time, not at user-report time.
+
+**Acceptance criteria:** `documents.embedding_status` is populated for every newly-ingested document and updates correctly on retry; the admin UI surfaces failed-embed documents distinctly from ready ones; an end-to-end test against a fresh-install stack uploads a fixture document and asserts the chunks come back embedded (not FTS-only); the gateway-misconfigured-worker class of bug surfaces as a CI failure on PR review rather than a silent production degradation.
+
 ### Workflow intelligence
 
 This subsection captures the bounded items that operationalize the M5+ Forward-Looking Workflow Intelligence direction (§8.5). The items are bounded enough to be picked up by community contributors as the M5+ roadmap matures. The architectural slot for the MCP-client subsystem is already committed for M1–M2 (§8 M1) so this subsection's items can be implemented incrementally without core refactoring.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2736,6 +2736,18 @@ Path (a) is recommended; the salt is the smaller change with cleaner round-trip 
 
 **Acceptance criteria:** No source document containing a literal pseudonym pattern can confuse the rehydrator's behavior; two parallel mappers produce structurally distinct pseudonym strings (verified by an updated round-trip test); the mapper's pseudonym format is updated; existing M2-B3 / M2-C3 tests pass with the new format (the cross-mapper test in `test_round_trip.py` flips its assertion when this lands — the test's docstring already calls this out); the change is documented in `docs/security/anonymization.md`.
 
+#### DE-275 — Embed M2 citations in chat-message envelope
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** M2-C2 wires the frontend to `GET /api/v1/chats/{chat_id}/messages/{message_id}/citations` as a lazy fetch immediately after each assistant message renders. The endpoint already exists (M2-A2) and the lazy-fetch path is the smallest change to surface the five-state citation UI without disturbing the chat-streaming pipeline. The cost is one extra round-trip per assistant message; in practice it runs in parallel with the user typing their next message, so end-user-perceived latency is near-zero on a healthy network.
+
+The structural cost is a second request per message — more api/ load, more network traffic, and a small extra failure mode (the citations fetch could fail independently of the chat response). A future refactor could embed the citation rows directly in the assistant-message JSON envelope so they land alongside `content`, removing the second round-trip entirely. M2-D2 (Citation Engine integration with the chat-send path) is the natural moment to revisit this; if measured latency or backend load shows up as a concern in the M2-F2 acceptance corpus, this DE is the path forward.
+
+**Specific scope:** Extend the assistant-message response shape (the chat-send return value and the chat-message read endpoint) to include a `citations` field — same per-row schema as `GET /messages/{id}/citations` returns, including `partial`. Update the frontend renderer to prefer the embedded citations when present and fall back to the lazy GET for older messages (or when the field is absent — e.g., a skill that doesn't emit citations). Keep the GET endpoint operational regardless; it remains the canonical surface for direct citation lookup (audit-log deep-linking, debugging, future operator tooling).
+
+**Acceptance criteria:** New assistant-message responses include a `citations` array reflecting the same data the GET endpoint returns; the frontend renders citations from the embedded data without an additional fetch when present; messages persisted before this lands continue to render correctly via the GET fallback; existing M2-C2 component tests pass with both data paths; `GET /messages/{id}/citations` is unchanged and remains the canonical source-of-truth endpoint.
+
 ### Workflow intelligence
 
 This subsection captures the bounded items that operationalize the M5+ Forward-Looking Workflow Intelligence direction (§8.5). The items are bounded enough to be picked up by community contributors as the M5+ roadmap matures. The architectural slot for the MCP-client subsystem is already committed for M1–M2 (§8 M1) so this subsection's items can be implemented incrementally without core refactoring.

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -3387,6 +3387,14 @@ components:
           type: string
           description: "Verbatim text from source — verified to appear in source"
         verified: {type: boolean, description: "Citation engine verified the quote"}
+        partial:
+          type: boolean
+          default: false
+          description: >-
+            True when the paraphrase judge (M2-C1) returned ``partial`` —
+            the source supports the claim but only partially. Drives the
+            M2-C2 UI's "verified with caveats" rendering (verified-paraphrase
+            state).
 
     SkillSummary:
       type: object

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -364,7 +364,7 @@ A few elements are intentionally omitted from the main diagram for readability; 
 - **Internal observability between components** — every service emits OpenTelemetry traces; the diagram shows the OTel sink rather than every individual instrumentation point.
 - **Database migrations and schema management** — Alembic for the FastAPI backend, similar in the gateway. Operational detail, not architecture.
 - **Container orchestration** (Docker Compose for development, Helm for Kubernetes production) — deployment topology rather than runtime architecture.
-- **Citation Engine internals** — within the Document Pipeline service, the Citation Engine is a multi-stage process (structured generation → deterministic substring verification → LLM-judge verification → side-panel rendering). [PRD §3.3](PRD.md#33-citation-engine-exact-quote) covers it in detail.
+- **Citation Engine internals** — within the Document Pipeline service, the Citation Engine is a multi-stage process (structured generation → deterministic substring verification → tolerant-match verification → paraphrase-judge verification → side-panel rendering). The chat surface renders each emitted citation in one of five visual states (M2-C2): verified-exact and verified-tolerant (both green), verified-paraphrase (yellow), unverified (greyed text + `[unverified]` marker), and system-error (yellow warning; deferred to M2-D when the pipeline emits the signal). The visual contract is load-bearing for procurement review — a reviewer scanning the report should be able to identify unverified citations without reading the tooltips. [PRD §3.3](PRD.md#33-citation-engine-exact-quote) covers the engine internals in detail.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -196,7 +196,15 @@ Severity-tagged findings with citations. For the sample NDA, expect:
 
 A few things to notice about the output:
 
-**Citations resolve.** Click any "[Section X]" reference and the citation engine highlights the cited language in the source document. This is character-fidelity citation — the skill is not paraphrasing what Section 4 says; it's pointing at the exact words.
+**Citations are visibly verified.** Every `"<quote>" (Source: [N])` the skill emits is run through the Citation Engine and rendered with a color-coded visual state in the chat surface (M2-C2):
+
+- **Green check + green underline** — verified verbatim against the source (exact match) or verified after minor formatting normalization (tolerant match). The model quoted the source faithfully.
+- **Yellow check + yellow underline** — verified by the paraphrase judge. The source supports the claim, possibly with caveats; hover the citation chip for the judge's confidence and partial-support framing.
+- **Greyed text + `[unverified]` marker** — the Citation Engine could not match the model's quote to a retrieved chunk. Treat as unverified; the model may have produced a claim that doesn't follow from the cited content.
+
+The visual treatment is deliberate: scrolling the report, a reviewer should be able to spot unverified citations without reading the tooltips. Procurement reviews and document-review work both benefit from being able to quickly distinguish citations the system stands behind from ones it does not. A fifth `system-error` state (yellow warning) is reserved for a future release when the Citation Engine surfaces verification-pipeline errors as their own signal (M2-D).
+
+Click-through-to-source-viewer (highlighting the cited span in the source document) is on the roadmap for M2-D2; the M2-C2 surface ships the visual contract and the data plumbing it builds on.
 
 **Severity tags follow the rubric.** Critical / Material / Minor — the [Skill-Authoring Guide](skill-authoring-guide.md#severity-rubric-for-review-skills) documents the calibration. None of the issues in the sample NDA rise to "Critical" because the sample is calibrated to be *plausibly real, with material issues*, not catastrophic.
 

--- a/web/cypress/e2e/m2-c2-citation-states.cy.ts
+++ b/web/cypress/e2e/m2-c2-citation-states.cy.ts
@@ -1,0 +1,233 @@
+/**
+ * M2-C2 — Citation Engine UI: end-to-end render coverage for the 4 currently-
+ * emitted citation states (verified-exact, verified-tolerant,
+ * verified-paraphrase, unverified). State 5 (system-error) is deferred to
+ * M2-D per the M2-C2 decision matrix and is not exercised here.
+ *
+ * Strategy: log in, create a real matter + chat (the chat shell needs a
+ * real session and a real chat-id to drive the load path), then intercept
+ * the two endpoints the message-render pipeline reads from:
+ *
+ *   GET /api/v1/chats/{chat_id}/messages          → synthetic message list
+ *   GET /api/v1/chats/{chat_id}/messages/{id}/citations
+ *                                                 → synthetic citation rows
+ *
+ * The synthetic assistant message embeds 4 `"<quote>" (Source: [N])`
+ * markers that match (or fail to match) the synthetic citation rows so
+ * the renderer hits each of the 4 states in a single page load. The
+ * fourth marker has no citation row — per the api's `_persist_message_citations`
+ * docstring, the absence of a row is the unverified signal.
+ *
+ * Run requires a live stack:
+ *   docker compose up -d
+ *   cd web && npx cypress run --spec 'cypress/e2e/m2-c2-citation-states.cy.ts'
+ */
+
+/// <reference types="cypress" />
+
+import { login, createSampleMatter } from '../support/lq-ai-helpers';
+
+const ADMIN_EMAIL = () => Cypress.env('LQAI_ADMIN_EMAIL') || 'admin@lq.ai';
+const ADMIN_PASSWORD = () => Cypress.env('LQAI_ADMIN_PASSWORD') || 'LQ-AI-smoke-test-Pw1!';
+
+// Synthetic content the assistant "produced". Quotes match the citation
+// source_text values below, except for the 4th marker (no matching row →
+// renders as unverified).
+const ASSISTANT_CONTENT = [
+	'The clause is clear: "exact verbatim verified text" (Source: [1]). ',
+	'A second passage reads "tolerant match verified" (Source: [2]). ',
+	'The judge confirmed "paraphrase judge verified" (Source: [3]). ',
+	'However, "unverifiable claim no source supports" (Source: [4]) is not in any retrieved document.'
+].join('');
+
+const SYNTHETIC_USER_ID = '11111111-1111-1111-1111-111111111111';
+const SYNTHETIC_ASSISTANT_ID = '22222222-2222-2222-2222-222222222222';
+
+function syntheticMessages(chatId: string) {
+	return {
+		items: [
+			{
+				id: SYNTHETIC_USER_ID,
+				chat_id: chatId,
+				role: 'user',
+				kind: 'user',
+				content: 'Cite the relevant passages from the contract.',
+				created_at: '2026-05-16T10:00:00.000Z'
+			},
+			{
+				id: SYNTHETIC_ASSISTANT_ID,
+				chat_id: chatId,
+				role: 'assistant',
+				kind: 'ai',
+				content: ASSISTANT_CONTENT,
+				applied_skills: [],
+				routed_inference_tier: 2,
+				routed_provider: 'synthetic-test-provider',
+				routed_model: 'synthetic-test-model',
+				created_at: '2026-05-16T10:00:01.000Z'
+			}
+		],
+		next_cursor: null
+	};
+}
+
+const SYNTHETIC_CITATIONS = [
+	{
+		id: 'aaaa1111-aaaa-1111-aaaa-111111111111',
+		source_file_id: 'ffff0001-ffff-0001-ffff-000111111111',
+		source_offset_start: 0,
+		source_offset_end: 32,
+		source_page: 1,
+		source_text: 'exact verbatim verified text',
+		verified: true,
+		verification_method: 'exact_match',
+		verification_confidence: 1.0,
+		partial: false,
+		created_at: '2026-05-16T10:00:01.500Z'
+	},
+	{
+		id: 'aaaa2222-aaaa-2222-aaaa-222222222222',
+		source_file_id: 'ffff0001-ffff-0001-ffff-000111111111',
+		source_offset_start: 64,
+		source_offset_end: 100,
+		source_page: 1,
+		source_text: 'tolerant match verified',
+		verified: true,
+		verification_method: 'tolerant_match',
+		verification_confidence: 0.96,
+		partial: false,
+		created_at: '2026-05-16T10:00:01.600Z'
+	},
+	{
+		id: 'aaaa3333-aaaa-3333-aaaa-333333333333',
+		source_file_id: 'ffff0001-ffff-0001-ffff-000111111111',
+		source_offset_start: 128,
+		source_offset_end: 165,
+		source_page: 2,
+		source_text: 'paraphrase judge verified',
+		verified: true,
+		verification_method: 'paraphrase_judge',
+		verification_confidence: 0.9,
+		partial: false,
+		created_at: '2026-05-16T10:00:01.700Z'
+	}
+	// Intentionally NO row for "unverifiable claim no source supports" —
+	// absence of a row is the unverified signal (per
+	// api/app/api/chats.py _persist_message_citations).
+];
+
+describe('M2-C2 — Citation Engine UI renders all four states', () => {
+	beforeEach(() => {
+		login(ADMIN_EMAIL(), ADMIN_PASSWORD());
+	});
+
+	it('renders 4 state-classified chips + 4 inline-decorated spans in one message', () => {
+		// Set up the listMessages intercept BEFORE creating the matter so it
+		// matches the first chat-load call. URL pattern: `/chats/{id}/messages`
+		// (the API client base prefixes `/api/v1`).
+		cy.intercept(
+			{ method: 'GET', url: /\/api\/v1\/chats\/[a-f0-9-]+\/messages(\?|$)/ },
+			(req) => {
+				const m = req.url.match(/chats\/([a-f0-9-]+)\/messages/);
+				const chatId = m ? m[1] : 'synthetic-chat-id';
+				req.reply(syntheticMessages(chatId));
+			}
+		).as('listMessages');
+
+		cy.intercept(
+			{
+				method: 'GET',
+				url: new RegExp(
+					`/api/v1/chats/[a-f0-9-]+/messages/${SYNTHETIC_ASSISTANT_ID}/citations(\\?|$)`
+				)
+			},
+			(req) => {
+				req.reply(SYNTHETIC_CITATIONS);
+			}
+		).as('getCitations');
+
+		createSampleMatter('M2-C2 Citation Render');
+
+		// createSampleMatter clicks "+ New Chat" which triggers selectChat
+		// → listMessages. The intercept fires; the synthetic assistant
+		// message lands in the message list and renders.
+		cy.wait('@listMessages', { timeout: 15000 });
+
+		// Wait for the assistant message bubble.
+		cy.get(`[data-testid="lq-ai-message-${SYNTHETIC_ASSISTANT_ID}"]`, { timeout: 15000 }).should(
+			'exist'
+		);
+
+		// Lazy-fetch fires once the bubble mounts and isStreaming=false.
+		cy.wait('@getCitations', { timeout: 15000 });
+
+		// ── Sidecar chips: 4 buttons, one per marker, each carrying its state ──
+		cy.get('[data-testid="m2-citations"]').should('exist');
+		cy.get('[data-testid="m2-citations"] button.lq-m2-cite-chip').should('have.length', 4);
+
+		cy.get('[data-testid="m2-citations"] button[data-state="verified-exact"]').should(
+			'have.length',
+			1
+		);
+		cy.get('[data-testid="m2-citations"] button[data-state="verified-tolerant"]').should(
+			'have.length',
+			1
+		);
+		cy.get('[data-testid="m2-citations"] button[data-state="verified-paraphrase"]').should(
+			'have.length',
+			1
+		);
+		cy.get('[data-testid="m2-citations"] button[data-state="unverified"]').should(
+			'have.length',
+			1
+		);
+
+		// The unverified chip is non-interactive (the source viewer doesn't
+		// have a row to highlight); the three verified chips are buttons.
+		cy.get('[data-testid="m2-citations"] button[data-state="unverified"]').should(
+			'be.disabled'
+		);
+		cy.get('[data-testid="m2-citations"] button[data-state="verified-exact"]').should(
+			'not.be.disabled'
+		);
+
+		// Each chip carries a tooltip via the `title` attribute. The
+		// procurement-reviewer test wants the visual to be scannable
+		// without reading tooltips, but the tooltips still have to be
+		// wired for screen-reader and hover paths.
+		cy.get('[data-testid="m2-citations"] button[data-state="verified-exact"]')
+			.invoke('attr', 'title')
+			.should('contain', 'Verified verbatim');
+		cy.get('[data-testid="m2-citations"] button[data-state="verified-paraphrase"]')
+			.invoke('attr', 'title')
+			.should('contain', 'judge');
+		cy.get('[data-testid="m2-citations"] button[data-state="unverified"]')
+			.invoke('attr', 'title')
+			.should('contain', 'Could not verify');
+
+		// ── Inline decoration: 4 quoted spans wrapped with state classes ──
+		const bubble = `[data-testid="lq-ai-message-${SYNTHETIC_ASSISTANT_ID}"]`;
+		cy.get(`${bubble} span.lq-cite-inline`).should('have.length', 4);
+		cy.get(`${bubble} span.lq-cite-inline-verified-exact`)
+			.should('have.length', 1)
+			.invoke('text')
+			.should('equal', 'exact verbatim verified text');
+		cy.get(`${bubble} span.lq-cite-inline-verified-tolerant`)
+			.should('have.length', 1)
+			.invoke('text')
+			.should('equal', 'tolerant match verified');
+		cy.get(`${bubble} span.lq-cite-inline-verified-paraphrase`)
+			.should('have.length', 1)
+			.invoke('text')
+			.should('equal', 'paraphrase judge verified');
+		cy.get(`${bubble} span.lq-cite-inline-unverified`)
+			.should('have.length', 1)
+			.invoke('text')
+			.should('equal', 'unverifiable claim no source supports');
+
+		// Screenshot for visual review — the procurement-reviewer test
+		// argues the differences must be scannable; the screenshot is the
+		// archived evidence the reviewer can flip through during PR review.
+		cy.screenshot('m2-c2-four-citation-states', { capture: 'fullPage' });
+	});
+});

--- a/web/cypress/support/e2e.ts
+++ b/web/cypress/support/e2e.ts
@@ -84,7 +84,8 @@ before(() => {
 	// OpenWebUI's auth-redirect on /lq-ai/login. Scope the bootstrap to
 	// upstream-OpenWebUI spec files only.
 	const spec = (Cypress.spec && Cypress.spec.name) || '';
-	const isLqAiSpec = spec.startsWith('wave-') || spec.startsWith('lq-ai-');
+	const isLqAiSpec =
+		spec.startsWith('wave-') || spec.startsWith('lq-ai-') || /^m\d+-/.test(spec);
 	if (!isLqAiSpec) {
 		cy.registerAdmin();
 	}

--- a/web/src/lib/lq-ai/__tests__/M2Citations.test.ts
+++ b/web/src/lib/lq-ai/__tests__/M2Citations.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the M2Citations.svelte chip-builder helpers.
+ *
+ * The Svelte template is glue (per the project's pure-helper testing
+ * convention); the chip-building logic is the testable surface. Full
+ * DOM-level rendering of the five visual states is covered by the
+ * Playwright visual-regression suite (M2-C2 Decision D).
+ */
+import { describe, expect, it } from 'vitest';
+import { buildCitationChips, previewQuote } from '../components/M2Citations.svelte';
+import type { Citation } from '../types';
+
+function makeCitation(overrides: Partial<Citation> = {}): Citation {
+	return {
+		id: 'cite-1',
+		source_file_id: 'file-1',
+		source_offset_start: 0,
+		source_offset_end: 10,
+		source_text: '',
+		verified: true,
+		...overrides
+	};
+}
+
+describe('previewQuote', () => {
+	it('returns short quotes unchanged', () => {
+		expect(previewQuote('short')).toBe('short');
+	});
+
+	it('trims leading/trailing whitespace', () => {
+		expect(previewQuote('  trimmed  ')).toBe('trimmed');
+	});
+
+	it('truncates long quotes with an ellipsis at the configured max', () => {
+		const long = 'a'.repeat(80);
+		const preview = previewQuote(long, 20);
+		expect(preview.length).toBeLessThanOrEqual(20);
+		expect(preview.endsWith('…')).toBe(true);
+	});
+});
+
+describe('buildCitationChips', () => {
+	it('produces an empty list when the content has no markers', () => {
+		expect(buildCitationChips('No citations here.', [])).toEqual([]);
+	});
+
+	it('produces one chip per marker', () => {
+		const content = '"alpha" (Source: [1]) and "beta" (Source: [2]).';
+		const chips = buildCitationChips(content, [
+			makeCitation({ id: 'cite-1', source_text: 'alpha', verification_method: 'exact_match' }),
+			makeCitation({ id: 'cite-2', source_text: 'beta', verification_method: 'tolerant_match' })
+		]);
+		expect(chips).toHaveLength(2);
+		expect(chips[0].state).toBe('verified-exact');
+		expect(chips[0].quote).toBe('alpha');
+		expect(chips[0].citationId).toBe('cite-1');
+		expect(chips[1].state).toBe('verified-tolerant');
+		expect(chips[1].quote).toBe('beta');
+		expect(chips[1].citationId).toBe('cite-2');
+	});
+
+	it('emits an unverified chip when a marker has no matching row', () => {
+		const content = '"alpha" (Source: [1]) and "unmatched" (Source: [2]).';
+		const chips = buildCitationChips(content, [
+			makeCitation({ id: 'cite-1', source_text: 'alpha', verification_method: 'exact_match' })
+		]);
+		expect(chips).toHaveLength(2);
+		expect(chips[0].state).toBe('verified-exact');
+		expect(chips[1].state).toBe('unverified');
+		expect(chips[1].citationId).toBeNull();
+	});
+
+	it('uses paraphrase_judge yellow regardless of partial flag (Decision G)', () => {
+		const content = '"strict" (Source: [1]) and "partial" (Source: [2]).';
+		const chips = buildCitationChips(content, [
+			makeCitation({
+				id: 'cite-1',
+				source_text: 'strict',
+				verification_method: 'paraphrase_judge',
+				partial: false
+			}),
+			makeCitation({
+				id: 'cite-2',
+				source_text: 'partial',
+				verification_method: 'paraphrase_judge',
+				partial: true
+			})
+		]);
+		expect(chips[0].state).toBe('verified-paraphrase');
+		expect(chips[1].state).toBe('verified-paraphrase');
+	});
+
+	it('reflects partial=true in the tooltip wording', () => {
+		const content = '"partial" (Source: [1]).';
+		const chips = buildCitationChips(content, [
+			makeCitation({
+				id: 'cite-1',
+				source_text: 'partial',
+				verification_method: 'paraphrase_judge',
+				partial: true,
+				verification_confidence: 0.7
+			})
+		]);
+		expect(chips[0].tooltip).toContain('partially');
+	});
+
+	it('preserves marker order even when citation rows are interleaved differently', () => {
+		const content = '"first" (Source: [1]) and "second" (Source: [2]).';
+		const chips = buildCitationChips(content, [
+			makeCitation({
+				id: 'cite-2',
+				source_text: 'second',
+				verification_method: 'exact_match'
+			}),
+			makeCitation({
+				id: 'cite-1',
+				source_text: 'first',
+				verification_method: 'paraphrase_judge'
+			})
+		]);
+		expect(chips.map((c) => c.quote)).toEqual(['first', 'second']);
+	});
+
+	it('truncates long quote previews for chip display', () => {
+		const longQuote = 'this is a very long quote that goes well beyond the chip preview limit';
+		const content = `"${longQuote}" (Source: [1]).`;
+		const chips = buildCitationChips(content, [
+			makeCitation({
+				id: 'cite-1',
+				source_text: longQuote,
+				verification_method: 'exact_match'
+			})
+		]);
+		expect(chips[0].quotePreview.length).toBeLessThan(longQuote.length);
+		expect(chips[0].quotePreview.endsWith('…')).toBe(true);
+		expect(chips[0].quote).toBe(longQuote);
+	});
+
+	it('renders all 4 currently-emitted states in one pass', () => {
+		const content =
+			'"exact" (Source: [1]) "tolerant" (Source: [2]) "judge" (Source: [3]) "missing" (Source: [4]).';
+		const chips = buildCitationChips(content, [
+			makeCitation({
+				id: 'c1',
+				source_text: 'exact',
+				verification_method: 'exact_match'
+			}),
+			makeCitation({
+				id: 'c2',
+				source_text: 'tolerant',
+				verification_method: 'tolerant_match'
+			}),
+			makeCitation({
+				id: 'c3',
+				source_text: 'judge',
+				verification_method: 'paraphrase_judge'
+			})
+		]);
+		expect(chips.map((c) => c.state)).toEqual([
+			'verified-exact',
+			'verified-tolerant',
+			'verified-paraphrase',
+			'unverified'
+		]);
+	});
+
+	it('assigns stable keys for verified chips and unique synthetic keys for unverified ones', () => {
+		const content = '"unmatched" (Source: [1]) and "unmatched" (Source: [2]).';
+		const chips = buildCitationChips(content, []);
+		expect(chips).toHaveLength(2);
+		// Both unverified — keys must be distinct so Svelte's keyed-each
+		// doesn't collapse them on render.
+		expect(new Set(chips.map((c) => c.key)).size).toBe(2);
+	});
+});

--- a/web/src/lib/lq-ai/__tests__/citation-render-state.test.ts
+++ b/web/src/lib/lq-ai/__tests__/citation-render-state.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for the M2-C2 citation render-state helpers.
+ *
+ * Mirrors the ProvenancePill / RefusalMessageBubble pattern: pure
+ * helpers exported from a module, exercised here in vitest. DOM
+ * rendering of the resulting visual states is covered separately
+ * via Playwright (M2-C2 Decision D).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+	CITATION_REGEX,
+	citationRenderState,
+	citationTooltip,
+	iterCitationMarkers,
+	matchMarkerState
+} from '../citations/state';
+import type { Citation } from '../types';
+
+function makeCitation(overrides: Partial<Citation> = {}): Citation {
+	return {
+		id: 'cite-1',
+		source_file_id: 'file-1',
+		source_offset_start: 0,
+		source_offset_end: 10,
+		source_text: '',
+		verified: true,
+		...overrides
+	};
+}
+
+describe('citationRenderState', () => {
+	it('exact_match → verified-exact', () => {
+		expect(
+			citationRenderState(makeCitation({ verification_method: 'exact_match' }))
+		).toBe('verified-exact');
+	});
+
+	it('tolerant_match → verified-tolerant', () => {
+		expect(
+			citationRenderState(makeCitation({ verification_method: 'tolerant_match' }))
+		).toBe('verified-tolerant');
+	});
+
+	it('paraphrase_judge maps to verified-paraphrase regardless of partial flag (Decision G)', () => {
+		expect(
+			citationRenderState(
+				makeCitation({ verification_method: 'paraphrase_judge', partial: false })
+			)
+		).toBe('verified-paraphrase');
+		expect(
+			citationRenderState(
+				makeCitation({ verification_method: 'paraphrase_judge', partial: true })
+			)
+		).toBe('verified-paraphrase');
+	});
+
+	it('llm_judge → verified-paraphrase (semantic verification, same color)', () => {
+		expect(
+			citationRenderState(makeCitation({ verification_method: 'llm_judge' }))
+		).toBe('verified-paraphrase');
+	});
+
+	it('ensemble → verified-tolerant (multi-stage agreement, green)', () => {
+		expect(
+			citationRenderState(makeCitation({ verification_method: 'ensemble' }))
+		).toBe('verified-tolerant');
+	});
+
+	it('failed → unverified', () => {
+		expect(
+			citationRenderState(makeCitation({ verification_method: 'failed', verified: false }))
+		).toBe('unverified');
+	});
+
+	it('null/absent method on a verified row → verified-tolerant (legacy-safe)', () => {
+		expect(
+			citationRenderState(makeCitation({ verification_method: null }))
+		).toBe('verified-tolerant');
+		expect(citationRenderState(makeCitation())).toBe('verified-tolerant');
+	});
+
+	it('verified=false → unverified regardless of method', () => {
+		expect(
+			citationRenderState(
+				makeCitation({ verified: false, verification_method: 'exact_match' })
+			)
+		).toBe('unverified');
+	});
+
+	it('null citation → unverified', () => {
+		expect(citationRenderState(null)).toBe('unverified');
+	});
+
+	it('unknown future method → degrades to verified-tolerant', () => {
+		expect(
+			citationRenderState(
+				makeCitation({
+					// Cast to bypass the union check — modeling an api that adds
+					// a method we haven't seen yet.
+					verification_method: 'multi_stage_super' as unknown as 'exact_match'
+				})
+			)
+		).toBe('verified-tolerant');
+	});
+});
+
+describe('CITATION_REGEX + iterCitationMarkers', () => {
+	it('matches a straight-quote citation', () => {
+		const text = 'The agreement says "no compete" (Source: [1]).';
+		const markers = Array.from(iterCitationMarkers(text));
+		expect(markers).toHaveLength(1);
+		expect(markers[0].quote).toBe('no compete');
+		expect(markers[0].sourceIndex).toBe(1);
+		expect(text.slice(markers[0].quoteStart, markers[0].quoteEnd)).toBe('no compete');
+	});
+
+	it('matches a curly-quote citation', () => {
+		const text = 'The agreement says “no compete” (Source: [2]).';
+		const markers = Array.from(iterCitationMarkers(text));
+		expect(markers).toHaveLength(1);
+		expect(markers[0].quote).toBe('no compete');
+		expect(markers[0].sourceIndex).toBe(2);
+	});
+
+	it('matches multiple citations in one message', () => {
+		const text =
+			'First "alpha" (Source: [1]) and second "beta" (Source: [2]) and third "gamma" (Source: [3]).';
+		const markers = Array.from(iterCitationMarkers(text));
+		expect(markers.map((m) => m.quote)).toEqual(['alpha', 'beta', 'gamma']);
+		expect(markers.map((m) => m.sourceIndex)).toEqual([1, 2, 3]);
+	});
+
+	it('mixes straight and curly quotes in one message', () => {
+		const text = 'A "first" (Source: [1]) and B “second” (Source: [2]).';
+		const markers = Array.from(iterCitationMarkers(text));
+		expect(markers).toHaveLength(2);
+		expect(markers[0].quote).toBe('first');
+		expect(markers[1].quote).toBe('second');
+	});
+
+	it('returns no markers for prose without citations', () => {
+		expect(Array.from(iterCitationMarkers('Just prose with no markers.'))).toHaveLength(0);
+	});
+
+	it('does not match a bare quote without (Source: [N])', () => {
+		expect(Array.from(iterCitationMarkers('Just "a quote" alone.'))).toHaveLength(0);
+	});
+
+	it('does not match Source marker without quoted prelude', () => {
+		expect(
+			Array.from(iterCitationMarkers('A bare reference (Source: [1]) without a quote.'))
+		).toHaveLength(0);
+	});
+
+	it('handles quote bodies that span line breaks (dotAll)', () => {
+		const text = 'See "first\nsecond" (Source: [1]).';
+		const markers = Array.from(iterCitationMarkers(text));
+		expect(markers).toHaveLength(1);
+		expect(markers[0].quote).toBe('first\nsecond');
+	});
+
+	it('uses lazy matching so two citations on the same line stay distinct', () => {
+		// Without lazy, the body would greedily span both quotes.
+		const text = '"one" (Source: [1]) and "two" (Source: [2])';
+		const markers = Array.from(iterCitationMarkers(text));
+		expect(markers.map((m) => m.quote)).toEqual(['one', 'two']);
+	});
+
+	it('quoteStart + quoteEnd select exactly the quoted body in the source', () => {
+		const text = 'Prefix "the body" (Source: [1]) suffix';
+		const [marker] = Array.from(iterCitationMarkers(text));
+		expect(text.slice(marker.quoteStart, marker.quoteEnd)).toBe('the body');
+	});
+
+	it('CITATION_REGEX is exported with the g + s flags (matchAll-safe)', () => {
+		expect(CITATION_REGEX.flags).toContain('g');
+		expect(CITATION_REGEX.flags).toContain('s');
+	});
+});
+
+describe('matchMarkerState', () => {
+	it('matches a marker to a citation row by source_text', () => {
+		const citations = [
+			makeCitation({
+				id: 'cite-1',
+				source_text: 'no compete',
+				verification_method: 'exact_match'
+			})
+		];
+		const [marker] = Array.from(
+			iterCitationMarkers('The agreement says "no compete" (Source: [1]).')
+		);
+		const { state, citation } = matchMarkerState(marker, citations);
+		expect(state).toBe('verified-exact');
+		expect(citation?.id).toBe('cite-1');
+	});
+
+	it('a marker with no matching row → unverified (per api absence-of-row contract)', () => {
+		const citations = [
+			makeCitation({
+				id: 'cite-1',
+				source_text: 'something else',
+				verification_method: 'exact_match'
+			})
+		];
+		const [marker] = Array.from(
+			iterCitationMarkers('"unverifiable" (Source: [1]).')
+		);
+		const { state, citation } = matchMarkerState(marker, citations);
+		expect(state).toBe('unverified');
+		expect(citation).toBeNull();
+	});
+
+	it('handles an empty citations array → all unverified', () => {
+		const [marker] = Array.from(iterCitationMarkers('"any" (Source: [1]).'));
+		const { state, citation } = matchMarkerState(marker, []);
+		expect(state).toBe('unverified');
+		expect(citation).toBeNull();
+	});
+});
+
+describe('citationTooltip', () => {
+	it('verified-exact tooltip is verbatim copy', () => {
+		expect(citationTooltip('verified-exact', makeCitation())).toBe(
+			'Verified verbatim against source.'
+		);
+	});
+
+	it('verified-tolerant tooltip mentions formatting differences', () => {
+		expect(citationTooltip('verified-tolerant', makeCitation())).toContain(
+			'minor formatting differences'
+		);
+	});
+
+	it('verified-paraphrase tooltip includes confidence label', () => {
+		expect(
+			citationTooltip(
+				'verified-paraphrase',
+				makeCitation({ verification_method: 'paraphrase_judge', verification_confidence: 0.9 })
+			)
+		).toContain('high confidence');
+		expect(
+			citationTooltip(
+				'verified-paraphrase',
+				makeCitation({ verification_method: 'paraphrase_judge', verification_confidence: 0.7 })
+			)
+		).toContain('medium confidence');
+		expect(
+			citationTooltip(
+				'verified-paraphrase',
+				makeCitation({ verification_method: 'paraphrase_judge', verification_confidence: 0.5 })
+			)
+		).toContain('low confidence');
+	});
+
+	it('partial=true alters the verified-paraphrase tooltip to flag partial support', () => {
+		const tooltip = citationTooltip(
+			'verified-paraphrase',
+			makeCitation({ partial: true, verification_confidence: 0.7 })
+		);
+		expect(tooltip).toContain('partially');
+	});
+
+	it('unverified tooltip is verbatim and matches the plan copy', () => {
+		const tooltip = citationTooltip('unverified', null);
+		expect(tooltip).toContain('Could not verify');
+		expect(tooltip).toContain("doesn't follow from the cited content");
+	});
+});

--- a/web/src/lib/lq-ai/api/citations.ts
+++ b/web/src/lib/lq-ai/api/citations.ts
@@ -1,0 +1,23 @@
+/**
+ * /api/v1/chats/{chat_id}/messages/{message_id}/citations — M2 citations.
+ *
+ * Lazy-fetched after each assistant message renders. The endpoint returns
+ * `MessageCitation` rows persisted by the M2 Citation Engine (M2-A2 through
+ * M2-C1). M2-C2 consumes this surface to render the five citation states.
+ *
+ * A future refactor (DE-275) may embed citations directly in the
+ * assistant-message envelope to avoid the second round-trip; until then the
+ * lazy fetch is the canonical client path.
+ */
+import { apiRequest } from './client';
+import type { Citation } from '../types';
+
+/** GET /api/v1/chats/{chat_id}/messages/{message_id}/citations */
+export async function getMessageCitations(
+	chatId: string,
+	messageId: string
+): Promise<Citation[]> {
+	return apiRequest<Citation[]>(
+		`/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(messageId)}/citations`
+	);
+}

--- a/web/src/lib/lq-ai/api/index.ts
+++ b/web/src/lib/lq-ai/api/index.ts
@@ -9,6 +9,7 @@ export * as authApi from './auth';
 export * as projectsApi from './projects';
 export * as chatsApi from './chats';
 export * as messagesApi from './messages';
+export * as citationsApi from './citations';
 export * as skillsApi from './skills';
 export * as filesApi from './files';
 export * as knowledgeBasesApi from './knowledgeBases';

--- a/web/src/lib/lq-ai/citations/decorate-inline.ts
+++ b/web/src/lib/lq-ai/citations/decorate-inline.ts
@@ -1,0 +1,149 @@
+/**
+ * `decorateCitationsInline` — Svelte action that wraps `"<quote>" (Source: [N])`
+ * markers in rendered message prose with a subtle, color-coded underline span
+ * keyed to the citation's render state (M2-C2 §F: hybrid inline + sidecar).
+ *
+ * The action keeps inline treatment intentionally minimal: a thin colored
+ * underline + a native `title` tooltip. Click behavior and the long-form
+ * tooltip live in the sidecar (`M2Citations.svelte`); inline is for the
+ * procurement-reviewer scrolling test — a reviewer scanning the report
+ * should be able to identify unverified citations by color alone.
+ *
+ * The action only decorates citation markers that fit inside a single text
+ * node — i.e., the model's output didn't insert inline HTML (e.g., bold,
+ * italic) mid-quote. Cross-element citations degrade gracefully to the
+ * sidecar chip without an inline marker.
+ */
+import { iterCitationMarkers, matchMarkerState, citationTooltip } from './state';
+import type { Citation } from '../types';
+
+export interface DecorateCitationsParams {
+	citations: Citation[];
+	/**
+	 * Streaming hint: when `false`, the action is a no-op. Callers pass
+	 * `false` while the message is still streaming and switch to `true`
+	 * once the assistant message completes — otherwise the regex would
+	 * match partial markers mid-stream and re-decorate on every token.
+	 */
+	enabled?: boolean;
+}
+
+const WRAPPER_CLASS = 'lq-cite-inline';
+
+/**
+ * Strip any previously-applied inline-decoration spans from `root`,
+ * collapsing their text content back into the parent so re-application
+ * starts from a clean baseline. Safe to call when no decorations exist.
+ */
+function undecorate(root: HTMLElement): void {
+	const wrappers = root.querySelectorAll(`span.${WRAPPER_CLASS}`);
+	wrappers.forEach((span) => {
+		const parent = span.parentNode;
+		if (!parent) return;
+		while (span.firstChild) {
+			parent.insertBefore(span.firstChild, span);
+		}
+		parent.removeChild(span);
+		// Adjacent text nodes left behind from the unwrap; let the browser
+		// re-coalesce on the next normalize().
+	});
+	root.normalize();
+}
+
+/**
+ * Walk text nodes inside `root` and wrap every quote that maps to a
+ * citation marker with a state-styled span. The walk uses a NodeIterator
+ * because we mutate the DOM as we go and want stable traversal of the
+ * pre-mutation snapshot.
+ */
+function decorate(root: HTMLElement, citations: Citation[]): void {
+	// Collect text nodes first, then mutate. Live-walking + mutating in
+	// one pass corrupts the iterator's position.
+	const textNodes: Text[] = [];
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+	let current = walker.nextNode();
+	while (current) {
+		textNodes.push(current as Text);
+		current = walker.nextNode();
+	}
+
+	for (const node of textNodes) {
+		const text = node.nodeValue ?? '';
+		const markers = Array.from(iterCitationMarkers(text));
+		if (markers.length === 0) continue;
+
+		// Build a replacement DocumentFragment piece by piece, alternating
+		// untouched text and state-styled spans. Walking markers in order
+		// of their `start` offset keeps the offsets coherent.
+		const fragment = document.createDocumentFragment();
+		let cursor = 0;
+		for (const marker of markers) {
+			// Leading untouched text between cursor and the marker start.
+			if (marker.quoteStart > cursor) {
+				fragment.appendChild(
+					document.createTextNode(text.slice(cursor, marker.quoteStart))
+				);
+			}
+
+			const { state, citation } = matchMarkerState(marker, citations);
+			const span = document.createElement('span');
+			span.className = `${WRAPPER_CLASS} ${WRAPPER_CLASS}-${state}`;
+			span.title = citationTooltip(state, citation);
+			if (citation) {
+				span.dataset.citeId = citation.id;
+			}
+			span.dataset.citeState = state;
+			span.textContent = text.slice(marker.quoteStart, marker.quoteEnd);
+			fragment.appendChild(span);
+
+			cursor = marker.quoteEnd;
+		}
+
+		// Trailing untouched text after the last marker.
+		if (cursor < text.length) {
+			fragment.appendChild(document.createTextNode(text.slice(cursor)));
+		}
+
+		node.parentNode?.replaceChild(fragment, node);
+	}
+}
+
+export function decorateCitationsInline(
+	node: HTMLElement,
+	params: DecorateCitationsParams
+): {
+	update(newParams: DecorateCitationsParams): void;
+	destroy(): void;
+} {
+	let current = params;
+
+	function apply(): void {
+		undecorate(node);
+		if (current.enabled === false) return;
+		if (current.citations.length === 0 && !nodeContainsAnyMarker(node)) {
+			// Nothing verified AND no markers in the text → skip the walk
+			// to keep streaming-tail render cheap.
+			return;
+		}
+		decorate(node, current.citations);
+	}
+
+	apply();
+
+	return {
+		update(newParams: DecorateCitationsParams) {
+			current = newParams;
+			apply();
+		},
+		destroy() {
+			undecorate(node);
+		}
+	};
+}
+
+/** Cheap probe: does the rendered prose contain ANY citation marker? */
+function nodeContainsAnyMarker(root: HTMLElement): boolean {
+	const text = root.textContent ?? '';
+	// Don't run the full regex iterator; a single test suffices.
+	return /(?:"[^"]+?"|“[^”]+?”)\s*\(Source:\s*\[\d+\]\)/s.test(text);
+}

--- a/web/src/lib/lq-ai/citations/state.ts
+++ b/web/src/lib/lq-ai/citations/state.ts
@@ -1,0 +1,167 @@
+/**
+ * Citation render-state helpers — shared by `M2Citations.svelte` (sidecar
+ * chip list) and `decorate-inline.ts` (inline prose decorator).
+ *
+ * Per M2-C2 the chat surface renders five citation states; M2-C2 itself
+ * ships four of them (per Decision H, 'system-error' is deferred to M2-D
+ * when the pipeline has a signal to emit). The fifth slot is reserved in
+ * the type union for forward compatibility — adding it later is purely
+ * additive on the renderer side.
+ */
+import type { Citation } from '../types';
+
+export type CitationRenderState =
+	| 'verified-exact'
+	| 'verified-tolerant'
+	| 'verified-paraphrase'
+	| 'unverified';
+
+/**
+ * Matches `"<quote>" (Source: [N])` pairs the model emits, both straight
+ * and curly quote variants. Mirrors the api/'s `_CITATION_RE` in
+ * `app/citation/extraction.py` so the frontend and backend extract from
+ * the exact same surface. The `s` (dotAll) flag lets the body span line
+ * breaks; `g` is required for iterative matching via `matchAll`.
+ *
+ * Capture groups:
+ *   1: straight-quote body, 2: straight-quote source index
+ *   3: curly-quote body,    4: curly-quote source index
+ * Exactly one of (1,2) or (3,4) is populated per match.
+ */
+export const CITATION_REGEX =
+	/"([^"]+?)"\s*\(Source:\s*\[(\d+)\]\)|“([^”]+?)”\s*\(Source:\s*\[(\d+)\]\)/gs;
+
+/** Convenience: parsed citation marker from a model response. */
+export interface ParsedCitationMarker {
+	quote: string;
+	sourceIndex: number;
+	/** Byte offsets of the full marker (including the `"..."` + ` (Source: [N])`). */
+	start: number;
+	end: number;
+	/** Byte offsets of just the quoted span (excluding the trailing source marker). */
+	quoteStart: number;
+	quoteEnd: number;
+}
+
+/**
+ * Map a citation row (or `null` for "no row found for this marker") to a
+ * render state. Per Decision G, `verification_method='paraphrase_judge'`
+ * always maps to verified-paraphrase (yellow), regardless of the
+ * `partial` flag — `partial` modulates the tooltip wording, not the
+ * color choice.
+ */
+export function citationRenderState(citation: Citation | null): CitationRenderState {
+	if (citation === null || !citation.verified) {
+		return 'unverified';
+	}
+	switch (citation.verification_method) {
+		case 'exact_match':
+			return 'verified-exact';
+		case 'tolerant_match':
+			return 'verified-tolerant';
+		case 'paraphrase_judge':
+		case 'llm_judge':
+			return 'verified-paraphrase';
+		case 'ensemble':
+			// Multi-model agreement is structurally a stronger verification
+			// than a single stage; render with the green treatment shared
+			// by exact / tolerant match.
+			return 'verified-tolerant';
+		case 'failed':
+			return 'unverified';
+		case null:
+		case undefined:
+			// Legacy rows without a method — be conservative and treat
+			// a verified=true row as the byte-level (green) treatment.
+			return 'verified-tolerant';
+		default:
+			// Unknown future stage — degrade to the closest safe state.
+			return 'verified-tolerant';
+	}
+}
+
+/**
+ * Iterate through `"<quote>" (Source: [N])` markers in `text`.
+ * Yields a parsed marker per match, with absolute string offsets so the
+ * caller can replace, wrap, or annotate the matched ranges in place.
+ */
+export function* iterCitationMarkers(text: string): IterableIterator<ParsedCitationMarker> {
+	// `matchAll` requires the `g` flag, which CITATION_REGEX has. Each
+	// match carries `index` (absolute start of the whole match).
+	for (const match of text.matchAll(CITATION_REGEX)) {
+		const start = match.index ?? 0;
+		const end = start + match[0].length;
+
+		// Exactly one of the two alternations populates per match.
+		const quote = match[1] ?? match[3];
+		const indexStr = match[2] ?? match[4];
+		if (quote === undefined || indexStr === undefined) {
+			continue;
+		}
+
+		// The quoted span begins one char in (skip the opening `"` / `“`)
+		// and spans `quote.length`. Compute absolute offsets for callers.
+		const quoteStart = start + 1;
+		const quoteEnd = quoteStart + quote.length;
+
+		yield {
+			quote,
+			sourceIndex: parseInt(indexStr, 10),
+			start,
+			end,
+			quoteStart,
+			quoteEnd
+		};
+	}
+}
+
+/**
+ * Resolve a marker's render state against a citations array. Matches a
+ * citation row whose `source_text` equals the marker's quote — that is
+ * the field the api persists for the verified hit, so an exact match is
+ * the right signal. Returns `'unverified'` when no row matches; per
+ * `_persist_message_citations` in the api, absence of a row is the
+ * unverified signal.
+ */
+export function matchMarkerState(
+	marker: ParsedCitationMarker,
+	citations: Citation[]
+): { state: CitationRenderState; citation: Citation | null } {
+	const hit = citations.find((c) => c.source_text === marker.quote);
+	return { state: citationRenderState(hit ?? null), citation: hit ?? null };
+}
+
+/**
+ * Tooltip text per render state. Mirrors the M2-C2 plan's spec verbatim
+ * for the four states the data pipeline currently emits. The
+ * paraphrase-judge tooltip is parameterised because it carries the
+ * judge's confidence + partial framing.
+ */
+export function citationTooltip(
+	state: CitationRenderState,
+	citation: Citation | null
+): string {
+	switch (state) {
+		case 'verified-exact':
+			return 'Verified verbatim against source.';
+		case 'verified-tolerant':
+			return 'Verified against source (minor formatting differences).';
+		case 'verified-paraphrase': {
+			const conf = citation?.verification_confidence;
+			const confLabel =
+				conf === null || conf === undefined
+					? 'judge'
+					: conf >= 0.85
+						? 'high confidence'
+						: conf >= 0.6
+							? 'medium confidence'
+							: 'low confidence';
+			if (citation?.partial) {
+				return `Verified by judge (${confLabel}): the source partially supports this claim.`;
+			}
+			return `Verified by judge (${confLabel}): the source supports this claim.`;
+		}
+		case 'unverified':
+			return "Could not verify this citation against the source. The model may have produced a claim that doesn't follow from the cited content.";
+	}
+}

--- a/web/src/lib/lq-ai/components/DualBrandingFooter.svelte
+++ b/web/src/lib/lq-ai/components/DualBrandingFooter.svelte
@@ -16,7 +16,7 @@
 	data-testid="lq-ai-dual-branding-footer"
 >
 	<span>
-		<strong>LQ.AI</strong> — open-source legal AI for in-house teams.
+		<strong>LQ.AI</strong> — Open-Source Legal AI
 	</span>
 	<span>
 		Web shell powered by

--- a/web/src/lib/lq-ai/components/M2Citations.svelte
+++ b/web/src/lib/lq-ai/components/M2Citations.svelte
@@ -1,0 +1,280 @@
+<script context="module" lang="ts">
+	/**
+	 * Helpers exported for unit tests — accessible without
+	 * `@testing-library/svelte` (mirrors the AttachKBModal / InfoTip
+	 * pattern; per CLAUDE.md "Don't add libraries without justification").
+	 */
+	import type { Citation } from '../types';
+	import {
+		iterCitationMarkers,
+		matchMarkerState,
+		citationTooltip,
+		type CitationRenderState,
+		type ParsedCitationMarker
+	} from '../citations/state';
+
+	export interface CitationChip {
+		key: string;
+		state: CitationRenderState;
+		quote: string;
+		quotePreview: string;
+		tooltip: string;
+		citationId: string | null;
+		sourceFileId: string | null;
+		sourcePage: number | null;
+		marker: ParsedCitationMarker;
+	}
+
+	/** Truncate a quote for chip display so a long sentence doesn't blow the layout. */
+	export function previewQuote(quote: string, maxChars = 60): string {
+		const trimmed = quote.trim();
+		if (trimmed.length <= maxChars) return trimmed;
+		return `${trimmed.slice(0, maxChars - 1).trimEnd()}…`;
+	}
+
+	/**
+	 * Build the chip list for a message: one chip per `"<quote>" (Source: [N])`
+	 * marker found in `content`, joined to its citation row by `source_text`.
+	 * Markers without a matching row become unverified chips (per the api's
+	 * "absence-of-row = unverified" contract).
+	 */
+	export function buildCitationChips(
+		content: string,
+		citations: Citation[]
+	): CitationChip[] {
+		const chips: CitationChip[] = [];
+		let i = 0;
+		for (const marker of iterCitationMarkers(content)) {
+			const { state, citation } = matchMarkerState(marker, citations);
+			chips.push({
+				key: citation ? `cite-${citation.id}` : `uncite-${marker.start}-${i}`,
+				state,
+				quote: marker.quote,
+				quotePreview: previewQuote(marker.quote),
+				tooltip: citationTooltip(state, citation),
+				citationId: citation?.id ?? null,
+				sourceFileId: citation?.source_file_id ?? null,
+				sourcePage: citation?.source_page ?? null,
+				marker
+			});
+			i++;
+		}
+		return chips;
+	}
+</script>
+
+<script lang="ts">
+	/**
+	 * `M2Citations.svelte` — sidecar chip list for the M2 Citation Engine's
+	 * five-state UI (M2-C2). Renders one chip per `"<quote>" (Source: [N])`
+	 * marker the assistant emitted: green for byte-level verification
+	 * (exact / tolerant match), yellow for paraphrase-judge verification,
+	 * grey for unverified attempts. The 'system-error' state is deferred
+	 * to M2-D per the M2-C2 decision matrix; the helper's render-state
+	 * union reserves the slot.
+	 *
+	 * Pairs with the `decorateCitationsInline` Svelte action which applies
+	 * a subtle inline color underline to the same quotes in the rendered
+	 * prose. Together they satisfy the plan's procurement-reviewer test:
+	 * "scrolling the report, a reviewer should be able to identify
+	 * unverified citations without reading the tooltips."
+	 *
+	 * The component is purely presentational — click behaviour for
+	 * jumping to the source span lives in M2-D2 once the source viewer
+	 * ships. For now, hover/focus reveals the state-specific tooltip.
+	 */
+	import { createEventDispatcher } from 'svelte';
+
+	/** Persisted verified citation rows from `GET /messages/{id}/citations`. */
+	export let citations: Citation[] = [];
+
+	/**
+	 * The assistant message's raw text. The component scans it for
+	 * citation markers — including unverified attempts whose absence
+	 * from `citations` is the unverified signal.
+	 */
+	export let messageContent: string = '';
+
+	/** Hidden visually for the rare case where the caller wants the data path without UI. */
+	export let hidden: boolean = false;
+
+	const dispatch = createEventDispatcher<{
+		select: { citation: Citation | null; quote: string };
+	}>();
+
+	$: chips = buildCitationChips(messageContent, citations);
+
+	function handleSelect(chip: CitationChip): void {
+		const fullCitation = chip.citationId
+			? citations.find((c) => c.id === chip.citationId) ?? null
+			: null;
+		dispatch('select', { citation: fullCitation, quote: chip.quote });
+	}
+</script>
+
+{#if !hidden && chips.length > 0}
+	<div
+		class="lq-m2-citations mt-2 flex flex-wrap items-center gap-1.5"
+		data-testid="m2-citations"
+		aria-label="Citation states for this message"
+	>
+		{#each chips as chip (chip.key)}
+			<button
+				type="button"
+				class="lq-m2-cite-chip"
+				class:state-verified-exact={chip.state === 'verified-exact'}
+				class:state-verified-tolerant={chip.state === 'verified-tolerant'}
+				class:state-verified-paraphrase={chip.state === 'verified-paraphrase'}
+				class:state-unverified={chip.state === 'unverified'}
+				data-state={chip.state}
+				aria-label={chip.tooltip}
+				title={chip.tooltip}
+				disabled={chip.state === 'unverified'}
+				on:click={() => handleSelect(chip)}
+			>
+				<span class="chip-icon" aria-hidden="true">
+					{#if chip.state === 'verified-exact' || chip.state === 'verified-tolerant'}
+						<!-- Checkmark — verified-green -->
+						<svg viewBox="0 0 12 12" width="12" height="12" fill="currentColor">
+							<path d="M10.28 3.22a.75.75 0 010 1.06L5.06 9.5 1.72 6.16a.75.75 0 011.06-1.06l2.28 2.28 4.16-4.16a.75.75 0 011.06 0z" />
+						</svg>
+					{:else if chip.state === 'verified-paraphrase'}
+						<!-- Checkmark — verified-yellow (judge) -->
+						<svg viewBox="0 0 12 12" width="12" height="12" fill="currentColor">
+							<path d="M10.28 3.22a.75.75 0 010 1.06L5.06 9.5 1.72 6.16a.75.75 0 011.06-1.06l2.28 2.28 4.16-4.16a.75.75 0 011.06 0z" />
+						</svg>
+					{:else}
+						<!-- Unverified marker -->
+						<svg viewBox="0 0 12 12" width="12" height="12" fill="currentColor">
+							<path d="M6 1a5 5 0 100 10A5 5 0 006 1zm0 2.25a.75.75 0 01.75.75v2.5a.75.75 0 01-1.5 0V4a.75.75 0 01.75-.75zm0 5a.875.875 0 110 1.75.875.875 0 010-1.75z" />
+						</svg>
+					{/if}
+				</span>
+				<span class="chip-text">
+					{#if chip.state === 'unverified'}<span class="chip-unverified-tag">[unverified]</span
+						>{/if}<span class="chip-quote">{chip.quotePreview}</span>
+				</span>
+			</button>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.lq-m2-citations {
+		font-size: 12px;
+		line-height: 1.4;
+	}
+
+	.lq-m2-cite-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 8px;
+		border-radius: 9999px;
+		border: 1px solid transparent;
+		background: transparent;
+		font: inherit;
+		cursor: pointer;
+		max-width: 360px;
+		transition: background-color 0.15s ease, border-color 0.15s ease;
+	}
+	.lq-m2-cite-chip:disabled {
+		cursor: default;
+	}
+	.lq-m2-cite-chip:focus-visible {
+		outline: 2px solid var(--lq-accent, #4338ca);
+		outline-offset: 1px;
+	}
+
+	.chip-icon {
+		display: inline-flex;
+		align-items: center;
+		flex-shrink: 0;
+	}
+	.chip-text {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 4px;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
+	.chip-unverified-tag {
+		font-weight: 500;
+		opacity: 0.8;
+	}
+	.chip-quote {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	/* verified-exact + verified-tolerant: emerald (green, WCAG AA against light + dark chat bgs) */
+	.state-verified-exact,
+	.state-verified-tolerant {
+		color: #047857; /* emerald-700 */
+		background-color: rgba(16, 185, 129, 0.08); /* emerald-500 @ 8% */
+		border-color: rgba(16, 185, 129, 0.32);
+	}
+	.state-verified-exact:hover,
+	.state-verified-tolerant:hover {
+		background-color: rgba(16, 185, 129, 0.16);
+	}
+	:global(.dark) .state-verified-exact,
+	:global(.dark) .state-verified-tolerant {
+		color: #6ee7b7; /* emerald-300 */
+		background-color: rgba(16, 185, 129, 0.12);
+		border-color: rgba(16, 185, 129, 0.36);
+	}
+
+	/* verified-paraphrase: amber (yellow). Distinct from the green cluster. */
+	.state-verified-paraphrase {
+		color: #b45309; /* amber-700 */
+		background-color: rgba(245, 158, 11, 0.08); /* amber-500 @ 8% */
+		border-color: rgba(245, 158, 11, 0.32);
+	}
+	.state-verified-paraphrase:hover {
+		background-color: rgba(245, 158, 11, 0.16);
+	}
+	:global(.dark) .state-verified-paraphrase {
+		color: #fcd34d; /* amber-300 */
+		background-color: rgba(245, 158, 11, 0.12);
+		border-color: rgba(245, 158, 11, 0.36);
+	}
+
+	/* unverified: greyed text + clear [unverified] tag. Not interactive. */
+	.state-unverified {
+		color: #6b7280; /* gray-500 */
+		background-color: rgba(107, 114, 128, 0.08);
+		border-color: rgba(107, 114, 128, 0.32);
+	}
+	:global(.dark) .state-unverified {
+		color: #9ca3af; /* gray-400 */
+		background-color: rgba(107, 114, 128, 0.16);
+		border-color: rgba(107, 114, 128, 0.36);
+	}
+
+	/* Inline counterpart — the `decorateCitationsInline` action injects
+	   `<span class="lq-cite-inline lq-cite-inline-{state}">`. Styles ride
+	   alongside the sidecar to keep the visual contract in one file. */
+	:global(.lq-cite-inline) {
+		text-decoration: underline;
+		text-decoration-thickness: 2px;
+		text-underline-offset: 2px;
+		text-decoration-skip-ink: none;
+	}
+	:global(.lq-cite-inline-verified-exact),
+	:global(.lq-cite-inline-verified-tolerant) {
+		text-decoration-color: #10b981; /* emerald-500 */
+	}
+	:global(.lq-cite-inline-verified-paraphrase) {
+		text-decoration-color: #f59e0b; /* amber-500 */
+	}
+	:global(.lq-cite-inline-unverified) {
+		color: #6b7280; /* gray-500 */
+		text-decoration-color: #9ca3af; /* gray-400 */
+		text-decoration-style: dotted;
+	}
+	:global(.dark .lq-cite-inline-unverified) {
+		color: #9ca3af; /* gray-400 */
+	}
+</style>

--- a/web/src/lib/lq-ai/components/MessageBubble.svelte
+++ b/web/src/lib/lq-ai/components/MessageBubble.svelte
@@ -18,11 +18,14 @@
 	import { marked } from 'marked';
 
 	import { captureAffordanceInline } from '$lib/lq-ai/preferences/capture-affordance';
+	import { citationsApi, LQAIApiError } from '$lib/lq-ai/api';
+	import { decorateCitationsInline } from '$lib/lq-ai/citations/decorate-inline';
 
-	import type { Message } from '../types';
+	import type { Citation, Message } from '../types';
 	import AppliedSkillsChip from './AppliedSkillsChip.svelte';
 	import CaptureSkillModal from './CaptureSkillModal.svelte';
 	import EnhancedDiffModal from './EnhancedDiffModal.svelte';
+	import M2Citations from './M2Citations.svelte';
 	import MessageOverflowMenu from './MessageOverflowMenu.svelte';
 	import ProvenancePill from './ProvenancePill.svelte';
 	import RefusalMessageBubble from './RefusalMessageBubble.svelte';
@@ -72,6 +75,45 @@
 	// handles teardown.
 	let captureOpen = false;
 
+	// M2-C2 — Citation Engine UI. Lazy-fetch per-message citations from
+	// `GET /messages/{id}/citations` once the assistant message has
+	// finished streaming (Decision B). `fetchedCitations === null` means
+	// "not yet fetched"; `[]` means "fetched, no rows". The decorator and
+	// the sidecar chip list both consume this array. DE-275 captures the
+	// future option to embed citations in the message envelope and skip
+	// this round-trip entirely.
+	let fetchedCitations: Citation[] | null = null;
+	let citationFetchInflight = false;
+
+	async function loadCitations(chatId: string, messageId: string): Promise<void> {
+		citationFetchInflight = true;
+		try {
+			fetchedCitations = await citationsApi.getMessageCitations(chatId, messageId);
+		} catch (err) {
+			// Degrade gracefully — a 404 here just means no rows have been
+			// persisted for this message yet (skills that don't cite, or
+			// pre-M2 historical messages). Anything else is logged but the
+			// bubble keeps rendering its content cleanly.
+			if (!(err instanceof LQAIApiError) || err.status !== 404) {
+				console.warn('[M2-C2] failed to load citations', err);
+			}
+			fetchedCitations = [];
+		} finally {
+			citationFetchInflight = false;
+		}
+	}
+
+	$: if (
+		message.role === 'assistant' &&
+		message.id &&
+		message.chat_id &&
+		!isStreaming &&
+		fetchedCitations === null &&
+		!citationFetchInflight
+	) {
+		void loadCitations(message.chat_id, message.id);
+	}
+
 	$: bubbleClasses =
 		message.role === 'user'
 			? 'bg-indigo-600 text-white self-end'
@@ -105,6 +147,10 @@
 			<div
 				class="prose prose-sm dark:prose-invert max-w-none"
 				data-testid="lq-ai-message-content"
+				use:decorateCitationsInline={{
+					citations: fetchedCitations ?? [],
+					enabled: !isStreaming
+				}}
 			>
 				{@html rendered}
 			</div>
@@ -208,15 +254,20 @@
 		{/if}
 
 		<!--
-			Citations footer intentionally omitted when the array is empty —
-			the placeholder text leaked the M1/M2 internal vocabulary to
-			users. The real citation engine lands in a future release; until
-			then we render nothing rather than telegraph a roadmap.
+			M2-C2 — Citation Engine sidecar chip list. Renders one chip per
+			`"<quote>" (Source: [N])` marker the assistant emitted, joined
+			to its persisted MessageCitation row. Markers without a row are
+			the unverified signal (per `_persist_message_citations` in
+			api/app/api/chats.py). The component returns nothing when the
+			message has no citation markers — older skills + non-RAG turns
+			stay visually unchanged.
 		-->
-		{#if message.citations && message.citations.length > 0}
-			<div class="mt-1 text-xs text-gray-500" data-testid="lq-ai-message-citations">
-				{message.citations.length}
-				{message.citations.length === 1 ? 'citation' : 'citations'}
+		{#if fetchedCitations !== null}
+			<div data-testid="lq-ai-message-citations">
+				<M2Citations
+					citations={fetchedCitations}
+					messageContent={message.content}
+				/>
 			</div>
 		{/if}
 	{/if}

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -200,6 +200,25 @@ export interface ChatSearchResponse {
 	query: string;
 }
 
+/**
+ * Which verification stage validated this citation. Mirrors
+ * `MessageCitation.verification_method` in the backend (M2-A2 / M2-B1 / M2-C1).
+ *
+ * - `exact_match` — Stage 1, byte-for-byte (M2-A2).
+ * - `tolerant_match` — Stage 2, normalized-whitespace + OCR artefacts (M2-B1).
+ * - `paraphrase_judge` — Stage 3, paraphrase judge (M2-C1).
+ * - `llm_judge` — reserved for future LLM-based semantic-match stages.
+ * - `ensemble` — Stage 4, multi-model agreement (M2-D1).
+ * - `failed` — every stage rejected; rendered as unverified in the M2-C2 UI.
+ */
+export type CitationVerificationMethod =
+	| 'exact_match'
+	| 'tolerant_match'
+	| 'paraphrase_judge'
+	| 'llm_judge'
+	| 'ensemble'
+	| 'failed';
+
 export interface Citation {
 	id: string;
 	source_file_id: string;
@@ -208,6 +227,18 @@ export interface Citation {
 	source_page?: number | null;
 	source_text: string;
 	verified: boolean;
+	/** Which verification stage validated this citation. Null on legacy rows. */
+	verification_method?: CitationVerificationMethod | null;
+	/** Stage-reported confidence in [0, 1]. Null on legacy rows. */
+	verification_confidence?: number | null;
+	/**
+	 * M2-C1: true when the paraphrase judge returned `partial` — the source
+	 * supports the claim only partially. Drives the M2-C2 UI's "verified
+	 * with caveats" rendering. Defaults to `false` server-side.
+	 */
+	partial?: boolean;
+	/** ISO-8601 timestamp the citation row was written. */
+	created_at?: string;
 }
 
 export type MessageRole = 'user' | 'assistant' | 'system' | 'tool';

--- a/web/src/routes/lq-ai/login/+page.svelte
+++ b/web/src/routes/lq-ai/login/+page.svelte
@@ -51,7 +51,7 @@
 				</span>
 				<div>
 					<h1 class="lq-text-page-h">Sign in to LQ.AI</h1>
-					<p class="lq-text-caption" style="color: var(--lq-text-tertiary);">Open-source legal AI for in-house teams.</p>
+					<p class="lq-text-caption" style="color: var(--lq-text-tertiary);">Open-Source Legal AI</p>
 				</div>
 			</div>
 


### PR DESCRIPTION
## Summary

Closes Phase C of M2 by shipping the chat-surface rendering layer for citations the Citation Engine verifies (M2-A2 through M2-C1). Renders 4 of 5 visual states; state 5 (`system-error`) is reserved for M2-D when the pipeline emits the signal.

Rendering uses the **hybrid pattern** (Decision F):
- Subtle inline color underline on each `"<quote>" (Source: [N])` marker via a Svelte action — satisfies the procurement-reviewer scrolling test (identify unverified citations without reading tooltips).
- Sidecar chip list below the assistant message with full state-styled tooltips — accessible alternative for the future click-to-source-viewer (M2-D2).

Citations are fetched lazily after each assistant message finishes streaming (Decision B); future refactor to embed in the message envelope tracked as **DE-275**.

> **Surfaced during manual verification:** the ingest worker has been silently failing to embed chunks since the embed-on-ingest pipeline shipped (missing `LQ_AI_GATEWAY_URL`/`LQ_AI_GATEWAY_KEY` env vars in `docker-compose.yml`). Fix landed as commit 5 + **DE-276** (PRD §9) tracks the broader observability gap.

## Decisions

| Dec | Choice | Note |
|---|---|---|
| A | New component alongside | M2Citations.svelte; OpenWebUI's Citations.svelte untouched |
| B | Lazy fetch | DE-275 filed for future envelope-embedding refactor |
| C | Tailwind + emerald/amber | WCAG AA confirmed for both light + dark chat surfaces |
| D | Both Vitest + Cypress | Vitest = 41 new tests passing; Cypress test deterministic via intercepts |
| E | Single M2-C2 PR | api `partial` field rolled in |
| F | Hybrid inline + sidecar | surfaced during implementation |
| G | paraphrase_judge → yellow | regardless of `partial` flag |
| H | Defer state 5 (system-error) | renderer-ready; no data path today |

## Commits

1. `bc8fe5a` — `chore(web,brand)`: tagline copy → "Open-Source Legal AI"
2. `6e4dcbe` — `feat(api,docs,m2-c2)`: expose `partial` flag in citations endpoint (api change + test + OpenAPI schema + DE-275)
3. `526e064` — `feat(web,m2-c2)`: Citation Engine 4-state UI — hybrid inline + sidecar (component + decorator + state helpers + client + types + MessageBubble wiring + 41 vitest tests + Cypress test + quickstart/architecture docs)
4. `4d5ea0c` — `test(web,cypress)`: widen LQ.AI spec-gate to also match `m2-/m3-/…` prefixes (so the M2-C2 Cypress spec doesn't trigger the OpenWebUI signup-pollution before() hook)
5. `b774147` — `fix(deploy)`: ingest worker missing gateway env — chunk embeddings silently fail (pre-existing latent bug + DE-276 for observability follow-on)

## Wider-than-planned scope (worth calling out)

The M2-C2 plan section said "Update chat-message rendering" assuming a sidecar list against existing wiring. Four things widened the scope:

- **No `web/` code was consuming `/messages/{id}/citations` yet** — the endpoint shipped in M2-A2 but the frontend had never been wired. M2-C2 had to wire it.
- **`MessageCitation.partial` was persisted but not in the API response** — required for the verified-paraphrase distinct rendering. One-line api fix included in this PR (Decision E).
- **Plan said snapshot tests at `web/tests/citation-render.test.tsx`** — the fork is Svelte (not React), and the project's e2e stack is Cypress (not Playwright; the handoff misread `web/cypress.config.ts`). Tests landed in the actual conventions: vitest for pure helpers, Cypress for end-to-end visual coverage.
- **Pre-existing bug surfaced during manual verification** — ingest worker missing gateway env vars (commit 5 + DE-276). Could have shipped as a separate PR but bundled here for atomic test-then-fix-then-verify continuity.

## Verification

| Check | Result |
|---|---|
| api mypy | clean (85 files) |
| api `ruff format --check` | clean (169 files) |
| api `ruff check` | clean |
| api pytest | **963 passed**, 1 skipped, 0 failed |
| web vitest | **451 passed** (includes 41 new) |
| web svelte-check (lq-ai-scoped) | **0 errors** in changed files |
| web eslint on changed files | clean |
| Cypress `m2-c2-citation-states.cy.ts` | ✔ 1 passing, all 4 states rendered |
| Manual KB-grounded chat (post-commit-5) | embed step now completes; chunks vectorised |

## Test plan

- [ ] Login at `/lq-ai/login` — confirm subtitle reads "Open-Source Legal AI"
- [ ] Footer on any LQ.AI page — confirm "**LQ.AI** — Open-Source Legal AI"
- [ ] Open a matter with a KB; send a quote-extraction prompt against the KB content
- [ ] Inline: quoted text in the assistant prose should have **colored underlines** (emerald exact/tolerant, amber paraphrase, grey-dotted unverified)
- [ ] Sidecar: state-styled chips below the message — hover for tooltips
- [ ] **Procurement-reviewer test:** scroll through a long mixed-citation response and identify unverified citations by color alone
- [ ] Regression: older chats + non-citing skills render normally
- [ ] Backup smoke: `cd web && npx cypress run --spec 'cypress/e2e/m2-c2-citation-states.cy.ts'` — runs in ~30s and asserts all 4 states deterministically

## Known limitations
- Citations spanning HTML elements (e.g., a quote crossing a `<strong>` boundary) won't get inline decoration; sidecar chip still surfaces them
- State 5 (`system-error`) is not wired (Decision H)
- Click-to-source-viewer not built — chips dispatch a `select` event but no source-viewer mounts (M2-D2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)