### PR TITLE
feat(api,gateway,m2-e2): per-judge cost calibration from routing log

### DIFF
--- a/api/alembic/versions/0029_inference_routing_log_purpose.py
+++ b/api/alembic/versions/0029_inference_routing_log_purpose.py
@@ -7,7 +7,7 @@ computing per-model cost calibration.
 
 Per the M2 plan §M2-E2, the cost pre-flight in ``api/app/api/chats.py``
 previously used a single hard-coded conservative constant
-(``FLAT_PER_JUDGE_USD = 0.005``). That constant is 5-8× off for some
+(``FLAT_PER_JUDGE_USD = 0.005``). That constant is 5-8x off for some
 judge-model choices (haiku → 0.001/call; opus → 0.04/call), which
 either causes unnecessary ensemble fallbacks (cost overestimate) or
 risks runaway spend (cost underestimate when operators select

--- a/api/alembic/versions/0029_inference_routing_log_purpose.py
+++ b/api/alembic/versions/0029_inference_routing_log_purpose.py
@@ -1,0 +1,64 @@
+"""add inference_routing_log.purpose — M2-E2
+
+Adds a nullable ``purpose`` column to ``inference_routing_log`` so
+the api/ side can disambiguate judge calls (Citation Engine Stage 3
+and Stage 4) from regular chat completions and embeddings when
+computing per-model cost calibration.
+
+Per the M2 plan §M2-E2, the cost pre-flight in ``api/app/api/chats.py``
+previously used a single hard-coded conservative constant
+(``FLAT_PER_JUDGE_USD = 0.005``). That constant is 5-8× off for some
+judge-model choices (haiku → 0.001/call; opus → 0.04/call), which
+either causes unnecessary ensemble fallbacks (cost overestimate) or
+risks runaway spend (cost underestimate when operators select
+larger judge models). The fix replaces the constant with a per-model
+rolling average computed from this log — which requires being able
+to filter rows down to judge calls only.
+
+Schema change:
+
+* ``inference_routing_log.purpose: varchar(32) NULL`` — values used in
+  application code: ``'chat'`` (default for chat completions),
+  ``'judge_paraphrase'`` (Citation Engine Stage 3/4 calls),
+  ``'embedding'`` (embeddings calls). Nullable for backwards
+  compatibility with pre-migration rows; downstream code treats NULL
+  the same as ``'chat'`` for cost-calibration purposes (the
+  conservative interpretation).
+* New composite index ``idx_inference_log_model_purpose_timestamp``
+  on ``(routed_model, purpose, timestamp DESC)`` to make the
+  per-model rolling-average query for the cost pre-flight cheap. The
+  existing ``idx_inference_log_timestamp`` covers other access
+  patterns.
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-05-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "inference_routing_log",
+        sa.Column("purpose", sa.String(length=32), nullable=True),
+    )
+    op.execute(
+        """
+        CREATE INDEX idx_inference_log_model_purpose_timestamp
+            ON inference_routing_log (routed_model, purpose, timestamp DESC)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_inference_log_model_purpose_timestamp")
+    op.drop_column("inference_routing_log", "purpose")

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -58,6 +58,7 @@ import re
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query, Request, Response, status
@@ -70,7 +71,7 @@ from app.api.dependencies import ActiveUser
 from app.api.skills import _resolve_skill_for_user
 from app.audit import audit_action
 from app.citation import extract_citations, verify
-from app.citation.verification import FLAT_PER_JUDGE_USD
+from app.citation.cost import estimate_judge_call_cost_usd
 from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
 from app.db.session import get_db
 from app.errors import LQAIError, NotFound, ValidationError
@@ -1401,6 +1402,7 @@ async def _resolve_ensemble_config(
     skill_registry: SkillRegistry | None,
     n_candidates: int,
     message_id: uuid.UUID,
+    db: AsyncSession | None = None,
 ) -> EnsembleConfig | None:
     """Decide whether Stage 4 should run for this message — M2-D1.
 
@@ -1418,11 +1420,18 @@ async def _resolve_ensemble_config(
     * The gateway's
       ``citation_engine.ensemble_verification.default_enabled``.
 
-    Cost-budget pre-flight uses :data:`FLAT_PER_JUDGE_USD` (a
-    deliberately conservative constant) so the check errs on the side
-    of dropping back to single-judge Stage 3 rather than letting an
-    ensemble silently overrun. M2-E2 will replace the flat constant
-    with measured numbers.
+    Cost-budget pre-flight uses M2-E2 per-model calibration via
+    :func:`estimate_judge_call_cost_usd` — each configured judge
+    model's recent rolling-average cost from ``inference_routing_log``
+    rows tagged ``purpose='judge_paraphrase'``. Cold-start (a model
+    with fewer than 5 recent judge calls) falls back to the
+    conservative constant. The check errs toward dropping back to
+    single-judge Stage 3 rather than letting an ensemble silently
+    overrun.
+
+    ``db=None`` is honored by tests that don't exercise the cost-budget
+    path; in that case the estimator skips the DB query and uses the
+    cold-start default. Production callers always pass a real session.
     """
 
     if gateway is None:
@@ -1451,7 +1460,16 @@ async def _resolve_ensemble_config(
     # ensemble spend exceeds the cap, fall back to single-judge Stage 3
     # by returning None (the cascade routes through verify_paraphrase
     # instead). Logged so operators can see when the cap bites.
-    estimated_usd = n_candidates * len(config.judge_models) * FLAT_PER_JUDGE_USD
+    #
+    # M2-E2: sum per-model rolling-average judge costs rather than
+    # multiplying a single flat constant — accuracy matters because
+    # judge models span order-of-magnitude cost differences
+    # (haiku ~$0.001 vs opus ~$0.04 per call).
+    per_judge_costs = [
+        await estimate_judge_call_cost_usd(db, judge_model=judge_model)
+        for judge_model in config.judge_models
+    ]
+    estimated_usd = float(Decimal(n_candidates) * sum(per_judge_costs, Decimal("0")))
     if estimated_usd > config.max_cost_per_message_usd:
         log.warning(
             "chat-send citations: ensemble budget exceeded, falling back to single judge",
@@ -1462,6 +1480,7 @@ async def _resolve_ensemble_config(
                 "n_judges": len(config.judge_models),
                 "estimated_usd": round(estimated_usd, 4),
                 "max_cost_per_message_usd": config.max_cost_per_message_usd,
+                "per_judge_usd": [float(c) for c in per_judge_costs],
             },
         )
         return None
@@ -1539,6 +1558,7 @@ async def _persist_message_citations(
     # skill registry; this function ORs them with the gateway's
     # default to decide whether to dispatch ensemble verification.
     ensemble_config = await _resolve_ensemble_config(
+        db=db,
         gateway=gateway,
         applied_skills=applied_skills,
         project_ensemble_verification=project_ensemble_verification,

--- a/api/app/citation/cost.py
+++ b/api/app/citation/cost.py
@@ -1,0 +1,199 @@
+"""Per-judge-model cost calibration from the inference routing log (M2-E2).
+
+Replaces the M2-D1 flat constant ``FLAT_PER_JUDGE_USD = 0.005`` with a
+per-model rolling average computed from production routing-log data.
+The constant remains as a conservative cold-start fallback.
+
+Why per-model
+-------------
+
+Judge models span order-of-magnitude cost differences:
+
+* ``claude-haiku-4-5`` — ~$0.001 per judge call (1 K input + 200 output).
+* ``claude-sonnet-4-6`` — ~$0.008 per judge call.
+* ``claude-opus-4-7`` — ~$0.040 per judge call.
+* ``gpt-4o-mini`` — ~$0.0008 per judge call.
+* ``gpt-4o`` — ~$0.013 per judge call.
+
+A single flat constant of 0.005 is 5x too conservative for haiku
+(causing unnecessary single-judge fallbacks even when the operator
+configured a cheap ensemble) and 8x too permissive for opus (letting
+ensembles silently overrun the per-message cap when the operator
+configured an expensive ensemble). Per-model calibration sourced from
+the actual routing log fixes both extremes without manual price
+maintenance.
+
+How the estimate works
+----------------------
+
+The gateway records actual ``cost_estimate`` on every inference call.
+M2-E2 added a ``purpose`` column (``'chat' | 'judge_paraphrase' |
+'embedding'``) so this estimator can filter to judge traffic only.
+The rolling average runs over the last 100 judge calls for the model
+(or the last 30 days, whichever cuts smaller) — fresh enough to track
+provider price changes, deep enough to smooth single-call noise.
+
+Cold-start posture
+------------------
+
+When a model has fewer than :data:`_MIN_SAMPLES` recent judge calls,
+the estimator returns :data:`DEFAULT_PER_JUDGE_USD` — the same
+conservative flat constant M2-D1 shipped. Operators with brand-new
+deployments see the conservative budget posture until enough judge
+traffic accumulates to calibrate; that matches the safety story of
+"err toward fallback rather than runaway spend".
+
+Caching
+-------
+
+Pre-flight cost-budget checks call this once per configured judge
+model on every ensemble-activated chat-send. Without caching, a
+3-model ensemble would hit the DB three times per message. The
+estimator caches per-model for ~5 minutes in-process — short enough
+that new judge calls feed back into the average reasonably quickly
+but long enough to amortize the DB hits. Per-process; multi-worker
+deployments accept the per-worker drift as benign noise.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.inference import InferenceRoutingLog
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_PER_JUDGE_USD: Decimal = Decimal("0.005")
+"""Cold-start fallback. Matches the M2-D1 ``FLAT_PER_JUDGE_USD``
+constant in :mod:`app.citation.verification`; intentionally
+conservative so the pre-flight errs toward fallback rather than
+overrun when no calibration data exists yet."""
+
+
+_MIN_SAMPLES = 5
+"""Minimum judge calls required before the rolling average is trusted
+over the cold-start fallback. Below this, a single outlier (e.g., a
+2000-token-input judge call against a long chunk) would distort the
+estimate."""
+
+_WINDOW_SAMPLES = 100
+"""Most recent N judge calls per model included in the rolling
+average. Large enough to smooth noise; small enough that the average
+tracks recent provider price changes within hours of typical traffic."""
+
+_WINDOW_DAYS = 30
+"""Maximum lookback window. Anything older than this is excluded even
+if the model hasn't seen :data:`_WINDOW_SAMPLES` recent calls.
+Protects against price-stale data on low-traffic deployments."""
+
+_CACHE_TTL_SECONDS = 300.0
+"""In-process cache TTL. Tradeoff: shorter = newer calibration data
+feeds in faster but more DB hits; longer = fewer DB hits but stale
+calibration. 5 minutes is the same TTL as the Anthropic prompt cache
+window — keeps the calibration consistent with the cache horizon."""
+
+
+_cache: dict[str, tuple[float, Decimal]] = {}
+
+
+async def estimate_judge_call_cost_usd(
+    db: AsyncSession | None,
+    *,
+    judge_model: str,
+) -> Decimal:
+    """Return the estimated USD cost of one judge call to ``judge_model``.
+
+    Computes the rolling average ``cost_estimate`` across the last
+    :data:`_WINDOW_SAMPLES` ``inference_routing_log`` rows where
+    ``routed_model = judge_model`` AND ``purpose = 'judge_paraphrase'``.
+    Returns :data:`DEFAULT_PER_JUDGE_USD` if fewer than
+    :data:`_MIN_SAMPLES` such rows exist.
+
+    ``db=None`` skips the query and returns :data:`DEFAULT_PER_JUDGE_USD`.
+    Honored by tests that exercise the activation-resolver logic without
+    caring about cost calibration; production callers always pass a real
+    session.
+
+    Cached in-process per :data:`_CACHE_TTL_SECONDS`. Tests can use
+    :func:`invalidate_cache` to reset between assertions.
+    """
+
+    if db is None:
+        return DEFAULT_PER_JUDGE_USD
+
+    now = time.monotonic()
+    cached = _cache.get(judge_model)
+    if cached is not None:
+        cached_at, cached_value = cached
+        if now - cached_at < _CACHE_TTL_SECONDS:
+            return cached_value
+
+    cutoff = datetime.now(UTC) - timedelta(days=_WINDOW_DAYS)
+    recent = (
+        select(InferenceRoutingLog.cost_estimate)
+        .where(
+            InferenceRoutingLog.routed_model == judge_model,
+            InferenceRoutingLog.purpose == "judge_paraphrase",
+            InferenceRoutingLog.cost_estimate.is_not(None),
+            InferenceRoutingLog.timestamp >= cutoff,
+        )
+        .order_by(InferenceRoutingLog.timestamp.desc())
+        .limit(_WINDOW_SAMPLES)
+        .subquery()
+    )
+    stmt = select(
+        func.avg(recent.c.cost_estimate),
+        func.count(recent.c.cost_estimate),
+    )
+
+    try:
+        result = await db.execute(stmt)
+        avg_raw, count = result.one()
+    except Exception as exc:
+        # Defensive: a DB hiccup on the cost pre-flight should never
+        # break chat-send. Fall back to the conservative default and
+        # log loud — operators care about audit-trail visibility on
+        # this failure mode.
+        logger.warning(
+            "judge cost calibration query failed: %s",
+            exc,
+            extra={
+                "event": "citation_cost_query_error",
+                "judge_model": judge_model,
+                "error_type": type(exc).__name__,
+            },
+        )
+        return DEFAULT_PER_JUDGE_USD
+
+    if count is None or count < _MIN_SAMPLES or avg_raw is None:
+        # Cold start — cache the fallback at a short TTL so cold-start
+        # deployments don't query repeatedly. Caching the fallback
+        # also limits DB load if a misconfigured model name is asked
+        # about hundreds of times per minute.
+        _cache[judge_model] = (now, DEFAULT_PER_JUDGE_USD)
+        return DEFAULT_PER_JUDGE_USD
+
+    estimate = Decimal(str(avg_raw))
+    _cache[judge_model] = (now, estimate)
+    return estimate
+
+
+def invalidate_cache(judge_model: str | None = None) -> None:
+    """Reset the in-process cache.
+
+    Tests call this between assertions. Operators can call it via an
+    admin endpoint (not currently exposed) when they know prices have
+    shifted out of band. ``judge_model=None`` clears all entries.
+    """
+
+    if judge_model is None:
+        _cache.clear()
+    else:
+        _cache.pop(judge_model, None)

--- a/api/app/citation/verification.py
+++ b/api/app/citation/verification.py
@@ -50,14 +50,16 @@ from app.schemas.gateway import ChatCompletionRequest
 logger = logging.getLogger(__name__)
 
 
-# Conservative per-judge-call cost estimate used for the M2-D1
-# pre-flight budget check. Real cost depends on the judge model and the
-# claim/chunk lengths; the gateway records actual spend in
-# ``inference_routing_log.cost_estimate`` for post-hoc analysis. This
-# constant is deliberately high (haiku-tier rates + generous tokens)
-# so the budget check errs on the side of falling back to single-judge
-# Stage 3 rather than letting an ensemble silently overrun. M2-E2
-# (ensemble calibration pass) replaces this with measured numbers.
+# Cold-start fallback for the per-judge-call cost pre-flight (M2-D1).
+# Production pre-flight uses :func:`app.citation.cost.estimate_judge_call_cost_usd`
+# which computes a per-model rolling average from the ``inference_routing_log``
+# rows tagged ``purpose='judge_paraphrase'`` (M2-E2). When a judge
+# model has fewer than 5 recent calls, the estimator falls back to
+# this constant — the same conservative value M2-D1 shipped, retained
+# so the cold-start posture is identical to the pre-M2-E2 behavior.
+# Re-exported here (rather than only from cost.py) so call sites that
+# only need the fallback can import without pulling in the SQLAlchemy
+# dependency.
 FLAT_PER_JUDGE_USD = 0.005
 
 
@@ -131,10 +133,12 @@ _MISS = VerificationResult(
 # rejecting genuine paraphrases — they live in the 70-90 range where
 # Stage 3's LLM judge belongs.
 #
-# Per M2-B1 the value is locked here; M2-E2 (ensemble calibration
-# against the M2-F1 acceptance corpus) revisits it with empirical
-# data and may move it. Keep the constant rather than inlining so
-# the calibration task changes one number.
+# Per M2-B1 the value is locked here. M2-E2 calibrated the per-judge
+# cost pre-flight against the routing log but did not adjust this
+# threshold — empirical calibration requires production telemetry
+# the project hasn't collected yet. DE-281 (operational-telemetry
+# calibration) is the future home for both this and the ensemble
+# aggregation rule. Until then the conservative default holds.
 TOLERANT_MATCH_THRESHOLD = 95.0
 
 
@@ -304,6 +308,9 @@ async def verify_paraphrase(
         # see actual content to verify it. Anonymized text would
         # destroy the semantics the judge is checking against.
         anonymize=False,
+        # M2-E2: tag the routing-log row so per-model cost calibration
+        # can filter judge calls from regular chat traffic.
+        lq_ai_purpose="judge_paraphrase",
     )
 
     try:

--- a/api/app/models/inference.py
+++ b/api/app/models/inference.py
@@ -87,6 +87,14 @@ class InferenceRoutingLog(Base):
 
     request_id: Mapped[str | None] = mapped_column(String, nullable=True)
 
+    # M2-E2: distinguishes Citation Engine Stage 3/4 judge calls from
+    # regular chat completions and embeddings. Values written by the
+    # gateway from the request's ``lq_ai_purpose`` extension field:
+    # ``'chat'`` (default), ``'judge_paraphrase'``, ``'embedding'``.
+    # Nullable for backwards compatibility with pre-0029 rows; cost
+    # calibration treats NULL the same as ``'chat'``.
+    purpose: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
     def __repr__(self) -> str:
         return (
             f"<InferenceRoutingLog id={self.id} "

--- a/api/app/schemas/gateway.py
+++ b/api/app/schemas/gateway.py
@@ -182,6 +182,15 @@ class ChatCompletionRequest(BaseModel):
     filesystem-canonical built-in. Omitted means "registry-only",
     which is the right behavior for non-user-bearing callers."""
 
+    lq_ai_purpose: str | None = None
+    """M2-E2: tag for the gateway's routing-log ``purpose`` column.
+    Distinguishes Citation Engine Stage 3/4 judge calls from regular
+    chat completions so per-model cost calibration filters
+    routing-log rows down to judge traffic. Known values used in
+    code: ``'judge_paraphrase'``. ``None`` or any unknown value
+    records as ``'chat'`` on the gateway side. Stripped from the
+    outbound provider body."""
+
 
 # --- Chat completion response -------------------------------------------------
 

--- a/api/tests/citation/test_cost.py
+++ b/api/tests/citation/test_cost.py
@@ -1,0 +1,397 @@
+"""Per-judge-model cost calibration — M2-E2.
+
+Targets :mod:`app.citation.cost`:
+
+* ``db=None`` cold-start fast-path.
+* Rolling-average computation against real routing-log rows.
+* Cold-start fallback when < _MIN_SAMPLES rows exist.
+* Filter correctness — ``purpose='judge_paraphrase'`` only, NULL
+  ``cost_estimate`` excluded, stale rows excluded.
+* Cache hits return without hitting the DB twice.
+* ``invalidate_cache`` resets entries.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.cost import (
+    DEFAULT_PER_JUDGE_USD,
+    estimate_judge_call_cost_usd,
+    invalidate_cache,
+)
+from app.models.inference import InferenceRoutingLog
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache() -> None:
+    """Reset the in-process cache between tests so cached values from
+    one test don't leak into the next."""
+
+    invalidate_cache()
+
+
+def _judge_row(
+    *,
+    routed_model: str,
+    cost_estimate: Decimal | None,
+    purpose: str | None = "judge_paraphrase",
+    timestamp: datetime | None = None,
+) -> InferenceRoutingLog:
+    return InferenceRoutingLog(
+        id=uuid.uuid4(),
+        timestamp=timestamp or datetime.now(UTC),
+        routed_provider="anthropic-prod",
+        routed_model=routed_model,
+        routed_inference_tier=3,
+        cost_estimate=cost_estimate,
+        purpose=purpose,
+    )
+
+
+# --- db=None ----------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_db_none_returns_default_without_query() -> None:
+    """``db=None`` is the test/cold-start fast-path; no DB hit needed."""
+
+    estimate = await estimate_judge_call_cost_usd(None, judge_model="claude-haiku-4-5")
+    assert estimate == DEFAULT_PER_JUDGE_USD
+
+
+# --- Cold start -------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_cold_start_no_rows_returns_default(db_session: AsyncSession) -> None:
+    """A model with no routing-log rows at all falls back to the default."""
+
+    estimate = await estimate_judge_call_cost_usd(db_session, judge_model="never-seen-judge")
+    assert estimate == DEFAULT_PER_JUDGE_USD
+
+
+@pytest.mark.integration
+async def test_below_min_samples_returns_default(db_session: AsyncSession) -> None:
+    """Fewer than _MIN_SAMPLES=5 judge rows → fall back to default."""
+
+    # Insert 3 judge rows (below the 5-sample minimum).
+    for _ in range(3):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.0010"),
+            )
+        )
+    await db_session.flush()
+
+    estimate = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+    assert estimate == DEFAULT_PER_JUDGE_USD
+
+
+# --- Rolling average --------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_rolling_average_computes_correctly(db_session: AsyncSession) -> None:
+    """5+ judge rows for a model → returns the average of cost_estimate."""
+
+    # Five judge calls at varying prices; average = 0.0030
+    prices = [
+        Decimal("0.0010"),
+        Decimal("0.0020"),
+        Decimal("0.0030"),
+        Decimal("0.0040"),
+        Decimal("0.0050"),
+    ]
+    for price in prices:
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=price,
+            )
+        )
+    await db_session.flush()
+
+    estimate = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+    # Allow tiny rounding tolerance — SQL AVG returns Numeric and we
+    # convert through Decimal(str(...)) which preserves the printed form.
+    assert estimate == Decimal("0.00300000000000000000") or estimate == Decimal("0.0030")
+
+
+# --- Filter correctness -----------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_purpose_filter_excludes_chat_rows(db_session: AsyncSession) -> None:
+    """Chat-purpose rows for the same model are ignored.
+
+    A model can serve both chat traffic and judge traffic — averaging
+    over both would let chat-token-distribution drown out judge cost.
+    """
+
+    # Five chat rows at $0.020 (a typical chat call) for the same model.
+    for _ in range(5):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.0200"),
+                purpose="chat",
+            )
+        )
+    await db_session.flush()
+
+    estimate = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+    # No judge_paraphrase rows → fall back to default, NOT 0.020.
+    assert estimate == DEFAULT_PER_JUDGE_USD
+
+
+@pytest.mark.integration
+async def test_purpose_filter_excludes_null_purpose_rows(db_session: AsyncSession) -> None:
+    """Rows with NULL purpose (pre-0029 backfill) are excluded.
+
+    Pre-migration rows don't have the column populated; treating them
+    as judge calls would be wrong because their token distribution
+    matches whatever the call actually was. Conservative interpretation:
+    only known-purpose 'judge_paraphrase' rows count.
+    """
+
+    for _ in range(5):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.0050"),
+                purpose=None,
+            )
+        )
+    await db_session.flush()
+
+    estimate = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+    assert estimate == DEFAULT_PER_JUDGE_USD
+
+
+@pytest.mark.integration
+async def test_null_cost_estimate_rows_excluded(db_session: AsyncSession) -> None:
+    """Judge rows missing ``cost_estimate`` don't poison the average.
+
+    Some providers (e.g., Ollama) don't carry a published per-token
+    price; the gateway records NULL ``cost_estimate`` on those rows.
+    Including them in the average would dilute or skew the estimate.
+    """
+
+    # 5 valid judge rows at $0.0010 + 10 NULL-cost judge rows.
+    for _ in range(5):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.0010"),
+            )
+        )
+    for _ in range(10):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=None,
+            )
+        )
+    await db_session.flush()
+
+    estimate = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+    assert estimate == Decimal("0.00100000000000000000") or estimate == Decimal("0.0010")
+
+
+@pytest.mark.integration
+async def test_stale_rows_excluded(db_session: AsyncSession) -> None:
+    """Rows older than _WINDOW_DAYS=30 are excluded.
+
+    Protects against price-stale data on low-traffic deployments. Five
+    valid recent rows at $0.001 + ten stale rows at $0.100 → estimate
+    reflects only the recent (cheap) data, not the stale outliers.
+    """
+
+    now = datetime.now(UTC)
+    stale = now - timedelta(days=60)
+
+    for _ in range(5):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.0010"),
+                timestamp=now,
+            )
+        )
+    for _ in range(10):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.1000"),
+                timestamp=stale,
+            )
+        )
+    await db_session.flush()
+
+    estimate = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+    # If the stale rows weren't excluded, the average would be ~0.067.
+    assert estimate < Decimal("0.005")
+    assert estimate == Decimal("0.00100000000000000000") or estimate == Decimal("0.0010")
+
+
+# --- Cache ------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_cache_returns_same_value_without_db_hit(db_session: AsyncSession) -> None:
+    """Second call within TTL returns cached value even if rows change.
+
+    The cache is keyed by ``judge_model`` only. Inserting new rows after
+    the cache populates should not change the returned estimate within
+    the TTL window — proves the cache is short-circuiting the query.
+    """
+
+    # Seed with 5 rows at $0.001
+    for _ in range(5):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.0010"),
+            )
+        )
+    await db_session.flush()
+
+    first = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+
+    # Add more expensive rows — would shift the average if cache miss.
+    for _ in range(10):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.1000"),
+            )
+        )
+    await db_session.flush()
+
+    second = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+    assert second == first
+
+
+@pytest.mark.integration
+async def test_invalidate_cache_clears_specific_model(
+    db_session: AsyncSession,
+) -> None:
+    """``invalidate_cache(model)`` re-queries on next call."""
+
+    for _ in range(5):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.0010"),
+            )
+        )
+    await db_session.flush()
+
+    first = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+    assert first != DEFAULT_PER_JUDGE_USD  # we got the calibrated value
+
+    invalidate_cache("claude-haiku-4-5")
+
+    # After invalidation + adding more rows, next call sees fresh average.
+    for _ in range(5):
+        db_session.add(
+            _judge_row(
+                routed_model="claude-haiku-4-5",
+                cost_estimate=Decimal("0.0100"),
+            )
+        )
+    await db_session.flush()
+
+    second = await estimate_judge_call_cost_usd(db_session, judge_model="claude-haiku-4-5")
+    # New average over 10 rows = (5x0.001 + 5x0.010) / 10 = 0.0055
+    assert second > first  # picked up the new expensive rows
+
+
+@pytest.mark.unit
+async def test_invalidate_cache_all_clears_everything() -> None:
+    """``invalidate_cache(None)`` clears all entries."""
+
+    # Populate cache for two models via the db=None fast path. The
+    # fast path doesn't write to the cache (it returns early), so we
+    # call through with db=None and assert the function still works.
+    # The clear-all behavior is exercised by the lack of side-effects
+    # observed in other tests' autouse cleanup.
+    await estimate_judge_call_cost_usd(None, judge_model="a")
+    await estimate_judge_call_cost_usd(None, judge_model="b")
+
+    invalidate_cache(None)  # should not raise
+
+
+# --- Pre-flight integration -------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_resolve_ensemble_uses_per_model_calibration(
+    db_session: AsyncSession,
+) -> None:
+    """End-to-end: a seeded routing-log shifts the pre-flight outcome.
+
+    With the M2-D1 flat constant (0.005), 2 candidates x 3 judges =
+    $0.03 — well under a $0.05 budget, so ensemble activates. With
+    M2-E2 per-model calibration where each judge averages $0.020
+    (a realistic opus rate), 2 x 3 x 0.020 = $0.12 — over budget, so
+    ensemble falls back. This test proves the per-model lookup is
+    wired into ``_resolve_ensemble_config`` and changes the decision.
+    """
+
+    from app.api.chats import _resolve_ensemble_config
+
+    # Seed enough judge rows per model that the rolling average kicks in.
+    for model in ("judge-a", "judge-b", "judge-c"):
+        for _ in range(5):
+            db_session.add(
+                _judge_row(
+                    routed_model=model,
+                    cost_estimate=Decimal("0.0200"),
+                )
+            )
+    await db_session.flush()
+
+    class _Cfg:
+        default_enabled = True
+        judge_models: tuple[str, ...] = ("judge-a", "judge-b", "judge-c")
+        aggregation_rule = "strict"
+        max_cost_per_message_usd = 0.05
+        envelope_tier = 3
+
+    class _Gw:
+        async def get_citation_engine_ensemble_config(self) -> _Cfg:
+            return _Cfg()
+
+    # WITHOUT calibration (db=None) the conservative default applies
+    # and the request passes the budget.
+    result_default = await _resolve_ensemble_config(
+        gateway=_Gw(),
+        applied_skills=[],
+        project_ensemble_verification=True,
+        skill_registry=None,
+        n_candidates=2,
+        message_id=uuid.uuid4(),
+        db=None,
+    )
+    assert result_default is not None  # 2 x 3 x 0.005 = $0.03 < $0.05
+
+    # WITH calibration (real db_session + seeded rows) the per-model
+    # average is $0.020/call, so 2 x 3 x 0.020 = $0.12 — falls back.
+    result_calibrated = await _resolve_ensemble_config(
+        gateway=_Gw(),
+        applied_skills=[],
+        project_ensemble_verification=True,
+        skill_registry=None,
+        n_candidates=2,
+        message_id=uuid.uuid4(),
+        db=db_session,
+    )
+    assert result_calibrated is None  # calibrated estimate exceeded budget

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2872,6 +2872,28 @@ Type 2 is high-priority for any deployment used in litigation work — a fabrica
 
 **Acceptance criteria:** judge calibrated against the gold set (≥0.85 precision @ ≥0.70 recall); end-to-end integration with DE-279 (a chat response with a case statement triggers DE-279 resolution + DE-280 content check in parallel); UI renders the case-statement verdict alongside KB-quote verdicts; cost-budget pre-flight handles long-opinion edge cases; documented end-to-end in `docs/citation-engine.md` under a new §3 "Case content accuracy"; depends on DE-279 landing first.
 
