### PR TITLE
docs(playbooks,m3-a3): retro-update NDA descriptions to match M3-A5 starting-point framing

### DIFF
--- a/skills/playbooks/nda-unilateral/playbook.yaml
+++ b/skills/playbooks/nda-unilateral/playbook.yaml
@@ -8,10 +8,13 @@
 # evaluation. Positions skew toward stronger Disclosing-Party protection
 # than the mutual variant.
 #
-# **Not legal advice.** Same posture as the mutual playbook: every
-# position represents one reasonable market position drafted by the
-# maintainer team. Operators must apply professional judgment and seek
-# licensed counsel before relying on this content.
+# **THIS IS A STARTING POINT, NOT A VETTED TEMPLATE, AND IT IS NOT
+# LEGAL ADVICE.** Same posture as the mutual NDA playbook: the
+# maintainer team has not reviewed or validated the legal content.
+# Positions were drafted as one reasonable market position to give
+# in-house counsel installing LQ.AI a head-start. You must apply
+# your own professional judgment and seek licensed counsel before
+# relying on this content for any client work.
 #
 # Companion file: ``api/alembic/versions/0032_seed_builtin_playbooks_nda.py``
 # ships an identical snapshot at version 1.0.0.
@@ -30,11 +33,18 @@ description: |
   what's "medium" in a mutual NDA may be "high" here because the
   Disclosing Party bears all the downside.
 
-  **This playbook is not legal advice.** Operators must apply
-  professional judgment, customize for their organization, and seek
-  licensed counsel for jurisdiction-specific or transaction-specific
-  variance. Use of this playbook does not establish an attorney-client
-  relationship with LegalQuants or any contributor.
+  **This playbook is a starting point, not a vetted template, and it
+  is not legal advice.** The LQ.AI maintainer team has not reviewed
+  or validated the positions, fallback tiers, or redline strategies
+  below — they were drafted as one reasonable market position to
+  give in-house counsel a head-start. You must apply your own
+  professional judgment, review every position against your
+  organization's standards and the applicable jurisdiction before
+  relying on this playbook for client work, and seek licensed
+  counsel for jurisdiction-specific or transaction-specific
+  variance. Fork it, customize it, or replace it entirely. Use of
+  this playbook does not establish an attorney-client relationship
+  with LegalQuants or any contributor.
 
 positions:
   # ---------------------------------------------------------------------------

--- a/skills/playbooks/nda/playbook.yaml
+++ b/skills/playbooks/nda/playbook.yaml
@@ -2,17 +2,20 @@
 # Built-in playbook: NDA — Mutual (M3-A3)
 # =============================================================================
 #
-# This is the canonical starter playbook for routine mutual non-disclosure
-# agreement review. It codifies a balanced, both-sides-protected posture
-# typical of vendor-evaluation, partnership-exploration, and customer-
-# engagement contexts.
+# A starter playbook for reviewing mutual non-disclosure agreements. It
+# codifies a balanced, both-sides-protected posture typical of
+# vendor-evaluation, partnership-exploration, and customer-engagement
+# contexts.
 #
-# **Not legal advice.** Every position, fallback tier, and redline strategy
-# here represents one reasonable market position drafted by the maintainer
-# team and reviewed before merge. It is not legal advice and must not be
-# relied upon without review by a legal professional licensed to practice
-# in the relevant jurisdiction. Operators are expected to apply their own
-# professional judgment, fork this playbook for their organization's
+# **THIS IS A STARTING POINT, NOT A VETTED TEMPLATE, AND IT IS NOT
+# LEGAL ADVICE.** The maintainer team has not reviewed or validated
+# the positions, fallback tiers, or redline strategies below. They
+# were drafted as one reasonable market position to give in-house
+# counsel installing LQ.AI a head-start. You — the attorney
+# installing this software — must review every position against your
+# organization's standards and applicable jurisdiction before
+# relying on this playbook for any client work. Apply your own
+# professional judgment, fork this playbook for your organization's
 # specific standards, or replace it entirely.
 #
 # Companion file: ``api/alembic/versions/0032_seed_builtin_playbooks_nda.py``
