### PR TITLE
M2-D2: Citation Engine ↔ Anonymization integration

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -1112,7 +1112,20 @@ async def send_message(
     gw_messages: list[ChatCompletionMessage] = []
     if retrieved_chunks:
         context_block = _format_retrieval_context_block(retrieved_chunks)
-        gw_messages.append(ChatCompletionMessage(role="system", content=context_block))
+        # M2-D2 / Decision M2-1: retrieved source documents are NOT
+        # pseudonymized when sent to the provider — the model needs
+        # intact source quotes for citation grounding. The skip flag
+        # tells the gateway's anonymization pre-middleware to leave
+        # this message's content unchanged even if the chat's other
+        # content is being pseudonymized. The pre-middleware still
+        # pseudonymizes the user turn + any chat-side system message.
+        gw_messages.append(
+            ChatCompletionMessage(
+                role="system",
+                content=context_block,
+                lq_ai_skip_anonymization=True,
+            )
+        )
         # T7-shape audit row. Same details schema as query_kb (kb_ids
         # plural here; query_kb is single-KB). The row commits with
         # its own boundary so it's durable even if the gateway call

--- a/api/app/schemas/gateway.py
+++ b/api/app/schemas/gateway.py
@@ -45,6 +45,13 @@ class ChatCompletionMessage(BaseModel):
     tool_call_id: str | None = None
     tool_calls: list[dict[str, Any]] | None = None
 
+    # M2-D2: when True, the gateway's anonymization pre-middleware
+    # leaves this message's content unchanged. The api/ sets this on
+    # the retrieval-context system message per Decision M2-1 so the
+    # model sees intact source quotes for citation grounding. Mirrors
+    # the gateway-side schema field of the same name.
+    lq_ai_skip_anonymization: bool = False
+
 
 class InlineSkillRef(BaseModel):
     """Wave D.2 Task 3.0 — one inline-body skill on a chat completion request.

--- a/api/tests/test_chat_citations.py
+++ b/api/tests/test_chat_citations.py
@@ -832,3 +832,85 @@ async def test_chat_send_judge_says_no_writes_no_citation(
 
     rows = (await db_session.execute(select(MessageCitation))).scalars().all()
     assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# M2-D2 — Citation Engine x Anonymization integration
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_chat_send_marks_retrieval_context_skip_anonymization(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb_attached: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """M2-D2 / Decision M2-1: retrieved source documents are NOT pseudonymized.
+
+    The api/ marks the retrieval-context system message with
+    ``lq_ai_skip_anonymization=True`` so the gateway middleware
+    leaves the chunk text untouched. The model needs intact source
+    quotes for citation grounding; pseudonymizing the retrieval
+    would make the model see ``PERSON_0001 agreed to ...`` and
+    produce citations the post-rehydrator must repair, polluting
+    the audit trail.
+
+    This test pins the api-side contract: the flag is set on the
+    retrieval message and ONLY on that message (user turn flag
+    stays default-False so the gateway middleware pseudonymizes
+    chat content as usual when anonymization is active).
+    """
+
+    import json as _stdlib_json
+
+    assistant_text = '"the employee shall not engage in any competing business" (Source: [1])'
+
+    captured_requests: list[dict[str, Any]] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(_stdlib_json.loads(request.content))
+        return httpx.Response(200, json=_success_payload(assistant_text))
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(side_effect=_capture)
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb_attached.id}/messages",
+            json={"content": "Quote the non-compete clause.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+    assert len(captured_requests) == 1
+    sent = captured_requests[0]
+
+    # The api/ injects a system message with the retrieval context as
+    # the first messages-array entry. Confirm it carries the skip
+    # marker.
+    system_msgs = [m for m in sent["messages"] if m.get("role") == "system"]
+    assert len(system_msgs) >= 1, "expected at least one system message (retrieval context)"
+    retrieval_msg = system_msgs[0]
+    assert "Retrieved context" in retrieval_msg.get("content", ""), (
+        "first system message should be the retrieval context block"
+    )
+    assert retrieval_msg.get("lq_ai_skip_anonymization") is True, (
+        "retrieval context system message must opt out of anonymization per M2-D2"
+    )
+
+    # The user turn must NOT carry the skip flag — its content is
+    # subject to anonymization when the middleware is active.
+    user_msgs = [m for m in sent["messages"] if m.get("role") == "user"]
+    assert len(user_msgs) >= 1
+    for msg in user_msgs:
+        assert msg.get("lq_ai_skip_anonymization", False) is False, (
+            "user turn must not opt out of anonymization"
+        )

--- a/api/tests/test_chat_rag.py
+++ b/api/tests/test_chat_rag.py
@@ -319,10 +319,14 @@ async def test_chat_send_with_attached_kb_writes_audit_and_prepends_context(
     assert "retrieved chunk #3" in messages[0]["content"]
     # File name + page rendered as the chunk header.
     assert "nda-template.pdf" in messages[0]["content"]
+    # M2-D2: retrieval-context system message opts out of anonymization
+    # so the model sees intact source quotes for citation grounding.
+    assert messages[0]["lq_ai_skip_anonymization"] is True
     # User turn unchanged at the end.
     assert messages[1] == {
         "role": "user",
         "content": "What does the NDA say about non-compete?",
+        "lq_ai_skip_anonymization": False,
     }
 
 
@@ -373,7 +377,9 @@ async def test_chat_send_with_attached_kb_and_empty_results_writes_no_audit(
 
     # Gateway request has only the user turn.
     sent_body = _json.loads(route.calls[0].request.read())
-    assert sent_body["messages"] == [{"role": "user", "content": "needle no haystack"}]
+    assert sent_body["messages"] == [
+        {"role": "user", "content": "needle no haystack", "lq_ai_skip_anonymization": False}
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -421,7 +427,9 @@ async def test_chat_send_with_project_but_no_kbs_skips_retrieval(
     assert audits == []
 
     sent_body = _json.loads(route.calls[0].request.read())
-    assert sent_body["messages"] == [{"role": "user", "content": "hello"}]
+    assert sent_body["messages"] == [
+        {"role": "user", "content": "hello", "lq_ai_skip_anonymization": False}
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -469,4 +477,6 @@ async def test_chat_send_standalone_chat_skips_retrieval(
     assert audits == []
 
     sent_body = _json.loads(route.calls[0].request.read())
-    assert sent_body["messages"] == [{"role": "user", "content": "hello world"}]
+    assert sent_body["messages"] == [
+        {"role": "user", "content": "hello world", "lq_ai_skip_anonymization": False}
+    ]

--- a/api/tests/test_chats_send_message.py
+++ b/api/tests/test_chats_send_message.py
@@ -345,7 +345,9 @@ async def test_send_message_translates_request_to_single_user_message(
 
     sent_body = _json.loads(route.calls[0].request.read())
     assert sent_body["model"] == "fast"
-    assert sent_body["messages"] == [{"role": "user", "content": "what is contract law"}]
+    assert sent_body["messages"] == [
+        {"role": "user", "content": "what is contract law", "lq_ai_skip_anonymization": False}
+    ]
     assert sent_body["chat_id"] == str(db_chat.id)
     # C3 — the new envelope fields are populated.
     assert sent_body["lq_ai_chat_id"] == str(db_chat.id)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2681,6 +2681,26 @@ This subsection consolidates security and compliance enhancements deferred from 
 
 **Acceptance criteria:** Capture of a chat reply containing a known injection pattern triggers the warning; the warning is keyboard-focusable; audit log captures the event with content hash + pattern matches; Cypress E2E covers both the clean-capture happy path and the warning-triggered review path.
 
+#### DE-269 — Anonymization Option A: pseudonymize source documents too
+
+**Priority:** P3 · **Effort:** M
+
+**Context:** Per **Decision M2-1** (M2 plan kickoff), the Anonymization Layer (§4.7) pseudonymizes only chat and skill content sent to the model; retrieved source documents stay un-pseudonymized so the model sees intact source quotes for citation grounding (§3.3). M2-D2 implements this by marking the retrieval-context system message with `lq_ai_skip_anonymization=True` so the gateway's pre-middleware leaves the content unchanged. The provider therefore sees:
+
+- Pseudonymized user/assistant chat content (`PERSON_0001` etc.)
+- Un-pseudonymized retrieved source chunks (`John Smith ...` from the source file)
+
+If the source-document corpus contains entities the operator considers sensitive (counterparty names, deal amounts, regulated identifiers), those entities reach the provider in cleartext as part of the retrieval payload. **Option A** is the alternative architecture: pseudonymize the source-document corpus too, on a copy used only for inference; render originals to the user via the rehydrator on the response path.
+
+**Specific scope:** Trade-offs to resolve:
+
+- **Citation grounding.** Stage 1 (exact-match) and Stage 2 (tolerant-match) verifiers read `documents.normalized_content` (un-pseudonymized) and compare against the model's emitted quote. Under Option A the model would quote `PERSON_0001`-style strings; the post-rehydrator would substitute originals before citation extraction sees them. This works today (the M2-B3 + M2-C3 round-trip suite implies it), but introduces an extra translation hop in the citation correctness path. Calibration of the cascade thresholds (M2-E2) might need re-running.
+- **Per-request pseudonym stability across mappers.** The per-request mapper already produces stable assignments for the same `(entity_type, original)` pair across user turn + retrieval. Under Option A, the same entity in multiple source documents would consistently pseudonymize to the same value within one request — but pseudonyms drift across requests, which is fine for one-shot Q&A but might surprise users who follow-up with `"What about COMPANY_0001?"` in a subsequent turn. Probably needs a cross-conversation stability mechanism (DE-XXX).
+- **Audit-log shape.** `inference_routing_log.anonymization_applied=true` would now be the common case rather than the careful-case; the field becomes less informative. May want a more granular signal (`anonymization_scope = "chat" | "chat+sources"`).
+- **Model reasoning quality.** Empirical question: does the model produce worse outputs when it must reason against pseudonymized source content rather than originals? A spot-check on the NDA Review / MSA Review skills before deciding to ship Option A.
+
+**Acceptance criteria:** Spot-check empirical study comparing model output quality on Option A vs M2-1 for at least three skills (NDA Review, MSA Review SaaS, DPA Checklist Review); cross-conversation pseudonym stability decision documented or filed as DE-XXX; audit-log shape extended if needed; `docs/security/anonymization.md` and `docs/citation-engine.md` updated to reflect Option A as the new default; existing M2-B3 / M2-C3 / M2-D2 round-trip tests passing with the new shape.
+
 #### DE-270 — Cryptography review: Fernet vs modern AEAD
 
 **Priority:** P3 · **Effort:** S

--- a/docs/citation-engine.md
+++ b/docs/citation-engine.md
@@ -150,21 +150,93 @@ per-judge `inference_routing_log` rows linked by `message_id`.
 
 ## Integration with Anonymization
 
-The Citation Engine and the Anonymization Layer coexist per Decision
-M2-1 (chat/skill content pseudonymized; retrieved source documents
-left un-pseudonymized). This means:
+The Citation Engine and the Anonymization Layer coexist per **Decision
+M2-1**: chat/skill content gets pseudonymized; retrieved source
+documents stay un-pseudonymized. The integration boundary is the
+`lq_ai_skip_anonymization` field on `ChatCompletionMessage`.
 
-- Citations operate on **un-pseudonymized** source text on both
-  extraction and verification sides — the Stage 3/4 judge sees the
-  real cited content and the real source chunk.
-- The model may emit citations that reference real entities (from
-  retrieved sources) AND prose that references pseudonyms (from
-  pseudonymized chat content). The post-anonymization middleware
-  rehydrates pseudonyms; citations need no rehydration step.
+### Data flow (M2-D2)
 
-M2-D2 ships the integration tests and documents the data flow in
-detail. See [docs/security/anonymization.md](security/anonymization.md)
-for the corresponding anonymization-side description.
+A chat send with both layers active follows this path:
+
+1. **User turn arrives at the api/** — `"What did Acme Corp agree to?"`.
+2. **api/ retrieves source chunks** via `hybrid_search` against the
+   chat's project KBs — chunks contain original entities verbatim
+   (`"Acme Corp agreed to ..."`).
+3. **api/ assembles the gateway request** — prepends the retrieval
+   chunks as a `system` message **with `lq_ai_skip_anonymization=True`**.
+   The user turn becomes a `user` message with no skip flag.
+4. **Gateway pre-anonymization middleware** runs:
+   - User turn → `"What did COMPANY_0001 agree to?"` (pseudonymized)
+   - Retrieval system message → unchanged (skip flag honored)
+   - Per-request `PseudonymMapper` carries the `COMPANY_0001 → Acme Corp`
+     mapping
+5. **Provider sees** pseudonymized user turn + un-pseudonymized
+   retrieval — the model has the original source quotes available
+   for citation grounding and can reason about `COMPANY_0001` as the
+   subject of the user's question.
+6. **Provider responds** with `'The agreement says "Acme Corp shall
+   not compete..." (Source: [1]). COMPANY_0001 is bound for 2
+   years.'` — quoting the retrieval verbatim, referring to the
+   pseudonym for the entity from the user turn.
+7. **Gateway post-anonymization middleware** rehydrates:
+   `"COMPANY_0001"` → `"Acme Corp"`. The cited quote (already real)
+   is unchanged.
+8. **api/ persist_citations** extracts `"Acme Corp shall not
+   compete..." (Source: [1])` from the rehydrated text; Stage 1
+   verifies the quote byte-for-byte against
+   `documents.normalized_content` (un-pseudonymized). Verified
+   citation row lands.
+
+### What the provider sees vs what the user sees
+
+| Layer | Provider sees | User sees |
+|---|---|---|
+| User turn | `COMPANY_0001` (pseudonymized) | `Acme Corp` (original; user typed it) |
+| Retrieved chunks | `Acme Corp` (un-pseudonymized, skip flag) | n/a (retrieval is gateway-internal) |
+| Assistant prose with pseudonyms | `COMPANY_0001 is bound` | `Acme Corp is bound` (rehydrated) |
+| Assistant citation quote | `"Acme Corp shall not compete..."` (real, came from un-pseudonymized retrieval) | `"Acme Corp shall not compete..."` (identical; no rehydration needed) |
+
+### Why this matters for citation correctness
+
+If the retrieval were pseudonymized too (the Option A path captured
+as [DE-269](PRD.md#de-269--anonymization-option-a-pseudonymize-source-documents-too)):
+
+- The model would see `"PERSON_0001 agreed to pay COMPANY_0001 ..."`
+  in the retrieved chunk.
+- The model would emit citations quoting pseudonyms: `'"PERSON_0001
+  agreed to pay COMPANY_0001 ..." (Source: [1])'`.
+- The post-rehydrator would have to fix the cited quote before
+  citation extraction sees it; the cascade would then verify the
+  rehydrated quote against the un-pseudonymized
+  `documents.normalized_content`. End-to-end this works, but it
+  adds a translation hop on the citation correctness path and makes
+  the audit trail noisier (everything is pseudonymized; the
+  `anonymization_applied` audit field stops carrying granular
+  signal).
+
+Decision M2-1 keeps the citation correctness path direct: the model
+sees real source quotes, emits real source quotes, and the verifier
+matches them against un-pseudonymized content with no translation
+hop.
+
+### Privileged chats (M2-B3)
+
+When the chat's project is `privileged: true`, the gateway
+pre-middleware **skips the entire request** (not just the retrieval
+message) — privileged content rides un-pseudonymized end-to-end.
+The skip flag is irrelevant in this case; everything bypasses
+pseudonymization. M2-D3 covers privileged-project handling in
+detail.
+
+### Tests pinning the integration
+
+- **api-side**: `tests/test_chat_citations.py::test_chat_send_marks_retrieval_context_skip_anonymization` pins that the api/ sets the skip flag on the retrieval system message and only on that message.
+- **gateway-side**: `tests/anonymization/test_middleware.py::test_pre_anonymize_skips_message_marked_skip_anonymization` pins that the middleware honors the flag.
+- **gateway-side**: `tests/test_openai_adapter.py::test_chat_completion_strips_per_message_lq_ai_skip_anonymization` pins that the field is stripped before reaching OpenAI (which 400s on unknown body fields).
+
+See [docs/security/anonymization.md](security/anonymization.md) for
+the anonymization-layer-side description of the same integration.
 
 ## References
 

--- a/docs/security/anonymization.md
+++ b/docs/security/anonymization.md
@@ -2,13 +2,13 @@
 
 > **Purpose.** Document the entity types LQ.AI's Anonymization Layer (PRD §4.7) recognizes by default, the deliberately-disabled defaults, and how to customize the recognizer set for a specific deployment's matter-numbering convention or domain-specific entities.
 >
-> **Status (2026-05-16).** M2-B3 complete: the gateway middleware now pseudonymizes outbound chat/skill content and rehydrates the response (streaming and non-streaming). M2-B2's custom legal recognizers + Presidio `AnalyzerEngine` configuration remain unchanged; M2-A3's `PseudonymMapper` is the request-scoped substitution table.
+> **Status (2026-05-17).** M2-B3 complete: the gateway middleware now pseudonymizes outbound chat/skill content and rehydrates the response (streaming and non-streaming). M2-D2 wires the retrieval-context skip flag so source chunks reach the provider un-pseudonymized (see [Retrieval-context skip](#retrieval-context-skip-m2-d2) below). M2-B2's custom legal recognizers + Presidio `AnalyzerEngine` configuration remain unchanged; M2-A3's `PseudonymMapper` is the request-scoped substitution table.
 
 ---
 
 ## What gets pseudonymized
 
-Per the **M2-1 decision** locked at M2 kickoff, anonymization applies only to **chat and skill content** sent to the model. Retrieved source documents stay un-pseudonymized so the existing retrieval surface continues to render real document text to the user. The alternative (Option A — pseudonymize the document corpus too) is filed as **DE-269** for future consideration.
+Per the **M2-1 decision** locked at M2 kickoff, anonymization applies only to **chat and skill content** sent to the model. Retrieved source documents stay un-pseudonymized so the model sees intact source quotes for citation grounding and the user-facing retrieval surface continues to render real document text. The skip mechanism is the `lq_ai_skip_anonymization` field on `ChatCompletionMessage`: the api/ marks the retrieval-context system message with `True`; the gateway middleware honors the flag and leaves that message's content alone. See [Retrieval-context skip](#retrieval-context-skip-m2-d2) below for the data flow. The alternative (Option A — pseudonymize the document corpus too) is filed as **[DE-269](../PRD.md#de-269--anonymization-option-a-pseudonymize-source-documents-too)** for future consideration.
 
 ## Recognizer set
 
@@ -173,6 +173,26 @@ Per **Decision A** and **Decision B (i)** locked in M2-B3 kickoff: a fresh `Pseu
 ### Privileged chats — why we skip
 
 The privileged-Project skip (Decision A) is a deliberate trade-off. Privileged chats are work product the attorney-client privilege protects; replacing names with pseudonyms before the model sees them — even with the rehydration on the way back — risks corrupting that work product if any step in the pipeline behaves unexpectedly. The conservative posture is to leave privileged content untouched. Operators who want pseudonymization in privileged chats can flip `lq_ai_privileged` off at the api/ layer per chat, but the default protects the legal-work-product invariant.
+
+### Retrieval-context skip (M2-D2)
+
+Per **Decision M2-1**, retrieved source documents are NOT pseudonymized when sent to the provider. The api/ marks the retrieval-context system message (the one carrying chunks returned from `hybrid_search`) with `lq_ai_skip_anonymization=True`; the pre-middleware honors the flag and leaves the message's content unchanged. The model therefore sees:
+
+- **User turn**: pseudonymized — `"What did COMPANY_0001 agree to?"`
+- **Retrieval context system message**: un-pseudonymized — `"Acme Corp agreed to ..."` from the source file
+- **Other system messages** (chat system instructions, skill-assembled prompts): pseudonymized normally — only the retrieval-context message bears the skip flag
+
+The skip flag is api-internal: the gateway strips it from each message before serializing the request to upstream providers (the OpenAI adapter is the only one where this matters — Anthropic and Ollama adapters build per-message dicts field-by-field and ignore unknown attributes implicitly).
+
+**Why this design.** The Citation Engine (§3.3 / [docs/citation-engine.md](../citation-engine.md)) verifies model-emitted quotes byte-for-byte against `documents.normalized_content` (un-pseudonymized). When the model sees real source quotes in retrieval, it emits real source quotes in its citations — Stage 1 verification matches directly with no translation hop. When the model emits pseudonyms in its prose (referencing entities from the pseudonymized user turn), the post-rehydrator on this layer substitutes originals back. The two layers compose cleanly: the model reasons about a consistent set of pseudonyms for chat-side entities and real names for source-side entities.
+
+The alternative — Option A, pseudonymize source documents too — is filed as [DE-269](../PRD.md#de-269--anonymization-option-a-pseudonymize-source-documents-too) for future consideration. Option A adds a translation hop on the citation correctness path and makes the audit trail less granular; the spot-check is whether the model produces materially better/worse output when reasoning against pseudonymized vs un-pseudonymized retrieval.
+
+Pinning tests:
+
+- `gateway/tests/anonymization/test_middleware.py::test_pre_anonymize_skips_message_marked_skip_anonymization` — middleware honors the flag.
+- `gateway/tests/test_openai_adapter.py::test_chat_completion_strips_per_message_lq_ai_skip_anonymization` — flag is stripped before reaching OpenAI.
+- `api/tests/test_chat_citations.py::test_chat_send_marks_retrieval_context_skip_anonymization` — the api/ sets the flag on the retrieval system message and ONLY on that message.
 
 ---
 

--- a/gateway/app/anonymization/middleware.py
+++ b/gateway/app/anonymization/middleware.py
@@ -94,6 +94,15 @@ def pre_anonymize_request(
             continue
         if message.content is None:
             continue
+        # M2-D2: per Decision M2-1, retrieved source documents stay
+        # un-pseudonymized so the model sees intact source quotes for
+        # citation grounding. The api/ marks the retrieval-context
+        # system message with ``lq_ai_skip_anonymization=True``; the
+        # middleware honors the flag here. Other system messages (the
+        # chat's own system instructions, skill-assembled prompts)
+        # still get pseudonymized normally.
+        if getattr(message, "lq_ai_skip_anonymization", False):
+            continue
         message.content = anonymizer.pseudonymize_into(message.content, mapper)
 
     if chat_request.lq_ai_skill_inputs:

--- a/gateway/app/providers/openai.py
+++ b/gateway/app/providers/openai.py
@@ -101,6 +101,12 @@ _LQ_AI_EXTENSION_KEYS = frozenset(
     }
 )
 
+# M2-D2: per-message LQ.AI extension keys that must not reach OpenAI.
+# Anthropic / Ollama adapters build message dicts field-by-field so
+# they ignore these implicitly; the OpenAI adapter uses ``model_dump``
+# and needs the explicit strip.
+_LQ_AI_MESSAGE_EXTENSION_KEYS = frozenset({"lq_ai_skip_anonymization"})
+
 logger = logging.getLogger(__name__)
 
 
@@ -476,6 +482,15 @@ def _to_openai_request(
     body = request.model_dump(mode="json", exclude_none=True)
     for key in _LQ_AI_EXTENSION_KEYS:
         body.pop(key, None)
+    # M2-D2: per-message LQ.AI keys (e.g., lq_ai_skip_anonymization)
+    # are api-internal markers; strip from each message so OpenAI's
+    # strict body validation doesn't reject the request.
+    messages = body.get("messages")
+    if isinstance(messages, list):
+        for msg in messages:
+            if isinstance(msg, dict):
+                for key in _LQ_AI_MESSAGE_EXTENSION_KEYS:
+                    msg.pop(key, None)
     body["model"] = model
     body["stream"] = stream
     # ``stream_options.include_usage`` is required for OpenAI to emit a

--- a/gateway/app/providers/openai_schema.py
+++ b/gateway/app/providers/openai_schema.py
@@ -73,6 +73,17 @@ class ChatCompletionMessage(BaseModel):
     tool_call_id: str | None = None
     tool_calls: list[dict[str, Any]] | None = None
 
+    # M2-D2: when True, the gateway's anonymization pre-middleware
+    # leaves this message's content unchanged even if anonymization
+    # is otherwise active for the request. Per Decision M2-1, the
+    # api/ sets this on the retrieval-context system message so
+    # source documents in retrieval are NOT pseudonymized before
+    # being sent to the provider — the model needs intact source
+    # quotes for citation grounding. The flag is api-internal
+    # (``lq_ai_`` prefix); it's stripped before the request leaves
+    # the gateway for any upstream provider.
+    lq_ai_skip_anonymization: bool = False
+
 
 class InlineSkillRef(BaseModel):
     """Wave D.2 Task 3.0 — one inline-body skill on a chat completion request.

--- a/gateway/tests/anonymization/test_middleware.py
+++ b/gateway/tests/anonymization/test_middleware.py
@@ -267,6 +267,88 @@ def test_pre_anonymize_same_name_across_messages_stable_pseudonym() -> None:
 
 
 @pytest.mark.unit
+def test_pre_anonymize_skips_message_marked_skip_anonymization() -> None:
+    """M2-D2: ``lq_ai_skip_anonymization=True`` bypasses pseudonymization.
+
+    Per Decision M2-1, the api/ marks the retrieval-context system
+    message with this flag so the model sees intact source quotes for
+    citation grounding. Other messages in the same request still get
+    pseudonymized normally — entities present in both the marked
+    message AND another message land with consistent pseudonyms on the
+    other-message side (the mapper is per-request).
+    """
+
+    req = _make_request(
+        messages=[
+            ChatCompletionMessage(
+                role="system",
+                content="Retrieved chunk: John Smith agreed to pay $100k.",
+                lq_ai_skip_anonymization=True,
+            ),
+            ChatCompletionMessage(
+                role="user",
+                content="What did John Smith agree to?",
+            ),
+        ]
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer(
+        {
+            # Both messages contain "John Smith" at the same offset;
+            # only the user turn should be pseudonymized.
+            "Retrieved chunk: John Smith agreed to pay $100k.": [_Span("PERSON", 17, 27)],
+            "What did John Smith agree to?": [_Span("PERSON", 9, 19)],
+        }
+    )
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    # Retrieval-context system message: unchanged (skip flag honored).
+    assert req.messages[0].content == "Retrieved chunk: John Smith agreed to pay $100k."
+    # User turn: pseudonymized normally.
+    assert req.messages[1].content == "What did PERSON_0001 agree to?"
+    # The mapper carries only the user-turn assignment; provider sees
+    # the real name in the retrieval chunk and the pseudonym in the
+    # user turn (the per-request mapper would have reused PERSON_0001
+    # if the skipped message had also been pseudonymized).
+    assert mapper.reverse() == {"PERSON_0001": "John Smith"}
+
+
+@pytest.mark.unit
+def test_pre_anonymize_skip_flag_false_pseudonymizes_normally() -> None:
+    """Default ``lq_ai_skip_anonymization=False`` retains M2-B3 behavior."""
+
+    req = _make_request(
+        messages=[
+            ChatCompletionMessage(
+                role="system",
+                content="Chat system: John Smith.",
+                # Explicit False; default would behave identically.
+                lq_ai_skip_anonymization=False,
+            ),
+        ]
+    )
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({"Chat system: John Smith.": [_Span("PERSON", 13, 23)]})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    assert req.messages[0].content == "Chat system: PERSON_0001."
+
+
+@pytest.mark.unit
 def test_pre_anonymize_skips_message_with_none_content() -> None:
     """``content=None`` messages (tool-call shaped) are left alone, not crashed."""
 

--- a/gateway/tests/test_openai_adapter.py
+++ b/gateway/tests/test_openai_adapter.py
@@ -470,6 +470,60 @@ async def test_chat_completion_strips_lq_ai_extension_keys() -> None:
 
 
 @pytest.mark.unit
+async def test_chat_completion_strips_per_message_lq_ai_skip_anonymization() -> None:
+    """M2-D2: per-message ``lq_ai_skip_anonymization`` is stripped before sending.
+
+    OpenAI's body validation rejects unknown fields, including
+    unknown per-message fields. The api/ sets this flag on the
+    retrieval-context system message so the gateway middleware
+    leaves the content un-pseudonymized, but the flag itself must
+    never leave the gateway — OpenAI would 400.
+    """
+
+    payload = {
+        "id": "x",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "gpt-4o",
+        "choices": [
+            {"index": 0, "message": {"role": "assistant", "content": ""}, "finish_reason": "stop"}
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1},
+    }
+    request = ChatCompletionRequest(
+        model="gpt-4o",
+        messages=[
+            ChatCompletionMessage(
+                role="system",
+                content="Retrieved context: ...",
+                lq_ai_skip_anonymization=True,
+            ),
+            ChatCompletionMessage(role="user", content="hi"),
+        ],
+    )
+    with respx.mock(base_url="https://api.openai.com/v1") as router:
+        route = router.post("/chat/completions").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        client = httpx.AsyncClient(base_url="https://api.openai.com/v1")
+        try:
+            adapter = OpenAIAdapter(
+                name="openai-prod",
+                base_url="https://api.openai.com/v1",
+                api_key="sk-test",
+                client=client,
+            )
+            await adapter.chat_completion(request, model="gpt-4o", stream=False)
+        finally:
+            await client.aclose()
+    sent = json.loads(route.calls.last.request.content)
+    for msg in sent["messages"]:
+        assert "lq_ai_skip_anonymization" not in msg, (
+            f"per-message LQ.AI extension leaked to OpenAI: {msg}"
+        )
+
+
+@pytest.mark.unit
 async def test_chat_completion_inline_skill_body_does_not_leak_to_openai() -> None:
     """Wave D.2 Task 3.0 security — ``lq_ai_inline_skills`` (and the
     verbatim user-drafted body inside it) must NEVER reach OpenAI.


### PR DESCRIPTION
## Summary

Closes the deviation between **Decision M2-1** (the chosen architecture) and the M2-B3 implementation, surfaced during M2-D2's "verify the integration in practice" step.

**The gap:** M2-1 says retrieved source documents are NOT pseudonymized when sent to the provider — the model needs intact source quotes for citation grounding. M2-B3's middleware was pseudonymizing every system message, including the retrieval-context block the api/ injects at [chats.py:1112](../blob/m2-d2-citation-anonymization/api/app/api/chats.py#L1112). That's effectively running **Option A** (the alternative the spec deferred as DE-269), not M2-1.

**Why this wasn't visible:** the rehydrator restores originals end-to-end before the citation cascade sees them, so citations still landed verified. The deviation only shows up in what the provider receives — the audit gap was real but had no observable correctness effect.

## Mechanism

`lq_ai_skip_anonymization: bool = False` field added to `ChatCompletionMessage`:

| Layer | Action |
|---|---|
| **api/** ([`chats.py:1112-1126`](../blob/m2-d2-citation-anonymization/api/app/api/chats.py#L1112-L1126)) | Sets the flag to `True` on the retrieval-context system message only. User turn + chat-side system messages keep default `False`. |
| **gateway middleware** ([`middleware.py:92-105`](../blob/m2-d2-citation-anonymization/gateway/app/anonymization/middleware.py#L92-L105)) | Honors the flag — skips pseudonymization for messages where `lq_ai_skip_anonymization=True`. |
| **OpenAI adapter** ([`openai.py:478-490`](../blob/m2-d2-citation-anonymization/gateway/app/providers/openai.py#L478-L490)) | Strips the field per-message before serialization (OpenAI 400s on unknown body fields). Anthropic / Ollama adapters ignore it implicitly since they build per-message dicts field-by-field. |

The two-layer composition works because the per-request `PseudonymMapper` produces stable assignments for the same `(entity_type, original)` pair across user turn + retrieval. The model sees:

- **User turn**: `"What did COMPANY_0001 agree to?"` (pseudonymized)
- **Retrieval chunks**: `"Acme Corp agreed to ..."` (un-pseudonymized, skip flag)
- **Reasons consistently**: same entity, different mention modes

Model emits citations quoting real source text directly. Cascade Stage 1 verifies byte-for-byte against `documents.normalized_content`. Post-rehydrator restores `COMPANY_0001 → Acme Corp` in model prose. Citations land verified with no translation hop.

## Documentation

- **`docs/citation-engine.md`** — replaces the M2-D1 placeholder with the full "Integration with Anonymization" section: step-by-step data flow, "what the provider sees vs what the user sees" table, why this matters for citation correctness, privileged-chat carve-out, pinning tests.
- **`docs/security/anonymization.md`** — adds the "Retrieval-context skip (M2-D2)" section; updates the top-of-doc M2-1 paragraph to mention the skip mechanism + cross-link DE-269.
- **`docs/PRD.md` §9 DE-269** (new) — "Anonymization Option A: pseudonymize source documents too" with the citation-grounding trade-off, per-request stability question, audit-log shape implications, and acceptance criteria (spot-check empirical study on three skills before flipping the default).

## Tests

| Layer | New | Updated |
|---|---|---|
| gateway middleware | 2 (skip honored / default-False pseudonymizes normally) | — |
| gateway OpenAI adapter | 1 (per-message skip flag stripped before reaching OpenAI) | — |
| api integration | 1 (api/ sets skip=True on retrieval, skip=False on user turn) | — |
| api existing assertions | — | 5 (test_chat_rag + test_chats_send_message fixtures include the new field) |

## Test plan

- [x] api/ ruff format + check + mypy clean
- [x] gateway/ ruff format + check + mypy strict clean
- [x] api/ full suite vs live postgres: **993 passed, 1 skipped** (+1 new)
- [x] gateway/ full suite: **490 passed, 2 skipped** (+3 new)
- [x] M2-B3 + M2-C3 round-trip suite still green (no semantic regression on existing anonymization behavior)
- [ ] Manual end-to-end test with a real-stack chat: anonymization enabled, RAG context retrieved, real provider key — verify provider sees pseudonymized chat + un-pseudonymized retrieval AND citations render verified (operator-side verification — same posture as M2-A2/M2-B3 outstanding items)

## Files

**Source:**
- `api/app/api/chats.py` — set skip flag on retrieval system message
- `api/app/schemas/gateway.py` — mirror field on api-side `ChatCompletionMessage`
- `gateway/app/providers/openai_schema.py` — field on gateway-side `ChatCompletionMessage`
- `gateway/app/anonymization/middleware.py` — middleware honors flag
- `gateway/app/providers/openai.py` — strip per-message before forwarding

**Docs:** `docs/citation-engine.md`, `docs/security/anonymization.md`, `docs/PRD.md` (§9 new DE-269)

**Tests:** 3 new + 5 updated

13 files changed, +419 / -22 LOC.

## Dependencies + downstream

- **Depends on**: M2-C3 (round-trip suite that pins the existing anonymization invariants this PR preserves), M2-D1 (cascade lands ensemble; D2 documents how the integration works for all four stages).
- **Unblocks**: M2-D3 (privileged-project handling — separate skip path, already implemented in M2-B3, D3 is the verification + audit-doc task), M2-D4 (edge-case sweep).
- **Defers to follow-on**: DE-269 (Option A spot-check + decision); operator-side manual smoke test against a real provider key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)