+#### DE-281 — Citation Engine operational-telemetry calibration (TOLERANT_MATCH_THRESHOLD + aggregation_rule)
+
+**Priority:** P2 · **Effort:** S
+
+**Context:** M2-E2 calibrated the per-judge-call cost pre-flight against the routing log (replacing the M2-D1 flat `FLAT_PER_JUDGE_USD = 0.005` constant with per-model rolling averages). Two other Citation Engine constants were originally scoped for M2-E2 calibration in the M2 plan but were not addressed because they require empirical workload data the project did not collect (M2-F1 closed via scope reframe rather than building an annotated corpus):
+
+- **`TOLERANT_MATCH_THRESHOLD = 95.0`** at `api/app/citation/verification.py:138` — rapidfuzz threshold for Stage 2 (tolerant-match) acceptance. 95 catches normalization-only differences (smart quotes, whitespace collapse, OCR confusions) while rejecting genuine paraphrases (~70-90 range) that belong to Stage 3. The 95 boundary is plausible but empirically uncalibrated — a real workload might want 92 or 97 to land on the precision/recall sweet spot.
+- **`aggregation_rule: strict`** default in `gateway.yaml.example` and `gateway/app/config.py` — Stage 4 ensemble aggregation. Strict requires unanimous agreement across N judges; majority needs N/2+1. The "strict produces too many verified-with-caveats surfaces" vs "majority is too permissive" tradeoff is a UX-and-correctness call that depends on observed disagreement rates the project hasn't measured.
+
+**The M2-E2 substrate enables this:** the per-purpose routing-log column (added in migration 0029) and the rolling-average query infrastructure (`api/app/citation/cost.py`) generalize cleanly to per-stage verdict telemetry. The same machinery that calibrates cost can calibrate accuracy once production deployments accumulate enough chat-send → citation-verdict telemetry to compute disagreement rates and stage-pass distributions.
+
+**Specific scope:**
+
+- Extend `inference_routing_log` (or add a sibling `citation_verdict_log` table) to record per-citation Stage-1-vs-Stage-2-vs-Stage-3 outcomes when Stage 4 ensemble fired, including the per-judge verdict tuples. Lets operators see "of the last 1000 ensemble verifications, how often did the 3 judges agree?" without a synthetic corpus.
+- New admin endpoint `GET /admin/v1/citation-calibration` exposing rolling stats: Stage 1 pass rate, Stage 2 pass rate (of Stage 1 misses), Stage 3 pass rate (of Stage 2 misses for single-judge), Stage 4 disagreement rate (per-judge tuple distribution), per-stage average cost.
+- Calibration recommendations: when disagreement rate exceeds X%, the admin surface suggests flipping `aggregation_rule` to `majority`. When Stage 2 pass rate is near-zero, suggest lowering `TOLERANT_MATCH_THRESHOLD`. When near-100%, suggest raising it.
+- `gateway.yaml` accepts both constants as configurable values (operators can override the defaults per deployment based on the recommendations).
+
+**Why deferred:** the current values are conservative and operator-overridable; no production deployment has accumulated the telemetry needed to calibrate them. The M2-E2 cost calibration shipped because per-model judge cost has obvious order-of-magnitude variation that's measurable from published price sheets; threshold + aggregation calibration both require observing how operators' real workloads behave, which is post-v0.2 work.
+
+**Acceptance criteria:** admin endpoint surfaces per-stage rolling stats with at least 30 days of telemetry; calibration recommendations match the documented decision rules; `gateway.yaml.example` adds documented override knobs for both constants; integration test exercises the recommendation logic against seeded telemetry data; `docs/citation-engine.md` adds a "Calibration" section linking the constants to the telemetry surface.
+
 ### Workflow intelligence
 
 This subsection captures the bounded items that operationalize the M5+ Forward-Looking Workflow Intelligence direction (§8.5). The items are bounded enough to be picked up by community contributors as the M5+ roadmap matures. The architectural slot for the MCP-client subsystem is already committed for M1–M2 (§8 M1) so this subsection's items can be implemented incrementally without core refactoring.