@@ -31,12 +34,18 @@ description: |
   of confidential information, permitted disclosures, term, survival,
   carveouts, remedies, governing law, and return / destruction.
 
-  **This playbook is not legal advice.** Every position represents one
-  reasonable market posture; it is the operator's responsibility to apply
-  professional judgment, customize for their organization, and seek
-  licensed counsel for jurisdiction-specific or transaction-specific
-  variance. Use of this playbook does not establish an attorney-client
-  relationship with LegalQuants or any contributor.
+  **This playbook is a starting point, not a vetted template, and it
+  is not legal advice.** The LQ.AI maintainer team has not reviewed
+  or validated the positions, fallback tiers, or redline strategies
+  below — they were drafted as one reasonable market position to
+  give in-house counsel a head-start. You must apply your own
+  professional judgment, review every position against your
+  organization's standards and the applicable jurisdiction before
+  relying on this playbook for client work, and seek licensed
+  counsel for jurisdiction-specific or transaction-specific
+  variance. Fork it, customize it, or replace it entirely. Use of
+  this playbook does not establish an attorney-client relationship
+  with LegalQuants or any contributor.
 
 positions:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Small docs alignment: retro-update the M3-A3 NDA — Mutual and NDA — Unilateral playbook descriptions to use M3-A5's stronger "starting point, not a vetted template" framing.

The M3-A3 descriptions used implicit framing ("operator's responsibility to apply professional judgment") that was technically consistent with Decision F but read as softer than M3-A5's explicit framing. The 2026-05-19 posture clarification (see `feedback_no_maintainer_legal_review.md`) locked in: the maintainer team does NOT review legal content; the in-house attorney is the validator; built-in playbooks are starting points / placeholders.

This commit makes the NDA descriptions explicit on that posture, matching the M3-A5 playbooks. Also removes one inadvertently-inaccurate line from the NDA-Mutual header comment ("drafted by the maintainer team and reviewed before merge") that conflicted with the actual posture.

## What changed

| File | Change |
|---|---|
| `skills/playbooks/nda/playbook.yaml` | Header comment + `description` updated to explicit "starting point, not a vetted template" framing |
| `skills/playbooks/nda-unilateral/playbook.yaml` | Same update; the unilateral variant had similar implicit framing |

**No legal content modified** — descriptions only. Positions, fallback tiers, redline strategies, severities, detection keywords/examples all unchanged.

## Tests

Both descriptions retain "professional judgment" alongside the new "starting point" phrasing, so:
- `test_description_includes_not_legal_advice_disclaimer` (M3-A3; strict on "professional judgment") still passes
- M3-A5's test (accepts either idiom) still passes

Verified: 50/50 tests pass across `test_builtin_nda_playbooks.py` + `test_builtin_msa_dpa_playbooks.py`.

## Migration drift caveat

Migration 0032's idempotency check (skip-if-(name, version)-exists) means existing operator stacks that have already run 0032 will NOT automatically see the new description — the v1.0.0 DB rows are locked. The YAML is now source-of-truth-correct for:
- Fresh installs (operators running 0032 for the first time)
- Operators who wipe + reapply

For description-only changes (no semantic content), the YAML-truth update is sufficient. A v1.0.1 backport migration is possible but not pursued here. Filed as a candidate follow-on if anyone wants existing stacks to surface the updated framing without a wipe.

## Test plan

- [x] Both NDA YAMLs parse and validate against `PlaybookCreate`
- [x] M3-A3 disclaimer test passes (description contains "not legal advice" AND "professional judgment")
- [x] M3-A5 disclaimer test passes (description contains "not legal advice" AND ("professional judgment" OR "starting point"))
- [x] Migration round-trip test passes (DB description matches YAML after fresh seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)