### PR TITLE
M2-D4: Edge case sweep — Phase D close

### DIFF
--- a/api/tests/citation/test_edge_cases.py
+++ b/api/tests/citation/test_edge_cases.py
@@ -1,0 +1,628 @@
+"""Citation Engine edge cases — M2-D4 sweep.
+
+Per docs/M2-IMPLEMENTATION-PLAN.md §M2-D4, this file pins regression
+tests for the citation-engine-side edge cases the M2 plan calls out:
+
+* **Chunk boundary citations** — citation source slice spans the boundary
+  between two adjacent chunks. The verifier reads from
+  ``documents.normalized_content`` (un-chunked), so chunk boundaries
+  are not directly visible to the verifier — but a citation whose
+  source_text was assembled by concatenating across-chunk text must
+  still verify cleanly against the underlying document slice.
+* **Empty source documents** — a document with an empty
+  ``normalized_content`` and a citation with offsets pointing into it
+  must fall through to MISS gracefully (no crash, no row written).
+* **Cross-document citations** — a message that cites multiple source
+  documents must verify each independently and persist one row per
+  successfully-verified citation.
+* **Failed retrieval / deleted source_file_id** — a citation whose
+  source_file_id no longer exists at verification time must be
+  handled defensively (no crash; no row persists — the M2-C2 UI
+  renders the absence as "unverified"; the M2-C2 Decision H deferred
+  state-5 system-error rendering to a future task tracked in DE-275).
+
+The integration test (``test_chat_send_*`` variants) drives the full
+chat-send pipeline; pure-cascade tests live alongside
+:mod:`tests.citation.test_verify_cascade` and exercise
+:func:`app.citation.verification.verify` directly with stubs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.verification import (
+    VerificationResult,
+    verify,
+    verify_exact_match,
+)
+from app.clients.gateway import GatewayClient, set_gateway_client
+from app.db.session import get_db
+from app.main import app
+from app.models.chat import Chat, MessageCitation
+from app.models.document import Document, DocumentChunk
+from app.models.file import File as FileModel
+from app.models.knowledge import KnowledgeBase
+from app.models.project import Project
+from app.models.project_knowledge_base import ProjectKnowledgeBase
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+GATEWAY_BASE = "http://test-gateway"
+GATEWAY_KEY = "test-gw-key"
+
+
+# ---------------------------------------------------------------------------
+# Unit-level stubs (mirror test_paraphrase_judge.py shape)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _StubDocument:
+    id: uuid.UUID
+    normalized_content: str
+    was_ocrd: bool = False
+
+
+@dataclass(slots=True)
+class _StubCandidate:
+    source_file_id: uuid.UUID
+    source_document_id: uuid.UUID
+    source_offset_start: int
+    source_offset_end: int
+    source_page: int | None
+    source_text: str
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — verify() against the cascade with edge-case inputs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_verify_exact_match_against_empty_normalized_content() -> None:
+    """Stage 1 on a document with empty ``normalized_content`` returns MISS.
+
+    Defensive: the ``_slice_in_range`` guard catches any positive
+    offset against a zero-length document and short-circuits. Without
+    this guard, ``content[start:end]`` on an empty string would return
+    ``""`` and the equality check against a non-empty ``source_text``
+    would fail naturally — but we still want explicit MISS rather than
+    relying on the equality coincidence.
+    """
+
+    doc = _StubDocument(id=uuid.uuid4(), normalized_content="")
+    cand = _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=0,
+        source_offset_end=10,
+        source_page=None,
+        source_text="something",
+    )
+
+    result = verify_exact_match(cand, doc)
+
+    assert result.verified is False
+    assert result.method is None
+
+
+@pytest.mark.unit
+async def test_verify_cascade_against_empty_normalized_content_no_crash() -> None:
+    """Full cascade against an empty document falls through to MISS cleanly.
+
+    Stages 1 + 2 short-circuit on the range guard; Stage 3 / 4 are
+    not reached because ``gateway=None`` short-circuits past them.
+    The contract is "no crash on degenerate document"; the assertion
+    is just that we get a MISS result back.
+    """
+
+    doc = _StubDocument(id=uuid.uuid4(), normalized_content="")
+    cand = _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=0,
+        source_offset_end=5,
+        source_page=None,
+        source_text="hello",
+    )
+
+    result = await verify(cand, doc, gateway=None)
+
+    assert result == VerificationResult(
+        verified=False, method=None, confidence=None, partial=False, tier_envelope=None
+    )
+
+
+@pytest.mark.unit
+def test_verify_exact_match_offsets_span_chunk_boundary_within_document() -> None:
+    """A citation whose offsets straddle a (logical) chunk boundary verifies.
+
+    The verifier reads from ``documents.normalized_content`` directly,
+    not from chunks — chunks are only used by retrieval. So a citation
+    whose source span happens to cross the boundary between two
+    retrieved chunks still verifies cleanly as long as the underlying
+    document text at those offsets matches the ``source_text``.
+
+    This test simulates the scenario: a 100-char document split into
+    two chunks at offset 50; the citation spans offsets [40, 70]
+    crossing the boundary. The verifier reads ``content[40:70]`` and
+    compares against the candidate's ``source_text``.
+    """
+
+    content = "A" * 50 + "B" * 50  # 100-char document
+    doc = _StubDocument(id=uuid.uuid4(), normalized_content=content)
+    # Citation spans [40, 70] — straddles the 50-char "boundary"
+    cand = _StubCandidate(
+        source_file_id=uuid.uuid4(),
+        source_document_id=doc.id,
+        source_offset_start=40,
+        source_offset_end=70,
+        source_page=None,
+        source_text="A" * 10 + "B" * 20,
+    )
+
+    result = verify_exact_match(cand, doc)
+
+    assert result.verified is True
+    assert result.method == "exact_match"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — full chat-send pipeline with edge-case fixtures
+# ---------------------------------------------------------------------------
+
+
+pytestmark = pytest.mark.integration
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    gw = GatewayClient(base_url=GATEWAY_BASE, gateway_key=GATEWAY_KEY)
+    set_gateway_client(gw)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    set_gateway_client(None)
+    await gw.aclose()
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def owner_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"edge-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Edge Cases Owner",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def project_for_owner(db_session: AsyncSession, owner_user: User) -> Project:
+    project = Project(
+        owner_id=owner_user.id,
+        name="Edge cases matter",
+        slug=f"edge-matter-{uuid.uuid4().hex[:8]}",
+    )
+    db_session.add(project)
+    await db_session.flush()
+    return project
+
+
+@pytest_asyncio.fixture
+async def kb_for_owner(db_session: AsyncSession, owner_user: User) -> KnowledgeBase:
+    kb = KnowledgeBase(
+        owner_id=owner_user.id,
+        name="Edge KB",
+        description="Edge-case integration tests",
+        hybrid_alpha=1.0,
+    )
+    db_session.add(kb)
+    await db_session.flush()
+    return kb
+
+
+@pytest_asyncio.fixture
+async def chat_with_kb(
+    db_session: AsyncSession,
+    owner_user: User,
+    project_for_owner: Project,
+    kb_for_owner: KnowledgeBase,
+) -> Chat:
+    junction = ProjectKnowledgeBase(
+        project_id=project_for_owner.id,
+        knowledge_base_id=kb_for_owner.id,
+    )
+    db_session.add(junction)
+    chat = Chat(
+        owner_id=owner_user.id,
+        project_id=project_for_owner.id,
+        title="edge-cases-test",
+    )
+    db_session.add(chat)
+    await db_session.flush()
+    return chat
+
+
+async def _make_file_doc_chunk(
+    db_session: AsyncSession,
+    *,
+    owner: User,
+    content: str,
+    filename: str,
+) -> tuple[FileModel, Document, DocumentChunk]:
+    f = FileModel(
+        owner_id=owner.id,
+        filename=filename,
+        mime_type="application/pdf",
+        size_bytes=1024,
+        hash_sha256="b" * 64,
+        storage_path=f"edge-fixture/{uuid.uuid4()}",
+        ingestion_status="ready",
+    )
+    db_session.add(f)
+    await db_session.flush()
+
+    doc = Document(
+        file_id=f.id,
+        parser="pymupdf-only",
+        parser_version="pymupdf=1.27",
+        page_count=1,
+        character_count=len(content),
+        normalized_content=content,
+        was_ocrd=False,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+
+    chunk = DocumentChunk(
+        document_id=doc.id,
+        chunk_index=0,
+        content=content,
+        page_start=1,
+        page_end=1,
+        char_offset_start=0,
+        char_offset_end=len(content),
+    )
+    db_session.add(chunk)
+    await db_session.flush()
+    return f, doc, chunk
+
+
+def _hybrid_result_for(
+    chunk: DocumentChunk,
+    document: Document,
+    file: FileModel,
+    *,
+    score: float = 0.9,
+) -> Any:
+    class _R:
+        def __init__(self) -> None:
+            self.chunk_id = chunk.id
+            self.document_id = document.id
+            self.file_id = file.id
+            self.file_name = file.filename
+            self.content = chunk.content
+            self.page_start = chunk.page_start
+            self.page_end = chunk.page_end
+            self.char_offset_start = chunk.char_offset_start
+            self.char_offset_end = chunk.char_offset_end
+            self.vector_score = score
+            self.fts_score = score
+            self.hybrid_score = score
+
+    return _R()
+
+
+def _bearer(user: User) -> str:
+    return create_access_token(user.id, user.email, is_admin=user.is_admin)
+
+
+def _h(user: User) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_bearer(user)}"}
+
+
+def _success_payload(content: str) -> dict[str, Any]:
+    return {
+        "id": "chatcmpl-edge",
+        "object": "chat.completion",
+        "created": 1_700_000_000,
+        "model": "claude-sonnet-4-6",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 12, "total_tokens": 17},
+        "routed_inference_tier": 3,
+        "routed_provider": "anthropic-prod",
+        "cost_estimate": 0.0001,
+    }
+
+
+@respx.mock
+async def test_cross_document_citations_persist_one_row_per_verified_citation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb: Chat,
+) -> None:
+    """Citations from N different source documents persist N independent rows.
+
+    The persist_citations loop batch-loads all referenced documents
+    in one SELECT then verifies each candidate against its own
+    document. This test confirms cross-document independence: a
+    message that cites two distinct files lands two citation rows,
+    each pointing at the right ``source_file_id``.
+    """
+
+    content_a = "Document A contains the alpha clause."
+    content_b = "Document B contains the beta clause."
+
+    file_a, doc_a, chunk_a = await _make_file_doc_chunk(
+        db_session, owner=owner_user, content=content_a, filename="doc-a.pdf"
+    )
+    file_b, doc_b, chunk_b = await _make_file_doc_chunk(
+        db_session, owner=owner_user, content=content_b, filename="doc-b.pdf"
+    )
+
+    quote_a = "the alpha clause"
+    quote_b = "the beta clause"
+    assistant_text = f'Per doc A: "{quote_a}" (Source: [1]). Per doc B: "{quote_b}" (Source: [2]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text))
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[
+                _hybrid_result_for(chunk_a, doc_a, file_a),
+                _hybrid_result_for(chunk_b, doc_b, file_b),
+            ]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb.id}/messages",
+            json={"content": "Quote both clauses.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCitation).where(
+                    MessageCitation.source_file_id.in_([file_a.id, file_b.id])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(rows) == 2, f"expected one row per document, got {len(rows)}"
+    by_file = {row.source_file_id: row for row in rows}
+    assert by_file[file_a.id].source_text == quote_a
+    assert by_file[file_a.id].verification_method == "exact_match"
+    assert by_file[file_b.id].source_text == quote_b
+    assert by_file[file_b.id].verification_method == "exact_match"
+
+
+@respx.mock
+async def test_chunk_boundary_spanning_citation_does_not_extract_today(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb: Chat,
+) -> None:
+    """Known limitation (M2-D4 / DE-277): spanning quotes drop at extraction.
+
+    The Citation Engine's extractor (:func:`app.citation.extraction.extract_citations`)
+    locates each quote inside the cited chunk's content via
+    :func:`app.citation.extraction._locate_in_chunk`. If a quote
+    actually spans the boundary between two retrieved chunks — i.e.,
+    no single chunk's content contains the full quote — the locator
+    returns ``None`` and the candidate is dropped silently. The
+    verifier never sees the candidate, so no row is persisted and the
+    M2-C2 UI renders the marker as "unverified".
+
+    In practice the model rarely emits genuinely spanning quotes —
+    instruction prompting in the retrieval-context block tells it to
+    pick the chunk containing the full quote. But the model could emit
+    such quotes (especially under adversarial or multi-chunk-paraphrase
+    prompting); the current pipeline silently degrades to unverified.
+
+    Future fix path (DE-277): the extractor falls back to scanning
+    ``documents.normalized_content`` via FK from the chunk to the doc
+    when ``_locate_in_chunk`` misses; same fuzzy-vs-exact two-stage
+    logic against the full document text rather than the chunk slice.
+
+    This test pins the current behavior so a future implementation
+    of DE-277 has a failing assertion to flip.
+    """
+
+    full_content = (
+        "Section 1: The non-compete clause provides for "
+        "a two-year restriction on competing business."
+    )
+    file_, doc, _whole_chunk = await _make_file_doc_chunk(
+        db_session, owner=owner_user, content=full_content, filename="span.pdf"
+    )
+
+    # Two adjacent half-chunks at indices 1 and 2 — together they
+    # cover the full document, but neither alone contains the
+    # spanning quote below.
+    chunk_a = DocumentChunk(
+        document_id=doc.id,
+        chunk_index=1,
+        content=full_content[:47],
+        page_start=1,
+        page_end=1,
+        char_offset_start=0,
+        char_offset_end=47,
+    )
+    chunk_b = DocumentChunk(
+        document_id=doc.id,
+        chunk_index=2,
+        content=full_content[47:],
+        page_start=1,
+        page_end=1,
+        char_offset_start=47,
+        char_offset_end=len(full_content),
+    )
+    db_session.add_all([chunk_a, chunk_b])
+    await db_session.flush()
+
+    # Quote spans the chunk boundary at offset 47 — present in the
+    # full document but in neither chunk alone.
+    spanning_quote = full_content[30:60]
+    assert spanning_quote not in chunk_a.content
+    assert spanning_quote not in chunk_b.content
+    assert spanning_quote in full_content
+
+    assistant_text = f'The agreement says "{spanning_quote}" (Source: [1]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text))
+    )
+
+    with patch(
+        "app.api.chats.hybrid_search",
+        new=AsyncMock(
+            return_value=[
+                _hybrid_result_for(chunk_a, doc, file_),
+                _hybrid_result_for(chunk_b, doc, file_),
+            ]
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb.id}/messages",
+            json={"content": "Quote a passage that spans chunks.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    assert response.status_code == 200, response.text
+
+    # Current behavior: extractor drops the spanning candidate; no
+    # citation row persists. When DE-277 lands, this assertion
+    # should flip to ``len(rows) == 1`` and the row should carry
+    # ``verification_method='exact_match'`` against the full-doc slice.
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCitation).where(MessageCitation.source_file_id == file_.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == [], (
+        f"Expected no rows for a chunk-boundary spanning quote (DE-277 known limitation); "
+        f"got {len(rows)}. If this test fails because rows were persisted, DE-277 may have "
+        "landed — flip this assertion to verify the full-doc-scan extractor fix instead."
+    )
+
+
+@respx.mock
+async def test_deleted_source_file_handled_gracefully_no_row_written(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+    chat_with_kb: Chat,
+) -> None:
+    """Citation referencing a deleted document falls through with no crash.
+
+    M2-C2 Decision H deferred the dedicated state-5 system-error UI
+    rendering to a future task — the current behavior is "no row
+    persisted, M2-C2 UI shows unverified red." This test pins that
+    current behavior so a future implementation of state-5 has a
+    failing test to flip.
+
+    Scenario: hybrid_search returns a chunk pointing at a document
+    that gets deleted before persist_citations runs. The verifier's
+    batch-load returns no document for that id; the defensive guard
+    at chats.py skips the candidate. The chat-send still returns 200
+    (the assistant response is independent of citation persistence
+    failures).
+    """
+
+    content = "The deleted document said something important."
+    file_, doc, chunk = await _make_file_doc_chunk(
+        db_session, owner=owner_user, content=content, filename="will-delete.pdf"
+    )
+
+    quote = "something important"
+    assistant_text = f'The doc said "{quote}" (Source: [1]).'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text))
+    )
+
+    # Stash references then delete the document right before the chat
+    # send dispatches. The hybrid_search mock returns the now-stale
+    # chunk reference; persist_citations will batch-load the document
+    # and find nothing.
+    deleted_doc_id = doc.id
+    captured_chunk_data = _hybrid_result_for(chunk, doc, file_)
+
+    async def _delete_doc_before_persist(*args: Any, **kwargs: Any) -> list[Any]:
+        # Mimic the race: doc gets deleted between retrieval and
+        # citation persistence.
+        await db_session.execute(
+            DocumentChunk.__table__.delete().where(DocumentChunk.document_id == deleted_doc_id)
+        )
+        await db_session.execute(Document.__table__.delete().where(Document.id == deleted_doc_id))
+        await db_session.flush()
+        return [captured_chunk_data]
+
+    with patch("app.api.chats.hybrid_search", new=_delete_doc_before_persist):
+        response = await client.post(
+            f"/api/v1/chats/{chat_with_kb.id}/messages",
+            json={"content": "Quote the deleted doc.", "model": "smart"},
+            headers=_h(owner_user),
+        )
+
+    # Chat send still succeeds — citation persistence is best-effort.
+    assert response.status_code == 200, response.text
+
+    # No citation row persisted (defensive skip in persist_citations
+    # because the referenced document no longer exists).
+    rows = (await db_session.execute(select(MessageCitation))).scalars().all()
+    assert rows == [], (
+        f"Expected no rows for a deleted-document citation; got {len(rows)}. "
+        "The M2-C2 UI renders the absence as the 'unverified' red state; "
+        "M2-C2 Decision H deferred state-5 system-error rendering to a "
+        "future task."
+    )

--- a/api/tests/citation/test_ensemble.py
+++ b/api/tests/citation/test_ensemble.py
@@ -344,6 +344,44 @@ async def test_empty_judge_models_misses_without_calling_gateway() -> None:
 
 
 @pytest.mark.unit
+async def test_ensemble_judge_calls_carry_anonymize_false_for_correctness() -> None:
+    """M2-D4 integration edge: every ensemble judge call opts out of anonymization.
+
+    The Stage 3 :func:`verify_paraphrase` request sets
+    ``anonymize=False`` (see verification.py docstring: "the judge needs
+    to see actual content to verify it; anonymized text would destroy
+    the semantics"). Ensemble dispatches multiple Stage 3 calls in
+    parallel; each one carries the same opt-out. This test pins the
+    contract: provider sees the real cited claim + chunk on every
+    ensemble judge dispatch even when chat-level anonymization is
+    active for the originating message.
+
+    Why this composition works: anonymization happens at the
+    chat-completion request level (per-request flag). Ensemble judge
+    calls are SEPARATE chat-completion requests dispatched by the api/
+    after the original chat response is persisted. Each judge request
+    is independently routed, anonymization-gated, and audit-logged by
+    the gateway. The api/-side ``anonymize=False`` flag forces the
+    middleware to skip pseudonymization regardless of the gateway's
+    default config.
+    """
+
+    gw = _StubGateway(response_contents=[_judge_json(verdict="yes")] * 3)
+    cfg = _ensemble(n=3, rule="strict")
+    doc = _doc()
+
+    result = await verify_ensemble(_candidate(doc), doc, gateway=gw, ensemble_config=cfg)
+
+    assert result.verified is True
+    assert gw.call_count == 3
+    for req in gw.requests:
+        assert req.anonymize is False, (
+            f"every ensemble judge request must set anonymize=False; "
+            f"got anonymize={req.anonymize!r} on model={req.model!r}"
+        )
+
+
+@pytest.mark.unit
 async def test_confidence_is_mean_of_verified_judges() -> None:
     """Mixed confidences average: high(0.90) + medium(0.70) = 0.80 mean."""
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2786,6 +2786,29 @@ The failure mode is structurally bad: a deployment misconfiguration (missing env
 
 **Acceptance criteria:** `documents.embedding_status` is populated for every newly-ingested document and updates correctly on retry; the admin UI surfaces failed-embed documents distinctly from ready ones; an end-to-end test against a fresh-install stack uploads a fixture document and asserts the chunks come back embedded (not FTS-only); the gateway-misconfigured-worker class of bug surfaces as a CI failure on PR review rather than a silent production degradation.
 
+#### DE-277 — Citation extractor: fallback to document scan on chunk-boundary miss
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** Surfaced during the M2-D4 edge-case sweep. The Citation Engine's extractor (`app/citation/extraction.py::extract_citations`) locates each quote by calling `_locate_in_chunk(quote, chunk.content)` against the single chunk the model cited via `(Source: [N])`. If the quote spans the boundary between two adjacent retrieved chunks — i.e., the quote is present in `documents.normalized_content` but in neither chunk's individual content — the locator returns `None` and the candidate is dropped silently. No row is persisted; the M2-C2 UI renders the marker as "unverified" (red) even though the underlying document text matches.
+
+In practice the model usually picks the chunk containing the full quote (the retrieval-context block instructs it to). The gap surfaces on adversarial multi-chunk paraphrases or when the model genuinely needs to cite text crossing a chunk seam — both rare but not impossible.
+
+The verifier itself reads against `documents.normalized_content` (un-chunked) and would verify a spanning quote correctly if it ever saw the candidate. The fix is upstream in extraction.
+
+**Specific scope:** Extend `_locate_in_chunk` (or the surrounding loop in `extract_citations`) to fall back to a full-document scan when the chunk-local search misses. Two-stage logic, mirroring the within-chunk pattern:
+
+- **Stage A — chunk-local exact:** current behavior.
+- **Stage B — chunk-local fuzzy:** current behavior.
+- **Stage C — full-document exact:** if A and B both miss, FK-load the chunk's parent document and `_locate_in_chunk(quote, doc.normalized_content)`. Resolved offsets are document-absolute (no `chunk.char_offset_start` arithmetic needed).
+- **Stage D — full-document fuzzy:** if C misses, fuzzy-search the full document. Resolved offsets again document-absolute.
+
+The persisted citation row's `source_offset_start` / `source_offset_end` already index into `documents.normalized_content` (not the chunk), so the downstream Stages 1–4 verifier consumes the document-absolute offsets without any further change.
+
+**Edge case the fix introduces:** a quote that's NOT in the cited chunk but IS elsewhere in the document — possibly the model cited the wrong chunk index. Stage C/D would surface this as verified, masking the mis-cite. Two-option resolution: (a) accept this as a feature (the verification is what matters; chunk-index correctness is decorative); (b) when Stage C/D fires, log a `citation_chunk_mismatch` warning so operators can spot model-side drift. Recommend (b) for observability.
+
+**Acceptance criteria:** the existing `test_chunk_boundary_spanning_citation_does_not_extract_today` test flips its assertion (rows DO persist; `verification_method='exact_match'`); a new test pins the chunk-mismatch warning case; no regression in the existing extraction test suite; `docs/citation-engine.md` "Known limitations" entry on chunk-boundary spanning is updated to either remove the limitation or note the residual chunk-mismatch behavior.
+
 ### Workflow intelligence
 
 This subsection captures the bounded items that operationalize the M5+ Forward-Looking Workflow Intelligence direction (§8.5). The items are bounded enough to be picked up by community contributors as the M5+ roadmap matures. The architectural slot for the MCP-client subsystem is already committed for M1–M2 (§8 M1) so this subsection's items can be implemented incrementally without core refactoring.

--- a/docs/citation-engine.md
+++ b/docs/citation-engine.md
@@ -238,10 +238,91 @@ detail.
 See [docs/security/anonymization.md](security/anonymization.md) for
 the anonymization-layer-side description of the same integration.
 
+## Known limitations (M2-D4)
+
+The Citation Engine is correctness-first but ships with several
+known limitations the M2-D4 sweep documented explicitly. Each
+limitation has either a regression test pinning current behavior or
+a deferred-enhancement entry tracking the future fix.
+
+### Chunk-boundary spanning quotes — silently drop today
+
+If a citation's source quote spans the boundary between two adjacent
+retrieved chunks (i.e., neither chunk alone contains the full quote),
+the extractor's `_locate_in_chunk` returns `None` and the candidate
+is dropped silently. The M2-C2 UI renders the absence as the
+"unverified" red state.
+
+**Current scope of the bug:** the extractor searches each cited
+chunk's `content` for the quote. The verifier (Stages 1–4) reads
+against `documents.normalized_content` (which spans all chunks of a
+document), but the verifier never sees the candidate because
+extraction drops it upstream.
+
+**When this matters:** the model usually picks the chunk containing
+the full quote — the retrieval-context block tells it to. The gap
+surfaces on adversarial multi-chunk paraphrases or when the model
+genuinely needs to cite text that crosses a chunk seam.
+
+**Future fix path:** [DE-277 — Citation extractor: scan full
+`documents.normalized_content` when chunk-local search misses](PRD.md#de-277--citation-extractor-fallback-to-document-scan-on-chunk-boundary-miss).
+The extractor falls back to scanning the full document text via FK
+from the chunk to the doc when `_locate_in_chunk` misses; same
+fuzzy-vs-exact two-stage logic against the full document. Pinned by
+`api/tests/citation/test_edge_cases.py::test_chunk_boundary_spanning_citation_does_not_extract_today`
+which flips its assertion when DE-277 lands.
+
+### Deleted source documents — render as "unverified," not "system error"
+
+If a chat message references a source document that gets deleted
+between retrieval and citation persistence (rare but possible —
+user-driven document deletion during an in-flight request), the
+verifier's batch-load returns no document for that ID and the
+defensive `if doc is None: continue` guard in `_persist_message_citations`
+skips the candidate silently. No row is persisted; the M2-C2 UI
+renders the marker as "unverified" (red).
+
+**The distinction the spec drew:** M2-D4 references a "system-error
+state" — visually distinct from "unverified" (red) — but the M2-C2
+Decision H deferred the dedicated state-5 rendering to a future
+task. Implementing state-5 means: persist a row with
+`verification_method='failed'` + a details field flagging "source
+deleted"; UI extends `CitationRenderState` with a fifth value;
+chip color + tooltip differ from the existing unverified state.
+
+**Future fix path:** part of [DE-275 — Embed M2 citations in
+chat-message envelope](PRD.md#de-275--embed-m2-citations-in-chat-message-envelope)
+(state-5 system-error rendering is grouped with the envelope
+enhancement work). Pinned by
+`api/tests/citation/test_edge_cases.py::test_deleted_source_file_handled_gracefully_no_row_written`.
+
+### Empty source documents — fall through to unverified gracefully
+
+A document with empty `normalized_content` and a citation referencing
+positive offsets into it triggers the `_slice_in_range` guard in
+`verify_exact_match` / `verify_tolerant_match`; both return MISS
+without crashing. Stage 3 / 4 only run if `gateway` is supplied;
+either way the candidate falls through to "unverified." This is
+defensive-by-design rather than a future-fix item — there is nothing
+to verify against an empty document.
+
+Pinned by:
+
+- `api/tests/citation/test_edge_cases.py::test_verify_exact_match_against_empty_normalized_content`
+- `api/tests/citation/test_edge_cases.py::test_verify_cascade_against_empty_normalized_content_no_crash`
+
+### Cross-document citations — supported
+
+A message citing multiple distinct source documents produces one
+verified row per cited document. The persistence loop batch-loads
+all referenced documents in one SELECT then verifies each candidate
+against its own document. Pinned by
+`api/tests/citation/test_edge_cases.py::test_cross_document_citations_persist_one_row_per_verified_citation`.
+
 ## References
 
 - PRD §3.3 (Citation Engine spec)
-- [docs/M2-IMPLEMENTATION-PLAN.md](M2-IMPLEMENTATION-PLAN.md) §M2-C1, §M2-D1
+- [docs/M2-IMPLEMENTATION-PLAN.md](M2-IMPLEMENTATION-PLAN.md) §M2-C1, §M2-D1, §M2-D4
 - [docs/db-schema.md](db-schema.md) — `message_citations` table
 - [gateway.yaml.example](../gateway.yaml.example) — operator config surface
 - [docs/skill-authoring-guide.md](skill-authoring-guide.md) — `ensemble_verification` frontmatter field

--- a/docs/security/anonymization.md
+++ b/docs/security/anonymization.md
@@ -259,6 +259,34 @@ The current pseudonym format `{ENTITY_TYPE}_{NNNN}` is deterministic and operato
 
 If you operate a deployment whose source corpus contains literal `{UPPERCASE}_{DIGITS}` patterns at risk of collision and you want resolution sooner than the roadmap, the simplest deployment-side mitigation is to override `PseudonymMapper.assign` with a salted format (e.g., `f"{entity_type}_{counter:04d}_{secrets.token_hex(2)}"`) and rebuild the gateway image.
 
+### Long entity names (>200 chars) — pseudonymize without truncation
+
+Entities of arbitrary length pseudonymize to the standard `{TYPE}_{NNNN}` format regardless of source-span length — the substitution shrinks the wire payload rather than expanding it. The mapper holds the full original (whatever its length) so the rehydrator restores it byte-for-byte on the response path. There is no length cap today; the binding constraint is Presidio's per-span analysis cost, which scales linearly with the analyzed text but is bounded by chat-message size.
+
+Pinned by `gateway/tests/anonymization/test_edge_cases.py::test_pre_anonymize_long_entity_name_substitutes_without_crash` and `::test_post_anonymize_rehydrates_long_entity_byte_for_byte`.
+
+### Multi-line entities (spans across `\n`) — substitute correctly
+
+A Presidio-detected span that crosses line boundaries (common for address blocks: `"Acme Corp\n123 Main St\nNew York, NY"`) substitutes as a single pseudonym; rehydration restores the full multi-line original including the embedded newlines. No special handling needed in the middleware — the substitution operates on raw character ranges.
+
+Pinned by `gateway/tests/anonymization/test_edge_cases.py::test_pre_anonymize_multiline_entity_substitutes_across_newline` and `::test_post_anonymize_rehydrates_multiline_entity_with_newlines_preserved`.
+
+### Foreign-language entities — out of scope for v1
+
+Presidio's `AnalyzerEngine` ships with English-only NLP models per [`gateway/app/anonymization/engine.py::get_analyzer_engine`](../../gateway/app/anonymization/engine.py); the spaCy `en_core_web_lg` model is the only language pipeline registered. Non-English text in a chat or skill input is passed through the analyzer but typically produces zero entity matches — the content reaches the provider in cleartext.
+
+**Operator implication:** for a deployment whose users send chat content in languages other than English, the anonymization layer effectively no-ops. Mitigations:
+
+1. Configure additional spaCy models per language (`pip install spacy && python -m spacy download xx_lg`) and extend `get_analyzer_engine` with per-language NLP engines.
+2. Disable anonymization entirely (`anonymization.enabled: false` in `gateway.yaml`) if the operator's privacy posture is incompatible with English-only detection.
+3. Route non-English content to a Tier-1 (local) inference path so the provider visibility question is moot.
+
+No PRD §9 DE entry today — this is a project posture choice (English-only legal practice is the primary user persona) rather than a deferred enhancement. Operators with multi-language needs should open an issue.
+
+### Citation extraction across chunk boundaries — see DE-277
+
+The Citation Engine's extractor has a related limitation: quotes that span the boundary between two retrieved chunks drop silently at extraction (the locator searches one chunk's content). The pseudonym layer is unaffected — substitution operates on raw message content, not on chunk-aligned text. See [`docs/citation-engine.md` §Known limitations](../citation-engine.md#chunk-boundary-spanning-quotes--silently-drop-today) for the citation-side detail and [DE-277](../PRD.md#de-277--citation-extractor-fallback-to-document-scan-on-chunk-boundary-miss) for the future fix.
+
 ---
 
 ## Related

--- a/gateway/tests/anonymization/test_edge_cases.py
+++ b/gateway/tests/anonymization/test_edge_cases.py
@@ -1,0 +1,323 @@
+"""Anonymization Layer edge cases — M2-D4 sweep.
+
+Per docs/M2-IMPLEMENTATION-PLAN.md §M2-D4, this file pins regression
+tests for the anonymization-side edge cases the M2 plan calls out:
+
+* **Long entity names (>200 chars)** — the pseudonymizer handles
+  arbitrarily long spans without crashing; the resulting pseudonym
+  is the standard ``{TYPE}_{NNNN}`` format regardless of source length.
+* **Multi-line entities** — spans that cross line boundaries
+  (``\\n`` characters inside an entity match) substitute correctly.
+* **Pseudonym collision with literal source text** — already covered
+  by ``test_round_trip.py::test_source_text_with_literal_pseudonym_survives_round_trip``
+  (DE-274 known limitation); this file adds a focused middleware-level
+  pin so the round-trip and middleware perspectives stay coherent.
+* **Entities in cited spans (post-rehydration)** — a model response
+  that contains a pseudonym AS PART OF a cited quote (e.g.,
+  ``"PERSON_0001 signed the agreement" (Source: [1])``) rehydrates
+  the pseudonym inside the quote on the response path. The cite-
+  extraction step on the api/ side then sees the rehydrated original.
+
+The foreign-language edge case is documented as a known limitation
+in ``docs/security/anonymization.md``; no test (Presidio's English-only
+configuration is the binding constraint and is out of scope for v1).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from app.anonymization.engine import Anonymizer
+from app.anonymization.mapper import PseudonymMapper
+from app.anonymization.middleware import (
+    StreamingRehydrator,
+    post_anonymize_response,
+    pre_anonymize_request,
+)
+from app.config import AnonymizationConfig
+from app.providers.openai_schema import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+
+# ---------------------------------------------------------------------------
+# Stub analyzer — same shape as test_middleware.py / test_anonymizer.py.
+# Duplicated here rather than imported (see test_middleware.py comment).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Span:
+    entity_type: str
+    start: int
+    end: int
+    score: float = 0.85
+
+
+class _StubAnalyzer:
+    def __init__(self, by_text: dict[str, list[_Span]]) -> None:
+        self._by_text = by_text
+
+    def analyze(self, *, text: str, language: str = "en", **_kwargs: object) -> list[_Span]:
+        return list(self._by_text.get(text, []))
+
+
+def _make_request(*, messages: list[ChatCompletionMessage]) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="smart",
+        messages=messages,
+        anonymize=True,
+        lq_ai_privileged=False,
+    )
+
+
+def _make_response(content: str) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        id="chatcmpl-edge",
+        created=0,
+        model="claude-sonnet-4-6",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=content),
+                finish_reason="stop",
+            )
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Long entity names (>200 chars)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pre_anonymize_long_entity_name_substitutes_without_crash() -> None:
+    """Entities >200 chars pseudonymize using the standard format.
+
+    Pseudonym format is ``{TYPE}_{NNNN}`` regardless of source-span
+    length — the substitution shrinks the wire payload rather than
+    expanding it for long entities. The mapper holds the full original
+    (whatever its length) so the rehydrator can restore it byte-for-byte
+    on the response path. No truncation today; the binding limit is
+    Presidio's per-span analysis cost.
+    """
+
+    long_name = "Very Long Organization Name " * 10 + "Inc."  # ~290 chars
+    content = f"Discussing {long_name} liability."
+    span_start = content.index(long_name)
+    span_end = span_start + len(long_name)
+
+    req = _make_request(messages=[ChatCompletionMessage(role="user", content=content)])
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({content: [_Span("ORGANIZATION", span_start, span_end)]})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    assert req.messages[0].content == "Discussing ORGANIZATION_0001 liability."
+    # Mapper holds the full original — rehydration restores it byte-for-byte.
+    reverse_map = mapper.reverse()
+    assert reverse_map["ORGANIZATION_0001"] == long_name
+    assert len(reverse_map["ORGANIZATION_0001"]) > 200
+
+
+@pytest.mark.unit
+def test_post_anonymize_rehydrates_long_entity_byte_for_byte() -> None:
+    """Round-trip preserves long-entity originals exactly."""
+
+    long_name = "Very Long Organization Name " * 10 + "Inc."  # ~290 chars
+    mapper = PseudonymMapper()
+    mapper.assign("ORGANIZATION", long_name)  # allocates ORGANIZATION_0001
+
+    response = _make_response(content="ORGANIZATION_0001 is the counterparty.")
+    analyzer = _StubAnalyzer({})  # not used by post_anonymize_response
+
+    post_anonymize_response(
+        response=response,
+        mapper=mapper,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert response.choices[0].message.content == f"{long_name} is the counterparty."
+
+
+# ---------------------------------------------------------------------------
+# Multi-line entities (span crosses \n)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pre_anonymize_multiline_entity_substitutes_across_newline() -> None:
+    """A span carrying ``\\n`` substitutes correctly.
+
+    Address blocks frequently include line breaks (``"Acme Corp\\n123
+    Main St\\nNew York, NY"``); a presidio-detected address entity may
+    span the whole block. The substitution replaces the entire range —
+    including the newlines — with a single pseudonym, then the response
+    rehydrator restores the original multi-line string.
+    """
+
+    multiline_address = "Acme Corp\n123 Main St\nNew York, NY 10001"
+    content = f"Contract counterparty:\n{multiline_address}\n\nSignatory: John Doe"
+    span_start = content.index(multiline_address)
+    span_end = span_start + len(multiline_address)
+
+    req = _make_request(messages=[ChatCompletionMessage(role="user", content=content)])
+    config = AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5])
+    analyzer = _StubAnalyzer({content: [_Span("LOCATION", span_start, span_end)]})
+
+    mapper = pre_anonymize_request(
+        chat_request=req,
+        config=config,
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=analyzer),
+    )
+
+    assert mapper is not None
+    assert req.messages[0].content == (
+        "Contract counterparty:\nLOCATION_0001\n\nSignatory: John Doe"
+    )
+    assert mapper.reverse()["LOCATION_0001"] == multiline_address
+
+
+@pytest.mark.unit
+def test_post_anonymize_rehydrates_multiline_entity_with_newlines_preserved() -> None:
+    """Rehydration of a multi-line pseudonym restores the embedded newlines."""
+
+    multiline_address = "Acme Corp\n123 Main St\nNew York, NY 10001"
+    mapper = PseudonymMapper()
+    mapper.assign("LOCATION", multiline_address)
+
+    response = _make_response(content="The counterparty at LOCATION_0001 signed the agreement.")
+    post_anonymize_response(
+        response=response,
+        mapper=mapper,
+        anonymizer=Anonymizer(analyzer=_StubAnalyzer({})),
+    )
+
+    assert response.choices[0].message.content == (
+        f"The counterparty at {multiline_address} signed the agreement."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pseudonym-collision middleware perspective (DE-274 cross-ref)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_post_anonymize_literal_pseudonym_in_response_passes_through() -> None:
+    """A response containing a literal pseudonym pattern that the mapper
+    has no entry for passes through unchanged.
+
+    Cross-references DE-274 (per-request salt). The rehydrator's
+    substitution is ``str.replace(pseudonym, original)`` keyed by the
+    mapper's contents. A literal ``"PERSON_0001"`` in the source
+    document — surfaced into the response via a model citation — that
+    happens to also be a pseudonym format string is a no-op when the
+    mapper has no matching entry. The literal preserves on the way
+    out (no false rehydration). When the mapper DOES have an entry
+    for ``PERSON_0001`` (because a real PERSON was detected in the
+    request), the response's literal gets rewritten to the original
+    — the cross-mapper collision DE-274 documents.
+
+    This test pins the no-mapper case; the with-mapper case is
+    pinned by the round-trip suite at
+    ``test_round_trip.py::test_source_text_with_literal_pseudonym_survives_round_trip``.
+    """
+
+    mapper = PseudonymMapper()  # empty — no entries
+
+    response = _make_response(content="The contract template uses PERSON_0001 as a placeholder.")
+    post_anonymize_response(
+        response=response,
+        mapper=mapper,
+        anonymizer=Anonymizer(analyzer=_StubAnalyzer({})),
+    )
+
+    # No-op: the literal "PERSON_0001" passes through unchanged.
+    assert response.choices[0].message.content == (
+        "The contract template uses PERSON_0001 as a placeholder."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entities in cited spans (post-rehydration walks citation text too)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_post_anonymize_rehydrates_pseudonyms_inside_quoted_citation_span() -> None:
+    """Rehydration scans the entire response content — including text
+    inside ``"..." (Source: [N])`` markers.
+
+    Per M2-D2 the api/ marks the retrieval-context system message
+    with ``lq_ai_skip_anonymization=True`` so source quotes reach the
+    model un-pseudonymized; in normal operation the model's citations
+    quote real source text directly and no rehydration inside the
+    quote is needed. But in edge scenarios (e.g., the model paraphrases
+    pseudonymized chat-turn content into something that *looks like*
+    a cited quote), the rehydrator still walks the whole response
+    string — pseudonyms anywhere in the content get restored. This
+    test pins that contract.
+    """
+
+    mapper = PseudonymMapper()
+    mapper.assign("PERSON", "John Smith")  # allocates PERSON_0001
+
+    response = _make_response(
+        content='The agreement says "PERSON_0001 shall not compete" (Source: [1]).'
+    )
+    post_anonymize_response(
+        response=response,
+        mapper=mapper,
+        anonymizer=Anonymizer(analyzer=_StubAnalyzer({})),
+    )
+
+    # Pseudonym inside the quote is restored along with anywhere else
+    # in the response content.
+    assert response.choices[0].message.content == (
+        'The agreement says "John Smith shall not compete" (Source: [1]).'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming rehydration of multi-line / long entities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_streaming_rehydrator_handles_long_entity_across_chunks() -> None:
+    """StreamingRehydrator restores a long-entity pseudonym that arrives
+    across several SSE chunks.
+
+    The pseudonym format is ``{TYPE}_{NNNN}`` (short — fewer than 30
+    chars typically), so the partial-pattern tail buffer easily
+    contains it. But the rehydrated ORIGINAL may be arbitrarily long;
+    this test confirms the rehydrator emits the full original even
+    when the source pseudonym arrived split.
+    """
+
+    long_name = "Very Long Organization Name " * 10 + "Inc."
+    mapper = PseudonymMapper()
+    mapper.assign("ORGANIZATION", long_name)
+
+    r = StreamingRehydrator(mapper=mapper, anonymizer=Anonymizer(analyzer=_StubAnalyzer({})))
+
+    # Split "ORGANIZATION_0001 is here." across three chunks
+    pieces = ["ORGAN", "IZATION_0001 ", "is here."]
+    out = "".join(r.process(p) for p in pieces) + r.flush()
+
+    assert out == f"{long_name} is here."


### PR DESCRIPTION
## Summary

Pins regression tests + documents known limitations across the M2-D4 sweep (Citation Engine + Anonymization Layer + Integration). **14 new tests** (6 api/, 7 gateway/, 1 integration); **1 new DE-277 entry** in PRD §9 capturing the one real bug surfaced (extractor drops spanning quotes). **Closes Phase D**.

## Tests (14 new)

### Citation Engine edge cases — `api/tests/citation/test_edge_cases.py` (6)

| Test | What it pins |
|---|---|
| `test_verify_exact_match_against_empty_normalized_content` | Stage 1 on empty document returns MISS via `_slice_in_range` guard |
| `test_verify_cascade_against_empty_normalized_content_no_crash` | Full cascade on empty document falls through to MISS without crashing |
| `test_verify_exact_match_offsets_span_chunk_boundary_within_document` | Verifier reads correctly when offsets straddle a logical chunk boundary (verifier reads `documents.normalized_content`; chunks invisible to verifier) |
| `test_cross_document_citations_persist_one_row_per_verified_citation` | Message with N citations from N distinct files persists N rows |
| `test_chunk_boundary_spanning_citation_does_not_extract_today` | **DE-277 known limitation** — extractor drops spanning quotes; assertion flips when DE-277 lands |
| `test_deleted_source_file_handled_gracefully_no_row_written` | Deleted source_file_id handled defensively; M2-C2 UI shows "unverified" (state-5 system-error rendering deferred per M2-C2 Decision H) |

### Anonymization edge cases — `gateway/tests/anonymization/test_edge_cases.py` (7)

| Test | What it pins |
|---|---|
| `test_pre_anonymize_long_entity_name_substitutes_without_crash` | Entities >200 chars use standard `{TYPE}_{NNNN}` format; no crash |
| `test_post_anonymize_rehydrates_long_entity_byte_for_byte` | Long entities rehydrate exactly on response path |
| `test_pre_anonymize_multiline_entity_substitutes_across_newline` | Spans carrying `\n` (address blocks) substitute correctly |
| `test_post_anonymize_rehydrates_multiline_entity_with_newlines_preserved` | Multi-line rehydration preserves embedded newlines |
| `test_post_anonymize_literal_pseudonym_in_response_passes_through` | DE-274 cross-ref no-mapper case: literal `PERSON_0001` passes through unchanged |
| `test_post_anonymize_rehydrates_pseudonyms_inside_quoted_citation_span` | Pseudonyms anywhere in response (including inside `"..." (Source: [N])`) rehydrate |
| `test_streaming_rehydrator_handles_long_entity_across_chunks` | StreamingRehydrator handles long-entity rehydration across SSE chunks |

### Integration edge case — `api/tests/citation/test_ensemble.py` (1)

| Test | What it pins |
|---|---|
| `test_ensemble_judge_calls_carry_anonymize_false_for_correctness` | Every ensemble judge call carries `anonymize=False` so providers see real cited content; middleware skips pseudonymization for judge requests regardless of chat-level anonymization status |

## Documentation

- **`docs/citation-engine.md`** — new "Known limitations (M2-D4)" section: chunk-boundary spanning (DE-277), deleted source documents (state-5 deferred), empty source documents (defensive fall-through), cross-document citations (supported)
- **`docs/security/anonymization.md`** — extends "Known limitations and roadmap" with: long entity names (no truncation), multi-line entities (preserved across `\n`), foreign-language entities (English-only Presidio per project posture; no DE entry, operators with multi-language needs open an issue), citation extraction across chunk boundaries (cross-ref DE-277)
- **`docs/PRD.md` §9 DE-277** (new) — "Citation extractor: fallback to document scan on chunk-boundary miss" with fix scope (four-stage fallback logic: chunk-local exact → chunk-local fuzzy → full-doc exact → full-doc fuzzy), edge-case discussion (mis-cite masking; suggest observability warning log), and acceptance criteria

## Scope decision

Per the M2-D4 brainstorm: chunk-boundary spanning quotes' extractor-side gap shipped as **documented limitation + DE-277** (recommended path) rather than fixed inside D4. Reasoning: fixing extraction adds ~2-3 hr beyond D4's verification-only effort budget; the gap surfaces only on adversarial multi-chunk paraphrases the model rarely emits in practice; DE-277 captures the fix with full context so it can be picked up cleanly later.

## Test plan

- [x] api/ ruff format + check + mypy clean
- [x] gateway/ ruff format + check + mypy strict clean
- [x] api/ full suite vs live postgres: **1001 passed, 1 skipped** (+7 new D4 tests)
- [x] gateway/ full suite: **497 passed, 2 skipped** (+7 new D4 tests)
- [x] web/ unchanged (no UI work in this sweep)

## Files

**Source:** none (D4 is verification + docs only — `chunk-boundary` extractor fix deferred to DE-277)

**Tests:**
- `api/tests/citation/test_edge_cases.py` (new, 6 tests)
- `gateway/tests/anonymization/test_edge_cases.py` (new, 7 tests)
- `api/tests/citation/test_ensemble.py` (+1 integration test)

**Docs:**
- `docs/citation-engine.md` — new "Known limitations (M2-D4)" section
- `docs/security/anonymization.md` — extended "Known limitations" section
- `docs/PRD.md` — new DE-277 entry

6 files changed, +1122 / -1 LOC.

## Dependencies + downstream

- **Depends on**: All of Phase C + M2-D1 + M2-D2 (verifies their composed behavior under edge inputs)
- **Closes**: M2 Phase D entirely (D1 #31 + D2 #32 + D3 #33 merged; D4 this PR)
- **Defers to follow-on**:
  - **DE-277** — Citation extractor full-document fallback (chunk-boundary spanning quotes)
  - **State-5 system-error UI rendering** — grouped with DE-275 (embed M2 citations in chat-message envelope); deferred from M2-C2 Decision H

## Phase D close

| Task | PR | Status |
|---|---|---|
| M2-D1 — Ensemble verification | #31 | ✓ merged at `fcecd30` |
| M2-D2 — Citation Engine × Anonymization integration | #32 | ✓ merged at `6817238` |
| M2-D3 — Privileged-project handling | #33 | ✓ merged at `dcec9f9` |
| M2-D4 — Edge case sweep | **this PR** | open |

After merge: M2 progress 13/18 tasks. Phase E (Azure adapter + ensemble calibration) and Phase F (acceptance corpora + docs finalization) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)