--- a/docs/citation-engine.md
+++ b/docs/citation-engine.md
@@ -156,20 +156,67 @@ resolution.
 
 ## Cost-budget pre-flight
 
-Stage 4 cost grows as `n_citations × n_judges`. To prevent runaway
-spend on a single message:
+Stage 4 cost grows as `n_citations × Σ(per-judge cost)`. To prevent
+runaway spend on a single message:
 
 ```
-estimated_usd = n_citations × n_judges × FLAT_PER_JUDGE_USD
+per_judge_costs = [estimate_judge_call_cost_usd(db, model)
+                   for model in config.judge_models]
+estimated_usd = n_citations × sum(per_judge_costs)
 if estimated_usd > max_cost_per_message_usd:
     fall back to single-judge Stage 3
 ```
 
-`FLAT_PER_JUDGE_USD = 0.005` is a deliberately conservative constant
-(haiku-tier rates + generous token estimates) so the check errs on
-the side of falling back rather than overrunning. M2-E2 (ensemble
-calibration pass) replaces it with measured numbers from the
-acceptance corpus.
+### Per-judge calibration (M2-E2)
+
+`estimate_judge_call_cost_usd(db, judge_model)` in
+[`api/app/citation/cost.py`](../api/app/citation/cost.py) computes a
+rolling average over the most recent 100 (or last 30 days, whichever
+is smaller) `inference_routing_log` rows where
+`routed_model = judge_model` AND `purpose = 'judge_paraphrase'`. The
+`purpose` column was added in migration 0029 and is set by the api/
+side via the `lq_ai_purpose` request envelope field — the gateway
+strips it from the outbound provider body and writes it to the
+routing-log row.
+
+Why per-model: judge costs span order-of-magnitude differences
+(`claude-haiku-4-5` ~$0.001/call vs `claude-opus-4-7` ~$0.04/call).
+A single flat constant of 0.005 is 5× too conservative for haiku
+ensembles (causing unnecessary fallbacks) and 8× too permissive for
+opus ensembles (risking runaway spend).
+
+### Cold-start fallback
+
+Models with fewer than 5 recent judge calls fall back to
+`DEFAULT_PER_JUDGE_USD = 0.005` — the same conservative constant
+shipped in M2-D1. Cold-start deployments see the conservative budget
+posture until enough judge traffic accumulates to calibrate; that
+matches the safety story of "err toward fallback rather than runaway
+spend".
+
+### Cache
+
+The estimator caches per-model results for 300 seconds (5 min)
+in-process. A 3-model ensemble pre-flight therefore costs at most 3
+DB queries every 5 minutes; subsequent pre-flights in the same
+window cost zero DB queries. Per-process; multi-worker deployments
+accept the per-worker drift as benign noise.
+
+### What's NOT calibrated (yet)
+
+Two Citation Engine constants remain at conservative pre-calibration
+defaults — they need empirical workload data the project hasn't
+collected yet:
+
+- `TOLERANT_MATCH_THRESHOLD = 95.0` (Stage 2 rapidfuzz threshold).
+- `aggregation_rule: strict` (Stage 4 ensemble default in
+  `gateway.yaml.example`).
+
+Both are tracked at [PRD §9 DE-281](PRD.md#de-281--citation-engine-operational-telemetry-calibration-tolerant_match_threshold--aggregation_rule)
+for operational-telemetry calibration once production deployments
+accumulate sufficient stage-pass distribution and disagreement-rate
+data. The M2-E2 per-purpose routing-log substrate generalizes
+cleanly to that future work.
 
 ## Privacy implications of Stage 4
 

--- a/gateway/app/api/inference.py
+++ b/gateway/app/api/inference.py
@@ -1181,6 +1181,7 @@ async def _stream_openai_sse(
             request_id=request_id,
             chat_id=chat_id,
             message_id=message_id,
+            purpose=_purpose_from_request(chat_request),
         )
     )
 
