### PR TITLE
docs(m2,citation,prd): M2-F1 scope reframe + DE-279/DE-280 for case-citation work

### DIFF
--- a/docs/M2-IMPLEMENTATION-PLAN.md
+++ b/docs/M2-IMPLEMENTATION-PLAN.md
@@ -552,42 +552,36 @@ The Azure OpenAI adapter lands (small but strategically important); ensemble ver
 
 The trust-layer documentation lands. Acceptance test corpora are built for both Citation Engine and Anonymization. Procurement docs reflect M2 capabilities.
 
-### Task M2-F1 — Citation Engine acceptance test corpus
+### Task M2-F1 — Citation Engine acceptance test corpus — ✓ Closed (scope reframe, 2026-05-17)
 
-**Scope:**
+**Status:** **✓ Closed via scope reframe** rather than separate corpus build. During M2-F1 kickoff Kevin clarified the three-type citation taxonomy:
+
+1. **KB-quote accuracy** — verify the model's response accurately represents the cited KB document.
+2. **Case citation validation** — verify a case citation refers to a real opinion. *Not in M2 scope; tracked at [PRD §9 DE-279](PRD.md#de-279--case-citation-validation-bluebook-resolution-via-courtlistener).*
+3. **Case-content accuracy** — verify a statement about a case matches the holding. *Not in M2 scope; tracked at [PRD §9 DE-280](PRD.md#de-280--case-content-accuracy-statement-vs-judicial-opinion).*
+
+M2 shipped type 1 across Phases A–D. Verification of type-1 behavior already lives in:
+
+- `api/tests/citation/test_extraction.py` + `test_verification.py` + `test_verify_ensemble.py` — unit coverage for Stages 1–4 (exact-match, tolerant-match, paraphrase-judge, ensemble).
+- `api/tests/test_chat_citations.py` — integration coverage for the full chat-emits-citation → engine-verifies → message_citations row persisted path, including the privileged-project audit-trail integration test.
+- `api/tests/citation/test_round_trip_correctness.py` — round-trip invariants (M2-C3, 17 slow-marked tests).
+- `web/cypress/e2e/m2-c2-citation-states.cy.ts` — UI rendering states across the four verification verdicts.
+- `api/tests/citation/test_edge_cases.py` + `gateway/tests/anonymization/test_edge_cases.py` — M2-D4 edge-case sweep (14 tests; closed Phase D).
+- Real-stack browser verification on uploaded NDAs during M2-C2 (cascade fixes for ingest-worker env + entrypoint surfaced and merged).
+
+A separate annotated corpus + eval runner would duplicate the existing pin coverage for type-1 behavior and would not move the project closer to types 2 or 3 (those are different surfaces; see DE-279 / DE-280 for their distinct architectures). The plan-stated targets (Stage 1 ≥40%, Stage 1+2 ≥75%, FP <2%, FN <10%) are claims the existing tests assert at the per-case level rather than aggregate metrics — operators reading the test fixtures can see exactly what behaviors are pinned.
+
+**Original scope (preserved for historical reference; not built):**
+
 - Curate 30–50 documents with ground-truth citation annotations.
-  - Sources: anonymized real documents from the operator's practice; supplemented with public-domain documents (e.g., SEC EDGAR filings with NDA/MSA exhibits).
-  - Each document has 5–10 ground-truth citations authored by a reviewing attorney: claim, verbatim text, source file ID, offsets.
-- Build runner: `scripts/run_citation_engine_eval.py` that:
-  - Loads the ground-truth corpus.
-  - Runs each citation through the verification pipeline.
-  - Records verdict per stage (which stage passed, or final unverified).
-  - Reports metrics:
-    - Stage 1 pass rate.
-    - Stage 2 pass rate (of those that failed Stage 1).
-    - Stage 3 pass rate (of those that failed Stage 2).
-    - False-positive rate (claims marked verified that ground truth says shouldn't be).
-    - False-negative rate (ground-truth verifiable claims marked unverified).
-    - Cost per evaluation.
-- Baseline targets:
-  - Stage 1 catches ≥40% of verbatim citations.
-  - Stage 1+2 together ≥75% of legitimate citations.
-  - Stage 3 catches another ~15% (the paraphrase cases).
-  - End-to-end false-positive rate <2%.
-  - End-to-end false-negative rate <10%.
-- Document the corpus, the runner, and the baseline metrics in `docs/citation-engine.md`.
-- Add the eval to CI as a nightly job (not blocking; informational).
+- Build runner: `scripts/run_citation_engine_eval.py` reporting per-stage pass rates, false-positive rate, false-negative rate, cost per evaluation.
+- Baseline targets: Stage 1 ≥40%, Stage 1+2 ≥75%, Stage 3 +~15%, FP <2%, FN <10%.
+- Document corpus + runner + baseline in `docs/citation-engine.md`.
+- Add eval to CI as a nightly job (not blocking; informational).
 
-**Dependencies:** All of Phase A–D.
+This original scope can be revisited if/when type-2 or type-3 validation lands — at that point an aggregate empirical baseline across all three types makes sense.
 
-**Output:** Citation Engine has an empirical baseline; regressions are detectable.
-
-**Verification:**
-- Eval runs against the curated corpus successfully.
-- Baseline metrics meet or exceed targets above.
-- Eval runs in CI nightly (not blocking PR merges; surfaces in a project dashboard).
-
-**Effort:** 12–16 hours (the corpus curation is the bulk).
+**Closeout sequence updated** (Kevin, 2026-05-17): M2-E1 ✓ → ~~M2-F1~~ ✓ (scope reframe) → **M2-E2 (next)** → M2-F2 → M2-F3.
 
 ---
 
@@ -694,7 +688,7 @@ The recommended workflow mirrors the M1 implementation:
 | Anonymization recognizes too cautiously (false negatives) | Provide custom-recognizer pattern for matter-specific entities; document customization path; track recall in acceptance-test eval. |
 | Ensemble verification cost overruns | Configurable cost budget per message; fall back to single-judge with warning when exceeded; track cost-per-message in admin dashboard. |
 | Privileged-project handling has subtle bug (anonymization-applied when it shouldn't be, or tier-routing wrong) | Dedicated test coverage (M2-D3); periodic audit-log review by security reviewer. |
-| Citation Engine verification creates a perf bottleneck | Stages 1 and 2 are sub-millisecond; Stage 3+ are LLM calls (already async). Pipeline runs in parallel with response streaming where possible. Track P95 latency in M2-F1. |
+| Citation Engine verification creates a perf bottleneck | Stages 1 and 2 are sub-millisecond; Stage 3+ are LLM calls (already async). Pipeline runs in parallel with response streaming where possible. P95 latency tracked via OTel spans on `verify()` / `verify_ensemble()` in production rather than via a synthetic corpus run. |
 | OpenAI / Anthropic SDK changes break adapters | Pin SDK versions; track upstream releases; bug-fix releases for SDK updates ship as patch versions. |
 
 ---

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2825,6 +2825,53 @@ The persisted citation row's `source_offset_start` / `source_offset_end` already
 
 **Acceptance criteria:** `auth_mode: ad` provider entries construct cleanly under managed identity (validated in a CI integration test that mocks `DefaultAzureCredential`); the `Authorization: Bearer <token>` header is set on chat/embeddings/health calls (mocked); a regression test pins that `api-key` is NOT set when `auth_mode: ad`; `gateway.yaml.example` documents both auth modes with a comment block; `azure-identity` added to the gateway's `pyproject.toml` with the same pin discipline as other deps; SBOM diff reviewed; one mocked integration test exercises the AD path end-to-end through the FastAPI lifespan.
 
+#### DE-279 — Case citation validation (Bluebook resolution via CourtListener)
+
+**Priority:** P1 · **Effort:** M
+
+**Context:** The M2 Citation Engine validates **type 1** of three distinct citation-checking surfaces ("KB-quote accuracy" — does a model's quote and the meaning it draws accurately represent a document in the operator's KB). The other two surfaces are not built and require architecturally distinct components:
+
+- **Type 2 (this DE) — case citation validation:** given a citation string in Bluebook form (e.g., `Smith v. Jones, 123 U.S. 456 (2020)`), verify that it refers to a real, resolvable judicial opinion. Catches the "the model fabricated a case" failure mode. Distinct from type 1 because the source-of-truth is not an operator-owned document but an external case database.
+- **Type 3 — case-content accuracy:** see [DE-280](#de-280--case-content-accuracy-statement-vs-judicial-opinion).
+
+Type 2 is high-priority for any deployment used in litigation work — a fabricated case citation in a brief or memo is the canonical embarrassment-and-sanctions story (e.g., the 2023 *Mata v. Avianca* sanctions). The architectural slot exists in the project's transparency posture (every model-emitted claim is checkable), and Tucuxi-Inc has reference prior art at [`Tucuxi-Inc/Legal-Week-Cite-Checker`](https://github.com/Tucuxi-Inc/Legal-Week-Cite-Checker) — a working implementation of Bluebook-citation detection + CourtListener resolution that can be ported and adapted to the LQ.AI stack.
+
+**Specific scope:**
+
+- New module `api/app/citation/case_resolver.py` with a Bluebook-citation detector (regex + parser; the Legal-Week-Cite-Checker port covers the common Bluebook forms: U.S. Supreme Court reporters, federal reporters F./F.2d/F.3d/F. Supp., state reporters, parallel citations) and a CourtListener client.
+- CourtListener resolution uses the public FreeLaw Foundation API (`https://www.courtlistener.com/api/rest/v3/`). Authentication via an operator-supplied API token (env `LQ_AI_COURTLISTENER_TOKEN`); the API is free for reasonable use but the token improves rate limits.
+- New `message_case_citations` table mirroring the shape of `message_citations` (id, message_id, citation_string, normalized_form, courtlistener_opinion_id, resolution_status, resolved_at). Migration follows the existing alembic versioning.
+- Detector runs on every chat response (parallel with type-1 verification — same pre-render guarantee). Failed resolutions surface in the UI as "unverified case citation — could not resolve" (same chip vocabulary as type 1 for UX consistency).
+- Configurable per-deployment: `citation_engine.case_validation.enabled: bool` in `gateway.yaml` so operators with no litigation use case can skip the CourtListener dependency.
+
+**Privacy + transparency implications:** the citation string itself is the only data sent to CourtListener — no claim text, no surrounding context, no user identifier. CourtListener is operated by the Free Law Project (501(c)(3) non-profit) which publishes a clear privacy posture; the request shape is auditable in the routing log.
+
+**Acceptance criteria:** detector recognizes ≥95% of citation strings in a curated test set covering the major Bluebook forms; resolution succeeds for ≥98% of real citations and ≤2% for fabricated citations (false-positive rate); a Cypress E2E exercises the failed-resolution UI state; CourtListener-down failure mode handled gracefully (citation marked "unverified — resolver unavailable", not blocked); documented end-to-end in `docs/citation-engine.md` under a new §2 "Case citation validation"; integration with the existing `message_citations`-style audit row in `api/app/api/chats.py`.
+
+#### DE-280 — Case-content accuracy (statement vs judicial opinion)
+
+**Priority:** P1 · **Effort:** L
+
+**Context:** **Type 3** of the three citation-checking surfaces (see [DE-279](#de-279--case-citation-validation-bluebook-resolution-via-courtlistener) for the taxonomy). Given a statement the model makes *about* a case — what it held, what its reasoning was, what facts it relied on — verify that the statement is an accurate, non-cherry-picked representation of the underlying judicial opinion. Hardest of the three because the source-of-truth (opinion full text) is long, the model's statement is short, and "accurate representation" is a paraphrase-semantics judgment that the existing Stage-3 paraphrase judge (type 1) handles only over short retrieved chunks.
+
+**Scope considerations:**
+
+- **Source-of-truth fetch.** Once a case citation resolves through DE-279, the full opinion text is retrievable from CourtListener (`/api/rest/v3/opinions/<id>/`). Opinions are often 10–50 pages; the judge must reason over the whole opinion, not a single chunk. This is a different verification surface than type 1's chunk-scoped paraphrase judge.
+- **Statement extraction.** The chat model emits statements about cases inline — `"the Smith court held that …"`. A detector pairs each statement with the case citation it references (the model is prompted to colocate them; absent colocation we fall back to nearest-citation heuristic).
+- **Paraphrase-vs-cherry-pick distinction.** A statement can be technically accurate (the opinion does say *X*) but misleading (the opinion's holding turned on a fact the statement omits). The judge prompt needs to evaluate both fidelity and completeness — a meaningful step beyond type 1's "does this quote support this claim" surface.
+- **Calibrated gold set.** Required for confidence thresholds. ~50 statement-vs-opinion pairs reviewed by an attorney for ground truth; calibrate the judge to ≥0.85 precision at recall ≥0.70 before declaring a verdict. This is the one place in the three-type taxonomy where attorney attestation in the contribution path is genuinely load-bearing (the gold set's quality determines what verdicts the system produces in production).
+
+**Specific scope (M4 target):**
+
+- New module `api/app/citation/case_content_judge.py` with a paraphrase-semantics judge over full opinion text. Uses the same gateway-judge surface as type 1's Stage 3 (`paraphrase_judge`), but with a longer-context model and a prompt structured for fidelity + completeness evaluation.
+- Token-cost handling: opinion full text + statement + judge prompt = ~10-30k input tokens per judgment. Pre-flight cost budget mirrors the existing M2-D1 ensemble pre-flight; falls back to "unverified — over-budget" when a deployment hits its cap.
+- Statement detector + citation pairing — built on top of DE-279's detector.
+- New `message_case_statements` table for the verdicts.
+- UI state: case-statement chips render alongside type-1 KB chips. Same hover/click affordances; same verbal vocabulary.
+- Calibrated gold set committed at `eval/case-content-accuracy/` with attorney-reviewed annotations.
+
+**Acceptance criteria:** judge calibrated against the gold set (≥0.85 precision @ ≥0.70 recall); end-to-end integration with DE-279 (a chat response with a case statement triggers DE-279 resolution + DE-280 content check in parallel); UI renders the case-statement verdict alongside KB-quote verdicts; cost-budget pre-flight handles long-opinion edge cases; documented end-to-end in `docs/citation-engine.md` under a new §3 "Case content accuracy"; depends on DE-279 landing first.
+
 ### Workflow intelligence
 
 This subsection captures the bounded items that operationalize the M5+ Forward-Looking Workflow Intelligence direction (§8.5). The items are bounded enough to be picked up by community contributors as the M5+ roadmap matures. The architectural slot for the MCP-client subsystem is already committed for M1–M2 (§8 M1) so this subsection's items can be implemented incrementally without core refactoring.

--- a/docs/citation-engine.md
+++ b/docs/citation-engine.md
@@ -15,6 +15,44 @@ integration boundary lives in §[Integration with Anonymization](#integration-wi
 
 ---
 
+## Scope
+
+"Citation checking" can mean three different things. M2 ships the first;
+the other two are tracked as M3–M4 work in PRD §9.
+
+1. **KB-quote accuracy** *(this engine, shipped in M2)* — when the
+   chat surfaces information retrieved from the operator's knowledge
+   base, the engine verifies that the model's quote and the meaning
+   it draws from that quote are an accurate representation of the
+   cited KB document. This is a textual-fidelity question between the
+   model's response and a document the operator owns.
+
+2. **Case citation validation** *(not built; tracked at
+   [PRD §9 DE-279](PRD.md#de-279--case-citation-validation-bluebook-resolution-via-courtlistener))*
+   — given a case citation in Bluebook form (e.g.,
+   `Smith v. Jones, 123 U.S. 456 (2020)`), verify it refers to a
+   real opinion that resolves through CourtListener / the FreeLaw
+   Foundation APIs. Catches fabricated citations. Tucuxi-Inc's prior
+   `Legal-Week-Cite-Checker` is the reference implementation.
+
+3. **Case-content accuracy** *(not built; tracked at
+   [PRD §9 DE-280](PRD.md#de-280--case-content-accuracy-statement-vs-judicial-opinion))*
+   — given a statement the model makes *about* what a case held or
+   reasoned, verify the statement is an accurate, non-cherry-picked
+   representation of the underlying judicial opinion. Hardest of the
+   three; requires fetching the opinion text and a paraphrase-judge
+   evaluation calibrated against a reviewed gold set.
+
+The three are architecturally distinct: type 1 operates on KB documents
+the operator uploaded; type 2 operates on Bluebook strings against
+external case databases; type 3 operates on summary statements against
+fetched opinion full text. Mixing them under one roof would be a
+category error. This document covers type 1 only; references to "the
+Citation Engine" elsewhere in the codebase also mean type 1 unless
+explicitly qualified.
+
+---
+
 ## Cascade
 
 Each citation the model emits (a `"<quote>" (Source: [N])` pair)


### PR DESCRIPTION
## Summary

- **Reframes \"citation checking\" into three distinct surfaces** and ships M2-F1 as a scope decision rather than a corpus build.
- M2 ships **type 1** (KB-quote accuracy — the model's response accurately represents cited KB documents). Already validated by unit / integration / Cypress / browser-verified / round-trip / edge-case test coverage built through Phases A-D.
- **Type 2** (case citation validation — Bluebook resolution via CourtListener) filed as new [DE-279](https://github.com/LegalQuants/lq-ai/blob/m2-citation-scope-docs/docs/PRD.md#de-279--case-citation-validation-bluebook-resolution-via-courtlistener). Prior art at [Tucuxi-Inc/Legal-Week-Cite-Checker](https://github.com/Tucuxi-Inc/Legal-Week-Cite-Checker). M3-M4 scope.
- **Type 3** (case-content accuracy — statement about a case matches the holding, no cherry-picking) filed as new [DE-280](https://github.com/LegalQuants/lq-ai/blob/m2-citation-scope-docs/docs/PRD.md#de-280--case-content-accuracy-statement-vs-judicial-opinion). M4 scope; this is the one type that genuinely needs an attorney-reviewed gold set for calibration.

## Why this is the right close for M2-F1

A type-1 acceptance corpus + eval runner would duplicate existing pin coverage without moving the project toward types 2 or 3 (those are architecturally distinct surfaces — different source-of-truth, different judge prompts, different audit shapes). The plan-stated targets (Stage 1 ≥40%, Stage 1+2 ≥75%, FP <2%, FN <10%) are claims the existing tests assert at the per-case level rather than aggregate metrics — operators reading the test fixtures see exactly what behaviors are pinned.

The original M2-F1 scope is preserved in the plan document for historical reference and can be revisited when types 2 or 3 land (at that point an aggregate empirical baseline across all three makes sense).

## Closeout sequence revised

Was: M2-E1 ✓ → M2-F1 → M2-F2 → M2-E2 → M2-F3
Now: M2-E1 ✓ → ~~M2-F1~~ ✓ (scope reframe) → **M2-E2 (next)** → M2-F2 → M2-F3

M2-E2 was originally going to calibrate \`FLAT_PER_JUDGE_USD\` against the M2-F1 corpus. With F1 closed without a corpus, E2 calibrates the placeholder against measured per-judge-call cost from any input — ~1-2 hr standalone work.

## Files changed

- \`docs/PRD.md\` — DE-279 + DE-280 added after DE-278 in §9
- \`docs/citation-engine.md\` — new \"Scope\" section near the top enumerating the three types and pointing at DE-279 / DE-280 for the unbuilt ones
- \`docs/M2-IMPLEMENTATION-PLAN.md\` — Task M2-F1 marked ✓ Closed (scope reframe, 2026-05-17); risk-row perf-bottleneck line updated to reference OTel spans rather than the corpus

No code changes. Doc-only PR.

## Test plan

- [x] Anchor links in DE-279 / DE-280 cross-references resolve via GFM heading-to-anchor rules
- [x] M2-F1 status block reads as honest closeout, not as overclaim
- [ ] Spot-review by Kevin that the three-type taxonomy as written matches the framing in conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)