### PR TITLE
M2-D1: Citation Engine Stage 4 — ensemble verification

### DIFF
--- a/api/alembic/versions/0027_ensemble_method_values.py
+++ b/api/alembic/versions/0027_ensemble_method_values.py
@@ -1,0 +1,115 @@
+"""ensemble verification on message_citations — method enum + tier envelope (M2-D1)
+
+The Citation Engine Stage 4 (ensemble verification) lands here. Two
+changes on ``message_citations``:
+
+1. **verification_method enum widening.** Per the M2 plan §M2-D1 the
+   persisted method distinguishes the two aggregation rules:
+   ``'ensemble_strict'`` (all judges must agree) and
+   ``'ensemble_majority'`` (simple majority wins). M2-C1's migration
+   0026 reserved a generic ``'ensemble'`` value pre-emptively; we
+   replace it with the two tighter labels here so the persisted method
+   always names the aggregation rule the operator chose. Stage 4 had
+   not shipped before this migration so no real row should exist with
+   the bare ``'ensemble'`` value; the downgrade reinstates it for
+   symmetry.
+
+2. **tier_envelope column (SMALLINT NULL).** Captures the privacy
+   envelope of the ensemble that verified a citation — the maximum
+   (weakest) inference tier across the judge models that ran. Per the
+   M2-D1 spec, sending a citation to an n-model ensemble means the
+   verification's privacy posture is the weakest tier in the set
+   (e.g., one Tier 4 judge in an otherwise Tier 3 ensemble makes the
+   verification a Tier 4 exposure). The column is NULL for non-
+   ensemble methods (Stages 1-3 are single-tier by construction) and
+   carries the integer envelope tier (1-5 per PRD §1.5.2) for
+   ensemble rows. Audit-only: no behavior gates on it, but operators
+   can query ``message_citations`` to surface chats whose
+   verification reached weaker tiers than their primary inference.
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-05-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0027"
+down_revision = "0026"
+branch_labels = None
+depends_on = None
+
+
+_NEW_METHOD_VALUES = (
+    "exact_match",
+    "tolerant_match",
+    "llm_judge",
+    "paraphrase_judge",
+    "ensemble_strict",
+    "ensemble_majority",
+    "failed",
+)
+
+_OLD_METHOD_VALUES = (
+    "exact_match",
+    "tolerant_match",
+    "llm_judge",
+    "paraphrase_judge",
+    "ensemble",
+    "failed",
+)
+
+
+def _method_check_sql(values: tuple[str, ...]) -> str:
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"verification_method IS NULL OR verification_method IN ({quoted})"
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "chk_message_citations_method_values",
+        "message_citations",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_message_citations_method_values",
+        "message_citations",
+        _method_check_sql(_NEW_METHOD_VALUES),
+    )
+
+    op.add_column(
+        "message_citations",
+        sa.Column(
+            "tier_envelope",
+            sa.SmallInteger(),
+            nullable=True,
+        ),
+    )
+    op.create_check_constraint(
+        "chk_message_citations_tier_envelope_range",
+        "message_citations",
+        "tier_envelope IS NULL OR (tier_envelope BETWEEN 1 AND 5)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "chk_message_citations_tier_envelope_range",
+        "message_citations",
+        type_="check",
+    )
+    op.drop_column("message_citations", "tier_envelope")
+
+    op.drop_constraint(
+        "chk_message_citations_method_values",
+        "message_citations",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_message_citations_method_values",
+        "message_citations",
+        _method_check_sql(_OLD_METHOD_VALUES),
+    )

--- a/api/alembic/versions/0028_projects_ensemble_verification.py
+++ b/api/alembic/versions/0028_projects_ensemble_verification.py
@@ -1,0 +1,53 @@
+"""add projects.ensemble_verification — M2-D1
+
+Adds the project-level activation flag for Citation Engine Stage 4
+(ensemble verification). Per the M2 plan §M2-D1, three independent
+sources can activate ensemble verification on a chat:
+
+1. The skill's frontmatter ``ensemble_verification: true`` (per-skill).
+2. The chat's project's ``ensemble_verification: true`` (per-project,
+   this column).
+3. The gateway's
+   ``citation_engine.ensemble_verification.default_enabled: true``
+   (deployment-wide default).
+
+A chat-send computes ``any(...)`` across the three signals and passes
+the resolved boolean into ``persist_citations`` → ``verify``. The
+column is added as ``NOT NULL DEFAULT false`` so existing rows stay
+on the deployment default — operators who want to flip an existing
+matter into ensemble mode do so explicitly with a project update.
+
+No index — the column is read per-message-send for the message's
+parent project (already indexed on PK lookup) and never used as a
+filter predicate.
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-05-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0028"
+down_revision = "0027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "projects",
+        sa.Column(
+            "ensemble_verification",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "ensemble_verification")

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -70,7 +70,8 @@ from app.api.dependencies import ActiveUser
 from app.api.skills import _resolve_skill_for_user
 from app.audit import audit_action
 from app.citation import extract_citations, verify
-from app.clients.gateway import GatewayClient, get_gateway_client
+from app.citation.verification import FLAT_PER_JUDGE_USD
+from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
 from app.db.session import get_db
 from app.errors import LQAIError, NotFound, ValidationError
 from app.knowledge.embed import DEFAULT_EMBEDDING_MODEL, request_embedding_vector
@@ -104,6 +105,7 @@ from app.schemas.gateway import (
     ChatCompletionRequest,
     InlineSkillRef,
 )
+from app.skills.registry import MutableSkillRegistry, SkillRegistry
 
 router = APIRouter(prefix="/chats", tags=["chats"])
 log = logging.getLogger(__name__)