@@ -1223,6 +1224,35 @@ def _correlation_ids(
     chat_id = _parse(chat_request.lq_ai_chat_id) or _parse(chat_request.chat_id)
     message_id = _parse(chat_request.lq_ai_message_id)
     return chat_id, message_id
+
+
+# Known values for the ``inference_routing_log.purpose`` column. Values
+# outside this set fall back to ``'chat'`` in :func:`_purpose_from_request`
+# so an arbitrary caller can't pollute the column with free-form strings.
+_KNOWN_PURPOSES = frozenset({"chat", "judge_paraphrase", "embedding"})
+
+
+def _purpose_from_request(chat_request: ChatCompletionRequest) -> str:
+    """Resolve the routing-log ``purpose`` tag from the chat request envelope.
+
+    M2-E2 added ``lq_ai_purpose`` to :class:`ChatCompletionRequest`. The
+    Citation Engine sets it to ``'judge_paraphrase'`` on every Stage 3
+    / Stage 4 judge call so the api/ cost-calibration query can filter
+    routing-log rows down to judge traffic only. Other callers leave
+    it unset and the row records ``'chat'``.
+
+    Unknown values fall back to ``'chat'`` defensively — the column is
+    ``varchar(32)`` and downstream code expects one of the known
+    values.
+    """
+
+    raw = chat_request.lq_ai_purpose
+    if raw is None:
+        return "chat"
+    value = raw.strip()
+    if value in _KNOWN_PURPOSES:
+        return value
+    return "chat"
 
 
 def _annotate_response(
@@ -1276,6 +1306,7 @@ async def _write_success(
             request_id=request_id,
             chat_id=chat_id,
             message_id=message_id,
+            purpose=_purpose_from_request(chat_request),
         )
     )
 
@@ -1322,6 +1353,7 @@ async def _write_failure(
             request_id=request_id,
             chat_id=chat_id,
             message_id=message_id,
+            purpose=_purpose_from_request(chat_request),
         )
     )
 
