### PR TITLE
feat(api,m3-a1): Playbook substrate — migration 0031 + ORM + Pydantic schemas + CRUD tests

### DIFF
--- a/api/alembic/versions/0031_playbooks.py
+++ b/api/alembic/versions/0031_playbooks.py
@@ -1,0 +1,257 @@
+"""create playbooks, playbook_positions, playbook_executions — M3-A1
+
+Substrate for the Playbook engine ([PRD §3.7](docs/PRD.md#37-playbooks))
+that ships in M3. A playbook codifies an organization's standard
+positions and fallback positions on common contract issues; when
+applied to a contract, the LangGraph executor (M3-A2) produces a
+per-position assessment (matches / deviates / missing) with redline
+suggestions.
+
+Schema overview
+---------------
+
+* ``playbooks`` — header row per playbook (name, contract_type, version,
+  author). Positions live in a child table.
+* ``playbook_positions`` — one row per issue in a playbook
+  (severity, detection keywords + examples, standard language,
+  fallback tiers as JSONB, redline strategy). Ordered by
+  ``position_order``.
+* ``playbook_executions`` — one row per execution of a playbook
+  against a target document. Status flows ``running`` → ``completed``
+  or ``error``; ``results`` is JSONB shaped per the M3-A2 executor.
+
+Fallback tiers are stored as a JSONB array on each position rather
+than as a separate ``playbook_fallback_tiers`` table — the per-position
+list is small (typically 2-3 ranked alternatives), fetched together
+with the position, and modelled as a single unit in the Pydantic
+``Position`` wire shape. The JSONB column keeps the schema readable
+and avoids a third join on the hot read path.
+
+Indexes
+-------
+
+* ``(playbook_id, position_order)`` on ``playbook_positions`` — the
+  executor walks a playbook's positions in order; an ordered index
+  makes the per-playbook fetch a single B-tree range scan.
+* ``(user_id, created_at DESC)`` on ``playbook_executions`` — the UI's
+  "my recent executions" view sorts by recency.
+* ``(target_document_id)`` on ``playbook_executions`` — the document
+  detail view answers "what playbooks have been run against this
+  document?" without scanning the table.
+
+CHECK constraints pin two enums at the storage layer: ``severity_if_missing``
+on ``playbook_positions`` (critical / high / medium / low per PRD §3.7)
+and ``status`` on ``playbook_executions`` (the M3-A2 executor lifecycle).
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2026-05-18
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0031"
+down_revision = "0030"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "playbooks",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("contract_type", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("version", sa.Text(), nullable=False, server_default="1.0.0"),
+        sa.Column(
+            "created_by",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL", name="fk_playbooks_created_by"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    op.create_table(
+        "playbook_positions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "playbook_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "playbooks.id",
+                ondelete="CASCADE",
+                name="fk_playbook_positions_playbook_id",
+            ),
+            nullable=False,
+        ),
+        sa.Column("issue", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("standard_language", sa.Text(), nullable=False),
+        sa.Column(
+            "fallback_tiers",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("redline_strategy", sa.Text(), nullable=False, server_default=""),
+        sa.Column("severity_if_missing", sa.Text(), nullable=False),
+        sa.Column(
+            "detection_keywords",
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+        sa.Column(
+            "detection_examples",
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+        sa.Column("position_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.CheckConstraint(
+            "severity_if_missing IN ('critical','high','medium','low')",
+            name="ck_playbook_positions_severity",
+        ),
+    )
+    # Ordered fetch — the executor walks a playbook's positions in
+    # ``position_order`` ASC. Single B-tree range scan.
+    op.create_index(
+        "idx_playbook_positions_playbook_order",
+        "playbook_positions",
+        ["playbook_id", "position_order"],
+    )
+
+    op.create_table(
+        "playbook_executions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "playbook_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "playbooks.id",
+                ondelete="CASCADE",
+                name="fk_playbook_executions_playbook_id",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "target_document_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "documents.id",
+                ondelete="CASCADE",
+                name="fk_playbook_executions_target_document_id",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "users.id",
+                ondelete="SET NULL",
+                name="fk_playbook_executions_user_id",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "projects.id",
+                ondelete="SET NULL",
+                name="fk_playbook_executions_project_id",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "results",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "completed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending','running','completed','error')",
+            name="ck_playbook_executions_status",
+        ),
+    )
+    # "My recent executions" view for the UI.
+    op.create_index(
+        "idx_playbook_executions_user_created",
+        "playbook_executions",
+        ["user_id", sa.text("created_at DESC")],
+    )
+    # "What playbooks have been run against this document?" — drives the
+    # document-detail view's playbook-history surface (M3-A4).
+    op.create_index(
+        "idx_playbook_executions_target_document",
+        "playbook_executions",
+        ["target_document_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_playbook_executions_target_document",
+        table_name="playbook_executions",
+    )
+    op.drop_index(
+        "idx_playbook_executions_user_created",
+        table_name="playbook_executions",
+    )
+    op.drop_table("playbook_executions")
+    op.drop_index(
+        "idx_playbook_positions_playbook_order",
+        table_name="playbook_positions",
+    )
+    op.drop_table("playbook_positions")
+    op.drop_table("playbooks")

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -18,6 +18,7 @@ from app.models.file import File
 from app.models.inference import InferenceRoutingLog
 from app.models.knowledge import KnowledgeBase, KnowledgeBaseFile
 from app.models.organization_profile import OrganizationProfile
+from app.models.playbook import Playbook, PlaybookExecution, PlaybookPosition
 from app.models.project import Project, ProjectFile, ProjectSkill
 from app.models.project_knowledge_base import ProjectKnowledgeBase
 from app.models.saved_prompt import SavedPrompt
@@ -39,6 +40,9 @@ __all__ = [
     "KnowledgeBaseFile",
     "Message",
     "OrganizationProfile",
+    "Playbook",
+    "PlaybookExecution",
+    "PlaybookPosition",
     "Project",
     "ProjectFile",
     "ProjectKnowledgeBase",

--- a/api/app/models/playbook.py
+++ b/api/app/models/playbook.py
@@ -1,0 +1,230 @@
+"""Playbook ORM models — M3-A1.
+
+Substrate for the Playbook engine ([PRD §3.7](docs/PRD.md#37-playbooks))
+landing in M3. A playbook codifies an organization's standard positions
+and fallback positions on common contract issues. The LangGraph
+executor (M3-A2) walks each position against a target contract and
+produces a per-position assessment.
+
+Three tables (migration ``0031_playbooks.py``):
+
+* :class:`Playbook` — header row per playbook. Positions live in a
+  child table; ``positions`` relationship loads them in
+  ``position_order``.
+* :class:`PlaybookPosition` — one row per issue. ``fallback_tiers``
+  is JSONB carrying the ranked list of acceptable alternatives.
+* :class:`PlaybookExecution` — one row per run of a playbook against
+  a target document. ``status`` lifecycle is
+  ``pending → running → completed | error``.
+
+The CHECK constraints on ``severity_if_missing`` and ``status`` are
+enforced at the storage layer (see migration 0031) so application
+bugs can't insert invalid enum values.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Text, text
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Playbook(Base):
+    """Header row per playbook — name, contract type, version, author.
+
+    ``contract_type`` is a free-form string per PRD §3.7
+    (``"NDA"``, ``"MSA-SaaS"``, ``"MSA-Commercial"``, ``"DPA"``, ...) so
+    new contract types don't require a migration. ``version`` is a
+    semver-like string the operator owns; built-in playbooks ship at
+    ``'1.0.0'`` per the seed migrations in M3-A3 / M3-A5.
+
+    ``created_by`` is nullable + ``ON DELETE SET NULL`` so a deleted
+    operator's playbook stays available to the rest of the team
+    (matches the project/skill ownership model — the playbook outlives
+    the individual author).
+    """
+
+    __tablename__ = "playbooks"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    contract_type: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    version: Mapped[str] = mapped_column(Text, nullable=False, server_default="1.0.0")
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL", name="fk_playbooks_created_by"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    positions: Mapped[list[PlaybookPosition]] = relationship(
+        "PlaybookPosition",
+        back_populates="playbook",
+        cascade="all, delete-orphan",
+        order_by="PlaybookPosition.position_order",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<Playbook id={self.id} name={self.name!r} "
+            f"contract_type={self.contract_type!r} version={self.version!r}>"
+        )
+
+
+class PlaybookPosition(Base):
+    """One issue in a playbook — the org's standard + fallbacks for a clause.
+
+    ``fallback_tiers`` is a JSONB array of ``FallbackTier`` shapes
+    (rank / description / language) — the per-position list is small
+    (typically 2-3 alternatives), fetched together with the position,
+    and modelled as a single unit in the Pydantic wire shape.
+    Normalizing to a third table would add a join on every read with
+    no upside.
+
+    ``detection_keywords`` and ``detection_examples`` feed the M3-A2
+    executor's retrieval step — the executor uses both the keywords
+    (for lexical match) and the examples (for embedding-based match)
+    to locate the position's clause(s) in the target contract.
+    """
+
+    __tablename__ = "playbook_positions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    playbook_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("playbooks.id", ondelete="CASCADE", name="fk_playbook_positions_playbook_id"),
+        nullable=False,
+    )
+    issue: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    standard_language: Mapped[str] = mapped_column(Text, nullable=False)
+    fallback_tiers: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+    )
+    redline_strategy: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    severity_if_missing: Mapped[str] = mapped_column(Text, nullable=False)
+    detection_keywords: Mapped[list[str]] = mapped_column(
+        ARRAY(Text),
+        nullable=False,
+        server_default=text("'{}'::text[]"),
+    )
+    detection_examples: Mapped[list[str]] = mapped_column(
+        ARRAY(Text),
+        nullable=False,
+        server_default=text("'{}'::text[]"),
+    )
+    position_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+
+    playbook: Mapped[Playbook] = relationship("Playbook", back_populates="positions")
+
+    def __repr__(self) -> str:
+        return (
+            f"<PlaybookPosition id={self.id} playbook_id={self.playbook_id} "
+            f"issue={self.issue!r} severity={self.severity_if_missing!r} "
+            f"order={self.position_order}>"
+        )
+
+
+class PlaybookExecution(Base):
+    """One execution of a playbook against a target document.
+
+    Status lifecycle (CHECK-constrained at the storage layer):
+
+    * ``pending`` — execution row written, executor not yet picked it up.
+    * ``running`` — executor walking positions.
+    * ``completed`` — every position has a verdict in ``results``;
+      ``completed_at`` set.
+    * ``error`` — executor raised mid-flight; ``error`` text populated;
+      ``results`` may carry partial output for whichever positions
+      completed before the failure.
+
+    ``results`` is JSONB shaped per the M3-A2 executor; this row
+    pre-allocates the column so the executor implementation does not
+    require another migration. ``user_id`` and ``project_id`` are both
+    ``ON DELETE SET NULL`` — historical executions survive operator or
+    project deletion so audit trails stay intact.
+    """
+
+    __tablename__ = "playbook_executions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    playbook_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "playbooks.id",
+            ondelete="CASCADE",
+            name="fk_playbook_executions_playbook_id",
+        ),
+        nullable=False,
+    )
+    target_document_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "documents.id",
+            ondelete="CASCADE",
+            name="fk_playbook_executions_target_document_id",
+        ),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL", name="fk_playbook_executions_user_id"),
+        nullable=True,
+    )
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "projects.id",
+            ondelete="SET NULL",
+            name="fk_playbook_executions_project_id",
+        ),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'pending'"))
+    results: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<PlaybookExecution id={self.id} playbook_id={self.playbook_id} "
+            f"target_document_id={self.target_document_id} status={self.status!r}>"
+        )