@@ -1071,14 +1073,18 @@ async def send_message(
     # Cheaper to fetch both in one SELECT than two round-trips.
     project_floor: int | None = None
     project_privileged: bool = False
+    project_ensemble_verification: bool = False
     if chat.project_id is not None:
-        project_stmt = select(Project.minimum_inference_tier, Project.privileged).where(
-            Project.id == chat.project_id
-        )
+        project_stmt = select(
+            Project.minimum_inference_tier,
+            Project.privileged,
+            Project.ensemble_verification,
+        ).where(Project.id == chat.project_id)
         project_row = (await db.execute(project_stmt)).one_or_none()
         if project_row is not None:
             project_floor = project_row[0]
             project_privileged = bool(project_row[1])
+            project_ensemble_verification = bool(project_row[2])
 
     # Wave D.1 T7b — RAG step: when the chat's project has KBs attached,
     # run hybrid_search across all of them for the user's just-sent
@@ -1183,6 +1189,7 @@ async def send_message(
             retrieved_chunks=retrieved_chunks,
             http_request=request,
             attached_skill_provenance=attached_skill_provenance,
+            project_ensemble_verification=project_ensemble_verification,
         )
     return await _non_streaming_response(
         db=db,
@@ -1198,6 +1205,7 @@ async def send_message(
         attached_skill_names=attached_skill_names,
         slash_unresolved=slash_unresolved,
         attached_skill_provenance=attached_skill_provenance,
+        project_ensemble_verification=project_ensemble_verification,
     )
 
 
@@ -1354,6 +1362,100 @@ async def _audit_message_sent(
     await db.commit()
 
 
+def _skill_registry_from_request(http_request: Request | None) -> SkillRegistry | None:
+    """Return the current :class:`SkillRegistry` snapshot, or None.
+
+    The lifespan handler installs ``app.state.skill_registry`` as a
+    :class:`MutableSkillRegistry`. Tests may install nothing (the
+    registry is optional for the chat-send path on Stages 1-3) so we
+    return None on absence rather than raise — M2-D1 Stage 4 then
+    silently skips skill-frontmatter activation.
+    """
+
+    if http_request is None:
+        return None
+    holder: MutableSkillRegistry | None = getattr(http_request.app.state, "skill_registry", None)
+    if holder is None:
+        return None
+    return holder.current()
+
+
+async def _resolve_ensemble_config(
+    *,
+    gateway: GatewayClient | None,
+    applied_skills: list[str] | None,
+    project_ensemble_verification: bool,
+    skill_registry: SkillRegistry | None,
+    n_candidates: int,
+    message_id: uuid.UUID,
+) -> EnsembleConfig | None:
+    """Decide whether Stage 4 should run for this message — M2-D1.
+
+    Returns the resolved :class:`EnsembleConfig` when ensemble is
+    activated AND the per-message cost-budget pre-flight passes.
+    Returns ``None`` when ensemble is not activated, the gateway has
+    no ensemble configured, or the cost estimate exceeds the budget
+    (cost-budget fallback → cascade drops back to Stage 3).
+
+    Activation is ``any()`` across three sources:
+
+    * The project's ``ensemble_verification`` column.
+    * Any skill in ``applied_skills`` whose frontmatter declares
+      ``ensemble_verification: true``.
+    * The gateway's
+      ``citation_engine.ensemble_verification.default_enabled``.
+
+    Cost-budget pre-flight uses :data:`FLAT_PER_JUDGE_USD` (a
+    deliberately conservative constant) so the check errs on the side
+    of dropping back to single-judge Stage 3 rather than letting an
+    ensemble silently overrun. M2-E2 will replace the flat constant
+    with measured numbers.
+    """
+
+    if gateway is None:
+        return None
+
+    skill_activated = False
+    if applied_skills and skill_registry is not None:
+        for skill_name in applied_skills:
+            skill = skill_registry.get_skill(skill_name)
+            if skill is not None and skill.ensemble_verification:
+                skill_activated = True
+                break
+
+    config = await gateway.get_citation_engine_ensemble_config()
+    if config is None:
+        # Gateway has no ensemble configured (empty judge_models or
+        # endpoint unreachable). Whatever the activation flags say,
+        # Stage 4 cannot run.
+        return None
+
+    activated = skill_activated or project_ensemble_verification or config.default_enabled
+    if not activated:
+        return None
+
+    # Pre-flight cost-budget check. Per-message cap; if the estimated
+    # ensemble spend exceeds the cap, fall back to single-judge Stage 3
+    # by returning None (the cascade routes through verify_paraphrase
+    # instead). Logged so operators can see when the cap bites.
+    estimated_usd = n_candidates * len(config.judge_models) * FLAT_PER_JUDGE_USD
+    if estimated_usd > config.max_cost_per_message_usd:
+        log.warning(
+            "chat-send citations: ensemble budget exceeded, falling back to single judge",
+            extra={
+                "event": "chat_message_ensemble_budget_fallback",
+                "message_id": str(message_id),
+                "n_candidates": n_candidates,
+                "n_judges": len(config.judge_models),
+                "estimated_usd": round(estimated_usd, 4),
+                "max_cost_per_message_usd": config.max_cost_per_message_usd,
+            },
+        )
+        return None
+
+    return config
+
+
 async def _persist_message_citations(
     db: AsyncSession,
     *,
@@ -1361,6 +1463,9 @@ async def _persist_message_citations(
     assistant_text: str,
     retrieved_chunks: list[HybridSearchResult],
     gateway: GatewayClient | None = None,
+    applied_skills: list[str] | None = None,
+    project_ensemble_verification: bool = False,
+    skill_registry: SkillRegistry | None = None,
 ) -> None:
     """Extract, verify, and persist citations from an assistant message — M2-A2.
 
@@ -1374,16 +1479,25 @@ async def _persist_message_citations(
     * Stage 1 (exact-match) — M2-A2.
     * Stage 2 (tolerant-match) — M2-B1.
     * Stage 3 (paraphrase judge) — M2-C1, runs only when ``gateway``
-      is supplied. The judge model is resolved via
-      :meth:`GatewayClient.get_citation_engine_judge_model` (cached
-      for the process) so the operator configures it once in
+      is supplied and ensemble is NOT activated. The judge model is
+      resolved via :meth:`GatewayClient.get_citation_engine_judge_model`
+      (cached for the process) so the operator configures it once in
       ``gateway.yaml`` rather than on the api/ side.
+    * Stage 4 (ensemble) — M2-D1. Activated when any of:
+      ``applied_skills`` includes a skill whose frontmatter declares
+      ``ensemble_verification: true``, OR ``project_ensemble_verification``
+      is True, OR the gateway's ``default_enabled`` is True. Replaces
+      Stage 3 on activation. Falls back to Stage 3 if the per-message
+      cost-budget pre-flight estimate exceeds the configured cap.
 
     Candidates that pass any stage persist with the stage's method
     string and confidence. Stage 3 ``partial`` verdicts persist with
     ``verified=true, partial=true`` — the M2-C2 UI renders these as
-    "verified with caveats". Candidates that miss every stage are NOT
-    persisted; their absence is the unverified signal the UI consumes.
+    "verified with caveats". Stage 4 ``ensemble_strict`` /
+    ``ensemble_majority`` rows additionally carry ``tier_envelope``
+    (the maximum tier across the judge ensemble). Candidates that
+    miss every stage are NOT persisted; their absence is the
+    unverified signal the UI consumes.
     """
 
     if not retrieved_chunks:
@@ -1407,6 +1521,19 @@ async def _persist_message_citations(
     if gateway is not None:
         judge_model = await gateway.get_citation_engine_judge_model()
 
+    # M2-D1: resolve Stage 4 (ensemble) activation. The chat-send
+    # caller passes the project's flag + the applied skills + the
+    # skill registry; this function ORs them with the gateway's
+    # default to decide whether to dispatch ensemble verification.
+    ensemble_config = await _resolve_ensemble_config(
+        gateway=gateway,
+        applied_skills=applied_skills,
+        project_ensemble_verification=project_ensemble_verification,
+        skill_registry=skill_registry,
+        n_candidates=len(candidates),
+        message_id=message_id,
+    )
+
     new_rows: list[MessageCitation] = []
     for cand in candidates:
         doc = docs_by_id.get(cand.source_document_id)
@@ -1416,7 +1543,13 @@ async def _persist_message_citations(
             # would reject anyway.
             continue
 
-        result = await verify(cand, doc, gateway=gateway, judge_model=judge_model)
+        result = await verify(
+            cand,
+            doc,
+            gateway=gateway,
+            judge_model=judge_model,
+            ensemble_config=ensemble_config,
+        )
         if not result.verified:
             # Every wired stage rejected the candidate. M2-C2's UI
             # consumes the *absence* of a row as the unverified
@@ -1436,6 +1569,7 @@ async def _persist_message_citations(
                 verification_method=result.method,
                 verification_confidence=result.confidence,
                 partial=result.partial,
+                tier_envelope=result.tier_envelope,
             )
         )
 
@@ -1593,6 +1727,7 @@ async def _non_streaming_response(
     attached_skill_names: list[str] | None = None,
     slash_unresolved: bool = False,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
+    project_ensemble_verification: bool = False,
 ) -> JSONResponse:
     """Run the non-streaming path: forward, persist, return JSON.
 
@@ -1645,16 +1780,20 @@ async def _non_streaming_response(
         error_code=None,
     )
 
-    # M2-A2 / M2-B1 / M2-C1: extract + verify + persist citations from
-    # the assistant response. The verifier cascade is Stage 1
-    # (exact-match) → Stage 2 (tolerant-match) → Stage 3 (paraphrase
-    # judge through the gateway). No-op when no chunks were retrieved.
+    # M2-A2 / M2-B1 / M2-C1 / M2-D1: extract + verify + persist
+    # citations from the assistant response. Cascade: Stage 1
+    # (exact-match) → Stage 2 (tolerant-match) → Stage 3 (single
+    # paraphrase judge) OR Stage 4 (ensemble) when activated. No-op
+    # when no chunks were retrieved.
     await _persist_message_citations(
         db,
         message_id=assistant_message_id,
         assistant_text=assistant_text,
         retrieved_chunks=retrieved_chunks or [],
         gateway=gateway,
+        applied_skills=applied_skills,
+        project_ensemble_verification=project_ensemble_verification,
+        skill_registry=_skill_registry_from_request(http_request),
     )
 
     await _audit_message_sent(
@@ -1708,6 +1847,7 @@ async def _stream_response(
     retrieved_chunks: list[HybridSearchResult] | None = None,
     http_request: Request | None = None,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
+    project_ensemble_verification: bool = False,
 ) -> StreamingResponse:
     """Run the streaming path: forward, stream SSE, persist at end."""
 
@@ -1806,9 +1946,10 @@ async def _stream_response(
                 applied_skills=last_applied_skills or [],
                 error_code=error_code,
             )
-            # M2-A2: citations from the streamed assistant content.
-            # Skipped on error_code (no full artifact to cite). Failures
-            # here must not block the stream; log and continue.
+            # M2-A2 / M2-D1: citations from the streamed assistant
+            # content. Skipped on error_code (no full artifact to
+            # cite). Failures here must not block the stream; log
+            # and continue.
             if error_code is None:
                 try:
                     await _persist_message_citations(
@@ -1817,6 +1958,9 @@ async def _stream_response(
                         assistant_text="".join(accumulated),
                         retrieved_chunks=retrieved_chunks or [],
                         gateway=gateway,
+                        applied_skills=last_applied_skills,
+                        project_ensemble_verification=project_ensemble_verification,
+                        skill_registry=_skill_registry_from_request(http_request),
                     )
                 except Exception as cite_exc:
                     log.warning(

--- a/api/app/citation/verification.py
+++ b/api/app/citation/verification.py
@@ -11,15 +11,21 @@ Stages live in canonical method-string order:
 
 * :func:`verify_exact_match` — Stage 1 (M2-A2). Byte-for-byte equality
   at the offsets the extractor produced. Trivially fast.
-* :func:`verify_tolerant_match` — Stage 2 (M2-B1; this task).
-  Normalizes both source-at-offsets and ``source_text`` via
+* :func:`verify_tolerant_match` — Stage 2 (M2-B1). Normalizes both
+  source-at-offsets and ``source_text`` via
   :func:`app.citation.normalization.normalize` and compares with
   ``rapidfuzz.fuzz.ratio`` at threshold 95. Catches smart-quote,
   whitespace, and (when ``document.was_ocrd``) OCR-confusion
   differences that Stage 1 rejects.
-* Stage 3 LLM judge (M2-C1) and Stage 4 ensemble (M2-D1) land in
-  later milestone tasks; :func:`verify` will route into them once
-  they ship.
+* :func:`verify_paraphrase` — Stage 3 (M2-C1). LLM paraphrase judge.
+  Dispatches one structured-JSON judge call through the gateway and
+  parses the verdict into ``yes`` / ``partial`` / ``no``.
+* :func:`verify_ensemble` — Stage 4 (M2-D1). Runs the paraphrase judge
+  in parallel across multiple models and aggregates verdicts under
+  the operator-chosen rule (strict = all agree; majority = simple
+  majority wins). Replaces Stage 3 when activated; cost-budget
+  fallback drops back to Stage 3 if the ensemble would exceed the
+  per-message cap.
 
 All stages share the :class:`VerificationResult` shape so the
 persistence layer can copy fields onto ``message_citations`` without
@@ -28,11 +34,12 @@ remapping.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 from rapidfuzz import fuzz
 
@@ -41,6 +48,17 @@ from app.citation.normalization import normalize
 from app.schemas.gateway import ChatCompletionRequest
 
 logger = logging.getLogger(__name__)
+
+
+# Conservative per-judge-call cost estimate used for the M2-D1
+# pre-flight budget check. Real cost depends on the judge model and the
+# claim/chunk lengths; the gateway records actual spend in
+# ``inference_routing_log.cost_estimate`` for post-hoc analysis. This
+# constant is deliberately high (haiku-tier rates + generous tokens)
+# so the budget check errs on the side of falling back to single-judge
+# Stage 3 rather than letting an ensemble silently overrun. M2-E2
+# (ensemble calibration pass) replaces this with measured numbers.
+FLAT_PER_JUDGE_USD = 0.005
 
 
 class _CandidateProtocol(Protocol):
@@ -87,16 +105,25 @@ class VerificationResult:
     but not all of the claim. Stages 1 and 2 always emit
     ``partial=False`` because they are exact-content stages — a
     partial match is, by their definition, no match.
+
+    M2-D1 added ``tier_envelope``: Stage 4 (ensemble) records the
+    maximum (weakest) inference tier across the judge models that
+    ran. Stages 1-3 are single-tier and emit ``tier_envelope=None``.
+    The persistence layer copies it onto
+    ``message_citations.tier_envelope``.
     """
 
     verified: bool
     method: str | None
     confidence: float | None
     partial: bool = False
+    tier_envelope: int | None = None
 
 
 # A sentinel result for misses, reused so callers don't allocate.
-_MISS = VerificationResult(verified=False, method=None, confidence=None, partial=False)
+_MISS = VerificationResult(
+    verified=False, method=None, confidence=None, partial=False, tier_envelope=None
+)
 
 # Stage 2 acceptance threshold on the rapidfuzz ratio scale (0-100).
 # 95 catches normalization-only differences (smart quotes, whitespace
@@ -364,32 +391,170 @@ def _parse_judge_response(response: Any) -> VerificationResult:
     )
 
 
+# --- Stage 4 — ensemble verification (M2-D1) ---------------------------------
+
+
+class _EnsembleConfigProtocol(Protocol):
+    """Shape :func:`verify_ensemble` reads from the ensemble config.
+
+    Production passes :class:`app.clients.gateway.EnsembleConfig` (a
+    frozen dataclass); tests pass an equivalent stub. Declared via
+    ``@property`` so frozen-dataclass read-only attributes match the
+    Protocol structurally (a plain attribute declaration would mark
+    the field as settable, which a frozen dataclass cannot satisfy).
+
+    ``judge_models`` is the list of aliases the gateway can resolve,
+    ``aggregation_rule`` selects strict vs majority, and
+    ``envelope_tier`` is the server-computed max tier across the
+    configured judge models (persisted on the citation row).
+    """
+
+    @property
+    def judge_models(self) -> tuple[str, ...]: ...
+
+    @property
+    def aggregation_rule(self) -> Literal["strict", "majority"]: ...
+
+    @property
+    def envelope_tier(self) -> int | None: ...
+
+
+async def verify_ensemble(
+    candidate: _CandidateProtocol,
+    document: _DocumentProtocol,
+    *,
+    gateway: _JudgeGatewayProtocol,
+    ensemble_config: _EnsembleConfigProtocol,
+) -> VerificationResult:
+    """Stage 4: run the paraphrase judge in parallel across N models.
+
+    Dispatches one :func:`verify_paraphrase` call per model in
+    ``ensemble_config.judge_models``, awaits all in parallel, and
+    aggregates verdicts under the configured rule:
+
+    * ``strict``: every judge must verdict verified (``yes`` or
+      ``partial``). Any miss → MISS. Persist as
+      ``'ensemble_strict'``; ``partial=true`` iff *any* judge said
+      partial (caller still sees a verified row, the partial flag
+      surfaces "some disagreement under the strict rule").
+    * ``majority``: simple majority of verified verdicts wins.
+      Ties (n=2 with one yes, one no) miss conservatively. Persist
+      as ``'ensemble_majority'``; ``partial=true`` iff *any*
+      verified judge said partial OR if any judge disagreed at all
+      (the "Models disagreed: K of N verified" tooltip case from
+      the M2-D1 spec).
+
+    The persisted confidence is the mean of the verified judges'
+    confidences (0.0 when no judges verified). ``tier_envelope`` is
+    set from ``ensemble_config.envelope_tier`` regardless of outcome
+    — the privacy exposure is the same whether the ensemble agreed.
+
+    Judge call failures (gateway error, malformed JSON) count as a
+    miss for that judge. An ensemble where most judges errored may
+    still produce a verified result under the majority rule with the
+    surviving verdicts — but with low confidence the UI's yellow
+    tooltip flags the disagreement.
+    """
+
+    if not ensemble_config.judge_models:
+        return _MISS
+
+    claim = candidate.source_text
+    if not claim:
+        return _MISS
+    if _source_chunk_with_context(candidate, document) is None:
+        return _MISS
+
+    verdicts = await asyncio.gather(
+        *[
+            verify_paraphrase(candidate, document, gateway=gateway, judge_model=model)
+            for model in ensemble_config.judge_models
+        ],
+        return_exceptions=False,
+    )
+
+    n_total = len(verdicts)
+    verified_verdicts = [v for v in verdicts if v.verified]
+    n_verified = len(verified_verdicts)
+
+    rule = ensemble_config.aggregation_rule
+    method = "ensemble_strict" if rule == "strict" else "ensemble_majority"
+
+    if rule == "strict":
+        if n_verified < n_total:
+            return _MISS
+        # All judges verified. Partial = any judge said partial.
+        partial = any(v.partial for v in verified_verdicts)
+    else:
+        # Majority: strict majority (> n/2). Even-N ties miss; we
+        # surface those rather than picking a side.
+        if n_verified * 2 <= n_total:
+            return _MISS
+        # Verified under majority. Partial flag = any judge said
+        # partial OR any judge dissented (per the M2-D1 spec's
+        # "disagreement is the yellow case" rendering).
+        any_dissent = n_verified < n_total
+        any_partial = any(v.partial for v in verified_verdicts)
+        partial = any_dissent or any_partial
+
+    mean_confidence = (
+        sum(v.confidence or 0.0 for v in verified_verdicts) / n_verified if n_verified else 0.0
+    )
+
+    return VerificationResult(
+        verified=True,
+        method=method,
+        confidence=mean_confidence,
+        partial=partial,
+        tier_envelope=ensemble_config.envelope_tier,
+    )
+
+
+# --- Cascade router ----------------------------------------------------------
+
+
 async def verify(
     candidate: _CandidateProtocol,
     document: _DocumentProtocol,
     *,
     gateway: _JudgeGatewayProtocol | None = None,
     judge_model: str = "fast",
+    ensemble_config: _EnsembleConfigProtocol | None = None,
 ) -> VerificationResult:
     """Run the verification cascade and return the first hit.
 
-    Order: Stage 1 (exact-match) → Stage 2 (tolerant-match) → Stage 3
-    (paraphrase judge). Returns :data:`_MISS` only when every stage
-    has rejected the candidate.
+    Order:
 
-    Stage 3 only runs when ``gateway`` is supplied. Callers without
-    an LLM (smoke tests, eval scripts that exercise only the
-    deterministic stages) pass ``gateway=None``; the cascade then
-    runs Stages 1+2 only and short-circuits to MISS if both miss.
+    * Stage 1 (exact-match) — pure Python; always runs.
+    * Stage 2 (tolerant-match) — pure Python; always runs on Stage 1
+      miss.
+    * When ``ensemble_config`` is supplied — **Stage 4 (ensemble)**
+      replaces Stage 3 (per M2-D1 decision B: ensemble replaces the
+      single-judge stage when activated).
+    * Otherwise — Stage 3 (single paraphrase judge).
+
+    Returns :data:`_MISS` only when every routed stage has rejected
+    the candidate.
+
+    Stages 3 and 4 only run when ``gateway`` is supplied. Callers
+    without an LLM (smoke tests, eval scripts that exercise only the
+    deterministic stages) pass ``gateway=None`` and the cascade
+    short-circuits to MISS after Stages 1+2.
 
     ``judge_model`` is the alias the gateway resolves for the Stage 3
     judge call. Default ``"fast"`` matches ``gateway.yaml.example``'s
     ``citation_engine.judge_model``; the chat-send caller passes the
-    value it pulled from ``GatewayClient.get_citation_engine_judge_model``.
+    value it pulled from
+    ``GatewayClient.get_citation_engine_judge_model``. Ignored when
+    ``ensemble_config`` is supplied (Stage 4 dispatches its own
+    per-judge aliases).
 
-    Made async in M2-C1: Stages 1 and 2 are still pure Python and run
-    synchronously inside the function; the ``async def`` is for
-    Stage 3's gateway call.
+    ``ensemble_config`` is the resolved Stage 4 config (from
+    ``GatewayClient.get_citation_engine_ensemble_config``). The
+    chat-send caller passes it for messages where ensemble has been
+    activated by skill / project / gateway default AND the per-message
+    cost-budget check passed. When the budget check fails the caller
+    drops the kwarg, falling the cascade back to Stage 3.
     """
 
     result = verify_exact_match(candidate, document)
@@ -402,5 +567,13 @@ async def verify(
 
     if gateway is None:
         return _MISS
+
+    if ensemble_config is not None:
+        return await verify_ensemble(
+            candidate,
+            document,
+            gateway=gateway,
+            ensemble_config=ensemble_config,
+        )
 
     return await verify_paraphrase(candidate, document, gateway=gateway, judge_model=judge_model)

--- a/api/app/clients/gateway.py
+++ b/api/app/clients/gateway.py
@@ -59,7 +59,8 @@ import contextlib
 import json
 import logging
 from collections.abc import AsyncIterator
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import httpx
 from pydantic import ValidationError as PydanticValidationError
@@ -105,6 +106,29 @@ def _structured_log_extra(**fields: Any) -> dict[str, Any]:
     """
 
     return {"event": "gateway_client", **fields}
+
+
+@dataclass(frozen=True, slots=True)
+class EnsembleConfig:
+    """Resolved Stage 4 ensemble config pulled from the gateway (M2-D1).
+
+    Returned by :meth:`GatewayClient.get_citation_engine_ensemble_config`.
+    Immutable; the gateway treats its YAML config as fixed for the
+    process lifetime so the api/-side cache stays valid until restart.
+
+    :attr:`envelope_tier` is server-computed by the gateway as the
+    max ``routed_inference_tier`` across all aliases in
+    :attr:`judge_models` (using each alias's primary target). The
+    api/ persists this value on ``message_citations.tier_envelope``
+    for ensemble-verified rows. ``None`` when the gateway couldn't
+    resolve any judge alias to a tier.
+    """
+
+    default_enabled: bool
+    judge_models: tuple[str, ...]
+    aggregation_rule: Literal["strict", "majority"]
+    max_cost_per_message_usd: float
+    envelope_tier: int | None
 
 
 class GatewayClient:
@@ -228,10 +252,118 @@ class GatewayClient:
         self._citation_engine_judge_model = judge_model
         return judge_model
 
+    _citation_engine_ensemble: EnsembleConfig | None = None
+    """Process-cached ensemble config; same lifecycle as the judge_model cache."""
+
+    _citation_engine_ensemble_loaded: bool = False
+    """Whether the cache attempt has been made.
+
+    Distinguishes "haven't fetched yet" from "fetched and got nothing
+    back" — the second case caches a sentinel so a misconfigured
+    gateway doesn't get re-polled on every Stage 4 evaluation.
+    """
+
+    async def get_citation_engine_ensemble_config(self) -> EnsembleConfig | None:
+        """Fetch the configured ensemble verification config (M2-D1).
+
+        Calls ``GET /v1/citation-engine/config`` once per process and
+        caches the result. Returns ``None`` when the gateway has no
+        ensemble configured (empty ``judge_models``), when the endpoint
+        is unreachable, or when the response is missing the
+        ``ensemble_verification`` block (older gateway). Callers treat
+        ``None`` as "Stage 4 cannot run" — the cascade falls back to
+        Stage 3 in that case.
+
+        On failure, caches a ``None`` sentinel so the next call doesn't
+        re-poll — the gateway config is immutable per-process and a
+        misconfiguration is sticky.
+        """
+
+        if self._citation_engine_ensemble_loaded:
+            return self._citation_engine_ensemble
+
+        try:
+            response = await self._client.get(
+                "/v1/citation-engine/config",
+                timeout=5.0,
+            )
+        except Exception as exc:
+            log.warning(
+                "citation-engine ensemble config fetch failed: %s",
+                exc,
+                extra=_structured_log_extra(
+                    op="get_citation_engine_ensemble_config",
+                    error_type=type(exc).__name__,
+                ),
+            )
+            self._citation_engine_ensemble_loaded = True
+            return None
+
+        if response.status_code != 200:
+            self._citation_engine_ensemble_loaded = True
+            return None
+
+        try:
+            payload = response.json()
+        except json.JSONDecodeError:
+            self._citation_engine_ensemble_loaded = True
+            return None
+
+        ensemble_block = payload.get("ensemble_verification") if isinstance(payload, dict) else None
+        if not isinstance(ensemble_block, dict):
+            # Older gateway predates M2-D1; treat as "no ensemble".
+            self._citation_engine_ensemble_loaded = True
+            return None
+
+        judge_models = ensemble_block.get("judge_models") or []
+        if not isinstance(judge_models, list) or not judge_models:
+            self._citation_engine_ensemble_loaded = True
+            return None
+
+        aggregation_rule = ensemble_block.get("aggregation_rule", "strict")
+        if aggregation_rule not in ("strict", "majority"):
+            log.warning(
+                "citation-engine ensemble config has unknown aggregation_rule %r",
+                aggregation_rule,
+                extra=_structured_log_extra(
+                    op="get_citation_engine_ensemble_config",
+                    aggregation_rule=aggregation_rule,
+                ),
+            )
+            self._citation_engine_ensemble_loaded = True
+            return None
+
+        envelope_tier_raw = ensemble_block.get("envelope_tier")
+        envelope_tier: int | None
+        if envelope_tier_raw is None:
+            envelope_tier = None
+        else:
+            try:
+                envelope_tier = int(envelope_tier_raw)
+            except (TypeError, ValueError):
+                envelope_tier = None
+
+        try:
+            max_cost = float(ensemble_block.get("max_cost_per_message_usd", 0.05))
+        except (TypeError, ValueError):
+            max_cost = 0.05
+
+        self._citation_engine_ensemble = EnsembleConfig(
+            default_enabled=bool(ensemble_block.get("default_enabled", False)),
+            judge_models=tuple(str(m) for m in judge_models),
+            aggregation_rule=aggregation_rule,
+            max_cost_per_message_usd=max_cost,
+            envelope_tier=envelope_tier,
+        )
+        self._citation_engine_ensemble_loaded = True
+        return self._citation_engine_ensemble
+
     def _reset_citation_engine_cache_for_tests(self) -> None:
-        """Drop the cached judge model. Tests use this to test re-fetch."""
+        """Drop both caches. Tests use this to test re-fetch."""
 
         self._citation_engine_judge_model = None
+        self._citation_engine_ensemble = None
+        self._citation_engine_ensemble_loaded = False
 
     # --- Health probe --------------------------------------------------------
 

--- a/api/app/models/chat.py
+++ b/api/app/models/chat.py
@@ -232,7 +232,12 @@ class MessageCitation(Base):
     * ``'llm_judge'`` — reserved for future LLM-based verification
       stages (semantic match, claim decomposition); ``'paraphrase_judge'``
       is the tighter label for the M2-C1 paraphrase-only path.
-    * ``'ensemble'`` — Stage 4, multi-model agreement (M2-D1).
+    * ``'ensemble_strict'`` — Stage 4 with strict aggregation: every
+      configured judge model verdict'd ``"yes"`` (M2-D1).
+    * ``'ensemble_majority'`` — Stage 4 with majority aggregation:
+      the verdict that won the majority is the persisted outcome
+      (M2-D1). Disagreement persists with ``partial=true`` so the UI
+      can flag it (per M2-D1 §UI rendering).
     * ``'failed'`` — every stage rejected; rendered as unverified in
       the UI (M2-C2).
 
@@ -245,6 +250,15 @@ class MessageCitation(Base):
     the claim" from "judge says the source supports it *partially*".
     Both persist with ``verified=true``; the partial flag drives the
     M2-C2 UI's visually-distinct "verified with caveats" rendering.
+
+    ``tier_envelope`` (M2-D1) records the privacy envelope of the
+    ensemble that verified this citation — the maximum (weakest)
+    inference tier across the judge models that ran. NULL for non-
+    ensemble methods (Stages 1-3 are single-tier by construction);
+    1-5 for ensemble rows per PRD §1.5.2. Audit-only column: no
+    behavior gates on it, but operators can query to surface chats
+    whose verification reached weaker tiers than their primary
+    inference.
     """
 
     __tablename__ = "message_citations"
@@ -260,7 +274,8 @@ class MessageCitation(Base):
         CheckConstraint(
             "verification_method IS NULL OR verification_method IN "
             "('exact_match', 'tolerant_match', 'llm_judge', "
-            "'paraphrase_judge', 'ensemble', 'failed')",
+            "'paraphrase_judge', 'ensemble_strict', 'ensemble_majority', "
+            "'failed')",
             name="chk_message_citations_method_values",
         ),
         CheckConstraint(
@@ -271,6 +286,10 @@ class MessageCitation(Base):
         CheckConstraint(
             "(verified = false) OR (verification_method IS NOT NULL)",
             name="chk_message_citations_verified_has_method",
+        ),
+        CheckConstraint(
+            "tier_envelope IS NULL OR (tier_envelope BETWEEN 1 AND 5)",
+            name="chk_message_citations_tier_envelope_range",
         ),
     )
 
@@ -316,6 +335,7 @@ class MessageCitation(Base):
         nullable=False,
         server_default=text("false"),
     )
+    tier_envelope: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/api/app/models/project.py
+++ b/api/app/models/project.py
@@ -104,6 +104,12 @@ class Project(Base):
         server_default=text("false"),
         default=False,
     )
+    ensemble_verification: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
+        default=False,
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/api/app/skills/schema.py
+++ b/api/app/skills/schema.py
@@ -84,6 +84,15 @@ class LQAIFrontmatter(BaseModel):
         "enforcement (D1) consults this. C1 only surfaces the value.",
     )
 
+    ensemble_verification: bool | None = Field(
+        default=None,
+        description="When true, the Citation Engine runs Stage 4 (ensemble "
+        "verification) for citations produced from chats using this skill. "
+        "Per M2-D1, OR'd against the chat's project ensemble flag and the "
+        "gateway's deployment default. None means 'no opinion' (treated as "
+        "false at the OR site).",
+    )
+
     use_organization_profile: bool | None = None
     is_organization_profile: bool | None = None
     self_improvement: bool | None = None
@@ -133,6 +142,7 @@ class SkillSummary(BaseModel):
     tags: list[str] = Field(default_factory=list)
     jurisdiction: str | None = None
     minimum_inference_tier: int | None = None
+    ensemble_verification: bool | None = None
     output_format: str | None = None
 
 
@@ -314,6 +324,7 @@ def derive_summary(
         tags=list(lq.tags),
         jurisdiction=lq.jurisdiction,
         minimum_inference_tier=lq.minimum_inference_tier,
+        ensemble_verification=lq.ensemble_verification,
         output_format=lq.output_format,
     )
 

--- a/api/tests/citation/test_ensemble.py
+++ b/api/tests/citation/test_ensemble.py
@@ -1,0 +1,708 @@
+"""Citation Engine Stage 4 — ensemble verification tests (M2-D1).
+
+``verify_ensemble(candidate, document, *, gateway, ensemble_config)``
+runs the Stage 3 paraphrase judge in parallel against N models and
+aggregates verdicts under the operator-chosen rule. These tests cover:
+
+* **Strict aggregation**: all judges must verify; any miss → MISS.
+  ``partial=True`` on the result when any judge said partial.
+* **Majority aggregation**: simple majority of verified verdicts wins;
+  ties (≤ n/2) miss conservatively. ``partial=True`` on dissent OR
+  any partial judge.
+* **Tier envelope propagation**: ``ensemble_config.envelope_tier``
+  copies onto the result regardless of outcome.
+* **Confidence**: mean across verified judges' confidences.
+* **Empty judge_models**: short-circuits to MISS.
+* **Cascade routing in :func:`verify`**: ensemble replaces Stage 3
+  when ``ensemble_config`` is supplied; falls back to Stage 3 when not.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+
+from app.citation.verification import (
+    VerificationResult,
+    verify,
+    verify_ensemble,
+)
+from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _StubDocument:
+    id: uuid.UUID
+    normalized_content: str
+    was_ocrd: bool = False
+
+
+@dataclass(slots=True)
+class _StubCandidate:
+    source_file_id: uuid.UUID
+    source_document_id: uuid.UUID
+    source_offset_start: int
+    source_offset_end: int
+    source_page: int | None
+    source_text: str
+
+
+@dataclass(slots=True)
+class _StubEnsembleConfig:
+    judge_models: tuple[str, ...]
+    aggregation_rule: Literal["strict", "majority"]
+    envelope_tier: int | None = 3
+
+
+class _StubGateway:
+    """Returns a different canned response per chat_completion call.
+
+    The verdict list cycles through ``response_contents`` in order so
+    a 3-judge ensemble with 3 entries delivers a deterministic
+    per-judge verdict — tests can assert on aggregation behavior
+    without mocking out call dispatch.
+    """
+
+    def __init__(self, *, response_contents: list[str | None]) -> None:
+        self._response_contents = response_contents
+        self.call_count = 0
+        self.requests: list[ChatCompletionRequest] = []
+
+    async def chat_completion(
+        self,
+        request: ChatCompletionRequest,
+        *,
+        request_id: str | None = None,
+    ) -> ChatCompletionResponse:
+        idx = self.call_count
+        self.call_count += 1
+        self.requests.append(request)
+        content = self._response_contents[idx % len(self._response_contents)]
+        return ChatCompletionResponse(
+            id=f"chatcmpl-judge-{idx}",
+            created=0,
+            model=request.model,
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content=content),
+                    finish_reason="stop",
+                )
+            ],
+            usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        )
+
+
+def _judge_json(
+    *,
+    verdict: str,
+    confidence: str = "high",
+    justification: str = "test",
+) -> str:
+    return json.dumps(
+        {"verdict": verdict, "confidence": confidence, "justification": justification}
+    )
+
+
+def _doc(text: str = "The agreement was signed on the third of June.") -> _StubDocument:
+    return _StubDocument(id=uuid.uuid4(), normalized_content=text)
+
+
+def _candidate(
+    doc: _StubDocument, *, source_text: str = "the agreement was signed"
+) -> _StubCandidate:
+    return _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=0,
+        source_offset_end=min(40, len(doc.normalized_content)),
+        source_page=None,
+        source_text=source_text,
+    )
+
+
+def _ensemble(
+    *,
+    n: int = 3,
+    rule: Literal["strict", "majority"] = "strict",
+    envelope_tier: int | None = 3,
+) -> _StubEnsembleConfig:
+    return _StubEnsembleConfig(
+        judge_models=tuple(f"judge-{i}" for i in range(n)),
+        aggregation_rule=rule,
+        envelope_tier=envelope_tier,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strict aggregation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_strict_all_yes_verified_not_partial() -> None:
+    """Strict + every judge says yes → verified, partial=False, method='ensemble_strict'."""
+
+    gw = _StubGateway(response_contents=[_judge_json(verdict="yes")] * 3)
+    doc = _doc()
+    cand = _candidate(doc)
+    cfg = _ensemble(n=3, rule="strict")
+
+    result = await verify_ensemble(cand, doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert result.method == "ensemble_strict"
+    assert result.partial is False
+    assert result.confidence == pytest.approx(0.90)
+    assert result.tier_envelope == 3
+    assert gw.call_count == 3
+
+
+@pytest.mark.unit
+async def test_strict_one_no_misses() -> None:
+    """Strict + one judge says no → MISS (no row persisted)."""
+
+    gw = _StubGateway(
+        response_contents=[
+            _judge_json(verdict="yes"),
+            _judge_json(verdict="no"),
+            _judge_json(verdict="yes"),
+        ]
+    )
+    cfg = _ensemble(n=3, rule="strict")
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is False
+    assert result.method is None
+
+
+@pytest.mark.unit
+async def test_strict_all_yes_with_one_partial_persists_partial_flag() -> None:
+    """Strict-verified but at least one judge said partial → verified, partial=True."""
+
+    gw = _StubGateway(
+        response_contents=[
+            _judge_json(verdict="yes"),
+            _judge_json(verdict="partial"),
+            _judge_json(verdict="yes"),
+        ]
+    )
+    cfg = _ensemble(n=3, rule="strict")
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert result.partial is True
+    assert result.method == "ensemble_strict"
+
+
+# ---------------------------------------------------------------------------
+# Majority aggregation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_majority_three_of_three_verified_not_partial() -> None:
+    """Majority + all agree → verified, partial=False."""
+
+    gw = _StubGateway(response_contents=[_judge_json(verdict="yes")] * 3)
+    cfg = _ensemble(n=3, rule="majority")
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert result.method == "ensemble_majority"
+    assert result.partial is False
+
+
+@pytest.mark.unit
+async def test_majority_two_of_three_verified_marks_partial_for_dissent() -> None:
+    """Majority + 2/3 verified → verified with partial=True (dissent flagged)."""
+
+    gw = _StubGateway(
+        response_contents=[
+            _judge_json(verdict="yes"),
+            _judge_json(verdict="no"),
+            _judge_json(verdict="yes"),
+        ]
+    )
+    cfg = _ensemble(n=3, rule="majority")
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert result.method == "ensemble_majority"
+    assert result.partial is True
+    # Confidence is mean of the verified judges' confidences (both
+    # high → 0.90).
+    assert result.confidence == pytest.approx(0.90)
+
+
+@pytest.mark.unit
+async def test_majority_one_of_three_misses() -> None:
+    """Majority + only 1/3 verified → MISS (not strict majority)."""
+
+    gw = _StubGateway(
+        response_contents=[
+            _judge_json(verdict="no"),
+            _judge_json(verdict="no"),
+            _judge_json(verdict="yes"),
+        ]
+    )
+    cfg = _ensemble(n=3, rule="majority")
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is False
+
+
+@pytest.mark.unit
+async def test_majority_tied_two_of_four_misses() -> None:
+    """Majority + 2/4 → MISS (strict-majority rule: > n/2)."""
+
+    gw = _StubGateway(
+        response_contents=[
+            _judge_json(verdict="yes"),
+            _judge_json(verdict="no"),
+            _judge_json(verdict="yes"),
+            _judge_json(verdict="no"),
+        ]
+    )
+    cfg = _ensemble(n=4, rule="majority")
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is False
+
+
+# ---------------------------------------------------------------------------
+# Tier-envelope propagation + edge cases.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_tier_envelope_propagates_when_verified() -> None:
+    """``ensemble_config.envelope_tier`` copies onto the verified result."""
+
+    gw = _StubGateway(response_contents=[_judge_json(verdict="yes")] * 2)
+    cfg = _ensemble(n=2, rule="strict", envelope_tier=4)
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert result.tier_envelope == 4
+
+
+@pytest.mark.unit
+async def test_tier_envelope_null_when_gateway_reported_no_tier() -> None:
+    """``envelope_tier=None`` propagates onto the result (no per-row override)."""
+
+    gw = _StubGateway(response_contents=[_judge_json(verdict="yes")] * 2)
+    cfg = _ensemble(n=2, rule="strict", envelope_tier=None)
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert result.tier_envelope is None
+
+
+@pytest.mark.unit
+async def test_empty_judge_models_misses_without_calling_gateway() -> None:
+    """No-judges config is a misconfiguration; short-circuit to MISS."""
+
+    gw = _StubGateway(response_contents=[_judge_json(verdict="yes")])
+    cfg = _StubEnsembleConfig(judge_models=(), aggregation_rule="strict", envelope_tier=3)
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is False
+    assert gw.call_count == 0
+
+
+@pytest.mark.unit
+async def test_confidence_is_mean_of_verified_judges() -> None:
+    """Mixed confidences average: high(0.90) + medium(0.70) = 0.80 mean."""
+
+    gw = _StubGateway(
+        response_contents=[
+            _judge_json(verdict="yes", confidence="high"),
+            _judge_json(verdict="yes", confidence="medium"),
+        ]
+    )
+    cfg = _ensemble(n=2, rule="strict")
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert result.confidence == pytest.approx(0.80)
+
+
+# ---------------------------------------------------------------------------
+# Cascade routing in verify().
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_verify_routes_to_ensemble_when_config_supplied() -> None:
+    """``verify(..., ensemble_config=cfg)`` runs Stage 4 instead of Stage 3."""
+
+    gw = _StubGateway(response_contents=[_judge_json(verdict="yes")] * 2)
+    cfg = _ensemble(n=2, rule="strict")
+    doc = _doc("Unrelated content; exact + tolerant miss.")
+    cand = _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=0,
+        source_offset_end=20,
+        source_page=None,
+        # Source text doesn't match the doc slice — Stages 1+2 miss
+        # and the cascade should route to Stage 4.
+        source_text="the agreement was signed last June",
+    )
+
+    result = await verify(cand, doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert result.method == "ensemble_strict"
+    assert gw.call_count == 2
+
+
+@pytest.mark.unit
+async def test_verify_falls_back_to_stage_3_when_no_ensemble_config() -> None:
+    """No ensemble_config kwarg → Stage 3 (single judge)."""
+
+    gw = _StubGateway(response_contents=[_judge_json(verdict="yes")])
+    doc = _doc("Unrelated content; exact + tolerant miss.")
+    cand = _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=0,
+        source_offset_end=20,
+        source_page=None,
+        source_text="the agreement was signed last June",
+    )
+
+    result = await verify(cand, doc, gateway=gw, judge_model="fast")
+
+    assert result.verified is True
+    assert result.method == "paraphrase_judge"
+    assert gw.call_count == 1
+
+
+@pytest.mark.unit
+async def test_verify_short_circuits_on_exact_match_even_with_ensemble_config() -> None:
+    """Stage 1 wins; Stage 4 never dispatches (no judge calls)."""
+
+    gw = _StubGateway(response_contents=[_judge_json(verdict="yes")] * 3)
+    cfg = _ensemble(n=3, rule="strict")
+    doc = _doc("the agreement was signed on the third of June.")
+    cand = _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=0,
+        source_offset_end=24,
+        source_page=None,
+        source_text="the agreement was signed",
+    )
+
+    result = await verify(cand, doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert result.method == "exact_match"
+    # Stage 4 never ran — Stage 1's byte-equality short-circuit hit.
+    assert gw.call_count == 0
+
+
+@pytest.mark.unit
+async def test_verify_returns_miss_without_gateway_even_with_ensemble_config() -> None:
+    """``gateway=None`` short-circuits past both Stage 3 and Stage 4."""
+
+    cfg = _ensemble(n=3, rule="strict")
+    doc = _doc("Unrelated content; exact + tolerant miss.")
+    cand = _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=0,
+        source_offset_end=10,
+        source_page=None,
+        source_text="completely different text",
+    )
+
+    result = await verify(cand, doc, gateway=None, ensemble_config=cfg)
+
+    assert result == VerificationResult(
+        verified=False, method=None, confidence=None, partial=False, tier_envelope=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_ensemble_config — activation + cost-budget pre-flight.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _StubResolvedEnsembleConfig:
+    """Mirrors :class:`app.clients.gateway.EnsembleConfig`."""
+
+    default_enabled: bool
+    judge_models: tuple[str, ...]
+    aggregation_rule: Literal["strict", "majority"]
+    max_cost_per_message_usd: float
+    envelope_tier: int | None
+
+
+class _StubGatewayForActivation:
+    """Returns a canned :class:`EnsembleConfig` from get_citation_engine_ensemble_config."""
+
+    def __init__(self, *, config: _StubResolvedEnsembleConfig | None) -> None:
+        self._config = config
+        self.fetch_count = 0
+
+    async def get_citation_engine_ensemble_config(self) -> _StubResolvedEnsembleConfig | None:
+        self.fetch_count += 1
+        return self._config
+
+
+@dataclass(slots=True)
+class _StubSkill:
+    """Mirrors :class:`app.skills.schema.Skill` for the activation check."""
+
+    ensemble_verification: bool | None
+
+
+class _StubSkillRegistry:
+    """Returns canned :class:`_StubSkill` objects by name."""
+
+    def __init__(self, skills: dict[str, _StubSkill]) -> None:
+        self._skills = skills
+
+    def get_skill(self, name: str) -> _StubSkill | None:
+        return self._skills.get(name)
+
+
+@pytest.fixture
+def _activation_config_off() -> _StubResolvedEnsembleConfig:
+    """Gateway has ensemble configured but default_enabled=False."""
+
+    return _StubResolvedEnsembleConfig(
+        default_enabled=False,
+        judge_models=("fast", "smart"),
+        aggregation_rule="strict",
+        max_cost_per_message_usd=0.05,
+        envelope_tier=3,
+    )
+
+
+@pytest.mark.unit
+async def test_resolve_activates_on_skill_flag(
+    _activation_config_off: _StubResolvedEnsembleConfig,
+) -> None:
+    """Skill frontmatter ensemble_verification:true activates Stage 4."""
+
+    from app.api.chats import _resolve_ensemble_config
+
+    gw = _StubGatewayForActivation(config=_activation_config_off)
+    registry = _StubSkillRegistry({"nda-review": _StubSkill(ensemble_verification=True)})
+
+    result = await _resolve_ensemble_config(
+        gateway=gw,
+        applied_skills=["nda-review"],
+        project_ensemble_verification=False,
+        skill_registry=registry,
+        n_candidates=2,
+        message_id=uuid.uuid4(),
+    )
+
+    assert result is not None
+    assert result.judge_models == ("fast", "smart")
+
+
+@pytest.mark.unit
+async def test_resolve_activates_on_project_flag(
+    _activation_config_off: _StubResolvedEnsembleConfig,
+) -> None:
+    """Project ensemble_verification:true activates Stage 4."""
+
+    from app.api.chats import _resolve_ensemble_config
+
+    gw = _StubGatewayForActivation(config=_activation_config_off)
+
+    result = await _resolve_ensemble_config(
+        gateway=gw,
+        applied_skills=[],
+        project_ensemble_verification=True,
+        skill_registry=None,
+        n_candidates=2,
+        message_id=uuid.uuid4(),
+    )
+
+    assert result is not None
+
+
+@pytest.mark.unit
+async def test_resolve_activates_on_gateway_default() -> None:
+    """Gateway default_enabled:true activates Stage 4 with no other signal."""
+
+    from app.api.chats import _resolve_ensemble_config
+
+    cfg = _StubResolvedEnsembleConfig(
+        default_enabled=True,
+        judge_models=("fast", "smart"),
+        aggregation_rule="strict",
+        max_cost_per_message_usd=0.05,
+        envelope_tier=3,
+    )
+    gw = _StubGatewayForActivation(config=cfg)
+
+    result = await _resolve_ensemble_config(
+        gateway=gw,
+        applied_skills=[],
+        project_ensemble_verification=False,
+        skill_registry=None,
+        n_candidates=2,
+        message_id=uuid.uuid4(),
+    )
+
+    assert result is not None
+
+
+@pytest.mark.unit
+async def test_resolve_no_activation_returns_none(
+    _activation_config_off: _StubResolvedEnsembleConfig,
+) -> None:
+    """No skill, no project, gateway default off → None (no Stage 4)."""
+
+    from app.api.chats import _resolve_ensemble_config
+
+    gw = _StubGatewayForActivation(config=_activation_config_off)
+
+    result = await _resolve_ensemble_config(
+        gateway=gw,
+        applied_skills=[],
+        project_ensemble_verification=False,
+        skill_registry=None,
+        n_candidates=2,
+        message_id=uuid.uuid4(),
+    )
+
+    assert result is None
+
+
+@pytest.mark.unit
+async def test_resolve_returns_none_when_gateway_missing() -> None:
+    """gateway=None means Stage 4 cannot run regardless of activation."""
+
+    from app.api.chats import _resolve_ensemble_config
+
+    result = await _resolve_ensemble_config(
+        gateway=None,
+        applied_skills=["nda-review"],
+        project_ensemble_verification=True,
+        skill_registry=None,
+        n_candidates=2,
+        message_id=uuid.uuid4(),
+    )
+
+    assert result is None
+
+
+@pytest.mark.unit
+async def test_resolve_returns_none_when_gateway_has_no_ensemble_config() -> None:
+    """Gateway with no ensemble configured (None) → None (no Stage 4)."""
+
+    from app.api.chats import _resolve_ensemble_config
+
+    gw = _StubGatewayForActivation(config=None)
+
+    result = await _resolve_ensemble_config(
+        gateway=gw,
+        applied_skills=[],
+        project_ensemble_verification=True,
+        skill_registry=None,
+        n_candidates=2,
+        message_id=uuid.uuid4(),
+    )
+
+    assert result is None
+
+
+@pytest.mark.unit
+async def test_resolve_cost_budget_fallback_returns_none() -> None:
+    """Estimated cost > max_cost_per_message_usd → None (fall back to Stage 3)."""
+
+    from app.api.chats import _resolve_ensemble_config
+
+    # 100 candidates * 3 judges * $0.005/judge = $1.50 estimated.
+    # Budget of $0.05 -> estimate exceeds, fall back.
+    cfg = _StubResolvedEnsembleConfig(
+        default_enabled=True,
+        judge_models=("a", "b", "c"),
+        aggregation_rule="strict",
+        max_cost_per_message_usd=0.05,
+        envelope_tier=3,
+    )
+    gw = _StubGatewayForActivation(config=cfg)
+
+    result = await _resolve_ensemble_config(
+        gateway=gw,
+        applied_skills=[],
+        project_ensemble_verification=False,
+        skill_registry=None,
+        n_candidates=100,
+        message_id=uuid.uuid4(),
+    )
+
+    assert result is None
+
+
+@pytest.mark.unit
+async def test_resolve_cost_budget_within_cap_activates() -> None:
+    """Estimated cost ≤ budget → ensemble activates."""
+
+    from app.api.chats import _resolve_ensemble_config
+
+    # 2 candidates * 3 judges * $0.005 = $0.030 estimated < $0.05 budget.
+    cfg = _StubResolvedEnsembleConfig(
+        default_enabled=True,
+        judge_models=("a", "b", "c"),
+        aggregation_rule="strict",
+        max_cost_per_message_usd=0.05,
+        envelope_tier=3,
+    )
+    gw = _StubGatewayForActivation(config=cfg)
+
+    result = await _resolve_ensemble_config(
+        gateway=gw,
+        applied_skills=[],
+        project_ensemble_verification=False,
+        skill_registry=None,
+        n_candidates=2,
+        message_id=uuid.uuid4(),
+    )
+
+    assert result is not None

--- a/api/tests/test_gateway_client.py
+++ b/api/tests/test_gateway_client.py
@@ -802,6 +802,157 @@ async def test_judge_model_failed_fetch_not_cached(client: GatewayClient) -> Non
     assert judge2 == "smart"
 
 
+# ---------------------------------------------------------------------------
+# Citation Engine ensemble-config fetch (M2-D1).
+#
+# The api/ pulls the Stage 4 ensemble config from the gateway over the
+# same GET /v1/citation-engine/config endpoint and caches it. Failure
+# modes (network, non-200, missing block, empty judge_models) return
+# None so Stage 4 silently disables — the cascade falls back to Stage 3.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_ensemble_config_fetched_from_gateway(client: GatewayClient) -> None:
+    """Happy path: full ensemble block parses into :class:`EnsembleConfig`."""
+
+    respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "judge_model": "fast",
+                "ensemble_verification": {
+                    "default_enabled": True,
+                    "judge_models": ["fast", "smart"],
+                    "aggregation_rule": "strict",
+                    "max_cost_per_message_usd": 0.10,
+                    "envelope_tier": 4,
+                },
+            },
+        )
+    )
+
+    cfg = await client.get_citation_engine_ensemble_config()
+
+    assert cfg is not None
+    assert cfg.default_enabled is True
+    assert cfg.judge_models == ("fast", "smart")
+    assert cfg.aggregation_rule == "strict"
+    assert cfg.max_cost_per_message_usd == 0.10
+    assert cfg.envelope_tier == 4
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_ensemble_config_caches_for_process(client: GatewayClient) -> None:
+    """Second call doesn't re-hit the gateway."""
+
+    route = respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "judge_model": "fast",
+                "ensemble_verification": {
+                    "default_enabled": False,
+                    "judge_models": ["fast"],
+                    "aggregation_rule": "strict",
+                    "max_cost_per_message_usd": 0.05,
+                    "envelope_tier": 3,
+                },
+            },
+        )
+    )
+
+    first = await client.get_citation_engine_ensemble_config()
+    second = await client.get_citation_engine_ensemble_config()
+
+    assert first is not None
+    assert second is not None
+    assert first == second
+    assert route.call_count == 1
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_ensemble_config_none_when_judge_models_empty(
+    client: GatewayClient,
+) -> None:
+    """An empty ``judge_models`` list disables Stage 4 entirely."""
+
+    respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "judge_model": "fast",
+                "ensemble_verification": {
+                    "default_enabled": True,
+                    "judge_models": [],
+                    "aggregation_rule": "strict",
+                    "max_cost_per_message_usd": 0.05,
+                    "envelope_tier": None,
+                },
+            },
+        )
+    )
+
+    cfg = await client.get_citation_engine_ensemble_config()
+
+    assert cfg is None
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_ensemble_config_none_when_block_missing(client: GatewayClient) -> None:
+    """Older gateway with no ``ensemble_verification`` block → None."""
+
+    respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(200, json={"judge_model": "fast"})
+    )
+
+    cfg = await client.get_citation_engine_ensemble_config()
+
+    assert cfg is None
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_ensemble_config_none_on_network_error(client: GatewayClient) -> None:
+    """Transport failure returns None (Stage 4 silently disabled)."""
+
+    respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+
+    cfg = await client.get_citation_engine_ensemble_config()
+
+    assert cfg is None
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_ensemble_config_failed_fetch_is_cached(client: GatewayClient) -> None:
+    """A failed fetch caches the None sentinel — no re-poll storm.
+
+    Distinct from the judge_model behavior (which retries on failure)
+    because the ensemble config is a stickier misconfiguration: a
+    deployment without ensemble configured stays that way until
+    operator-driven gateway restart, and we don't want every chat
+    send to re-hit the endpoint just to confirm.
+    """
+
+    route = respx.get(f"{GATEWAY_BASE}/v1/citation-engine/config").mock(
+        return_value=httpx.Response(500, text="oops")
+    )
+
+    cfg1 = await client.get_citation_engine_ensemble_config()
+    cfg2 = await client.get_citation_engine_ensemble_config()
+
+    assert cfg1 is None
+    assert cfg2 is None
+    assert route.call_count == 1
+
+
 # Suppress the "task pending" warning that respx can emit on cancellation.
 @pytest.fixture(autouse=True)
 def _suppress_pending_task_warnings() -> None:

--- a/docs/citation-engine.md
+++ b/docs/citation-engine.md
@@ -1,0 +1,175 @@
+# Citation Engine
+
+> The Citation Engine verifies every model-produced citation against
+> its source before rendering — failed citations surface as
+> "unverified" rather than as confident-looking wrong text. Per PRD
+> §3.3 / §1.3 (transparency as a founding principle): a wrong answer
+> the lawyer can see is wrong is dramatically more useful than a wrong
+> answer that looks right.
+
+This doc describes the production cascade, the persisted row shape,
+the UI rendering states, the configuration surface, and the privacy
+implications of the ensemble stage. It pairs with
+[docs/security/anonymization.md](security/anonymization.md) (the
+integration boundary lives in §[Integration with Anonymization](#integration-with-anonymization)).
+
+---
+
+## Cascade
+
+Each citation the model emits (a `"<quote>" (Source: [N])` pair)
+becomes a `CitationCandidate` and runs through staged verification.
+The first stage to verify wins; the persisted method names the stage.
+Misses propagate to the next stage. A row that misses *every* stage
+is not persisted — its absence is the unverified signal the M2-C2 UI
+consumes.
+
+| Stage | Method (DB) | Description | Cost |
+|---|---|---|---|
+| 1 | `exact_match` | Byte-for-byte equality of `source_text` against `documents.normalized_content[offset_start:offset_end]`. | Free (pure Python). |
+| 2 | `tolerant_match` | After normalizing both sides (whitespace, smart quotes, OCR confusions when `was_ocrd=true`), `rapidfuzz.fuzz.ratio ≥ 95`. | Free (pure Python). |
+| 3 | `paraphrase_judge` | LLM judge call through the gateway. Returns `yes` / `partial` / `no` with `high` / `medium` / `low` confidence (mapped to 0.90 / 0.70 / 0.50). `partial=true` persists to flag "source partially supports the claim." | One judge call per citation. |
+| 4 | `ensemble_strict` / `ensemble_majority` | The paraphrase judge runs in parallel across N models (configured in `gateway.yaml`). Replaces Stage 3 when activated. Aggregation rule decides whether disagreement misses or majority wins. | N judge calls per citation (pre-flight budget check enforces a per-message cap). |
+
+Stage 3 vs Stage 4 is exclusive: when ensemble is activated, Stage 3
+does not run as a pre-flight. The cascade goes 1 → 2 → 4 (per M2-D1
+decision B; the single-judge stage would be redundant with N parallel
+judges already in flight).
+
+## Persisted row shape
+
+The `message_citations` table mirrors the result of whatever stage
+verified the citation. See [docs/db-schema.md](db-schema.md) for the
+column list; the citation-relevant columns are:
+
+- `verification_method` — the stage that verified (string enum).
+- `verification_confidence` — `[0, 1]`, per-stage scale.
+- `partial` — Stage 3+ flag for "source partially supports."
+- `tier_envelope` — Stage 4 only; the maximum (weakest) inference tier
+  across the judge models that ran (1-5 per PRD §1.5.2).
+
+Stages 1-2 always emit `partial=false` and `tier_envelope=null`.
+
+## UI rendering (M2-C2 + M2-D1)
+
+The M2-C2 chat surface renders citations as inline chips and a
+sidecar list, with four visual states:
+
+| State | Color | When |
+|---|---|---|
+| `verified-exact` | green | `verification_method='exact_match'` |
+| `verified-tolerant` | green | `verification_method='tolerant_match'` |
+| `verified-paraphrase` | yellow | `verification_method` in (`paraphrase_judge`, `llm_judge`, `ensemble_strict`, `ensemble_majority`) |
+| `unverified` | red | no row, or `verified=false`, or `verification_method='failed'` |
+
+Per M2-D1 Decision F, Stage 4 ensemble methods render as
+`verified-paraphrase` (yellow). The tooltip varies by method:
+
+- `paraphrase_judge` → "Verified by judge ({confidence}): the source supports this claim."
+- `ensemble_strict` → "Verified by ensemble ({confidence}): all judges agreed."
+- `ensemble_strict` + `partial=true` → "...all judges agreed, but the source partially supports this claim."
+- `ensemble_majority` → "Verified by ensemble ({confidence}): majority of judges verified."
+- `ensemble_majority` + `partial=true` → "...majority of judges verified, but some disagreed."
+
+The fifth state (`system-error`) was deferred from M2-C2 per Decision H
+and is reserved in the type union for forward compatibility.
+
+## Activation (Stage 4 only)
+
+Stages 1-3 always run on every citation. Stage 4 is opt-in. Three
+independent signals can activate it — the api/ ORs across all three:
+
+1. **Skill frontmatter** — `lq_ai.ensemble_verification: true` on
+   a skill applied to the message.
+2. **Project flag** — `projects.ensemble_verification = true` on
+   the chat's parent project.
+3. **Deployment default** — `gateway.yaml`'s
+   `citation_engine.ensemble_verification.default_enabled: true`.
+
+When activated AND the per-message cost-budget pre-flight passes,
+the cascade routes to Stage 4. When the cost estimate exceeds the
+configured cap (`max_cost_per_message_usd`), the cascade falls back
+to Stage 3 with a `chat_message_ensemble_budget_fallback` warning
+logged — the operator's budget setting is a hard cap, not advisory.
+
+## Configuration
+
+The api/ pulls Stage 3 and Stage 4 config from the gateway over
+`GET /v1/citation-engine/config` at startup and caches it for the
+process lifetime. Operator-facing knobs:
+
+```yaml
+citation_engine:
+  judge_model: fast   # Stage 3 judge alias (default 'fast')
+
+  ensemble_verification:
+    default_enabled: false
+    judge_models: []                  # empty disables Stage 4
+    aggregation_rule: strict           # strict | majority
+    max_cost_per_message_usd: 0.05
+```
+
+`judge_models` accepts gateway aliases (`fast`, `smart`, `budget`) or
+fully-qualified `provider/model` strings. The gateway computes the
+envelope tier server-side (max `routed_inference_tier` across the
+list) and surfaces it on the config endpoint response so the api/
+can persist it on each citation row without doing its own alias
+resolution.
+
+## Cost-budget pre-flight
+
+Stage 4 cost grows as `n_citations × n_judges`. To prevent runaway
+spend on a single message:
+
+```
+estimated_usd = n_citations × n_judges × FLAT_PER_JUDGE_USD
+if estimated_usd > max_cost_per_message_usd:
+    fall back to single-judge Stage 3
+```
+
+`FLAT_PER_JUDGE_USD = 0.005` is a deliberately conservative constant
+(haiku-tier rates + generous token estimates) so the check errs on
+the side of falling back rather than overrunning. M2-E2 (ensemble
+calibration pass) replaces it with measured numbers from the
+acceptance corpus.
+
+## Privacy implications of Stage 4
+
+Each judge dispatch is an inference request that routes through the
+gateway like any other — subject to the same tier-routing,
+anonymization middleware, and audit-logging. When `judge_models`
+spans multiple provider tiers, the verification's privacy envelope
+is the *weakest* (highest-numbered) tier in the set. The
+`message_citations.tier_envelope` column persists this per row so
+operators can audit which chats had citations sent to weaker tiers.
+
+The privacy envelope is computed eagerly at config-load time
+(server-side, using the primary target of each judge alias). Fallback
+targets could route weaker at runtime; those are visible through the
+per-judge `inference_routing_log` rows linked by `message_id`.
+
+## Integration with Anonymization
+
+The Citation Engine and the Anonymization Layer coexist per Decision
+M2-1 (chat/skill content pseudonymized; retrieved source documents
+left un-pseudonymized). This means:
+
+- Citations operate on **un-pseudonymized** source text on both
+  extraction and verification sides — the Stage 3/4 judge sees the
+  real cited content and the real source chunk.
+- The model may emit citations that reference real entities (from
+  retrieved sources) AND prose that references pseudonyms (from
+  pseudonymized chat content). The post-anonymization middleware
+  rehydrates pseudonyms; citations need no rehydration step.
+
+M2-D2 ships the integration tests and documents the data flow in
+detail. See [docs/security/anonymization.md](security/anonymization.md)
+for the corresponding anonymization-side description.
+
+## References
+
+- PRD §3.3 (Citation Engine spec)
+- [docs/M2-IMPLEMENTATION-PLAN.md](M2-IMPLEMENTATION-PLAN.md) §M2-C1, §M2-D1
+- [docs/db-schema.md](db-schema.md) — `message_citations` table
+- [gateway.yaml.example](../gateway.yaml.example) — operator config surface
+- [docs/skill-authoring-guide.md](skill-authoring-guide.md) — `ensemble_verification` frontmatter field

--- a/docs/skill-authoring-guide.md
+++ b/docs/skill-authoring-guide.md
@@ -58,6 +58,7 @@ lq_ai:
         description: ...
   output_format: report     # report | table | issues_list | redline
   minimum_inference_tier: 2 # optional; defaults to no minimum
+  ensemble_verification: true  # optional; M2-D1; default false
   use_organization_profile: true   # default true
   is_organization_profile: false   # singleton; only true on the org profile
   self_improvement: false   # default false for v1.0.0 skills
@@ -85,6 +86,7 @@ lq_ai:
 ### Optional fields
 
 - **`lq_ai.minimum_inference_tier`** — refuses to run if the chat's routed Inference Tier is below this. Use for skills that handle particularly sensitive content; default is no minimum.
+- **`lq_ai.ensemble_verification`** — when `true`, the Citation Engine runs **Stage 4 (ensemble verification)** on every citation the model produces while this skill is applied. Stage 4 dispatches the paraphrase judge in parallel across N models (configured deployment-side in `gateway.yaml`'s `citation_engine.ensemble_verification.judge_models`) and aggregates the verdicts under the operator-chosen rule (`strict` = all judges must agree; `majority` = simple majority wins). The persisted citation row carries `verification_method='ensemble_strict'` or `'ensemble_majority'` plus the maximum tier across the judge ensemble. Use for skills whose output is especially high-stakes (regulatory filings, board materials) and where multi-model agreement materially raises confidence. Default `false`. NOTE: ensemble verification implies each citation is sent to N providers; the privacy envelope is the *weakest* tier in the configured judge set (e.g., a Tier 4 commercial-cloud judge bumps the envelope to Tier 4 even if the primary judge is Tier 3 ZDR-enterprise). The `message_citations.tier_envelope` audit column captures this per row.
 - **`lq_ai.use_organization_profile`** — defaults to `true`. Set to `false` only for skills that should run independent of organization-specific context (rare).
 - **`lq_ai.is_organization_profile`** — set to `true` only for the singleton Organization Profile skill. Every other skill leaves this `false` or omits it.
 - **`lq_ai.self_improvement`** — defaults to `false` for v1.0.0 skills. Self-improvement is a deferred enhancement; v1.0.0 skills are stable artifacts under semver, not learning systems.

--- a/gateway.yaml.example
+++ b/gateway.yaml.example
@@ -406,6 +406,51 @@ anonymization:
 citation_engine:
   judge_model: fast
 
+  # ----------------------------------------------------------------
+  # Stage 4 — ensemble verification (M2-D1)
+  # ----------------------------------------------------------------
+  # When activated, the paraphrase judge runs in parallel across
+  # ``judge_models`` and the verdicts aggregate under
+  # ``aggregation_rule``. Activation is the OR of:
+  #
+  #   1. A skill's frontmatter ``ensemble_verification: true``
+  #   2. The chat's project ``ensemble_verification`` flag
+  #   3. ``default_enabled`` below
+  #
+  # Replaces Stage 3 (single-judge) when activated. Cost-budget
+  # pre-flight: the api/ estimates spend per message
+  # (citations × n_judges × ~$0.005); if the estimate exceeds
+  # ``max_cost_per_message_usd`` the cascade falls back to single-
+  # judge Stage 3 with a warning logged.
+  #
+  # PRIVACY NOTE: each judge dispatch is an inference request that
+  # routes through the gateway like any other. If judge_models
+  # spans multiple provider tiers, the verification's privacy
+  # envelope is the *weakest* (highest-numbered) tier across the
+  # ensemble — exposed on ``message_citations.tier_envelope`` per
+  # row so operators can audit ensemble exposure post-hoc.
+  #
+  # Default is fully opt-in: empty ``judge_models`` disables Stage 4
+  # even when ``default_enabled: true`` (defense in depth against
+  # misconfiguration).
+  ensemble_verification:
+    default_enabled: false
+    judge_models: []
+    # ``strict`` — every judge must verdict verified. Any miss → MISS.
+    # ``majority`` — simple majority of verified verdicts wins;
+    #   even-N ties (e.g., 2-of-4) miss conservatively. Dissent
+    #   surfaces via the ``partial=true`` flag on the persisted row.
+    aggregation_rule: strict
+    max_cost_per_message_usd: 0.05
+  #
+  # Example operator configuration (commented for safety):
+  #
+  # ensemble_verification:
+  #   default_enabled: true
+  #   judge_models: [fast, fast-anthropic, fast-vertex]
+  #   aggregation_rule: strict
+  #   max_cost_per_message_usd: 0.10
+
 # ============================================================
 # COST TRACKING
 # ============================================================

--- a/gateway/app/api/inference.py
+++ b/gateway/app/api/inference.py
@@ -96,6 +96,7 @@ from app.router import (
     RoutedProviderError,
     Router,
     estimate_cost,
+    resolve_alias_chain,
     synthesize_request_id,
 )
 from app.routing_log import (
@@ -902,19 +903,36 @@ async def list_models(request: Request) -> dict[str, Any]:
 
 
 @router.get("/citation-engine/config")
-async def citation_engine_config(request: Request) -> dict[str, str]:
-    """Expose the citation_engine block for the api/'s Citation Engine (M2-C1).
+async def citation_engine_config(request: Request) -> dict[str, Any]:
+    """Expose the citation_engine block for the api/'s Citation Engine (M2-C1 / M2-D1).
 
-    The api/ runs Stage 3 (LLM paraphrase judge) of the Citation
-    Engine cascade and reads the judge-model alias from this endpoint
-    at startup so the operator configures model choices in one place
-    (``gateway.yaml``) rather than mirroring them on the api/ side.
+    The api/ runs Stage 3 (LLM paraphrase judge) and Stage 4 (ensemble)
+    of the Citation Engine cascade and reads its configuration from
+    this endpoint at startup so the operator configures model choices
+    in one place (``gateway.yaml``) rather than mirroring them on the
+    api/ side.
 
-    Response shape:
+    Response shape (M2-D1):
 
     .. code-block:: json
 
-       {"judge_model": "fast"}
+       {
+         "judge_model": "fast",
+         "ensemble_verification": {
+           "default_enabled": false,
+           "judge_models": ["fast", "smart"],
+           "aggregation_rule": "strict",
+           "max_cost_per_message_usd": 0.05,
+           "envelope_tier": 3
+         }
+       }
+
+    ``ensemble_verification.envelope_tier`` is server-computed as
+    ``max(routed_inference_tier for each judge_model)`` using the
+    primary target of each alias (fallbacks could route weaker at
+    runtime, but the primary is the operator's intent; runtime
+    weakening is visible via per-call routing_log rows). NULL when
+    ``judge_models`` is empty.
 
     The api/ caches the value for the process lifetime; restarting the
     gateway after an alias change is the deployment story for now.
@@ -923,7 +941,33 @@ async def citation_engine_config(request: Request) -> dict[str, str]:
     """
 
     config = _config(request)
-    return {"judge_model": config.citation_engine.judge_model}
+    ensemble = config.citation_engine.ensemble_verification
+
+    envelope_tier: int | None = None
+    if ensemble.judge_models:
+        tiers: list[int] = []
+        for judge in ensemble.judge_models:
+            try:
+                resolved = resolve_alias_chain(requested_model=judge, config=config)
+            except ModelResolutionError:
+                # Misconfigured judge alias — skip it for envelope
+                # computation; the dispatch-time error message will
+                # surface the typo when verification actually runs.
+                continue
+            if resolved:
+                tiers.append(resolved[0].routed_inference_tier)
+        envelope_tier = max(tiers) if tiers else None
+
+    return {
+        "judge_model": config.citation_engine.judge_model,
+        "ensemble_verification": {
+            "default_enabled": ensemble.default_enabled,
+            "judge_models": list(ensemble.judge_models),
+            "aggregation_rule": ensemble.aggregation_rule,
+            "max_cost_per_message_usd": ensemble.max_cost_per_message_usd,
+            "envelope_tier": envelope_tier,
+        },
+    }
 
 
 # --- Streaming helpers --------------------------------------------------------

--- a/gateway/app/config.py
+++ b/gateway/app/config.py
@@ -335,8 +335,51 @@ class DevModeConfig(BaseModel):
     enabled: bool = False
 
 
+class EnsembleVerificationConfig(BaseModel):
+    """``citation_engine.ensemble_verification:`` block — M2-D1.
+
+    Stage 4 of the Citation Engine cascade. When activated (per-skill,
+    per-project, or per-deployment), the paraphrase judge runs in
+    parallel across :attr:`judge_models` and the verdicts aggregate
+    under :attr:`aggregation_rule`.
+
+    Activation is computed by the api/ at chat-send time: ``any()``
+    across the skill frontmatter ``ensemble_verification`` flag, the
+    project's ``ensemble_verification`` column, and this block's
+    :attr:`default_enabled`. The gateway exposes the resolved config
+    via ``GET /v1/citation-engine/config``; the api/ caches it for the
+    process and reads it on every verify() call.
+
+    :attr:`judge_models` is a list of aliases (or fully-qualified
+    ``provider/model``) the gateway's router can resolve. Three is the
+    canonical M2-D1 baseline (primary judge + 2 alternates from
+    different provider families); operators may choose more or fewer.
+    An empty list disables ensemble even when :attr:`default_enabled`
+    is True — defense-in-depth against misconfiguration.
+
+    :attr:`aggregation_rule` selects strict (all judges must verdict
+    ``"yes"``) or majority (simple majority wins). The persisted
+    ``message_citations.verification_method`` is
+    ``'ensemble_strict'`` or ``'ensemble_majority'`` accordingly.
+
+    :attr:`max_cost_per_message_usd` is the pre-flight budget cap. The
+    api/ estimates ``input_tokens * len(judge_models) * max_judge_rate``
+    before dispatch; if the estimate exceeds the cap, verification
+    falls back to a single Stage 3 judge call with a warning logged.
+    Default ``0.05`` is a conservative ceiling; operators tune per
+    their cost posture.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    default_enabled: bool = False
+    judge_models: list[str] = Field(default_factory=list)
+    aggregation_rule: Literal["strict", "majority"] = "strict"
+    max_cost_per_message_usd: float = Field(default=0.05, ge=0.0)
+
+
 class CitationEngineConfig(BaseModel):
-    """``citation_engine:`` block — M2-C1.
+    """``citation_engine:`` block — M2-C1 / M2-D1.
 
     The Citation Engine runs in the api/ but reads the *model name* it
     should use for the Stage 3 (paraphrase) judge from the gateway's
@@ -350,11 +393,19 @@ class CitationEngineConfig(BaseModel):
     (``anthropic-prod/claude-haiku-4-5``). Defaults to ``"fast"`` —
     deliberately a smaller model than the typical citation-generating
     model so the judge cost is bounded.
+
+    :attr:`ensemble_verification` (M2-D1) is the Stage 4 ensemble
+    block. See :class:`EnsembleVerificationConfig` for the per-field
+    contract. Default-constructed (``default_enabled=False``, empty
+    ``judge_models``) means Stage 4 is opt-in per skill or project.
     """
 
     model_config = ConfigDict(extra="allow")
 
     judge_model: str = Field(default="fast", min_length=1)
+    ensemble_verification: EnsembleVerificationConfig = Field(
+        default_factory=EnsembleVerificationConfig
+    )
 
 
 # --- Top-level config ---------------------------------------------------------

--- a/gateway/tests/test_inference.py
+++ b/gateway/tests/test_inference.py
@@ -21,7 +21,10 @@ and ``test_anthropic_provider.py`` (real-key, marked ``provider``).
 from __future__ import annotations
 
 import pytest
+from fastapi import FastAPI
 from httpx import AsyncClient
+
+from app.config import EnsembleVerificationConfig
 
 
 @pytest.mark.unit
@@ -147,20 +150,91 @@ async def test_models_returns_configured_aliases(client: AsyncClient) -> None:
 
 
 @pytest.mark.unit
-async def test_citation_engine_config_returns_judge_model(client: AsyncClient) -> None:
-    """``GET /v1/citation-engine/config`` exposes the loaded judge_model (M2-C1).
+async def test_citation_engine_config_returns_judge_model_and_ensemble(
+    client: AsyncClient,
+) -> None:
+    """``GET /v1/citation-engine/config`` exposes both M2-C1 and M2-D1 blocks.
 
     The api/'s Citation Engine pulls this at startup so the operator
-    configures the Stage 3 judge model in one place (``gateway.yaml``)
-    rather than mirroring it on the api/ side.
+    configures the Stage 3 judge model and the Stage 4 ensemble
+    settings in one place (``gateway.yaml``) rather than mirroring
+    them on the api/ side.
     """
 
     response = await client.get("/v1/citation-engine/config")
 
     assert response.status_code == 200
     body = response.json()
-    # The example config ships ``citation_engine.judge_model: fast``.
-    assert body == {"judge_model": "fast"}
+    # The example config ships ``citation_engine.judge_model: fast``
+    # and no ensemble block (default-constructed).
+    assert body["judge_model"] == "fast"
+    assert body["ensemble_verification"] == {
+        "default_enabled": False,
+        "judge_models": [],
+        "aggregation_rule": "strict",
+        "max_cost_per_message_usd": 0.05,
+        "envelope_tier": None,
+    }
+
+
+@pytest.mark.unit
+async def test_citation_engine_config_computes_envelope_tier_server_side(
+    gateway_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    """When ensemble is configured, envelope_tier is max(tier) across judge_models.
+
+    Per M2-D1 decision E (api-side audit), the gateway computes the
+    envelope server-side so the api/ side has a ready-to-persist
+    tier value without doing its own alias resolution.
+    """
+
+    # gateway.yaml.example: ``fast`` → anthropic-prod (tier 4),
+    # ``budget`` → anthropic-prod (tier 4). Both tier 4 → envelope 4.
+    gateway_app.state.config.citation_engine.ensemble_verification = EnsembleVerificationConfig(
+        default_enabled=True,
+        judge_models=["fast", "budget"],
+        aggregation_rule="majority",
+        max_cost_per_message_usd=0.10,
+    )
+
+    response = await client.get("/v1/citation-engine/config")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ensemble_verification"]["default_enabled"] is True
+    assert body["ensemble_verification"]["judge_models"] == ["fast", "budget"]
+    assert body["ensemble_verification"]["aggregation_rule"] == "majority"
+    assert body["ensemble_verification"]["max_cost_per_message_usd"] == 0.10
+    # Both aliases resolve to anthropic-prod, default tier 4.
+    assert body["ensemble_verification"]["envelope_tier"] == 4
+
+
+@pytest.mark.unit
+async def test_citation_engine_config_envelope_tier_null_on_unresolvable_judges(
+    gateway_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    """Unresolvable judge aliases are skipped; envelope_tier=None when none resolve.
+
+    A misconfigured judge alias surfaces the typo via the dispatch-time
+    error at verification time, not via a config-fetch failure — the
+    api/ still treats Stage 4 as disabled when envelope_tier is None
+    but the rest of the block surfaces.
+    """
+
+    gateway_app.state.config.citation_engine.ensemble_verification = EnsembleVerificationConfig(
+        default_enabled=True,
+        judge_models=["nonexistent-alias", "another-typo"],
+        aggregation_rule="strict",
+        max_cost_per_message_usd=0.05,
+    )
+
+    response = await client.get("/v1/citation-engine/config")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ensemble_verification"]["envelope_tier"] is None
 
 
 @pytest.mark.unit

--- a/web/src/lib/lq-ai/__tests__/citation-render-state.test.ts
+++ b/web/src/lib/lq-ai/__tests__/citation-render-state.test.ts
@@ -60,10 +60,23 @@ describe('citationRenderState', () => {
 		).toBe('verified-paraphrase');
 	});
 
-	it('ensemble → verified-tolerant (multi-stage agreement, green)', () => {
+	it('ensemble_strict → verified-paraphrase (yellow, per M2-D1 Decision F)', () => {
 		expect(
-			citationRenderState(makeCitation({ verification_method: 'ensemble' }))
-		).toBe('verified-tolerant');
+			citationRenderState(makeCitation({ verification_method: 'ensemble_strict' }))
+		).toBe('verified-paraphrase');
+	});
+
+	it('ensemble_majority → verified-paraphrase regardless of partial flag', () => {
+		expect(
+			citationRenderState(
+				makeCitation({ verification_method: 'ensemble_majority', partial: false })
+			)
+		).toBe('verified-paraphrase');
+		expect(
+			citationRenderState(
+				makeCitation({ verification_method: 'ensemble_majority', partial: true })
+			)
+		).toBe('verified-paraphrase');
 	});
 
 	it('failed → unverified', () => {
@@ -265,5 +278,54 @@ describe('citationTooltip', () => {
 		const tooltip = citationTooltip('unverified', null);
 		expect(tooltip).toContain('Could not verify');
 		expect(tooltip).toContain("doesn't follow from the cited content");
+	});
+
+	it('ensemble_strict tooltip mentions all judges agreed (M2-D1)', () => {
+		const tooltip = citationTooltip(
+			'verified-paraphrase',
+			makeCitation({
+				verification_method: 'ensemble_strict',
+				verification_confidence: 0.9
+			})
+		);
+		expect(tooltip).toContain('ensemble');
+		expect(tooltip).toContain('all judges agreed');
+	});
+
+	it('ensemble_strict tooltip with partial=true flags partial source support', () => {
+		const tooltip = citationTooltip(
+			'verified-paraphrase',
+			makeCitation({
+				verification_method: 'ensemble_strict',
+				verification_confidence: 0.9,
+				partial: true
+			})
+		);
+		expect(tooltip).toContain('all judges agreed');
+		expect(tooltip).toContain('partially supports');
+	});
+
+	it('ensemble_majority tooltip mentions majority of judges (M2-D1)', () => {
+		const tooltip = citationTooltip(
+			'verified-paraphrase',
+			makeCitation({
+				verification_method: 'ensemble_majority',
+				verification_confidence: 0.8
+			})
+		);
+		expect(tooltip).toContain('majority of judges verified');
+	});
+
+	it('ensemble_majority tooltip with partial=true flags disagreement', () => {
+		const tooltip = citationTooltip(
+			'verified-paraphrase',
+			makeCitation({
+				verification_method: 'ensemble_majority',
+				verification_confidence: 0.8,
+				partial: true
+			})
+		);
+		expect(tooltip).toContain('majority of judges verified');
+		expect(tooltip).toContain('some disagreed');
 	});
 });

--- a/web/src/lib/lq-ai/citations/state.ts
+++ b/web/src/lib/lq-ai/citations/state.ts
@@ -49,6 +49,13 @@ export interface ParsedCitationMarker {
  * always maps to verified-paraphrase (yellow), regardless of the
  * `partial` flag — `partial` modulates the tooltip wording, not the
  * color choice.
+ *
+ * Per M2-D1 Decision F, ensemble methods (`ensemble_strict` and
+ * `ensemble_majority`) also render as yellow, reusing the
+ * verified-paraphrase chip. The tooltip varies by method + partial
+ * flag (e.g., "Models disagreed: K of N verified" for majority with
+ * dissent). Reusing the chip rather than adding a 5th visual state
+ * keeps the M2-C2 design surface small.
  */
 export function citationRenderState(citation: Citation | null): CitationRenderState {
 	if (citation === null || !citation.verified) {
@@ -61,12 +68,9 @@ export function citationRenderState(citation: Citation | null): CitationRenderSt
 			return 'verified-tolerant';
 		case 'paraphrase_judge':
 		case 'llm_judge':
+		case 'ensemble_strict':
+		case 'ensemble_majority':
 			return 'verified-paraphrase';
-		case 'ensemble':
-			// Multi-model agreement is structurally a stronger verification
-			// than a single stage; render with the green treatment shared
-			// by exact / tolerant match.
-			return 'verified-tolerant';
 		case 'failed':
 			return 'unverified';
 		case null:
@@ -156,6 +160,26 @@ export function citationTooltip(
 						: conf >= 0.6
 							? 'medium confidence'
 							: 'low confidence';
+			const method = citation?.verification_method;
+			// M2-D1: ensemble methods get distinct tooltip wording.
+			// `ensemble_strict` always means every judge agreed
+			// (otherwise the row wouldn't have persisted); `partial=true`
+			// in that case flags that at least one judge said partial.
+			// `ensemble_majority` with `partial=true` flags dissent
+			// (at least one judge missed) — the spec's "Models
+			// disagreed" case.
+			if (method === 'ensemble_strict') {
+				if (citation?.partial) {
+					return `Verified by ensemble (${confLabel}): all judges agreed, but the source partially supports this claim.`;
+				}
+				return `Verified by ensemble (${confLabel}): all judges agreed.`;
+			}
+			if (method === 'ensemble_majority') {
+				if (citation?.partial) {
+					return `Verified by ensemble (${confLabel}): majority of judges verified, but some disagreed.`;
+				}
+				return `Verified by ensemble (${confLabel}): majority of judges verified.`;
+			}
 			if (citation?.partial) {
 				return `Verified by judge (${confLabel}): the source partially supports this claim.`;
 			}

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -202,13 +202,17 @@ export interface ChatSearchResponse {
 
 /**
  * Which verification stage validated this citation. Mirrors
- * `MessageCitation.verification_method` in the backend (M2-A2 / M2-B1 / M2-C1).
+ * `MessageCitation.verification_method` in the backend (M2-A2 / M2-B1 / M2-C1 / M2-D1).
  *
  * - `exact_match` — Stage 1, byte-for-byte (M2-A2).
  * - `tolerant_match` — Stage 2, normalized-whitespace + OCR artefacts (M2-B1).
  * - `paraphrase_judge` — Stage 3, paraphrase judge (M2-C1).
  * - `llm_judge` — reserved for future LLM-based semantic-match stages.
- * - `ensemble` — Stage 4, multi-model agreement (M2-D1).
+ * - `ensemble_strict` — Stage 4 with strict aggregation: every judge
+ *   verified (M2-D1).
+ * - `ensemble_majority` — Stage 4 with majority aggregation: simple
+ *   majority of judges verified (M2-D1). `partial=true` flags
+ *   disagreement (some judges dissented) per the M2-D1 UI spec.
  * - `failed` — every stage rejected; rendered as unverified in the M2-C2 UI.
  */
 export type CitationVerificationMethod =
@@ -216,7 +220,8 @@ export type CitationVerificationMethod =
 	| 'tolerant_match'
 	| 'paraphrase_judge'
 	| 'llm_judge'
-	| 'ensemble'
+	| 'ensemble_strict'
+	| 'ensemble_majority'
 	| 'failed';
 
 export interface Citation {
@@ -235,8 +240,20 @@ export interface Citation {
 	 * M2-C1: true when the paraphrase judge returned `partial` — the source
 	 * supports the claim only partially. Drives the M2-C2 UI's "verified
 	 * with caveats" rendering. Defaults to `false` server-side.
+	 *
+	 * M2-D1 reuses the same flag for ensemble disagreement: an
+	 * `ensemble_majority` row with `partial=true` indicates at least one
+	 * judge dissented (the tooltip surfaces "Models disagreed").
 	 */
 	partial?: boolean;
+	/**
+	 * M2-D1: the maximum (weakest) inference tier across the judge
+	 * models that ran for ensemble-verified rows. Null for non-ensemble
+	 * methods. 1-5 per PRD §1.5.2. Audit-only; the UI does not gate
+	 * rendering on this value, but a future Receipts surface may
+	 * highlight ensembles that exposed citations to weaker tiers.
+	 */
+	tier_envelope?: number | null;
 	/** ISO-8601 timestamp the citation row was written. */
 	created_at?: string;
 }


### PR DESCRIPTION
## Summary

Stage 4 (ensemble verification) of the M2 Citation Engine cascade per [docs/M2-IMPLEMENTATION-PLAN.md §M2-D1](../blob/m2-d1-ensemble/docs/M2-IMPLEMENTATION-PLAN.md#L349). The paraphrase judge runs in parallel across N models; verdicts aggregate under operator-chosen `strict` (all must agree) / `majority` (simple majority wins) rules. Disagreement persists with `partial=true` so the M2-C2 UI flags it via tooltip.

**Six decisions locked at task kickoff** (M2-D1-A through M2-D1-F):

| ID | Decision |
|---|---|
| A | Replace bare `'ensemble'` with `'ensemble_strict'` / `'ensemble_majority'` in `verification_method` enum (migration 0027) |
| B | Cascade `1 → 2 → 4` when ensemble activated (Stage 3 skipped) |
| C | Pre-flight cost-budget estimate; fall back to single-judge Stage 3 if estimated > `max_cost_per_message_usd` |
| D | `projects.ensemble_verification` bool column (migration 0028); OR'd with skill flag + gateway default for activation |
| E | `message_citations.tier_envelope` SMALLINT for audit (api-side; chat tier untouched). _Pivoted from the originally-proposed gateway-routing-log column when implementation cost was ~200 LoC across both subsystems; api-side column is ~30 LoC._ |
| F | Reuse verified-paraphrase yellow chip for ensemble; tooltip wording varies by method + `partial` flag |

## Activation (Stage 4 only)

Three signals OR'd at the chat-send handler:

1. **Skill frontmatter**: `lq_ai.ensemble_verification: true` on any applied skill
2. **Project flag**: `projects.ensemble_verification = true`
3. **Gateway default**: `citation_engine.ensemble_verification.default_enabled: true`

When activated AND the per-message cost-budget pre-flight passes, the cascade routes to Stage 4. Budget overrun (`n_citations × n_judges × FLAT_PER_JUDGE_USD > max_cost_per_message_usd`) triggers `chat_message_ensemble_budget_fallback` warning and drops to Stage 3.

## Privacy envelope

Each judge dispatch is an inference request through the gateway. When `judge_models` spans tiers, the envelope is the *weakest* (highest-numbered) tier — computed server-side, surfaced via the config endpoint, persisted on `message_citations.tier_envelope` per row. Operators can audit which chats had citations exposed to weaker tiers.

## Test plan

- [x] api/ ruff format + check clean
- [x] gateway/ ruff format + check clean
- [x] api/ mypy clean (all files)
- [x] gateway/ mypy strict clean
- [x] api/ unit + integration tests pass against live postgres: **992 passed, 1 skipped** (+29 new)
- [x] gateway/ tests pass: **487 passed, 2 skipped** (+2 new)
- [x] web/ vitest: **456 passed** (+5 new)
- [x] Migrations 0027 + 0028 upgrade applied cleanly to live postgres
- [x] Migrations 0027 + 0028 downgrade applied cleanly (verified symmetric)
- [x] Re-upgrade after downgrade applied cleanly
- [ ] Manual end-to-end test with a real-stack chat configured with `ensemble_verification: true` on a skill + real provider key (operator-side verification — same posture as M2-A2/M2-B3 outstanding items)

## Files

**Source:**
- `api/alembic/versions/0027_ensemble_method_values.py` (new) — enum widening + `tier_envelope` column
- `api/alembic/versions/0028_projects_ensemble_verification.py` (new) — project activation flag
- `api/app/citation/verification.py` — `verify_ensemble()` + cascade router
- `api/app/api/chats.py` — `_resolve_ensemble_config()` activation + budget pre-flight; both streaming + non-streaming paths plumbed
- `api/app/clients/gateway.py` — `EnsembleConfig` dataclass + `get_citation_engine_ensemble_config()`
- `api/app/skills/schema.py` — `lq_ai.ensemble_verification` frontmatter field
- `api/app/models/chat.py` + `api/app/models/project.py` — schema model updates
- `gateway/app/config.py` + `gateway/app/api/inference.py` — config schema + endpoint extension with server-computed `envelope_tier`
- `web/src/lib/lq-ai/citations/state.ts` + `types.ts` — render-state + tooltip wording

**Docs:**
- `docs/citation-engine.md` (new) — full cascade reference; M2-D2 will extend with anonymization-integration section
- `docs/skill-authoring-guide.md` — `ensemble_verification` frontmatter field with privacy-envelope caveat
- `gateway.yaml.example` — operator-facing example + privacy note

**Tests:**
- `api/tests/citation/test_ensemble.py` (new, 23 tests)
- `api/tests/test_gateway_client.py` (6 new)
- `gateway/tests/test_inference.py` (2 new)
- `web/src/lib/lq-ai/__tests__/citation-render-state.test.ts` (5 new)

19 files changed, +2074 / -67 LOC.

## Dependencies + downstream

- **Depends on**: M2-C1 (paraphrase judge — Stage 3 implementation reused inside the ensemble).
- **Unblocks**: M2-D2 (Citation Engine ↔ Anonymization integration), M2-D4 (edge-case sweep), M2-E2 (ensemble calibration replaces `FLAT_PER_JUDGE_USD = 0.005` with measured numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)