@@ -1350,6 +1382,7 @@ async def _write_unavailable(
             request_id=request_id,
             chat_id=chat_id,
             message_id=message_id,
+            purpose=_purpose_from_request(chat_request),
         )
     )
 
@@ -1388,6 +1421,7 @@ async def _write_refusal(
             request_id=request_id,
             chat_id=chat_id,
             message_id=message_id,
+            purpose=_purpose_from_request(chat_request),
         )
     )
 
@@ -1424,6 +1458,7 @@ async def _write_unresolved(
             request_id=request_id,
             chat_id=chat_id,
             message_id=message_id,
+            purpose=_purpose_from_request(chat_request),
         )
     )
 
@@ -1516,6 +1551,7 @@ async def _write_embeddings_success(
             cost_estimate=cost,
             latency_ms=latency_ms,
             request_id=request_id,
+            purpose="embedding",
         )
     )
 
@@ -1541,6 +1577,7 @@ async def _write_embeddings_failure(
             refused=False,
             refusal_reason=f"upstream_error:{error.code}",
             request_id=request_id,
+            purpose="embedding",
         )
     )
 
@@ -1564,6 +1601,7 @@ async def _write_embeddings_unavailable(
             refused=False,
             refusal_reason=f"adapter_unavailable:{message}",
             request_id=request_id,
+            purpose="embedding",
         )
     )
 
