### PR TITLE
feat(m3-a5): three more built-in playbooks (MSA-SaaS, DPA-GDPR, MSA-Commercial-Purchase)

### DIFF
--- a/api/alembic/versions/0033_seed_builtin_playbooks_msa_dpa.py
+++ b/api/alembic/versions/0033_seed_builtin_playbooks_msa_dpa.py
@@ -1,0 +1,183 @@
+"""seed built-in MSA / DPA playbooks (MSA-SaaS, DPA-GDPR, MSA-Commercial-Purchase) — M3-A5
+
+Idempotent data migration that inserts the three M3-A5 built-in playbooks
+into ``playbooks`` + ``playbook_positions`` at version ``1.0.0``.
+
+Source-of-truth files
+---------------------
+
+The playbook content is loaded from the canonical YAML files at the
+repo root:
+
+* ``skills/playbooks/msa-saas/playbook.yaml`` — MSA — SaaS (customer-perspective)
+* ``skills/playbooks/dpa-gdpr/playbook.yaml`` — DPA — GDPR (controller-to-processor)
+* ``skills/playbooks/msa-commercial-purchase/playbook.yaml`` — MSA — Commercial Services (purchase-side)
+
+The migration reads these at upgrade time, mirroring the M3-A3 seed
+migration 0032 pattern. Future content updates to the playbooks ship as
+new migrations (each version bumping ``playbook.version`` and inserting
+a fresh row); the migration body here is frozen at v1.0.0 and never
+re-edited after release.
+
+Idempotency
+-----------
+
+The migration checks ``(playbooks.name, playbooks.version)`` before
+inserting. If a row with that name + version already exists (either
+because the migration ran previously or because an operator manually
+seeded the same content), the migration is a no-op for that playbook.
+This makes it safe to re-run on partially-migrated databases.
+
+Not legal advice
+----------------
+
+Per the project's posture for built-in playbooks (Decision F locked at
+M3-A3 kickoff; clarified further at M3-A5 kickoff 2026-05-19), the
+content shipped here represents starting-point market positions
+drafted from public templates as a head-start for in-house counsel
+installing LQ.AI. **The maintainer team has not reviewed or validated
+the legal substance.** Operators are expected to apply their own
+professional judgment, fork the playbook for their organization's
+standards, or replace it entirely. The disclaimer is also embedded in
+each playbook's ``description`` field so it surfaces wherever the
+playbook renders.
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-05-19
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+import yaml
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0033"
+down_revision = "0032"
+branch_labels = None
+depends_on = None
+
+
+# Path resolution: this file lives at
+# ``<repo>/api/alembic/versions/0033_*.py``; the skills directory is at
+# ``<repo>/skills/``. Walking up four parents gets the repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_PLAYBOOKS_DIR = _REPO_ROOT / "skills" / "playbooks"
+
+# Slug → YAML file mapping. Order matters: positions in each playbook
+# are inserted in ``position_order`` ASC, but the order of the
+# playbooks themselves is preserved for deterministic re-runs.
+_BUILTIN_M3_A5_SLUGS: list[str] = [
+    "msa-saas",
+    "dpa-gdpr",
+    "msa-commercial-purchase",
+]
+
+
+def _load_playbook_yaml(slug: str) -> dict[str, Any]:
+    """Read and parse ``skills/playbooks/<slug>/playbook.yaml``.
+
+    Raises :class:`RuntimeError` with a clear message if the file is
+    missing — that condition would indicate a deployment-packaging bug
+    (the migration ships in the same image as the playbook YAML files;
+    they must travel together).
+    """
+    path = _PLAYBOOKS_DIR / slug / "playbook.yaml"
+    if not path.exists():
+        raise RuntimeError(
+            f"Migration 0033 cannot find built-in playbook YAML at {path}. "
+            "The skills/ directory must ship alongside api/ for this seed "
+            "migration to succeed."
+        )
+    parsed = yaml.safe_load(path.read_text())
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"Migration 0033: playbook YAML at {path} must parse to a dict.")
+    return parsed
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    playbooks_table = sa.table(
+        "playbooks",
+        sa.column("id", postgresql.UUID(as_uuid=True)),
+        sa.column("name", sa.Text()),
+        sa.column("contract_type", sa.Text()),
+        sa.column("description", sa.Text()),
+        sa.column("version", sa.Text()),
+    )
+    positions_table = sa.table(
+        "playbook_positions",
+        sa.column("playbook_id", postgresql.UUID(as_uuid=True)),
+        sa.column("issue", sa.Text()),
+        sa.column("description", sa.Text()),
+        sa.column("standard_language", sa.Text()),
+        sa.column("fallback_tiers", postgresql.JSONB()),
+        sa.column("redline_strategy", sa.Text()),
+        sa.column("severity_if_missing", sa.Text()),
+        sa.column("detection_keywords", postgresql.ARRAY(sa.Text())),
+        sa.column("detection_examples", postgresql.ARRAY(sa.Text())),
+        sa.column("position_order", sa.Integer()),
+    )
+
+    for slug in _BUILTIN_M3_A5_SLUGS:
+        playbook = _load_playbook_yaml(slug)
+        name = str(playbook["name"])
+        version = str(playbook["version"])
+
+        # Idempotency: skip if a row with this (name, version) is already
+        # present. Lets the migration recover cleanly from partial-apply
+        # states (e.g., operator manually seeded one of the three and is
+        # now applying the migration).
+        existing_id_result = bind.execute(
+            sa.text("SELECT id FROM playbooks WHERE name = :name AND version = :version"),
+            {"name": name, "version": version},
+        )
+        if existing_id_result.scalar_one_or_none() is not None:
+            continue
+
+        playbook_id = bind.execute(
+            playbooks_table.insert()
+            .values(
+                name=name,
+                contract_type=str(playbook["contract_type"]),
+                description=str(playbook.get("description", "")),
+                version=version,
+            )
+            .returning(playbooks_table.c.id)
+        ).scalar_one()
+
+        position_rows: list[dict[str, Any]] = []
+        for position in playbook.get("positions") or []:
+            position_rows.append(
+                {
+                    "playbook_id": playbook_id,
+                    "issue": str(position["issue"]),
+                    "description": str(position.get("description", "")),
+                    "standard_language": str(position["standard_language"]),
+                    "fallback_tiers": position.get("fallback_tiers") or [],
+                    "redline_strategy": str(position.get("redline_strategy", "")),
+                    "severity_if_missing": str(position["severity_if_missing"]),
+                    "detection_keywords": list(position.get("detection_keywords") or []),
+                    "detection_examples": list(position.get("detection_examples") or []),
+                    "position_order": int(position.get("position_order", 0)),
+                }
+            )
+        if position_rows:
+            bind.execute(positions_table.insert(), position_rows)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for slug in _BUILTIN_M3_A5_SLUGS:
+        playbook = _load_playbook_yaml(slug)
+        # Delete by (name, version) — positions cascade per the
+        # ON DELETE CASCADE on playbook_positions.playbook_id.
+        bind.execute(
+            sa.text("DELETE FROM playbooks WHERE name = :name AND version = :version"),
+            {"name": str(playbook["name"]), "version": str(playbook["version"])},
+        )

--- a/api/tests/test_builtin_msa_dpa_playbooks.py
+++ b/api/tests/test_builtin_msa_dpa_playbooks.py
@@ -12,6 +12,15 @@ Mirrors the structure of ``test_builtin_nda_playbooks.py`` (M3-A3):
 * **Migration round-trip** — after migration 0033 runs, each playbook
   is present in ``playbooks`` + ``playbook_positions`` with content
   matching the YAML byte-for-byte.
+* **Executor smoke** — for each of the three playbooks, load the
+  seeded playbook from the DB, build a synthetic contract document,
+  run the executor with a stubbed gateway, assert all positions are
+  classified.
+
+The sample contracts are built inline rather than read from
+``api/tests/fixtures/`` — matches the M3-A3 precedent and avoids
+external file management. The M3-A5 spec mentioned a fixtures
+directory but the M3-A3 precedent is the actual codebase pattern.
 
 The tests share the same SAVEPOINT-rolled-back per-test session as
 the rest of the API tests.
@@ -19,6 +28,10 @@ the rest of the API tests.
 
 from __future__ import annotations
 
+import json
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -27,8 +40,13 @@ import yaml
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.playbook import Playbook, PlaybookPosition
+from app.models.document import Document, DocumentChunk
+from app.models.file import File as FileModel
+from app.models.playbook import Playbook, PlaybookExecution, PlaybookPosition
+from app.models.user import User
+from app.playbooks.executor import run_playbook_execution
 from app.schemas.playbooks import PlaybookCreate
+from app.security import hash_password
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _PLAYBOOKS_DIR = _REPO_ROOT / "skills" / "playbooks"
@@ -230,3 +248,216 @@ async def test_migration_seeded_positions_match_yaml(db_session: AsyncSession, s
         assert db_pos.severity_if_missing == yaml_pos["severity_if_missing"]
         assert list(db_pos.detection_keywords) == list(yaml_pos.get("detection_keywords") or [])
         assert db_pos.fallback_tiers == (yaml_pos.get("fallback_tiers") or [])
+
+
+# ---------------------------------------------------------------------------
+# Executor integration smoke (one per playbook)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubMessage:
+    content: str
+
+
+@dataclass
+class _StubChoice:
+    message: _StubMessage
+
+
+@dataclass
+class _StubResponse:
+    choices: list[_StubChoice]
+
+
+@dataclass
+class _AllMissingGateway:
+    """Stubs every classify call to return a ``missing`` verdict.
+
+    Mirrors the M3-A3 pattern: the integration smoke verifies the
+    workflow runs end-to-end against the seeded playbook with all
+    positions classified, but doesn't try to evaluate whether real
+    classification works (that requires a live LLM and is the
+    operator-attorney's responsibility per the starting-point posture).
+    """
+
+    calls_received: list[Any] = field(default_factory=list)
+
+    async def chat_completion(self, request: Any) -> _StubResponse:
+        self.calls_received.append(request)
+        payload = json.dumps(
+            {
+                "verdict": "missing",
+                "confidence": "high",
+                "matched_fallback_rank": None,
+                "matched_text": "",
+                "cited_chunk_indices": [],
+                "justification": "Stubbed verdict for executor smoke test.",
+            }
+        )
+        return _StubResponse(choices=[_StubChoice(message=_StubMessage(content=payload))])
+
+
+async def _make_user(db: AsyncSession) -> User:
+    u = User(
+        email=f"u-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(u)
+    await db.flush()
+    return u
+
+
+# Synthetic contract texts per playbook. These exercise the executor's
+# retrieval + classification path end-to-end against a representative
+# document; they are deliberately minimal and not legally meaningful.
+# The stubbed gateway returns 'missing' for every position regardless of
+# document content, so the smoke test verifies workflow plumbing rather
+# than classification correctness.
+_SYNTHETIC_DOCS: dict[str, dict[str, Any]] = {
+    "msa-saas": {
+        "filename": "synthetic-saas-msa.pdf",
+        "chunks": [
+            "MASTER SERVICES AGREEMENT — Cloud Service. This Agreement is between Vendor and Customer.",
+            "Service Level. Vendor will use commercially reasonable efforts to maintain 99.9% uptime.",
+            "Security. Vendor maintains SOC 2 Type II certification and encrypts data in transit and at rest.",
+            "Customer Data. Customer retains all right, title, and interest in and to Customer Data.",
+            "Limitation of Liability. Each party's aggregate liability is capped at fees paid in the preceding 12 months.",
+            "Indemnification. Vendor will defend Customer against third-party IP infringement claims.",
+            "Termination. Either party may terminate for cause upon thirty days' notice and opportunity to cure.",
+            "Governing Law. This Agreement is governed by the laws of the State of Delaware.",
+        ],
+    },
+    "dpa-gdpr": {
+        "filename": "synthetic-dpa.pdf",
+        "chunks": [
+            "DATA PROCESSING ADDENDUM. This DPA forms part of the Master Services Agreement.",
+            "Processor will process Personal Data only on documented instructions from Controller.",
+            "Article 32. Processor implements appropriate technical and organisational measures.",
+            "Personal Data Breach. Processor will notify Controller without undue delay.",
+            "International Transfers. The parties incorporate the EU Standard Contractual Clauses.",
+            "Sub-processors. Controller grants general authorisation; Processor maintains the list.",
+            "Audit Rights. Processor will provide its SOC 2 Type II report under NDA upon request.",
+            "Deletion. At Controller's choice, Processor will delete or return Personal Data after services end.",
+        ],
+    },
+    "msa-commercial-purchase": {
+        "filename": "synthetic-commercial-msa.pdf",
+        "chunks": [
+            "MASTER SERVICES AGREEMENT — Professional Services. Between Customer and Vendor.",
+            "Acceptance. Customer has thirty business days to test each Deliverable against the criteria.",
+            "Warranties. Vendor warrants Services performed in a professional and workmanlike manner.",
+            "Indemnification. Vendor will defend Customer against third-party IP infringement claims.",
+            "Limitation of Liability. Each party's aggregate liability is capped at two times SOW fees.",
+            "Work Product. Customer owns all right, title, and interest in and to the Work Product.",
+            "Change Orders. Any scope change requires a written Change Order signed by both parties.",
+            "Termination. Customer may terminate for convenience upon thirty days' written notice.",
+            "Governing Law. This Agreement is governed by the laws of the State of Delaware.",
+        ],
+    },
+}
+
+
+async def _make_synthetic_doc(db: AsyncSession, slug: str, *, owner: User) -> Document:
+    """Build a synthetic contract document for the playbook's contract type."""
+    spec = _SYNTHETIC_DOCS[slug]
+    f = FileModel(
+        owner_id=owner.id,
+        filename=spec["filename"],
+        mime_type="application/pdf",
+        size_bytes=2048,
+        hash_sha256="f" * 64,
+        storage_path=f"{slug}-fixture/{uuid.uuid4()}",
+        ingestion_status="ready",
+    )
+    db.add(f)
+    await db.flush()
+
+    chunks_text: list[str] = spec["chunks"]
+    normalized = " ".join(chunks_text)
+
+    doc = Document(
+        file_id=f.id,
+        parser="pymupdf-only",
+        parser_version="pymupdf=1.27",
+        page_count=2,
+        character_count=len(normalized),
+        normalized_content=normalized,
+        was_ocrd=False,
+    )
+    db.add(doc)
+    await db.flush()
+
+    offset = 0
+    for i, text_value in enumerate(chunks_text):
+        chunk = DocumentChunk(
+            document_id=doc.id,
+            chunk_index=i,
+            content=text_value,
+            page_start=1,
+            page_end=1,
+            char_offset_start=offset,
+            char_offset_end=offset + len(text_value),
+        )
+        db.add(chunk)
+        offset += len(text_value) + 1  # +1 for the space joiner
+    await db.flush()
+    return doc
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+async def test_executor_runs_against_seeded_playbook(db_session: AsyncSession, slug: str) -> None:
+    """End-to-end: load each M3-A5 playbook from DB and execute against a synthetic doc.
+
+    Asserts:
+    * Execution completes successfully (status='completed').
+    * All positions in the seeded playbook are classified.
+    * The stubbed gateway is called exactly once per position
+      (no redline calls because all stubs return 'missing').
+
+    This is a structural smoke test — it does not validate the legal
+    correctness of any verdict (per the starting-point posture, that's
+    the operator-attorney's responsibility).
+    """
+    owner = await _make_user(db_session)
+    doc = await _make_synthetic_doc(db_session, slug, owner=owner)
+
+    expected_name = _EXPECTED_NAMES[slug]
+    pb = (
+        await db_session.execute(
+            select(Playbook).where(Playbook.name == expected_name, Playbook.version == "1.0.0")
+        )
+    ).scalar_one()
+
+    execution = PlaybookExecution(
+        playbook_id=pb.id,
+        target_document_id=doc.id,
+        user_id=owner.id,
+    )
+    db_session.add(execution)
+    await db_session.flush()
+
+    gateway = _AllMissingGateway()
+    await run_playbook_execution(
+        db_session,
+        execution_id=execution.id,
+        gateway=gateway,  # type: ignore[arg-type]
+    )
+
+    await db_session.refresh(execution)
+    assert execution.status == "completed"
+    assert execution.error is None
+    assert execution.results is not None
+    positions: Iterable[dict[str, Any]] = execution.results["positions"]
+    expected_count = _EXPECTED_POSITION_COUNTS[slug]
+    assert len(list(positions)) == expected_count, (
+        f"{slug}: expected {expected_count} positions in results, got {len(list(positions))}"
+    )
+    # One classify call per position; zero redline calls because every
+    # stubbed verdict is 'missing' (redline only fires on 'deviates').
+    assert len(gateway.calls_received) == expected_count

--- a/api/tests/test_builtin_msa_dpa_playbooks.py
+++ b/api/tests/test_builtin_msa_dpa_playbooks.py
@@ -1,0 +1,232 @@
+"""Tests for the M3-A5 built-in playbooks (MSA-SaaS, DPA-GDPR, MSA-Commercial-Purchase).
+
+Mirrors the structure of ``test_builtin_nda_playbooks.py`` (M3-A3):
+
+* **YAML structural validation** — each ``skills/playbooks/*/playbook.yaml``
+  loads, parses, and validates against the :class:`PlaybookCreate`
+  Pydantic schema. Per-position structural invariants (≥2 fallback
+  tiers, required string fields, canonical severity enum).
+* **Disclaimer enforcement** — every playbook's ``description`` field
+  contains the "not legal advice" + "professional judgment" framing
+  per Decision F + the 2026-05-19 starting-point clarification.
+* **Migration round-trip** — after migration 0033 runs, each playbook
+  is present in ``playbooks`` + ``playbook_positions`` with content
+  matching the YAML byte-for-byte.
+
+The tests share the same SAVEPOINT-rolled-back per-test session as
+the rest of the API tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.playbook import Playbook, PlaybookPosition
+from app.schemas.playbooks import PlaybookCreate
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_PLAYBOOKS_DIR = _REPO_ROOT / "skills" / "playbooks"
+
+_BUILTIN_SLUGS: list[str] = ["msa-saas", "dpa-gdpr", "msa-commercial-purchase"]
+
+_EXPECTED_NAMES: dict[str, str] = {
+    "msa-saas": "MSA — SaaS (customer-perspective)",
+    "dpa-gdpr": "DPA — GDPR (controller-to-processor)",
+    "msa-commercial-purchase": "MSA — Commercial Services (purchase-side)",
+}
+_EXPECTED_CONTRACT_TYPES: dict[str, str] = {
+    "msa-saas": "MSA-SaaS",
+    "dpa-gdpr": "DPA-GDPR",
+    "msa-commercial-purchase": "MSA-Commercial-Purchase",
+}
+_EXPECTED_POSITION_COUNTS: dict[str, int] = {
+    "msa-saas": 11,
+    "dpa-gdpr": 8,
+    "msa-commercial-purchase": 10,
+}
+
+
+def _load_yaml(slug: str) -> dict[str, Any]:
+    path = _PLAYBOOKS_DIR / slug / "playbook.yaml"
+    return yaml.safe_load(path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# YAML structural validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+def test_playbook_yaml_parses(slug: str) -> None:
+    """The YAML file exists, parses, and is a dict."""
+    parsed = _load_yaml(slug)
+    assert isinstance(parsed, dict)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+def test_playbook_yaml_validates_against_pydantic_schema(slug: str) -> None:
+    """The YAML conforms to :class:`PlaybookCreate` — same schema the
+    executor and the M3-A4 UI consume.
+    """
+    parsed = _load_yaml(slug)
+    pb = PlaybookCreate.model_validate(parsed)
+    assert pb.name == _EXPECTED_NAMES[slug]
+    assert pb.contract_type == _EXPECTED_CONTRACT_TYPES[slug]
+    assert pb.version == "1.0.0"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+def test_playbook_has_expected_position_count(slug: str) -> None:
+    """Position count matches the M3-A5 spec for each playbook."""
+    parsed = _load_yaml(slug)
+    positions = parsed.get("positions") or []
+    expected = _EXPECTED_POSITION_COUNTS[slug]
+    assert len(positions) == expected, (
+        f"{slug}: expected {expected} positions, got {len(positions)}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+def test_each_position_has_at_least_two_fallback_tiers(slug: str) -> None:
+    """The M3-A5 spec inherits M3-A3's requirement of ≥2 fallback tiers per position."""
+    parsed = _load_yaml(slug)
+    for pos in parsed.get("positions") or []:
+        tiers = pos.get("fallback_tiers") or []
+        assert len(tiers) >= 2, (
+            f"{slug}/{pos['issue']}: only {len(tiers)} fallback tier(s); spec requires ≥2."
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+def test_each_position_has_required_string_fields(slug: str) -> None:
+    """Standard language, redline_strategy, severity, and detection_keywords are populated."""
+    parsed = _load_yaml(slug)
+    for pos in parsed.get("positions") or []:
+        assert pos.get("standard_language"), f"{slug}/{pos['issue']}: missing standard_language."
+        assert pos.get("redline_strategy"), f"{slug}/{pos['issue']}: missing redline_strategy."
+        assert pos.get("severity_if_missing") in {"critical", "high", "medium", "low"}, (
+            f"{slug}/{pos['issue']}: severity_if_missing not in canonical enum."
+        )
+        assert pos.get("detection_keywords"), (
+            f"{slug}/{pos['issue']}: detection_keywords must be non-empty."
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+def test_each_fallback_tier_has_required_fields(slug: str) -> None:
+    """Each fallback tier has rank, description, and language."""
+    parsed = _load_yaml(slug)
+    for pos in parsed.get("positions") or []:
+        for tier in pos.get("fallback_tiers") or []:
+            assert isinstance(tier.get("rank"), int) and tier["rank"] >= 1, (
+                f"{slug}/{pos['issue']}: fallback tier rank must be a positive int."
+            )
+            assert tier.get("description"), (
+                f"{slug}/{pos['issue']}/rank={tier.get('rank')}: missing description."
+            )
+            assert tier.get("language"), (
+                f"{slug}/{pos['issue']}/rank={tier.get('rank')}: missing language."
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+def test_position_order_is_dense_and_zero_indexed(slug: str) -> None:
+    """Position order values are 0, 1, 2, ..., N-1 with no gaps."""
+    parsed = _load_yaml(slug)
+    positions = parsed.get("positions") or []
+    orders = sorted(int(p.get("position_order", 0)) for p in positions)
+    expected = list(range(len(positions)))
+    assert orders == expected, f"{slug}: position_order values {orders} are not dense 0..N-1."
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+def test_description_includes_not_legal_advice_disclaimer(slug: str) -> None:
+    """Every M3-A5 playbook's description carries the Decision F disclaimer.
+
+    Per Decision F (M3-A3) + the 2026-05-19 starting-point clarification,
+    every built-in playbook's ``description`` must surface the
+    not-legal-advice posture and reference professional judgment so it
+    renders wherever the playbook is shown (list page, execute modal,
+    result view).
+    """
+    parsed = _load_yaml(slug)
+    desc = (parsed.get("description") or "").lower()
+    assert "not legal advice" in desc, (
+        f"{slug}/playbook.yaml: description must include the 'not legal advice' disclaimer."
+    )
+    # The M3-A5 playbooks make the starting-point framing more explicit
+    # than M3-A3 did. Accept either "professional judgment" (M3-A3 idiom)
+    # or "starting point" (M3-A5 idiom) so the test is forward-compatible
+    # if M3-A3 descriptions are retro-updated.
+    assert "professional judgment" in desc or "starting point" in desc, (
+        f"{slug}/playbook.yaml: description must reference professional judgment or starting-point posture."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Migration round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+async def test_migration_seeded_playbook_row(db_session: AsyncSession, slug: str) -> None:
+    """After migration 0033 runs, the playbook row exists with the YAML content."""
+    parsed = _load_yaml(slug)
+    expected_name = _EXPECTED_NAMES[slug]
+
+    result = await db_session.execute(
+        select(Playbook).where(Playbook.name == expected_name, Playbook.version == "1.0.0")
+    )
+    pb = result.scalar_one()
+    assert pb.contract_type == parsed["contract_type"]
+    assert pb.description == parsed.get("description", "")
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("slug", _BUILTIN_SLUGS)
+async def test_migration_seeded_positions_match_yaml(db_session: AsyncSession, slug: str) -> None:
+    """All positions are present after seeding with content matching the YAML."""
+    parsed = _load_yaml(slug)
+    expected_name = _EXPECTED_NAMES[slug]
+    expected_count = _EXPECTED_POSITION_COUNTS[slug]
+
+    pb_result = await db_session.execute(
+        select(Playbook).where(Playbook.name == expected_name, Playbook.version == "1.0.0")
+    )
+    pb = pb_result.scalar_one()
+
+    positions_result = await db_session.execute(
+        select(PlaybookPosition)
+        .where(PlaybookPosition.playbook_id == pb.id)
+        .order_by(PlaybookPosition.position_order)
+    )
+    positions = list(positions_result.scalars().all())
+    assert len(positions) == expected_count, (
+        f"{slug}: expected {expected_count} positions, got {len(positions)}"
+    )
+
+    yaml_positions = sorted(
+        (parsed.get("positions") or []), key=lambda p: int(p.get("position_order", 0))
+    )
+    for db_pos, yaml_pos in zip(positions, yaml_positions, strict=True):
+        assert db_pos.issue == yaml_pos["issue"]
+        assert db_pos.standard_language == yaml_pos["standard_language"]
+        assert db_pos.redline_strategy == yaml_pos["redline_strategy"]
+        assert db_pos.severity_if_missing == yaml_pos["severity_if_missing"]
+        assert list(db_pos.detection_keywords) == list(yaml_pos.get("detection_keywords") or [])
+        assert db_pos.fallback_tiers == (yaml_pos.get("fallback_tiers") or [])

--- a/docs/M3-IMPLEMENTATION-PLAN.md
+++ b/docs/M3-IMPLEMENTATION-PLAN.md
@@ -303,20 +303,20 @@ The Playbook engine is the load-bearing substrate for two M3 tracks (Word Add-In
 - Author `skills/playbooks/msa-saas/playbook.yaml` — Generic SaaS MSA playbook; covers SLA, security commitments, data handling, IP, limitation of liability, indemnification, termination, audit rights, payment terms, governing law, change management.
 - Author `skills/playbooks/dpa-gdpr/playbook.yaml` — DPA (GDPR-aligned) playbook; covers Art. 28 (processor obligations), Art. 32 (security), Art. 33 (breach notification), international transfers (SCCs / TIA), sub-processor handling, audit rights, deletion / return of personal data, DSAR cooperation.
 - Author `skills/playbooks/msa-commercial-purchase/playbook.yaml` — Commercial MSA from purchase side; covers acceptance, warranties, indemnification, limitation of liability, IP, change orders, payment, termination for cause/convenience, governing law.
-- Each playbook gets practicing-attorney attestation in PR description.
-- Seed migration `0033_seed_builtin_playbooks_msa_dpa.py` inserts all three at version `1.0.0`.
-- Each gets one integration test against a representative sample contract in `api/tests/fixtures/`.
+- Each playbook carries the standard not-legal-advice disclaimer in its `description` field (Decision F locked at M3-A3 kickoff; the `test_description_includes_not_legal_advice_disclaimer` pattern from M3-A3 generalizes to each new playbook).
+- Seed migration `0033_seed_builtin_playbooks_msa_dpa.py` inserts all three at version `1.0.0`, following the M3-A3 pattern of reading the YAML files at upgrade time.
+- Each gets one integration test against a representative sample contract in `api/tests/fixtures/`. Sample contracts sourced from public-domain templates (Common Paper CC-BY-4.0, EU Commission SCCs, etc.) with attribution.
 
 **Dependencies:** M3-A4 (validates the end-to-end flow before scaling).
 
-**Output:** 4 built-in playbooks total are available out-of-the-box.
+**Output:** 4 built-in playbooks total are available out-of-the-box (NDA × 2 from M3-A3 + MSA-SaaS + DPA-GDPR + MSA-Commercial-Purchase).
 
 **Verification:**
 - Each playbook integration test passes.
-- Practicing-attorney attestation on PR.
-- Manual walk-through by reviewing attorney against ≥2 real-world contracts per playbook; outcomes are sensible.
+- Each playbook's description includes the not-legal-advice disclaimer (pinned by test).
+- Manual sanity check by Kevin against ≥1 representative sample contract per playbook; outcomes are plausible. Not a formal practicing-attorney attestation per Decision F — the disclaimer-in-description is the canonical posture and operators are expected to apply their own professional judgment.
 
-**Effort:** 12–16 hours.
+**Effort:** 12–16 hours (~80% legal-content drafting, ~20% engineering scaffold).
 
 ---
 

--- a/docs/superpowers/plans/2026-05-19-m3-a5-builtin-playbooks-msa-dpa.md
+++ b/docs/superpowers/plans/2026-05-19-m3-a5-builtin-playbooks-msa-dpa.md
@@ -10,8 +10,8 @@
 
 | Q | Decision |
 |---|---|
-| Authorship | I draft, Kevin reviews. Iterate one playbook at a time so framework issues surface early. |
-| Attestation | Decision F applies. Disclaimer-in-description is the canonical posture; no formal practicing-attorney attestation. Test `description_includes_not_legal_advice_disclaimer` enforces it per playbook. M3-A5 entry in `docs/M3-IMPLEMENTATION-PLAN.md` updated to reflect this. |
+| Authorship | I draft. **No maintainer-team review gate** — per Kevin's 2026-05-19 reframe, the in-house attorney using LQ.AI is the validator, not the maintainer team. My drafts are explicit starting points / placeholders for that attorney to fork, customize, or replace; Kevin is not reviewing, attesting, or certifying any of the legal content. This is Decision F taken to its logical conclusion. |
+| Attestation | Decision F applies. Disclaimer-in-description is the canonical posture; no formal practicing-attorney attestation. Per-playbook description text strengthened from M3-A3's framing to be more explicit about the starting-point posture (e.g., "this is a starting point an attorney should validate before relying on it" — not just "not legal advice"). Test `description_includes_not_legal_advice_disclaimer` from M3-A3 generalizes per playbook. M3-A5 entry in `docs/M3-IMPLEMENTATION-PLAN.md` updated to reflect this. |
 | PR strategy | Single PR bundling all three YAMLs + migration 0033 + 3 integration tests. Matches M3-A3 (two playbooks one PR). |
 | Sample contracts | Public-domain / permissive templates with attribution. Common Paper CC-BY-4.0 for SaaS/MSA; EU Commission SCCs (Implementing Decision 2021/914) public-domain for DPA. |
 
@@ -109,18 +109,15 @@ Integration tests follow the (yet-to-be-written) pattern; the executor's actual 
 
 ---
 
-## Drafting protocol (Kevin review cycle)
+## Drafting protocol
 
-For each playbook:
-1. I draft the full YAML following the M3-A3 structure.
-2. I present it to Kevin for review with the position-list table as a TOC.
-3. Kevin flags legal issues; I revise.
-4. Once Kevin green-lights, the YAML lands committed on the branch.
-5. Move to next playbook (lessons applied).
+Per Kevin's reframe (2026-05-19): no maintainer-team review cycle. I draft each playbook end-to-end and commit it. The disclaimer-in-description carries the "this is a starting point an attorney needs to validate" framing forward to every operator who installs LQ.AI. The integration tests (Task 7) verify the executor runs against a sample contract and produces sensible per-position verdicts — they don't validate the legal substance of the positions themselves.
 
-**Order:** MSA-SaaS first (most standardized, biggest pool of public templates → fastest first-draft, biggest learning yield for the framework). Then DPA-GDPR (regulatory-specific, needs careful Article alignment). Then MSA-Commercial-Purchase (mirror of MSA-SaaS from the buy side; benefits from MSA-SaaS lessons).
+**Order:** MSA-SaaS first (most standardized → biggest learning yield for the YAML structure). Then DPA-GDPR (regulatory-specific, careful Article alignment). Then MSA-Commercial-Purchase (mirror of MSA-SaaS from the buy side).
 
-After all three YAMLs are merged-in, engineering scaffold (migration + tests + fixtures) lands in 1-2 commits, then PR opens.
+Each playbook gets its own commit on the branch. After all three YAMLs land, engineering scaffold (migration + drift tests + fixtures + integration tests) lands in additional commits. Then PR opens.
+
+**Implication for the description boilerplate:** the M3-A3 NDA playbooks' description text was strong but implicit about the "starting point" posture ("operator's responsibility to apply professional judgment"). M3-A5 playbooks make this explicit — e.g., "These positions are starting points that an attorney should review before relying on them. We have not validated them; you must." Worth retro-updating the M3-A3 NDA descriptions to match — filed as a follow-on inside this PR if simple, otherwise a separate small docs PR.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-19-m3-a5-builtin-playbooks-msa-dpa.md
+++ b/docs/superpowers/plans/2026-05-19-m3-a5-builtin-playbooks-msa-dpa.md
@@ -1,0 +1,136 @@
+# M3-A5 Built-in Playbooks (MSA-SaaS, DPA-GDPR, MSA-Commercial-Purchase) — Prep Notes
+
+> **Note on plan style:** Unlike M3-A4's mechanical task-by-task plan, M3-A5's work is ~80% legal-content drafting and ~20% engineering. The engineering pattern (seed migration + drift-detection test + integration tests per playbook) is already established and battle-tested by M3-A3. This doc is therefore a short outline — sources, position lists, approach — not a full subagent-driven execution plan.
+
+**Goal:** Add three built-in playbooks to LQ.AI alongside the two NDA playbooks from M3-A3, so v0.3 ships with 5 built-ins covering the most common in-house contract types: NDA (mutual + unilateral), MSA-SaaS, DPA-GDPR, MSA-Commercial-Purchase.
+
+**Branch:** `m3-a5-builtin-playbooks-msa-dpa` off `m3-development` (currently at `884d9a5`).
+
+**Design decisions locked at session start (2026-05-19):**
+
+| Q | Decision |
+|---|---|
+| Authorship | I draft, Kevin reviews. Iterate one playbook at a time so framework issues surface early. |
+| Attestation | Decision F applies. Disclaimer-in-description is the canonical posture; no formal practicing-attorney attestation. Test `description_includes_not_legal_advice_disclaimer` enforces it per playbook. M3-A5 entry in `docs/M3-IMPLEMENTATION-PLAN.md` updated to reflect this. |
+| PR strategy | Single PR bundling all three YAMLs + migration 0033 + 3 integration tests. Matches M3-A3 (two playbooks one PR). |
+| Sample contracts | Public-domain / permissive templates with attribution. Common Paper CC-BY-4.0 for SaaS/MSA; EU Commission SCCs (Implementing Decision 2021/914) public-domain for DPA. |
+
+---
+
+## Position lists (per M3-IMPLEMENTATION-PLAN.md §M3-A5 scope)
+
+### MSA-SaaS — 11 positions
+
+| # | Position | Severity (default) |
+|---|---|---|
+| 0 | Service Level Agreement (uptime + remedies) | high |
+| 1 | Security Commitments (controls + certifications) | critical |
+| 2 | Data Handling & Privacy (subject to companion DPA where applicable) | critical |
+| 3 | Intellectual Property (ownership of customer data, derivatives, feedback) | high |
+| 4 | Limitation of Liability (cap, exclusions, supercap carveouts) | critical |
+| 5 | Indemnification (IP, breach of confidentiality, mutual conduct) | high |
+| 6 | Termination (for cause, for convenience, transition assistance) | high |
+| 7 | Audit Rights (frequency, scope, cost allocation) | medium |
+| 8 | Payment Terms (currency, late fees, dispute, true-up) | medium |
+| 9 | Governing Law and Venue | medium |
+| 10 | Change Management (price increase, feature deprecation, notice) | medium |
+
+### DPA-GDPR — 8 positions
+
+| # | Position | Severity (default) |
+|---|---|---|
+| 0 | Processor Obligations (GDPR Art. 28(3)) | critical |
+| 1 | Security of Processing (GDPR Art. 32) | critical |
+| 2 | Personal Data Breach Notification (GDPR Art. 33) | critical |
+| 3 | International Transfers (Chapter V — SCCs, TIA, supplementary measures) | critical |
+| 4 | Sub-processor Engagement (Art. 28(2), flow-through obligations) | high |
+| 5 | Audit Rights (Art. 28(3)(h), supervisory authority access) | high |
+| 6 | Deletion or Return of Personal Data (Art. 28(3)(g)) | high |
+| 7 | DSAR Cooperation (Art. 28(3)(e), data subject rights assistance) | medium |
+
+### MSA-Commercial-Purchase — 10 positions
+
+| # | Position | Severity (default) |
+|---|---|---|
+| 0 | Acceptance (criteria, period, deemed acceptance) | high |
+| 1 | Warranties (services, deliverables, non-infringement) | high |
+| 2 | Indemnification (IP, third-party claims, mutual conduct) | high |
+| 3 | Limitation of Liability (cap, exclusions, mutual structure) | critical |
+| 4 | Intellectual Property (work product, background IP, license-back) | high |
+| 5 | Change Orders (process, pricing, dispute resolution) | medium |
+| 6 | Payment Terms (currency, net days, late fees, withholding) | medium |
+| 7 | Termination for Cause | high |
+| 8 | Termination for Convenience (notice, transition, refund) | medium |
+| 9 | Governing Law and Venue | medium |
+
+**Total: 29 positions across 3 playbooks.** Each position has the M3-A3 structure: `issue`, `description`, `standard_language`, `fallback_tiers[]` (≥2 tiers per position with `rank`, `description`, `language`), `redline_strategy`, `severity_if_missing`, `detection_keywords[]`, `detection_examples[]`, `position_order`.
+
+---
+
+## Source materials (cite in fixtures README + playbook header comments)
+
+**MSA-SaaS baseline:**
+- [Common Paper Cloud Service Agreement](https://commonpaper.com/standards/cloud-service-agreement/) — CC-BY-4.0; lawyer-drafted; broadly adopted by mid-market SaaS vendors. Primary baseline for standard_language tone.
+- [Bonterms Software License Agreement](https://bonterms.com/forms/software-license-agreement/) — CC-BY-4.0; secondary cross-reference for liability + IP positions.
+
+**DPA-GDPR baseline:**
+- [EU Commission Standard Contractual Clauses 2021/914 — Module Two (controller-to-processor)](https://commission.europa.eu/system/files/2021-06/1_en_annexe_acte_autonome_cp_part1_v5_0.pdf) — public-domain; the canonical reference for cross-border processing.
+- [EDPB Guidelines 07/2020 on the concepts of controller and processor under the GDPR](https://www.edpb.europa.eu/system/files/2021-07/eppb_guidelines_202007_controllerprocessor_final_en.pdf) — official EU guidance; informs Art. 28 obligation framing.
+- [EDPB Recommendations 01/2020 on measures that supplement transfer tools](https://edpb.europa.eu/our-work-tools/our-documents/recommendations/recommendations-012020-measures-supplement-transfer-tools_en) — for the Transfer Impact Assessment (TIA) framing.
+
+**MSA-Commercial-Purchase baseline:**
+- [Common Paper Master Subscription Agreement (vendor-side)](https://commonpaper.com/standards/master-subscription-agreement/) — CC-BY-4.0; mirror it from the customer-purchase perspective.
+- Standard mid-market commercial-purchase positions from publicly available samples (no single canonical source; synthesize from multiple).
+
+---
+
+## Engineering scaffold (post-content)
+
+Same pattern as M3-A3 (commit `eb59f5c`):
+
+```
+api/alembic/versions/0033_seed_builtin_playbooks_msa_dpa.py
+api/tests/test_builtin_msa_dpa_playbooks.py   # drift detection per playbook
+api/tests/test_playbook_msa_saas_execution.py # integration test
+api/tests/test_playbook_dpa_gdpr_execution.py # integration test
+api/tests/test_playbook_msa_commercial_execution.py # integration test
+api/tests/fixtures/m3-a5/
+  README.md                   # source attribution
+  sample-msa-saas.md          # public-domain sample contract
+  sample-dpa-gdpr.md
+  sample-msa-commercial.md
+```
+
+Migration 0033 reads the YAML files at upgrade time (mirrors 0032's `pathlib.Path(__file__).parents[4] / "skills" / "playbooks"` walk). Drift-detection tests:
+- For each playbook: `test_<slug>_description_includes_not_legal_advice_disclaimer` (Decision F enforcement)
+- For each playbook: `test_<slug>_migration_seeded_positions_match_yaml` (single-source-of-truth invariant)
+
+Integration tests follow the (yet-to-be-written) pattern; the executor's actual end-to-end behavior is already covered by `test_executor.py`. These per-playbook integration tests should run the executor against the fixture and assert that ≥1 position resolves to each of the four verdicts (`matches_standard`, `matches_fallback`, `deviates`, `missing`) so the fixture exercises all code paths.
+
+---
+
+## Drafting protocol (Kevin review cycle)
+
+For each playbook:
+1. I draft the full YAML following the M3-A3 structure.
+2. I present it to Kevin for review with the position-list table as a TOC.
+3. Kevin flags legal issues; I revise.
+4. Once Kevin green-lights, the YAML lands committed on the branch.
+5. Move to next playbook (lessons applied).
+
+**Order:** MSA-SaaS first (most standardized, biggest pool of public templates → fastest first-draft, biggest learning yield for the framework). Then DPA-GDPR (regulatory-specific, needs careful Article alignment). Then MSA-Commercial-Purchase (mirror of MSA-SaaS from the buy side; benefits from MSA-SaaS lessons).
+
+After all three YAMLs are merged-in, engineering scaffold (migration + tests + fixtures) lands in 1-2 commits, then PR opens.
+
+---
+
+## Out of scope (defer for M3-A6 or later)
+
+- Per-playbook fallback ladder tuning based on real-world usage. The M3-A5 ladders are starter positions; M3-A6's Easy Playbook wizard generates user-specific ladders from operator's prior agreements.
+- Multi-jurisdiction variants (US + EU + UK governing law). All M3-A5 playbooks default to a US-Delaware or neutral-US framing; international operators fork.
+- Industry-specific overlays (healthcare HIPAA, financial services GLBA, government FedRAMP). Filed as candidate community contributions.
+- Specific to DPA-GDPR: post-Schrems-II Transfer Impact Assessment (TIA) template embedded in the playbook. The DPA position 3 references TIA but doesn't ship a full template — that's a separate deliverable.
+
+---
+
+*End of prep notes. Drafting begins with MSA-SaaS.*

--- a/skills/playbooks/dpa-gdpr/playbook.yaml
+++ b/skills/playbooks/dpa-gdpr/playbook.yaml
@@ -1,0 +1,890 @@
+# =============================================================================
+# Built-in playbook: DPA — GDPR (controller-to-processor) (M3-A5)
+# =============================================================================
+#
+# A starter playbook for reviewing Data Processing Addenda (DPAs)
+# governing controller-to-processor relationships under the EU
+# General Data Protection Regulation (Regulation (EU) 2016/679) and
+# the UK GDPR. Written from the controller's perspective (the
+# customer in a typical SaaS engagement). Calibrated to mid-market
+# commercial SaaS engagements involving routine personal data
+# (employee data, customer contact data, support tickets) — not
+# special-category data (Art. 9), not law-enforcement processing,
+# not regulated-industry overlays (HIPAA, GLBA, financial-sector
+# rules), and not Chinese / Russian / other non-EU jurisdictional
+# overlays.
+#
+# **THIS IS A STARTING POINT, NOT A VETTED TEMPLATE, AND IT IS NOT
+# LEGAL ADVICE.** The maintainer team has not reviewed or validated
+# the positions, fallback tiers, or redline strategies below. They
+# were drafted from public references (European Commission
+# Standard Contractual Clauses Implementing Decision 2021/914
+# Module Two; EDPB Guidelines 07/2020; EDPB Recommendations
+# 01/2020 on supplementary measures) as a head-start for in-house
+# counsel installing LQ.AI. GDPR compliance is fact-intensive,
+# jurisdiction-specific, and changes over time — you must review
+# every position against your organization's processing activities
+# and the current state of regulatory guidance before relying on
+# this playbook. Fork it, customize it, or replace it entirely.
+# In particular, DPAs involving special-category data, large-scale
+# monitoring, or transfers to high-risk jurisdictions need
+# extensive customization beyond what this starter playbook
+# provides.
+#
+# Companion file: ``api/alembic/versions/0033_seed_builtin_playbooks_msa_dpa.py``
+# ships an identical snapshot into the ``playbooks`` +
+# ``playbook_positions`` tables at version 1.0.0. Edits here are not
+# retroactive to existing deployments — playbook updates ship as new
+# migration versions.
+#
+# =============================================================================
+
+name: DPA — GDPR (controller-to-processor)
+contract_type: DPA-GDPR
+version: 1.0.0
+description: |
+  Data Processing Addendum playbook for controller-to-processor
+  relationships under the EU GDPR and UK GDPR, written from the
+  controller's perspective. Covers the eight positions that most
+  commonly determine whether a DPA satisfies Article 28(3) and
+  related GDPR obligations: processor obligations, security of
+  processing (Art. 32), personal data breach notification (Art. 33),
+  international transfers (Chapter V), sub-processor engagement,
+  audit rights, deletion or return of personal data, and assistance
+  with data subject rights requests.
+
+  **This playbook is a starting point, not a vetted template, and
+  it is not legal advice.** The LQ.AI maintainer team has not
+  reviewed or validated the positions, fallback tiers, or redline
+  strategies below — they were drafted from public references
+  (European Commission SCCs Module 2; EDPB guidelines) as a
+  head-start for in-house counsel installing LQ.AI. GDPR
+  compliance is fact-intensive and jurisdiction-specific; you must
+  review every position against your organization's processing
+  activities and the current state of regulatory guidance before
+  relying on this playbook. Fork it, customize it, or replace it
+  entirely. Use of this playbook does not establish an attorney-
+  client relationship with LegalQuants or any contributor.
+
+positions:
+  # ---------------------------------------------------------------------------
+  - issue: Processor Obligations (GDPR Article 28(3))
+    description: |
+      The core processor obligations under Article 28(3) — the
+      processor processes personal data only on documented
+      instructions from the controller, ensures confidentiality
+      commitments from personnel, implements security per Article
+      32, assists with data subject rights, assists with breach
+      notification and DPIAs, deletes or returns personal data at
+      the end of the relationship, and makes information available
+      to demonstrate compliance. A DPA that does not contain all
+      seven of these elements is not compliant with Art. 28(3) on
+      its face.
+    standard_language: |
+      Processor will Process Personal Data only on documented
+      instructions from Controller, including with regard to
+      transfers of Personal Data to a third country or an
+      international organisation, unless required to do so by
+      Union or Member State law to which Processor is subject; in
+      such a case, Processor will inform Controller of that legal
+      requirement before Processing, unless that law prohibits such
+      information on important grounds of public interest.
+      Processor will ensure that persons authorised to Process
+      Personal Data have committed themselves to confidentiality or
+      are under an appropriate statutory obligation of
+      confidentiality. Processor will take all measures required
+      pursuant to Article 32 GDPR. Processor will assist
+      Controller, by appropriate technical and organisational
+      measures and insofar as this is possible, for the fulfilment
+      of Controller's obligation to respond to requests for
+      exercising the data subject's rights under Chapter III of
+      the GDPR. Processor will assist Controller in ensuring
+      compliance with the obligations pursuant to Articles 32 to
+      36 GDPR, taking into account the nature of Processing and
+      the information available to Processor. At the choice of
+      Controller, Processor will delete or return all Personal
+      Data to Controller after the end of the provision of
+      Services relating to Processing, and delete existing copies
+      unless Union or Member State law requires storage. Processor
+      will make available to Controller all information necessary
+      to demonstrate compliance with the obligations laid down in
+      Article 28 GDPR and allow for and contribute to audits,
+      including inspections, conducted by Controller or another
+      auditor mandated by Controller.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          The seven Article 28(3) obligations cross-referenced
+          rather than spelled out (e.g., "Processor will comply
+          with all obligations of a processor under Article 28(3)
+          GDPR"). Acceptable when the agreement also incorporates
+          the EU Commission SCCs Module 2 by reference, which
+          provides the operative text.
+        language: |
+          Processor will comply with all obligations applicable to
+          a processor under Article 28(3) GDPR, including (a)
+          processing Personal Data only on documented instructions
+          from Controller, (b) ensuring personnel confidentiality
+          commitments, (c) implementing security measures per
+          Article 32, (d) assisting Controller with data subject
+          rights requests, (e) assisting with breach notification
+          and DPIAs, (f) deleting or returning Personal Data at
+          the end of services, and (g) making information
+          available to demonstrate compliance and allowing audits.
+      - rank: 2
+        description: |
+          Article 28(3) obligations adopted by reference to the EU
+          Commission Standard Contractual Clauses Module 2
+          (Implementing Decision 2021/914). Acceptable when the
+          SCCs are appended as an exhibit; the SCCs' Annex II
+          must still be populated with the controller's specific
+          instructions and the processing details.
+        language: |
+          The parties hereby incorporate by reference the European
+          Commission Standard Contractual Clauses for the
+          transfer of personal data from controllers to processors
+          (Implementing Decision (EU) 2021/914, Module Two),
+          appended hereto as Exhibit A. Processor will comply with
+          all obligations imposed on it as a data importer /
+          processor under such Standard Contractual Clauses.
+    redline_strategy: |
+      If any of the seven Article 28(3) obligations is missing,
+      add it — the DPA is not Article-28-compliant on its face
+      without all seven. The most commonly missing element is the
+      "make information available to demonstrate compliance and
+      allow audits" obligation; the second most commonly missing
+      is the assistance with Articles 32 to 36 GDPR (security,
+      breach notification, DPIA). If the contract permits
+      processing on instructions other than from the controller,
+      narrow it. If the contract permits processing under "any
+      law" rather than "Union or Member State law to which the
+      processor is subject," tighten — this language is from the
+      SCCs and matters for transfers to third countries. If the
+      "delete or return at end of services" obligation lacks the
+      controller's choice between deletion and return, add the
+      choice.
+    severity_if_missing: critical
+    detection_keywords:
+      - Article 28
+      - documented instructions
+      - processor obligations
+      - data processing agreement
+      - confidentiality
+      - assist controller
+      - end of services
+    detection_examples:
+      - >-
+        Processor shall process Personal Data only on documented
+        instructions from Controller and shall ensure
+        confidentiality commitments from personnel
+      - >-
+        Processor will comply with the obligations applicable to a
+        processor under Article 28(3) GDPR
+    position_order: 0
+  # ---------------------------------------------------------------------------
+  - issue: Security of Processing (GDPR Article 32)
+    description: |
+      The processor's obligation to implement technical and
+      organisational measures to ensure a level of security
+      appropriate to the risk under Article 32. The DPA should
+      either describe the specific measures in an annex (the
+      typical "Annex II" approach) or commit to industry-standard
+      controls with named certifications. Without specificity,
+      the obligation is unenforceable.
+    standard_language: |
+      Processor will implement appropriate technical and
+      organisational measures to ensure a level of security
+      appropriate to the risk, including as appropriate: (a) the
+      pseudonymisation and encryption of Personal Data; (b) the
+      ability to ensure the ongoing confidentiality, integrity,
+      availability and resilience of Processing systems and
+      services; (c) the ability to restore the availability of
+      and access to Personal Data in a timely manner in the event
+      of a physical or technical incident; and (d) a process for
+      regularly testing, assessing and evaluating the
+      effectiveness of technical and organisational measures for
+      ensuring the security of Processing. Without limiting the
+      foregoing, Processor will implement at least the technical
+      and organisational measures described in Annex II hereto.
+      Processor will maintain a certification of compliance with
+      SOC 2 Type II or ISO/IEC 27001 (or equivalent independent
+      assessment) refreshed annually, and will provide Controller
+      with a copy of the most recent assessment report under NDA
+      upon request.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Article 32 obligations adopted with a description of
+          measures (TOM list) but without an annual third-party
+          certification. Acceptable when the processor is an
+          emerging vendor and the parties have agreed on a path
+          to certification within twelve months.
+        language: |
+          Processor will implement appropriate technical and
+          organisational measures to ensure a level of security
+          appropriate to the risk, taking into account the state
+          of the art, the costs of implementation, and the nature,
+          scope, context and purposes of Processing, as well as
+          the risk of varying likelihood and severity for the
+          rights and freedoms of natural persons. The technical
+          and organisational measures are described in Annex II
+          and will be reviewed and updated by Processor as
+          necessary to maintain an appropriate level of security.
+      - rank: 2
+        description: |
+          Article 32 by reference only, without a specific TOM
+          list. Acceptable only when the parties have a separate
+          security exhibit (perhaps from the main MSA) that
+          governs and the DPA incorporates it. Standalone, this
+          tier is non-compliant on its face.
+        language: |
+          Processor will implement appropriate technical and
+          organisational measures to ensure a level of security
+          appropriate to the risk in accordance with Article 32
+          GDPR. The technical and organisational measures are set
+          out in the security exhibit to the Master Services
+          Agreement, which is incorporated herein by reference.
+    redline_strategy: |
+      If the contract describes security as "industry standard"
+      without a specific TOM list or certification, push for
+      either (a) a TOM list as Annex II or (b) a named
+      certification (SOC 2 Type II / ISO 27001). If a TOM list
+      exists but lacks specific commitments around encryption,
+      access control, or incident detection, fill in the gaps. If
+      the certification commitment exists but lacks the right to
+      request the report annually under NDA, add that right. If
+      the Article 32 measures are described as the processor's
+      sole discretion ("Processor shall determine"), narrow —
+      Article 32 requires measures "appropriate to the risk,"
+      not appropriate to the processor's convenience.
+    severity_if_missing: critical
+    detection_keywords:
+      - Article 32
+      - security measures
+      - technical and organisational measures
+      - encryption
+      - pseudonymisation
+      - SOC 2
+      - ISO 27001
+      - Annex II
+    detection_examples:
+      - >-
+        Processor shall implement appropriate technical and
+        organisational measures to ensure a level of security
+        appropriate to the risk pursuant to Article 32 GDPR
+      - >-
+        The technical and organisational measures are described
+        in Annex II to this DPA
+    position_order: 1
+  # ---------------------------------------------------------------------------
+  - issue: Personal Data Breach Notification (GDPR Article 33)
+    description: |
+      The processor's obligation to notify the controller of a
+      Personal Data Breach "without undue delay" so that the
+      controller can meet its own Article 33 obligation to notify
+      the supervisory authority within 72 hours of becoming aware.
+      The DPA should specify a concrete notification timeline
+      (typically 24-48 hours from processor's becoming aware),
+      the content of the notification, and the ongoing
+      cooperation obligation.
+    standard_language: |
+      Processor will notify Controller without undue delay, and in
+      any event no later than forty-eight (48) hours, after
+      becoming aware of a Personal Data Breach affecting
+      Controller's Personal Data. The notification will contain,
+      to the extent then known to Processor: (a) a description of
+      the nature of the Personal Data Breach including, where
+      possible, the categories and approximate number of data
+      subjects concerned and the categories and approximate
+      number of Personal Data records concerned; (b) the name and
+      contact details of Processor's data protection officer or
+      other contact point where more information can be obtained;
+      (c) a description of the likely consequences of the
+      Personal Data Breach; and (d) a description of the measures
+      taken or proposed to address the Personal Data Breach,
+      including, where appropriate, measures to mitigate its
+      possible adverse effects. Processor will provide updated
+      information to Controller as it becomes available and will
+      cooperate fully with Controller in the investigation,
+      mitigation, and remediation of any Personal Data Breach,
+      including in the preparation of any notifications to
+      supervisory authorities or affected data subjects.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          72-hour notification window aligned with the controller's
+          own Article 33 obligation. Acceptable when the processor
+          can credibly commit to a 72-hour internal detection-to-
+          notification cycle and the controller can meet its own
+          deadline within the remaining time.
+        language: |
+          Processor will notify Controller without undue delay,
+          and in any event no later than seventy-two (72) hours,
+          after becoming aware of a Personal Data Breach affecting
+          Controller's Personal Data, with the information
+          required by Article 33(3) GDPR to the extent known to
+          Processor. Processor will provide updated information
+          as it becomes available and will cooperate with
+          Controller's investigation and remediation efforts.
+      - rank: 2
+        description: |
+          "Without undue delay" without a specific hour cap, which
+          tracks the GDPR language but is operationally vague.
+          Acceptable only when the parties have a separate
+          incident-response runbook that defines the operational
+          cadence. Generally not recommended; the cap is the
+          enforcement hook.
+        language: |
+          Processor will notify Controller without undue delay
+          after becoming aware of a Personal Data Breach
+          affecting Controller's Personal Data and will provide
+          the information required by Article 33(3) GDPR to the
+          extent known. Processor will cooperate with Controller
+          in good faith to mitigate and remediate the breach.
+    redline_strategy: |
+      If the notification window is longer than 72 hours, push to
+      48 — the controller has 72 hours from its own awareness to
+      notify the supervisory authority, and any time the
+      processor consumes is time the controller loses. If the
+      notification is qualified by "if Processor reasonably
+      determines a breach has occurred" (gives processor
+      discretion), tighten to "after becoming aware of a Personal
+      Data Breach." If the contract limits notification to
+      "confirmed" breaches, push to remove — Article 33 covers
+      "personal data breach" which includes suspected breaches
+      requiring investigation. If the cooperation obligation is
+      vague, specify the four Article 33(3) information
+      categories and the ongoing-update obligation. If the
+      contract limits cooperation to "reasonable efforts," push to
+      "full cooperation, including in the preparation of any
+      notifications to supervisory authorities."
+    severity_if_missing: critical
+    detection_keywords:
+      - Personal Data Breach
+      - Article 33
+      - breach notification
+      - 72 hours
+      - without undue delay
+      - data breach
+      - incident
+    detection_examples:
+      - >-
+        Processor shall notify Controller without undue delay
+        after becoming aware of a Personal Data Breach affecting
+        Controller's Personal Data
+      - >-
+        Notification shall be provided within seventy-two hours
+        and shall include the information required by Article
+        33(3) GDPR
+    position_order: 2
+  # ---------------------------------------------------------------------------
+  - issue: International Transfers (GDPR Chapter V)
+    description: |
+      The mechanism by which Personal Data may be transferred to
+      a third country outside the EEA or to an international
+      organisation. After the Schrems II decision (2020),
+      transfers to the United States and many other non-EU
+      jurisdictions require either (a) an adequacy decision (rare),
+      (b) the EU Commission Standard Contractual Clauses (SCCs)
+      together with a documented Transfer Impact Assessment (TIA)
+      and supplementary measures where necessary, or (c) Binding
+      Corporate Rules. The DPA should specify which mechanism
+      applies and incorporate the SCCs by reference if applicable.
+    standard_language: |
+      To the extent that Processor's Processing of Personal Data
+      involves a transfer to a third country or international
+      organisation outside the EEA that is not the subject of an
+      adequacy decision under Article 45 GDPR, such transfer will
+      be effected pursuant to the European Commission Standard
+      Contractual Clauses for the transfer of personal data to
+      third countries (Implementing Decision (EU) 2021/914,
+      Module Two), which are hereby incorporated by reference and
+      attached as Exhibit B (the "Standard Contractual Clauses").
+      The parties will execute the Standard Contractual Clauses
+      including Annexes I, II, and III as completed in Exhibit B.
+      Processor has conducted, and will maintain, a Transfer
+      Impact Assessment evaluating the laws and practices of the
+      third country of destination and will implement
+      supplementary technical, contractual, and organisational
+      measures as necessary to ensure that the level of
+      protection of Personal Data is essentially equivalent to
+      that guaranteed within the EU. Upon Controller's request,
+      Processor will provide a summary of the Transfer Impact
+      Assessment and the supplementary measures implemented. To
+      the extent UK Personal Data is transferred, the parties
+      additionally incorporate the UK International Data Transfer
+      Addendum (or UK IDTA) issued by the Information
+      Commissioner's Office.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          SCCs incorporated by reference with a representation of
+          TIA completion, but without the contractual obligation
+          to share the TIA with the controller on request.
+          Acceptable when the processor's TIA practice is
+          documented elsewhere (e.g., in a Trust Center) and the
+          controller is comfortable verifying through that
+          channel.
+        language: |
+          Where Processor transfers Personal Data to a third
+          country outside the EEA not benefitting from an
+          adequacy decision, the parties hereby incorporate the
+          EU Standard Contractual Clauses (Implementing Decision
+          (EU) 2021/914, Module Two) as set forth in Exhibit B.
+          Processor has conducted a Transfer Impact Assessment
+          and implemented appropriate supplementary measures.
+          The UK IDTA applies to UK Personal Data transfers.
+      - rank: 2
+        description: |
+          SCCs by reference without an explicit TIA obligation.
+          Acceptable only when the processing involves no high-
+          risk jurisdictions (US, China, Russia, etc.) — the TIA
+          is a substantive Schrems-II requirement and absent it
+          the transfer mechanism may be invalid notwithstanding
+          the SCCs being in place. Generally not recommended.
+        language: |
+          Where Processor transfers Personal Data outside the
+          EEA, the parties incorporate the EU Standard
+          Contractual Clauses (Implementing Decision (EU)
+          2021/914) as a transfer mechanism, attached as
+          Exhibit B.
+    redline_strategy: |
+      If the DPA permits transfers to third countries without
+      specifying a Chapter V transfer mechanism, push to add the
+      SCCs (Module Two) and complete Annexes I-III. If the SCCs
+      are referenced but the annexes are not populated, push to
+      complete them as a precondition to signing — unpopulated
+      SCCs are not operative. If there is no TIA representation,
+      add the obligation to conduct and maintain a TIA and to
+      provide a summary on request. If UK Personal Data is in
+      scope and the UK IDTA (or the UK Addendum to the EU SCCs)
+      is missing, add it. If the Swiss Federal Data Protection
+      Act is in scope, similarly add the Swiss-specific
+      supplementary clauses. If supplementary measures are
+      asserted but undescribed, push for at least a high-level
+      description (e.g., encryption with controller-held keys,
+      access controls preventing third-country-government
+      access).
+    severity_if_missing: critical
+    detection_keywords:
+      - international transfer
+      - Standard Contractual Clauses
+      - SCCs
+      - Chapter V
+      - third country
+      - adequacy decision
+      - Transfer Impact Assessment
+      - TIA
+      - Schrems
+      - UK IDTA
+    detection_examples:
+      - >-
+        Transfers of Personal Data outside the EEA shall be
+        subject to the European Commission Standard Contractual
+        Clauses, which are incorporated herein as Exhibit B
+      - >-
+        Processor has conducted a Transfer Impact Assessment and
+        implemented supplementary measures where appropriate
+    position_order: 3
+  # ---------------------------------------------------------------------------
+  - issue: Sub-processor Engagement (GDPR Article 28(2))
+    description: |
+      The processor's right to engage sub-processors, the
+      controller's right to object to specific sub-processors,
+      and the flow-through obligations that sub-processors must
+      satisfy. Two industry-standard models exist: the "general
+      authorisation" model (processor maintains a list of
+      sub-processors and notifies the controller of changes with
+      a right to object) and the "specific authorisation" model
+      (every sub-processor requires prior controller approval).
+      General authorisation is by far the more common in SaaS;
+      specific authorisation is used for high-sensitivity
+      processing.
+    standard_language: |
+      Controller hereby grants Processor general written
+      authorisation to engage sub-processors to Process Personal
+      Data on Controller's behalf, subject to the conditions in
+      this Section. Processor maintains a list of current
+      sub-processors at the URL set forth in Annex III, which
+      Processor updates from time to time. Processor will notify
+      Controller of any intended changes concerning the addition
+      or replacement of sub-processors at least thirty (30) days
+      in advance (or such shorter period as is reasonable given
+      the urgency of the change), thereby giving Controller the
+      opportunity to object to such changes. If Controller
+      reasonably objects on the basis that the proposed
+      sub-processor presents a material risk to Personal Data
+      protection that cannot be adequately mitigated, Processor
+      will use commercially reasonable efforts to make available
+      a change in the Service to avoid Processing of Controller's
+      Personal Data by the objected-to sub-processor without
+      unreasonably burdening Controller. If Processor is unable to
+      avoid such Processing, Controller may, as its sole and
+      exclusive remedy, terminate the affected portion of the
+      Service for cause upon thirty (30) days' written notice and
+      receive a pro-rata refund of prepaid fees. Processor will
+      impose on each sub-processor, by contract or other binding
+      legal act, data protection obligations no less protective
+      than those imposed on Processor under this DPA. Processor
+      remains fully liable to Controller for the performance of
+      any sub-processor's obligations.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          General authorisation with longer notice (60 days) and
+          standard flow-through obligations. Acceptable for
+          controllers who want more lead time to evaluate
+          sub-processor changes.
+        language: |
+          Controller grants Processor general authorisation to
+          engage sub-processors, subject to: (a) Processor
+          maintaining a current list of sub-processors and
+          providing it to Controller upon request; (b) Processor
+          notifying Controller of changes at least sixty (60) days
+          in advance; (c) Controller's right to object to any new
+          sub-processor on reasonable grounds; and (d) flow-
+          through of data protection obligations no less
+          protective than this DPA. Processor remains liable for
+          its sub-processors' performance.
+      - rank: 2
+        description: |
+          Specific authorisation — each sub-processor requires
+          prior written consent from Controller. Acceptable only
+          for high-sensitivity processing (special-category data
+          under Article 9, large-scale monitoring of a public
+          area, etc.); operationally constrains the processor's
+          ability to scale and may be impractical in commercial
+          SaaS.
+        language: |
+          Processor will not engage any sub-processor to Process
+          Personal Data without Controller's prior written
+          consent. For each sub-processor for which Controller
+          consents, Processor will impose, by contract, data
+          protection obligations no less protective than those
+          imposed on Processor under this DPA. Processor remains
+          fully liable to Controller for the performance of each
+          sub-processor's obligations.
+    redline_strategy: |
+      If the DPA permits sub-processors without notice to the
+      controller, push for at least general authorisation with
+      notification and right to object. If notification is
+      provided but with no right to object, add the objection
+      right with a termination-of-affected-portion remedy. If
+      the flow-through obligations are weak ("substantially
+      similar" rather than "no less protective"), strengthen. If
+      processor liability for sub-processors is excluded or
+      capped, push for full liability — Article 28(4) requires
+      the processor to remain fully liable to the controller for
+      sub-processor performance.
+    severity_if_missing: high
+    detection_keywords:
+      - sub-processor
+      - sub-processors
+      - Article 28(2)
+      - general authorisation
+      - prior consent
+      - flow-through
+      - liability for sub-processor
+    detection_examples:
+      - >-
+        Controller grants Processor general written authorisation
+        to engage sub-processors subject to thirty days notice
+      - >-
+        Processor shall impose on each sub-processor data
+        protection obligations no less protective than those in
+        this DPA
+    position_order: 4
+  # ---------------------------------------------------------------------------
+  - issue: Audit Rights (GDPR Article 28(3)(h))
+    description: |
+      The controller's right to audit the processor's compliance
+      with the DPA, including by way of inspections conducted by
+      the controller or a third-party auditor. Article 28(3)(h)
+      requires processors to allow for and contribute to audits.
+      In practice, controllers rarely conduct on-site inspections
+      and instead rely on third-party certifications (SOC 2 Type
+      II, ISO 27001) supplemented by questionnaires; the DPA
+      should preserve the on-site right while making the
+      certification-based path the operational default.
+    standard_language: |
+      Processor will make available to Controller all information
+      necessary to demonstrate compliance with Article 28 GDPR and
+      this DPA. Once per twelve (12) month period (more frequently
+      in the event of a confirmed Personal Data Breach affecting
+      Controller's Personal Data), and upon at least thirty (30)
+      days' prior written notice (or such shorter notice as is
+      reasonable given the urgency), Controller may audit
+      Processor's compliance with this DPA, including by way of
+      an on-site inspection conducted by Controller or a mutually
+      acceptable third-party auditor (under NDA). The scope of
+      any such audit will be reasonable in light of the
+      obligations being audited, will be conducted during normal
+      business hours, and will be conducted in a manner that does
+      not unreasonably interfere with Processor's operations. In
+      lieu of an on-site inspection, Processor may satisfy this
+      obligation by providing to Controller (a) the most recent
+      SOC 2 Type II report (or equivalent independent assessment)
+      under NDA and (b) responses to a reasonable audit
+      questionnaire. Controller's audit costs are at Controller's
+      expense; if an audit reveals a material compliance failure,
+      Processor will reimburse Controller's reasonable audit
+      costs. Nothing in this Section will limit any audit or
+      inspection rights of a supervisory authority under
+      applicable law.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Audit right limited to provision of SOC 2 / ISO 27001
+          reports and questionnaire responses, with on-site rights
+          only after confirmed breach. Acceptable for mid-market
+          deployments where the controller is willing to rely on
+          third-party certifications. Aligns with the
+          corresponding MSA-SaaS Audit Rights fallback tier 1.
+        language: |
+          Processor will, once per twelve months and upon
+          reasonable notice, provide Controller with (a) the
+          most recent SOC 2 Type II report or equivalent
+          independent assessment under NDA and (b) responses to
+          a reasonable audit questionnaire. In the event of a
+          confirmed Personal Data Breach affecting Controller's
+          Personal Data, Controller may also conduct an on-site
+          audit on reasonable notice at Controller's expense.
+      - rank: 2
+        description: |
+          Article 28(3)(h) cross-reference only — operational
+          mechanics governed by the corresponding MSA audit
+          section. Acceptable when the DPA explicitly incorporates
+          the MSA's audit provisions.
+        language: |
+          Processor will make available all information necessary
+          to demonstrate compliance with Article 28 GDPR and will
+          allow for and contribute to audits, including
+          inspections, conducted by Controller or another auditor
+          mandated by Controller in accordance with the audit
+          procedures set forth in the Master Services Agreement.
+    redline_strategy: |
+      If the DPA lacks any audit right, push for at least an
+      annual SOC 2 report under NDA with on-site rights after a
+      confirmed breach — Article 28(3)(h) requires processors to
+      allow audits; an audit right is not waivable in the abstract.
+      If the right is qualified by "reasonable cause" or similar
+      gating, broaden to routine annual rights. If audit costs
+      are always controller's expense without a reimbursement
+      mechanism for material findings, add the reimbursement
+      trigger. If the supervisory-authority preservation language
+      is missing, add it — Article 58 powers cannot be limited
+      by private contract.
+    severity_if_missing: high
+    detection_keywords:
+      - audit
+      - inspection
+      - Article 28(3)(h)
+      - SOC 2 report
+      - audit questionnaire
+      - supervisory authority
+    detection_examples:
+      - >-
+        Processor shall make available to Controller all
+        information necessary to demonstrate compliance and shall
+        allow audits by Controller or a third-party auditor
+      - >-
+        Processor will provide a copy of its most recent SOC 2
+        Type II report to Controller under NDA upon request
+    position_order: 5
+  # ---------------------------------------------------------------------------
+  - issue: Deletion or Return of Personal Data (GDPR Article 28(3)(g))
+    description: |
+      The processor's obligation, at the end of the provision of
+      services, to delete or return all Personal Data to the
+      controller at the controller's choice, and to delete any
+      remaining copies unless Union or Member State law requires
+      storage. Two operational details matter: which party
+      chooses between deletion and return, and what counts as
+      "delete" given backup retention and automated archival
+      systems.
+    standard_language: |
+      At Controller's choice, Processor will delete or return all
+      Personal Data to Controller after the end of the provision
+      of Services relating to Processing, and will delete
+      existing copies, unless Union or Member State law to which
+      Processor is subject requires storage of the Personal Data,
+      in which case Processor will inform Controller of any such
+      legal requirement. Processor will complete the deletion or
+      return within thirty (30) days of the end of the provision
+      of Services and will, upon Controller's request, certify in
+      writing that Personal Data has been deleted or returned and
+      that any retained copies are limited to those required by
+      law. Personal Data residing in Processor's automated backup
+      and archival systems will be deleted in accordance with
+      Processor's standard backup retention policies (which will
+      not exceed twelve months) and will remain subject to the
+      confidentiality and security obligations of this DPA until
+      so deleted. Return of Personal Data, where elected, will
+      be in a structured, commonly used, and machine-readable
+      format.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Same obligations but with a longer backup-retention
+          tail (up to 24 months) and certification of deletion
+          only upon request. Acceptable when the processor's
+          backup architecture genuinely requires longer cycles
+          and the controller is willing to accept the residual
+          retention as long as it is subject to the same
+          security obligations.
+        language: |
+          At Controller's choice, Processor will delete or return
+          all Personal Data after the end of services and will
+          delete existing copies, unless required to retain by
+          law. Active-system deletion or return will be
+          completed within thirty days. Personal Data in backup
+          systems will be deleted in accordance with Processor's
+          standard backup retention policies and will remain
+          subject to the confidentiality and security
+          obligations of this DPA until so deleted. Upon
+          Controller's request, Processor will provide written
+          certification of deletion.
+      - rank: 2
+        description: |
+          Article 28(3)(g) by reference only, leaving the
+          operational details to the underlying services
+          agreement. Acceptable only when the MSA has equivalent
+          deletion/return provisions; standalone, this tier is
+          operationally vague.
+        language: |
+          At Controller's choice, Processor will delete or return
+          all Personal Data after the end of services in
+          accordance with the data return and deletion procedures
+          set forth in the Master Services Agreement and will
+          delete existing copies, except as required by
+          applicable law.
+    redline_strategy: |
+      If the DPA permits processor to retain Personal Data after
+      the end of services without specifying a basis, push for
+      either deletion or return at controller's choice with
+      retention only as legally required. If the choice between
+      deletion and return is vested in the processor rather than
+      the controller, reverse it — Article 28(3)(g) requires
+      controller choice. If the deletion window is undefined or
+      longer than 90 days, push for 30 days from end of services.
+      If the contract is silent on backup retention, add a
+      bounded backup retention tail (12 months is common) with
+      confidentiality/security obligations continuing through
+      deletion. If certification of deletion is not contemplated,
+      add it on request. If the return format is unspecified,
+      add structured/commonly-used/machine-readable.
+    severity_if_missing: high
+    detection_keywords:
+      - delete or return
+      - end of services
+      - Article 28(3)(g)
+      - deletion
+      - return of Personal Data
+      - backup retention
+      - certify deletion
+    detection_examples:
+      - >-
+        At Controller's choice, Processor shall delete or return
+        all Personal Data after the end of services and shall
+        delete existing copies
+      - >-
+        Processor shall certify in writing that Personal Data has
+        been deleted or returned within thirty days of the end
+        of the provision of services
+    position_order: 6
+  # ---------------------------------------------------------------------------
+  - issue: DSAR Cooperation (GDPR Article 28(3)(e))
+    description: |
+      The processor's obligation to assist the controller in
+      responding to data subject rights requests under Chapter III
+      of the GDPR — access, rectification, erasure, restriction of
+      processing, data portability, and objection. Without an
+      explicit assistance obligation, the controller may have no
+      contractual hook to compel the processor to extract personal
+      data from its systems within the GDPR's tight timelines
+      (one month from receipt of the request, with a possible
+      two-month extension).
+    standard_language: |
+      Processor will, taking into account the nature of
+      Processing, assist Controller by appropriate technical and
+      organisational measures, insofar as this is possible, for
+      the fulfilment of Controller's obligation to respond to
+      requests from data subjects exercising their rights under
+      Chapter III of the GDPR (including the rights of access,
+      rectification, erasure, restriction of Processing, data
+      portability, and objection). Processor will, upon
+      Controller's reasonable request, provide such assistance
+      within a timeframe that allows Controller to respond to the
+      data subject within the time limits required by Article 12
+      GDPR. If Processor receives any request directly from a
+      data subject concerning Personal Data Processed on
+      Controller's behalf, Processor will, without undue delay,
+      forward the request to Controller and will not respond
+      directly to the data subject unless and until Controller
+      authorises it. Where Processor's assistance with a
+      particular request involves substantial effort beyond
+      ordinary cooperation, Controller will reimburse Processor's
+      reasonable costs of providing such assistance.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Assistance obligation with a slightly higher threshold
+          for cost reimbursement ("commercially reasonable
+          assistance at no additional charge"). Acceptable when
+          DSAR volumes are anticipated to be modest and the
+          processor's tooling makes routine DSAR fulfilment
+          inexpensive.
+        language: |
+          Processor will provide commercially reasonable
+          assistance to Controller in responding to data subject
+          rights requests under Chapter III of the GDPR. Routine
+          assistance is provided at no additional charge.
+          Processor will not respond directly to a data subject
+          request received from a data subject and will instead
+          promptly forward such request to Controller.
+      - rank: 2
+        description: |
+          Article 28(3)(e) cross-reference with assistance
+          provided at processor's then-current professional
+          services rates. Acceptable only when the controller has
+          its own data-subject-rights tooling and needs only
+          occasional processor cooperation.
+        language: |
+          Processor will assist Controller in responding to data
+          subject rights requests under Chapter III of the GDPR
+          in accordance with Article 28(3)(e) GDPR. Assistance
+          beyond providing Personal Data exports through standard
+          self-service features will be provided at Processor's
+          then-current professional services rates.
+    redline_strategy: |
+      If the DPA lacks any DSAR assistance obligation, push for
+      one — without it, the controller has no contractual mechanism
+      to compel the processor to assist within the GDPR's
+      one-month response window. If the assistance is qualified
+      by "if and when reasonably practicable" with no commitment
+      to a timeframe, tighten to "within a timeframe that allows
+      Controller to respond within Article 12 time limits."  If
+      the processor reserves the right to respond directly to data
+      subjects, reverse — the controller must be the responder. If
+      assistance is always charged at professional-services rates
+      including for routine requests, push for routine assistance
+      at no charge with charges only for "substantial effort."
+    severity_if_missing: medium
+    detection_keywords:
+      - data subject rights
+      - DSAR
+      - Article 28(3)(e)
+      - Chapter III
+      - access request
+      - erasure
+      - data portability
+      - assist Controller
+    detection_examples:
+      - >-
+        Processor shall assist Controller in responding to
+        requests from data subjects exercising their rights
+        under Chapter III of the GDPR
+      - >-
+        Processor will forward any data subject request received
+        directly to Controller without undue delay
+    position_order: 7

--- a/skills/playbooks/msa-commercial-purchase/playbook.yaml
+++ b/skills/playbooks/msa-commercial-purchase/playbook.yaml
@@ -1,0 +1,1082 @@
+# =============================================================================
+# Built-in playbook: MSA — Commercial Services (purchase side) (M3-A5)
+# =============================================================================
+#
+# A starter playbook for reviewing commercial Master Services
+# Agreements where the operator is the customer purchasing services
+# or deliverables (consulting, professional services, software
+# development, integration work). Written from the customer /
+# purchaser's perspective. Calibrated to mid-market commercial
+# engagements — not government procurement, not strategic
+# outsourcing megadeals, not regulated-industry overlays.
+#
+# Sister playbook to ``msa-saas/playbook.yaml`` (which addresses
+# SaaS-subscription MSAs). The MSA-Commercial playbook differs in
+# four substantive ways from MSA-SaaS:
+#   1. Acceptance: deliverables require an acceptance process; SaaS
+#      services are ongoing and have an SLA instead.
+#   2. IP allocation: customer typically owns work product;
+#      vendor retains background IP and gets a license-back to
+#      improvements. SaaS keeps vendor IP firmly with vendor.
+#   3. Change orders: scope/price changes need a formal process;
+#      SaaS handles via the change management section.
+#   4. Termination is split into "for cause" and "for convenience"
+#      sections (separated because the dynamics differ on a
+#      project-based engagement vs. an ongoing subscription).
+#
+# **THIS IS A STARTING POINT, NOT A VETTED TEMPLATE, AND IT IS NOT
+# LEGAL ADVICE.** The maintainer team has not reviewed or validated
+# the positions, fallback tiers, or redline strategies below. They
+# were drafted from public CC-BY-4.0 templates (Common Paper Master
+# Subscription Agreement, adapted to the purchase side) and standard
+# mid-market commercial-purchase positions as a head-start for in-
+# house counsel installing LQ.AI. You — the attorney installing
+# this software — must review every position against your
+# organization's standards and applicable jurisdiction before
+# relying on this playbook for any client work. Fork it, customize
+# it, or replace it entirely.
+#
+# Companion file: ``api/alembic/versions/0033_seed_builtin_playbooks_msa_dpa.py``
+# ships an identical snapshot into the ``playbooks`` +
+# ``playbook_positions`` tables at version 1.0.0. Edits here are not
+# retroactive to existing deployments — playbook updates ship as new
+# migration versions.
+#
+# =============================================================================
+
+name: MSA — Commercial Services (purchase-side)
+contract_type: MSA-Commercial-Purchase
+version: 1.0.0
+description: |
+  Master Services Agreement playbook for commercial services and
+  deliverables purchases, written from the customer / purchaser's
+  perspective. Covers the ten positions that most commonly
+  determine whether a commercial-services MSA is fit for purpose:
+  acceptance, warranties, indemnification, limitation of liability,
+  intellectual property allocation, change orders, payment terms,
+  termination for cause, termination for convenience, and governing
+  law and venue.
+
+  **This playbook is a starting point, not a vetted template, and
+  it is not legal advice.** The LQ.AI maintainer team has not
+  reviewed or validated the positions, fallback tiers, or redline
+  strategies below — they were drafted from public templates
+  (Common Paper, adapted to the purchase side) and standard
+  mid-market commercial-purchase positions as a head-start for in-
+  house counsel installing LQ.AI. You must review every position
+  against your organization's standards and the applicable
+  jurisdiction before relying on this playbook for client work.
+  Fork it, customize it, or replace it entirely. Use of this
+  playbook does not establish an attorney-client relationship
+  with LegalQuants or any contributor.
+
+positions:
+  # ---------------------------------------------------------------------------
+  - issue: Acceptance (criteria, period, deemed acceptance)
+    description: |
+      The mechanism by which deliverables are accepted or rejected.
+      Without a structured acceptance process, "deemed acceptance"
+      provisions (vendor delivers; if customer doesn't object
+      within X days, the deliverable is accepted) can lock the
+      customer into paying for work that hasn't been validated.
+      The structure: documented acceptance criteria in the SOW,
+      an acceptance period long enough for meaningful testing
+      (typically 15-30 business days), a defined rejection
+      mechanism with reasonable cure cycles, and deemed
+      acceptance only after a clear written acceptance period.
+    standard_language: |
+      Each Statement of Work ("SOW") will identify the deliverables
+      (the "Deliverables") and the acceptance criteria for each
+      Deliverable. Vendor will deliver each Deliverable in
+      accordance with the SOW. Customer will have thirty (30)
+      business days following delivery (the "Acceptance Period")
+      to test the Deliverable against the acceptance criteria and
+      to deliver to Vendor a written notice of acceptance or a
+      written notice of rejection specifying in reasonable detail
+      the failures to satisfy the acceptance criteria. If Customer
+      delivers a rejection notice within the Acceptance Period,
+      Vendor will, at its expense, correct the identified
+      deficiencies and re-deliver the Deliverable within fifteen
+      (15) business days, after which a new Acceptance Period of
+      fifteen (15) business days will apply. If the corrected
+      Deliverable is rejected for the same material deficiencies
+      on the second occasion, Customer may, at its option, (a)
+      grant Vendor a further cure period, (b) accept the
+      Deliverable subject to a price reduction reasonably
+      reflecting the deficiencies, or (c) terminate the affected
+      SOW and receive a refund of all fees paid for the rejected
+      Deliverable. If Customer does not deliver a written notice
+      within the Acceptance Period, the Deliverable will be
+      deemed accepted on the last day of the Acceptance Period.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Shorter acceptance window (15 business days) with the
+          same rejection and cure mechanics. Acceptable for
+          smaller deliverables where 30 business days is
+          disproportionate to the scope of work.
+        language: |
+          Each SOW will identify the Deliverables and the
+          acceptance criteria. Customer has fifteen (15) business
+          days following delivery to provide written notice of
+          acceptance or rejection. If rejected, Vendor will cure
+          within ten (10) business days at its expense. If the
+          cured Deliverable is rejected for the same material
+          deficiencies, Customer may terminate the affected SOW
+          and receive a pro-rata refund. Deemed acceptance applies
+          after the Acceptance Period.
+      - rank: 2
+        description: |
+          Acceptance criteria optional in the SOW; deemed
+          acceptance after a 10-business-day period. Acceptable
+          only for time-and-materials engagements where there are
+          no discrete deliverables to accept (e.g., staff
+          augmentation). Generally not recommended for
+          deliverable-based work.
+        language: |
+          If a SOW identifies Deliverables and acceptance criteria,
+          Customer will have ten (10) business days following
+          delivery to provide written notice of any failure to
+          satisfy the acceptance criteria. Vendor will cure
+          identified deficiencies at its expense. If a SOW does
+          not identify acceptance criteria, work is performed on
+          a time-and-materials basis and is deemed accepted upon
+          delivery.
+    redline_strategy: |
+      If the SOW lacks acceptance criteria entirely, push to add
+      them as a precondition to signing — without criteria, there
+      is nothing to test against and "deemed acceptance" becomes
+      automatic. If the acceptance period is shorter than 15
+      business days, push to extend (operational testing rarely
+      fits in less). If the cure cycle has no cap on the number
+      of iterations or no termination-with-refund remedy on
+      repeated failure, add a cap (typically two cure cycles)
+      with a termination remedy. If "deemed acceptance" runs
+      from delivery rather than from the Acceptance Period
+      expiring with no objection, tighten — without the
+      objection-based trigger, deemed acceptance can fire
+      before Customer has had a chance to test.
+    severity_if_missing: high
+    detection_keywords:
+      - acceptance
+      - acceptance criteria
+      - acceptance period
+      - deliverable
+      - rejection
+      - deemed accepted
+      - cure period
+    detection_examples:
+      - >-
+        Customer shall have thirty business days from delivery to
+        test the Deliverable against the acceptance criteria
+      - >-
+        If Customer does not provide a written rejection notice
+        within the acceptance period, the Deliverable shall be
+        deemed accepted
+    position_order: 0
+  # ---------------------------------------------------------------------------
+  - issue: Warranties (services, deliverables, non-infringement)
+    description: |
+      The vendor's affirmative representations about the quality
+      of its work — that services will be performed in a
+      professional, workmanlike manner; that deliverables will
+      conform to the agreed specifications; and that the
+      deliverables will not infringe third-party rights. Without
+      explicit warranties, the customer's only recourse is
+      whatever the implied warranties under the governing law
+      provide (often disclaimed or limited).
+    standard_language: |
+      Vendor represents and warrants that: (a) the Services will
+      be performed in a professional and workmanlike manner by
+      qualified personnel in accordance with industry standards
+      for similar services; (b) each Deliverable will conform to
+      the specifications and acceptance criteria set forth in
+      the applicable SOW, both at the time of delivery and for a
+      period of ninety (90) days thereafter; (c) Vendor will use
+      commercially reasonable efforts to ensure that the
+      Deliverables and Services do not contain any viruses,
+      worms, time bombs, or other malicious code; and (d) the
+      Services and Deliverables, as delivered by Vendor and used
+      by Customer in accordance with this Agreement, will not
+      infringe, misappropriate, or violate any patent, copyright,
+      trademark, trade secret, or other intellectual property
+      right of any third party. EXCEPT AS EXPRESSLY SET FORTH IN
+      THIS AGREEMENT, VENDOR DISCLAIMS ALL OTHER WARRANTIES,
+      EXPRESS OR IMPLIED, INCLUDING THE IMPLIED WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+      NON-INFRINGEMENT, EXCEPT FOR THE EXPRESS NON-INFRINGEMENT
+      WARRANTY IN CLAUSE (D) ABOVE. Customer's sole and exclusive
+      remedy for a breach of the services or deliverables
+      warranty is, at Vendor's option, re-performance of the
+      affected Services or correction of the affected
+      Deliverable, provided Customer notifies Vendor of the
+      breach within the applicable warranty period.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Standard warranties with a shorter 60-day deliverable
+          warranty period and re-performance-only remedy.
+          Acceptable for shorter engagements where 90 days
+          significantly exceeds the engagement duration.
+        language: |
+          Vendor warrants that (a) Services will be performed in
+          a professional, workmanlike manner, (b) Deliverables
+          will conform to the specifications for sixty (60) days
+          following delivery, and (c) Deliverables will not
+          infringe third-party intellectual property rights.
+          Customer's remedy for breach of these warranties is
+          re-performance of Services or correction of the
+          Deliverable. Vendor disclaims all other warranties.
+      - rank: 2
+        description: |
+          Services warranty only ("professional and workmanlike")
+          with no deliverable conformity warranty and no
+          non-infringement warranty. Acceptable only for very
+          low-risk engagements where the customer has independent
+          confidence in vendor's IP hygiene. Generally not
+          recommended; the non-infringement warranty is critical.
+        language: |
+          Vendor warrants that the Services will be performed in
+          a professional and workmanlike manner consistent with
+          industry standards. EXCEPT AS EXPRESSLY SET FORTH IN
+          THIS AGREEMENT, VENDOR DISCLAIMS ALL WARRANTIES,
+          EXPRESS OR IMPLIED.
+    redline_strategy: |
+      If the contract has no non-infringement warranty, push for
+      one — without it, an IP claim against the vendor's work
+      product becomes the customer's exposure with no contractual
+      recourse. If the services warranty is qualified by "best
+      efforts" rather than "professional and workmanlike,"
+      tighten — "professional and workmanlike" is the enforceable
+      standard. If the deliverable warranty period is less than
+      60 days, push for at least 90 days. If the warranty remedy
+      is limited to re-performance with no termination right for
+      repeated failures, add a termination trigger after a
+      defined number of cure cycles. If the warranty disclaimer
+      is so broad it swallows the express warranties (e.g.,
+      disclaims all warranties without preserving the express
+      ones), tighten the disclaimer.
+    severity_if_missing: high
+    detection_keywords:
+      - warrant
+      - warranty
+      - represent
+      - professional and workmanlike
+      - non-infringement
+      - conform to specifications
+      - disclaimer
+    detection_examples:
+      - >-
+        Vendor warrants that Services will be performed in a
+        professional and workmanlike manner and that Deliverables
+        will conform to the specifications
+      - >-
+        Vendor warrants that the Deliverables will not infringe
+        any third-party intellectual property rights
+    position_order: 1
+  # ---------------------------------------------------------------------------
+  - issue: Indemnification (IP, third-party claims, mutual conduct)
+    description: |
+      The vendor's obligation to defend and indemnify the customer
+      against third-party claims arising from the work product
+      (primarily IP infringement claims), and the customer's
+      reciprocal obligation for claims arising from customer-
+      provided materials and instructions. The mutual conduct
+      requirements (notice, control of defense, settlement
+      consent) make the mechanism workable in practice.
+    standard_language: |
+      Vendor will defend Customer against any third-party claim
+      alleging that the Deliverables or Services, as delivered or
+      performed by Vendor, infringe, misappropriate, or violate
+      any patent, copyright, trademark, trade secret, or other
+      intellectual property right of any third party (a "Vendor
+      IP Claim"), and will indemnify Customer against any damages
+      and costs (including reasonable attorneys' fees) finally
+      awarded against Customer by a court of competent
+      jurisdiction or paid in a settlement approved by Vendor in
+      connection with such Vendor IP Claim. The foregoing
+      indemnification does not apply to the extent the alleged
+      infringement arises from (a) Customer's combination of the
+      Deliverables with products or services not furnished by
+      Vendor where the infringement would not have occurred but
+      for such combination, (b) modifications to the Deliverables
+      made by anyone other than Vendor where the unmodified
+      Deliverable would not have infringed, or (c) Customer's use
+      of the Deliverables in a manner not contemplated by this
+      Agreement or the applicable SOW. Customer will defend
+      Vendor against any third-party claim arising from materials
+      or instructions provided by Customer to Vendor for use in
+      the Services or Deliverables. The indemnifying party's
+      obligations are conditioned on the indemnified party (a)
+      promptly notifying the indemnifying party of the claim in
+      writing, (b) giving the indemnifying party sole control of
+      the defense and settlement of the claim (provided the
+      indemnifying party may not settle any claim that imposes a
+      material obligation on the indemnified party without its
+      written consent), and (c) providing reasonable cooperation
+      in the defense at the indemnifying party's expense. If a
+      Vendor IP Claim arises or is likely to arise, Vendor may,
+      at its option, (i) procure for Customer the right to
+      continue using the affected Deliverable, (ii) modify the
+      Deliverable so it is non-infringing without materially
+      diminishing its functionality, or (iii) refund the fees
+      paid by Customer for the affected Deliverable upon return
+      of such Deliverable.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Mutual IP and customer-materials indemnification with
+          standard conduct requirements, but without the explicit
+          "procure / modify / refund" remedy ladder. Acceptable
+          when the customer is willing to rely on the broader
+          indemnification language without spelling out vendor's
+          options.
+        language: |
+          Vendor will defend and indemnify Customer against any
+          third-party claim that the Deliverables or Services
+          infringe third-party intellectual property rights,
+          subject to standard exclusions for combination with
+          non-vendor products, customer modifications, and out-of-
+          scope use. Customer will defend and indemnify Vendor
+          against any claim arising from materials or
+          instructions provided by Customer. The standard conduct
+          requirements (prompt notice, sole control of defense,
+          settlement consent for material obligations) apply.
+      - rank: 2
+        description: |
+          Vendor IP indemnification only (no customer-materials
+          reciprocal). Acceptable when the customer is not
+          providing materials that create third-party claim
+          exposure for the vendor (e.g., consulting engagement
+          with no customer-supplied content).
+        language: |
+          Vendor will defend Customer against any third-party
+          claim that the Deliverables or Services infringe third-
+          party intellectual property rights and will indemnify
+          Customer against finally-awarded damages, subject to
+          the standard combination/modification/out-of-scope
+          exclusions and conduct requirements.
+    redline_strategy: |
+      If the contract lacks any indemnification, push for at
+      least a vendor IP indemnification. If the IP exclusions
+      are so broad they swallow the indemnification (e.g.,
+      excludes claims arising from any combination with other
+      products), tighten — the standard combination exclusion
+      requires "but for" causation (the infringement would not
+      have occurred but for the combination). If the indemnity
+      lacks the "procure / modify / refund" remedy ladder, add
+      it — this is what makes the indemnification operationally
+      useful when an infringement is alleged. If the customer
+      side has a broader indemnity than vendor (asymmetric), push
+      for mutuality. If the indemnification is capped by the LoL,
+      push for IP indemnification to be a carveout from the cap.
+    severity_if_missing: high
+    detection_keywords:
+      - indemnification
+      - indemnify
+      - defend
+      - third-party claim
+      - infringement
+      - hold harmless
+      - intellectual property indemnity
+    detection_examples:
+      - >-
+        Vendor shall defend, indemnify, and hold harmless Customer
+        from any third-party claim alleging that the Deliverables
+        infringe intellectual property rights
+      - >-
+        Vendor's indemnification obligations do not apply to
+        claims arising from Customer's combination of the
+        Deliverables with non-Vendor products
+    position_order: 2
+  # ---------------------------------------------------------------------------
+  - issue: Limitation of Liability
+    description: |
+      The cap on damages and the exclusions from that cap. In a
+      commercial-purchase MSA, the standard cap is typically a
+      multiple of the fees paid under the affected SOW (e.g., 1×
+      or 2× SOW fees) rather than 12-month rolling fees, because
+      the engagement is project-based rather than subscription-
+      based. Carveouts from the cap are critical: IP
+      indemnification, gross negligence, willful misconduct,
+      confidentiality breach, and (if applicable) data breach.
+    standard_language: |
+      EXCEPT FOR EXCLUDED CLAIMS (DEFINED BELOW), EACH PARTY'S
+      AGGREGATE LIABILITY ARISING OUT OF OR RELATING TO THIS
+      AGREEMENT OR ANY SOW WILL NOT EXCEED TWO (2) TIMES THE
+      TOTAL FEES PAID OR PAYABLE BY CUSTOMER TO VENDOR UNDER THE
+      SOW GIVING RISE TO THE CLAIM (OR, IF NO SOW IS APPLICABLE,
+      THE FEES PAID OR PAYABLE IN THE TWELVE (12) MONTHS
+      PRECEDING THE EVENT GIVING RISE TO THE CLAIM). EXCEPT FOR
+      EXCLUDED CLAIMS, IN NO EVENT WILL EITHER PARTY BE LIABLE
+      FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL,
+      EXEMPLARY, OR PUNITIVE DAMAGES, OR FOR ANY LOST PROFITS,
+      LOST REVENUES, OR LOST DATA, EVEN IF ADVISED OF THE
+      POSSIBILITY OF SUCH DAMAGES. "EXCLUDED CLAIMS" MEANS (A)
+      EITHER PARTY'S INDEMNIFICATION OBLIGATIONS UNDER THIS
+      AGREEMENT; (B) EITHER PARTY'S BREACH OF ITS CONFIDENTIALITY
+      OBLIGATIONS; (C) EITHER PARTY'S GROSS NEGLIGENCE OR WILLFUL
+      MISCONDUCT; (D) ANY BREACH OF VENDOR'S WARRANTIES THAT
+      RESULTS IN BODILY INJURY OR DEATH; AND (E) AMOUNTS OWED FOR
+      FEES.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Cap at 1× SOW fees with the same carveouts. Acceptable
+          when the engagement is lower-risk or the vendor's
+          financial profile cannot bear a 2× exposure.
+        language: |
+          Each party's aggregate liability is capped at one (1)
+          times the total fees paid or payable under the SOW
+          giving rise to the claim, except for the Excluded
+          Claims (indemnification, confidentiality breach, gross
+          negligence, willful misconduct, and amounts owed for
+          fees), which are uncapped.
+      - rank: 2
+        description: |
+          Mutual cap at 1× SOW fees with narrower carveouts (IP
+          indemnification and willful misconduct only). Acceptable
+          only for low-risk, low-stakes engagements; not
+          appropriate where confidentiality or significant
+          warranty exposure is in play.
+        language: |
+          Each party's aggregate liability under this Agreement
+          is capped at the total fees paid or payable under the
+          applicable SOW. This cap does not apply to either
+          party's indemnification obligations or to liability
+          arising from a party's willful misconduct.
+    redline_strategy: |
+      If the contract's LoL applies to ALL claims with no
+      carveouts, push for the standard carveout set
+      (indemnification, confidentiality, gross negligence,
+      willful misconduct). If the cap is less than 1× SOW fees,
+      push for at least 1×. If the cap is one-way (vendor-
+      favorable), push for mutuality. If the cap measurement
+      basis is unclear ("amounts paid" without specifying time
+      period or SOW scope), push for explicit "fees paid under
+      the SOW giving rise to the claim." If the cap covers
+      vendor's IP indemnification (a vendor-favored move), push
+      to carve IP indemnification out — IP exposure should not
+      be capped at SOW fees because a patent damages award can
+      vastly exceed the contract value.
+    severity_if_missing: critical
+    detection_keywords:
+      - limitation of liability
+      - aggregate liability
+      - cap on damages
+      - consequential damages
+      - excluded claims
+      - indirect damages
+    detection_examples:
+      - >-
+        EACH PARTY'S AGGREGATE LIABILITY UNDER THIS AGREEMENT
+        SHALL NOT EXCEED TWO TIMES THE TOTAL FEES PAID OR PAYABLE
+        UNDER THE APPLICABLE SOW
+      - >-
+        IN NO EVENT SHALL EITHER PARTY BE LIABLE FOR ANY INDIRECT,
+        INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+    position_order: 3
+  # ---------------------------------------------------------------------------
+  - issue: Intellectual Property Allocation (work product, background IP, license-back)
+    description: |
+      The most consequential clause in a commercial services
+      agreement: who owns the work product the vendor creates for
+      the customer, what background IP the vendor brought to the
+      engagement, and what licenses flow between the parties.
+      The customer-favored default in mid-market commercial
+      purchases: customer owns the work product (defined as
+      items created specifically for customer under the SOW);
+      vendor retains its background IP and gets a license-back
+      to any general-purpose improvements that don't include
+      customer-specific content.
+    standard_language: |
+      "Work Product" means all materials, documents, software,
+      designs, processes, methods, and other items created by
+      Vendor specifically for Customer under a SOW. "Background
+      IP" means Vendor's pre-existing intellectual property,
+      tools, methodologies, and general-purpose software not
+      created specifically for Customer, including any
+      improvements thereto that are general-purpose and do not
+      include or rely on Customer Confidential Information or
+      Customer-specific content. As between the parties: (a)
+      Customer will own all right, title, and interest in and to
+      the Work Product, including all intellectual property
+      rights therein, and Vendor hereby irrevocably assigns to
+      Customer all such right, title, and interest, effective
+      upon Customer's payment of fees for the applicable Work
+      Product; (b) Vendor retains all right, title, and interest
+      in and to Background IP; (c) to the extent any Background
+      IP is incorporated into or necessary to use the Work
+      Product, Vendor hereby grants Customer a perpetual,
+      irrevocable, worldwide, royalty-free, non-exclusive
+      license to use, modify, and create derivative works of
+      such Background IP solely as incorporated into the Work
+      Product and for Customer's internal business purposes; and
+      (d) Customer hereby grants Vendor a non-exclusive,
+      worldwide, royalty-free license to use general-purpose
+      improvements to Background IP made in the course of
+      performing the Services, provided such improvements do not
+      include or rely on Customer Confidential Information,
+      Customer Data, or Customer-specific content.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Work product owned by Customer with a broader Background
+          IP license to Vendor (includes the right to incorporate
+          general learnings from the engagement into Vendor's
+          product roadmap). Acceptable when the engagement is in
+          a domain where Vendor's general-purpose improvements
+          are valuable to its broader business and the Customer
+          is comfortable with that.
+        language: |
+          Customer owns all Work Product created specifically for
+          Customer under a SOW, with full assignment of rights
+          from Vendor effective upon payment. Vendor retains its
+          Background IP and grants Customer a perpetual,
+          royalty-free license to use Background IP as
+          incorporated into Work Product. Customer grants Vendor
+          a non-exclusive license to use general learnings and
+          methodologies developed in the course of performing
+          Services for Vendor's broader business.
+      - rank: 2
+        description: |
+          Vendor owns Work Product; Customer gets a perpetual,
+          royalty-free, non-exclusive license to use it.
+          Acceptable for commodity engagements where the Work
+          Product is heavily based on Vendor's pre-existing
+          template (e.g., a standard report from a research firm)
+          and Customer has no need for exclusivity. Generally not
+          recommended for bespoke work product.
+        language: |
+          Vendor retains all right, title, and interest in and to
+          the Work Product. Vendor grants Customer a perpetual,
+          irrevocable, worldwide, royalty-free, non-exclusive
+          license to use, copy, modify, and create derivative
+          works of the Work Product for Customer's internal
+          business purposes.
+    redline_strategy: |
+      If the contract vests Work Product ownership in Vendor by
+      default, reverse it — for bespoke commercial-purchase work,
+      Customer should own. If the assignment is effective only on
+      "full payment of all amounts under the Agreement" rather
+      than fees for the specific Work Product, narrow — Customer
+      should not have to pay every SOW fee to own the Work
+      Product from an unrelated SOW. If the Background IP
+      definition is so broad it sweeps in the Work Product
+      ("everything Vendor uses or creates"), tighten — Background
+      IP should be limited to pre-existing IP and general-purpose
+      improvements. If the Background IP license to Customer is
+      revocable or term-limited, push for perpetual. If the
+      license-back from Customer to Vendor sweeps in Customer
+      Confidential Information, narrow it.
+    severity_if_missing: high
+    detection_keywords:
+      - work product
+      - deliverable
+      - intellectual property
+      - background IP
+      - assignment
+      - ownership
+      - license-back
+    detection_examples:
+      - >-
+        Customer shall own all right, title, and interest in and
+        to the Work Product, and Vendor hereby assigns all such
+        rights to Customer
+      - >-
+        Vendor retains all right, title, and interest in and to
+        its Background IP, including any improvements thereto
+    position_order: 4
+  # ---------------------------------------------------------------------------
+  - issue: Change Orders (process, pricing, dispute resolution)
+    description: |
+      The formal process for modifying scope, pricing, or schedule
+      mid-engagement. Without a defined change-order process,
+      "scope creep" disputes are routine — the vendor performs
+      work it considers out-of-scope; the customer disputes the
+      additional charges; the relationship sours. A workable
+      change-order section defines who can initiate, who must
+      authorize, what's needed for an authorization, what happens
+      to work performed prior to authorization, and how disputes
+      are resolved.
+    standard_language: |
+      Any change to the scope, fees, schedule, or other terms of
+      a SOW must be authorized in writing through a "Change
+      Order" signed by an authorized representative of each party.
+      Either party may propose a Change Order. Vendor will
+      promptly evaluate any Change Order proposed by Customer and
+      will, within five (5) business days, deliver to Customer a
+      written response that specifies the impact of the proposed
+      change on the SOW's scope, fees, schedule, and any other
+      affected terms. Customer will then accept, reject, or
+      counter-propose. Vendor will not perform any work outside
+      the scope of an authorized SOW or Change Order, and any
+      such work performed without authorization is at Vendor's
+      sole cost and risk and creates no obligation on Customer
+      to pay for it. If the parties are unable to agree on a
+      proposed Change Order, the parties will continue to perform
+      under the existing SOW; if continued performance is
+      impractical due to the unresolved change, either party may
+      terminate the affected SOW for convenience upon thirty (30)
+      days' written notice with no penalty.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Standard Change Order mechanics with a longer response
+          window (10 business days) and an internal escalation
+          process before SOW termination. Acceptable when the
+          engagement is complex enough that Change Order
+          evaluations take meaningful analysis.
+        language: |
+          Changes to a SOW require a written Change Order signed
+          by both parties. Vendor will respond to a proposed
+          Change Order within ten (10) business days with an
+          impact assessment. Work outside the SOW scope without
+          a Change Order is at Vendor's sole cost. If the
+          parties cannot agree on a Change Order, the matter
+          will be escalated to designated executives; if
+          unresolved after fifteen days, either party may
+          terminate the SOW for convenience with thirty days
+          notice.
+      - rank: 2
+        description: |
+          Change Order requirement but with no specified response
+          timeframe and no work-without-authorization protection
+          for Customer. Acceptable only when the relationship is
+          high-trust and the parties have a long history; risks
+          scope creep disputes.
+        language: |
+          Any change to a SOW will be documented in a written
+          Change Order signed by both parties. Vendor will
+          evaluate proposed Change Orders in good faith. Pending
+          a signed Change Order, the parties will continue
+          performance under the existing SOW.
+    redline_strategy: |
+      If the contract permits Vendor to perform additional work
+      and bill it without prior written authorization, fix this
+      — the work-without-authorization protection is the single
+      most important element for Customer. If Change Order
+      requires authorization but the response timeframe is
+      undefined, add a 5-10 business day window. If the Change
+      Order needs Vendor's signature only (not Customer's),
+      fix — Customer must authorize. If there's no termination
+      remedy when parties can't agree on a Change Order, add the
+      30-day convenience termination. If a Change Order can
+      modify the Agreement (not just the SOW), narrow — Change
+      Orders should only modify the affected SOW.
+    severity_if_missing: medium
+    detection_keywords:
+      - change order
+      - change request
+      - scope change
+      - modification to SOW
+      - out of scope
+      - additional work
+    detection_examples:
+      - >-
+        Any change to the scope, fees, or schedule of a SOW must
+        be authorized in writing through a Change Order signed by
+        both parties
+      - >-
+        Vendor shall not perform work outside the scope of an
+        authorized SOW or Change Order without prior written
+        authorization
+    position_order: 5
+  # ---------------------------------------------------------------------------
+  - issue: Payment Terms (currency, net days, late fees, withholding)
+    description: |
+      How and when fees are paid, how invoicing works for
+      milestone-based deliverables, what triggers withholding of
+      payment, and what late-payment remedies apply. In a
+      commercial-purchase MSA, payment is typically tied to
+      milestones or delivery, with a holdback (often 10-15%)
+      retained until final acceptance or completion of
+      transition.
+    standard_language: |
+      Customer will pay Vendor the fees set forth in each SOW.
+      Unless otherwise stated in a SOW, all fees are payable in
+      U.S. dollars within thirty (30) days after the date of
+      Vendor's correct invoice. Vendor may invoice Customer upon
+      completion of the milestones identified in the applicable
+      SOW; Vendor will not invoice for milestones that have not
+      been accepted in accordance with the Acceptance section.
+      Each SOW may identify a "Holdback" amount, not to exceed
+      fifteen percent (15%) of the total SOW fees, which Customer
+      will pay upon the later of (a) Customer's acceptance of all
+      Deliverables under the SOW and (b) completion of any
+      transition assistance required under the SOW. Fees are
+      exclusive of all taxes (excluding taxes based on Vendor's
+      net income), and Customer will be responsible for the
+      payment of all such taxes. If Customer fails to pay any
+      undisputed invoice when due, Vendor may charge interest on
+      the past-due amount at the rate of one and one-half
+      percent (1.5%) per month or the highest rate permitted by
+      applicable law (whichever is lower). Customer may dispute
+      any invoice in good faith by providing written notice
+      within thirty (30) days of receipt; the disputed amount
+      will not accrue late fees during good-faith resolution
+      efforts. Customer may withhold from any payment any
+      amount Vendor owes to Customer under this Agreement,
+      provided Customer first notifies Vendor of the basis for
+      the withholding.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Net 45 with smaller Holdback (10%) and no setoff right.
+          Acceptable when the Customer's procurement process
+          requires a longer cycle and the Vendor cannot tolerate
+          the setoff exposure.
+        language: |
+          Customer will pay all undisputed invoices within
+          forty-five (45) days of receipt. Each SOW may identify
+          a Holdback of up to ten percent (10%) of total fees,
+          payable upon Customer's acceptance of all Deliverables.
+          Late payments accrue interest at 1.5% per month or the
+          highest rate permitted by law. Customer may dispute
+          any invoice in good faith within thirty days; disputed
+          amounts do not accrue late fees during good-faith
+          resolution.
+      - rank: 2
+        description: |
+          Net 30 with no Holdback and no withholding right.
+          Acceptable for short-duration, lower-risk engagements
+          where milestone-based payment is the only retention
+          mechanism. Generally not recommended for engagements
+          with significant transition obligations.
+        language: |
+          Customer will pay all undisputed invoices within thirty
+          (30) days of receipt. Late payments accrue interest at
+          1.5% per month or the highest rate permitted by law.
+          Customer may dispute any invoice in good faith within
+          thirty days.
+    redline_strategy: |
+      If the contract requires payment in advance of milestone
+      completion or before deliverable acceptance, push for
+      milestone-based or deliverable-based invoicing. If there's
+      no Holdback, propose one (10-15% is market). If late fees
+      exceed 1.5% per month, push down (some state usury laws
+      cap this). If the contract permits suspension or
+      termination for unpaid disputed amounts, narrow — only
+      undisputed past-due amounts should trigger remedies. If
+      there's no good-faith dispute mechanism, add one. If
+      withholding/setoff is excluded, push to add a controlled
+      setoff right for amounts Vendor owes Customer.
+    severity_if_missing: medium
+    detection_keywords:
+      - payment terms
+      - net 30
+      - invoice
+      - milestone
+      - holdback
+      - retention
+      - late fees
+      - dispute
+    detection_examples:
+      - >-
+        Customer shall pay all undisputed invoices within thirty
+        days of receipt; each SOW may identify a Holdback of up
+        to fifteen percent
+      - >-
+        Late payments shall accrue interest at the rate of 1.5%
+        per month or the highest rate permitted by applicable law
+    position_order: 6
+  # ---------------------------------------------------------------------------
+  - issue: Termination for Cause
+    description: |
+      Each party's right to terminate the Agreement (or an
+      affected SOW) on the other party's material breach. The
+      standard structure: written notice describing the breach,
+      cure period (typically 30 days), termination effective if
+      not cured. Insolvency-based termination is typically
+      immediate. The customer-side considerations: ensure a
+      meaningful cure window, ensure no cure right for breaches
+      that cannot be cured (confidentiality, IP), ensure
+      survival of indemnification and other ongoing obligations.
+    standard_language: |
+      Either party may terminate this Agreement or any SOW upon
+      thirty (30) days' prior written notice if the other party
+      materially breaches the Agreement or the SOW and fails to
+      cure such breach within the notice period, except that no
+      cure period is required for (a) breaches that by their
+      nature cannot be cured (including a confidentiality breach
+      involving public disclosure or material misappropriation
+      of intellectual property), (b) breaches of payment
+      obligations not cured within an additional ten (10)
+      business day grace period following the cure notice, or
+      (c) repeated breaches of the same type that have been the
+      subject of two or more prior cure notices within the
+      preceding twelve months. Either party may also terminate
+      this Agreement or any SOW immediately upon written notice
+      if the other party (i) becomes insolvent, makes a general
+      assignment for the benefit of creditors, files a voluntary
+      petition in bankruptcy, suffers the appointment of a
+      receiver or trustee for substantially all of its assets,
+      or has an involuntary bankruptcy proceeding instituted
+      against it that is not dismissed within sixty (60) days,
+      or (ii) ceases business operations. The provisions of
+      this Agreement that by their nature should survive
+      termination (including indemnification, limitation of
+      liability, confidentiality, intellectual property, and
+      governing law) will survive.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Standard 30-day cure with the same insolvency triggers
+          but without the repeated-breach exception. Acceptable
+          when the engagement is not at risk of pattern-of-
+          breach disputes.
+        language: |
+          Either party may terminate this Agreement or any SOW
+          upon thirty (30) days' prior written notice if the
+          other party materially breaches the Agreement or SOW
+          and fails to cure within the notice period, except
+          that no cure is required for non-curable breaches
+          (such as a confidentiality breach involving public
+          disclosure). Either party may terminate immediately
+          upon the other party's insolvency, assignment for
+          benefit of creditors, or bankruptcy. Surviving
+          provisions survive.
+      - rank: 2
+        description: |
+          Termination for cause with longer cure period (60 days)
+          and no immediate-termination right for non-curable
+          breaches. Acceptable for high-trust, long-running
+          engagements where the parties want to maximize cure
+          opportunities; generally not recommended where
+          confidentiality or IP exposure is high.
+        language: |
+          Either party may terminate this Agreement or any SOW
+          upon sixty (60) days' prior written notice if the
+          other party materially breaches and fails to cure
+          within the notice period. Insolvency-based termination
+          and survival of obligations follow the standard
+          pattern.
+    redline_strategy: |
+      If the contract lacks a cure period entirely, add a
+      30-day cure for curable breaches. If the cure period
+      applies even to non-curable breaches (confidentiality, IP
+      misappropriation), carve those out. If insolvency
+      triggers are missing or limited (e.g., only voluntary
+      bankruptcy), broaden to include involuntary bankruptcy,
+      receivership, assignment for benefit of creditors, and
+      cessation of business. If termination is one-way (only
+      one party may terminate for cause), push for mutuality.
+      If the survival clause is missing or too narrow, add the
+      standard survival categories (indemnification, LoL,
+      confidentiality, IP, governing law).
+    severity_if_missing: high
+    detection_keywords:
+      - termination for cause
+      - material breach
+      - cure period
+      - insolvency
+      - bankruptcy
+      - survive termination
+      - survival
+    detection_examples:
+      - >-
+        Either party may terminate this Agreement for cause upon
+        thirty days' prior written notice if the other party
+        materially breaches and fails to cure
+      - >-
+        The provisions of this Agreement that by their nature
+        should survive termination shall survive
+    position_order: 7
+  # ---------------------------------------------------------------------------
+  - issue: Termination for Convenience
+    description: |
+      The customer's right to terminate the engagement without
+      cause, typically with a notice period and a defined
+      financial settlement (typically: payment for work
+      completed plus accepted, payment for work-in-progress as
+      of the termination date, and possibly a termination fee
+      for unrecoverable Vendor costs). In commercial-purchase
+      MSAs (unlike SaaS subscriptions), convenience termination
+      is common and important because business needs change
+      and the customer should not be locked into an engagement
+      that no longer serves its purposes.
+    standard_language: |
+      Customer may terminate this Agreement or any SOW for
+      convenience upon thirty (30) days' prior written notice
+      to Vendor. Upon a termination for convenience, Vendor
+      will, as of the effective date of termination, (a)
+      cease all work under the affected SOW or Agreement, (b)
+      deliver to Customer all completed and in-progress Work
+      Product as of the termination date, and (c) submit a
+      final invoice for (i) all completed and accepted Work
+      Product, (ii) work-in-progress as of the effective
+      termination date based on the percentage of completion
+      and the agreed pricing, and (iii) any reasonable,
+      documented unrecoverable third-party commitments Vendor
+      made specifically to perform the affected SOW work,
+      provided that the aggregate of items (ii) and (iii) does
+      not exceed twenty percent (20%) of the remaining unpaid
+      fees that would have been payable under the affected
+      SOW had it run to its scheduled completion. Customer
+      will pay Vendor's final invoice within thirty (30) days
+      of receipt, subject to the standard good-faith dispute
+      mechanism. Vendor will provide reasonable transition
+      assistance for a period of up to ninety (90) days
+      following the effective date of termination at Vendor's
+      then-current professional services rates, including
+      knowledge transfer and continued access to Work Product
+      in a structured, commonly used, and machine-readable
+      format.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Convenience termination with a longer notice period
+          (60 days) and a slightly higher termination fee cap
+          (30% of remaining fees). Acceptable when the
+          engagement is longer-duration or the Vendor's
+          unrecoverable costs are likely to be higher (e.g.,
+          dedicated personnel commitments).
+        language: |
+          Customer may terminate this Agreement or any SOW for
+          convenience upon sixty (60) days' prior written
+          notice. On termination, Customer will pay for
+          completed and accepted Work Product, work-in-progress
+          based on percentage completion, and reasonable
+          documented unrecoverable third-party commitments,
+          provided the aggregate termination payment does not
+          exceed thirty percent (30%) of remaining unpaid fees.
+          Vendor provides transition assistance for ninety
+          days post-termination.
+      - rank: 2
+        description: |
+          Convenience termination only at the end of a
+          Subscription Term or scheduled SOW completion; no
+          mid-SOW convenience right. Acceptable only when the
+          customer's risk of needing to exit mid-engagement is
+          low (e.g., a fixed-scope short-duration deliverable
+          where any need to exit can wait until completion).
+          Generally not recommended for longer or open-ended
+          engagements.
+        language: |
+          Customer may decline to renew or extend any SOW upon
+          thirty days' written notice before the scheduled
+          completion date. No mid-SOW convenience termination
+          right is granted; for early termination, the
+          termination-for-cause section governs.
+    redline_strategy: |
+      If the customer has no convenience termination right at
+      all, push for one — without it, the customer is locked
+      in even if business needs change materially. If the
+      notice period is longer than 30 days for mid-SOW
+      termination, push to 30. If the financial settlement
+      includes "lost profits" or "expected fees through end
+      of SOW," push down — customer should pay for completed
+      and in-progress work, not for opportunity. If the
+      termination fee cap is missing or exceeds 30% of
+      remaining fees, push down. If there's no transition
+      assistance obligation, add 90 days at standard
+      professional-services rates with knowledge transfer
+      and machine-readable Work Product delivery.
+    severity_if_missing: medium
+    detection_keywords:
+      - termination for convenience
+      - terminate without cause
+      - work in progress
+      - unrecoverable costs
+      - transition assistance
+      - wind down
+    detection_examples:
+      - >-
+        Customer may terminate this Agreement or any SOW for
+        convenience upon thirty days' prior written notice
+      - >-
+        On termination for convenience, Customer shall pay for
+        completed and in-progress Work Product and any
+        unrecoverable third-party commitments
+    position_order: 8
+  # ---------------------------------------------------------------------------
+  - issue: Governing Law and Venue
+    description: |
+      Which jurisdiction's law governs the agreement and where
+      disputes are resolved. Affects substantive contract law,
+      remedies, jury trial availability, and the cost /
+      convenience of enforcement. For U.S. commercial-purchase
+      MSAs, Delaware and New York are the standard neutral
+      choices.
+    standard_language: |
+      This Agreement is governed by and will be construed in
+      accordance with the laws of the State of Delaware, without
+      regard to its conflict-of-laws principles. The parties
+      hereby irrevocably submit to the exclusive jurisdiction
+      of the state and federal courts located in Wilmington,
+      Delaware for any dispute arising out of or relating to
+      this Agreement, and each party irrevocably waives any
+      objection to the venue of any such court on the grounds
+      of inconvenient forum or lack of jurisdiction. EACH PARTY
+      WAIVES ANY RIGHT TO A JURY TRIAL IN ANY DISPUTE ARISING
+      OUT OF OR RELATING TO THIS AGREEMENT. Before initiating
+      formal legal proceedings, the parties will attempt in
+      good faith to resolve any dispute by escalation to
+      designated executives of each party; if not resolved
+      within thirty (30) days of escalation, either party may
+      proceed to litigation.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          New York law and venue; widely-used alternative with
+          well-developed commercial-contract case law.
+          Acceptable when the parties are not Delaware-based
+          and want a familiar commercial forum.
+        language: |
+          This Agreement is governed by the laws of the State
+          of New York, without regard to conflict-of-laws
+          principles. The state and federal courts located in
+          New York County, New York have exclusive jurisdiction
+          over any dispute. Each party waives any right to a
+          jury trial. The parties will attempt in good faith
+          to resolve disputes by executive escalation before
+          litigation.
+      - rank: 2
+        description: |
+          AAA commercial arbitration in a neutral location with
+          expedited procedures. Acceptable when the parties
+          prefer a confidential, faster forum and are willing
+          to accept limited appellate review.
+        language: |
+          Any dispute arising out of or relating to this
+          Agreement will be finally resolved by binding
+          arbitration administered by the American Arbitration
+          Association under its Commercial Arbitration Rules
+          (including the Expedited Procedures for claims under
+          $1 million), with a single arbitrator and venue in
+          New York, New York. Judgment on the arbitration award
+          may be entered in any court of competent
+          jurisdiction.
+    redline_strategy: |
+      If the contract specifies the vendor's home jurisdiction
+      and the customer is not there, counter with Delaware or
+      New York (neutral commercial forums). If arbitration is
+      specified, evaluate whether the rules are reasonable —
+      for commercial-purchase MSAs, arbitration is acceptable
+      but check for class-action waivers, expedited procedure
+      thresholds, and any vendor-favorable rule selection. If
+      the contract waives jury trial unilaterally (vendor
+      only), push for mutuality. If there's no pre-litigation
+      executive-escalation mechanism, add one — it preserves
+      relationships and often resolves disputes before they
+      escalate.
+    severity_if_missing: medium
+    detection_keywords:
+      - governing law
+      - jurisdiction
+      - venue
+      - exclusive jurisdiction
+      - conflict of laws
+      - arbitration
+      - jury trial
+      - executive escalation
+    detection_examples:
+      - >-
+        This Agreement shall be governed by the laws of the
+        State of Delaware, without regard to conflict-of-laws
+        principles
+      - >-
+        Any dispute arising under this Agreement shall be
+        subject to the exclusive jurisdiction of the courts of
+        New York County
+    position_order: 9

--- a/skills/playbooks/msa-saas/playbook.yaml
+++ b/skills/playbooks/msa-saas/playbook.yaml
@@ -1,0 +1,1034 @@
+# =============================================================================
+# Built-in playbook: MSA — SaaS (vendor-customer, mid-market) (M3-A5)
+# =============================================================================
+#
+# A starter playbook for reviewing Master Services Agreements covering
+# general SaaS subscriptions, written from the customer's perspective.
+# Calibrated to mid-market commercial SaaS engagements — not enterprise
+# bespoke negotiations, not strategic platform deals, not regulated-
+# industry overlays (those need additional jurisdiction-specific or
+# industry-specific position sets).
+#
+# **THIS IS A STARTING POINT, NOT A VETTED TEMPLATE, AND IT IS NOT
+# LEGAL ADVICE.** The maintainer team has not reviewed or validated
+# the positions, fallback tiers, or redline strategies below. They
+# were drafted from public CC-BY-4.0 templates (Common Paper Cloud
+# Service Agreement; Bonterms Software License Agreement) as a
+# head-start for in-house counsel installing LQ.AI. You — the
+# attorney installing this software — must review every position
+# against your organization's standards and applicable jurisdiction
+# before relying on this playbook for any client work. Fork it,
+# customize it, or replace it entirely.
+#
+# Companion file: ``api/alembic/versions/0033_seed_builtin_playbooks_msa_dpa.py``
+# ships an identical snapshot into the ``playbooks`` +
+# ``playbook_positions`` tables at version 1.0.0. Edits here are not
+# retroactive to existing deployments — playbook updates ship as new
+# migration versions.
+#
+# =============================================================================
+
+name: MSA — SaaS (customer-perspective)
+contract_type: MSA-SaaS
+version: 1.0.0
+description: |
+  Master Services Agreement playbook for general SaaS subscriptions,
+  written from the customer's perspective. Covers the eleven
+  positions most likely to determine whether a SaaS MSA is fit for
+  purpose: service levels, security commitments, data handling,
+  intellectual property allocation, limitation of liability,
+  indemnification, termination, audit rights, payment terms,
+  governing law, and change management.
+
+  **This playbook is a starting point, not a vetted template, and it
+  is not legal advice.** The LQ.AI maintainer team has not reviewed
+  or validated the positions, fallback tiers, or redline strategies
+  below — they were drafted from public templates (Common Paper
+  CC-BY-4.0; Bonterms CC-BY-4.0) as a head-start for in-house counsel
+  installing LQ.AI. You must review every position against your
+  organization's standards and the applicable jurisdiction before
+  relying on this playbook for client work. Fork it, customize it,
+  or replace it entirely. Use of this playbook does not establish
+  an attorney-client relationship with LegalQuants or any
+  contributor.
+
+positions:
+  # ---------------------------------------------------------------------------
+  - issue: Service Level Agreement (uptime and remedies)
+    description: |
+      Vendor's commitment to service availability and the customer's
+      remedies when the vendor falls short. The uptime percentage,
+      the exclusions (scheduled maintenance, force majeure, customer-
+      caused downtime), and the remedy mechanism (service credits
+      versus refunds versus termination) together determine whether
+      the SLA is actually load-bearing or just a comfort clause.
+    standard_language: |
+      Vendor will use commercially reasonable efforts to make the
+      Service available with a Monthly Uptime Percentage of at least
+      99.9%, excluding (a) scheduled maintenance announced at least
+      forty-eight (48) hours in advance, (b) emergency maintenance
+      not to exceed two (2) hours per calendar month, (c) force
+      majeure events, and (d) downtime caused by Customer's acts or
+      omissions. If the Monthly Uptime Percentage falls below 99.9%
+      in a given calendar month, Customer is entitled to service
+      credits as follows: 10% of the monthly subscription fee for
+      that month if uptime is 99.0%–99.89%; 25% if 95.0%–98.99%; 50%
+      if below 95.0%. If the Service fails to meet 99.0% uptime in
+      any three consecutive months or any four months in a rolling
+      twelve-month period, Customer may terminate the Agreement for
+      cause and receive a pro-rata refund of any prepaid fees for
+      the unused portion of the term.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          99.5% uptime with the same credit and termination
+          structure. Acceptable for non-mission-critical applications
+          (internal collaboration tools, marketing automation) where
+          a few hours of monthly downtime is tolerable.
+        language: |
+          Vendor will use commercially reasonable efforts to make the
+          Service available with a Monthly Uptime Percentage of at
+          least 99.5%, subject to the standard exclusions. Service
+          credits apply at 10% / 25% / 50% as the Monthly Uptime
+          Percentage falls below 99.5% / 98.0% / 95.0% respectively.
+          Termination for cause is available after three consecutive
+          months below 98.0% uptime.
+      - rank: 2
+        description: |
+          99.0% uptime with credits-only remedy (no termination
+          right). Acceptable only for low-cost, easily-replaceable
+          services where the cost of switching exceeds the cost of
+          occasional downtime.
+        language: |
+          Vendor will use commercially reasonable efforts to maintain
+          a Monthly Uptime Percentage of at least 99.0%. If uptime
+          falls below this threshold in a given month, Customer's
+          sole remedy is a service credit equal to 10% of the monthly
+          subscription fee for that month.
+    redline_strategy: |
+      If the SLA lacks a definition of "Monthly Uptime Percentage"
+      (the formula matters: usually (total minutes - downtime
+      minutes) / total minutes, but some vendors exclude many
+      categories of downtime from the numerator), push for an
+      explicit formula. If the only remedy is "use commercially
+      reasonable efforts" with no service credits, push for credits
+      tied to specific uptime thresholds. If service credits are the
+      sole and exclusive remedy with no termination right for
+      sustained breach, push to add a termination trigger (three
+      consecutive months or four in twelve below threshold). If
+      scheduled maintenance is unlimited or undefined, cap it (e.g.,
+      four hours per month) and require advance notice.
+    severity_if_missing: high
+    detection_keywords:
+      - service level
+      - uptime
+      - availability
+      - service credit
+      - SLA
+      - downtime
+      - scheduled maintenance
+    detection_examples:
+      - >-
+        Vendor shall use commercially reasonable efforts to maintain
+        99.9% uptime, measured on a monthly basis
+      - >-
+        Customer's sole and exclusive remedy for any failure to
+        meet the service level shall be a service credit
+    position_order: 0
+  # ---------------------------------------------------------------------------
+  - issue: Security Commitments (controls and certifications)
+    description: |
+      The vendor's contractual security posture — what controls it
+      maintains, what certifications it holds, and how it
+      demonstrates ongoing compliance. The gap between "we have a
+      security program" (unenforceable) and "we maintain SOC 2 Type
+      II certification refreshed annually with reports available to
+      Customer under NDA" (enforceable) is the entire game.
+    standard_language: |
+      Vendor will maintain a written information security program
+      that includes administrative, physical, and technical
+      safeguards designed to protect Customer Data against
+      unauthorized access, use, disclosure, alteration, or
+      destruction. At a minimum, Vendor will: (a) maintain SOC 2
+      Type II certification (or equivalent ISO/IEC 27001
+      certification) with annual third-party assessments and make
+      the most recent report available to Customer under NDA upon
+      request, but no more than once per twelve-month period; (b)
+      encrypt Customer Data in transit using TLS 1.2 or higher and
+      at rest using AES-256 or equivalent; (c) maintain role-based
+      access controls with the principle of least privilege; (d)
+      conduct background checks on personnel with access to Customer
+      Data; (e) maintain a documented incident response plan and
+      test it at least annually; and (f) notify Customer of any
+      material change in certification status within thirty (30)
+      days.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Maintains a security program with annual third-party
+          assessment (allows SOC 2 Type I or equivalent in lieu of
+          Type II for emerging vendors). Acceptable for newer
+          vendors who are on a Type II roadmap; pair with a
+          contractual milestone to achieve Type II within twelve
+          months.
+        language: |
+          Vendor will maintain a written information security program
+          consistent with industry standards, including encryption of
+          Customer Data in transit and at rest, role-based access
+          controls, and annual third-party security assessment.
+          Vendor will provide its most recent third-party assessment
+          report to Customer under NDA upon request.
+      - rank: 2
+        description: |
+          Self-attestation of security controls without third-party
+          certification. Acceptable only for very low-risk
+          deployments (no sensitive data, no regulated data) where
+          the cost of imposing certification requirements exceeds
+          the marginal risk reduction.
+        language: |
+          Vendor will maintain administrative, physical, and
+          technical safeguards designed to protect Customer Data
+          and will encrypt Customer Data in transit and at rest.
+          Vendor will provide a written security overview upon
+          Customer's reasonable request.
+    redline_strategy: |
+      If the contract lacks any certification requirement, push for
+      SOC 2 Type II (or ISO 27001) as a minimum. If certifications
+      are listed but there is no obligation to maintain them or
+      notify Customer of changes, add the maintenance obligation
+      and the 30-day notification of material change. If encryption
+      standards are not specified (just "industry standard"),
+      specify TLS 1.2+ and AES-256+. If the contract is silent on
+      access reports, add the right to request the most recent
+      certification report under NDA once per year.
+    severity_if_missing: critical
+    detection_keywords:
+      - information security
+      - SOC 2
+      - ISO 27001
+      - encryption
+      - security program
+      - safeguards
+      - access controls
+    detection_examples:
+      - >-
+        Vendor shall maintain a security program consistent with
+        industry standards and SOC 2 Type II certification
+      - >-
+        All Customer Data shall be encrypted in transit and at
+        rest using industry-standard encryption
+    position_order: 1
+  # ---------------------------------------------------------------------------
+  - issue: Data Handling and Privacy
+    description: |
+      Who owns Customer Data, what the vendor may and may not do
+      with it, and how the relationship is structured under
+      applicable privacy laws. Distinct from the security position
+      (which addresses how data is protected) — this position
+      addresses what the data can be used for and who has rights to
+      it. Modern best practice: customer owns its data, vendor
+      processes per a companion DPA, and the vendor explicitly does
+      not use customer data for AI/ML model training.
+    standard_language: |
+      As between the parties, Customer retains all right, title, and
+      interest in and to Customer Data. Customer hereby grants
+      Vendor a limited, non-exclusive, non-transferable, worldwide
+      license to use, host, copy, transmit, display, and process
+      Customer Data solely to the extent necessary to (a) provide
+      the Service to Customer in accordance with this Agreement and
+      (b) prevent or address service or technical problems. Vendor
+      will not use Customer Data to train, fine-tune, or otherwise
+      develop machine-learning models for any purpose other than
+      providing the Service to Customer, and Vendor will not use
+      Customer Data to develop products or services that compete
+      with Customer. To the extent Vendor processes Personal Data
+      (as defined under applicable data protection laws) on behalf
+      of Customer, the parties will enter into a Data Processing
+      Addendum substantially in the form attached as Exhibit A,
+      which is incorporated into this Agreement by reference. Upon
+      termination or expiration of this Agreement, Vendor will,
+      within thirty (30) days, return or delete all Customer Data
+      at Customer's option, subject to retention required by
+      applicable law.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Customer owns its data; vendor's license is for service
+          provision and security; vendor may use aggregated and
+          anonymized data for product improvement. Acceptable when
+          aggregation is rigorous (cannot be reidentified) and the
+          aggregation right is bounded (no third-party sharing).
+        language: |
+          Customer owns Customer Data. Customer grants Vendor a
+          license to process Customer Data solely to provide the
+          Service and to maintain the security and integrity of the
+          Service. Vendor may use aggregated and anonymized data
+          derived from Customer Data for the purpose of improving
+          the Service, provided such data does not identify
+          Customer or any individual and is not shared with third
+          parties.
+      - rank: 2
+        description: |
+          Customer-owned data with vendor analytics rights and a
+          standard DPA for personal data processing. The weakest
+          position acceptable; explicitly does not foreclose
+          machine-learning use of customer data, which has become
+          a sharp issue in 2024-2025.
+        language: |
+          Customer retains ownership of Customer Data. Customer
+          grants Vendor a license to use Customer Data to operate
+          the Service, perform analytics, and improve the Service.
+          The parties will enter into a Data Processing Addendum
+          for the processing of any personal data.
+    redline_strategy: |
+      If the contract grants vendor a broad license to "use Customer
+      Data for any purpose," narrow it to service provision and
+      security. If the contract is silent on machine-learning, add
+      an explicit prohibition on using Customer Data to train or
+      fine-tune models. If the contract permits aggregated data
+      use but does not require de-identification, add a
+      reidentification prohibition. If the contract lacks a return-
+      or-delete obligation at termination, add the 30-day return-or-
+      delete mechanism. If a DPA is referenced but not attached or
+      mutually agreed, push to attach it before signature.
+    severity_if_missing: critical
+    detection_keywords:
+      - customer data
+      - data ownership
+      - data processing
+      - personal data
+      - DPA
+      - aggregated data
+      - machine learning
+      - model training
+    detection_examples:
+      - >-
+        Customer retains all right, title, and interest in and to
+        Customer Data
+      - >-
+        Vendor may use aggregated and anonymized data derived from
+        Customer Data for analytics and product improvement
+    position_order: 2
+  # ---------------------------------------------------------------------------
+  - issue: Intellectual Property Allocation
+    description: |
+      Who owns what in the SaaS relationship — vendor's underlying
+      service IP, customer's data and derivatives, customer's
+      feedback to the vendor, and any work product created jointly
+      or as part of professional services. The default lines:
+      vendor owns the platform, customer owns its data and outputs,
+      feedback is freely licensable to vendor.
+    standard_language: |
+      As between the parties: (a) Vendor retains all right, title,
+      and interest in and to the Service, including all
+      modifications, enhancements, and derivative works of the
+      Service, and all intellectual property rights therein
+      (collectively, "Vendor IP"); (b) Customer retains all right,
+      title, and interest in and to Customer Data and any reports,
+      analyses, or other outputs generated by the Service from
+      Customer Data ("Customer Outputs"), provided that Customer
+      Outputs do not include any Vendor IP; and (c) if Customer
+      provides Vendor with suggestions, comments, or other feedback
+      regarding the Service ("Feedback"), Customer hereby grants
+      Vendor a perpetual, irrevocable, royalty-free, worldwide
+      license to use, modify, and incorporate the Feedback into the
+      Service, provided that Vendor will not identify Customer as
+      the source of any Feedback without Customer's prior written
+      consent.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Standard allocation but with broader feedback license
+          (vendor may identify Customer as source of feedback).
+          Acceptable when the customer has no concern about being
+          associated with vendor's product development.
+        language: |
+          Vendor retains all rights in and to the Service. Customer
+          retains all rights in and to Customer Data and outputs
+          generated from Customer Data. Customer grants Vendor a
+          perpetual, royalty-free license to use any feedback
+          Customer provides regarding the Service.
+      - rank: 2
+        description: |
+          Customer-favorable variant: Customer owns Customer Data
+          and outputs; vendor owns the Service; feedback is
+          provided as-is with no broad license-back. Acceptable
+          when the customer expects to be a major contributor to
+          the vendor's roadmap and does not want a perpetual
+          unattributed license.
+        language: |
+          Each party retains all right, title, and interest in
+          their respective intellectual property. Customer Data
+          and outputs derived from Customer Data are owned by
+          Customer. The Service and all improvements to the
+          Service are owned by Vendor. Any feedback Customer
+          provides is provided on an as-is basis with no implied
+          license.
+    redline_strategy: |
+      If the contract assigns ownership of Customer Data outputs to
+      the vendor (or characterizes them as "derivative works of
+      the Service"), reverse that — customer outputs from customer
+      data should remain customer-owned. If the feedback license
+      lets vendor publicly attribute feedback to Customer, add a
+      consent requirement. If the contract is silent on outputs,
+      add explicit customer ownership of outputs derived from
+      customer data. If the contract characterizes customizations
+      or customer-configured workflows as vendor IP, push to
+      carve those out as customer-owned.
+    severity_if_missing: high
+    detection_keywords:
+      - intellectual property
+      - ownership
+      - work product
+      - feedback
+      - improvements
+      - derivative works
+      - IP rights
+    detection_examples:
+      - >-
+        Vendor retains all right, title, and interest in and to the
+        Service and any improvements or modifications thereto
+      - >-
+        Customer grants Vendor a perpetual, royalty-free license
+        to use any feedback or suggestions provided by Customer
+    position_order: 3
+  # ---------------------------------------------------------------------------
+  - issue: Limitation of Liability
+    description: |
+      The cap on damages and the exclusions from that cap. Without
+      a sensible LoL framework, a vendor's exposure can be
+      unbounded; with one that's too vendor-favorable, the customer
+      has no real recourse for material breach. The key questions:
+      how big is the cap (typically 1× or 2× annual fees), what's
+      mutual and what's one-way, and which categories of damages
+      are carved out from the cap (typically IP indemnification,
+      breach of confidentiality, gross negligence, willful
+      misconduct, data breach involving Personal Data).
+    standard_language: |
+      EXCEPT FOR EXCLUDED CLAIMS (DEFINED BELOW), EACH PARTY'S
+      AGGREGATE LIABILITY ARISING OUT OF OR RELATING TO THIS
+      AGREEMENT WILL NOT EXCEED THE TOTAL AMOUNTS PAID OR PAYABLE
+      BY CUSTOMER TO VENDOR UNDER THIS AGREEMENT IN THE TWELVE (12)
+      MONTHS PRECEDING THE EVENT GIVING RISE TO THE CLAIM. EXCEPT
+      FOR EXCLUDED CLAIMS, IN NO EVENT WILL EITHER PARTY BE LIABLE
+      FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL,
+      EXEMPLARY, OR PUNITIVE DAMAGES, OR FOR ANY LOST PROFITS, LOST
+      REVENUES, OR LOST DATA, EVEN IF ADVISED OF THE POSSIBILITY
+      OF SUCH DAMAGES. "EXCLUDED CLAIMS" MEANS (A) EITHER PARTY'S
+      INDEMNIFICATION OBLIGATIONS UNDER THIS AGREEMENT; (B) EITHER
+      PARTY'S BREACH OF ITS CONFIDENTIALITY OBLIGATIONS; (C) EITHER
+      PARTY'S GROSS NEGLIGENCE OR WILLFUL MISCONDUCT; (D) VENDOR'S
+      BREACH OF ITS DATA PROTECTION AND SECURITY OBLIGATIONS THAT
+      RESULTS IN A DATA BREACH AFFECTING PERSONAL DATA; AND (E)
+      AMOUNTS OWED FOR FEES.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Liability capped at 12 months fees with a super-cap (2×
+          fees) for data breach and security failures, rather than
+          full carveout. Acceptable when the vendor's risk appetite
+          is constrained and the customer's exposure to a data
+          breach is limited (low volume of personal data, low
+          regulatory risk).
+        language: |
+          Each party's aggregate liability is capped at the fees
+          paid in the preceding twelve months, except that
+          Vendor's liability for breach of its data protection and
+          security obligations resulting in a data breach is capped
+          at two (2) times that amount (the "Super-Cap"). The
+          standard cap and Super-Cap do not apply to either party's
+          indemnification obligations, breach of confidentiality,
+          gross negligence, or willful misconduct, which are
+          uncapped.
+      - rank: 2
+        description: |
+          Mutual cap at fees paid with narrower carveouts (IP
+          indemnification and willful misconduct only). Acceptable
+          only for low-risk, low-data-volume engagements; not
+          appropriate where Personal Data or trade secrets are at
+          stake.
+        language: |
+          Each party's aggregate liability under this Agreement is
+          capped at the total amounts paid or payable by Customer
+          to Vendor in the twelve (12) months preceding the event
+          giving rise to the claim. This cap does not apply to
+          either party's indemnification obligations under this
+          Agreement or to liability arising from a party's willful
+          misconduct.
+    redline_strategy: |
+      If the contract's LoL applies to ALL claims with no carveouts,
+      push for the standard carveout set (IP indemnification,
+      confidentiality breach, gross negligence, willful misconduct,
+      data breach). If the carveouts exist but data breach is not
+      among them, add it — data breach exposure can dwarf the
+      contract value. If the cap is "fees paid" rather than "fees
+      paid in the preceding 12 months," push for the 12-month
+      rolling cap. If the cap is one-way (vendor-favorable), push
+      for mutuality. If consequential damages are excluded for
+      vendor but not customer (asymmetric), push for mutuality.
+      If the cap is below 12 months fees (e.g., 3 months), push for
+      12 months or two times annual fees.
+    severity_if_missing: critical
+    detection_keywords:
+      - limitation of liability
+      - aggregate liability
+      - cap on damages
+      - consequential damages
+      - excluded claims
+      - super-cap
+      - indirect damages
+    detection_examples:
+      - >-
+        EACH PARTY'S AGGREGATE LIABILITY UNDER THIS AGREEMENT
+        SHALL NOT EXCEED THE FEES PAID IN THE PRECEDING TWELVE
+        MONTHS
+      - >-
+        IN NO EVENT SHALL EITHER PARTY BE LIABLE FOR ANY INDIRECT,
+        INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+    position_order: 4
+  # ---------------------------------------------------------------------------
+  - issue: Indemnification
+    description: |
+      The vendor's obligation to defend and indemnify the customer
+      against third-party claims arising from the customer's use of
+      the service (primarily IP infringement claims), and the
+      customer's reciprocal obligation for customer-data-related
+      claims against the vendor. The mutual conduct requirements
+      (notice, control of defense, settlement consent) make the
+      mechanism workable in practice.
+    standard_language: |
+      Vendor will defend Customer against any third-party claim
+      alleging that Customer's use of the Service as authorized
+      under this Agreement infringes such third party's
+      intellectual property rights (a "Vendor IP Claim"), and will
+      indemnify Customer against any damages and costs (including
+      reasonable attorneys' fees) finally awarded against Customer
+      by a court of competent jurisdiction or paid in a settlement
+      approved by Vendor in connection with such Vendor IP Claim.
+      Customer will defend Vendor against any third-party claim
+      arising from Customer Data, including any claim that the
+      collection or use of Customer Data violates applicable law
+      (a "Customer Data Claim"), and will indemnify Vendor against
+      any damages and costs finally awarded or paid in settlement.
+      The indemnifying party's obligations are conditioned on the
+      indemnified party (a) promptly notifying the indemnifying
+      party of the claim in writing, (b) giving the indemnifying
+      party sole control of the defense and settlement of the
+      claim (provided the indemnifying party may not settle any
+      claim that imposes a material obligation on the indemnified
+      party without its written consent), and (c) providing
+      reasonable cooperation in the defense at the indemnifying
+      party's expense. If a Vendor IP Claim arises or is likely to
+      arise, Vendor may, at its option, (i) procure for Customer
+      the right to continue using the Service, (ii) modify the
+      Service so it is non-infringing, or (iii) terminate the
+      Agreement and refund any prepaid fees for the unused portion
+      of the term.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Mutual IP indemnification with standard conduct
+          requirements, but without the explicit "modify-or-
+          refund" remedy ladder. Acceptable when the customer is
+          willing to rely on the broader indemnification language
+          without spelling out vendor's options.
+        language: |
+          Each party will defend and indemnify the other against
+          third-party claims that arise from a breach of this
+          Agreement by the indemnifying party. The indemnified
+          party will promptly notify the indemnifying party of any
+          claim and give the indemnifying party sole control of
+          the defense, subject to the indemnified party's consent
+          to any settlement imposing a material obligation on the
+          indemnified party.
+      - rank: 2
+        description: |
+          Vendor IP indemnification only (no customer-data
+          indemnification reciprocal). Acceptable when the
+          customer's use of the service does not involve
+          customer-provided content that creates third-party
+          claim exposure for the vendor (e.g., the customer is
+          uploading only its own internal data).
+        language: |
+          Vendor will defend Customer against any third-party
+          claim alleging that Customer's use of the Service as
+          authorized under this Agreement infringes such third
+          party's intellectual property rights, subject to the
+          standard conduct requirements (prompt notice, sole
+          control of defense, cooperation).
+    redline_strategy: |
+      If the contract lacks any indemnification, push for at least
+      a vendor IP indemnification — without it, a third-party
+      patent claim against the customer's use of the service is
+      the customer's problem. If the IP indemnification has
+      excessive carveouts (e.g., excludes claims arising from
+      "customer's use of the service" — circular), tighten the
+      carveouts to specific scenarios (combination with non-vendor
+      products, customer modifications, use outside the
+      documentation). If the indemnification lacks the "procure /
+      modify / terminate-and-refund" remedy ladder, add it — it's
+      what makes the indemnification operationally useful. If the
+      settlement consent right is missing, add it — without it,
+      vendor could settle on terms that bind customer.
+    severity_if_missing: high
+    detection_keywords:
+      - indemnification
+      - indemnify
+      - defend
+      - third-party claim
+      - infringement
+      - hold harmless
+    detection_examples:
+      - >-
+        Vendor shall defend, indemnify, and hold harmless Customer
+        from any third-party claim alleging that the Service
+        infringes intellectual property rights
+      - >-
+        The indemnified party shall promptly notify the
+        indemnifying party of any claim and provide sole control
+        of the defense
+    position_order: 5
+  # ---------------------------------------------------------------------------
+  - issue: Termination
+    description: |
+      How and when each party may exit the relationship. Covers
+      termination for cause (typically with a cure period for
+      material breach), termination for convenience (with notice
+      period and pro-rata refund), and the transition assistance
+      period during which the vendor continues providing the
+      service while the customer migrates off.
+    standard_language: |
+      Either party may terminate this Agreement for cause upon
+      thirty (30) days' prior written notice if the other party
+      materially breaches this Agreement and fails to cure such
+      breach within the notice period, except that no cure period
+      is required for breaches that by their nature cannot be
+      cured (such as a confidentiality breach involving public
+      disclosure or a breach of payment obligations after the
+      grace period). Customer may terminate this Agreement for
+      convenience upon ninety (90) days' prior written notice,
+      effective at the end of the then-current Subscription Term;
+      Customer's termination for convenience does not entitle
+      Customer to a refund of fees paid for the terminated term.
+      Upon any termination, the parties will cooperate in good
+      faith to facilitate an orderly transition. Vendor will
+      provide Customer with reasonable transition assistance for a
+      period of up to ninety (90) days after the effective date of
+      termination at Vendor's then-current professional services
+      rates, including continued access to Customer Data in a
+      machine-readable format and reasonable cooperation with
+      Customer's migration to a replacement service.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Termination for cause with 30-day cure; convenience
+          termination only at the end of the Subscription Term
+          with 60-day notice. Acceptable for multi-year terms
+          where the customer accepts that the term commitment is
+          the bargain — early exit costs the full prepaid fees.
+        language: |
+          Either party may terminate this Agreement for cause upon
+          thirty (30) days' prior written notice and opportunity
+          to cure. Customer may terminate this Agreement for
+          convenience effective at the end of the then-current
+          Subscription Term upon sixty (60) days' prior written
+          notice. The terminating party will receive a thirty
+          (30) day transition assistance period.
+      - rank: 2
+        description: |
+          Termination for cause only (no convenience termination
+          right). Acceptable only when the term is short (one year
+          or less) and the customer's switching cost is low.
+          Generally not recommended; the lack of a convenience
+          right is a significant constraint over a multi-year
+          relationship.
+        language: |
+          Either party may terminate this Agreement for cause upon
+          thirty (30) days' prior written notice and opportunity
+          to cure material breach. Either party may also terminate
+          immediately upon the other party's insolvency,
+          assignment for the benefit of creditors, or bankruptcy.
+    redline_strategy: |
+      If the contract lacks a customer right to terminate for
+      convenience, push for one — without it, the customer is
+      locked in for the full term regardless of service degradation
+      that doesn't rise to material breach. If termination for cause
+      lacks a cure period, push for 30 days. If the cure period
+      applies even to non-curable breaches (confidentiality, payment
+      default), carve those out. If the transition assistance
+      obligation is absent or capped at less than 90 days, push to
+      add or extend it — without transition assistance, customer
+      may face a hard cutoff that disrupts business operations. If
+      the data return obligation at termination is missing, add it
+      (see Data Handling position).
+    severity_if_missing: high
+    detection_keywords:
+      - termination
+      - terminate for cause
+      - terminate for convenience
+      - material breach
+      - cure period
+      - transition assistance
+      - wind-down
+    detection_examples:
+      - >-
+        Either party may terminate this Agreement for cause upon
+        thirty days' prior written notice if the other party
+        materially breaches this Agreement and fails to cure
+      - >-
+        Customer may terminate this Agreement for convenience
+        upon ninety days' prior written notice
+    position_order: 6
+  # ---------------------------------------------------------------------------
+  - issue: Audit Rights
+    description: |
+      The customer's right to verify vendor's compliance with the
+      contract, particularly for security and data handling
+      obligations. Without audit rights, the customer has no
+      independent way to verify representations the vendor makes
+      about its controls. The right has to be calibrated — too
+      narrow (only when there's reason to suspect a breach) and
+      it's unenforceable; too broad (unlimited inspections of
+      vendor facilities) and it's commercially unworkable.
+    standard_language: |
+      No more than once per twelve (12) month period (except in the
+      event of a confirmed security incident affecting Customer
+      Data, in which case the frequency limitation does not apply),
+      and upon at least thirty (30) days' prior written notice,
+      Customer may, at its own expense, conduct or have a mutually
+      acceptable third-party auditor (under NDA) conduct an audit
+      of Vendor's compliance with its security and data protection
+      obligations under this Agreement. The scope of the audit
+      will be reasonable in light of the obligations being audited
+      and will be conducted during normal business hours in a
+      manner that does not unreasonably interfere with Vendor's
+      operations. Vendor will provide reasonable cooperation,
+      including access to relevant personnel, policies, and
+      records. In lieu of an on-site audit, Vendor may satisfy this
+      obligation by providing Customer with a copy of Vendor's most
+      recent SOC 2 Type II report (or equivalent independent
+      assessment) under NDA. If an audit reveals a material
+      compliance failure, Vendor will reimburse Customer's
+      reasonable audit costs.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Audit right limited to vendor-provided third-party
+          certification reports (SOC 2, ISO 27001) with no
+          on-site audit right except after a confirmed material
+          breach. Acceptable for mid-market deployments where the
+          customer is willing to rely on the vendor's
+          certification rather than independent verification.
+        language: |
+          Vendor will provide its most recent SOC 2 Type II
+          report (or equivalent independent assessment) to
+          Customer under NDA upon request, not more than once per
+          twelve months. In the event of a material breach
+          affecting Customer Data, Customer may, at its own
+          expense and upon reasonable notice, conduct or have a
+          third-party auditor conduct a focused audit of the
+          breach scope.
+      - rank: 2
+        description: |
+          Self-attestation only with no third-party report and no
+          on-site audit. Acceptable only for very low-risk
+          engagements with no sensitive data; aligns with the
+          tier-2 fallback under Security Commitments.
+        language: |
+          Vendor will, upon Customer's reasonable request and not
+          more than once per twelve months, provide Customer with
+          a written attestation of compliance with Vendor's
+          security obligations under this Agreement and answer
+          reasonable security questionnaires.
+    redline_strategy: |
+      If the contract has no audit right at all, push for at least
+      a right to request the SOC 2 report under NDA annually.
+      If the audit right exists but is limited to "reasonable
+      cause" or "confirmed breach," push for a routine annual
+      right plus expanded rights after confirmed breach. If audit
+      costs are always vendor's expense (rare; vendor will push
+      back), accept customer-cost with vendor-cost-reimbursement
+      upon material finding. If the auditor must be a Big 4 firm
+      (vendor sometimes asks), push for "mutually acceptable
+      third-party auditor under NDA" instead.
+    severity_if_missing: medium
+    detection_keywords:
+      - audit
+      - inspection
+      - compliance audit
+      - third-party auditor
+      - SOC 2 report
+      - assessment
+    detection_examples:
+      - >-
+        Customer may, at its own expense and upon reasonable
+        prior written notice, audit Vendor's compliance with the
+        security obligations under this Agreement
+      - >-
+        Vendor shall provide a copy of its SOC 2 Type II report
+        to Customer under NDA upon request
+    position_order: 7
+  # ---------------------------------------------------------------------------
+  - issue: Payment Terms
+    description: |
+      How and when fees are paid, how disputes are handled, and
+      what happens when payment is late. Critical operational
+      details that can become deal-breakers in negotiation when
+      the customer's procurement process doesn't match the
+      vendor's standard terms.
+    standard_language: |
+      Customer will pay Vendor the fees set forth in the applicable
+      Order Form. Unless otherwise stated in the Order Form, all
+      fees are payable in U.S. dollars within thirty (30) days
+      after the date of Vendor's invoice. Fees are exclusive of all
+      taxes, levies, and duties imposed by any taxing authority
+      (excluding taxes based on Vendor's net income), and Customer
+      will be responsible for the payment of all such taxes. If
+      Customer fails to make any payment when due, then, in
+      addition to all other remedies that may be available, (a)
+      Vendor may charge interest on the past due amount at the
+      rate of one and one-half percent (1.5%) per month or the
+      highest rate permitted by applicable law (whichever is
+      lower), calculated daily and compounded monthly, and (b)
+      Vendor may suspend the Service upon ten (10) business days'
+      notice if the past-due amount has not been cured. Customer
+      may dispute any invoice in good faith by providing written
+      notice to Vendor within thirty (30) days of receipt of the
+      invoice, describing the basis of the dispute in reasonable
+      detail; the disputed amount will not accrue late fees or
+      give rise to suspension during good-faith resolution efforts,
+      but undisputed amounts must be paid when due.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Net 45 payment terms with standard suspension and late-
+          fee mechanics. Acceptable when the customer's procurement
+          process requires a longer cycle. Net 60 is increasingly
+          common in mid-market and is also acceptable for larger
+          customers.
+        language: |
+          Customer will pay all undisputed invoices within forty-
+          five (45) days of receipt. Late payments accrue interest
+          at 1.5% per month or the highest rate permitted by law.
+          Customer may dispute any invoice in good faith within
+          thirty days of receipt; disputed amounts will not accrue
+          late fees pending resolution.
+      - rank: 2
+        description: |
+          Net 60 with no suspension right for vendor (only the
+          late-fee remedy) and a longer dispute window. Acceptable
+          for large enterprise customers with established credit;
+          generally not recommended for mid-market.
+        language: |
+          Customer will pay all undisputed invoices within sixty
+          (60) days of receipt. Late payments accrue interest at
+          the rate of one percent per month or the highest rate
+          permitted by law. Customer may dispute any invoice in
+          good faith within forty-five days; pending good-faith
+          resolution, neither suspension nor late fees apply to
+          the disputed amount.
+    redline_strategy: |
+      If the payment terms are shorter than Net 30, push for at
+      least Net 30 — this is the market standard for B2B SaaS. If
+      late fees are above 1.5% per month, push down (state usury
+      laws often cap this). If the contract permits suspension
+      with less than 10 business days' notice, push for at least
+      10 business days. If there is no good-faith dispute
+      mechanism, add one — without it, customer must pay obviously
+      erroneous invoices to avoid suspension. If invoicing is
+      annual upfront but the customer wants quarterly or monthly,
+      negotiate (annual upfront is the vendor preference; quarterly
+      is acceptable for larger commitments).
+    severity_if_missing: medium
+    detection_keywords:
+      - payment terms
+      - net 30
+      - invoice
+      - late fees
+      - interest
+      - suspension
+      - dispute
+      - fees
+    detection_examples:
+      - >-
+        Customer shall pay all undisputed invoices within thirty
+        days of receipt
+      - >-
+        Late payments shall accrue interest at the rate of 1.5%
+        per month or the highest rate permitted by applicable law
+    position_order: 8
+  # ---------------------------------------------------------------------------
+  - issue: Governing Law and Venue
+    description: |
+      Which jurisdiction's law governs the agreement and where
+      disputes are resolved. Affects substantive contract law,
+      remedies, jury trial availability, and the cost / convenience
+      of enforcement. The market default for U.S. SaaS is Delaware
+      law (consistent body of commercial-contract case law); New
+      York is the common alternative.
+    standard_language: |
+      This Agreement is governed by and will be construed in
+      accordance with the laws of the State of Delaware, without
+      regard to its conflict-of-laws principles. The parties
+      hereby irrevocably submit to the exclusive jurisdiction of
+      the state and federal courts located in Wilmington, Delaware
+      for any dispute arising out of or relating to this Agreement,
+      and each party irrevocably waives any objection to the venue
+      of any such court on the grounds of inconvenient forum or
+      lack of jurisdiction. EACH PARTY WAIVES ANY RIGHT TO A JURY
+      TRIAL IN ANY DISPUTE ARISING OUT OF OR RELATING TO THIS
+      AGREEMENT.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          New York law and venue; widely-used alternative with
+          well-developed commercial-contract case law. Acceptable
+          when the parties are not Delaware-based and want a
+          familiar commercial forum.
+        language: |
+          This Agreement is governed by the laws of the State of
+          New York, without regard to conflict-of-laws principles.
+          The state and federal courts located in New York County,
+          New York have exclusive jurisdiction over any dispute.
+          Each party waives any right to a jury trial.
+      - rank: 2
+        description: |
+          California law and venue, often pushed by California-
+          based vendors. Less customer-favorable on commercial-
+          contract disputes than Delaware or New York (California
+          courts are sometimes more willing to set aside
+          contractual limitations as unconscionable). Acceptable
+          when the vendor is California-based and the customer is
+          willing to litigate there.
+        language: |
+          This Agreement is governed by the laws of the State of
+          California, without regard to conflict-of-laws
+          principles. The state and federal courts located in
+          San Francisco County, California have exclusive
+          jurisdiction over any dispute.
+    redline_strategy: |
+      If the contract specifies the vendor's home jurisdiction and
+      the customer is not there, counter with Delaware or New York
+      (neutral commercial forums). If arbitration is specified
+      (some vendors prefer JAMS or AAA arbitration), evaluate
+      whether it suits the customer's needs — arbitration is
+      faster and more confidential but less precedent-creating
+      and provides less appellate review. If the contract waives
+      jury trial unilaterally (vendor only) or for one type of
+      claim but not another, push for mutuality. If a class-action
+      waiver is included, evaluate whether it's enforceable in the
+      governing-law jurisdiction and whether customer wants it.
+    severity_if_missing: medium
+    detection_keywords:
+      - governing law
+      - jurisdiction
+      - venue
+      - exclusive jurisdiction
+      - conflict of laws
+      - arbitration
+      - jury trial
+    detection_examples:
+      - >-
+        This Agreement shall be governed by the laws of the State
+        of Delaware, without regard to conflict-of-laws principles
+      - >-
+        Any dispute arising under this Agreement shall be subject
+        to the exclusive jurisdiction of the courts of New York
+    position_order: 9
+  # ---------------------------------------------------------------------------
+  - issue: Change Management (price increases and material changes)
+    description: |
+      How the vendor may change the service, the pricing, or the
+      terms during the term, and what notice and customer rights
+      attach to those changes. Without explicit change-management
+      provisions, the customer can find itself with surprise
+      price increases, removed features, or unilaterally amended
+      terms. The structure: separate handling for service changes
+      (notice + minor changes permitted; material changes give
+      customer termination right), pricing changes (capped by a
+      formula or rate), and terms-of-service changes (formal
+      amendment process).
+    standard_language: |
+      Vendor may modify the Service from time to time, provided
+      that Vendor will not materially diminish the functionality
+      of the Service during the then-current Subscription Term.
+      For any material reduction in functionality or material
+      adverse change to the Service that Vendor announces during
+      the then-current Subscription Term, Vendor will provide
+      Customer with at least sixty (60) days' prior written
+      notice, and Customer may terminate the affected portion of
+      the Service for convenience upon written notice within
+      thirty (30) days of Vendor's announcement, with a pro-rata
+      refund of any prepaid fees for the terminated portion of
+      the unused term. Vendor may increase fees for renewal terms
+      by providing Customer with at least ninety (90) days' prior
+      written notice before the start of the renewal term;
+      Customer may decline to renew if the proposed increase is
+      not acceptable. Vendor will not modify the terms of this
+      Agreement (other than the Service itself, as governed by
+      this Section) without Customer's written consent, except
+      that Vendor may make changes to its Acceptable Use Policy
+      or similar operational policies referenced in this Agreement
+      upon at least thirty (30) days' prior written notice.
+    fallback_tiers:
+      - rank: 1
+        description: |
+          Material change rights with shorter notice (30 days for
+          material changes; 60 days for renewal-term price
+          increases) and the same termination remedy. Acceptable
+          when the vendor's release cadence is faster and the
+          customer prefers the agility tradeoff.
+        language: |
+          Vendor may modify the Service with thirty (30) days'
+          notice for material changes; Customer may terminate the
+          affected portion within fifteen days of such notice
+          with a pro-rata refund. Vendor may increase fees for
+          renewal terms upon sixty (60) days' prior notice;
+          Customer may decline to renew if the proposed increase
+          is not acceptable.
+      - rank: 2
+        description: |
+          Service-modification right with no Customer termination
+          remedy except at the end of the Subscription Term;
+          pricing increases capped to a formula (e.g., CPI + 3%
+          per renewal). Acceptable when the customer can absorb
+          mid-term service changes without an exit right but
+          wants predictable pricing.
+        language: |
+          Vendor may modify the Service from time to time at its
+          discretion. Vendor may increase fees for renewal terms
+          by no more than the greater of (a) three percent (3%)
+          or (b) the percentage change in the Consumer Price Index
+          for All Urban Consumers (CPI-U) over the preceding
+          twelve months. Customer may decline to renew at the end
+          of the then-current Subscription Term.
+    redline_strategy: |
+      If the contract permits unilateral mid-term material
+      changes with no customer remedy, add the material-change
+      termination right with pro-rata refund. If pricing
+      increases at renewal are unconstrained, push for a CPI-
+      based cap or a fixed percentage cap (CPI + 3% is
+      reasonable). If the contract permits unilateral amendment
+      of the agreement terms (sometimes by changing a referenced
+      online policy), tighten — operational policies (AUP) are
+      acceptable to change with notice; agreement terms should
+      require mutual amendment. If the change-notice period is
+      less than 60 days for material changes, push for 60.
+    severity_if_missing: medium
+    detection_keywords:
+      - modification
+      - changes to the service
+      - price increase
+      - renewal pricing
+      - acceptable use policy
+      - amendment
+      - notice of change
+    detection_examples:
+      - >-
+        Vendor may modify the Service from time to time provided
+        that Vendor will not materially reduce the functionality
+        during the then-current term
+      - >-
+        Vendor may increase fees for renewal terms upon ninety
+        days prior written notice
+    position_order: 10


### PR DESCRIPTION
## Summary

M3 Phase A, fifth task. Adds three built-in playbooks alongside the two NDA playbooks from M3-A3, so v0.3 ships with 5 built-ins covering the most common in-house contract types:

| Playbook | Positions | Lines | Severity mix |
|---|---|---|---|
| MSA — SaaS (customer-perspective) | 11 | 1,034 | 3 critical, 4 high, 4 medium |
| DPA — GDPR (controller-to-processor) | 8 | 890 | 4 critical, 3 high, 1 medium |
| MSA — Commercial Services (purchase-side) | 10 | 1,082 | 1 critical, 5 high, 4 medium |
| **Total new** | **29** | **3,006** | |

Each playbook covers the positions documented in M3-IMPLEMENTATION-PLAN.md §M3-A5 scope, with the M3-A3 structural template: ≥2 fallback tiers per position, redline strategy, severity, detection keywords, detection examples.

## Posture: starting points, not vetted templates

Per the 2026-05-19 reframe of Decision F (committed to `feedback_no_maintainer_legal_review.md` memory + the M3-A5 prep doc), **the maintainer team has not reviewed or validated the legal content**. The in-house attorney installing LQ.AI is the validator. Each playbook's description carries the explicit "starting point, not a vetted template, not legal advice" framing — stronger than the M3-A3 NDA descriptions, which used implicit "operator's responsibility to apply professional judgment" language. Worth a follow-on PR to retro-update M3-A3 descriptions to match.

Sources cited in each playbook's header comment:
- **MSA-SaaS** — Common Paper Cloud Service Agreement (CC-BY-4.0); Bonterms Software License Agreement (CC-BY-4.0)
- **DPA-GDPR** — EU Commission SCCs Implementing Decision 2021/914 Module Two (public-domain); EDPB Guidelines 07/2020 + Recommendations 01/2020
- **MSA-Commercial-Purchase** — Common Paper Master Subscription Agreement (CC-BY-4.0), adapted to the purchase side

## Engineering scaffold

* `api/alembic/versions/0033_seed_builtin_playbooks_msa_dpa.py` — idempotent seed migration mirroring 0032 verbatim (3 slugs instead of 2); reads YAML at upgrade time.
* `api/tests/test_builtin_msa_dpa_playbooks.py` — 33 tests:
  * **8 unit tests × 3 slugs = 24** structural validators (YAML parses, Pydantic schema, position count, ≥2 fallback tiers, required string fields, fallback-tier shape, dense zero-indexed position order, disclaimer in description)
  * **2 integration tests × 3 slugs = 6** migration round-trip (playbook row + positions match YAML byte-for-byte)
  * **1 integration test × 3 slugs = 3** executor smoke (load seeded playbook from DB, run executor against a synthetic contract, assert N classify calls + N positions in results)

## Test deltas

| Suite | Baseline (post-M3-A4) | After M3-A5 | Delta |
|---|---|---|---|
| `api/` pytest | 1112 | 1126 | **+14** (parametrized; +33 raw cases) |
| Total playbook-related tests | 21 | 51 | +30 |

All gates green: ruff format + check, pytest, no regressions on M3-A3 or M3-A4 tests.

## Deferred from M3-A5 scope (recorded for M3 milestone summary)

1. **Sample contracts as external fixtures under `api/tests/fixtures/m3-a5/`** — the M3-A5 spec mentioned this, but the M3-A3 precedent is inline synthetic documents. Followed the precedent; documented inline in the test file's module docstring.
2. **Retro-update M3-A3 NDA playbook descriptions to match the stronger M3-A5 "starting point" framing** — small docs change, worth a separate small PR.
3. **`.dockerignore` for `* [0-9].*` Finder duplicates** — the local working tree keeps regenerating duplicate files that break docker builds. Hit during M3-A4 (3×) and again during M3-A5. Worth a one-PR fix: `.dockerignore` excluding `* [0-9].*` patterns + a one-line script that cleans them out for local dev.

## Out-of-scope explicitly NOT in M3-A5

- Per-playbook fallback ladder tuning based on real-world usage (M3-A6 wizard generates these from operator's prior agreements)
- Multi-jurisdiction variants (US + EU + UK governing law) — all M3-A5 playbooks default to US-Delaware framing
- Industry-specific overlays (HIPAA, GLBA, FedRAMP) — candidate community contributions
- TIA template for DPA-GDPR — referenced in position 3 but not a full template

## Test plan

- [x] `api/` pytest green (1126 / 1 skipped; +14 from baseline)
- [x] M3-A3 + M3-A4 regression: 51 playbook-related tests all pass
- [x] ruff format + ruff check clean
- [x] Each playbook's description includes "not legal advice" + ("professional judgment" OR "starting point") — pinned by test
- [x] Migration 0033 round-trips against `playbooks` + `playbook_positions` tables (byte-for-byte YAML match)
- [x] Executor smoke tests pass for all three new playbooks
- [ ] **Manual UI check** (Kevin or any future user): visit `/lq-ai/playbooks` and confirm 5 built-ins are listed (NDA — Mutual, NDA — Unilateral (Discloser-favorable), MSA — SaaS, DPA — GDPR, MSA — Commercial Services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)