### PR TITLE
feat(api,m3-0-2): DE-277 citation extractor — full-document fallback for chunk-boundary spanning quotes

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -1535,16 +1535,23 @@ async def _persist_message_citations(
     if not retrieved_chunks:
         return
 
-    candidates = extract_citations(assistant_text, retrieved_chunks)
+    # Batch-load the documents the retrieved chunks point at so the
+    # verifier has ``document.normalized_content`` and the extractor
+    # has the same surface for the M3-0.2 / DE-277 chunk-boundary
+    # fallback. Loading by retrieved-chunk document_ids (rather than
+    # by candidate document_ids as M2 did) is a superset: every
+    # candidate's document is in this set by construction, and the
+    # extra documents the verifier never consults are negligible.
+    chunk_doc_ids = {chunk.document_id for chunk in retrieved_chunks}
+    doc_rows = (
+        (await db.execute(select(Document).where(Document.id.in_(chunk_doc_ids)))).scalars().all()
+    )
+    docs_by_id = {d.id: d for d in doc_rows}
+    doc_contents = {d.id: d.normalized_content for d in doc_rows}
+
+    candidates = extract_citations(assistant_text, retrieved_chunks, doc_contents)
     if not candidates:
         return
-
-    # Batch-load the documents the candidates point at so we don't
-    # round-trip the DB per citation. The verifier needs
-    # ``document.normalized_content`` to confirm the slice.
-    doc_ids = {c.source_document_id for c in candidates}
-    doc_rows = (await db.execute(select(Document).where(Document.id.in_(doc_ids)))).scalars().all()
-    docs_by_id = {d.id: d for d in doc_rows}
 
     # M2-C1: resolve the Stage 3 judge model once per persist call.
     # The lookup is process-cached on the GatewayClient, so the per-

--- a/api/app/citation/extraction.py
+++ b/api/app/citation/extraction.py
@@ -20,6 +20,16 @@ Resolution mechanics:
      the Stage 2 verifier's 95, so a candidate that survives
      extraction may still get rejected by verification. Quotes with
      no real overlap (an unrelated model fabrication) drop here.
+   * **Chunk-boundary fallback (M3-0.2 / DE-277):** when the chunk-local
+     search misses but the caller supplied ``document_contents``, retry
+     the same exact-then-fuzzy locator against the full document text.
+     This catches quotes that legitimately span two adjacent chunks
+     (present in ``documents.normalized_content`` but in neither chunk
+     individually) plus quotes where the model misnumbered the cited
+     chunk index. The resolved offsets are document-absolute — no
+     chunk-offset arithmetic is applied — so the downstream verifier
+     (which already reads against ``document.normalized_content``)
+     consumes them with no change.
 4. Materialize a :class:`CitationCandidate` carrying the source
    document id + file id + byte-precise offsets + the model's quote
    verbatim. The verifier cascade (``app.citation.verification.verify``)
@@ -37,17 +47,30 @@ normalization-only differences, but the candidates never reached it.
 M2-B1 loosens extraction so the verifier sees more candidates and
 ultimately the model's smart-quote citations land as
 ``verified=True, method='tolerant_match'``.
+
+Chunk-mismatch observability (DE-277 option b)
+----------------------------------------------
+
+When the chunk-boundary fallback fires AND the chunk-local search had
+missed, the extractor emits a structured ``citation_chunk_mismatch``
+warning. The citation still verifies — quote-against-document is the
+load-bearing correctness check — but the mismatch signal lets operators
+spot model-side drift (e.g., the model consistently citing the wrong
+``[N]`` index for a particular skill or prompt template).
 """
 
 from __future__ import annotations
 
+import logging
 import re
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
 from rapidfuzz import fuzz
+
+logger = logging.getLogger(__name__)
 
 
 # A protocol so the extractor accepts any chunk-shaped object — the
@@ -127,6 +150,7 @@ def _locate_in_chunk(quote: str, chunk_content: str) -> tuple[int, int] | None:
 def extract_citations(
     response_text: str,
     retrieved_chunks: Sequence[_RetrievedChunk],
+    document_contents: Mapping[uuid.UUID, str] | None = None,
 ) -> list[CitationCandidate]:
     """Extract citations from the assistant response.
 
@@ -135,13 +159,21 @@ def extract_citations(
         retrieved_chunks: The RAG-retrieved chunks delivered to the
             model in this turn's prompt, in the same order they were
             numbered ``[1], [2], …`` in the context block.
+        document_contents: Optional map of document id →
+            ``documents.normalized_content`` (M2-A1 surface). When
+            supplied, enables the M3-0.2 / DE-277 chunk-boundary
+            fallback: a quote that misses inside the cited chunk is
+            retried against the full document text. When ``None`` (the
+            default), the function behaves exactly as M2-B1 shipped —
+            chunk-local search only.
 
     Returns:
         One :class:`CitationCandidate` per ``"..." (Source: [N])``
         pair (straight or curly quotes) whose quote could be located
-        inside its cited chunk — exactly or via fuzzy alignment
-        above the extraction threshold. Pairs whose quote is
-        unfindable or whose index is out of range are dropped silently.
+        inside its cited chunk OR (when ``document_contents`` is
+        supplied) inside the cited chunk's parent document. Pairs
+        whose quote survives neither search, and pairs whose index
+        is out of range, are dropped silently.
     """
 
     candidates: list[CitationCandidate] = []
@@ -159,15 +191,49 @@ def extract_citations(
 
         chunk = retrieved_chunks[index_1based - 1]
         located = _locate_in_chunk(quote, chunk.content)
-        if located is None:
-            # Quote is neither a byte-for-byte substring nor a
-            # close-enough fuzzy match. The model either fabricated
-            # the quote or mis-cited the chunk index.
-            continue
+        if located is not None:
+            in_chunk_start, in_chunk_end = located
+            offset_start = chunk.char_offset_start + in_chunk_start
+            offset_end = chunk.char_offset_start + in_chunk_end
+        else:
+            # M3-0.2 / DE-277: chunk-local search missed. Fall back to a
+            # full-document scan when the caller supplied
+            # normalized-content for the chunk's parent document. The
+            # resolved offsets are document-absolute already (the
+            # full document is the substring search space) so no
+            # ``chunk.char_offset_start`` arithmetic is applied.
+            doc_content = (
+                document_contents.get(chunk.document_id) if document_contents is not None else None
+            )
+            if doc_content is None:
+                # No full-document text available — either the caller
+                # didn't supply the map, or the document was not loaded
+                # (e.g., deleted between retrieval and persistence).
+                # Drop the candidate; the model either fabricated the
+                # quote or mis-cited an index pointing at content not
+                # in the retrieved-chunk window.
+                continue
 
-        in_chunk_start, in_chunk_end = located
-        offset_start = chunk.char_offset_start + in_chunk_start
-        offset_end = chunk.char_offset_start + in_chunk_end
+            doc_located = _locate_in_chunk(quote, doc_content)
+            if doc_located is None:
+                # Quote is not in the document at all. Drop.
+                continue
+
+            offset_start, offset_end = doc_located
+            # DE-277 option (b): observability for chunk-mismatches.
+            # The citation still verifies (quote-against-document is the
+            # correctness check); the warning surfaces a model-side
+            # signal worth investigating in aggregate.
+            logger.warning(
+                "citation chunk-boundary mismatch — quote located via "
+                "full-document scan rather than cited chunk",
+                extra={
+                    "event": "citation_chunk_mismatch",
+                    "document_id": str(chunk.document_id),
+                    "cited_chunk_index": index_1based,
+                    "quote_prefix": quote[:40],
+                },
+            )
 
         candidates.append(
             CitationCandidate(

--- a/api/tests/citation/test_chunk_boundary.py
+++ b/api/tests/citation/test_chunk_boundary.py
@@ -1,0 +1,276 @@
+"""Chunk-boundary fallback tests for the citation extractor — M3-0.2 / DE-277.
+
+Until DE-277 landed, the extractor located each quote inside the cited
+chunk's content only. A quote spanning the boundary between two
+adjacent retrieved chunks — present in
+``documents.normalized_content`` but in neither chunk individually —
+dropped silently. The marker rendered as "unverified" in the M2-C2 UI
+even though the underlying text matched.
+
+DE-277 extends the extractor's locator with a full-document fallback:
+when the chunk-local search misses, retry the same exact-then-fuzzy
+locator against the chunk's parent document's
+``normalized_content``. The resolved offsets are document-absolute
+(no ``chunk.char_offset_start`` arithmetic) so the downstream verifier
+consumes them with no change.
+
+These are pure unit tests against the extractor function; the
+end-to-end persistence path is exercised separately by
+``test_edge_cases.py::test_chunk_boundary_spanning_citation_verifies_via_full_doc_scan``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+from app.citation.extraction import extract_citations
+
+
+@dataclass(slots=True)
+class _StubChunk:
+    """HybridSearchResult-shaped stub — no DB needed for extractor tests."""
+
+    document_id: uuid.UUID
+    file_id: uuid.UUID
+    content: str
+    page_start: int | None
+    char_offset_start: int
+    char_offset_end: int
+
+
+def _make_doc_with_two_chunks(
+    full_content: str, split_at: int
+) -> tuple[uuid.UUID, uuid.UUID, list[_StubChunk]]:
+    """Build a document split into two adjacent half-chunks.
+
+    Returns ``(doc_id, file_id, [chunk_a, chunk_b])``. Both chunks
+    share the same ``document_id`` and ``file_id``; their
+    ``char_offset_*`` are document-absolute and the union of their
+    content equals ``full_content``.
+    """
+    doc_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    chunk_a = _StubChunk(
+        document_id=doc_id,
+        file_id=file_id,
+        content=full_content[:split_at],
+        page_start=1,
+        char_offset_start=0,
+        char_offset_end=split_at,
+    )
+    chunk_b = _StubChunk(
+        document_id=doc_id,
+        file_id=file_id,
+        content=full_content[split_at:],
+        page_start=1,
+        char_offset_start=split_at,
+        char_offset_end=len(full_content),
+    )
+    return doc_id, file_id, [chunk_a, chunk_b]
+
+
+@pytest.mark.unit
+def test_two_chunk_span_verifies_via_doc_scan() -> None:
+    """Quote spanning two adjacent chunks resolves with document-absolute offsets."""
+
+    full = "Section 1: The non-compete clause provides for a two-year restriction."
+    doc_id, file_id, chunks = _make_doc_with_two_chunks(full, split_at=35)
+
+    # The quote sits in the middle of the document, straddling chunks.
+    quote_start, quote_end = 20, 55
+    quote = full[quote_start:quote_end]
+    assert quote not in chunks[0].content
+    assert quote not in chunks[1].content
+    assert quote in full
+
+    response = f'The agreement says "{quote}" (Source: [1]).'
+
+    candidates = extract_citations(response, chunks, document_contents={doc_id: full})
+
+    assert len(candidates) == 1
+    cite = candidates[0]
+    assert cite.source_document_id == doc_id
+    assert cite.source_file_id == file_id
+    # Document-absolute offsets, NOT chunk-relative + chunk_offset_start.
+    assert cite.source_offset_start == quote_start
+    assert cite.source_offset_end == quote_end
+    assert cite.source_text == quote
+
+
+@pytest.mark.unit
+def test_three_chunk_span_verifies_via_doc_scan() -> None:
+    """Quotes spanning three adjacent chunks (long quotes) also resolve."""
+
+    full = (
+        "Article 1. Confidential Information. "
+        "Each Party shall hold in confidence all Confidential Information disclosed. "
+        "Permitted Disclosures include legal counsel and regulators."
+    )
+    doc_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+
+    boundaries = [(0, 40), (40, 110), (110, len(full))]
+    chunks = [
+        _StubChunk(
+            document_id=doc_id,
+            file_id=file_id,
+            content=full[start:end],
+            page_start=1,
+            char_offset_start=start,
+            char_offset_end=end,
+        )
+        for start, end in boundaries
+    ]
+
+    # Quote spans all three chunks.
+    quote_start, quote_end = 20, 135
+    quote = full[quote_start:quote_end]
+    assert all(quote not in c.content for c in chunks)
+    assert quote in full
+
+    response = f'The agreement says "{quote}" (Source: [1]).'
+
+    candidates = extract_citations(response, chunks, document_contents={doc_id: full})
+
+    assert len(candidates) == 1
+    cite = candidates[0]
+    assert cite.source_offset_start == quote_start
+    assert cite.source_offset_end == quote_end
+    assert cite.source_text == quote
+
+
+@pytest.mark.unit
+def test_single_chunk_citation_uses_chunk_local_path_no_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Quote entirely inside the cited chunk → chunk-arithmetic path, no warning.
+
+    Regression case: existing single-chunk citations must continue to
+    flow through the chunk-local locator and apply
+    ``chunk.char_offset_start`` arithmetic. The ``citation_chunk_mismatch``
+    warning must NOT fire — that signal is reserved for cases where the
+    full-document fallback actually fired.
+    """
+
+    full = "The contract term shall be five years from the effective date."
+    doc_id, _file_id, chunks = _make_doc_with_two_chunks(full, split_at=27)
+
+    # Quote fits entirely inside chunk_b — chunk-local search succeeds.
+    quote = "five years from the effective date."
+    assert quote in chunks[1].content
+
+    response = f'The agreement says "{quote}" (Source: [2]).'
+
+    with caplog.at_level(logging.WARNING, logger="app.citation.extraction"):
+        candidates = extract_citations(response, chunks, document_contents={doc_id: full})
+
+    assert len(candidates) == 1
+    cite = candidates[0]
+    # Document-absolute via chunk_b.char_offset_start + in_chunk_start.
+    expected_start = chunks[1].char_offset_start + chunks[1].content.find(quote)
+    assert cite.source_offset_start == expected_start
+    assert cite.source_offset_end == expected_start + len(quote)
+
+    # The chunk-mismatch warning is reserved for the fallback path. A
+    # successful chunk-local hit must NOT emit it.
+    mismatch_records = [
+        r for r in caplog.records if r.__dict__.get("event") == "citation_chunk_mismatch"
+    ]
+    assert mismatch_records == []
+
+
+@pytest.mark.unit
+def test_spanning_fallback_emits_chunk_mismatch_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When the doc-scan fallback fires, emit the operator-observability warning."""
+
+    full = "Section 1: The non-compete clause provides for a two-year restriction."
+    doc_id, _file_id, chunks = _make_doc_with_two_chunks(full, split_at=35)
+
+    quote = full[20:55]
+    assert quote not in chunks[0].content
+    assert quote not in chunks[1].content
+    assert quote in full
+
+    response = f'The agreement says "{quote}" (Source: [1]).'
+
+    with caplog.at_level(logging.WARNING, logger="app.citation.extraction"):
+        candidates = extract_citations(response, chunks, document_contents={doc_id: full})
+
+    assert len(candidates) == 1
+    mismatch_records = [
+        r for r in caplog.records if r.__dict__.get("event") == "citation_chunk_mismatch"
+    ]
+    assert len(mismatch_records) == 1
+    record = mismatch_records[0]
+    assert record.__dict__["document_id"] == str(doc_id)
+    assert record.__dict__["cited_chunk_index"] == 1
+    assert record.__dict__["quote_prefix"] == quote[:40]
+
+
+@pytest.mark.unit
+def test_quote_not_in_document_drops() -> None:
+    """Quote absent from both the chunk AND the document → no candidate."""
+
+    full = "Section 1: The non-compete clause provides for a two-year restriction."
+    doc_id, _file_id, chunks = _make_doc_with_two_chunks(full, split_at=35)
+
+    # Quote fabricated by the model — not in the document anywhere.
+    fabricated = "five-year exclusive license to undisclosed third parties"
+    assert fabricated not in full
+
+    response = f'The agreement says "{fabricated}" (Source: [1]).'
+
+    candidates = extract_citations(response, chunks, document_contents={doc_id: full})
+
+    assert candidates == []
+
+
+@pytest.mark.unit
+def test_no_document_contents_preserves_pre_de277_behavior() -> None:
+    """Without ``document_contents``, the extractor behaves exactly as it did pre-DE-277.
+
+    Spanning quotes drop silently — same as the M2-B1 shipped behavior.
+    Backward compatibility for any caller that hasn't yet adopted the
+    new map parameter.
+    """
+
+    full = "Section 1: The non-compete clause provides for a two-year restriction."
+    _doc_id, _file_id, chunks = _make_doc_with_two_chunks(full, split_at=35)
+
+    quote = full[20:55]
+    response = f'The agreement says "{quote}" (Source: [1]).'
+
+    candidates = extract_citations(response, chunks)  # no document_contents arg
+
+    assert candidates == []
+
+
+@pytest.mark.unit
+def test_document_contents_map_missing_doc_id_drops_safely() -> None:
+    """If the caller's map omits a chunk's doc_id, that candidate falls back to drop.
+
+    Defensive: rather than crashing or raising KeyError, the extractor
+    treats a missing entry the same as the no-map case for that
+    specific chunk.
+    """
+
+    full = "Section 1: The non-compete clause provides for a two-year restriction."
+    doc_id, _file_id, chunks = _make_doc_with_two_chunks(full, split_at=35)
+
+    quote = full[20:55]
+    response = f'The agreement says "{quote}" (Source: [1]).'
+
+    # Empty map (or map keyed by some unrelated id) — extractor must
+    # not raise.
+    candidates = extract_citations(response, chunks, document_contents={uuid.uuid4(): "unrelated"})
+    assert candidates == []
+
+    # Confirm the success path still works when the right id is present.
+    candidates_ok = extract_citations(response, chunks, document_contents={doc_id: full})
+    assert len(candidates_ok) == 1

--- a/api/tests/citation/test_edge_cases.py
+++ b/api/tests/citation/test_edge_cases.py
@@ -441,36 +441,31 @@ async def test_cross_document_citations_persist_one_row_per_verified_citation(
 
 
 @respx.mock
-async def test_chunk_boundary_spanning_citation_does_not_extract_today(
+async def test_chunk_boundary_spanning_citation_verifies_via_full_doc_scan(
     client: AsyncClient,
     db_session: AsyncSession,
     owner_user: User,
     chat_with_kb: Chat,
 ) -> None:
-    """Known limitation (M2-D4 / DE-277): spanning quotes drop at extraction.
+    """M3-0.2 / DE-277: spanning quotes verify via the full-document fallback.
 
-    The Citation Engine's extractor (:func:`app.citation.extraction.extract_citations`)
-    locates each quote inside the cited chunk's content via
-    :func:`app.citation.extraction._locate_in_chunk`. If a quote
-    actually spans the boundary between two retrieved chunks — i.e.,
-    no single chunk's content contains the full quote — the locator
-    returns ``None`` and the candidate is dropped silently. The
-    verifier never sees the candidate, so no row is persisted and the
-    M2-C2 UI renders the marker as "unverified".
+    Until DE-277 landed, the Citation Engine's extractor located each
+    quote inside the cited chunk's content via
+    :func:`app.citation.extraction._locate_in_chunk`. A quote spanning
+    the boundary between two retrieved chunks — present in
+    ``documents.normalized_content`` but in neither chunk individually —
+    dropped silently and rendered as "unverified" in the UI.
 
-    In practice the model rarely emits genuinely spanning quotes —
-    instruction prompting in the retrieval-context block tells it to
-    pick the chunk containing the full quote. But the model could emit
-    such quotes (especially under adversarial or multi-chunk-paraphrase
-    prompting); the current pipeline silently degrades to unverified.
+    DE-277 extends the extractor: when the chunk-local locator misses,
+    it retries against the chunk's parent document's
+    ``normalized_content`` (M2-A1 surface) and emits the candidate
+    with document-absolute offsets. The downstream verifier already
+    reads against ``normalized_content`` so the spanning candidate
+    verifies cleanly via the same Stage 1 / Stage 2 logic.
 
-    Future fix path (DE-277): the extractor falls back to scanning
-    ``documents.normalized_content`` via FK from the chunk to the doc
-    when ``_locate_in_chunk`` misses; same fuzzy-vs-exact two-stage
-    logic against the full document text rather than the chunk slice.
-
-    This test pins the current behavior so a future implementation
-    of DE-277 has a failing assertion to flip.
+    This test pins the new behavior end-to-end: the spanning quote
+    persists with ``verification_method='exact_match'`` and the
+    persisted offsets are document-absolute.
     """
 
     full_content = (
@@ -535,10 +530,10 @@ async def test_chunk_boundary_spanning_citation_does_not_extract_today(
 
     assert response.status_code == 200, response.text
 
-    # Current behavior: extractor drops the spanning candidate; no
-    # citation row persists. When DE-277 lands, this assertion
-    # should flip to ``len(rows) == 1`` and the row should carry
-    # ``verification_method='exact_match'`` against the full-doc slice.
+    # DE-277 behavior: extractor falls back to the document-level scan,
+    # the candidate verifies with byte-for-byte equality against
+    # ``documents.normalized_content``, and one row persists with
+    # document-absolute offsets and ``verification_method='exact_match'``.
     rows = (
         (
             await db_session.execute(
@@ -548,11 +543,15 @@ async def test_chunk_boundary_spanning_citation_does_not_extract_today(
         .scalars()
         .all()
     )
-    assert rows == [], (
-        f"Expected no rows for a chunk-boundary spanning quote (DE-277 known limitation); "
-        f"got {len(rows)}. If this test fails because rows were persisted, DE-277 may have "
-        "landed — flip this assertion to verify the full-doc-scan extractor fix instead."
+    assert len(rows) == 1, (
+        f"Expected exactly one row from the DE-277 spanning fallback; got {len(rows)}."
     )
+    row = rows[0]
+    assert row.verification_method == "exact_match"
+    assert row.verified is True
+    assert row.source_offset_start == 30
+    assert row.source_offset_end == 60
+    assert row.source_text == spanning_quote
 
 
 @respx.mock

--- a/docs/M3-IMPLEMENTATION-PLAN.md
+++ b/docs/M3-IMPLEMENTATION-PLAN.md
@@ -113,19 +113,23 @@ Three deferred enhancements surfaced during M2 land before the M3 tracks begin. 
 
 ### Task M3-0.2 — DE-277: Citation extractor chunk-boundary fallback
 
-**Scope:**
-- Implement document-scan fallback in `api/app/citation/verification.py` for the case where a citation's offsets fall on a chunk boundary and the cited span is split across two chunks.
-- On a Stage 1 or Stage 2 miss where the citation's `chunk_id` is adjacent to the next chunk in the same document, reconstruct the spanning region from `documents.normalized_content` (M2-A1 surface) and re-run Stage 1/2 against the spanning region.
-- Add a `verification_method = 'exact_match_spanning'` / `'tolerant_match_spanning'` variant to record that the verification used the cross-boundary path. UI renders this identically to the regular variants.
-- Unit tests in `api/tests/citation/test_chunk_boundary.py` covering: citation spanning two chunks; citation spanning three chunks (rare but possible for long quotes); citation entirely within one chunk (regression test — unaffected).
+**Scope** (corrected to track [DE-277 in PRD §9](PRD.md#de-277--citation-extractor-fallback-to-document-scan-on-chunk-boundary-miss) verbatim — the plan's original task description placed the fix in `verification.py`, but the actual gap is in `extraction.py`'s locator):
+
+- Extend `app/citation/extraction.py::extract_citations` with a full-document fallback. When the chunk-local locator (`_locate_in_chunk(quote, chunk.content)`) misses but the caller supplies the chunk's parent document's `normalized_content` (M2-A1 surface), retry the same exact-then-fuzzy locator against the full document.
+- Resolved offsets from the document-level scan are document-absolute already (no `chunk.char_offset_start` arithmetic); the downstream verifier reads against `documents.normalized_content` so the Stage 1 / Stage 2 logic verifies spanning candidates with no change. **No new `verification_method` values are required.**
+- Wire the chat-send pipeline (`app/api/chats.py::_persist_message_citations`) to pre-load documents for the retrieved-chunk doc_ids and pass the normalized-content map to `extract_citations`. The same loaded docs are reused by the verifier (no duplicate DB roundtrip).
+- Emit a structured `citation_chunk_mismatch` warning when the fallback fires (per [DE-277](PRD.md#de-277--citation-extractor-fallback-to-document-scan-on-chunk-boundary-miss) option b) — the citation still verifies, but the mismatch signal is worth surfacing for aggregate observability.
+- Unit tests in `api/tests/citation/test_chunk_boundary.py` covering: citation spanning two chunks; citation spanning three chunks (rare but possible for long quotes); citation entirely within one chunk (regression test — unaffected); chunk-mismatch warning emitted only on fallback path; backward compatibility when `document_contents` is not supplied.
+- Flip the existing `test_edge_cases.py::test_chunk_boundary_spanning_citation_does_not_extract_today` to assert the new behavior (`verification_method='exact_match'`, document-absolute offsets persisted).
 
 **Dependencies:** M2-A1 (normalized_content); M2-A2 (Stage 1); M2-B1 (Stage 2). All shipped at v0.2.0.
 
-**Output:** Citations split across chunk boundaries no longer fall to Stage 3 (LLM judge) when they could be verified verbatim.
+**Output:** Citations split across chunk boundaries no longer fall to Stage 3 (LLM judge) when they could be verified verbatim against the source document.
 
 **Verification:**
-- Test corpus includes citations deliberately authored across chunk boundaries; new spanning paths verify them.
+- Test corpus includes citations deliberately authored across chunk boundaries; the spanning fallback resolves them.
 - No regression in single-chunk verification (existing test suite passes unchanged).
+- The `citation_chunk_mismatch` warning surfaces in logs / Langfuse spans when the fallback fires.
 
 **Effort:** 4–6 hours.
 


### PR DESCRIPTION
## What this PR does

Second task of M3 — Phase 0 pre-M3 hardening. Closes DE-277: a quote in an assistant response that spans the boundary between two retrieved chunks no longer drops silently at extraction; it now falls back to a full-document scan and verifies through the existing Stage 1 / Stage 2 cascade.

## Why

Surfaced during M2-D4 edge-case sweep ([PRD §9 / DE-277](../blob/main/docs/PRD.md#de-277--citation-extractor-fallback-to-document-scan-on-chunk-boundary-miss)). The extractor located quotes via `_locate_in_chunk(quote, chunk.content)` against the single chunk the model cited. When the quote spanned the boundary between two adjacent retrieved chunks — present in `documents.normalized_content` but in neither chunk individually — the locator returned `None` and the candidate dropped. The M2-C2 UI rendered the marker as "unverified" red even though the underlying document text matched.

In practice the model rarely emits spanning quotes (the retrieval-context prompt steers it to a single chunk). The gap surfaced on adversarial multi-chunk paraphrases and on genuinely long quotes.

## Deviation from M3-IMPLEMENTATION-PLAN.md as originally committed

The M3 plan's M3-0.2 task description placed the fix in `api/app/citation/verification.py` and called for new `verification_method = 'exact_match_spanning'` / `'tolerant_match_spanning'` enum values.

Reading the actual code revealed the gap is **upstream in `extraction.py`'s locator** — the verifier never sees the spanning candidate today because the extractor drops it. Once the extractor emits **document-absolute offsets** via the full-document scan, the verifier (which already reads against `documents.normalized_content`) verifies the candidate via the existing Stage 1 / Stage 2 logic with no change. `verification_method` stays `'exact_match'` or `'tolerant_match'`.

This matches [PRD §9 / DE-277](../blob/main/docs/PRD.md#de-277--citation-extractor-fallback-to-document-scan-on-chunk-boundary-miss) verbatim. `docs/M3-IMPLEMENTATION-PLAN.md` is updated in this PR to correct the M3-0.2 task description for future contributors.

## Surface

### Extractor

`extract_citations` gains an optional parameter:

```python
def extract_citations(
    response_text: str,
    retrieved_chunks: Sequence[_RetrievedChunk],
    document_contents: Mapping[uuid.UUID, str] | None = None,
) -> list[CitationCandidate]:
```

When the chunk-local locator misses AND `document_contents` is supplied, the extractor retries the same exact-then-fuzzy search against the chunk's parent document's `normalized_content`. Document-absolute offsets are emitted directly (no `chunk.char_offset_start` arithmetic).

When `document_contents` is omitted, behavior is identical to the M2-B1 shipped extractor (backward-compatible).

### Chat-send pipeline

`_persist_message_citations` is rewired:

```python
# Pre-load docs for retrieved-chunk doc_ids BEFORE extraction so the
# extractor has the fallback surface; the same docs are reused for
# the verifier path.
chunk_doc_ids = {chunk.document_id for chunk in retrieved_chunks}
doc_rows = ... # batch-load Document rows
doc_contents = {d.id: d.normalized_content for d in doc_rows}

candidates = extract_citations(assistant_text, retrieved_chunks, doc_contents)
```

The DB roundtrip is unchanged in count — it just moves before extraction instead of after. The loaded `docs_by_id` is reused for verification (no duplicate query).

### Observability

When the fallback path fires (chunk-local miss + doc-level hit), the extractor emits a structured warning:

```
WARNING app.citation.extraction: citation chunk-boundary mismatch — quote located via full-document scan rather than cited chunk
  event: citation_chunk_mismatch
  document_id: <uuid>
  cited_chunk_index: 1
  quote_prefix: <first 40 chars>
```

The citation still verifies (quote-against-document is the correctness check), but operators can grep logs / Langfuse for `event=citation_chunk_mismatch` to surface model-drift signals in aggregate (per DE-277 option b).

## What this PR does *not* do

- Does **not** introduce new `verification_method` enum values. The persistence schema stays unchanged; spanning citations persist with `verification_method='exact_match'` (or `'tolerant_match'` if Stage 2 catches them on the fallback path).
- Does **not** rate-limit the chunk-mismatch warning. If a deployment hits this path frequently, that itself is the signal worth investigating.
- Does **not** address DE-279 (case citation validation) or DE-280 (case-content accuracy) — those are separate citation surfaces (types 2 and 3) tracked for M3.x / M4.

## Type of change

- [x] Bug fix (closes a M2-D4 known limitation that was deliberately deferred)
- [x] Documentation update (M3-IMPLEMENTATION-PLAN.md task spec corrected)

## Testing

- [x] Unit tests added — 7 new tests in `api/tests/citation/test_chunk_boundary.py`:
  1. Two-chunk span verifies via doc-scan with document-absolute offsets
  2. Three-chunk span verifies (long quotes)
  3. Single-chunk citation uses chunk-local path; chunk-mismatch warning NOT emitted (regression)
  4. Fallback path emits the `citation_chunk_mismatch` warning with structured fields
  5. Fabricated quote (not in chunk OR document) still drops
  6. No `document_contents` arg preserves pre-DE-277 behavior (backward-compat)
  7. Missing doc_id in the map drops safely (defensive)
- [x] Integration test flipped — `test_edge_cases.py::test_chunk_boundary_spanning_citation_verifies_via_full_doc_scan` (renamed from `_does_not_extract_today`) now asserts the row persists with `verification_method='exact_match'` and document-absolute offsets.
- [x] Static gates green: ruff format + ruff check ✓; mypy ✓; pytest ✓ full api suite **1026 passed, 1 skipped** (1018 → 1026: +7 new unit tests, +1 flipped integration assertion).
- [x] No frontend changes; svelte-check + Vitest unaffected.

## Documentation

- [x] PRD updated — DE-277 entry already names this exact fix path; no edits needed beyond the M3 plan correction.
- [x] M3-IMPLEMENTATION-PLAN.md — M3-0.2 task description corrected (was placed in `verification.py` / new enum values; now placed in `extraction.py` / no new enums).
- [x] OpenAPI schema — no API surface change.

## DCO sign-off

- [x] All commits in this PR are signed off

## Related issues

Closes the second task in [`docs/M3-IMPLEMENTATION-PLAN.md`](../blob/main/docs/M3-IMPLEMENTATION-PLAN.md) Phase 0. Refs DE-277.

## Reviewer notes

- The chat-send pipeline now batch-loads documents BEFORE extraction (based on retrieved-chunk doc_ids). This is a superset of what the verifier needs (every candidate's doc is in this set by construction). One extra DB roundtrip in the no-citations case is the trade-off — accepted because chat-sends already do 10+ DB ops and one more for citation accuracy is negligible.
- The chunk-mismatch warning is informational, not actionable per-call. If a deployment sees this firing frequently for a specific skill or prompt template, that's the signal worth investigating (the model is misnumbering its `[N]` indices).
- All 7 new unit tests are pure (no DB; stub `_RetrievedChunk` dataclass). The end-to-end persistence path is exercised by the flipped integration test against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)