@@ -1586,5 +1624,6 @@ async def _write_unresolved_embeddings(
             refused=True,
             refusal_reason=f"invalid_model:{message}",
             request_id=request_id,
+            purpose="embedding",
         )
     )

--- a/gateway/app/providers/openai.py
+++ b/gateway/app/providers/openai.py
@@ -98,6 +98,7 @@ _LQ_AI_EXTENSION_KEYS = frozenset(
         "lq_ai_chat_id",
         "lq_ai_message_id",
         "lq_ai_user_id",
+        "lq_ai_purpose",
     }
 )
 

--- a/gateway/app/providers/openai_schema.py
+++ b/gateway/app/providers/openai_schema.py
@@ -267,6 +267,14 @@ class ChatCompletionRequest(BaseModel):
     "registry-only", which is the right behavior for non-user-bearing
     callers (smoke scripts, internal admin tooling, etc.)."""
 
+    lq_ai_purpose: str | None = None
+    """M2-E2: tag for the routing-log ``purpose`` column. Distinguishes
+    judge calls (Citation Engine Stage 3/4) from regular chat
+    completions so per-model cost calibration filters down to judge
+    traffic. Known values used in code: ``'judge_paraphrase'``;
+    ``None`` or any unknown value falls back to ``'chat'`` in the
+    persisted row. Stripped from the outbound provider body."""
+
 
 # --- Chat completion response -------------------------------------------------
 

--- a/gateway/app/routing_log.py
+++ b/gateway/app/routing_log.py
@@ -79,6 +79,11 @@ class InferenceRoutingLogRow:
     refused: bool = False
     refusal_reason: str | None = None
     request_id: str | None = None
+    # M2-E2: 'chat' | 'judge_paraphrase' | 'embedding'. Sourced from the
+    # request's ``lq_ai_purpose`` extension field on chat paths, hardcoded
+    # to ``'embedding'`` on embeddings paths. Lets per-model cost
+    # calibration filter routing-log rows down to judge-call traffic.
+    purpose: str | None = None
     timestamp: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
 
 
@@ -104,7 +109,8 @@ _INSERT_SQL = text(
         anonymization_applied,
         refused,
         refusal_reason,
-        request_id
+        request_id,
+        purpose
     ) VALUES (
         :timestamp,
         :user_id,
@@ -121,7 +127,8 @@ _INSERT_SQL = text(
         :anonymization_applied,
         :refused,
         :refusal_reason,
-        :request_id
+        :request_id,
+        :purpose
     )
     """
 )
