### PR TITLE
M2-D3: Privileged-project handling — verification + procurement-readiness

### DIFF
--- a/api/tests/test_chat_citations.py
+++ b/api/tests/test_chat_citations.py
@@ -914,3 +914,184 @@ async def test_chat_send_marks_retrieval_context_skip_anonymization(
         assert msg.get("lq_ai_skip_anonymization", False) is False, (
             "user turn must not opt out of anonymization"
         )
+
+
+# ---------------------------------------------------------------------------
+# M2-D3 — Privileged-project handling (verification + audit trail)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def privileged_project_for_owner(db_session: AsyncSession, owner_user: User) -> Project:
+    """A privileged project — anonymization middleware skips its chats.
+
+    The CHECK ``chk_projects_privileged_implies_tier`` requires a
+    non-NULL ``minimum_inference_tier`` when ``privileged=True``;
+    Tier 2 is the typical posture for privileged matters per PRD §5.3
+    (local Tier 1 preferred where possible; Tier 2 allows enterprise-
+    ZDR upstreams when local capacity is insufficient).
+    """
+
+    project = Project(
+        owner_id=owner_user.id,
+        name="Privileged matter (Smith v Acme)",
+        slug=f"privileged-{uuid.uuid4().hex[:8]}",
+        privileged=True,
+        minimum_inference_tier=2,
+    )
+    db_session.add(project)
+    await db_session.flush()
+    return project
+
+
+@pytest_asyncio.fixture
+async def privileged_chat_with_kb(
+    db_session: AsyncSession,
+    owner_user: User,
+    privileged_project_for_owner: Project,
+    kb_for_owner: KnowledgeBase,
+) -> Chat:
+    """A chat inside a privileged project, with a KB attached.
+
+    Combines the M2-D3 privileged-handling path with the Citation
+    Engine retrieval path so a single end-to-end test can pin both
+    behaviors at once.
+    """
+
+    junction = ProjectKnowledgeBase(
+        project_id=privileged_project_for_owner.id,
+        knowledge_base_id=kb_for_owner.id,
+    )
+    db_session.add(junction)
+    chat = Chat(
+        owner_id=owner_user.id,
+        project_id=privileged_project_for_owner.id,
+        title="privileged-chat-test",
+    )
+    db_session.add(chat)
+    await db_session.flush()
+    return chat
+
+
+@respx.mock
+async def test_chat_send_privileged_project_full_audit_trail(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    privileged_project_for_owner: Project,
+    privileged_chat_with_kb: Chat,
+    source_file: FileModel,
+    source_document: Document,
+    source_chunk: DocumentChunk,
+) -> None:
+    """M2-D3: a chat in a privileged project produces a clean audit trail.
+
+    Three invariants pinned by this test:
+
+    1. **Gateway request carries the privilege signal.** The api/
+       reads ``Project.privileged`` and forwards
+       ``lq_ai_privileged=True`` + ``lq_ai_project_minimum_inference_tier=2``
+       so the gateway middleware can skip pseudonymization and the
+       tier-floor enforcement applies.
+    2. **audit_log row marks the action privileged.** The
+       ``audit_action`` helper resolves the project's privilege flag
+       and writes ``privilege_marked=True`` + ``privilege_basis``
+       containing the project name on the ``chat.message_sent`` row.
+    3. **Citation Engine operates normally.** No special path for
+       privileged projects on the citation verification side; the
+       verbatim quote is verified and persisted exactly as for a
+       non-privileged chat.
+
+    The gateway-side invariants (middleware skip + provider receives
+    un-pseudonymized content + ``routing_log.anonymization_applied=False``)
+    are covered by ``gateway/tests/test_inference_anonymization.py::
+    test_privileged_request_skips_middleware``; this test pins the
+    api-side contract feeding into that gateway behavior.
+    """
+
+    import json as _stdlib_json
+
+    quote = "the employee shall not engage in any competing business"
+    assert quote in source_chunk.content
+    assistant_text = (
+        f'Per the agreement, "{quote}" (Source: [1]). This is a privileged matter context.'
+    )
+
+    captured_requests: list[dict[str, Any]] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(_stdlib_json.loads(request.content))
+        return httpx.Response(200, json=_success_payload(assistant_text))
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(side_effect=_capture)
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[_hybrid_result_for(source_chunk, source_document, source_file)]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{privileged_chat_with_kb.id}/messages",
+            json={"content": "What does the non-compete say?", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+    assert len(captured_requests) == 1
+    sent = captured_requests[0]
+
+    # Invariant 1: privilege signal reaches the gateway.
+    assert sent.get("lq_ai_privileged") is True, (
+        "privileged chats must forward lq_ai_privileged=True so the gateway "
+        "middleware can skip pseudonymization"
+    )
+    assert sent.get("lq_ai_project_minimum_inference_tier") == 2, (
+        "privileged projects forward their tier floor so the gateway can enforce it"
+    )
+
+    # Invariant 2: audit_log row marks the chat-message-sent action privileged.
+    from app.models.audit import AuditLog
+
+    audit_rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.user_id == owner_user.id,
+                    AuditLog.action == "chat.message_sent",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audit_rows) == 1, f"expected one chat.message_sent row, got {len(audit_rows)}"
+    row = audit_rows[0]
+    assert row.privilege_marked is True, "privileged-project actions must be marked"
+    assert row.privilege_basis is not None
+    assert privileged_project_for_owner.name in row.privilege_basis, (
+        f"privilege_basis should name the project; got {row.privilege_basis!r}"
+    )
+    assert row.routed_inference_tier == 3, (
+        "routed_inference_tier should mirror the gateway response's tier"
+    )
+
+    # Invariant 3: Citation Engine operates normally — no special path
+    # for privileged projects. The verbatim quote verified via Stage 1
+    # exactly as for a non-privileged chat.
+    citation_rows = (
+        (
+            await db_session.execute(
+                select(MessageCitation).where(MessageCitation.source_file_id == source_file.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(citation_rows) == 1, (
+        f"Citation Engine must operate normally for privileged chats; got {len(citation_rows)} rows"
+    )
+    cite = citation_rows[0]
+    assert cite.verified is True
+    assert cite.verification_method == "exact_match"
+    assert cite.source_text == quote

--- a/docs/procurement/README.md
+++ b/docs/procurement/README.md
@@ -10,7 +10,7 @@ The Procurement-Readiness Pack is the project's contribution to that work: pre-f
 
 | Document | Status | Description |
 |---|---|---|
-| `sig-lite.md` | TBD ([DE-086](../PRD.md#de-086--procurement-readiness-pack)) | Pre-filled SIG Lite questionnaire calibrated to the typical LQ.AI deployment. |
+| [`sig-lite.md`](sig-lite.md) | **Starter (M2-D3)** — privileged-matter handling only; full pack [DE-086](../PRD.md#de-086--procurement-readiness-pack) | Pre-filled SIG Lite responses calibrated to the typical LQ.AI deployment. The M2-D3 starter covers the data-protection + audit questions whose answers depend on the privileged-project handling; community contributions fill in the remaining ~15 SIG Lite domains. |
 | `caiq.md` | TBD ([DE-086](../PRD.md#de-086--procurement-readiness-pack)) | Pre-filled CAIQ Lite questionnaire mapped to CSA Cloud Controls Matrix. |
 | `cover-letter.md` | TBD | Sample cover letter the operator can adapt for their procurement team — explains what LQ.AI is, why it's an unusual procurement (self-hosted open source rather than SaaS), and points at relevant artifacts. |
 | `aup-soc-template.md` | Future | Template Acceptable Use Policy and Statement of Operational Controls the operator can adapt for their internal AI-governance program. |

--- a/docs/procurement/sig-lite.md
+++ b/docs/procurement/sig-lite.md
@@ -1,0 +1,98 @@
+# SIG Lite — Privileged-Matter Handling (M2-D3 starter scope)
+
+> **Scope of this file**: a **focused starter** covering only the SIG Lite questions whose answers depend on the privileged-project handling implemented in M2-B3 / verified in M2-D3. The **full Procurement-Readiness Pack** (every SIG Lite domain, plus CAIQ, plus cover letter) is **out of scope here** and tracked as [DE-086](../PRD.md#de-086--procurement-readiness-pack); this file is the starter for that work.
+>
+> Operators reviewing this file for their own procurement cycle should treat it as a complement to (not a substitute for) the full SIG Lite questionnaire. Items not covered here either don't bear on privileged-matter handling or belong to a SIG Lite domain DE-086 will fill in.
+
+---
+
+## How to read this file
+
+Each question below follows the format established in [`docs/procurement/README.md`](README.md):
+
+- **Question** — text from the SIG Lite questionnaire (paraphrased where the source uses domain-specific shorthand).
+- **Project response** — the answer applicable to a standard LQ.AI deployment with privileged matters configured per the recommended posture.
+- **`[OPERATOR-CONFIGURABLE]`** — where the answer depends on operator-specific deployment choices.
+- **References** — relevant PRD sections, security artifacts, and code-side enforcement points.
+
+---
+
+## Data Protection & Privacy Domain (D — selected questions)
+
+### D.1.3 — How is sensitive data classified, and what controls apply to each classification?
+
+**Project response.** LQ.AI provides a two-tier classification mechanism at the application layer:
+
+1. **Non-privileged matters** — the default. Anonymization Layer (PRD §4.7) pseudonymizes user/assistant chat content before transmission to the configured inference provider; retrieved source documents remain un-pseudonymized so the model can reason against intact source text (per [Decision M2-1](anonymization.md#what-gets-pseudonymized)). The pre-anonymization step covers the standard Presidio entity set (PERSON, ORGANIZATION, EMAIL_ADDRESS, PHONE_NUMBER, LOCATION) plus two custom legal recognizers (CaseNumberRecognizer, MatterNumberRecognizer per M2-B2). The post-anonymization step rehydrates pseudonyms back to originals in the model's response before it reaches the user.
+
+2. **Privileged matters** — explicit operator/user designation via the `Project.privileged` flag (`docs/db-schema.md` → `projects` table). Anonymization is **disabled** for chats inside privileged projects (per [Decision A — privileged-skip](anonymization.md#privileged-chats--why-we-skip-m2-b3--m2-d3)): the content reaches the provider verbatim because rewriting privileged work product risks corrupting it and may complicate later assertion of privilege over the artifact. Privileged projects pair with `minimum_inference_tier` (DB CHECK constraint enforces non-NULL when `privileged=true`) so the operator can require local-only (Tier 1) routing for the most sensitive matters.
+
+The control set differs by classification:
+
+| Control | Non-privileged | Privileged (Tier 1 local) | Privileged (Tier 2+ ZDR) |
+|---|---|---|---|
+| Pre-transmission pseudonymization | Yes | N/A (no transmission) | No |
+| Tier-floor enforcement (gateway) | Optional per project | Tier 1 required | Tier 2+ allowed per project setting |
+| Audit `privilege_marked` | `false` | `true` | `true` |
+| Audit `privilege_basis` | NULL | `project:<name>` | `project:<name>` |
+| Provider sees raw entity names | No (pseudonymized) | N/A (local) | Yes |
+
+**References:** [`docs/security/anonymization.md` §What gets pseudonymized](anonymization.md#what-gets-pseudonymized); [`docs/security/anonymization.md` §Privileged chats](anonymization.md#privileged-chats--why-we-skip-m2-b3--m2-d3); PRD §1.5.2 (Inference Tiers), PRD §4.7 (Anonymization Layer).
+
+---
+
+### D.2.7 — Are any controls applied to data classified as attorney work-product or covered by attorney-client privilege?
+
+**Project response.** Yes. The application provides a first-class **privileged-project** designation that:
+
+1. **Bypasses pseudonymization end-to-end.** The pre-anonymization middleware short-circuits when the incoming request carries `lq_ai_privileged=true` (`gateway/app/anonymization/middleware.py`); the response-path rehydrator is a no-op because nothing was substituted on the request path. The content reaches the inference provider exactly as the user composed it.
+
+2. **Audit-logs the privilege designation as a first-class column.** Every state-changing action on a privileged-project resource writes an `audit_log` row with `privilege_marked=true` and `privilege_basis="project:<project name>"`. The column is indexed and queryable; operators querying for "every action against privileged-matter content over date range X" use `SELECT * FROM audit_log WHERE privilege_marked = true AND timestamp BETWEEN ...`. The CHECK constraint `chk_audit_log_privileged_with_basis` enforces that `privilege_marked=true` rows always have a non-NULL `privilege_basis`.
+
+3. **Honors a per-project tier-floor.** Privileged projects must declare a `minimum_inference_tier` (DB CHECK constraint `chk_projects_privileged_implies_tier`). The gateway's tier-floor logic (PRD §4.4) refuses any routing weaker than the declared tier with HTTP 403 `tier_below_minimum`. The recommended configuration for privileged matters is `minimum_inference_tier=1` (local Ollama only) so the content never leaves the operator's deployment.
+
+4. **Preserves Citation Engine functionality.** Citation verification operates on the chat content directly; no special-casing for privileged projects. A privileged-matter chat with attached source documents produces verified citations exactly as a non-privileged chat does.
+
+**`[OPERATOR-CONFIGURABLE]`** — The operator decides which projects are privileged and which tier floor applies per project. The default posture for new projects is non-privileged + no tier floor; operators set the privileged flag and tier floor when creating or updating the project (`POST /api/v1/projects`, `PATCH /api/v1/projects/{id}`).
+
+**`[OPERATOR-CONFIGURABLE]`** — For privileged matters routed at Tier 2 (enterprise ZDR upstream) rather than Tier 1 (local), the operator's procurement agreement / DPA / BAA with that provider is the binding contractual control covering the unsubstituted content. The application surfaces what tier was used per request via `inference_routing_log.routed_inference_tier`; the contractual control is the operator's responsibility to negotiate and maintain with the upstream.
+
+**References:** [`docs/security/anonymization.md` §Privileged chats](anonymization.md#privileged-chats--why-we-skip-m2-b3--m2-d3); PRD §3.11 (Projects), PRD §4.4 (Tier-Floor Enforcement), PRD §5.3 (Audit Log); `api/app/audit.py::_resolve_project_privilege`; `gateway/app/anonymization/middleware.py` skip conditions.
+
+---
+
+## Audit & Logging Domain (L — selected questions)
+
+### L.2.5 — Are administrative actions on customer data logged in a tamper-evident manner?
+
+**Project response.** Yes, with the following posture:
+
+- **Append-only at the application layer.** The `audit_log` table has no UPDATE or DELETE paths exposed through the API; every state-changing action writes one row at the time of the action. The audit-log writer (`api/app/audit.py::audit_action`) is the only authorized writer; the row is added to the request's outer transaction so the audit row commits atomically with the underlying state change (no audit row without a state change; no state change without an audit row).
+
+- **First-class privilege + tier columns.** The privilege fields (`privilege_marked`, `privilege_basis`) and the routing fields (`routed_inference_tier`, `routed_provider`) are first-class columns rather than JSONB so audit queries can filter on them efficiently. The CHECK constraint `chk_audit_log_privileged_with_basis` prevents writing `privilege_marked=true` without a `privilege_basis`.
+
+- **Request correlation.** Each row carries a `request_id` (the X-Request-ID header value) so audit-log entries cross-reference to gateway `inference_routing_log` rows and application logs.
+
+**`[OPERATOR-CONFIGURABLE]`** — Tamper-evidence at the **DB level** (e.g., row-level signatures, append-only Postgres extensions, periodic snapshot hashes) is the operator's responsibility per their deployment posture. The application does not implement cryptographic tamper-evidence on `audit_log` rows in v0.2; operators with that requirement typically address it via Postgres-level controls (immutable schemas, role-restricted writes, WAL archiving with integrity checking).
+
+**`[OPERATOR-CONFIGURABLE]`** — Retention policy for `audit_log` is operator-controlled. The application writes rows indefinitely; operators with retention-period requirements run a periodic `DELETE FROM audit_log WHERE timestamp < ...` job sized to their policy.
+
+**References:** [`docs/db-schema.md` `audit_log` table](../db-schema.md#audit_log); PRD §5.3 (Audit Log).
+
+---
+
+### L.3.2 — Can administrators surface every action taken on a customer's data within a defined time window?
+
+**Project response.** Yes, via the `GET /admin/audit-log` endpoint (admin-gated). Query parameters include `user_id`, `resource_type`, `resource_id`, `action`, `privilege_marked`, `routed_inference_tier`, `from_timestamp`, `to_timestamp`. The response is paginated (default 100 rows; max 500) so large windows can be walked with cursor-style pagination.
+
+For privileged-matter compliance evidence specifically: `GET /admin/audit-log?privilege_marked=true&from_timestamp=...&to_timestamp=...` returns every audited action against privileged-project resources in the window. Cross-reference to the gateway's `inference_routing_log` table (joined on `request_id`) yields the full pipeline view including which provider/model handled each request and whether anonymization fired.
+
+**References:** [`api/app/api/admin.py` audit-log endpoint]; PRD §5.3 (Audit Log).
+
+---
+
+## Out of scope for this file
+
+The full SIG Lite questionnaire covers 18 domains spanning data protection, access controls, network security, vulnerability management, incident response, business continuity, supplier management, and more. This starter file covers only the questions whose responses materially differ depending on the privileged-project handling.
+
+For the full procurement-readiness pack — pre-filled responses across every SIG Lite domain plus CAIQ Lite plus a cover letter template — see [DE-086](../PRD.md#de-086--procurement-readiness-pack). Community contributions to that work are explicitly welcomed; see [`docs/procurement/README.md` §Contributing](README.md#contributing) for the contribution path.

--- a/docs/security/anonymization.md
+++ b/docs/security/anonymization.md
@@ -170,9 +170,37 @@ Every routed request writes one row to `inference_routing_log`. The middleware s
 
 Per **Decision A** and **Decision B (i)** locked in M2-B3 kickoff: a fresh `PseudonymMapper` is constructed inside the request scope, populated by the pre-pass, read by the post-pass, and dropped on function exit. **It is never persisted, never logged, and never serialized to any side channel.** A new request gets a new mapper; counters reset every time.
 
-### Privileged chats — why we skip
+### Privileged chats — why we skip (M2-B3 + M2-D3)
 
 The privileged-Project skip (Decision A) is a deliberate trade-off. Privileged chats are work product the attorney-client privilege protects; replacing names with pseudonyms before the model sees them — even with the rehydration on the way back — risks corrupting that work product if any step in the pipeline behaves unexpectedly. The conservative posture is to leave privileged content untouched. Operators who want pseudonymization in privileged chats can flip `lq_ai_privileged` off at the api/ layer per chat, but the default protects the legal-work-product invariant.
+
+**The intended posture for privileged content is Tier 1 (local).** Privileged matters are best handled by local-only inference (per PRD §1.5.2: "no outbound network is required; customer data, prompts, and model outputs never leave the deployment") — that's the only path where the substitution layer's behavior is structurally irrelevant because no upstream provider ever sees the content in the first place. Operators configuring a privileged project typically pair `privileged=true` with `minimum_inference_tier=1` so the tier-floor enforcement refuses any routing weaker than local. Where local capacity is insufficient and the operator must use a Tier-2 (ZDR enterprise) upstream, the anonymization skip means privileged content reaches the provider verbatim — the operator's procurement / DPA terms with that provider are the binding control at that point.
+
+**Why anonymization complicates privilege analysis.** Pseudonymization rewrites identifying terms (names, organizations, matter numbers, case numbers) before the model sees them. For non-privileged content this is a privacy boost: the operator sends `"PERSON_0001 v COMPANY_0001"` to the provider instead of `"Smith v Acme"`. For privileged content the same transform creates two correctness risks:
+
+1. **Substitution errors corrupt the privileged work product.** If Presidio misidentifies an entity (false-positive on a non-name token; false-negative on a non-standard name format), the rehydrator either over-restores or leaves a fragment unrestored. For ordinary content this is a minor annoyance; for privileged work product the corruption may render the work less useful as a referenceable artifact and may complicate later assertion of privilege over the artifact's contents.
+2. **The substitution itself may be discoverable.** In a future-litigation context where the operator must assert privilege over the AI-assisted work product, the existence of a rewritten-then-restored intermediate version (even if never persisted) is one more piece of context opposing counsel can probe. Keeping the content unsubstituted means there is exactly one version of the work product — the original — at every stage.
+
+**Audit-log shape for privileged-project chats** (per M2-D3 verification):
+
+| Table | Column | Value for privileged-project chat |
+|---|---|---|
+| `audit_log` (api/) | `privilege_marked` | `true` |
+| `audit_log` (api/) | `privilege_basis` | `"project:<project name>"` |
+| `audit_log` (api/) | `routed_inference_tier` | actual routed tier (typically 1 or 2 per the project's `minimum_inference_tier`) |
+| `inference_routing_log` (gateway) | `anonymization_applied` | `false` |
+| `inference_routing_log` (gateway) | `routed_inference_tier` | same value; cross-table consistency for joins |
+
+The privilege fields on `audit_log` are first-class columns (per `docs/db-schema.md`) so audit queries can filter on privilege without descending into JSONB. Operators reviewing the audit trail for compliance evidence query `audit_log WHERE privilege_marked = true` to surface every action on privileged-project content; cross-referenced to `inference_routing_log` via `request_id`, they get the full pipeline view including which provider/model handled each request.
+
+**Combination invariant** ("privileged + Tier 1"): a privileged project with `minimum_inference_tier=1` produces fully sealed inference — local Ollama dispatches the request, no outbound network, no anonymization rewriting, audit row captures the local routing. This is the recommended posture for sensitive privileged matters; the configuration is enforced at the gateway's tier-floor layer (PRD §4.4) so a misrouted attempt to a Tier-3+ provider returns HTTP 403 with `tier_below_minimum` rather than silently downgrading the privacy posture.
+
+Pinning tests:
+
+- `gateway/tests/test_inference_anonymization.py::test_privileged_request_skips_middleware` — gateway middleware honors `lq_ai_privileged=True`; provider receives un-pseudonymized content; `routing_log.anonymization_applied=false`.
+- `api/tests/test_chat_citations.py::test_chat_send_privileged_project_full_audit_trail` — api/ forwards `lq_ai_privileged=True` + tier floor on the gateway request; `audit_log` row has `privilege_marked=true` + `privilege_basis` containing the project name; Citation Engine still operates normally for privileged chats.
+
+Procurement-readiness: see [`docs/procurement/sig-lite.md`](../procurement/sig-lite.md) for the privileged-project-relevant SIG Lite responses.
 
 ### Retrieval-context skip (M2-D2)
 


### PR DESCRIPTION
## Summary

M2-D3 is verification + documentation of the privileged-project anonymization-skip path implemented in M2-B3. All plumbing existed: `Project.privileged` flag forwards to `ChatCompletionRequest.lq_ai_privileged` at [`chats.py:1162`](../blob/m2-d3-privileged-handling/api/app/api/chats.py#L1162), the gateway middleware short-circuits at [`middleware.py:85`](../blob/m2-d3-privileged-handling/gateway/app/anonymization/middleware.py#L85) when the flag is True, and `audit_action` resolves the project privilege flag automatically via `_resolve_project_privilege`.

This PR pins the full end-to-end chain with **one integration test** and documents the resulting posture for procurement reviewers.

## Tests (1 new)

`test_chat_send_privileged_project_full_audit_trail` pins three invariants in a single end-to-end chat send (privileged project + KB-attached chat):

| # | Invariant | Where |
|---|---|---|
| 1 | Gateway request carries `lq_ai_privileged=True` + `lq_ai_project_minimum_inference_tier=2` | api/ → gateway request body |
| 2 | `audit_log` row has `privilege_marked=True` + `privilege_basis="project:<name>"` + `routed_inference_tier` | `api/app/api/chats.py::_audit_message_sent` → `audit_action` resolution |
| 3 | Citation Engine operates normally — no special-casing on the verification side; `exact_match` fires and the citation row persists | `message_citations` table |

The gateway-side invariants (middleware skip + provider receives un-pseudonymized content + `routing_log.anonymization_applied=false`) are pinned by the existing M2-B3 test `gateway/tests/test_inference_anonymization.py::test_privileged_request_skips_middleware` — this PR cross-links rather than duplicates.

## Documentation

### `docs/security/anonymization.md`

Extends the existing "Privileged chats — why we skip" section with:

- **Intended posture** — Tier 1 / local for privileged matters; the only path where the substitution layer's behavior is structurally irrelevant
- **Why anonymization complicates privilege analysis** — substitution-error corruption risk + intermediate-version discoverability in litigation
- **Audit-log shape table** — spans api/ `audit_log` and gateway `inference_routing_log` so an operator reviewing the audit trail knows exactly what columns to query for compliance evidence
- **"Privileged + Tier 1" combination invariant** — fully sealed local inference enforced by the tier-floor layer (HTTP 403 on misroute attempt)
- **Cross-link** to `docs/procurement/sig-lite.md` for procurement-team responses

### `docs/procurement/sig-lite.md` (new, M2-D3 starter scope)

**Focused starter** covering only the SIG Lite questions whose answers depend on privileged-project handling:

| Question | Domain |
|---|---|
| D.1.3 | How is sensitive data classified, and what controls apply per classification? |
| D.2.7 | Are any controls applied to attorney work-product / privileged data? |
| L.2.5 | Are admin actions on customer data logged tamper-evidently? |
| L.3.2 | Can admins surface every action on a customer's data within a time window? |

Each response uses the README format with `[OPERATOR-CONFIGURABLE]` markers where the answer depends on deployment choices. Out-of-scope items (the remaining ~15 SIG Lite domains) explicitly defer to [DE-086](https://github.com/LegalQuants/lq-ai/blob/m2-d3-privileged-handling/docs/PRD.md#de-086--procurement-readiness-pack).

### `docs/procurement/README.md`

Updates the `sig-lite.md` row in the "What lands here" table from "TBD" to "**Starter (M2-D3)** — privileged-matter handling only".

## Scope decisions

Per the M2-D3 brainstorm: the spec's "update `sig-lite.md`" line was ambiguous because the file didn't exist (it's a `TBD` under [DE-086](../blob/m2-d3-privileged-handling/docs/PRD.md#de-086--procurement-readiness-pack)). Three options surfaced; **focused starter chosen** (recommended path) — satisfies the M2-D3 spec without claiming DE-086 is complete. The file's header explicitly scopes it to privileged-matter handling and points at DE-086 for the full pack.

## Test plan

- [x] api/ ruff format + check + mypy clean
- [x] api/ full suite vs live postgres: **994 passed, 1 skipped** (+1 new D3 test)
- [x] gateway/ unchanged — no code modifications; existing M2-B3 privileged-skip test continues to cover the gateway-side invariants
- [ ] Manual operator-side procurement review of `sig-lite.md` content — content is technical-accurate per the code references but the SIG Lite phrasing benefits from a procurement-team review

## Files

**Source:** none (M2-D3 is verification + docs)

**Tests:** `api/tests/test_chat_citations.py` (+1 new test)

**Docs:**
- `docs/security/anonymization.md` — extended privileged-skip section
- `docs/procurement/sig-lite.md` (new) — M2-D3-scoped SIG Lite starter
- `docs/procurement/README.md` — table row updated

4 files changed, +309 / -2 LOC.

## Dependencies + downstream

- **Depends on**: M2-B3 (all of the privileged-skip plumbing this PR verifies + documents)
- **Runs parallel to**: M2-D2 (now merged at 6817238; D3 was rebased onto the D2-merged tip so docs/security/anonymization.md edits compose cleanly)
- **Unblocks**: M2-D4 (edge-case sweep; all of Phase D structural work is now in place)
- **Defers to follow-on**: [DE-086](../blob/m2-d3-privileged-handling/docs/PRD.md#de-086--procurement-readiness-pack) (full Procurement-Readiness Pack — privileged-matter starter from this PR becomes the foundation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)