### PR TITLE
docs(m2,anonymization,prd): M2-F2 transparency-first closeout + DE-282 for community contribution

### DIFF
--- a/docs/HONEST-STATE.md
+++ b/docs/HONEST-STATE.md
@@ -75,7 +75,7 @@ The Inference Gateway is the security boundary — the only component holding pr
 | AWS Bedrock provider adapter | deferred (community-friendly) | Fully spec'd in [PRD §9 DE-035](PRD.md#de-035--aws-bedrock-provider-adapter-anthropic-on-bedrock) with AWS Event Stream parser + SigV4 acceptance criteria |
 | Tier enforcement (Tiers 1 – 5) | M1 | `gateway/app/tier_floor.py` |
 | Privileged-matter tier floor enforcement | M1 + M2-D3 (verification) | `web/cypress/e2e/wave-d1-power-features.cy.ts` Test 3 + Test 5; M2-D3 added end-to-end audit-trail integration test at `api/tests/test_chat_citations.py::test_chat_send_privileged_project_full_audit_trail` |
-| Anonymization pre/post middleware | M2 | `gateway/app/anonymization/middleware.py`; see §3.2 below |
+| Anonymization pre/post middleware | M2 (recognizer accuracy on legal corpus: empirically unmeasured — see [PRD §9 DE-282](PRD.md#de-282--anonymization-layer-empirical-validation-on-legal-document-corpus) and [`docs/security/anonymization.md` §"What's validated vs what's unvalidated"](security/anonymization.md#whats-validated-vs-whats-unvalidated)) | `gateway/app/anonymization/middleware.py`; see §3.2 below |
 | Routing log (per-inference) | M1 | `gateway/app/routing_log.py` |
 | Citation Engine config endpoint (`GET /v1/citation-engine/config`) | M2-C1 + M2-D1 | `gateway/app/api/inference.py::citation_engine_config` — returns judge_model + ensemble block with server-computed `envelope_tier` |
 | Provider-key encryption at rest (Fernet-wrapped master-key path) | M1 | `gateway/app/secrets.py`; `docs/security/encrypted-keys.md` |
@@ -299,7 +299,7 @@ The verification budget is the operator's to set, on a timeline the operator cho
 
 ## 10. Maintenance note
 
-This document is maintained per release. Items leave the deferred lists when they ship; items join when they are scoped. Last updated alongside M2 Phase D + E1 close — Citation Engine 4-stage cascade, Anonymization Layer with custom legal recognizers, privileged-project handling, Azure OpenAI provider adapter (M2-E1, API-key auth; AD path tracked at DE-278); 2026-05-17.
+This document is maintained per release. Items leave the deferred lists when they ship; items join when they are scoped. Last updated alongside the M2 closeout chain — Phase D + E1 + E2 shipped, F1 closed via scope reframe, F2 closed via transparency-first deferral (DE-282 invites community contribution for empirical PII-recognition validation on legal corpus); 2026-05-17.
 
 The substantive content that drives this doc lives in:
 

--- a/docs/M2-IMPLEMENTATION-PLAN.md
+++ b/docs/M2-IMPLEMENTATION-PLAN.md
@@ -585,36 +585,31 @@ This original scope can be revisited if/when type-2 or type-3 validation lands �
 
 ---
 
-### Task M2-F2 — Anonymization acceptance test corpus
+### Task M2-F2 — Anonymization acceptance test corpus — ✓ Closed (transparency-first deferral, 2026-05-17)
 
-**Scope:**
+**Status:** **✓ Closed via transparency-first deferral.** Unlike [M2-F1](#task-m2-f1--citation-engine-acceptance-test-corpus--closed-scope-reframe-2026-05-17) where the existing test coverage made the corpus redundant, M2-F2's underlying question is **genuinely open**: Presidio default-recognizer recall + precision on legal-document corpus is empirically unmeasured, and the maintainer team does not have the practice-specific judgment needed to author ground-truth annotations across the diversity of in-house legal workflows the project serves.
+
+The chosen response, per Kevin's framing on 2026-05-17:
+
+> "What we're shooting for is if we don't do something to the highest level of transparency, confidentiality and privilege we note it and ask for the community to contribute to accomplish it — honest, transparent and lets the user know where to trust and where to be careful — for example, absent this, a user might choose to use local inference to hedge against the risk — let's give them all the information they need to make the right professional decision — we win on transparency."
+
+Specifically:
+
+1. **`docs/security/anonymization.md` gained a top-level "What's validated vs what's unvalidated" section** that explicitly enumerates what the existing test coverage measures (custom recognizers, middleware integration, round-trip correctness, edge cases) and what it does not measure (Presidio default-recognizer recall + precision on legal corpus, disabled-recognizer trade-offs per practice area).
+2. **The risk framing is explicit**: a recognizer miss is a silent confidentiality incident, distinct from citation-verification misses which surface in the UI. Operational telemetry cannot recover the leak post-hoc — pre-deployment empirical validation is the right shape of work, but the project does not have the data to produce it.
+3. **Actionable guidance is provided**: practicing attorneys who cannot accept the unvalidated risk for a given matter are pointed to Tier 1 (fully local) inference, the explicit "disable anonymization" posture, pre-redaction at upload, or manual per-message review. The user has all the information they need to make the right professional decision.
+4. **The work is invited from the community via [PRD §9 / DE-282](PRD.md#de-282--anonymization-layer-empirical-validation-on-legal-document-corpus)**, structured to combine bounded technical work (runner + metrics + CI wiring) with practice-specific judgment work (entity-type prioritization, ground-truth annotations, recognizer-set re-evaluation per practice area). Personal-injury, employment, immigration, benefits, healthcare, and international-practice contributors are explicitly welcomed.
+
+The original M2-F2 scope (curate ~50 docs, build runner, hit baseline targets) is preserved verbatim in DE-282 — a contributor picking up the DE can execute against the same plan.
+
+**Original scope (preserved at DE-282 for contributors; not built by the maintainer team in v0.2):**
+
 - Curate ~50 legal documents with ground-truth entity annotations.
-  - Sources: anonymized real documents; supplemented with public-domain legal documents.
-  - Annotations: per entity type, list of (text, start_offset, end_offset, type) tuples.
-- Build runner: `scripts/run_anonymization_eval.py` that:
-  - Loads the corpus and ground-truth annotations.
-  - Runs each document through the Analyzer.
-  - Reports per-entity-type:
-    - Recall: % of ground-truth entities caught.
-    - Precision: % of caught entities that are actual entities.
-    - F1 score.
-- Baseline targets:
-  - PERSON, ORG: recall ≥95%, precision ≥90%.
-  - EMAIL, PHONE: recall ≥98%, precision ≥98% (regex-based, should be near-perfect).
-  - ADDRESS: recall ≥85%, precision ≥80% (variability is higher).
-  - CASE_NUMBER, MATTER_NUMBER: recall ≥70%, precision ≥75% (custom recognizers; harder).
-- Document the corpus, runner, and baseline metrics in `docs/security/anonymization.md`.
-- Add to CI as nightly.
+- Build runner: `scripts/run_anonymization_eval.py` reporting per-entity-type recall, precision, F1.
+- Baseline targets: PERSON / ORG ≥95% / ≥90%; EMAIL / PHONE ≥98% / ≥98%; ADDRESS ≥85% / ≥80%; CASE_NUMBER / MATTER_NUMBER ≥70% / ≥75%.
+- Document the baseline in `docs/security/anonymization.md`.
 
-**Dependencies:** All of Phase A–D.
-
-**Output:** Anonymization has an empirical baseline.
-
-**Verification:**
-- Eval runs successfully.
-- Baseline metrics meet or exceed targets above.
-
-**Effort:** 10–14 hours.
+**Closeout sequence final** (Kevin, 2026-05-17): M2-E1 ✓ → ~~M2-F1~~ ✓ (scope reframe; existing coverage is sufficient) → M2-E2 ✓ (cost calibration shipped) → ~~M2-F2~~ ✓ (transparency-first deferral; DE-282 invites community contribution) → **M2-F3 (next, final)**.
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2894,6 +2894,52 @@ Type 2 is high-priority for any deployment used in litigation work — a fabrica
 
 **Acceptance criteria:** admin endpoint surfaces per-stage rolling stats with at least 30 days of telemetry; calibration recommendations match the documented decision rules; `gateway.yaml.example` adds documented override knobs for both constants; integration test exercises the recommendation logic against seeded telemetry data; `docs/citation-engine.md` adds a "Calibration" section linking the constants to the telemetry surface.
 
+#### DE-282 — Anonymization Layer empirical validation on legal-document corpus
+
+**Priority:** P1 · **Effort:** M (10–14 hours of focused work; structured for incremental community contribution)
+
+**Status:** **Open — community contribution welcomed.** This DE captures the original [M2-F2 plan scope](M2-IMPLEMENTATION-PLAN.md#task-m2-f2--anonymization-acceptance-test-corpus) which the maintainers chose not to ship in v0.2 in favor of transparent disclosure of the validation gap (see [`docs/security/anonymization.md` §"What's validated vs what's unvalidated"](security/anonymization.md#whats-validated-vs-whats-unvalidated)). The choice keeps v0.2's ship cadence intact while inviting contributions from practitioners whose practice areas have specific recognizer needs.
+
+**Context:** The M2 Anonymization Layer (§4.7) enables 6 Presidio default recognizers (`PERSON`, `ORGANIZATION`, `EMAIL_ADDRESS`, `PHONE_NUMBER`, `US_BANK_NUMBER`, `LOCATION`) plus 2 custom legal recognizers (`CaseNumberRecognizer`, `MatterNumberRecognizer`), and disables 7 noisy defaults (`UsSsn`, `UsPassport`, `UsLicense`, `Crypto`, `Iban`, `Ip`, `MedicalLicense`). The enable/disable judgments reflect engineering reasoning about typical legal-document corpus — **not** empirical recall + precision measurements on a curated corpus of contracts, briefs, and correspondence.
+
+For citation verification, a recognizer miss surfaces visibly to the user as an "unverified" chip. For anonymization, **a miss is a silent confidentiality incident** — unredacted client data reaches the model provider before the operator has any signal something went wrong. Operational-telemetry calibration (the path used for cost in [DE-281](#de-281--citation-engine-operational-telemetry-calibration-tolerant_match_threshold--aggregation_rule)) can't address this because by the time a miss is observable, the leak has already happened. Pre-deployment empirical validation against representative legal-document corpus is the right shape of work.
+
+**Specific scope (port of the original M2-F2 plan):**
+
+- **Curate ~50 documents** with ground-truth entity annotations. Sources can mix:
+  - Anonymized real practice documents (operator/contributor-supplied; the corpus itself ships under whatever license the contributor specifies, including potentially a separate license tier from the main project).
+  - Public-domain legal documents (federal/state statutes via `uscode.house.gov`, court opinions from CourtListener, SEC EDGAR contract exhibits).
+  - Synthetic but representative documents authored under the project's license.
+- **Annotations format:** per entity type, list of `(text, start_offset, end_offset, type)` tuples. JSONL recommended for diff-friendliness in git.
+- **Build runner:** `scripts/run_anonymization_eval.py` that loads the corpus, runs each document through `get_analyzer_engine().analyze(...)`, computes per-entity-type recall / precision / F1 against ground truth, reports the aggregate baseline.
+- **Baseline targets** (restated from the original M2-F2 plan; revisit if contributor evidence suggests they need recalibration):
+  - `PERSON`, `ORGANIZATION`: recall ≥95%, precision ≥90%.
+  - `EMAIL_ADDRESS`, `PHONE_NUMBER`: recall ≥98%, precision ≥98% (regex-based; should be near-perfect).
+  - `LOCATION` (ADDRESS): recall ≥85%, precision ≥80%.
+  - `CASE_NUMBER`, `MATTER_NUMBER`: recall ≥70%, precision ≥75%.
+- **Document the corpus, runner, and baseline metrics** in `docs/security/anonymization.md`, replacing the "What's NOT validated" section's "Unknown" placeholders with measured values.
+- **Optional CI nightly** — informational, non-blocking. The corpus is stable enough that meaningful changes only happen when the recognizer set changes, so PR-time CI is sufficient to catch regressions for most contributors.
+
+**Practice-area sub-areas welcomed:**
+
+- **Personal-injury / employment / benefits / immigration practices** — re-evaluate the `UsSsnRecognizer` disable. These practices routinely handle real SSNs; the current disable is correct for general civil litigation but potentially wrong for these areas. Contribution shape: corpus subset that exercises real SSN density in representative documents, plus a measured FP-rate analysis for the case-number collision Presidio's SSN recognizer produces.
+- **Healthcare / regulated-industry practices** — re-evaluate `MedicalLicenseRecognizer`, possibly add new recognizers for DEA numbers, NPI numbers, NDC codes. Practice-specific entity types are valuable additions.
+- **International practices** — extend beyond Presidio's US-centric defaults. Foreign-language detection is a separate gap tracked in the [Foreign-language entities](security/anonymization.md#foreign-language-entities--out-of-scope-for-v1) section; recognizer-set extensions for non-US jurisdictions belong here.
+- **Document Bates numbering, account numbers, social media handles, date-of-birth patterns** — entity types not in the current set that operators have flagged or might flag.
+
+**Acceptance criteria:**
+
+- Corpus of at least 30 documents committed under `eval/anonymization/corpus/` (or a similar path), with documented sourcing and license per document.
+- Annotations file at `eval/anonymization/annotations.jsonl` with schema documented in `eval/anonymization/README.md`.
+- Eval runner at `scripts/run_anonymization_eval.py` produces per-entity-type metrics.
+- Measured baseline numbers replace the "Unknown" placeholders in `docs/security/anonymization.md` §"What's NOT validated".
+- If any recognizer-set changes are proposed alongside the corpus (e.g., re-enabling `UsSsn` for a practice-area variant), the corpus includes positive and negative examples justifying the change.
+- DCO sign-off + attestation per the project's [skill-contribution model](../skills/CONTRIBUTING.md): the contributor confirms the corpus and annotations were authored under their practice judgment.
+
+**Why this is the right kind of community contribution:**
+
+This DE intentionally combines bounded technical work with practice-specific judgment work. The technical pieces (runner, metrics, CI wiring) are picked up cleanly by any contributor familiar with Python + Presidio. The judgment pieces (which entity types matter, which disable choices to reconsider, which patterns are realistic) require the kind of practice-specific knowledge no single maintainer can supply across the diversity of in-house legal teams' workflows. Splitting the work across contributors who own their respective practice areas is the right shape — and the project's [transparency principle](#13-transparency-as-a-founding-principle) is what makes the invitation honest in the first place.
+
 ### Workflow intelligence
 
 This subsection captures the bounded items that operationalize the M5+ Forward-Looking Workflow Intelligence direction (§8.5). The items are bounded enough to be picked up by community contributors as the M5+ roadmap matures. The architectural slot for the MCP-client subsystem is already committed for M1–M2 (§8 M1) so this subsection's items can be implemented incrementally without core refactoring.

--- a/docs/security/anonymization.md
+++ b/docs/security/anonymization.md
@@ -6,6 +6,50 @@
 
 ---
 
+## What's validated vs what's unvalidated
+
+This section exists because LQ.AI's [founding transparency principle](../PRD.md#13-transparency-as-a-founding-principle) requires us to be explicit about where this layer has been measured and where it has not — so practicing attorneys can make informed professional judgments about confidentiality posture per matter.
+
+### What is validated
+
+- **Custom legal recognizers** (`CaseNumberRecognizer`, `MatterNumberRecognizer`): ~24 unit tests in `gateway/tests/anonymization/test_recognizers.py` exercise the pattern matchers on hand-crafted positive and negative examples (federal reporter cites, state reporter cites, docket-number variants, alpha-year-sequence matter numbers, dotted matter numbers, and adversarial near-misses). The recognizers do what they claim against the patterns we anticipated.
+- **Middleware pre/post integration**: pre-anonymization fires before the request leaves the gateway, post-anonymization rehydrates the response (including SSE-streaming tail-buffer for pseudonyms that span chunk boundaries). Pinned by `test_middleware.py` + `test_round_trip.py` + the M2-C3 17-test round-trip correctness suite.
+- **Edge cases pinned in M2-D4**: long entity names, multi-line entities (address blocks spanning `\n`), the retrieval-context skip flag, the privileged-project tier-floor invariant. See `test_edge_cases.py`.
+- **Pseudonym format stability**: `{ENTITY_TYPE}_{NNNN}` is deterministic per-request and idempotent on re-substitution.
+
+### What is NOT validated
+
+**Presidio default-recognizer accuracy on legal-document corpus.** The Anonymization Layer enables 6 of Presidio's default recognizers (`PERSON`, `ORGANIZATION`, `EMAIL_ADDRESS`, `PHONE_NUMBER`, `US_BANK_NUMBER`, `LOCATION`) and disables 7 others (`UsSsnRecognizer`, `UsPassportRecognizer`, `UsLicenseRecognizer`, `CryptoRecognizer`, `IbanRecognizer`, `IpRecognizer`, `MedicalLicenseRecognizer`). The choices reflect engineering judgment about typical legal-document corpus, **not** empirical recall + precision measurements on a curated corpus of contracts, briefs, and correspondence.
+
+Specifically, the following are unmeasured:
+
+- **Recall per entity type** — when a real contract contains 10 PERSON names, how many does Presidio actually catch? 95%? 80%? Unknown.
+- **Precision per entity type** — when Presidio flags a string as a PERSON, how often is that flag correct on legal prose vs the news/social-media corpus Presidio was developed against? Unknown.
+- **Disabled-recognizer trade-offs** — `UsSsnRecognizer` was disabled because the `123-45-6789` shape collides with case numbers and exhibit IDs in general legal corpus. But personal-injury, employment-discrimination, immigration, and benefits practices routinely handle real SSNs. The disable choice is correct for general civil litigation; it is potentially wrong for those specific practice areas, and the trade-off has not been measured.
+- **Custom-recognizer performance on real legal text** — the unit tests cover anticipated patterns. Recall against unanticipated drafting styles (international citation conventions, pre-2010 docket-number formats, firm-specific matter-number conventions) is unmeasured.
+
+### Why this matters — a miss is a silent confidentiality incident
+
+For citation verification, a miss surfaces in the user interface as an "unverified" chip — the lawyer sees the system's uncertainty and can react. For anonymization, **a miss is silent**: a PERSON name slips through, the unredacted text reaches the model provider, the response comes back rehydrated as if nothing happened, and the lawyer has no in-app signal that client confidentiality was breached. Operational telemetry cannot recover the leak post-hoc — by the time the miss is observable, the unredacted content has already been transmitted, logged, and possibly used in provider-side training (depending on the routed [Inference Tier](../PRD.md#152-the-inference-tier-model)).
+
+This is a meaningfully different load-bearing posture than the citation-verification layer's "wrong answers visibly marked unverified" story. We document it explicitly so practicing attorneys can apply the **professional-judgment standard** that confidentiality work warrants — and so the project does not overclaim a privacy guarantee it has not yet empirically supported.
+
+### What to do if you can't accept the unvalidated risk
+
+Operators with confidentiality requirements that demand validated PII recognition (e.g., privileged matter work, regulated-data practices, or any matter where a single PII miss is unacceptable) have one principal mitigation today: **route to a Tier 1 (fully local) inference path** so the question is moot. Per [PRD §1.5.2](../PRD.md#152-the-inference-tier-model), Tier 1 keeps the chat content inside the operator's environment — Ollama via `docker compose --profile local up` is the default — and no provider call leaves the deployment at all. The Anonymization Layer still runs (the pseudonym/rehydrate round-trip is observable in logs for the operator's own audit), but its failure mode shifts from "leak to a third party" to "leak inside your own infrastructure," which is a categorically different risk surface.
+
+Other paths to consider (without full Tier 1 routing):
+
+1. **Disable anonymization entirely** (`anonymization.enabled: false` in `gateway.yaml`) and rely on the routed Inference Tier's contractual protections (ZDR / no-training agreements at Tier 3 and 4). Honest posture: the operator has decided the provider's contractual commitments are sufficient, and the gateway is no longer attempting recognition.
+2. **Pre-redact at upload time** outside the LQ.AI pipeline so the chat-send path operates on already-redacted content. Suitable for narrow matter sets where the operator's existing tooling handles PII removal.
+3. **Manual review on a per-message basis** — operators who route highly sensitive chats can flip the per-chat anonymization toggle off (where exposed in the UI) and inspect each outbound chat themselves before sending. Slow; only viable for a small volume of work.
+
+### Path to closing the gap
+
+This gap is tracked at [PRD §9 / DE-282 — Anonymization Layer empirical validation on legal-document corpus](../PRD.md#de-282--anonymization-layer-empirical-validation-on-legal-document-corpus). The DE is **scoped as a community-contribution opportunity**: it needs (a) practicing-attorney judgment for entity-type prioritization and ground-truth annotation, and (b) bounded technical work for the eval runner and metrics. The original M2-F2 plan (curate ~50 legal documents, annotate per entity type, build the eval runner, report recall/precision/F1, document the baseline in this file) is preserved as the contribution-ready scope. Contributors from specific practice areas — particularly those whose work routinely involves SSN / driver-license / passport recognition, or matter-number conventions outside the current defaults — are explicitly welcomed to extend the corpus and propose recognizer-set changes.
+
+---
+
 ## What gets pseudonymized
 
 Per the **M2-1 decision** locked at M2 kickoff, anonymization applies only to **chat and skill content** sent to the model. Retrieved source documents stay un-pseudonymized so the model sees intact source quotes for citation grounding and the user-facing retrieval surface continues to render real document text. The skip mechanism is the `lq_ai_skip_anonymization` field on `ChatCompletionMessage`: the api/ marks the retrieval-context system message with `True`; the gateway middleware honors the flag and leaves that message's content alone. See [Retrieval-context skip](#retrieval-context-skip-m2-d2) below for the data flow. The alternative (Option A — pseudonymize the document corpus too) is filed as **[DE-269](../PRD.md#de-269--anonymization-option-a-pseudonymize-source-documents-too)** for future consideration.


### PR DESCRIPTION
## Summary

Closes M2-F2 (Anonymization acceptance test corpus) via **transparency-first deferral** rather than maintainer-built corpus. The underlying question is genuinely open — Presidio default-recognizer recall + precision on legal-document corpus is empirically unmeasured — but the project's response is to **document the gap honestly and invite community contribution** rather than ship a partial corpus authored without the practice-specific judgment the work warrants.

**Kevin's framing (2026-05-17):** *"if we don't do something to the highest level of transparency, confidentiality and privilege we note it and ask for the community to contribute to accomplish it — honest, transparent and lets the user know where to trust and where to be careful — for example, absent this, a user might choose to use local inference to hedge against the risk — let's give them all the information they need to make the right professional decision — we win on transparency."*

## What's different from M2-F1 and M2-E2 closeouts

- **M2-F1** closed because existing unit + integration + Cypress + browser + round-trip tests already covered the load-bearing surface — corpus was redundant.
- **M2-E2** shipped because cost calibration had an architecturally right answer (per-purpose routing-log + per-model rolling averages) — measurable from production data.
- **M2-F2** closes because: (a) the question is open and the data is real, (b) a recognizer miss is a *silent confidentiality incident* (unlike citation misses which surface in UI), (c) operational telemetry can't recover the leak post-hoc, (d) pre-deployment empirical validation needs practice-specific judgment the maintainer team doesn't have alone. The principled response is transparency + community invitation, not a partial corpus.

## What ships (doc-only, no code)

- **\`docs/security/anonymization.md\`** gains a top-level "What's validated vs what's unvalidated" section near the document head. Enumerates what's tested vs what's not. Risk framing: misses are silent. Actionable guidance for users who can't accept the unvalidated risk — route to Tier 1 (Ollama local), disable anonymization with honest contractual-protection posture, pre-redact at upload, or per-message review. Links to DE-282.
- **PRD §9 DE-282** added — Anonymization Layer empirical validation. Structured as a community-contribution opportunity. Restates the original M2-F2 plan scope as the contribution-ready surface. Welcomes practice-area sub-contributions (personal-injury / employment / immigration / benefits for the SSN re-enable question; healthcare for medical-license + adjacent entities; international for non-US recognizer extensions).
- **\`docs/M2-IMPLEMENTATION-PLAN.md\`** Task M2-F2 marked ✓ Closed with the transparency-first reasoning. Original scope preserved verbatim at DE-282.
- **\`docs/HONEST-STATE.md\`** anonymization row + timeline updated.

## Test plan

- [x] No code changes; no test runs needed
- [x] All anchor links in DE-282 ↔ anonymization.md ↔ HONEST-STATE.md cross-references verified
- [ ] Spot-review by Kevin that the disclosure tone matches the founding transparency principle

## M2 closeout chain

Final sequence: M2-E1 ✓ → ~~M2-F1~~ ✓ (scope reframe) → M2-E2 ✓ (cost calibration shipped) → ~~M2-F2~~ ✓ (transparency-first deferral; this PR) → **M2-F3 (next, final)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)