@@ -210,4 +217,5 @@ def _to_params(row: InferenceRoutingLogRow) -> dict[str, object]:
         "refused": row.refused,
         "refusal_reason": row.refusal_reason,
         "request_id": row.request_id,
+        "purpose": row.purpose,
     }

--- a/gateway/tests/test_inference_b4.py
+++ b/gateway/tests/test_inference_b4.py
@@ -332,3 +332,116 @@ async def test_streaming_response_carries_tier(
     assert row.routed_provider == "anthropic-prod"
     assert row.tokens_in == 3
     assert row.tokens_out == 1
+
+
+# --- M2-E2: purpose column ---------------------------------------------------
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_routing_log_purpose_defaults_to_chat(
+    client_with_recorder: tuple[AsyncClient, RecordingRoutingLogWriter],
+) -> None:
+    """M2-E2: a regular chat-send writes ``purpose='chat'`` on the routing log."""
+
+    client, recorder = client_with_recorder
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "msg_purpose_chat",
+                "model": "claude-opus-4-7",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 2},
+            },
+        )
+    )
+
+    response = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert response.status_code == 200
+    assert len(recorder.rows) == 1
+    assert recorder.rows[0].purpose == "chat"
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_routing_log_purpose_judge_paraphrase_propagates(
+    client_with_recorder: tuple[AsyncClient, RecordingRoutingLogWriter],
+) -> None:
+    """M2-E2: ``lq_ai_purpose='judge_paraphrase'`` on the request lands on the row.
+
+    Citation Engine Stage 3/4 sets this so api/-side cost calibration
+    can filter routing-log rows down to judge traffic only.
+    """
+
+    client, recorder = client_with_recorder
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "msg_purpose_judge",
+                "model": "claude-opus-4-7",
+                "content": [{"type": "text", "text": '{"verdict":"yes"}'}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 800, "output_tokens": 50},
+            },
+        )
+    )
+
+    response = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "smart",
+            "messages": [{"role": "user", "content": "judge this"}],
+            "lq_ai_purpose": "judge_paraphrase",
+        },
+    )
+    assert response.status_code == 200
+    assert len(recorder.rows) == 1
+    assert recorder.rows[0].purpose == "judge_paraphrase"
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_routing_log_purpose_unknown_value_sanitizes_to_chat(
+    client_with_recorder: tuple[AsyncClient, RecordingRoutingLogWriter],
+) -> None:
+    """M2-E2: an unknown ``lq_ai_purpose`` value falls back to ``'chat'``.
+
+    Defensive: the column is ``varchar(32)`` and downstream code expects
+    one of the known values. An arbitrary caller can't pollute the
+    column with free-form strings.
+    """
+
+    client, recorder = client_with_recorder
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "msg_purpose_unknown",
+                "model": "claude-opus-4-7",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 3, "output_tokens": 1},
+            },
+        )
+    )
+
+    response = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "smart",
+            "messages": [{"role": "user", "content": "hi"}],
+            "lq_ai_purpose": "evil_attacker_string",
+        },
+    )
+    assert response.status_code == 200
+    assert len(recorder.rows) == 1
+    assert recorder.rows[0].purpose == "chat"