--- a/api/app/schemas/playbooks.py
+++ b/api/app/schemas/playbooks.py
@@ -1,0 +1,192 @@
+"""Pydantic schemas for the Playbook engine — M3-A1.
+
+Wire shapes for the ``/api/v1/playbooks`` and
+``/api/v1/playbook-executions`` surfaces ([PRD §3.7](docs/PRD.md#37-playbooks)).
+The ORM models live in :mod:`app.models.playbook`; this module is the
+request / response surface for the endpoints that land in M3-A2.
+
+PRD §3.7 sketches the ``Playbook`` and ``Position`` shapes; this module
+adds the missing pieces:
+
+* :class:`FallbackTier` — the PRD references ``List[FallbackTier]`` on
+  ``Position`` but does not spec the shape. We pick a minimal,
+  forward-compatible shape: ranked tier + description + alternative
+  language. Stored as JSONB so additional fields can be added later
+  without a migration.
+* :class:`PlaybookExecutionStatus` — enum literal for the lifecycle
+  the executor (M3-A2) walks: ``pending → running → completed | error``.
+
+The schemas live as their own module rather than alongside
+``chats.py`` / ``projects.py`` so the surface is discoverable for the
+M3-A2 executor and the M3-A4 UI without grep-spelunking.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PlaybookExecutionStatus = Literal["pending", "running", "completed", "error"]
+"""Lifecycle states for a :class:`PlaybookExecution`. Matches the CHECK
+constraint on ``playbook_executions.status`` (migration 0031)."""
+
+PositionSeverity = Literal["critical", "high", "medium", "low"]
+"""Severity bucket for a missing position. Matches the CHECK constraint
+on ``playbook_positions.severity_if_missing`` (migration 0031) and the
+``severity_if_missing`` enum documented in [PRD §3.7](docs/PRD.md#37-playbooks)."""
+
+
+class FallbackTier(BaseModel):
+    """One acceptable alternative to a position's standard language.
+
+    The PRD's ``Position`` schema references ``List[FallbackTier]`` but
+    does not define ``FallbackTier``. We pick a minimal, ranked shape:
+
+    * ``rank`` — 1-based order of preference (1 = preferred fallback,
+      2 = next, etc.).
+    * ``description`` — what makes this tier acceptable
+      (e.g., "12-month liability cap" vs. the standard "uncapped").
+    * ``language`` — the actual clause text the playbook will accept.
+
+    Stored as JSONB on ``playbook_positions.fallback_tiers`` so
+    additional fields (e.g., approval workflow, escalation contact)
+    can land in a future iteration without a schema migration.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    rank: int = Field(ge=1, description="1-based order of preference.")
+    description: str = Field(description="Why this tier is acceptable.")
+    language: str = Field(description="The alternative clause text.")
+
+
+class Position(BaseModel):
+    """One issue in a playbook — org's standard + fallbacks for a clause.
+
+    Mirrors the ``Position`` shape in [PRD §3.7](docs/PRD.md#37-playbooks)
+    with the ``id`` and ``position_order`` fields the storage layer
+    needs. ``detection_keywords`` and ``detection_examples`` feed the
+    M3-A2 executor's retrieval step (lexical + embedding match).
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    issue: str = Field(description='e.g. "Limitation of Liability".')
+    description: str = ""
+    standard_language: str = Field(description="The org's preferred clause.")
+    fallback_tiers: list[FallbackTier] = Field(
+        default_factory=list,
+        description="Ranked acceptable alternatives.",
+    )
+    redline_strategy: str = Field(
+        default="",
+        description="How to redline if the contract deviates.",
+    )
+    severity_if_missing: PositionSeverity
+    detection_keywords: list[str] = Field(
+        default_factory=list,
+        description="Keywords for the executor's lexical match step.",
+    )
+    detection_examples: list[str] = Field(
+        default_factory=list,
+        description="Example clauses for the executor's embedding match step.",
+    )
+    position_order: int = Field(
+        default=0,
+        ge=0,
+        description="Ascending walk order. Stable per playbook.",
+    )
+
+
+class PositionCreate(BaseModel):
+    """Request shape for creating a position — same as :class:`Position` minus ``id``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    issue: str
+    description: str = ""
+    standard_language: str
+    fallback_tiers: list[FallbackTier] = Field(default_factory=list)
+    redline_strategy: str = ""
+    severity_if_missing: PositionSeverity
+    detection_keywords: list[str] = Field(default_factory=list)
+    detection_examples: list[str] = Field(default_factory=list)
+    position_order: int = Field(default=0, ge=0)
+
+
+class Playbook(BaseModel):
+    """Full playbook — header plus ordered positions.
+
+    Mirrors the ``Playbook`` shape in [PRD §3.7](docs/PRD.md#37-playbooks).
+    ``contract_type`` is free-form text per PRD; the canonical values
+    used by the built-in playbooks are ``"NDA"``, ``"NDA-unilateral"``,
+    ``"MSA-SaaS"``, ``"MSA-Commercial"``, ``"DPA"``, but operators may
+    define their own.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    contract_type: str
+    description: str = ""
+    version: str = "1.0.0"
+    created_by: uuid.UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+    positions: list[Position] = Field(default_factory=list)
+
+
+class PlaybookCreate(BaseModel):
+    """Request shape for ``POST /api/v1/playbooks``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    contract_type: str
+    description: str = ""
+    version: str = "1.0.0"
+    positions: list[PositionCreate] = Field(default_factory=list)
+
+
+class PlaybookExecution(BaseModel):
+    """One execution of a playbook against a target document.
+
+    ``results`` is a free-form JSONB payload populated by the M3-A2
+    executor; this schema doesn't pin its shape because the executor
+    surface is still being defined. The wire-level guarantee at this
+    layer is just "if status='completed', results is present; if
+    status='error', error text is populated."
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    playbook_id: uuid.UUID
+    target_document_id: uuid.UUID
+    user_id: uuid.UUID | None = None
+    project_id: uuid.UUID | None = None
+    status: PlaybookExecutionStatus
+    results: dict[str, Any] | None = None
+    error: str | None = None
+    created_at: datetime
+    completed_at: datetime | None = None
+
+
+class PlaybookExecutionCreate(BaseModel):
+    """Request shape for ``POST /api/v1/playbooks/{id}/execute``.
+
+    ``project_id`` is optional — the executor uses it for RBAC scoping
+    and to inherit the project's ``minimum_inference_tier`` /
+    ``ensemble_verification`` flags. A null ``project_id`` runs the
+    playbook against the document in the caller's personal scope.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_document_id: uuid.UUID
+    project_id: uuid.UUID | None = None

--- a/api/tests/test_playbook_models.py
+++ b/api/tests/test_playbook_models.py
@@ -1,0 +1,547 @@
+"""Model + migration tests for the Playbook substrate — M3-A1.
+
+Covers:
+
+* CRUD round-trip on all three new tables (``playbooks``,
+  ``playbook_positions``, ``playbook_executions``).
+* Cascade delete from ``playbooks`` → ``playbook_positions`` and
+  ``playbook_executions``.
+* ON DELETE SET NULL on ``playbooks.created_by`` and
+  ``playbook_executions.user_id`` / ``project_id`` — historical rows
+  survive operator / project deletion.
+* CHECK constraints pin both enums at the storage layer
+  (``severity_if_missing``, ``status``).
+* Index on ``(playbook_id, position_order)`` produces an ordered fetch
+  via the ORM relationship.
+* JSONB ``fallback_tiers`` and ``results`` round-trip cleanly.
+
+Tests run against the same SAVEPOINT-rolled-back per-test session as
+the rest of the API tests (per ``tests/conftest.py``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import inspect, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.document import Document
+from app.models.file import File as FileModel
+from app.models.playbook import Playbook, PlaybookExecution, PlaybookPosition
+from app.models.project import Project
+from app.models.user import User
+from app.security import hash_password
+
+
+async def _make_user(db: AsyncSession, *, is_admin: bool = False) -> User:
+    user = User(
+        email=f"u-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        is_admin=is_admin,
+        role="admin" if is_admin else "member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_document(db: AsyncSession, *, owner: User) -> tuple[FileModel, Document]:
+    f = FileModel(
+        owner_id=owner.id,
+        filename=f"playbook-target-{uuid.uuid4().hex[:8]}.pdf",
+        mime_type="application/pdf",
+        size_bytes=1024,
+        hash_sha256="a" * 64,
+        storage_path=f"playbook-fixture/{uuid.uuid4()}",
+        ingestion_status="ready",
+    )
+    db.add(f)
+    await db.flush()
+    doc = Document(
+        file_id=f.id,
+        parser="pymupdf-only",
+        parser_version="pymupdf=1.27",
+        page_count=10,
+        character_count=5000,
+        normalized_content="x" * 5000,
+        was_ocrd=False,
+    )
+    db.add(doc)
+    await db.flush()
+    return f, doc
+
+
+# ---------------------------------------------------------------------------
+# Playbook CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_playbook_round_trip(db_session: AsyncSession) -> None:
+    """Insert + read returns the same Playbook with timestamps populated."""
+    author = await _make_user(db_session)
+
+    pb = Playbook(
+        name="Test NDA Playbook",
+        contract_type="NDA",
+        description="A test playbook for round-trip coverage.",
+        version="1.0.0",
+        created_by=author.id,
+    )
+    db_session.add(pb)
+    await db_session.flush()
+    await db_session.refresh(pb)
+
+    assert pb.id is not None
+    assert isinstance(pb.id, uuid.UUID)
+    assert pb.created_at is not None
+    assert pb.updated_at is not None
+
+    result = await db_session.execute(select(Playbook).where(Playbook.id == pb.id))
+    fetched = result.scalar_one()
+    assert fetched.name == "Test NDA Playbook"
+    assert fetched.contract_type == "NDA"
+    assert fetched.version == "1.0.0"
+    assert fetched.created_by == author.id
+
+
+@pytest.mark.integration
+async def test_playbook_positions_load_in_order(db_session: AsyncSession) -> None:
+    """The ``positions`` relationship returns rows in ``position_order`` ASC."""
+    pb = Playbook(name="Ordered", contract_type="NDA")
+    db_session.add(pb)
+    await db_session.flush()
+
+    # Insert out of order so the ordering must come from the relationship.
+    db_session.add_all(
+        [
+            PlaybookPosition(
+                playbook_id=pb.id,
+                issue="Survival",
+                standard_language="...",
+                severity_if_missing="medium",
+                position_order=2,
+            ),
+            PlaybookPosition(
+                playbook_id=pb.id,
+                issue="Definition of confidential information",
+                standard_language="...",
+                severity_if_missing="critical",
+                position_order=0,
+            ),
+            PlaybookPosition(
+                playbook_id=pb.id,
+                issue="Term",
+                standard_language="...",
+                severity_if_missing="high",
+                position_order=1,
+            ),
+        ]
+    )
+    await db_session.flush()
+    await db_session.refresh(pb, attribute_names=["positions"])
+
+    ordering = [p.issue for p in pb.positions]
+    assert ordering == [
+        "Definition of confidential information",
+        "Term",
+        "Survival",
+    ]
+
+
+@pytest.mark.integration
+async def test_playbook_position_severity_check_constraint(
+    db_session: AsyncSession,
+) -> None:
+    """The CHECK constraint pins the severity enum at the storage layer."""
+    pb = Playbook(name="Bad", contract_type="NDA")
+    db_session.add(pb)
+    await db_session.flush()
+
+    bad = PlaybookPosition(
+        playbook_id=pb.id,
+        issue="Whatever",
+        standard_language="...",
+        severity_if_missing="catastrophic",  # not in the enum
+    )
+    db_session.add(bad)
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.integration
+async def test_playbook_position_fallback_tiers_jsonb_round_trip(
+    db_session: AsyncSession,
+) -> None:
+    """JSONB ``fallback_tiers`` round-trips the Pydantic FallbackTier shape."""
+    pb = Playbook(name="JSONB", contract_type="MSA-SaaS")
+    db_session.add(pb)
+    await db_session.flush()
+
+    tiers = [
+        {"rank": 1, "description": "12-month cap", "language": "...."},
+        {"rank": 2, "description": "24-month cap", "language": "...."},
+        {"rank": 3, "description": "Uncapped only for breach", "language": "...."},
+    ]
+    position = PlaybookPosition(
+        playbook_id=pb.id,
+        issue="Limitation of Liability",
+        standard_language="The party's aggregate liability shall be ...",
+        severity_if_missing="critical",
+        fallback_tiers=tiers,
+        detection_keywords=["liability", "cap", "limitation"],
+        detection_examples=[
+            "Each party's aggregate liability shall not exceed the fees paid in the prior 12 months."
+        ],
+    )
+    db_session.add(position)
+    await db_session.flush()
+    await db_session.refresh(position)
+
+    assert position.fallback_tiers == tiers
+    assert position.detection_keywords == ["liability", "cap", "limitation"]
+    assert len(position.detection_examples) == 1
+
+
+@pytest.mark.integration
+async def test_playbook_delete_cascades_to_positions(db_session: AsyncSession) -> None:
+    """Deleting a playbook removes its positions (ON DELETE CASCADE)."""
+    pb = Playbook(name="Cascade", contract_type="NDA")
+    db_session.add(pb)
+    await db_session.flush()
+    db_session.add(
+        PlaybookPosition(
+            playbook_id=pb.id,
+            issue="Test",
+            standard_language="...",
+            severity_if_missing="low",
+        )
+    )
+    await db_session.flush()
+
+    await db_session.delete(pb)
+    await db_session.flush()
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(PlaybookPosition).where(PlaybookPosition.playbook_id == pb.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+@pytest.mark.integration
+async def test_playbook_created_by_set_null_on_user_delete(
+    db_session: AsyncSession,
+) -> None:
+    """Deleting the author of a playbook nulls ``created_by`` rather than the row."""
+    author = await _make_user(db_session)
+    pb = Playbook(name="Author Survives", contract_type="NDA", created_by=author.id)
+    db_session.add(pb)
+    await db_session.flush()
+    pb_id = pb.id
+
+    await db_session.delete(author)
+    await db_session.flush()
+    # The FK ON DELETE SET NULL fires at the DB level; the ORM session's
+    # identity-mapped Playbook still carries the old created_by. Expire
+    # so the refetch reads from the DB.
+    db_session.expire_all()
+
+    fetched = (await db_session.execute(select(Playbook).where(Playbook.id == pb_id))).scalar_one()
+    assert fetched.created_by is None
+    assert fetched.name == "Author Survives"
+
+
+# ---------------------------------------------------------------------------
+# PlaybookExecution CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_playbook_execution_round_trip(db_session: AsyncSession) -> None:
+    """Insert + read returns a PlaybookExecution with default 'pending' status."""
+    author = await _make_user(db_session)
+    _file, doc = await _make_document(db_session, owner=author)
+    pb = Playbook(name="Execute Me", contract_type="NDA", created_by=author.id)
+    db_session.add(pb)
+    await db_session.flush()
+
+    execution = PlaybookExecution(
+        playbook_id=pb.id,
+        target_document_id=doc.id,
+        user_id=author.id,
+    )
+    db_session.add(execution)
+    await db_session.flush()
+    await db_session.refresh(execution)
+
+    assert execution.id is not None
+    assert execution.status == "pending"
+    assert execution.results is None
+    assert execution.error is None
+    assert execution.completed_at is None
+
+
+@pytest.mark.integration
+async def test_playbook_execution_status_check_constraint(
+    db_session: AsyncSession,
+) -> None:
+    """The CHECK constraint pins the execution-status enum."""
+    author = await _make_user(db_session)
+    _file, doc = await _make_document(db_session, owner=author)
+    pb = Playbook(name="Bad Status", contract_type="NDA")
+    db_session.add(pb)
+    await db_session.flush()
+
+    bad = PlaybookExecution(
+        playbook_id=pb.id,
+        target_document_id=doc.id,
+        user_id=author.id,
+        status="warp_speed",  # not in the enum
+    )
+    db_session.add(bad)
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.integration
+async def test_playbook_execution_results_jsonb_round_trip(
+    db_session: AsyncSession,
+) -> None:
+    """The ``results`` column round-trips arbitrary JSONB payloads."""
+    author = await _make_user(db_session)
+    _file, doc = await _make_document(db_session, owner=author)
+    pb = Playbook(name="Results Shape", contract_type="MSA-SaaS")
+    db_session.add(pb)
+    await db_session.flush()
+
+    payload = {
+        "positions": [
+            {"id": str(uuid.uuid4()), "verdict": "matches_standard", "confidence": 0.95},
+            {
+                "id": str(uuid.uuid4()),
+                "verdict": "deviates",
+                "confidence": 0.6,
+                "redline": {"old": "uncapped", "new": "capped at 12 months fees"},
+            },
+        ],
+        "summary": "1 deviation flagged.",
+    }
+    execution = PlaybookExecution(
+        playbook_id=pb.id,
+        target_document_id=doc.id,
+        user_id=author.id,
+        status="completed",
+        results=payload,
+        completed_at=datetime.now(UTC),
+    )
+    db_session.add(execution)
+    await db_session.flush()
+    await db_session.refresh(execution)
+
+    assert execution.results == payload
+
+
+@pytest.mark.integration
+async def test_playbook_delete_cascades_to_executions(
+    db_session: AsyncSession,
+) -> None:
+    """Deleting a playbook removes its executions (history audit trail)."""
+    author = await _make_user(db_session)
+    _file, doc = await _make_document(db_session, owner=author)
+    pb = Playbook(name="Cascaded", contract_type="NDA")
+    db_session.add(pb)
+    await db_session.flush()
+    db_session.add(
+        PlaybookExecution(
+            playbook_id=pb.id,
+            target_document_id=doc.id,
+            user_id=author.id,
+        )
+    )
+    await db_session.flush()
+
+    await db_session.delete(pb)
+    await db_session.flush()
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(PlaybookExecution).where(PlaybookExecution.playbook_id == pb.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+@pytest.mark.integration
+async def test_playbook_execution_user_set_null_on_user_delete(
+    db_session: AsyncSession,
+) -> None:
+    """Deleting the executing user nulls ``user_id`` (history preserved).
+
+    Uses two distinct users — ``file_owner`` owns the underlying file
+    (the files table's ``owner_id`` FK uses NO ACTION so we can't
+    delete that one) and ``executor`` is the operator who ran the
+    playbook. Only ``executor`` is deleted in this test.
+    """
+    file_owner = await _make_user(db_session)
+    executor = await _make_user(db_session)
+    _file, doc = await _make_document(db_session, owner=file_owner)
+    pb = Playbook(name="History", contract_type="NDA")
+    db_session.add(pb)
+    await db_session.flush()
+    execution = PlaybookExecution(
+        playbook_id=pb.id,
+        target_document_id=doc.id,
+        user_id=executor.id,
+    )
+    db_session.add(execution)
+    await db_session.flush()
+    execution_id = execution.id
+
+    await db_session.delete(executor)
+    await db_session.flush()
+    db_session.expire_all()
+
+    fetched = (
+        await db_session.execute(
+            select(PlaybookExecution).where(PlaybookExecution.id == execution_id)
+        )
+    ).scalar_one()
+    assert fetched.user_id is None
+
+
+@pytest.mark.integration
+async def test_playbook_execution_project_set_null_on_project_delete(
+    db_session: AsyncSession,
+) -> None:
+    """Deleting the project nulls ``project_id`` on historical executions."""
+    author = await _make_user(db_session)
+    _file, doc = await _make_document(db_session, owner=author)
+    proj = Project(
+        owner_id=author.id,
+        name="P",
+        slug=f"p-{uuid.uuid4().hex[:8]}",
+    )
+    db_session.add(proj)
+    await db_session.flush()
+    pb = Playbook(name="Proj-scoped", contract_type="NDA")
+    db_session.add(pb)
+    await db_session.flush()
+    execution = PlaybookExecution(
+        playbook_id=pb.id,
+        target_document_id=doc.id,
+        user_id=author.id,
+        project_id=proj.id,
+    )
+    db_session.add(execution)
+    await db_session.flush()
+    execution_id = execution.id
+
+    await db_session.delete(proj)
+    await db_session.flush()
+    db_session.expire_all()
+
+    fetched = (
+        await db_session.execute(
+            select(PlaybookExecution).where(PlaybookExecution.id == execution_id)
+        )
+    ).scalar_one()
+    assert fetched.project_id is None
+
+
+# ---------------------------------------------------------------------------
+# Schema-level smoke: indexes present per the migration spec
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_playbook_indexes_present_on_disk(db_session: AsyncSession) -> None:
+    """The three indexes the M3-A1 spec requires exist after migration."""
+    result = await db_session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE schemaname = current_schema() "
+            "AND indexname IN ("
+            "'idx_playbook_positions_playbook_order',"
+            "'idx_playbook_executions_user_created',"
+            "'idx_playbook_executions_target_document'"
+            ")"
+        )
+    )
+    present = {row[0] for row in result.all()}
+    assert present == {
+        "idx_playbook_positions_playbook_order",
+        "idx_playbook_executions_user_created",
+        "idx_playbook_executions_target_document",
+    }
+
+
+@pytest.mark.unit
+def test_playbook_models_registered_with_metadata() -> None:
+    """Importing the models module registers all three tables with the Base."""
+    from app.db.base import Base
+
+    table_names = set(Base.metadata.tables.keys())
+    assert "playbooks" in table_names
+    assert "playbook_positions" in table_names
+    assert "playbook_executions" in table_names
+
+
+@pytest.mark.unit
+def test_playbook_columns_match_migration() -> None:
+    """The ORM model columns line up with the migration's column set."""
+    pb_cols = {c.name for c in inspect(Playbook).columns}
+    assert pb_cols == {
+        "id",
+        "name",
+        "contract_type",
+        "description",
+        "version",
+        "created_by",
+        "created_at",
+        "updated_at",
+    }
+
+    pos_cols = {c.name for c in inspect(PlaybookPosition).columns}
+    assert pos_cols == {
+        "id",
+        "playbook_id",
+        "issue",
+        "description",
+        "standard_language",
+        "fallback_tiers",
+        "redline_strategy",
+        "severity_if_missing",
+        "detection_keywords",
+        "detection_examples",
+        "position_order",
+    }
+
+    exec_cols = {c.name for c in inspect(PlaybookExecution).columns}
+    assert exec_cols == {
+        "id",
+        "playbook_id",
+        "target_document_id",
+        "user_id",
+        "project_id",
+        "status",
+        "results",
+        "error",
+        "created_at",
+        "completed_at",
+    }

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -988,42 +988,118 @@ CREATE INDEX idx_inference_log_refused ON inference_routing_log(timestamp DESC) 
 
 ---
 
-## M3+ tables (sketched, land at the indicated milestone)
+## Playbooks (per [PRD §3.7](docs/PRD.md#37-playbooks), M3-A1)
+
+Substrate for the Playbook engine landing in M3. A playbook codifies an
+organization's standard positions and fallback positions on common
+contract issues; the LangGraph executor (M3-A2) walks each position
+against a target contract and produces a per-position assessment with
+redline suggestions. Three tables, all introduced by migration
+`0031_playbooks.py`:
+
+* `playbooks` — header row per playbook (name, contract type, version,
+  author).
+* `playbook_positions` — one row per issue inside a playbook. The
+  per-position list of acceptable alternatives lives in a JSONB
+  `fallback_tiers` column rather than a third normalized table (small
+  per-position lists; always fetched together with the position).
+* `playbook_executions` — one row per run of a playbook against a
+  target document. `results` is JSONB shaped per the M3-A2 executor.
 
 ### `playbooks` (M3)
 
 ```sql
 CREATE TABLE playbooks (
-    id              UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name            TEXT NOT NULL,
-    version         TEXT NOT NULL,
-    scope           TEXT NOT NULL CHECK (scope IN ('builtin','user','team')),
-    owner_id        UUID REFERENCES users(id) ON DELETE CASCADE,
-    title           TEXT NOT NULL,
-    description     TEXT,
-    content_yaml    TEXT NOT NULL,
+    contract_type   TEXT NOT NULL,         -- e.g. 'NDA' | 'MSA-SaaS' | 'DPA' | 'MSA-Commercial'
+    description     TEXT NOT NULL DEFAULT '',
+    version         TEXT NOT NULL DEFAULT '1.0.0',
+    created_by      UUID REFERENCES users(id) ON DELETE SET NULL,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    deleted_at      TIMESTAMPTZ,
-    UNIQUE (name, version, scope, owner_id)
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 ```
 
-### `playbook_runs` (M3)
+`created_by` is nullable + `ON DELETE SET NULL` so a deleted operator's
+playbook stays available to the rest of the team — playbooks outlive
+their individual authors (matches the project / skill ownership model).
+
+`contract_type` is free-form per [PRD §3.7](docs/PRD.md#37-playbooks);
+the canonical values used by the M3-A3 / M3-A5 built-ins are `'NDA'`,
+`'NDA-unilateral'`, `'MSA-SaaS'`, `'MSA-Commercial'`, `'DPA'`, but
+operators may define their own without a migration.
+
+### `playbook_positions` (M3)
 
 ```sql
-CREATE TABLE playbook_runs (
-    id                UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
-    playbook_id       UUID NOT NULL REFERENCES playbooks(id) ON DELETE RESTRICT,
-    chat_id           UUID NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
-    started_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
-    completed_at      TIMESTAMPTZ,
-    status            TEXT NOT NULL CHECK (status IN ('running','completed','failed','cancelled')),
-    output_summary    TEXT,
-    findings_count    INTEGER,
-    error             TEXT
+CREATE TABLE playbook_positions (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    playbook_id         UUID NOT NULL REFERENCES playbooks(id) ON DELETE CASCADE,
+    issue               TEXT NOT NULL,                                  -- e.g. 'Limitation of Liability'
+    description         TEXT NOT NULL DEFAULT '',
+    standard_language   TEXT NOT NULL,                                  -- the org's preferred clause
+    fallback_tiers      JSONB NOT NULL DEFAULT '[]'::jsonb,             -- ranked acceptable alternatives
+    redline_strategy    TEXT NOT NULL DEFAULT '',
+    severity_if_missing TEXT NOT NULL
+        CHECK (severity_if_missing IN ('critical','high','medium','low')),
+    detection_keywords  TEXT[] NOT NULL DEFAULT '{}'::text[],           -- lexical match
+    detection_examples  TEXT[] NOT NULL DEFAULT '{}'::text[],           -- embedding match
+    position_order      INTEGER NOT NULL DEFAULT 0
 );
+
+CREATE INDEX idx_playbook_positions_playbook_order
+    ON playbook_positions(playbook_id, position_order);
 ```
+
+The `fallback_tiers` JSONB array carries objects matching the Pydantic
+`FallbackTier` shape (`{rank, description, language}`). Storing as
+JSONB rather than a normalized table avoids a join on every executor
+read — the per-position list is small (typically 2-3 alternatives) and
+always loaded with the position.
+
+`detection_keywords` and `detection_examples` feed the M3-A2 executor's
+retrieval step: keywords drive a lexical match against the target
+contract; examples drive an embedding-based match.
+
+### `playbook_executions` (M3)
+
+```sql
+CREATE TABLE playbook_executions (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    playbook_id         UUID NOT NULL REFERENCES playbooks(id) ON DELETE CASCADE,
+    target_document_id  UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    user_id             UUID REFERENCES users(id) ON DELETE SET NULL,
+    project_id          UUID REFERENCES projects(id) ON DELETE SET NULL,
+    status              TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending','running','completed','error')),
+    results             JSONB,                                          -- M3-A2 executor's payload
+    error               TEXT,                                           -- populated when status='error'
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at        TIMESTAMPTZ
+);
+
+-- "My recent executions" view for the UI (M3-A4).
+CREATE INDEX idx_playbook_executions_user_created
+    ON playbook_executions(user_id, created_at DESC);
+
+-- "What playbooks have been run against this document?" — drives the
+-- document-detail view's playbook-history surface (M3-A4).
+CREATE INDEX idx_playbook_executions_target_document
+    ON playbook_executions(target_document_id);
+```
+
+Status lifecycle: `pending → running → completed | error`. The CHECK
+constraint pins the enum at the storage layer.
+
+`user_id` and `project_id` are both `ON DELETE SET NULL` so historical
+executions survive operator or project deletion — audit trails stay
+intact even after the actor or matter is removed. The
+`target_document_id` FK is `ON DELETE CASCADE` because an execution
+against a deleted document has no anchor (the source the executor
+ran against is gone).
+
+## M4+ tables (sketched, land at the indicated milestone)
 
 ### `autonomous_tasks` (M4)
 


### PR DESCRIPTION
## What this PR does

First task of M3 Phase A — the data substrate for the Playbook engine ([PRD §3.7](../blob/main/docs/PRD.md#37-playbooks)). No executor, no endpoints, no UI — those land in M3-A2 / M3-A4. This PR is the schema + ORM + wire shapes the rest of Phase A consumes.

## Why this comes first

Per the M3 plan's sequential-by-complexity ordering, the Playbook engine is the substrate Word Add-In (Phase B) and Tabular Review (Phase C) both build on. Inside Phase A, the schema needs to land before:

- **M3-A2** — LangGraph executor walks against this schema
- **M3-A3** — NDA built-in seeds rows into it
- **M3-A4** — execution UI renders `playbook_executions.results`

Splitting schema-first means each subsequent Phase A PR has a tighter review surface.

## Surface

### Migration 0031 (three tables)

| Table | Purpose | Key choices |
|---|---|---|
| `playbooks` | Header per playbook | `created_by` ON DELETE SET NULL — playbooks outlive individual authors |
| `playbook_positions` | One row per issue | `fallback_tiers` JSONB on the position (not normalized — small lists always loaded together); CHECK constraint pins severity to `critical \| high \| medium \| low` per PRD §3.7; `(playbook_id, position_order)` index gives the executor a single ordered B-tree range scan |
| `playbook_executions` | One run of a playbook | Status lifecycle `pending → running → completed \| error` CHECK-pinned; `user_id` + `project_id` ON DELETE SET NULL (audit trail survives deletions); indexes on `(user_id, created_at DESC)` and `(target_document_id)` |

### ORM models — `api/app/models/playbook.py`

`Playbook` / `PlaybookPosition` / `PlaybookExecution` with relationships wired:
- `playbook.positions` cascades from delete; loads in `position_order` ASC.
- All FK cascades match the migration (CASCADE for owning relationships; SET NULL for audit-history relationships).

### Pydantic schemas — `api/app/schemas/playbooks.py`

The PRD references `FallbackTier` on the `Position` shape but doesn't spec it. This module picks a minimal, forward-compatible shape (rank / description / language) stored as JSONB so additional fields land later without a migration. Two `Literal` types (`PlaybookExecutionStatus`, `PositionSeverity`) mirror the CHECK enums so handler code inherits the constraint from a single source.

## Tests — 15 new in `api/tests/test_playbook_models.py`

| Group | Coverage |
|---|---|
| CRUD round-trip | Playbook, PlaybookExecution insert+read, timestamps populated |
| Relationships | `positions` loads in `position_order` ASC regardless of insert order |
| CHECK constraints | `severity_if_missing` and `status` enums enforced at storage |
| JSONB round-trip | `fallback_tiers` (list of dict) and `results` (arbitrary) survive write+read |
| Cascade deletes | Deleting a playbook removes positions + executions |
| SET NULL on user delete | `playbooks.created_by` and `playbook_executions.user_id` null cleanly (used two distinct users to avoid the files-table FK constraint that owns the document fixture) |
| SET NULL on project delete | `playbook_executions.project_id` nulls cleanly |
| Schema-level smoke | All three indexes from the M3-A1 spec exist on disk; column sets match the migration exactly; models register with Base.metadata |

## What this PR does *not* do

- **No executor** — `playbook_executions` is pre-allocated so M3-A2 can wire LangGraph against it without a schema change.
- **No `langgraph` dep** — pinned in M3-A2 alongside the executor module.
- **No API endpoints** — Pydantic schemas exist so M3-A2 wires endpoints against them.
- **No built-in playbooks** — NDA + variants land in M3-A3 (migration 0032); MSA-SaaS / DPA / Commercial MSA in M3-A5 (migration 0033).
- **No `contract_type` enum** — per PRD §3.7 the field is free-form so operators can define new contract types without a migration.

## Type of change

- [x] New feature (data substrate for M3 Phase A)
- [x] Documentation update (db-schema.md sections)

## Testing

- [x] Unit tests added — `test_playbook_models_registered_with_metadata` + `test_playbook_columns_match_migration` (no DB needed)
- [x] Integration tests added — 13 covering CRUD / cascades / constraints / JSONB / indexes
- [x] Static gates green: ruff format + ruff check ✓; mypy ✓; pytest ✓ full api suite **1051 passed, 1 skipped** (1036 → 1051, +15 new)
- [x] No frontend changes; svelte-check + Vitest unaffected
- [x] Alembic `upgrade head` runs cleanly against a fresh test DB (verified by conftest.py fixture executing migration on every test session)

## Documentation

- [x] `docs/db-schema.md` — three new sections under a new `## Playbooks (per PRD §3.7, M3-A1)` heading. Replaces the old M3-sketch placeholders for `playbooks` / `playbook_runs` that were superseded by this implementation. Moved M4 placeholders (`autonomous_tasks`, `contract_relationships`) to their own `## M4+ tables (sketched)` heading.
- [x] Migration 0031 has a long-form module docstring explaining the JSONB-vs-normalized-table decision, the CHECK constraints, and the index choices.
- [x] ORM modules have field-level docstrings explaining the SET NULL vs CASCADE decisions and the wire-vs-storage relationship for `fallback_tiers`.

## DCO sign-off

- [x] All commits in this PR are signed off

## Related issues

Closes the first task in [`docs/M3-IMPLEMENTATION-PLAN.md`](../blob/main/docs/M3-IMPLEMENTATION-PLAN.md) Phase A. Refs [PRD §3.7 Playbooks](../blob/main/docs/PRD.md#37-playbooks).

## Reviewer notes

- The `fallback_tiers` JSONB-vs-normalized-table decision is explicit in both the migration docstring and the ORM comment. Reviewer pushback welcome if you'd prefer a third table — the cost is one join per position read + a fourth migration target if we ever rename fields. The benefit is tighter schema constraints. Defaulting to JSONB matches the lower-friction shape for "small per-parent list always loaded with the parent" cases throughout the codebase (e.g., `message_citations` is normalized because it's mid-cardinality with its own access patterns; `fallback_tiers` is low-cardinality per parent and never queried independently).
- `contract_type` is free-form by design. A future M3.x PR could add a `contract_types` reference table if operators want validation, but PRD §3.7 explicitly says new types shouldn't require a migration.
- The "two distinct users" pattern in `test_playbook_execution_user_set_null_on_user_delete` exists because the document fixture's `files.owner_id` FK is NO ACTION; deleting the file owner cascades a constraint violation before the SET NULL on `playbook_executions.user_id` can fire. The test makes the separation explicit so it's not a foot-gun for the next person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)