### PR TITLE
feat(api,web,m3-0-1): DE-283 fresh-install login UX — bootstrap-password hint on first 401

### DIFF
--- a/api/app/api/__init__.py
+++ b/api/app/api/__init__.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Depends
 from app.api import (
     admin,
     auth,
+    bootstrap,
     chat_receipts,
     chats,
     enhance_prompt,
@@ -49,6 +50,11 @@ api_router = APIRouter(prefix="/api/v1")
 # Routers with mixed per-endpoint policies — see each module for details.
 api_router.include_router(auth.router)
 api_router.include_router(users.router)
+
+# Unauthenticated probe used by the login UI to surface fresh-install hints
+# (M3-0.1 / DE-283). Mounted without `_active` because the login screen
+# consults it before the operator has credentials.
+api_router.include_router(bootstrap.router)
 
 # Service-to-service router (gateway → backend). Authenticated by the
 # shared X-LQ-AI-Gateway-Key header per ADR 0006, NOT by the user-token

--- a/api/app/api/bootstrap.py
+++ b/api/app/api/bootstrap.py
@@ -1,0 +1,92 @@
+"""Bootstrap-state endpoint — M3-0.1 / DE-283.
+
+The fresh-install operator lands on the login screen with a randomly
+generated admin password printed to the API container's logs. The web
+app surfaces that path more gently than a generic 401 by asking the
+backend whether the deployment is still in fresh-install state.
+
+This module exposes:
+
+* ``GET /api/v1/admin/bootstrap-status`` — unauthenticated; returns
+  ``{"default_password_active": bool, "logs_hint": str}``.
+
+The endpoint is intentionally unauthenticated — it is consulted by the
+login screen *before* the operator has credentials. The signal it
+exposes (is an admin user still in ``must_change_password=True`` state?)
+is low-sensitivity: the bootstrap password itself is 24 chars of CSPRNG
+output, so knowing the deployment is fresh-install does not measurably
+help an attacker who lacks the log line.
+
+The detection signal mirrors the one used by ``ensure_first_run_admin``
+in :mod:`app.admin_bootstrap`: an admin user with
+``must_change_password=True`` indicates the operator has not yet
+rotated. Once they hit ``POST /api/v1/auth/change-password`` the flag
+flips to False and ``default_password_active`` returns False — the
+login UI hides the hint automatically.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.models.user import User
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+# The exact command operators run to retrieve the bootstrap password. This
+# string is rendered verbatim by the login UI in a copy-friendly chip, so
+# the grep target must match the log line emitted by the lifespan handler
+# in :mod:`app.main`, which logs the plaintext password once at WARNING.
+# The "First-run admin password" prefix is the canonical grep pattern
+# already documented in :doc:`/quickstart` (Step 1 / Troubleshooting).
+_LOGS_HINT = 'docker compose logs api 2>&1 | grep "First-run admin password"'
+
+
+class BootstrapStatus(BaseModel):
+    """Wire shape for ``GET /api/v1/admin/bootstrap-status``."""
+
+    default_password_active: bool = Field(
+        description=(
+            "True when at least one non-deleted admin user still has "
+            "must_change_password=True — the bootstrap password printed at "
+            "first start has not been rotated yet."
+        )
+    )
+    logs_hint: str = Field(
+        description=(
+            "Shell command an operator can run to retrieve the bootstrap "
+            "password from the API container's logs."
+        )
+    )
+
+
+@router.get(
+    "/bootstrap-status",
+    response_model=BootstrapStatus,
+    summary="Report whether the first-run bootstrap admin password is still active.",
+)
+async def get_bootstrap_status(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> BootstrapStatus:
+    """Unauthenticated probe used by the login UI to render fresh-install hints."""
+    result = await db.execute(
+        select(User.id)
+        .where(
+            User.is_admin.is_(True),
+            User.must_change_password.is_(True),
+            User.deleted_at.is_(None),
+        )
+        .limit(1)
+    )
+    default_password_active = result.scalar_one_or_none() is not None
+    return BootstrapStatus(
+        default_password_active=default_password_active,
+        logs_hint=_LOGS_HINT,
+    )

--- a/api/tests/test_bootstrap_status.py
+++ b/api/tests/test_bootstrap_status.py
@@ -1,0 +1,161 @@
+"""Tests for the M3-0.1 / DE-283 bootstrap-status endpoint.
+
+Covers the contract documented in :mod:`app.api.bootstrap`:
+
+* The endpoint is unauthenticated (login screen consults it pre-auth).
+* ``default_password_active`` is True when an admin with
+  ``must_change_password=True`` exists.
+* ``default_password_active`` flips to False once the operator has
+  rotated (the existing change-password flow clears the flag).
+* Soft-deleted admins do not keep the hint visible.
+* The ``logs_hint`` string matches the grep target operators are told
+  to use in :doc:`/quickstart`.
+
+Tests run against the same SAVEPOINT-rolled-back per-test session as
+the rest of the API tests (per ``tests/conftest.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.main import app
+from app.models.user import User
+from app.security import hash_password
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    """Async HTTP client wired to the in-process app, sharing the test session."""
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.integration
+async def test_bootstrap_status_active_when_admin_has_must_change_password(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Fresh-install state: admin exists with ``must_change_password=True``."""
+    db_session.add(
+        User(
+            email="admin@lq.ai",
+            hashed_password=hash_password("bootstrap-pw"),
+            is_admin=True,
+            role="admin",
+            mfa_enabled=False,
+            must_change_password=True,
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/v1/admin/bootstrap-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["default_password_active"] is True
+    assert body["logs_hint"] == ('docker compose logs api 2>&1 | grep "First-run admin password"')
+
+
+@pytest.mark.integration
+async def test_bootstrap_status_inactive_after_password_rotation(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Once the operator rotates, ``must_change_password`` flips False."""
+    db_session.add(
+        User(
+            email="admin@lq.ai",
+            hashed_password=hash_password("a-rotated-password"),
+            is_admin=True,
+            role="admin",
+            mfa_enabled=False,
+            must_change_password=False,
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/v1/admin/bootstrap-status")
+    assert resp.status_code == 200
+    assert resp.json()["default_password_active"] is False
+
+
+@pytest.mark.integration
+async def test_bootstrap_status_inactive_when_no_admin_exists(
+    client: AsyncClient,
+) -> None:
+    """Defensive: zero admin rows → not "active" (there is nothing to hint at)."""
+    resp = await client.get("/api/v1/admin/bootstrap-status")
+    assert resp.status_code == 200
+    assert resp.json()["default_password_active"] is False
+
+
+@pytest.mark.integration
+async def test_bootstrap_status_ignores_soft_deleted_admins(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A soft-deleted admin must not keep the hint visible."""
+    db_session.add(
+        User(
+            email="ex-admin@lq.ai",
+            hashed_password=hash_password("doesn't matter"),
+            is_admin=True,
+            role="admin",
+            mfa_enabled=False,
+            must_change_password=True,
+            deleted_at=datetime.now(UTC),
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/v1/admin/bootstrap-status")
+    assert resp.status_code == 200
+    assert resp.json()["default_password_active"] is False
+
+
+@pytest.mark.integration
+async def test_bootstrap_status_ignores_non_admin_users_with_flag(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``must_change_password`` on a non-admin is irrelevant to this signal."""
+    db_session.add(
+        User(
+            email="member@example.com",
+            hashed_password=hash_password("pw"),
+            is_admin=False,
+            role="member",
+            mfa_enabled=False,
+            must_change_password=True,
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/v1/admin/bootstrap-status")
+    assert resp.status_code == 200
+    assert resp.json()["default_password_active"] is False
+
+
+@pytest.mark.integration
+async def test_bootstrap_status_is_unauthenticated(client: AsyncClient) -> None:
+    """No bearer token, no must_change_password gate — anyone can probe.
+
+    The endpoint is consulted by the login screen before the operator has
+    credentials. A 401 here would defeat the entire purpose.
+    """
+    resp = await client.get("/api/v1/admin/bootstrap-status")
+    # 200 (or whatever the actual state is) — emphatically not 401/403.
+    assert resp.status_code == 200

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -163,6 +163,8 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("GET", "/api/v1/chats/{chat_id}/receipts/export.jsonl"),
     # D0 — Model availability (proxy to gateway /v1/models)
     ("GET", "/api/v1/models"),
+    # M3-0.1 / DE-283 — unauthenticated fresh-install state probe
+    ("GET", "/api/v1/admin/bootstrap-status"),
     # D0.5 — Admin alias CRUD proxy
     ("GET", "/api/v1/admin/aliases"),
     ("GET", "/api/v1/admin/aliases/{name}"),

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -111,6 +111,8 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         # admin
         "/api/v1/admin/audit-log",
         "/api/v1/admin/tier-policy",
+        # M3-0.1 / DE-283 — unauthenticated fresh-install state probe
+        "/api/v1/admin/bootstrap-status",
         # D0.5 — model alias admin
         "/api/v1/admin/config",
         "/api/v1/admin/aliases",
@@ -157,7 +159,8 @@ async def test_openapi_paths_match_sketch() -> None:
     # + Wave D.1 T4's /inference/override-tier-floor
     # + Wave D.2's three paths: /user-skills/{id}/versions,
     # /skills/autocomplete, /projects/sandbox/ensure.
-    assert len(actual) == 73
+    # + M3-0.1's /admin/bootstrap-status.
+    assert len(actual) == 74
 
 
 @pytest.mark.unit

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2964,9 +2964,11 @@ This DE intentionally combines bounded technical work with practice-specific jud
 
 #### DE-283 — Fresh-install login UX: surface the bootstrap-password path on first 401
 
-**Priority:** P2 · **Effort:** S (~30 min — community-friendly first PR)
+**Priority:** P2 · **Effort:** S (~3–4 h as actually shipped)
 
-**Status:** Open — surfaced during the M2 pre-tag fresh-install validation (2026-05-17). The maintainer team hit it; an attentive quickstart reader would not, but the failure mode is undocumented at the point it actually happens (the login screen), only at the point a careful reader is meant to have already addressed it (the quickstart Step 4).
+**Status:** **SHIPPED at M3-0.1** (Phase 0, pre-M3 hardening). Implemented as a new unauthenticated `GET /api/v1/admin/bootstrap-status` endpoint the web login screen consults on the first 401 to decide whether to surface a bootstrap-password hint; the hint hides automatically once the operator rotates (signal: any non-deleted admin still has `must_change_password=true`). Approach is a variant of the DE-283 specific-scope option (b) below — separate-endpoint rather than embedded-in-401-response, so the login endpoint's wire shape stays unchanged. Preserved as a reference example of a small, well-scoped contribution; see the M3-0.1 implementation for the pattern (single backend module + Pydantic schema + integration tests; single Svelte component change + Cypress E2E; one quickstart paragraph).
+
+**Original context (preserved for the historical record):** Surfaced during the M2 pre-tag fresh-install validation (2026-05-17). The maintainer team hit it; an attentive quickstart reader would not, but the failure mode is undocumented at the point it actually happens (the login screen), only at the point a careful reader is meant to have already addressed it (the quickstart Step 4).
 
 **Context:** When an operator deploys a fresh stack (or wipes volumes and restarts), the bootstrap path in `api/app/admin_bootstrap.py` creates a default admin user `admin@lq.ai` with a randomly-generated password printed once to the API container's logs ("First-run admin password: …"). The [quickstart §Step 4](quickstart.md#step-4--sign-in-as-the-first-run-admin) tells operators to grep the logs. Three failure modes routinely reach the login screen instead:
 

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -2339,6 +2339,49 @@ paths:
                   next_cursor: {type: string, nullable: true}
 
   # ----------- ADMIN: MODEL ALIAS CRUD (D0.5) -----------
+  /api/v1/admin/bootstrap-status:
+    get:
+      tags: [admin]
+      summary: Report whether the first-run bootstrap admin password is still active
+      description: |
+        **Unauthenticated.** Consulted by the login UI before the operator
+        has credentials, so it can render a fresh-install hint pointing at
+        the API container logs when the bootstrap password has not yet
+        been rotated (M3-0.1 / DE-283).
+
+        ``default_password_active`` is True when at least one non-deleted
+        admin user still has ``must_change_password=True``. The flag flips
+        to False once the operator hits ``POST /api/v1/auth/change-password``,
+        at which point the login UI stops surfacing the hint.
+
+        The signal exposed by this endpoint is low-sensitivity: the
+        bootstrap password is 24 characters of CSPRNG output, so knowing
+        a deployment is in fresh-install state does not measurably help
+        an attacker who lacks the log line.
+      responses:
+        '200':
+          description: Bootstrap state
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [default_password_active, logs_hint]
+                properties:
+                  default_password_active:
+                    type: boolean
+                    description: |
+                      True when at least one admin user is still in the
+                      ``must_change_password=True`` state, indicating the
+                      first-run bootstrap password has not been rotated.
+                  logs_hint:
+                    type: string
+                    description: |
+                      Shell command an operator can run to retrieve the
+                      bootstrap password from the API container's logs.
+                example:
+                  default_password_active: true
+                  logs_hint: 'docker compose logs api 2>&1 | grep "First-run admin password"'
+
   /api/v1/admin/aliases:
     get:
       tags: [admin]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -74,6 +74,8 @@ Save the password. You'll use it momentarily.
 
 Open <http://localhost:3000/lq-ai> in your browser. The LQ.AI chat shell lives at `/lq-ai` per [ADR 0009](adr/0009-web-lq-ai-shell-coexistence.md); the upstream OpenWebUI shell at `/` is preserved untouched and is not the canonical experience for this quickstart. Sign in with email `admin@lq.ai` (the default — configurable via `LQ_AI_FIRST_RUN_ADMIN_EMAIL`) and the password from the previous step. The first time you sign in, you're prompted to set a permanent password; do so.
 
+> **Forgot to copy the bootstrap password?** Type any password and submit. If the deployment is still in fresh-install state, the login screen surfaces an inline hint with the exact `docker compose logs` command above and a one-click copy button (M3-0.1 / DE-283). The hint hides itself automatically once you've set your permanent password.
+
 > **Admin tip — Settings → Models.** Once signed in as an admin you'll see a **Settings** link in the top-right of the LQ.AI shell. It opens the model alias editor (D0.5) at `/lq-ai/admin/models`, where you can edit the `smart` / `fast` / `budget` / `local` / `embedding` aliases without restarting the gateway. Edits write `gateway.yaml` atomically and hot-reload the gateway in process; in-flight requests finish on the prior config and the next request picks up the new mapping. See [ADR 0010](adr/0010-gateway-config-hot-reload.md) for the full design.
 
 You then land on the first-run setup checklist. Four steps, in order, none blocking:

--- a/web/cypress/e2e/m3-0-fresh-install-login.cy.ts
+++ b/web/cypress/e2e/m3-0-fresh-install-login.cy.ts
@@ -1,0 +1,113 @@
+/**
+ * M3-0.1 / DE-283 — Fresh-install login UX.
+ *
+ * Verifies that the login screen surfaces an actionable bootstrap-password
+ * hint after a failed login attempt against a fresh-install deployment, and
+ * stays silent once the operator has rotated.
+ *
+ * The hint is conditional on `GET /api/v1/admin/bootstrap-status` reporting
+ * `default_password_active=true`. We mock that endpoint with `cy.intercept`
+ * so each scenario can pin the state explicitly instead of relying on the
+ * mutable state of the live stack.
+ *
+ * Run requires a live stack:
+ *   docker compose up -d
+ *   cd web && npx cypress run --spec 'cypress/e2e/m3-0-fresh-install-login.cy.ts'
+ *
+ * No matter / chat / KB scaffolding is needed — this spec exercises the
+ * login surface only.
+ */
+
+/// <reference types="cypress" />
+
+const BOOTSTRAP_HINT_COMMAND =
+	'docker compose logs api 2>&1 | grep "First-run admin password"';
+
+describe('M3-0.1 / DE-283 — fresh-install login UX', () => {
+	it('initial page load shows no bootstrap hint (no 401 yet)', () => {
+		// Even with fresh-install state, the hint is gated on a failed login
+		// attempt — operators who have credentials shouldn't see it.
+		cy.intercept('GET', '**/api/v1/admin/bootstrap-status', {
+			statusCode: 200,
+			body: { default_password_active: true, logs_hint: BOOTSTRAP_HINT_COMMAND }
+		}).as('bootstrapStatus');
+
+		cy.visit('/lq-ai/login');
+		cy.get('[data-testid="lq-ai-bootstrap-hint"]').should('not.exist');
+	});
+
+	it('first 401 against fresh-install state renders the bootstrap hint', () => {
+		cy.intercept('POST', '**/api/v1/auth/login', {
+			statusCode: 401,
+			body: { detail: { code: 'invalid_credentials', message: 'Invalid email or password.' } }
+		}).as('login');
+		cy.intercept('GET', '**/api/v1/admin/bootstrap-status', {
+			statusCode: 200,
+			body: { default_password_active: true, logs_hint: BOOTSTRAP_HINT_COMMAND }
+		}).as('bootstrapStatus');
+
+		cy.visit('/lq-ai/login');
+		cy.get('[data-testid="lq-ai-login-email"]').type('admin@lq.ai');
+		cy.get('[data-testid="lq-ai-login-password"]').type('wrong-password');
+		cy.get('[data-testid="lq-ai-login-submit"]').click();
+
+		cy.wait('@login');
+		cy.wait('@bootstrapStatus');
+
+		cy.get('[data-testid="lq-ai-login-error"]').should('be.visible');
+		cy.get('[data-testid="lq-ai-bootstrap-hint"]').should('be.visible');
+		cy.get('[data-testid="lq-ai-bootstrap-hint-command"]')
+			.should('be.visible')
+			.and('contain.text', 'docker compose logs api')
+			.and('contain.text', 'First-run admin password');
+	});
+
+	it('first 401 against rotated deployment does not render the bootstrap hint', () => {
+		cy.intercept('POST', '**/api/v1/auth/login', {
+			statusCode: 401,
+			body: { detail: { code: 'invalid_credentials', message: 'Invalid email or password.' } }
+		}).as('login');
+		cy.intercept('GET', '**/api/v1/admin/bootstrap-status', {
+			statusCode: 200,
+			body: { default_password_active: false, logs_hint: BOOTSTRAP_HINT_COMMAND }
+		}).as('bootstrapStatus');
+
+		cy.visit('/lq-ai/login');
+		cy.get('[data-testid="lq-ai-login-email"]').type('admin@lq.ai');
+		cy.get('[data-testid="lq-ai-login-password"]').type('still-wrong');
+		cy.get('[data-testid="lq-ai-login-submit"]').click();
+
+		cy.wait('@login');
+		cy.wait('@bootstrapStatus');
+
+		// Generic 401 surfaces, but the hint stays hidden — the operator has
+		// already rotated; surfacing the bootstrap path would be noise.
+		cy.get('[data-testid="lq-ai-login-error"]').should('be.visible');
+		cy.get('[data-testid="lq-ai-bootstrap-hint"]').should('not.exist');
+	});
+
+	it('bootstrap-status probe failure does not mask the generic 401', () => {
+		// If the probe itself errors, the login UI must still show the
+		// underlying auth error — a hint-fetch failure is not a substitute
+		// for telling the operator their credentials were rejected.
+		cy.intercept('POST', '**/api/v1/auth/login', {
+			statusCode: 401,
+			body: { detail: { code: 'invalid_credentials', message: 'Invalid email or password.' } }
+		}).as('login');
+		cy.intercept('GET', '**/api/v1/admin/bootstrap-status', {
+			statusCode: 500,
+			body: { detail: { code: 'internal_error', message: 'probe failed' } }
+		}).as('bootstrapStatus');
+
+		cy.visit('/lq-ai/login');
+		cy.get('[data-testid="lq-ai-login-email"]').type('admin@lq.ai');
+		cy.get('[data-testid="lq-ai-login-password"]').type('still-wrong');
+		cy.get('[data-testid="lq-ai-login-submit"]').click();
+
+		cy.wait('@login');
+		cy.wait('@bootstrapStatus');
+
+		cy.get('[data-testid="lq-ai-login-error"]').should('be.visible');
+		cy.get('[data-testid="lq-ai-bootstrap-hint"]').should('not.exist');
+	});
+});

--- a/web/src/lib/lq-ai/api/bootstrap.ts
+++ b/web/src/lib/lq-ai/api/bootstrap.ts
@@ -1,0 +1,25 @@
+/**
+ * Bootstrap-state probe — M3-0.1 / DE-283.
+ *
+ * Unauthenticated read of `/api/v1/admin/bootstrap-status`, consulted by the
+ * login screen on the first failed login attempt. When the deployment is in
+ * fresh-install state (an admin user still has `must_change_password=true`),
+ * the login UI escalates a generic 401 into an actionable hint pointing the
+ * operator at `docker compose logs api`.
+ *
+ * `skipAuth: true` is load-bearing here — the caller has no token yet, and
+ * the endpoint must not be gated on one.
+ */
+import { apiRequest } from './client';
+
+export interface BootstrapStatus {
+	default_password_active: boolean;
+	logs_hint: string;
+}
+
+export async function getBootstrapStatus(): Promise<BootstrapStatus> {
+	return apiRequest<BootstrapStatus>('/admin/bootstrap-status', {
+		skipAuth: true,
+		skipRefresh: true
+	});
+}

--- a/web/src/lib/lq-ai/api/index.ts
+++ b/web/src/lib/lq-ai/api/index.ts
@@ -6,6 +6,7 @@
  */
 export * from './client';
 export * as authApi from './auth';
+export * as bootstrapApi from './bootstrap';
 export * as projectsApi from './projects';
 export * as chatsApi from './chats';
 export * as messagesApi from './messages';

--- a/web/src/routes/lq-ai/login/+page.svelte
+++ b/web/src/routes/lq-ai/login/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 
-	import { authApi } from '$lib/lq-ai/api';
+	import { authApi, bootstrapApi } from '$lib/lq-ai/api';
 	import { LQAIApiError } from '$lib/lq-ai/api/client';
 	import DualBrandingFooter from '$lib/lq-ai/components/DualBrandingFooter.svelte';
 
@@ -9,6 +9,11 @@
 	let password = '';
 	let error: string | null = null;
 	let busy = false;
+	// M3-0.1 / DE-283 — populated after the first 401 if the deployment is
+	// still in fresh-install state. Stays null in all other paths so the
+	// hint never appears to operators who have already rotated.
+	let bootstrapLogsHint: string | null = null;
+	let hintCopied = false;
 
 	async function submit() {
 		error = null;
@@ -23,6 +28,13 @@
 		} catch (e: unknown) {
 			if (e instanceof LQAIApiError) {
 				error = e.status === 401 ? 'Invalid email or password.' : e.message;
+				if (e.status === 401) {
+					// Probe the fresh-install state lazily — only after the
+					// operator has already tried and failed. A clean 401 from a
+					// rotated deployment is the common case; we don't want to
+					// load extra signal there.
+					void checkBootstrapStatus();
+				}
 			} else if (e instanceof Error) {
 				error = e.message;
 			} else {
@@ -30,6 +42,31 @@
 			}
 		} finally {
 			busy = false;
+		}
+	}
+
+	async function checkBootstrapStatus() {
+		try {
+			const status = await bootstrapApi.getBootstrapStatus();
+			bootstrapLogsHint = status.default_password_active ? status.logs_hint : null;
+		} catch {
+			// Best-effort surface: if the probe itself fails, fall back to the
+			// plain 401. Don't mask the real auth error with a hint error.
+			bootstrapLogsHint = null;
+		}
+	}
+
+	async function copyHint() {
+		if (!bootstrapLogsHint) return;
+		try {
+			await navigator.clipboard.writeText(bootstrapLogsHint);
+			hintCopied = true;
+			setTimeout(() => {
+				hintCopied = false;
+			}, 1500);
+		} catch {
+			// Clipboard write can fail under restrictive iframe sandboxes; the
+			// command stays visible inline so manual copy still works.
 		}
 	}
 </script>
@@ -88,6 +125,39 @@
 				</div>
 			{/if}
 
+			{#if bootstrapLogsHint}
+				<div
+					class="lq-bootstrap-hint text-sm rounded border px-3 py-2 space-y-2"
+					data-testid="lq-ai-bootstrap-hint"
+					role="status"
+					aria-live="polite"
+				>
+					<p class="font-medium">First-run deployment?</p>
+					<p>
+						The bootstrap admin password is printed once to the API
+						container's logs. Run the command below to retrieve it,
+						sign in, then rotate immediately.
+					</p>
+					<div class="flex items-stretch gap-2">
+						<code
+							class="flex-1 px-2 py-1 rounded bg-white dark:bg-gray-900 border border-amber-200 dark:border-amber-700 text-xs overflow-x-auto whitespace-nowrap"
+							data-testid="lq-ai-bootstrap-hint-command"
+						>
+							{bootstrapLogsHint}
+						</code>
+						<button
+							type="button"
+							class="px-2 py-1 text-xs rounded border border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900"
+							on:click={copyHint}
+							data-testid="lq-ai-bootstrap-hint-copy"
+							aria-label="Copy command to clipboard"
+						>
+							{hintCopied ? 'Copied' : 'Copy'}
+						</button>
+					</div>
+				</div>
+			{/if}
+
 			<button
 				type="submit"
 				class="lq-btn-primary w-full"
@@ -96,11 +166,6 @@
 			>
 				{busy ? 'Signing in…' : 'Sign in'}
 			</button>
-
-			<p class="lq-text-caption text-center" style="color: var(--lq-text-tertiary);">
-				First-run? Check the API logs for the auto-generated admin password (per Quickstart Step
-				2).
-			</p>
 		</form>
 	</main>
 	<DualBrandingFooter />
@@ -130,5 +195,17 @@
 	.lq-btn-primary:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.lq-bootstrap-hint {
+		background: #fffbeb;
+		border-color: #fcd34d;
+		color: #78350f;
+	}
+
+	:global(.dark) .lq-bootstrap-hint {
+		background: rgba(120, 53, 15, 0.25);
+		border-color: rgba(252, 211, 77, 0.4);
+		color: #fde68a;
 	}
 </style>


### PR DESCRIPTION
## What this PR does

First task of M3 — Phase 0 pre-M3 hardening. Closes DE-283: when a fresh-install operator (or someone who wiped volumes) types their best-guess password into the login screen, instead of a generic 401 they now see an inline informational panel pointing them at the exact `docker compose logs api` command that surfaces the bootstrap admin password.

## Why

Surfaced during M2 pre-tag fresh-install validation (PRD §9 / DE-283). Three operator failure modes routinely reach the login screen with no actionable guidance:

1. Skimming past quickstart Step 4 ("the password is in the logs").
2. Wiping volumes mid-project — the cached password no longer matches the freshly bootstrapped admin.
3. Losing the printed password between first `docker compose up` and the first login attempt.

The fix is small, the procurement story improves immediately, and the PR doubles as a worked example of the kind of small, well-scoped contribution future community contributors should expect to see merged.

## Architectural choice

DE-283's specific-scope option (b) suggested embedding a `hint` field on the 401 response itself. M3-0.1's plan locked the **separate-endpoint** variant: `GET /api/v1/admin/bootstrap-status` (unauthenticated, read-only). The login UI consults it lazily on 401.

| Aspect | Embed-in-401 (DE-283 option b) | Separate endpoint (this PR) |
|---|---|---|
| Login response shape | Changes | Unchanged |
| Hint fetch | Always (every 401) | Lazy (only after failed login) |
| Exposed signal | Same | Same |
| Implementation surface | Login endpoint + UI | New module + UI |

The separate-endpoint approach keeps the auth surface untouched and surfaces a single, low-sensitivity bit (the bootstrap password is 24 chars of CSPRNG output; knowing fresh-install state doesn't measurably help an attacker).

## Surface

- **Backend:** `api/app/api/bootstrap.py` (new module). Pydantic `BootstrapStatus` schema. Mounted in `api/app/api/__init__.py` without the `_active` dependency, matching how `auth.router` is mounted.
- **Frontend:** `web/src/lib/lq-ai/api/bootstrap.ts` (typed client with `skipAuth: true`); `web/src/routes/lq-ai/login/+page.svelte` (conditional hint panel + copy chip on 401).
- **Tests:** 6 backend integration tests + 4 Cypress E2E scenarios (no-401-yet, fresh-install 401 → hint, rotated 401 → no hint, probe-failure does not mask 401).
- **Docs:** `docs/quickstart.md` Step 2 callout; `docs/PRD.md` DE-283 marked `SHIPPED at M3-0.1`; `docs/api/backend-openapi.yaml` new path entry.

## What this PR does *not* do

- Does **not** modify the `/api/v1/auth/login` wire shape. The hint is a separate, lazy probe.
- Does **not** address DE-276 (ingest observability) or DE-277 (citation chunk-boundary) — those are Phase 0 tasks landing in subsequent PRs per [M3-IMPLEMENTATION-PLAN.md](https://github.com/LegalQuants/lq-ai/blob/main/docs/M3-IMPLEMENTATION-PLAN.md).
- Does **not** rate-limit the bootstrap-status probe. Standard FastAPI middleware applies; rate-limiting this specific endpoint is filed as a follow-on consideration if abuse patterns emerge.

## Type of change

- [x] New feature (non-breaking change that adds capability)
- [x] Documentation update

## Testing

- [x] Unit tests added/updated — 6 integration tests in `api/tests/test_bootstrap_status.py` covering: active state, rotated state, no-admin defense, soft-deleted admin ignored, non-admin-with-flag ignored, unauthenticated probe.
- [x] Integration tests added/updated — same file (`@pytest.mark.integration`).
- [x] E2E tests added — `web/cypress/e2e/m3-0-fresh-install-login.cy.ts` with 4 scenarios.
- [ ] Manually tested against a real deployment — **pending Docker image rebuild**. The current running stack is a variant from a different repository (operator note); the rebuild + live verification will follow on this PR before merge.
- [x] Static gates green: ruff format + ruff check ✓; mypy ✓; pytest ✓ (full api suite 1018 + 6 new); svelte-check ✓ (0 errors); vitest ✓ (456 passed, no regressions).

<details>
<summary>Manual testing notes</summary>

Live E2E + fresh-install reproduction (per the M3-0.1 verification spec) will run after `docker compose build api web && docker compose up -d --no-deps api web`. The Cypress spec uses `cy.intercept` so the deterministic UI behavior is verifiable against the rebuilt stack without depending on the actual DB state.

</details>

## Documentation

- [x] PRD updated — DE-283 marked `SHIPPED at M3-0.1`, original specific-scope options preserved for the historical record.
- [x] README — unchanged; existing "good first contributions" framing in README/EASIEST-CONTRIBUTIONS.md was already DE-283-aware.
- [x] Quickstart updated — Step 2 callout naming the new in-UI hint surface.
- [x] OpenAPI schema regenerated — `docs/api/backend-openapi.yaml` new path entry with example.

## DCO sign-off

- [x] All commits in this PR are signed off

## Related issues

Closes the first task in [`docs/M3-IMPLEMENTATION-PLAN.md`](../blob/main/docs/M3-IMPLEMENTATION-PLAN.md) Phase 0. Refs DE-283.

## Reviewer notes

- The endpoint signal lives entirely on the `users` table (no new column, no migration). I chose `must_change_password=true on a non-deleted admin` because it's the existing flag the bootstrap flow already manages.
- The login page's pre-existing always-visible "First-run? Check the API logs..." caption (added during DE-273 polish) is removed in favor of the conditional surface. Strictly better UX for rotated deployments (no stale text); for fresh-install operators the cost is "type any password once" before the hint appears — matches the DE-283 spec ("renders on first 401").
- Test-suite drift in `test_openapi.py` / `test_endpoints.py` is fixed by adding the new path to the implemented-routes/expected-paths sets. The path-count assertion in `test_openapi.py` is bumped 73 → 74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)