--- a/gateway/tests/test_openai_adapter.py
+++ b/gateway/tests/test_openai_adapter.py
@@ -434,6 +434,7 @@ async def test_chat_completion_strips_lq_ai_extension_keys() -> None:
         lq_ai_chat_id="11111111-1111-1111-1111-111111111111",
         lq_ai_message_id="22222222-2222-2222-2222-222222222222",
         lq_ai_user_id="33333333-3333-3333-3333-333333333333",
+        lq_ai_purpose="judge_paraphrase",
         chat_id="audit-tag",
         anonymize=True,
     )
@@ -465,6 +466,7 @@ async def test_chat_completion_strips_lq_ai_extension_keys() -> None:
         "lq_ai_chat_id",
         "lq_ai_message_id",
         "lq_ai_user_id",
+        "lq_ai_purpose",
     ):
         assert forbidden not in sent, f"LQ.AI extension {forbidden!r} leaked to OpenAI"
 

--- a/gateway/tests/test_routing_log.py
+++ b/gateway/tests/test_routing_log.py
@@ -84,6 +84,7 @@ def test_to_params_emits_all_columns() -> None:
         "refused",
         "refusal_reason",
         "request_id",
+        "purpose",
     }
     assert set(params.keys()) == expected
     assert params["routed_provider"] == "p"


### PR DESCRIPTION
## Summary

- **Replaces** the M2-D1 conservative flat \`FLAT_PER_JUDGE_USD = 0.005\` constant in the ensemble cost-budget pre-flight with **per-model rolling averages** computed from the actual \`inference_routing_log\` table.
- **Why:** the flat constant is 5x too conservative for cheap judges (\`claude-haiku-4-5\` ~\$0.001/call) and 8x too permissive for expensive ones (\`claude-opus-4-7\` ~\$0.04/call). Rolling-average path fixes both extremes without manual price-table maintenance.
- **Filed [DE-281](https://github.com/LegalQuants/lq-ai/blob/m2-e2-cost-calibration/docs/PRD.md#de-281--citation-engine-operational-telemetry-calibration-tolerant_match_threshold--aggregation_rule)** for the two other Citation Engine constants the M2 plan originally scoped to E2 (TOLERANT_MATCH_THRESHOLD + aggregation_rule). Those need empirical workload data the project hasn't collected; the M2-E2 per-purpose routing-log substrate generalizes cleanly to that future work.

## What ships

**Migration 0029** — \`inference_routing_log.purpose\` (varchar(32), nullable) + composite index \`(routed_model, purpose, timestamp DESC)\` for the rolling-average query.

**Per-purpose tagging:**
- \`ChatCompletionRequest\` gains \`lq_ai_purpose: str | None\`. Gateway adds to \`_LQ_AI_EXTENSION_KEYS\` so it strips from outbound bodies. All 10 routing-log row constructions in \`gateway/app/api/inference.py\` write the resolved value (chat handlers use \`_purpose_from_request\` with 'chat' default + unknown-value sanitization; embedding handlers hardcode 'embedding').
- Citation Engine's \`verify_paraphrase\` sets \`lq_ai_purpose='judge_paraphrase'\` on every Stage 3/4 judge call.

**Estimator** (\`api/app/citation/cost.py\`):
- \`estimate_judge_call_cost_usd(db, *, judge_model)\` queries last 100 (or 30 days, whichever cuts smaller) routing-log rows where \`routed_model = X AND purpose = 'judge_paraphrase' AND cost_estimate IS NOT NULL\`.
- Returns rolling average if >=5 samples; otherwise the conservative \`DEFAULT_PER_JUDGE_USD = 0.005\` cold-start fallback (same value M2-D1 shipped).
- 5-min in-process per-model cache amortizes DB load on pre-flight.
- DB errors fall back to default + log loud so operators have audit-trail visibility.
- \`db=None\` short-circuit returns default — keeps existing stub-based activation tests green.

**Pre-flight call site** (\`api/app/api/chats.py::_resolve_ensemble_config\`):
- Sums per-model rolling-average judge costs rather than multiplying a single constant.
- \`db\` is a new optional kwarg defaulting to None.
- Budget-fallback warning now stamps the per-model cost breakdown so operators can see which model in a heterogeneous ensemble drove the cap.

## Test plan

- [x] api/ unit + integration: 1001 → **1013** (+12 in test_cost.py: db=None fast-path, cold-start, rolling average, purpose filter, NULL cost_estimate exclusion, 30-day window, cache hit/invalidate, end-to-end pre-flight integration). Zero regressions.
- [x] gateway/ unit + integration: 512 → **515** (+3 in test_inference_b4.py: purpose defaults to 'chat', 'judge_paraphrase' propagates, unknown values sanitize). Zero regressions.
- [x] ruff format + ruff check + mypy strict (gateway) + mypy standard (api) — all green
- [x] Migration 0029 verified end-to-end via integration tests running \`alembic upgrade head\` against test Postgres
- [ ] Live verification with real provider keys (operator-side, same posture as M2-D1)

## DE-281 (filed in this PR)

Two constants intentionally **not** calibrated this PR — they need empirical workload data the project hasn't collected:

- \`TOLERANT_MATCH_THRESHOLD = 95.0\` (Stage 2 rapidfuzz threshold)
- \`aggregation_rule: strict\` (Stage 4 ensemble default in \`gateway.yaml.example\`)

DE-281 outlines the operational-telemetry calibration path: extend the routing-log telemetry substrate this PR builds, expose stage-pass distribution + disagreement rate via a new admin endpoint, surface calibration recommendations to operators based on observed traffic.

## Files changed (16)

3 new: migration 0029, \`api/app/citation/cost.py\`, \`api/tests/citation/test_cost.py\`.
13 modified: chats.py, verification.py, inference.py model, schemas/gateway.py, PRD.md, citation-engine.md, gateway inference.py + providers/openai.py + providers/openai_schema.py + routing_log.py + 3 test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)