### PR TITLE
M3 Phase C — Tabular / Multi-Document Review (M3-C1 in progress)

### DIFF
--- a/api/alembic/versions/0036_tabular_executions.py
+++ b/api/alembic/versions/0036_tabular_executions.py
@@ -1,0 +1,190 @@
+"""create tabular_executions table — M3-C2
+
+The Tabular Review LangGraph workflow (M3-C2) runs as an ARQ-dispatched
+async job on the existing ``arq:m3a6`` queue (Decision C-3 from the
+Phase C prep doc: reuse the queue, don't add a second worker
+container). Each execution walks ``documents x columns`` and produces
+a row-per-document by column-per-spec grid; this table persists the
+inputs + status + results so the result view can re-render the grid
+a week later.
+
+Schema
+------
+
+* ``id`` — UUID PK.
+* ``user_id`` — caller's user id; nullable + ``ON DELETE SET NULL``
+  so historical executions survive operator deletion (matches the
+  ``easy_playbook_generations.user_id`` posture from migration 0035).
+* ``parent_execution_id`` — UUID nullable self-FK; non-null on bulk-op
+  sibling rows (Decision C-9: bulk ops spawn sibling
+  ``tabular_executions`` rows rather than mutating the original grid,
+  preserving the original's auditability). ``ON DELETE SET NULL`` so
+  deleting a parent doesn't cascade-delete siblings.
+* ``skill_name`` — text nullable; the source skill's ``name``
+  (filesystem-canonical, not DB-backed; matches the Skill Service
+  reference style elsewhere in the codebase). Null for ad-hoc
+  executions where the operator typed columns directly in the
+  wizard's column step.
+* ``status`` — lifecycle
+  ``pending -> running -> completed | failed | cancelled``.
+  CHECK-constrained at the storage layer.
+* ``document_ids`` — array of source document UUIDs from the
+  caller's selection. NOT a foreign key (documents can be
+  soft-deleted after execution completes; we preserve the row
+  for audit; matches the ``easy_playbook_generations`` pattern).
+* ``columns`` — JSONB; the resolved column spec at execution start
+  (snapshot of the skill's ``lq_ai.columns`` block OR the operator's
+  ad-hoc list). Snapshotting at execution start is the load-bearing
+  invariant: re-rendering the grid later must be honest about what
+  was actually run, not what the skill currently says.
+* ``results`` — JSONB nullable; the assembled grid shape
+  ``{rows: [{document_id, document_name, cells: {column_name:
+  CellResult}}]}`` once status is ``completed``.
+* ``cost_estimate_usd`` — numeric nullable; the operator-confirmed
+  estimate at execution start (from ``POST /tabular/preview-cost``).
+* ``cost_actual_usd`` — numeric nullable; populated incrementally
+  by the worker as cells complete. Operators see drift between
+  estimate and actual in the result view.
+* ``error_text`` — text nullable; populated on ``status='failed'``.
+* ``created_at`` / ``started_at`` / ``completed_at`` / ``deleted_at``
+  — lifecycle timestamps. ``deleted_at`` enables soft delete per
+  Decision C-9 (matches the M3-A6 ``playbooks.deleted_at`` pattern
+  from migration 0034).
+
+Indexes
+-------
+
+* ``(user_id, created_at DESC)`` partial index where
+  ``deleted_at IS NULL`` — the list endpoint sorts the caller's
+  non-deleted executions by recency.
+* ``(parent_execution_id)`` — bulk-op siblings query their parent.
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2026-05-21
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0036"
+down_revision = "0035"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tabular_executions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "users.id",
+                ondelete="SET NULL",
+                name="fk_tabular_executions_user_id",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "parent_execution_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "tabular_executions.id",
+                ondelete="SET NULL",
+                name="fk_tabular_executions_parent_execution_id",
+            ),
+            nullable=True,
+        ),
+        sa.Column("skill_name", sa.Text(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "document_ids",
+            postgresql.ARRAY(postgresql.UUID(as_uuid=True)),
+            nullable=False,
+            server_default=sa.text("'{}'::uuid[]"),
+        ),
+        sa.Column(
+            "columns",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "results",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "cost_estimate_usd",
+            sa.Numeric(10, 4),
+            nullable=True,
+        ),
+        sa.Column(
+            "cost_actual_usd",
+            sa.Numeric(10, 4),
+            nullable=True,
+        ),
+        sa.Column("error_text", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "completed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "deleted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending','running','completed','failed','cancelled')",
+            name="chk_tabular_executions_status",
+        ),
+    )
+
+    op.execute(
+        """
+        CREATE INDEX idx_tabular_executions_user_recent
+            ON tabular_executions (user_id, created_at DESC)
+            WHERE deleted_at IS NULL
+        """
+    )
+
+    op.execute(
+        """
+        CREATE INDEX idx_tabular_executions_parent
+            ON tabular_executions (parent_execution_id)
+            WHERE parent_execution_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_tabular_executions_parent")
+    op.execute("DROP INDEX IF EXISTS idx_tabular_executions_user_recent")
+    op.drop_table("tabular_executions")

--- a/api/app/api/__init__.py
+++ b/api/app/api/__init__.py
@@ -40,6 +40,7 @@ from app.api import (
     projects,
     saved_prompts,
     skills,
+    tabular,
     teams,
     user_skills,
     users,
@@ -93,6 +94,12 @@ api_router.include_router(admin.router, dependencies=_active)
 # (``/playbooks/{id}/execute`` and ``/playbook-executions/{id}``) so
 # they live alongside the M3-A4 list/CRUD endpoints in the same module.
 api_router.include_router(playbooks_api.router, dependencies=_active)
+# M3-C2: Tabular / Multi-Document Review surface (PRD §3.14). Six
+# endpoints under /tabular/ — preview-cost / execute / list / detail /
+# delete / cancel. The shared playbook ARQ worker
+# (:mod:`app.workers.tabular_worker`) consumes from the same queue
+# as Easy Playbook per Phase C prep doc Decision C-3.
+api_router.include_router(tabular.router, dependencies=_active)
 # M3-B1: Word add-in admin surface (manifest generation). Mounted with
 # the AdminUser dep at handler level. M3-B8's version-handshake route
 # lives in the same module but on a separate ``public_router`` mounted

--- a/api/app/api/tabular.py
+++ b/api/app/api/tabular.py
@@ -54,7 +54,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -167,8 +167,11 @@ async def _load_caller_owned_documents(
 
     Mirrors the M3-A6 Easy Playbook helper. The visibility rule:
     each :class:`Document` has a parent :class:`File` whose
-    ``owner_id`` must match the caller (admins see all). Missing /
-    cross-owner documents collapse into "not found" at the caller.
+    ``owner_id`` must match the caller (admins see all) AND which
+    has not been soft-deleted. Missing / cross-owner / soft-deleted
+    documents collapse into "not found" at the caller — running
+    tabular extraction over documents the user no longer "has"
+    would surprise on the audit trail.
     """
 
     from app.models.file import File as FileModel
@@ -177,6 +180,7 @@ async def _load_caller_owned_documents(
         select(Document)
         .where(Document.id.in_(document_ids))
         .join(FileModel, Document.file_id == FileModel.id)
+        .where(FileModel.deleted_at.is_(None))
     )
     if not user.is_admin:
         stmt = stmt.where(FileModel.owner_id == user.id)
@@ -375,13 +379,14 @@ async def get_tabular_execution(
     "/tabular/executions/{execution_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Soft-delete a tabular execution.",
+    response_class=Response,
 )
 async def delete_tabular_execution(
     execution_id: uuid.UUID,
     user: ActiveUser,
     request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
-) -> None:
+) -> Response:
     """Soft-delete (sets ``deleted_at``). Already-deleted rows return 404."""
 
     row = await _load_caller_execution(db, execution_id=execution_id, user=user)
@@ -395,6 +400,7 @@ async def delete_tabular_execution(
         request=request,
     )
     await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post(

--- a/api/app/api/tabular.py
+++ b/api/app/api/tabular.py
@@ -1,0 +1,510 @@
+"""Tabular / Multi-Document Review endpoints — M3-C2.
+
+Surface (per [PRD §3.14](docs/PRD.md#314-tabular--multi-document-review-m3)):
+
+* ``POST   /api/v1/tabular/preview-cost`` — synchronous cost preview;
+  no execution row is created. The UI calls this before showing the
+  confirmation modal (Decision C-5).
+* ``POST   /api/v1/tabular/execute`` — kick off a tabular execution.
+  Creates a :class:`TabularExecution` row at ``status='pending'``,
+  enqueues the ARQ worker job on the shared playbook queue (per
+  Decision C-3 — same queue as Easy Playbook). Returns 202 + the row.
+* ``GET    /api/v1/tabular/executions`` — list the caller's
+  executions (paginated, recent-first, soft-deleted excluded).
+* ``GET    /api/v1/tabular/executions/{id}`` — full state + grid.
+* ``DELETE /api/v1/tabular/executions/{id}`` — soft delete; sets
+  ``deleted_at``.
+* ``POST   /api/v1/tabular/executions/{id}/cancel`` — set status to
+  ``cancelled``; the worker honours this on the next cell-iteration
+  boundary check.
+
+Authorization
+-------------
+
+Router-level ``Depends(get_active_user)`` gates every endpoint.
+Per-endpoint: rows are scoped to ``user_id == caller.id`` (admins
+see everything). 404 collapses missing + unauthorized (no
+information leakage), matching the M3-A6 Easy Playbook posture.
+
+Column-spec resolution
+----------------------
+
+Either ``skill_name`` (resolved at execution start from the live
+:class:`SkillRegistry` by reading the skill's
+``lq_ai.columns``) OR ``columns`` (ad-hoc spec) is required. The
+resolved column list is snapshotted onto the row at request time
+(Decision C-1 snapshotting posture: re-rendering the grid a week
+later must be honest about what was actually run).
+
+Cost-preview shape
+------------------
+
+Per Decision C-5, the preview returns ``cells_count``,
+``estimated_tokens``, ``estimated_cost_usd``, and a
+``per_tier_breakdown`` informational map. The frontend gates the
+big "Run" button behind a confirmation checkbox for previews
+above ``CONFIRMATION_THRESHOLD_USD`` ($1.00 default per the prep
+doc — the threshold is enforced UI-side, not server-side).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import ActiveUser
+from app.audit import audit_action
+from app.db.session import get_db
+from app.models.document import Document
+from app.models.tabular import TabularExecution
+from app.schemas.tabular import (
+    ColumnSpec,
+    TabularExecutionCreate,
+    TabularExecutionResponse,
+    TabularExecutionSummary,
+    TabularPreviewCostRequest,
+    TabularPreviewCostResponse,
+)
+from app.skills.registry import MutableSkillRegistry
+from app.tabular.cost import estimate_tabular_execution_cost
+from app.workers.queue import enqueue_tabular_execution_job
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["tabular"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _registry(request: Request) -> MutableSkillRegistry:
+    """Return the live :class:`MutableSkillRegistry` from app state.
+
+    Mirrors :func:`app.api.skills._registry`. The lifespan handler
+    installs ``app.state.skill_registry``; if the handler is somehow
+    exercised before that, surface a clear error rather than
+    AttributeError.
+    """
+
+    holder: MutableSkillRegistry | None = getattr(request.app.state, "skill_registry", None)
+    if holder is None:
+        from app.errors import InternalError
+
+        raise InternalError(
+            message="Skill registry is not initialised; the API process is "
+            "not yet ready to serve tabular requests.",
+            details={"hint": "lifespan startup did not run"},
+        )
+    return holder
+
+
+def _resolve_columns(
+    request: Request,
+    *,
+    skill_name: str | None,
+    ad_hoc: list[ColumnSpec] | None,
+) -> tuple[str | None, list[ColumnSpec]]:
+    """Resolve the request's column spec to (skill_name, columns).
+
+    Either ``skill_name`` OR ``ad_hoc`` must be supplied. When
+    ``skill_name`` is given, look up the registered skill's
+    ``lq_ai.columns`` and snapshot the list. When ``ad_hoc`` is
+    given, use it directly. Both-or-neither is a 400.
+
+    Returns the resolved skill_name (None for ad-hoc) + a non-empty
+    list of :class:`ColumnSpec`. Raises HTTPException(400) on
+    validation errors and HTTPException(404) on unknown skill /
+    skill-without-columns.
+    """
+
+    if skill_name and ad_hoc:
+        raise HTTPException(
+            status_code=400,
+            detail="provide either skill_name or columns, not both",
+        )
+    if not skill_name and not ad_hoc:
+        raise HTTPException(
+            status_code=400,
+            detail="provide either skill_name or columns",
+        )
+
+    if skill_name:
+        record = _registry(request).current().get(skill_name)
+        if record is None:
+            raise HTTPException(status_code=404, detail=f"skill {skill_name!r} not found")
+        skill_columns = record.frontmatter.lq_ai.columns
+        if not skill_columns:
+            raise HTTPException(
+                status_code=400,
+                detail=f"skill {skill_name!r} has no columns (not a table-mode skill)",
+            )
+        # Re-validate through the wire-side ColumnSpec so any
+        # skill-side fields the wire schema doesn't honor are
+        # stripped consistently.
+        return skill_name, [ColumnSpec.model_validate(col.model_dump()) for col in skill_columns]
+
+    # ad_hoc branch — the request-validation min_length=1 on columns
+    # in TabularExecutionCreate already covers the empty case.
+    assert ad_hoc is not None  # for the type checker
+    return None, ad_hoc
+
+
+async def _load_caller_owned_documents(
+    db: AsyncSession,
+    *,
+    document_ids: list[uuid.UUID],
+    user: ActiveUser,
+) -> list[Document]:
+    """Load documents the caller has access to via the file ownership chain.
+
+    Mirrors the M3-A6 Easy Playbook helper. The visibility rule:
+    each :class:`Document` has a parent :class:`File` whose
+    ``owner_id`` must match the caller (admins see all). Missing /
+    cross-owner documents collapse into "not found" at the caller.
+    """
+
+    from app.models.file import File as FileModel
+
+    stmt = (
+        select(Document)
+        .where(Document.id.in_(document_ids))
+        .join(FileModel, Document.file_id == FileModel.id)
+    )
+    if not user.is_admin:
+        stmt = stmt.where(FileModel.owner_id == user.id)
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/tabular/preview-cost",
+    response_model=TabularPreviewCostResponse,
+    summary="Preview the cost of a proposed tabular execution.",
+)
+async def preview_tabular_cost(
+    body: TabularPreviewCostRequest,
+    request: Request,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TabularPreviewCostResponse:
+    """Synchronous cost preview — no execution row is created.
+
+    The UI calls this before showing the confirmation modal so the
+    operator sees the cell-count + estimated cost + per-tier
+    breakdown (Decision C-5). The estimator's rolling average
+    (M2-E2 pattern) caches per ~5 minutes in-process; rapid re-previews
+    during column-spec editing don't thrash the DB.
+
+    Authorization is the router-level ``get_active_user`` gate — any
+    authenticated caller may preview costs against their own document
+    selection. The document-ownership check is enforced at execute
+    time; preview doesn't load the documents.
+    """
+
+    _ = user  # gate-only; no per-user logic on preview
+
+    _, columns = _resolve_columns(
+        request,
+        skill_name=body.skill_name,
+        ad_hoc=body.columns,
+    )
+
+    return await estimate_tabular_execution_cost(
+        db,
+        document_ids=list(body.document_ids),
+        columns=columns,
+    )
+
+
+@router.post(
+    "/tabular/execute",
+    response_model=TabularExecutionResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Start a tabular execution.",
+)
+async def create_tabular_execution(
+    body: TabularExecutionCreate,
+    request: Request,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TabularExecutionResponse:
+    """Kick off a tabular execution against the supplied document corpus.
+
+    Authorization: the caller must own every document in
+    ``document_ids``. Cross-user or non-existent ids collapse into a
+    single 404 (no information leakage), matching the M3-A6 Easy
+    Playbook posture.
+
+    Creates a :class:`TabularExecution` row at ``status='pending'``
+    and enqueues the ARQ worker job on the shared playbook queue
+    (per Decision C-3). Returns 202 immediately with the row; the
+    result-view polls
+    ``GET /api/v1/tabular/executions/{id}`` until status reaches
+    a terminal state.
+
+    Per the M3-C2 quality bar, "execution completed" does NOT mean
+    every cell is correct — the result-view's per-cell citation
+    drawer is where the user-attorney validates extractions before
+    relying on them.
+    """
+
+    documents = await _load_caller_owned_documents(
+        db,
+        document_ids=list(body.document_ids),
+        user=user,
+    )
+    if len(documents) != len(body.document_ids):
+        raise HTTPException(status_code=404, detail="one or more documents not found")
+
+    resolved_skill_name, columns = _resolve_columns(
+        request,
+        skill_name=body.skill_name,
+        ad_hoc=body.columns,
+    )
+
+    # Snapshot the column spec to the row's JSONB so re-rendering a
+    # week later honours Decision C-1's snapshotting invariant.
+    columns_json = [col.model_dump(mode="json") for col in columns]
+
+    execution = TabularExecution(
+        user_id=user.id,
+        skill_name=resolved_skill_name,
+        status="pending",
+        document_ids=list(body.document_ids),
+        columns=columns_json,
+        cost_estimate_usd=body.confirmed_cost_usd,
+    )
+    db.add(execution)
+    await db.flush()
+
+    await audit_action(
+        db,
+        user_id=user.id,
+        action="tabular.execution_started",
+        resource_type="tabular_execution",
+        resource_id=str(execution.id),
+        request=request,
+        details={
+            "document_count": len(body.document_ids),
+            "column_count": len(columns),
+            "skill_name": resolved_skill_name,
+            "confirmed_cost_usd": (
+                str(body.confirmed_cost_usd) if body.confirmed_cost_usd is not None else None
+            ),
+        },
+    )
+    await db.commit()
+    await db.refresh(execution)
+
+    enqueued = await enqueue_tabular_execution_job(execution.id)
+    logger.info(
+        "tabular_execution_started",
+        extra={
+            "event": "tabular_execution_started",
+            "user_id": str(user.id),
+            "execution_id": str(execution.id),
+            "enqueued": enqueued,
+            "document_count": len(body.document_ids),
+            "column_count": len(columns),
+        },
+    )
+
+    return _to_response(execution)
+
+
+@router.get(
+    "/tabular/executions",
+    response_model=list[TabularExecutionSummary],
+    summary="List the caller's tabular executions.",
+)
+async def list_tabular_executions(
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: int = 50,
+) -> list[TabularExecutionSummary]:
+    """Return the caller's tabular executions, recent-first, soft-deleted excluded.
+
+    Admins see all executions; non-admins see only their own
+    (matches the Easy Playbook list posture).
+    """
+
+    stmt = select(TabularExecution).where(TabularExecution.deleted_at.is_(None))
+    if not user.is_admin:
+        stmt = stmt.where(
+            or_(TabularExecution.user_id == user.id, TabularExecution.user_id.is_(None))
+        )
+    stmt = stmt.order_by(TabularExecution.created_at.desc()).limit(limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_to_summary(row) for row in rows]
+
+
+@router.get(
+    "/tabular/executions/{execution_id}",
+    response_model=TabularExecutionResponse,
+    summary="Get a tabular execution by id.",
+)
+async def get_tabular_execution(
+    execution_id: uuid.UUID,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TabularExecutionResponse:
+    """Return one tabular execution — full state + grid results.
+
+    Authorization: caller must be the row's ``user_id`` OR an admin.
+    Cross-user / missing / soft-deleted rows collapse into 404.
+    """
+
+    row = await _load_caller_execution(db, execution_id=execution_id, user=user)
+    return _to_response(row)
+
+
+@router.delete(
+    "/tabular/executions/{execution_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Soft-delete a tabular execution.",
+)
+async def delete_tabular_execution(
+    execution_id: uuid.UUID,
+    user: ActiveUser,
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    """Soft-delete (sets ``deleted_at``). Already-deleted rows return 404."""
+
+    row = await _load_caller_execution(db, execution_id=execution_id, user=user)
+    row.deleted_at = datetime.now(UTC)
+    await audit_action(
+        db,
+        user_id=user.id,
+        action="tabular.execution_deleted",
+        resource_type="tabular_execution",
+        resource_id=str(execution_id),
+        request=request,
+    )
+    await db.commit()
+
+
+@router.post(
+    "/tabular/executions/{execution_id}/cancel",
+    response_model=TabularExecutionResponse,
+    summary="Cancel a pending or running tabular execution.",
+)
+async def cancel_tabular_execution(
+    execution_id: uuid.UUID,
+    user: ActiveUser,
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TabularExecutionResponse:
+    """Set status to ``cancelled``.
+
+    The worker's per-cell loop checks the row status at each cell
+    boundary; on cancellation it stops accepting new cells and the
+    aggregate node writes whatever partial results landed. Already-
+    terminal rows (``completed`` / ``failed`` / ``cancelled``) are
+    a 409 — operators wanting a clean re-run start a new execution
+    via ``POST /tabular/execute``.
+    """
+
+    row = await _load_caller_execution(db, execution_id=execution_id, user=user)
+    if row.status in {"completed", "failed", "cancelled"}:
+        raise HTTPException(
+            status_code=409,
+            detail=f"execution already in terminal status {row.status!r}",
+        )
+    row.status = "cancelled"
+    row.completed_at = datetime.now(UTC)
+    await audit_action(
+        db,
+        user_id=user.id,
+        action="tabular.execution_cancelled",
+        resource_type="tabular_execution",
+        resource_id=str(execution_id),
+        request=request,
+    )
+    await db.commit()
+    await db.refresh(row)
+    return _to_response(row)
+
+
+# ---------------------------------------------------------------------------
+# Response shaping
+# ---------------------------------------------------------------------------
+
+
+async def _load_caller_execution(
+    db: AsyncSession,
+    *,
+    execution_id: uuid.UUID,
+    user: ActiveUser,
+) -> TabularExecution:
+    """Load one execution + apply the caller-scope visibility rule.
+
+    404 on missing / unauthorized / soft-deleted (single error
+    surface; no information leakage).
+    """
+
+    row = await db.get(TabularExecution, execution_id)
+    if row is None or row.deleted_at is not None:
+        raise HTTPException(status_code=404, detail="execution not found")
+    if not user.is_admin and row.user_id != user.id:
+        raise HTTPException(status_code=404, detail="execution not found")
+    return row
+
+
+def _to_response(row: TabularExecution) -> TabularExecutionResponse:
+    """Convert the ORM row to the response wire shape."""
+
+    return TabularExecutionResponse.model_validate(
+        {
+            "id": row.id,
+            "user_id": row.user_id,
+            "parent_execution_id": row.parent_execution_id,
+            "skill_name": row.skill_name,
+            "status": row.status,
+            "document_ids": list(row.document_ids),
+            "columns": list(row.columns),
+            "results": row.results,
+            "cost_estimate_usd": row.cost_estimate_usd,
+            "cost_actual_usd": row.cost_actual_usd,
+            "error_text": row.error_text,
+            "created_at": row.created_at,
+            "started_at": row.started_at,
+            "completed_at": row.completed_at,
+        }
+    )
+
+
+def _to_summary(row: TabularExecution) -> TabularExecutionSummary:
+    """Compact list-endpoint projection."""
+
+    return TabularExecutionSummary.model_validate(
+        {
+            "id": row.id,
+            "user_id": row.user_id,
+            "parent_execution_id": row.parent_execution_id,
+            "skill_name": row.skill_name,
+            "status": row.status,
+            "document_count": len(row.document_ids),
+            "column_count": len(row.columns),
+            "cost_estimate_usd": row.cost_estimate_usd,
+            "cost_actual_usd": row.cost_actual_usd,
+            "created_at": row.created_at,
+            "completed_at": row.completed_at,
+        }
+    )
+
+
+__all__ = ["router"]

--- a/api/app/api/tabular.py
+++ b/api/app/api/tabular.py
@@ -326,7 +326,7 @@ async def create_tabular_execution(
         },
     )
 
-    return _to_response(execution)
+    return await _to_response(db, execution)
 
 
 @router.get(
@@ -372,7 +372,7 @@ async def get_tabular_execution(
     """
 
     row = await _load_caller_execution(db, execution_id=execution_id, user=user)
-    return _to_response(row)
+    return await _to_response(db, row)
 
 
 @router.delete(
@@ -442,7 +442,7 @@ async def cancel_tabular_execution(
     )
     await db.commit()
     await db.refresh(row)
-    return _to_response(row)
+    return await _to_response(db, row)
 
 
 # ---------------------------------------------------------------------------
@@ -470,9 +470,42 @@ async def _load_caller_execution(
     return row
 
 
-def _to_response(row: TabularExecution) -> TabularExecutionResponse:
-    """Convert the ORM row to the response wire shape."""
+async def _load_document_names(
+    db: AsyncSession, document_ids: list[uuid.UUID]
+) -> dict[uuid.UUID, str]:
+    """Return a ``{document_id: filename}`` map for the given ids.
 
+    Joins ``documents → files.filename``. Soft-deleted files are
+    excluded — the caller treats a missing id as a deleted document
+    (renders as the empty string in the response, which the UI flags
+    as "deleted document")."""
+
+    from app.models.file import File as FileModel
+
+    if not document_ids:
+        return {}
+    stmt = (
+        select(Document.id, FileModel.filename)
+        .join(FileModel, Document.file_id == FileModel.id)
+        .where(Document.id.in_(document_ids), FileModel.deleted_at.is_(None))
+    )
+    rows = (await db.execute(stmt)).all()
+    return {row.id: row.filename for row in rows}
+
+
+async def _to_response(
+    db: AsyncSession, row: TabularExecution
+) -> TabularExecutionResponse:
+    """Convert the ORM row to the response wire shape.
+
+    Async because the response includes a ``document_names`` field
+    that requires a join on ``files`` — keeping the join inside the
+    response builder means every endpoint that returns a single
+    execution gets the names without duplicating the query."""
+
+    document_ids = list(row.document_ids)
+    name_by_id = await _load_document_names(db, document_ids)
+    document_names = [name_by_id.get(did, "") for did in document_ids]
     return TabularExecutionResponse.model_validate(
         {
             "id": row.id,
@@ -480,7 +513,8 @@ def _to_response(row: TabularExecution) -> TabularExecutionResponse:
             "parent_execution_id": row.parent_execution_id,
             "skill_name": row.skill_name,
             "status": row.status,
-            "document_ids": list(row.document_ids),
+            "document_ids": document_ids,
+            "document_names": document_names,
             "columns": list(row.columns),
             "results": row.results,
             "cost_estimate_usd": row.cost_estimate_usd,

--- a/api/app/api/tabular.py
+++ b/api/app/api/tabular.py
@@ -493,9 +493,7 @@ async def _load_document_names(
     return {row.id: row.filename for row in rows}
 
 
-async def _to_response(
-    db: AsyncSession, row: TabularExecution
-) -> TabularExecutionResponse:
+async def _to_response(db: AsyncSession, row: TabularExecution) -> TabularExecutionResponse:
     """Convert the ORM row to the response wire shape.
 
     Async because the response includes a ``document_names`` field

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.playbook import Playbook, PlaybookExecution, PlaybookPosition
 from app.models.project import Project, ProjectFile, ProjectSkill
 from app.models.project_knowledge_base import ProjectKnowledgeBase
 from app.models.saved_prompt import SavedPrompt
+from app.models.tabular import TabularExecution
 from app.models.team import Team, TeamMember
 from app.models.user import User, UserSession
 from app.models.user_export import UserExportJob
@@ -48,6 +49,7 @@ __all__ = [
     "ProjectKnowledgeBase",
     "ProjectSkill",
     "SavedPrompt",
+    "TabularExecution",
     "Team",
     "TeamMember",
     "User",

--- a/api/app/models/tabular.py
+++ b/api/app/models/tabular.py
@@ -1,0 +1,147 @@
+"""Tabular Review ORM models — M3-C2.
+
+Substrate for the Tabular / Multi-Document Review surface
+([PRD §3.14](docs/PRD.md#314-tabular--multi-document-review-m3))
+landing in M3. Each row is one tabular execution — a row-per-document
+by column-per-spec grid run as a LangGraph workflow on the
+``arq:m3a6`` queue (Decision C-3 from the Phase C prep doc).
+
+One table (migration ``0036_tabular_executions.py``):
+
+* :class:`TabularExecution` — one row per execution. Status lifecycle
+  is ``pending -> running -> completed | failed | cancelled``.
+  ``parent_execution_id`` is non-NULL on bulk-op sibling rows
+  (Decision C-9; bulk ops spawn siblings rather than mutating the
+  original grid).
+
+The CHECK constraint on ``status`` is enforced at the storage layer
+(migration 0036) so application bugs can't insert invalid enum values.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Numeric, Text, text
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class TabularExecution(Base):
+    """One Tabular Review execution — M3-C2.
+
+    Lifecycle (CHECK-constrained per migration 0036):
+
+    * ``pending`` — row written by the POST handler; the ARQ worker
+      hasn't picked it up yet.
+    * ``running`` — worker is walking the documents x columns grid
+      (per-cell Citation-Engine-grounded extraction).
+    * ``completed`` — ``results`` JSONB is populated with the
+      assembled grid; ``completed_at`` is set.
+    * ``failed`` — worker raised mid-flight; ``error_text`` populated;
+      ``results`` may be NULL or carry partial output;
+      ``completed_at`` is set.
+    * ``cancelled`` — operator cancelled via
+      ``POST /tabular/executions/{id}/cancel`` before the worker
+      finished; ``completed_at`` is set.
+
+    ``document_ids`` is the snapshot of source documents at request
+    time; not an FK so a later soft-delete of one of the source files
+    doesn't cascade-clear the audit row.
+
+    ``columns`` is the snapshot of the resolved column spec at
+    execution start (either the skill's ``lq_ai.columns`` block at
+    that moment, or the operator's ad-hoc list). Snapshotting is the
+    load-bearing invariant: re-rendering the grid a week later must
+    be honest about what was actually run, not what the skill
+    currently says.
+
+    ``parent_execution_id`` is non-NULL on bulk-op sibling rows
+    (Decision C-9). A "Redline column N" bulk op creates a child row
+    pointing at the original execution; the result view renders the
+    bulk-op output as a tab next to the original grid.
+
+    Soft delete via ``deleted_at`` matches the
+    ``Playbook.deleted_at`` pattern from M3-A6's migration 0034.
+    """
+
+    __tablename__ = "tabular_executions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "users.id",
+            ondelete="SET NULL",
+            name="fk_tabular_executions_user_id",
+        ),
+        nullable=True,
+    )
+    parent_execution_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "tabular_executions.id",
+            ondelete="SET NULL",
+            name="fk_tabular_executions_parent_execution_id",
+        ),
+        nullable=True,
+    )
+    skill_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default=text("'pending'"),
+    )
+    document_ids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)),
+        nullable=False,
+        server_default=text("'{}'::uuid[]"),
+    )
+    columns: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+    )
+    results: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    cost_estimate_usd: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 4),
+        nullable=True,
+    )
+    cost_actual_usd: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 4),
+        nullable=True,
+    )
+    error_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<TabularExecution id={self.id} user_id={self.user_id} "
+            f"status={self.status!r} docs={len(self.document_ids)} "
+            f"cols={len(self.columns)}>"
+        )

--- a/api/app/schemas/tabular.py
+++ b/api/app/schemas/tabular.py
@@ -1,0 +1,265 @@
+"""Pydantic schemas for Tabular / Multi-Document Review — M3-C2.
+
+Wire shapes for the ``/api/v1/tabular`` surface
+([PRD §3.14](docs/PRD.md#314-tabular--multi-document-review-m3)).
+The ORM model lives in :mod:`app.models.tabular`; this module is the
+request / response surface for the endpoints landing in M3-C2.
+
+Per Phase C prep doc Decision C-1, table-mode skills declare columns
+via ``lq_ai.columns`` in their frontmatter (the :class:`ColumnSpec`
+already defined in :mod:`app.skills.schema`). This module redefines the
+wire-side ``ColumnSpec`` rather than importing the skills-side one
+because the contexts differ: skills-side ``ColumnSpec`` is loaded from
+SKILL.md frontmatter at startup; this wire-side ``ColumnSpec`` arrives
+on each tabular-execution request as JSON. The shapes are identical
+today; if they diverge (e.g., ad-hoc executions add ad-hoc-only
+fields), this module owns the wire surface independent of the
+authoring surface.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+TabularExecutionStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
+"""Lifecycle states for a :class:`TabularExecution`. Matches the CHECK
+constraint on ``tabular_executions.status`` (migration 0036)."""
+
+CellConfidence = Literal["high", "medium", "low", "failed"]
+"""Per-cell confidence from the Citation Engine cascade. ``failed``
+is the M3-C2 / Decision C-10 state for cells where extraction itself
+errored (distinct from Citation Engine's red ``unverified`` state)."""
+
+
+class ColumnSpec(BaseModel):
+    """One column in a tabular execution's column spec.
+
+    Mirrors :class:`app.skills.schema.ColumnSpec` — kept separate so
+    the wire surface can evolve independently of the authoring surface
+    (e.g., ad-hoc executions could add fields that don't make sense
+    in SKILL.md frontmatter).
+    """
+
+    name: str
+    """Grid column header. Required."""
+
+    query: str
+    """Per-row extraction prompt instantiated against each document.
+    Required."""
+
+    ensemble_verification: bool | None = None
+    """Per-column override of the skill-level
+    ``ensemble_verification`` field."""
+
+    minimum_inference_tier: int | None = Field(
+        default=None,
+        ge=1,
+        le=5,
+        description="Per-column tier floor (1-5).",
+    )
+
+
+class Citation(BaseModel):
+    """A single citation backing a cell value.
+
+    Lightweight projection of the M2 Citation Engine's
+    :class:`app.models.message_citation.MessageCitation` shape — kept
+    minimal here because tabular cells reference citations by ID; the
+    cell renderer looks up the full citation row via the existing
+    Citation Engine surface (no duplicate persistence)."""
+
+    citation_id: uuid.UUID
+    document_id: uuid.UUID
+    """The source document this citation lands in."""
+
+    chunk_id: uuid.UUID | None = None
+    """The specific chunk inside the document, when the cascade
+    resolved one. None for chunk-boundary-spanning citations."""
+
+    confidence: CellConfidence
+
+
+class CellResult(BaseModel):
+    """One cell in the tabular grid.
+
+    Failed extraction renders as ``confidence='failed'`` + ``error``
+    populated (Decision C-10). Successful extractions carry the
+    extracted ``value`` plus the list of citations the Citation
+    Engine grounded it against.
+    """
+
+    value: str | None = None
+    """The extracted value. ``None`` when ``confidence='failed'``."""
+
+    citations: list[Citation] = Field(default_factory=list)
+    """Citations backing the cell value. Empty for failed cells or
+    cells the Citation Engine couldn't ground."""
+
+    confidence: CellConfidence
+    tier_used: int | None = None
+    """Inference tier actually routed for this cell. Set on success;
+    None on failure before tier was selected."""
+
+    cost_usd: Decimal | None = None
+    """Per-cell cost. Sum across cells = ``cost_actual_usd`` on the
+    parent execution row."""
+
+    error: str | None = None
+    """Error message when ``confidence='failed'``. Populated by the
+    cell node's try/except (model error, no citation found,
+    Citation Engine rejection)."""
+
+
+class TabularRow(BaseModel):
+    """One row in the tabular grid — all cells for a single document.
+
+    Rows are returned in the order of the execution's
+    ``document_ids`` array (NOT sorted by document name), so the grid
+    matches the operator's selection order."""
+
+    document_id: uuid.UUID
+    document_name: str
+    """Display name for the row label (the leftmost sticky column)."""
+
+    cells: dict[str, CellResult]
+    """Map of column name -> CellResult. Keys match the column names
+    declared in the execution's column spec."""
+
+
+class TabularResults(BaseModel):
+    """Aggregated grid shape persisted in ``tabular_executions.results``
+    once status is ``completed``."""
+
+    rows: list[TabularRow]
+
+
+# --- Wire shapes for endpoints --------------------------------------------
+
+
+class TabularExecutionCreate(BaseModel):
+    """Request body for ``POST /api/v1/tabular/execute``.
+
+    Either ``skill_name`` (resolved at execution start to snapshot
+    the skill's ``lq_ai.columns``) OR ``columns`` (ad-hoc spec) is
+    required. The handler resolves to the columns list either way
+    before persisting.
+
+    ``confirmed_cost_usd`` is the echo of the
+    ``POST /api/v1/tabular/preview-cost`` response value; persisting
+    it gives an audit trail of the operator confirming a specific
+    cost ceiling before kickoff."""
+
+    document_ids: list[uuid.UUID] = Field(min_length=1)
+    skill_name: str | None = None
+    columns: list[ColumnSpec] | None = None
+    confirmed_cost_usd: Decimal | None = None
+
+
+class TabularPreviewCostRequest(BaseModel):
+    """Request body for ``POST /api/v1/tabular/preview-cost``.
+
+    Cheaper synchronous endpoint; no execution row is created. The
+    UI calls this before showing the cost-confirmation modal."""
+
+    document_ids: list[uuid.UUID] = Field(min_length=1)
+    skill_name: str | None = None
+    columns: list[ColumnSpec] | None = None
+
+
+class TabularPreviewCostResponse(BaseModel):
+    """Response from ``POST /api/v1/tabular/preview-cost``.
+
+    The UI uses ``estimated_cost_usd`` to decide whether to render
+    the confirmation-checkbox gate (Decision C-5: gate above $1.00,
+    no friction below)."""
+
+    cells_count: int
+    estimated_tokens: int
+    estimated_cost_usd: Decimal
+    per_tier_breakdown: dict[str, int]
+    """Map of tier name (e.g., ``"tier_2"``) -> cell count routed
+    at that tier. Lets the operator see "20 cells at Tier 2,
+    4 cells at Tier 4 for the high-stakes columns."""
+
+
+class TabularExecutionResponse(BaseModel):
+    """Wire shape returned by every tabular execution endpoint
+    (``POST /execute``, ``GET /executions/{id}``, etc.)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    user_id: uuid.UUID | None
+    parent_execution_id: uuid.UUID | None
+    skill_name: str | None
+    status: TabularExecutionStatus
+    document_ids: list[uuid.UUID]
+    columns: list[ColumnSpec]
+    results: TabularResults | None = None
+    cost_estimate_usd: Decimal | None = None
+    cost_actual_usd: Decimal | None = None
+    error_text: str | None = None
+    created_at: datetime
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
+class TabularExecutionSummary(BaseModel):
+    """Compact wire shape for the list endpoint
+    (``GET /api/v1/tabular/executions``).
+
+    Drops the (potentially large) ``results`` payload — operators
+    fetch the full execution row when they open one."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    user_id: uuid.UUID | None
+    parent_execution_id: uuid.UUID | None
+    skill_name: str | None
+    status: TabularExecutionStatus
+    document_count: int
+    column_count: int
+    cost_estimate_usd: Decimal | None = None
+    cost_actual_usd: Decimal | None = None
+    created_at: datetime
+    completed_at: datetime | None = None
+
+
+class TabularBulkOpRequest(BaseModel):
+    """Request body for
+    ``POST /api/v1/tabular/executions/{id}/bulk-op`` (M3-C4).
+
+    Per Decision C-9, bulk ops spawn sibling execution rows rather
+    than mutating the original grid. The sibling carries
+    ``parent_execution_id`` set to this execution's ID."""
+
+    op: Literal["redline", "summarize"]
+    column_name: str
+    skill_name_override: str | None = None
+    """Override the default skill used for the operation. Default for
+    ``redline`` is ``nda-review`` (or skill matched to the parent
+    execution's skill family); default for ``summarize`` is the
+    deployment-configured summary skill."""
+
+
+__all__ = [
+    "CellConfidence",
+    "CellResult",
+    "Citation",
+    "ColumnSpec",
+    "TabularBulkOpRequest",
+    "TabularExecutionCreate",
+    "TabularExecutionResponse",
+    "TabularExecutionStatus",
+    "TabularExecutionSummary",
+    "TabularPreviewCostRequest",
+    "TabularPreviewCostResponse",
+    "TabularResults",
+    "TabularRow",
+]

--- a/api/app/schemas/tabular.py
+++ b/api/app/schemas/tabular.py
@@ -199,6 +199,15 @@ class TabularExecutionResponse(BaseModel):
     skill_name: str | None
     status: TabularExecutionStatus
     document_ids: list[uuid.UUID]
+    document_names: list[str]
+    """Filenames in the same order as ``document_ids`` — joined from
+    ``documents → files.filename`` at response build time. Lets the
+    UI render grid headers with human-readable labels from the moment
+    the execution is created (before any row is populated by the
+    worker), instead of falling back to raw UUIDs. Missing entries
+    (file soft-deleted between create and fetch) surface as the empty
+    string; the UI treats those as "deleted document" placeholders."""
+
     columns: list[ColumnSpec]
     results: TabularResults | None = None
     cost_estimate_usd: Decimal | None = None

--- a/api/app/skills/schema.py
+++ b/api/app/skills/schema.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # All built-in M1 skills are filesystem-canonical; user/team-scope forks
 # land later and gain ``user`` / ``team`` values for ``scope``. C1 only
@@ -39,6 +39,44 @@ SkillScope = Literal["builtin", "user", "team"]
 # mirrors their ``scope`` value — the frontend can use ``source`` for
 # badge rendering without inspecting ``scope``.
 SkillSource = Literal["built-in", "community", "user", "team"]
+
+
+class ColumnSpec(BaseModel):
+    """One column in an ``output_format: table`` Skill (M3-C1).
+
+    A table-mode skill produces a row-per-document by column-per-spec
+    grid; each column carries its own per-row extraction query plus
+    optional overrides for the skill-level ``ensemble_verification``
+    and ``minimum_inference_tier``. The Tabular Review LangGraph
+    workflow (M3-C2) dispatches one Citation-Engine-grounded extraction
+    per ``(document, column)`` cell.
+
+    Per Decision C-1 (Phase C prep, 2026-05-21): every cell value is a
+    string in v0.3.0; typed columns are a follow-on DE if user-attorney
+    walkthrough surfaces the need.
+    """
+
+    name: str
+    """The grid column header. Required."""
+
+    query: str
+    """The per-row extraction prompt instantiated against each document.
+    Required."""
+
+    ensemble_verification: bool | None = None
+    """When ``True``, this column's cells route through Stage 4 of the
+    Citation Engine cascade (ensemble verification). Overrides the
+    skill-level field when both are set. ``None`` means 'inherit from
+    skill / project / deployment default'."""
+
+    minimum_inference_tier: int | None = Field(
+        default=None,
+        ge=1,
+        le=5,
+        description="Per-column tier floor (1-5). Overrides the skill-level "
+        "tier floor when both are set. High-stakes columns can demand Tier 4+ "
+        "while routine columns route Tier 1.",
+    )
 
 
 class LQAIFrontmatter(BaseModel):
@@ -74,7 +112,20 @@ class LQAIFrontmatter(BaseModel):
 
     output_format: str | None = None
     """Free-form per corpus (``report``, ``markdown``,
-    ``structured_checklist``, ``redline``, etc.)."""
+    ``structured_checklist``, ``redline``, ``table``, etc.).
+
+    The ``table`` value (M3-C1) signals to the Tabular Review surface that
+    this skill produces a grid; the column spec lives in :attr:`columns`."""
+
+    columns: list[ColumnSpec] | None = None
+    """Column definitions for an ``output_format: table`` skill (M3-C1).
+
+    ``None`` for non-table skills. The loader (``app/skills/loader.py``)
+    emits a WARNING and skips the skill when ``output_format == 'table'``
+    but ``columns`` is missing or empty — mirroring the existing pattern
+    for required-but-missing fields. A non-table skill may carry a
+    ``columns`` value (e.g., a skill author iterating on output mode);
+    downstream surfaces ignore it unless ``output_format == 'table'``."""
 
     minimum_inference_tier: int | None = Field(
         default=None,
@@ -98,6 +149,23 @@ class LQAIFrontmatter(BaseModel):
     self_improvement: bool | None = None
 
     trigger_examples: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _table_mode_requires_columns(self) -> LQAIFrontmatter:
+        """``output_format: table`` requires a non-empty ``columns`` list.
+
+        Enforced at model layer so the loader's existing
+        ``ValidationError → LoaderError → WARNING → skip`` path catches
+        malformed table-mode skills the same way it catches any other
+        frontmatter mistake (per Decision C-1, M3-C1).
+        """
+
+        if self.output_format == "table" and not self.columns:
+            raise ValueError(
+                "output_format: table requires a non-empty 'columns' list "
+                "(see docs/skill-authoring-guide.md §Table-mode skills)"
+            )
+        return self
 
 
 class SkillFrontmatter(BaseModel):
@@ -358,6 +426,7 @@ def filter_summary_for_response(summary: SkillSummary) -> dict[str, Any]:
 
 
 __all__ = [
+    "ColumnSpec",
     "LQAIFrontmatter",
     "Skill",
     "SkillFile",

--- a/api/app/tabular/__init__.py
+++ b/api/app/tabular/__init__.py
@@ -1,0 +1,7 @@
+"""Tabular / Multi-Document Review backend — M3-C2.
+
+LangGraph workflow that walks ``documents x columns`` and produces a
+row-per-document-by-column-per-spec grid. See PRD §3.14 and the Phase C
+prep doc at ``docs/superpowers/plans/2026-05-21-m3-phase-c-tabular-review.md``
+for the full design.
+"""

--- a/api/app/tabular/cost.py
+++ b/api/app/tabular/cost.py
@@ -1,0 +1,335 @@
+"""Per-cell cost calibration for Tabular Review — M3-C2.
+
+Mirrors :mod:`app.citation.cost` (M2-E2 rolling-average estimator).
+The Tabular variant differs in scope: cells fan out across whatever
+inference tier their column demands, so the primitive is a single
+rolling average over all tabular-extraction calls (not per-model).
+Per-column tier overrides surface in the
+:class:`~app.schemas.tabular.TabularPreviewCostResponse`
+``per_tier_breakdown`` as informational cell counts; the per-cell
+cost itself is one average across all tiers in v0.3.0.
+
+Why single-primitive (not per-tier)
+-----------------------------------
+
+Splitting the rolling average per-tier would let the cost preview
+report Tier 4 cells at 3x the price of Tier 2 cells (which they are,
+roughly). The trade-off is each per-tier bucket needs its own cold-
+start path; tiers that have never been routed return the conservative
+default x bucket-count and the operator sees a misleadingly wide cost
+band. Single-average gives a tighter, more honest pre-flight number
+at the cost of less per-tier resolution. If operators start asking
+"why is my Tier 4-heavy run priced the same as my Tier 1-heavy run?"
+that's a follow-on DE.
+
+How the estimate works
+----------------------
+
+* The gateway records actual ``cost_estimate`` on every inference call.
+* M2-E2 added a ``purpose`` column. The Tabular executor's cell node
+  tags every gateway call with ``lq_ai_purpose='tabular_extraction'``
+  (the value defined here as :data:`TABULAR_EXTRACTION_PURPOSE`).
+* The rolling average runs over the last 100 tabular-extraction calls
+  (or last 30 days, whichever cuts smaller).
+
+Cold-start posture
+------------------
+
+When fewer than :data:`_MIN_SAMPLES` recent tabular-extraction rows
+exist, the estimator returns :data:`DEFAULT_PER_CELL_USD` —
+intentionally permissive so the pre-flight errs toward fallback
+rather than over-promising a tiny cost on a brand-new deployment.
+
+Caching
+-------
+
+The cost-preview endpoint runs synchronously per
+``POST /api/v1/tabular/preview-cost``. Without caching, every
+keystroke that triggers a re-preview (column-spec edits in the
+wizard) would re-query. The estimator caches per ~5 minutes in-process
+(matches the M2-E2 + Anthropic prompt-cache horizon).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.inference import InferenceRoutingLog
+from app.schemas.tabular import ColumnSpec, TabularPreviewCostResponse
+
+logger = logging.getLogger(__name__)
+
+
+TABULAR_EXTRACTION_PURPOSE = "tabular_extraction"
+"""Value the cell node tags every gateway call with via
+``lq_ai_purpose``. The gateway writes this through to
+``inference_routing_log.purpose`` (M2-E2). The cost estimator filters
+on it so chat / judge / embedding traffic does not pollute the
+per-cell average."""
+
+
+DEFAULT_PER_CELL_USD: Decimal = Decimal("0.005")
+"""Cold-start per-cell cost fallback.
+
+Matches the M2-D1 ``FLAT_PER_JUDGE_USD`` constant —
+intentionally conservative. A 200-doc x 10-col run at the default
+estimates to $10.00 in the cost-preview before any calibration data
+exists, which gates the operator behind the $1.00 confirmation
+checkbox (Decision C-5). Real per-cell cost typically lands between
+$0.002 (Haiku) and $0.020 (Opus on a long context); the default
+trends toward the cheaper side so operators don't see scary numbers
+on cold-start, but stays conservative enough to gate large runs."""
+
+
+DEFAULT_TOKENS_PER_CELL: int = 2000
+"""Cold-start tokens-per-cell fallback. Rough heuristic:
+~1.8K input (system prompt + 4 retrieved chunks averaging ~400
+chars each) + ~200 output (extraction value + brief justification).
+Surfaced in the preview's ``estimated_tokens`` so operators see the
+inference-budget shape even before calibration kicks in."""
+
+
+DEFAULT_TIER_LABEL = "default"
+"""Bucket key for cells whose column has no explicit
+``minimum_inference_tier``. Distinct from ``tier_N`` keys so the UI
+can render the bucket as "Default tier (gateway routing)" instead
+of pinning to a specific number that the gateway's router may not
+actually pick."""
+
+
+_MIN_SAMPLES = 5
+"""Minimum tabular-extraction rows required before the rolling
+average is trusted over the cold-start fallback."""
+
+_WINDOW_SAMPLES = 100
+"""Most recent N tabular-extraction calls included in the rolling
+average. Large enough to smooth noise; small enough to track recent
+provider price changes within hours of typical traffic."""
+
+_WINDOW_DAYS = 30
+"""Maximum lookback window. Protects against price-stale data on
+low-traffic deployments."""
+
+_CACHE_TTL_SECONDS = 300.0
+"""In-process cache TTL — matches the M2-E2 + Anthropic prompt-cache
+window so cost calibration stays consistent with the cache horizon."""
+
+
+# Single-entry cache: the per-cell average is global (not keyed by
+# model or tier), so one slot is enough. Tuple is ``(cached_at,
+# (cost_per_cell, tokens_per_cell))``.
+_cache: dict[str, tuple[float, tuple[Decimal, int]]] = {}
+_CACHE_KEY = "per_cell_metrics"
+
+
+async def estimate_per_cell_cost_usd(db: AsyncSession | None) -> Decimal:
+    """Return the rolling-average per-cell cost in USD.
+
+    Computes the average ``cost_estimate`` across the last
+    :data:`_WINDOW_SAMPLES` ``inference_routing_log`` rows where
+    ``purpose = 'tabular_extraction'``. Returns
+    :data:`DEFAULT_PER_CELL_USD` if fewer than :data:`_MIN_SAMPLES`
+    such rows exist.
+
+    ``db=None`` skips the query and returns the default. Honored by
+    unit tests that exercise wiring without caring about calibration;
+    production callers always pass a real session.
+
+    Cached in-process per :data:`_CACHE_TTL_SECONDS`.
+    """
+
+    cost, _ = await _estimate_per_cell_metrics(db)
+    return cost
+
+
+async def estimate_per_cell_tokens(db: AsyncSession | None) -> int:
+    """Return the rolling-average tokens-per-cell.
+
+    Mirrors :func:`estimate_per_cell_cost_usd` but for the
+    ``tokens_in + tokens_out`` sum on tabular-extraction rows. The
+    preview UX surfaces this as ``estimated_tokens`` so operators see
+    inference-budget shape independent of the dollar cost.
+    """
+
+    _, tokens = await _estimate_per_cell_metrics(db)
+    return tokens
+
+
+async def estimate_tabular_execution_cost(
+    db: AsyncSession | None,
+    *,
+    document_ids: list[UUID],
+    columns: list[ColumnSpec],
+) -> TabularPreviewCostResponse:
+    """Compute the full cost-preview payload for one tabular execution.
+
+    Multiplies ``len(document_ids) * len(columns)`` to derive
+    ``cells_count``; multiplies the per-cell cost / tokens by the
+    cell count; bucketizes cells by ``minimum_inference_tier`` for
+    the ``per_tier_breakdown`` informational field.
+
+    Edge case: an empty column list yields a zero-cell preview with
+    zero cost / zero tokens / empty breakdown. The endpoint layer's
+    request validation rejects this before it reaches the estimator
+    (``min_length=1`` on ``columns`` in the request schema), but the
+    estimator is defensive about edge inputs so callers building
+    previews internally don't crash on empty drafts.
+    """
+
+    cells_count = len(document_ids) * len(columns)
+
+    if cells_count == 0:
+        return TabularPreviewCostResponse(
+            cells_count=0,
+            estimated_tokens=0,
+            estimated_cost_usd=Decimal("0"),
+            per_tier_breakdown={},
+        )
+
+    per_cell_cost, per_cell_tokens = await _estimate_per_cell_metrics(db)
+
+    estimated_cost = per_cell_cost * Decimal(cells_count)
+    estimated_tokens = per_cell_tokens * cells_count
+
+    per_tier_breakdown = _bucketize_cells_by_tier(
+        n_docs=len(document_ids),
+        columns=columns,
+    )
+
+    return TabularPreviewCostResponse(
+        cells_count=cells_count,
+        estimated_tokens=estimated_tokens,
+        estimated_cost_usd=estimated_cost,
+        per_tier_breakdown=per_tier_breakdown,
+    )
+
+
+def invalidate_cache() -> None:
+    """Reset the in-process cache. Tests call this between assertions."""
+
+    _cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+async def _estimate_per_cell_metrics(
+    db: AsyncSession | None,
+) -> tuple[Decimal, int]:
+    """Shared primitive — returns (per-cell cost USD, per-cell tokens).
+
+    One DB hit fetches both the average cost AND the average token
+    total in the same query, then both estimators share the cache so
+    a preview that needs both metrics only pays one round-trip.
+    """
+
+    if db is None:
+        return DEFAULT_PER_CELL_USD, DEFAULT_TOKENS_PER_CELL
+
+    now = time.monotonic()
+    cached = _cache.get(_CACHE_KEY)
+    if cached is not None:
+        cached_at, cached_value = cached
+        if now - cached_at < _CACHE_TTL_SECONDS:
+            return cached_value
+
+    cutoff = datetime.now(UTC) - timedelta(days=_WINDOW_DAYS)
+    recent = (
+        select(
+            InferenceRoutingLog.cost_estimate,
+            InferenceRoutingLog.tokens_in,
+            InferenceRoutingLog.tokens_out,
+        )
+        .where(
+            InferenceRoutingLog.purpose == TABULAR_EXTRACTION_PURPOSE,
+            InferenceRoutingLog.cost_estimate.is_not(None),
+            InferenceRoutingLog.timestamp >= cutoff,
+        )
+        .order_by(InferenceRoutingLog.timestamp.desc())
+        .limit(_WINDOW_SAMPLES)
+        .subquery()
+    )
+    # AVG over the sub-select. ``func.coalesce(tokens_in, 0) +
+    # coalesce(tokens_out, 0)`` so rows where the gateway recorded
+    # cost but not token counts (e.g., provider didn't return usage)
+    # still contribute their cost without poisoning the token average.
+    stmt = select(
+        func.avg(recent.c.cost_estimate),
+        func.avg(
+            func.coalesce(recent.c.tokens_in, 0) + func.coalesce(recent.c.tokens_out, 0),
+        ),
+        func.count(recent.c.cost_estimate),
+    )
+
+    try:
+        result = await db.execute(stmt)
+        avg_cost_raw, avg_tokens_raw, count = result.one()
+    except Exception as exc:
+        # Defensive: a DB hiccup on the cost pre-flight should never
+        # break execute-tabular. Fall back to the conservative
+        # defaults and log loud.
+        logger.warning(
+            "tabular cost calibration query failed: %s",
+            exc,
+            extra={
+                "event": "tabular_cost_query_error",
+                "error_type": type(exc).__name__,
+            },
+        )
+        return DEFAULT_PER_CELL_USD, DEFAULT_TOKENS_PER_CELL
+
+    if count is None or count < _MIN_SAMPLES or avg_cost_raw is None:
+        _cache[_CACHE_KEY] = (now, (DEFAULT_PER_CELL_USD, DEFAULT_TOKENS_PER_CELL))
+        return DEFAULT_PER_CELL_USD, DEFAULT_TOKENS_PER_CELL
+
+    cost_estimate = Decimal(str(avg_cost_raw))
+    tokens_estimate = int(avg_tokens_raw) if avg_tokens_raw is not None else DEFAULT_TOKENS_PER_CELL
+
+    metrics: tuple[Decimal, int] = (cost_estimate, tokens_estimate)
+    _cache[_CACHE_KEY] = (now, metrics)
+    return metrics
+
+
+def _bucketize_cells_by_tier(
+    *,
+    n_docs: int,
+    columns: list[ColumnSpec],
+) -> dict[str, int]:
+    """Count cells per tier bucket for the informational breakdown.
+
+    Columns with ``minimum_inference_tier`` set get a ``tier_N`` key;
+    columns without get the :data:`DEFAULT_TIER_LABEL` bucket. The UI
+    renders the breakdown so operators see the tier-mix of their
+    proposed execution before confirming.
+    """
+
+    buckets: dict[str, int] = {}
+    for col in columns:
+        key = (
+            f"tier_{col.minimum_inference_tier}"
+            if col.minimum_inference_tier
+            else DEFAULT_TIER_LABEL
+        )
+        buckets[key] = buckets.get(key, 0) + n_docs
+    return buckets
+
+
+__all__ = [
+    "DEFAULT_PER_CELL_USD",
+    "DEFAULT_TIER_LABEL",
+    "DEFAULT_TOKENS_PER_CELL",
+    "TABULAR_EXTRACTION_PURPOSE",
+    "estimate_per_cell_cost_usd",
+    "estimate_per_cell_tokens",
+    "estimate_tabular_execution_cost",
+    "invalidate_cache",
+]

--- a/api/app/tabular/executor.py
+++ b/api/app/tabular/executor.py
@@ -1,0 +1,195 @@
+"""Tabular Review executor — builds the LangGraph workflow and runs it.
+
+Public surface: :func:`run_tabular_execution`. The ARQ worker
+(``app.workers.tabular_worker.tabular_execution_job``) calls it after
+pulling a ``tabular_executions`` row by id.
+
+Graph shape
+-----------
+
+load_documents → extract_cells → aggregate → END
+
+All nodes are sequential; per-cell parallelism is a v0.3.x follow-on
+if the 200 x 10 latency case forces it (Decision C-3 + risk row 1).
+The LangGraph runtime is the right substrate because:
+
+* It already runs in-process inside the existing arq-worker container.
+* The same shape pattern as the M3-A2 Playbook executor keeps the two
+  workflows mentally cheap to maintain.
+* A future per-node checkpointing pass drops in without restructuring.
+
+The executor catches exceptions at the graph-invocation boundary and
+writes ``status='failed'`` to the row so the kick-off endpoint's
+caller always sees a terminal state on poll.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from langgraph.graph import END, StateGraph
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.tabular import TabularExecution
+from app.tabular.nodes import (
+    make_aggregate_node,
+    make_extract_cells_node,
+    make_load_documents_node,
+)
+from app.tabular.state import TabularExecutionState
+
+if TYPE_CHECKING:
+    from app.clients.gateway import GatewayClient
+
+logger = logging.getLogger(__name__)
+
+# Default judge-model alias for cell extraction. Matches the
+# M3-A2 playbook executor's posture — a per-execution model override
+# is a v0.3.x follow-on if operators ask for one.
+DEFAULT_JUDGE_MODEL = "smart"
+
+
+class TabularExecutorError(Exception):
+    """Raised when the executor cannot start (e.g., row missing).
+
+    Distinct from in-graph failures (which surface via
+    ``status='failed'`` + ``error_text`` on the
+    ``tabular_executions`` row).
+    """
+
+
+async def run_tabular_execution(
+    db: AsyncSession,
+    *,
+    execution_id: uuid.UUID,
+    gateway: GatewayClient,
+    judge_model: str = DEFAULT_JUDGE_MODEL,
+) -> None:
+    """Run the tabular execution identified by ``execution_id``.
+
+    Lifecycle:
+
+    * ``pending → running`` on entry; sets ``started_at``.
+    * On graph success: aggregate node writes ``results``,
+      ``cost_actual_usd``, flips status to ``completed`` (or
+      ``failed`` if a node set ``state['error']``), sets
+      ``completed_at``.
+    * On uncaught exception (executor pre-start failure): flips row to
+      ``failed`` + populates ``error_text``; raises only the
+      pre-start :class:`TabularExecutorError` (in-graph exceptions
+      are caught and persisted).
+
+    Raises :class:`TabularExecutorError` if the row is missing.
+    Otherwise in-graph failures are caught and persisted rather than
+    re-raised — the kick-off endpoint runs this via ARQ; an uncaught
+    exception would crash the worker task.
+    """
+
+    execution = await db.get(TabularExecution, execution_id)
+    if execution is None:
+        raise TabularExecutorError(f"TabularExecution {execution_id} not found")
+
+    # Move to running so the UI can poll for mid-flight status rather
+    # than seeing 'pending' indefinitely.
+    from datetime import UTC, datetime
+
+    execution.status = "running"
+    execution.started_at = datetime.now(UTC)
+    await db.commit()
+
+    try:
+        # The columns + document_ids are already snapshotted on the row
+        # at request time (per Decision C-1's snapshotting posture).
+        document_ids = [uuid.UUID(str(did)) for did in execution.document_ids]
+        columns_state = list(execution.columns)
+
+        initial_state: dict[str, Any] = {
+            "execution_id": str(execution_id),
+            "columns": columns_state,
+            "judge_model": judge_model,
+            "documents": [],
+            "per_cell_results": [],
+            "error": None,
+        }
+
+        graph = _build_graph(
+            db=db,
+            gateway=gateway,
+            document_ids=document_ids,
+            judge_model=judge_model,
+        )
+        await graph.ainvoke(initial_state)
+
+    except TabularExecutorError:
+        # Pre-start failure — flip the row to failed and re-raise.
+        await _mark_failed(db, execution, "executor: unable to start")
+        raise
+    except Exception as exc:
+        # Any in-graph exception: persist the failure and don't re-raise.
+        logger.exception(
+            "tabular executor crashed mid-graph",
+            extra={
+                "event": "tabular_executor_crash",
+                "execution_id": str(execution_id),
+            },
+        )
+        await _mark_failed(db, execution, f"{type(exc).__name__}: {exc}")
+
+
+def _build_graph(
+    *,
+    db: AsyncSession,
+    gateway: GatewayClient,
+    document_ids: list[uuid.UUID],
+    judge_model: str,
+) -> Any:
+    """Compile the LangGraph workflow for one tabular execution.
+
+    Three nodes sequentially: load_documents → extract_cells → aggregate.
+    """
+
+    graph = StateGraph(TabularExecutionState)
+    graph.add_node("load_documents", make_load_documents_node(db, document_ids))
+    graph.add_node(
+        "extract_cells",
+        make_extract_cells_node(db=db, gateway=gateway, judge_model=judge_model),
+    )
+    graph.add_node("aggregate", make_aggregate_node(db))
+
+    graph.add_edge("load_documents", "extract_cells")
+    graph.add_edge("extract_cells", "aggregate")
+    graph.add_edge("aggregate", END)
+    graph.set_entry_point("load_documents")
+
+    return graph.compile()
+
+
+async def _mark_failed(
+    db: AsyncSession,
+    execution: TabularExecution,
+    error_text: str,
+) -> None:
+    """Best-effort write of the failed terminal state."""
+
+    from datetime import UTC, datetime
+
+    execution.status = "failed"
+    execution.error_text = error_text[:2000]
+    execution.completed_at = datetime.now(UTC)
+    try:
+        await db.commit()
+    except Exception as exc:  # pragma: no cover - DB best-effort
+        logger.warning(
+            "tabular executor: failed-state write failed: %s",
+            exc,
+            extra={"event": "tabular_executor_persist_failed_error"},
+        )
+
+
+__all__ = [
+    "DEFAULT_JUDGE_MODEL",
+    "TabularExecutorError",
+    "run_tabular_execution",
+]

--- a/api/app/tabular/nodes.py
+++ b/api/app/tabular/nodes.py
@@ -1,0 +1,603 @@
+"""LangGraph nodes for the Tabular Review executor — M3-C2.
+
+Three nodes run sequentially:
+
+1. :func:`load_documents_node` — resolve ``document_ids`` to
+   :class:`app.models.document.Document` rows; emit a list of
+   document snapshots (id + name) the extraction node reads. Documents
+   that have been soft-deleted between request time and worker pickup
+   are skipped silently — the row is preserved as audit but the result
+   set is honest about which sources were resolvable.
+2. :func:`extract_cells_node` — for each ``(document, column)`` pair,
+   FTS over the document's chunks using the column's ``query`` as
+   keyword input, then run a structured-output LLM call to extract the
+   answer + cited chunk indices. Per-cell try/except: any failure (no
+   chunks, gateway error, malformed response) lands as
+   ``confidence='failed'`` per Decision C-10. Sequential dispatch in
+   v0.3.0; per-cell parallelism is a follow-on if 200 x 10 latency
+   forces it.
+3. :func:`aggregate_node` — group per-cell results by document into
+   the final ``tabular_executions.results`` JSONB payload. Flips status
+   to ``'completed'`` (or ``'failed'`` if a prior node set
+   ``state['error']``). Persists ``cost_actual_usd`` as the sum across
+   all cells.
+
+Failure handling: any node may set ``state['error']`` to short-circuit
+later nodes. :func:`aggregate_node` reads ``error`` and routes the row
+to ``'failed'`` rather than ``'completed'``. Gateway / DB exceptions
+inside a node bubble up; the executor catches them at the
+graph-invocation boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.document import Document, DocumentChunk
+from app.models.tabular import TabularExecution
+from app.schemas.gateway import ChatCompletionMessage, ChatCompletionRequest
+from app.schemas.tabular import ColumnSpec
+from app.tabular.cost import TABULAR_EXTRACTION_PURPOSE
+from app.tabular.state import TabularExecutionState
+
+if TYPE_CHECKING:
+    from app.clients.gateway import GatewayClient
+
+logger = logging.getLogger(__name__)
+
+
+# Top-k chunks retrieved per cell. Bounded so the per-cell LLM context
+# stays reasonable across the 200 x 10 cell upper bound — at 4 chunks
+# x ~500 chars each, input is ~2K plus the system prompt.
+RETRIEVAL_TOP_K = 4
+
+# Max tokens for the cell-extraction LLM call. The structured output
+# is short — value + cited indices + confidence + brief justification.
+EXTRACT_MAX_TOKENS = 500
+
+# Schema-version stamp on the persisted ``results`` JSONB. Bumped on
+# any shape-breaking change so the result-view renderer can refuse to
+# render unknown versions instead of crashing.
+RESULTS_SCHEMA_VERSION = "m3-c2-v1"
+
+_VALID_CONFIDENCES: frozenset[str] = frozenset({"high", "medium", "low", "failed"})
+
+
+# ---------------------------------------------------------------------------
+# load_documents_node
+# ---------------------------------------------------------------------------
+
+
+def make_load_documents_node(
+    db: AsyncSession,
+    document_ids: list[uuid.UUID],
+) -> Callable[[TabularExecutionState], Awaitable[dict[str, Any]]]:
+    """Build the load-documents node bound to a DB session."""
+
+    async def load_documents_node(state: TabularExecutionState) -> dict[str, Any]:
+        stmt = select(Document).where(Document.id.in_(document_ids))
+        rows = (await db.execute(stmt)).scalars().all()
+        by_id = {row.id: row for row in rows}
+
+        # Preserve the operator's selection order (matches the playbook
+        # easy_playbook_worker's _load_documents helper); missing rows
+        # are silently skipped.
+        documents: list[dict[str, str]] = []
+        for did in document_ids:
+            row = by_id.get(did)
+            if row is None:
+                logger.info(
+                    "tabular_executor.load_documents: document missing; skipping",
+                    extra={
+                        "event": "tabular_load_documents_missing",
+                        "document_id": str(did),
+                    },
+                )
+                continue
+            documents.append(
+                {
+                    "id": str(row.id),
+                    "name": _document_display_name(row),
+                }
+            )
+
+        return {"documents": documents}
+
+    return load_documents_node
+
+
+def _document_display_name(document: Document) -> str:
+    """Best-effort display name for a Document.
+
+    Tries ``original_filename`` (the operator-uploaded name) first, then
+    falls back to the row id. Matches the existing UI convention in
+    the playbook execution-view renderer.
+    """
+
+    name = getattr(document, "original_filename", None) or getattr(document, "name", None)
+    if name:
+        return str(name)
+    return str(document.id)
+
+
+# ---------------------------------------------------------------------------
+# extract_cells_node
+# ---------------------------------------------------------------------------
+
+
+_EXTRACT_SYSTEM_PROMPT = """\
+You are a Tabular Extraction Assistant for a legal AI tool.
+
+You will be given:
+* A DOCUMENT NAME (for context).
+* A QUERY (the column header's per-row prompt).
+* A ranked list of DOCUMENT EXCERPTS retrieved via lexical search over
+  the document.
+
+Your job: extract a concise answer to the QUERY from the EXCERPTS, and
+cite which excerpts back your answer.
+
+Output STRICTLY VALID JSON in this exact shape:
+
+  {"value": "<extracted value as a short string; empty string if not present>",
+   "cited_chunk_indices": [<int>, ...],
+   "confidence": "high" | "medium" | "low" | "failed",
+   "justification": "<one or two sentences explaining the value or why none was found>"}
+
+Confidence meanings:
+
+* "high" — the answer is stated explicitly in one or more excerpts.
+* "medium" — the answer is implied but not stated verbatim.
+* "low" — the excerpts only weakly support the answer; flag for human review.
+* "failed" — the excerpts do not contain enough information to answer.
+
+The ``cited_chunk_indices`` field is a list of 0-based indices of the
+excerpts (in the order presented below) whose content supports your
+answer. Always include at least one index for non-"failed" confidence.
+
+Bias toward "failed" when the document does not address the QUERY at
+all — false positives are worse than false negatives in tabular review.
+"""
+
+
+def make_extract_cells_node(
+    *,
+    db: AsyncSession,
+    gateway: GatewayClient,
+    judge_model: str,
+) -> Callable[[TabularExecutionState], Awaitable[dict[str, Any]]]:
+    """Build the cell-extraction node bound to a DB session + gateway.
+
+    Walks ``documents x columns`` sequentially; per cell, fetches the
+    top-K relevant chunks via FTS using the column's query as keyword
+    input, then calls :func:`extract_cell` to dispatch the LLM call.
+    Accumulates results into ``state['per_cell_results']``.
+    """
+
+    async def extract_cells_node(state: TabularExecutionState) -> dict[str, Any]:
+        documents = state.get("documents", []) or []
+        columns_raw = state.get("columns", []) or []
+        # Re-hydrate the column spec from the state dict shape; the
+        # serializable representation lives in state but the cell-level
+        # logic wants the Pydantic shape for field access.
+        columns = [ColumnSpec.model_validate(col) for col in columns_raw]
+
+        per_cell_results: list[dict[str, Any]] = []
+
+        for document in documents:
+            document_id = uuid.UUID(document["id"])
+            for column in columns:
+                chunks = await _fts_over_document(
+                    db,
+                    document_id=document_id,
+                    query=column.query,
+                    limit=RETRIEVAL_TOP_K,
+                )
+                cell = await extract_cell(
+                    gateway=gateway,
+                    judge_model=judge_model,
+                    document_name=document["name"],
+                    chunks=chunks,
+                    column=column,
+                )
+                cell["document_id"] = str(document_id)
+                cell["column_name"] = column.name
+                per_cell_results.append(cell)
+
+        return {"per_cell_results": per_cell_results}
+
+    return extract_cells_node
+
+
+async def extract_cell(
+    *,
+    gateway: GatewayClient,
+    judge_model: str,
+    document_name: str,
+    chunks: list[dict[str, Any]],
+    column: ColumnSpec,
+) -> dict[str, Any]:
+    """Run one cell extraction; return a cell-result dict.
+
+    Public surface (not just an internal helper) so the unit tests can
+    exercise the LLM-dispatch + parsing logic without standing up the
+    full LangGraph workflow + DB.
+
+    Failure paths:
+
+    * No chunks retrieved (empty document or no FTS hits at all on a
+      cold-keywordless query) → short-circuit to ``confidence='failed'``
+      without a gateway call.
+    * Gateway raises → ``confidence='failed'`` with ``error`` populated.
+    * LLM response is malformed JSON or missing ``value`` →
+      ``confidence='failed'``.
+    """
+
+    if not chunks:
+        return _failed_cell("no chunks retrieved")
+
+    messages = _build_extract_messages(
+        document_name=document_name,
+        column=column,
+        chunks=chunks,
+    )
+
+    request = ChatCompletionRequest(
+        model=judge_model,
+        messages=messages,
+        max_tokens=EXTRACT_MAX_TOKENS,
+        anonymize=False,
+        lq_ai_purpose=TABULAR_EXTRACTION_PURPOSE,
+        minimum_inference_tier=column.minimum_inference_tier,
+    )
+
+    try:
+        response = await gateway.chat_completion(request)
+    except Exception as exc:
+        logger.warning(
+            "tabular extract_cell gateway error: %s",
+            exc,
+            extra={
+                "event": "tabular_extract_cell_error",
+                "error_type": type(exc).__name__,
+            },
+        )
+        return _failed_cell(f"{type(exc).__name__}: {exc}")
+
+    try:
+        choices = response.choices
+        if not choices:
+            return _failed_cell("empty response from gateway")
+        content = choices[0].message.content
+    except AttributeError:
+        return _failed_cell("malformed gateway response")
+
+    if not content:
+        return _failed_cell("empty response content")
+
+    parsed = _parse_cell_response(content)
+    value = parsed.get("value")
+    if not value or not isinstance(value, str) or not value.strip():
+        return _failed_cell("no value in extraction response")
+
+    confidence = _coerce_confidence(parsed.get("confidence"))
+    cited_indices = _coerce_chunk_indices(
+        parsed.get("cited_chunk_indices"),
+        n_chunks=len(chunks),
+    )
+    cited_chunk_ids = [chunks[i]["id"] for i in cited_indices]
+
+    return {
+        "value": value.strip(),
+        "cited_chunk_ids": cited_chunk_ids,
+        "confidence": confidence,
+        "tier_used": column.minimum_inference_tier,
+        # cost_usd is best filled by the gateway response surface; for
+        # v0.3.0 we leave it at 0 here and reconcile from the routing
+        # log post-hoc in the aggregate node. The cost-estimator's
+        # rolling-average converges off the routing log either way.
+        "cost_usd": "0",
+        "error": None,
+    }
+
+
+def _failed_cell(reason: str) -> dict[str, Any]:
+    return {
+        "value": None,
+        "cited_chunk_ids": [],
+        "confidence": "failed",
+        "tier_used": None,
+        "cost_usd": "0",
+        "error": reason,
+    }
+
+
+def _build_extract_messages(
+    *,
+    document_name: str,
+    column: ColumnSpec,
+    chunks: list[dict[str, Any]],
+) -> list[ChatCompletionMessage]:
+    """Render the extraction-prompt messages for one cell."""
+
+    chunk_blocks: list[str] = []
+    for i, chunk in enumerate(chunks):
+        chunk_blocks.append(f"[CHUNK {i}]\n{chunk['content']}")
+
+    user_content = (
+        f"DOCUMENT NAME: {document_name}\n\n"
+        f"QUERY: {column.query}\n\n"
+        f"DOCUMENT EXCERPTS:\n" + ("\n\n".join(chunk_blocks) if chunk_blocks else "(none)")
+    )
+    return [
+        ChatCompletionMessage(role="system", content=_EXTRACT_SYSTEM_PROMPT),
+        ChatCompletionMessage(role="user", content=user_content),
+    ]
+
+
+async def _fts_over_document(
+    db: AsyncSession,
+    *,
+    document_id: uuid.UUID,
+    query: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Lexical FTS over ``document_chunks`` scoped to one document.
+
+    Mirrors :func:`app.playbooks.nodes._fts_over_document` — uses
+    ``websearch_to_tsquery`` so multi-word queries with OR-like
+    semantics rank chunks that hit any token. Falls back to the first
+    N chunks when FTS yields nothing (so the LLM still sees document
+    context to evaluate)."""
+
+    if not query.strip():
+        return await _fetch_first_chunks(db, document_id, limit=limit)
+
+    result = await db.execute(
+        text(
+            "SELECT dc.id::text, dc.chunk_index, dc.content, "
+            "dc.char_offset_start, dc.char_offset_end, dc.page_start, "
+            "ts_rank_cd(dc.content_tsv, websearch_to_tsquery('english', :q)) AS rank "
+            "FROM document_chunks dc "
+            "WHERE dc.document_id = :doc_id "
+            "AND dc.content_tsv @@ websearch_to_tsquery('english', :q) "
+            "ORDER BY rank DESC, dc.chunk_index ASC "
+            "LIMIT :limit"
+        ),
+        {"q": query, "doc_id": str(document_id), "limit": limit},
+    )
+    rows = [
+        {
+            "id": row.id,
+            "chunk_index": row.chunk_index,
+            "content": row.content,
+            "char_offset_start": row.char_offset_start,
+            "char_offset_end": row.char_offset_end,
+            "page_start": row.page_start,
+        }
+        for row in result
+    ]
+    if rows:
+        return rows
+    return await _fetch_first_chunks(db, document_id, limit=limit)
+
+
+async def _fetch_first_chunks(
+    db: AsyncSession,
+    document_id: uuid.UUID,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Defensive fallback when FTS yields no rows."""
+
+    stmt = (
+        select(DocumentChunk)
+        .where(DocumentChunk.document_id == document_id)
+        .order_by(DocumentChunk.chunk_index)
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": str(row.id),
+            "chunk_index": row.chunk_index,
+            "content": row.content,
+            "char_offset_start": row.char_offset_start,
+            "char_offset_end": row.char_offset_end,
+            "page_start": row.page_start,
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# aggregate_node — group cells by document, persist results
+# ---------------------------------------------------------------------------
+
+
+def make_aggregate_node(
+    db: AsyncSession,
+) -> Callable[[TabularExecutionState], Awaitable[dict[str, Any]]]:
+    """Build the aggregation node bound to a DB session.
+
+    Groups ``state['per_cell_results']`` by document into the final
+    ``tabular_executions.results`` JSONB shape; flips status to
+    ``'completed'`` (or ``'failed'`` if a prior node set
+    ``state['error']``); writes ``cost_actual_usd`` as the sum across
+    cells; sets ``completed_at``.
+    """
+
+    async def aggregate_node(state: TabularExecutionState) -> dict[str, Any]:
+        execution_id = uuid.UUID(state["execution_id"])
+        documents = state.get("documents", []) or []
+        per_cell_results = state.get("per_cell_results", []) or []
+        error = state.get("error")
+
+        results_payload = _shape_results_payload(per_cell_results, documents)
+        cost_actual = _sum_cell_costs(per_cell_results)
+
+        values: dict[str, Any] = {
+            "results": results_payload,
+            "cost_actual_usd": cost_actual,
+            "completed_at": datetime.now(UTC),
+        }
+        if error:
+            values["status"] = "failed"
+            values["error_text"] = str(error)[:2000]
+        else:
+            values["status"] = "completed"
+
+        await db.execute(
+            update(TabularExecution).where(TabularExecution.id == execution_id).values(**values)
+        )
+        await db.commit()
+        return {}
+
+    return aggregate_node
+
+
+def _assemble_rows(
+    per_cell_results: list[dict[str, Any]],
+    documents: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Group cells by document and emit rows in ``documents`` order.
+
+    Cells are keyed by ``column_name`` within each row. The per-cell
+    in-flight shape (with ``document_id`` + ``column_name`` keys) gets
+    converted to the persisted :class:`app.schemas.tabular.CellResult`
+    shape (no document_id / column_name; those live on the row /
+    cell-map key)."""
+
+    by_doc: dict[str, dict[str, dict[str, Any]]] = {}
+    for cell in per_cell_results:
+        doc_id = cell.get("document_id")
+        col_name = cell.get("column_name")
+        if not doc_id or not col_name:
+            continue
+        by_doc.setdefault(doc_id, {})[col_name] = _strip_state_keys(cell)
+
+    rows: list[dict[str, Any]] = []
+    for doc in documents:
+        cells = by_doc.get(doc["id"], {})
+        rows.append(
+            {
+                "document_id": doc["id"],
+                "document_name": doc["name"],
+                "cells": cells,
+            }
+        )
+    return rows
+
+
+def _strip_state_keys(cell: dict[str, Any]) -> dict[str, Any]:
+    """Project the in-flight cell shape down to the persisted shape."""
+    keys = ("value", "cited_chunk_ids", "confidence", "tier_used", "cost_usd", "error")
+    return {key: cell.get(key) for key in keys}
+
+
+def _shape_results_payload(
+    per_cell_results: list[dict[str, Any]],
+    documents: list[dict[str, str]],
+) -> dict[str, Any]:
+    """Render the per-cell results into the JSONB payload shape."""
+
+    rows = _assemble_rows(per_cell_results, documents)
+    total = len(per_cell_results)
+    failed = sum(1 for c in per_cell_results if c.get("confidence") == "failed")
+    return {
+        "schema_version": RESULTS_SCHEMA_VERSION,
+        "rows": rows,
+        "summary": {
+            "total_cells": total,
+            "failed_cells": failed,
+        },
+    }
+
+
+def _sum_cell_costs(per_cell_results: list[dict[str, Any]]) -> Decimal:
+    """Sum per-cell costs to derive ``cost_actual_usd``.
+
+    Cells without a recorded cost contribute 0 — the v0.3.0 cell node
+    does not yet propagate per-call cost back from the gateway
+    response surface, so this defaults to 0 across all cells until
+    the gateway returns cost in its response shape. Once it does,
+    this sum becomes the authoritative actual."""
+
+    total = Decimal("0")
+    for cell in per_cell_results:
+        raw = cell.get("cost_usd")
+        if raw is None:
+            continue
+        try:
+            total += Decimal(str(raw))
+        except Exception:
+            continue
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Structured-output JSON parser (lenient)
+# ---------------------------------------------------------------------------
+
+
+def _parse_cell_response(content: str) -> dict[str, Any]:
+    """Lenient JSON parse — trim a leading code fence if present, then
+    :func:`json.loads`."""
+
+    stripped = content.strip()
+    if stripped.startswith("```"):
+        stripped = stripped.split("```", 2)[1]
+        if stripped.startswith("json"):
+            stripped = stripped[4:]
+        stripped = stripped.rstrip("`").strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "tabular extract_cell returned malformed JSON: %s",
+            exc,
+            extra={"event": "tabular_extract_cell_malformed_json"},
+        )
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return parsed
+
+
+def _coerce_confidence(raw: Any) -> str:
+    """Normalize confidence to one of the four valid values; default ``low``."""
+
+    if isinstance(raw, str) and raw in _VALID_CONFIDENCES:
+        return raw
+    return "low"
+
+
+def _coerce_chunk_indices(raw: Any, *, n_chunks: int) -> list[int]:
+    """Filter the model-emitted index list to valid 0-based ints inside the chunk count."""
+
+    if not isinstance(raw, list):
+        return []
+    out: list[int] = []
+    for item in raw:
+        if isinstance(item, int) and not isinstance(item, bool) and 0 <= item < n_chunks:
+            out.append(item)
+    return out
+
+
+__all__ = [
+    "RESULTS_SCHEMA_VERSION",
+    "RETRIEVAL_TOP_K",
+    "extract_cell",
+    "make_aggregate_node",
+    "make_extract_cells_node",
+    "make_load_documents_node",
+]

--- a/api/app/tabular/nodes.py
+++ b/api/app/tabular/nodes.py
@@ -466,8 +466,8 @@ def make_aggregate_node(
 
 
 def _assemble_rows(
-    per_cell_results: list[dict[str, Any]],
-    documents: list[dict[str, str]],
+    per_cell_results: list[Any],
+    documents: list[Any],
 ) -> list[dict[str, Any]]:
     """Group cells by document and emit rows in ``documents`` order.
 
@@ -505,8 +505,8 @@ def _strip_state_keys(cell: dict[str, Any]) -> dict[str, Any]:
 
 
 def _shape_results_payload(
-    per_cell_results: list[dict[str, Any]],
-    documents: list[dict[str, str]],
+    per_cell_results: list[Any],
+    documents: list[Any],
 ) -> dict[str, Any]:
     """Render the per-cell results into the JSONB payload shape."""
 
@@ -523,7 +523,7 @@ def _shape_results_payload(
     }
 
 
-def _sum_cell_costs(per_cell_results: list[dict[str, Any]]) -> Decimal:
+def _sum_cell_costs(per_cell_results: list[Any]) -> Decimal:
     """Sum per-cell costs to derive ``cost_actual_usd``.
 
     Cells without a recorded cost contribute 0 — the v0.3.0 cell node

--- a/api/app/tabular/state.py
+++ b/api/app/tabular/state.py
@@ -1,0 +1,121 @@
+"""LangGraph state for the Tabular Review executor — M3-C2.
+
+Mirrors the M3-A2 :mod:`app.playbooks.state` pattern. The state is a
+single :class:`TabularExecutionState` TypedDict that the executor's
+nodes (load-documents / extract-cells / aggregate) read and extend.
+
+Per Decision C-3 the runtime runs inside the ARQ worker; per-node
+checkpointing is deliberately not wired in v0.3.0. A failure mid-flight
+surfaces as a single ``error`` field and the row flips to
+``status='failed'``; the operator restarts a fresh execution rather
+than resuming partial state. Per-node checkpointing is a candidate
+enhancement once production failure modes are better understood.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class _ColumnSpecState(TypedDict, total=False):
+    """A column spec, serialized for the executor's state.
+
+    Mirrors :class:`app.schemas.tabular.ColumnSpec` but as a TypedDict
+    so LangGraph's state serialization stays straightforward (Pydantic
+    models inside the state are fine but a TypedDict signals the
+    intent: this is data, not behavior)."""
+
+    name: str
+    query: str
+    ensemble_verification: bool | None
+    minimum_inference_tier: int | None
+
+
+class _DocumentSnapshot(TypedDict):
+    """A document loaded for the run — minimal shape the executor needs.
+
+    Loaded once at the top of :func:`app.tabular.executor.run_tabular_execution`
+    so the cell-extraction node doesn't re-hit the DB per cell. The
+    document's normalized content lives on the row (for FTS) but the
+    cell extraction works against the per-chunk content fetched at
+    cell time."""
+
+    id: str
+    name: str
+
+
+class _CellResultState(TypedDict, total=False):
+    """One cell result accumulated by the extraction node.
+
+    Kept ``total=False`` so the extraction failure path can write
+    partial keys without satisfying every field. The aggregation node
+    reads keys defensively (``.get``) so a missing key defaults to a
+    sensible value.
+
+    Persisted shape (post-aggregation) is
+    :class:`app.schemas.tabular.CellResult`. This TypedDict is the
+    in-flight shape carrying the document_id + column_name so the
+    aggregation node can group cells back into rows.
+    """
+
+    document_id: str
+    column_name: str
+    value: str | None
+    cited_chunk_ids: list[str]
+    confidence: str  # high|medium|low|failed
+    tier_used: int | None
+    cost_usd: str  # Decimal as string for JSON serializability
+    error: str | None
+
+
+class TabularExecutionState(TypedDict, total=False):
+    """LangGraph state for one tabular execution.
+
+    Fields populated at graph entry (by :func:`run_tabular_execution`):
+
+    * ``execution_id`` — the row in ``tabular_executions`` being filled.
+    * ``columns`` — resolved column spec (snapshot of skill's
+      ``lq_ai.columns`` OR operator's ad-hoc list — already decided at
+      request time).
+    * ``judge_model`` — alias the gateway resolves for cell-extraction
+      calls (typically ``"smart"``).
+
+    Fields populated by intermediate nodes:
+
+    * ``documents`` — loaded by :func:`load_documents_node`; passed
+      through to the extraction node.
+    * ``per_cell_results`` — accumulated by :func:`extract_cells_node`;
+      grouped by document_id by :func:`aggregate_node` into the final
+      ``tabular_executions.results`` JSONB payload.
+
+    Failure state:
+
+    * ``error`` — populated when a node raises; :func:`aggregate_node`
+      flips the execution status to ``'failed'`` rather than
+      ``'completed'``.
+    """
+
+    execution_id: str
+    columns: list[_ColumnSpecState]
+    judge_model: str
+
+    documents: list[_DocumentSnapshot]
+    per_cell_results: list[_CellResultState]
+    error: str | None
+
+
+# Public-ish helpers for outside-the-graph callers. Anything the
+# worker or endpoint imports for type hints lives here.
+
+__all__ = [
+    "TabularExecutionState",
+]
+
+
+# Internal re-export — keeps the nodes module from re-deriving the
+# CellResult shape; outside callers continue to use the Pydantic
+# :class:`app.schemas.tabular.CellResult` for the wire surface.
+_InternalCellResult = _CellResultState
+_InternalDocumentSnapshot = _DocumentSnapshot
+_InternalColumnSpec = _ColumnSpecState
+_InternalAny = Any  # mypy-friendly forward-compat placeholder

--- a/api/app/workers/arq_setup.py
+++ b/api/app/workers/arq_setup.py
@@ -1,4 +1,5 @@
-"""M3-A6 ``arq`` worker — background jobs for the Playbook Service.
+"""Shared playbook ``arq`` worker — background jobs for Easy Playbook
+generation (M3-A6) and Tabular Review execution (M3-C2).
 
 Sister worker to :mod:`app.workers.document_pipeline` (the ``ingest-worker``
 container). Both processes share the same Redis instance for coordination
@@ -8,23 +9,37 @@ delay the other.
 Why a separate queue
 --------------------
 
-The Easy Playbook generation pipeline (M3-A6 Phase 5) is a long-running
-job — the PRD §3.7 NFR allows up to 10 minutes for a 10-document corpus.
-If easy-playbook jobs landed on the default ``arq:queue`` they would
-compete with document-ingest jobs and either side could starve the other
+Long-running jobs — both Easy Playbook generation (PRD §3.7 NFR up to
+10 minutes for a 10-document corpus) and Tabular Review execution (up
+to 200 docs x 10 cols = 2000 cells over hours per Phase C prep doc
+Decision C-3) — landing on the default ``arq:queue`` would compete
+with document-ingest jobs and either side could starve the other
 depending on queue depth. Worse, each worker would receive jobs whose
 function name it does not register and reject them.
 
-The new worker therefore declares ``queue_name = M3A6_QUEUE_NAME`` and
-the API-side enqueue helpers (added in Phase 5) build their pool with
-``default_queue_name=M3A6_QUEUE_NAME`` so the two pipelines never mix.
+The worker therefore declares ``queue_name = M3_PLAYBOOK_QUEUE_NAME``
+and the API-side enqueue helpers build their pool with
+``default_queue_name=M3_PLAYBOOK_QUEUE_NAME`` so the playbook +
+tabular pipelines never mix with the ingest pipeline.
+
+Why share the queue between Easy Playbook + Tabular
+---------------------------------------------------
+
+Per Decision C-3: two arq containers per deployment would double the
+operational surface for no isolation win — both workloads are bursty
+in different shapes (Easy Playbook = 1-10 docs over ~10 min; Tabular =
+up to 2000 cells over hours), but neither saturates a worker long
+enough to deserve isolation. If we see queue contention in production,
+splitting is a follow-on PR; the queue string stays ``arq:m3a6`` for
+on-the-wire compatibility (rename is constant-name-only).
 
 Registered functions:
 
-* ``noop_job`` (Phase 1) — kept indefinitely as a lightweight
-  "is the worker consuming?" health probe.
+* ``noop_job`` — lightweight "is the worker consuming?" health probe.
 * :func:`app.workers.easy_playbook_worker.easy_playbook_generation_job`
-  (Phase 5) — the real Easy Playbook generation pipeline.
+  (M3-A6) — Easy Playbook generation pipeline.
+* :func:`app.workers.tabular_worker.tabular_execution_job`
+  (M3-C2) — Tabular Review execution pipeline.
 
 Discovered by the ``arq`` CLI via::
 
@@ -42,16 +57,27 @@ from typing import Any, ClassVar
 from app.config import get_settings
 from app.db.session import dispose_engine
 from app.workers.easy_playbook_worker import easy_playbook_generation_job
+from app.workers.tabular_worker import tabular_execution_job
 
 log = logging.getLogger(__name__)
 
 
-M3A6_QUEUE_NAME = "arq:m3a6"
-"""Dedicated arq queue for M3-A6+ background work. Disjoint from the
-ingest-worker's default ``arq:queue`` so a backlog on either side does
-not affect the other. Phase 5 introduces the API-side enqueue helper
-that targets this queue; Phase 1 only proves the worker consumes from
-it (via the smoke test)."""
+M3_PLAYBOOK_QUEUE_NAME = "arq:m3a6"
+"""Dedicated arq queue for shared playbook + tabular background work.
+Disjoint from the ingest-worker's default ``arq:queue`` so a backlog
+on either side does not affect the other.
+
+Queue string stays ``arq:m3a6`` (the original M3-A6 name) for
+on-the-wire compatibility — only the Python constant was renamed to
+better describe its current workload (Easy Playbook + Tabular share
+this queue per Phase C prep doc Decision C-3). The
+:data:`M3A6_QUEUE_NAME` alias below stays exported for one release so
+in-flight code / external integrations keep working."""
+
+M3A6_QUEUE_NAME = M3_PLAYBOOK_QUEUE_NAME
+"""Backward-compat alias for the renamed :data:`M3_PLAYBOOK_QUEUE_NAME`.
+Will be removed in a future release; new code should use
+:data:`M3_PLAYBOOK_QUEUE_NAME`."""
 
 
 # ---------------------------------------------------------------------------
@@ -90,9 +116,11 @@ async def on_startup(ctx: dict[str, Any]) -> None:
     """
 
     log.info(
-        "arq-worker startup: M3-A6 queue=%s ready",
-        M3A6_QUEUE_NAME,
-        extra={"event": "arq_m3a6_startup", "queue": M3A6_QUEUE_NAME},
+        "arq-worker startup: playbook queue=%s ready",
+        M3_PLAYBOOK_QUEUE_NAME,
+        # Event name kept stable for log-query consumers; the queue
+        # value uses the renamed constant (same string either way).
+        extra={"event": "arq_m3a6_startup", "queue": M3_PLAYBOOK_QUEUE_NAME},
     )
 
 
@@ -134,8 +162,12 @@ class WorkerSettings:
     See https://arq-docs.helpmanual.io/#workersettings for the schema.
     """
 
-    functions: ClassVar[list[Any]] = [noop_job, easy_playbook_generation_job]
-    queue_name: ClassVar[str] = M3A6_QUEUE_NAME
+    functions: ClassVar[list[Any]] = [
+        noop_job,
+        easy_playbook_generation_job,
+        tabular_execution_job,
+    ]
+    queue_name: ClassVar[str] = M3_PLAYBOOK_QUEUE_NAME
     # PRD §3.7 NFR caps generation at 10 min for a 10-doc corpus on the
     # default judge model. A 5-doc corpus is ~5 min, so the prior
     # default-300s ceiling cut runs off mid-assembly. 900s = NFR + 50%

--- a/api/app/workers/queue.py
+++ b/api/app/workers/queue.py
@@ -46,15 +46,29 @@ and writes it to MinIO under ``exports/<user_id>/<job_id>.zip``."""
 
 EASY_PLAYBOOK_JOB_NAME = "easy_playbook_generation_job"
 """M3-A6 Phase 5 — Easy Playbook generation pipeline. Triggered by
-the API when a user calls ``POST /api/v1/playbooks/easy``; the M3-A6
-worker (see :mod:`app.workers.arq_setup`) consumes from the dedicated
-``arq:m3a6`` queue, walks the document corpus, and writes the
+the API when a user calls ``POST /api/v1/playbooks/easy``; the
+playbook worker (see :mod:`app.workers.arq_setup`) consumes from the
+shared playbook queue, walks the document corpus, and writes the
 assembled draft playbook back to the ``easy_playbook_generations`` row."""
 
-M3A6_QUEUE_NAME = "arq:m3a6"
-"""Mirror of :data:`app.workers.arq_setup.M3A6_QUEUE_NAME` (kept here
-to avoid a circular import). Must stay in sync; a discrepancy would
-queue jobs that the worker never sees."""
+TABULAR_JOB_NAME = "tabular_execution_job"
+"""M3-C2 — Tabular Review execution pipeline. Triggered by the API
+when a user calls ``POST /api/v1/tabular/execute``; the playbook
+worker consumes from the same shared queue as Easy Playbook (per
+Decision C-3) and walks the documents x columns grid via the
+LangGraph executor."""
+
+M3_PLAYBOOK_QUEUE_NAME = "arq:m3a6"
+"""Mirror of :data:`app.workers.arq_setup.M3_PLAYBOOK_QUEUE_NAME` (kept
+here to avoid a circular import). Must stay in sync; a discrepancy
+would queue jobs that the worker never sees. Queue string stays
+``arq:m3a6`` for on-the-wire compatibility — only the Python constant
+was renamed."""
+
+M3A6_QUEUE_NAME = M3_PLAYBOOK_QUEUE_NAME
+"""Backward-compat alias for the renamed :data:`M3_PLAYBOOK_QUEUE_NAME`.
+Will be removed in a future release; new code should use
+:data:`M3_PLAYBOOK_QUEUE_NAME`."""
 
 _pool: Any = None
 _m3a6_pool: Any = None
@@ -128,7 +142,7 @@ async def _get_m3a6_pool() -> Any:
 
     settings = get_settings()
     redis_settings = RedisSettings.from_dsn(settings.redis_url)
-    _m3a6_pool = await create_pool(redis_settings, default_queue_name=M3A6_QUEUE_NAME)
+    _m3a6_pool = await create_pool(redis_settings, default_queue_name=M3_PLAYBOOK_QUEUE_NAME)
     return _m3a6_pool
 
 
@@ -189,7 +203,7 @@ async def enqueue_embed_job(file_id: uuid.UUID) -> bool:
 
 
 async def enqueue_easy_playbook_generation_job(generation_id: uuid.UUID) -> bool:
-    """Enqueue an Easy Playbook generation job onto the ``arq:m3a6`` queue.
+    """Enqueue an Easy Playbook generation job onto the shared playbook queue.
 
     Returns True on success, False on transport / import failure
     (matching the other ``enqueue_*`` helpers' best-effort posture).
@@ -215,6 +229,42 @@ async def enqueue_easy_playbook_generation_job(generation_id: uuid.UUID) -> bool
             extra={
                 "event": "easy_playbook_enqueue_failed",
                 "generation_id": str(generation_id),
+                "error": str(exc),
+            },
+        )
+        return False
+
+
+async def enqueue_tabular_execution_job(execution_id: uuid.UUID) -> bool:
+    """Enqueue a Tabular Review execution job onto the shared playbook queue.
+
+    Shares the M3-A6-original queue with Easy Playbook per Decision C-3
+    (one shared worker container for both long-running playbook /
+    tabular workloads).
+
+    Returns True on success, False on transport / import failure. The
+    POST handler logs at WARNING on failure but does NOT roll back
+    the row — the result-view polls regardless, and an operator can
+    re-enqueue manually if the row is stuck at ``pending``.
+    """
+
+    try:
+        pool = await _get_m3a6_pool()
+        await pool.enqueue_job(TABULAR_JOB_NAME, str(execution_id))
+        log.info(
+            "enqueue_tabular_execution_job: enqueued",
+            extra={
+                "event": "tabular_execution_enqueue",
+                "execution_id": str(execution_id),
+            },
+        )
+        return True
+    except Exception as exc:
+        log.warning(
+            "enqueue_tabular_execution_job: failed; row stays pending",
+            extra={
+                "event": "tabular_execution_enqueue_failed",
+                "execution_id": str(execution_id),
                 "error": str(exc),
             },
         )

--- a/api/app/workers/tabular_worker.py
+++ b/api/app/workers/tabular_worker.py
@@ -1,0 +1,165 @@
+"""ARQ worker function for the Tabular Review execution pipeline — M3-C2.
+
+The ``POST /api/v1/tabular/execute`` handler creates a
+:class:`TabularExecution` row at ``status='pending'`` and enqueues this
+job (via :func:`app.workers.queue.enqueue_tabular_execution_job`) onto
+the shared playbook queue (``arq:m3a6`` — see Decision C-3 in the
+Phase C prep doc; the queue stays shared with Easy Playbook generation
+to avoid splitting one workload across two worker containers).
+
+The worker picks up the job, resolves a :class:`GatewayClient`, opens
+its own session via the standard factory, and dispatches to
+:func:`app.tabular.executor.run_tabular_execution`. The executor
+manages the lifecycle (running → completed | failed) internally; this
+function's responsibility is the orchestration layer around it (the
+BaseException cancellation-path bookkeeping that matches the
+M3-A6 ``easy_playbook_generation_job`` pattern).
+
+Per the M3-C2 quality bar, the assembled grid is itself a starting
+point the user-attorney reviews. Worker "success" means the executor
+produced a structurally-valid ``tabular_executions.results`` payload
+— not that the extractions are correct, complete, or fit for use
+without review.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import update
+
+from app.db.session import get_session_factory
+from app.models.tabular import TabularExecution
+from app.tabular.executor import run_tabular_execution
+
+if TYPE_CHECKING:
+    from app.clients.gateway import GatewayClient
+
+logger = logging.getLogger(__name__)
+
+
+# Function name registered on the worker — must match the constant in
+# :mod:`app.workers.queue` so the api-side enqueue helper targets the
+# right function on the shared playbook queue.
+TABULAR_EXECUTION_JOB_NAME = "tabular_execution_job"
+
+
+async def tabular_execution_job(ctx: dict[str, Any], execution_id_str: str) -> dict[str, Any]:
+    """ARQ job — run the Tabular Review pipeline for one execution row.
+
+    Lifecycle (delegated to :func:`run_tabular_execution`):
+
+    * On entry: ``pending → running``; sets ``started_at``.
+    * On success: ``running → completed``; sets ``completed_at`` +
+      writes ``results`` JSONB and ``cost_actual_usd`` via the
+      aggregate node.
+    * On in-graph exception: ``running → failed``; sets
+      ``error_text`` + ``completed_at``.
+
+    This wrapper additionally handles:
+
+    * Missing row — graceful early return.
+    * BaseException (ARQ ``job_timeout`` cancellation) — writes the
+      failed terminal state then re-raises so arq's shutdown
+      machinery still sees the cancel. Matches the
+      :func:`app.workers.easy_playbook_worker.easy_playbook_generation_job`
+      pattern.
+
+    Returns a small dict for arq's result-tracking. All real state
+    lives on the execution row.
+    """
+
+    execution_id = uuid.UUID(execution_id_str)
+    logger.info(
+        "tabular_worker: job start",
+        extra={
+            "event": "tabular_worker_start",
+            "execution_id": execution_id_str,
+        },
+    )
+
+    factory = get_session_factory()
+    gateway = _gateway_from_ctx(ctx)
+
+    async with factory() as session:
+        execution = await session.get(TabularExecution, execution_id)
+        if execution is None:
+            logger.warning(
+                "tabular_worker: row not found; nothing to do",
+                extra={
+                    "event": "tabular_worker_row_missing",
+                    "execution_id": execution_id_str,
+                },
+            )
+            return {"execution_id": execution_id_str, "status": "missing"}
+
+        try:
+            await run_tabular_execution(
+                session,
+                execution_id=execution_id,
+                gateway=gateway,
+            )
+        except BaseException as exc:
+            # The executor catches Exception subclasses internally but
+            # not BaseException (CancelledError, SystemExit). On those
+            # paths, write a failed terminal state ourselves so the
+            # row doesn't get stuck at 'running' indefinitely.
+            logger.exception(
+                "tabular_worker: pipeline failed at orchestration layer",
+                extra={
+                    "event": "tabular_worker_orchestration_error",
+                    "execution_id": execution_id_str,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            await session.execute(
+                update(TabularExecution)
+                .where(TabularExecution.id == execution_id)
+                .values(
+                    status="failed",
+                    error_text=f"{type(exc).__name__}: {exc}"[:2000],
+                    completed_at=datetime.now(UTC),
+                )
+            )
+            await session.commit()
+            # Re-raise BaseException subclasses after bookkeeping so
+            # arq's shutdown machinery still sees the cancel.
+            if not isinstance(exc, Exception):
+                raise
+            return {
+                "execution_id": execution_id_str,
+                "status": "failed",
+                "error": str(exc),
+            }
+
+        logger.info(
+            "tabular_worker: job complete",
+            extra={
+                "event": "tabular_worker_complete",
+                "execution_id": execution_id_str,
+            },
+        )
+        return {"execution_id": execution_id_str, "status": "completed"}
+
+
+def _gateway_from_ctx(ctx: dict[str, Any]) -> GatewayClient:
+    """Resolve a :class:`GatewayClient` from the arq worker ``ctx``.
+
+    Mirrors :func:`app.workers.easy_playbook_worker._gateway_from_ctx`
+    — builds one on demand via the api's standard factory if the worker
+    didn't pre-populate ``ctx['gateway']`` at startup. Future
+    optimization: hoist into ``on_startup`` so every job reuses one
+    client.
+    """
+
+    # Lazy import — keeps the worker module importable in environments
+    # where the gateway client isn't yet configured.
+    from app.clients.gateway import GatewayClient, get_gateway_client
+
+    existing = ctx.get("gateway")
+    if isinstance(existing, GatewayClient):
+        return existing
+    return get_gateway_client()

--- a/api/tests/tabular/test_cost.py
+++ b/api/tests/tabular/test_cost.py
@@ -1,0 +1,375 @@
+"""Per-cell cost calibration for Tabular Review — M3-C2.
+
+Targets :mod:`app.tabular.cost`:
+
+* ``db=None`` cold-start fast-path returns the conservative default.
+* Cold-start with empty DB returns the conservative default.
+* Rolling-average computation against real routing-log rows.
+* ``purpose='tabular_extraction'`` filter excludes chat / judge / NULL rows.
+* NULL ``cost_estimate`` rows excluded.
+* Stale rows (older than ``_WINDOW_DAYS``) excluded.
+* Cache hits return cached value without re-querying.
+* ``invalidate_cache()`` resets the cache.
+* Public entry point :func:`estimate_tabular_execution_cost` derives
+  ``cells_count``, ``estimated_tokens``, ``estimated_cost_usd``, and the
+  ``per_tier_breakdown`` from the column spec + document list.
+
+Mirrors the M2-E2 cost-test surface in ``tests/citation/test_cost.py``;
+the Tabular variant is single-primitive (not per-model) because cells
+fan out across whatever tier their column demands. The rolling average
+is over all tabular-extraction calls regardless of routed model.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.inference import InferenceRoutingLog
+from app.schemas.tabular import ColumnSpec
+from app.tabular.cost import (
+    DEFAULT_PER_CELL_USD,
+    DEFAULT_TOKENS_PER_CELL,
+    TABULAR_EXTRACTION_PURPOSE,
+    estimate_per_cell_cost_usd,
+    estimate_tabular_execution_cost,
+    invalidate_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache() -> None:
+    """Reset the in-process cache between tests so cached values from
+    one test don't leak into the next."""
+
+    invalidate_cache()
+
+
+def _tabular_row(
+    *,
+    cost_estimate: Decimal | None = Decimal("0.0030"),
+    tokens_in: int | None = 1800,
+    tokens_out: int | None = 200,
+    purpose: str | None = TABULAR_EXTRACTION_PURPOSE,
+    timestamp: datetime | None = None,
+    routed_model: str = "claude-sonnet-4-6",
+    routed_inference_tier: int = 2,
+) -> InferenceRoutingLog:
+    return InferenceRoutingLog(
+        id=uuid.uuid4(),
+        timestamp=timestamp or datetime.now(UTC),
+        routed_provider="anthropic-prod",
+        routed_model=routed_model,
+        routed_inference_tier=routed_inference_tier,
+        cost_estimate=cost_estimate,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        purpose=purpose,
+    )
+
+
+# --- estimate_per_cell_cost_usd: db=None ------------------------------------
+
+
+@pytest.mark.unit
+async def test_per_cell_db_none_returns_default_without_query() -> None:
+    """``db=None`` is the cold-start fast-path; no DB hit needed."""
+
+    estimate = await estimate_per_cell_cost_usd(None)
+    assert estimate == DEFAULT_PER_CELL_USD
+
+
+# --- estimate_per_cell_cost_usd: cold start ---------------------------------
+
+
+@pytest.mark.integration
+async def test_per_cell_cold_start_no_rows_returns_default(db_session: AsyncSession) -> None:
+    """An empty routing log falls back to the conservative default."""
+
+    estimate = await estimate_per_cell_cost_usd(db_session)
+    assert estimate == DEFAULT_PER_CELL_USD
+
+
+@pytest.mark.integration
+async def test_per_cell_below_min_samples_returns_default(db_session: AsyncSession) -> None:
+    """Fewer than _MIN_SAMPLES tabular rows → fall back to default."""
+
+    for _ in range(3):
+        db_session.add(_tabular_row(cost_estimate=Decimal("0.0010")))
+    await db_session.flush()
+
+    estimate = await estimate_per_cell_cost_usd(db_session)
+    assert estimate == DEFAULT_PER_CELL_USD
+
+
+# --- estimate_per_cell_cost_usd: rolling average ----------------------------
+
+
+@pytest.mark.integration
+async def test_per_cell_rolling_average_computes_correctly(db_session: AsyncSession) -> None:
+    """5+ tabular rows → returns the average of cost_estimate."""
+
+    prices = [
+        Decimal("0.0010"),
+        Decimal("0.0020"),
+        Decimal("0.0030"),
+        Decimal("0.0040"),
+        Decimal("0.0050"),
+    ]
+    for price in prices:
+        db_session.add(_tabular_row(cost_estimate=price))
+    await db_session.flush()
+
+    estimate = await estimate_per_cell_cost_usd(db_session)
+    # average = 0.0030
+    assert estimate == Decimal("0.00300000000000000000") or estimate == Decimal("0.0030")
+
+
+# --- Filter correctness -----------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_per_cell_purpose_filter_excludes_chat_rows(db_session: AsyncSession) -> None:
+    """Chat-purpose rows for the same model are ignored.
+
+    Chat traffic has very different token distribution from tabular
+    extraction (chat ≈ free-form generation, tabular ≈ structured
+    extraction over retrieved chunks). Averaging across both would
+    pollute the per-cell estimate.
+    """
+
+    for _ in range(5):
+        db_session.add(
+            _tabular_row(cost_estimate=Decimal("0.0200"), purpose="chat"),
+        )
+    await db_session.flush()
+
+    estimate = await estimate_per_cell_cost_usd(db_session)
+    assert estimate == DEFAULT_PER_CELL_USD
+
+
+@pytest.mark.integration
+async def test_per_cell_purpose_filter_excludes_null_purpose_rows(
+    db_session: AsyncSession,
+) -> None:
+    """Rows with NULL purpose are excluded (matches the citation/cost.py posture)."""
+
+    for _ in range(5):
+        db_session.add(_tabular_row(cost_estimate=Decimal("0.0050"), purpose=None))
+    await db_session.flush()
+
+    estimate = await estimate_per_cell_cost_usd(db_session)
+    assert estimate == DEFAULT_PER_CELL_USD
+
+
+@pytest.mark.integration
+async def test_per_cell_purpose_filter_excludes_judge_paraphrase_rows(
+    db_session: AsyncSession,
+) -> None:
+    """``judge_paraphrase`` rows are excluded from the tabular average.
+
+    A model can serve all three workloads; only the tabular-extraction
+    rows reflect cell-shaped traffic.
+    """
+
+    for _ in range(5):
+        db_session.add(
+            _tabular_row(cost_estimate=Decimal("0.0080"), purpose="judge_paraphrase"),
+        )
+    await db_session.flush()
+
+    estimate = await estimate_per_cell_cost_usd(db_session)
+    assert estimate == DEFAULT_PER_CELL_USD
+
+
+@pytest.mark.integration
+async def test_per_cell_null_cost_estimate_rows_excluded(db_session: AsyncSession) -> None:
+    """Tabular rows missing ``cost_estimate`` don't poison the average."""
+
+    for _ in range(5):
+        db_session.add(_tabular_row(cost_estimate=Decimal("0.0010")))
+    for _ in range(10):
+        db_session.add(_tabular_row(cost_estimate=None))
+    await db_session.flush()
+
+    estimate = await estimate_per_cell_cost_usd(db_session)
+    assert estimate == Decimal("0.00100000000000000000") or estimate == Decimal("0.0010")
+
+
+@pytest.mark.integration
+async def test_per_cell_stale_rows_excluded(db_session: AsyncSession) -> None:
+    """Rows older than _WINDOW_DAYS are excluded.
+
+    Protects against price-stale data on low-traffic deployments.
+    """
+
+    now = datetime.now(UTC)
+    stale = now - timedelta(days=60)
+
+    for _ in range(5):
+        db_session.add(_tabular_row(cost_estimate=Decimal("0.0010"), timestamp=now))
+    for _ in range(10):
+        db_session.add(_tabular_row(cost_estimate=Decimal("0.1000"), timestamp=stale))
+    await db_session.flush()
+
+    estimate = await estimate_per_cell_cost_usd(db_session)
+    # If stale rows weren't excluded, average ≈ 0.067.
+    assert estimate < Decimal("0.005")
+
+
+# --- Cache ------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_per_cell_cache_returns_same_value_without_db_hit(
+    db_session: AsyncSession,
+) -> None:
+    """Second call within TTL returns cached value even if rows change."""
+
+    for _ in range(5):
+        db_session.add(_tabular_row(cost_estimate=Decimal("0.0010")))
+    await db_session.flush()
+
+    first = await estimate_per_cell_cost_usd(db_session)
+
+    for _ in range(10):
+        db_session.add(_tabular_row(cost_estimate=Decimal("0.1000")))
+    await db_session.flush()
+
+    second = await estimate_per_cell_cost_usd(db_session)
+    assert second == first
+
+
+@pytest.mark.unit
+async def test_invalidate_cache_all_clears_everything() -> None:
+    """``invalidate_cache()`` clears state without raising."""
+
+    await estimate_per_cell_cost_usd(None)
+    invalidate_cache()  # should not raise
+
+
+# --- estimate_tabular_execution_cost: public entry point --------------------
+
+
+@pytest.mark.unit
+async def test_execution_cost_cells_count_is_docs_times_columns() -> None:
+    """``cells_count = len(document_ids) * len(columns)``."""
+
+    doc_ids = [uuid.uuid4() for _ in range(5)]
+    cols = [
+        ColumnSpec(name="Term", query="What is the term?"),
+        ColumnSpec(name="Survival", query="What is the survival period?"),
+        ColumnSpec(name="Carveouts", query="What are the carveouts?"),
+        ColumnSpec(name="Governing Law", query="What is the governing law?"),
+    ]
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+    )
+    assert preview.cells_count == 20
+
+
+@pytest.mark.unit
+async def test_execution_cost_uses_default_per_cell_when_db_none() -> None:
+    """``db=None`` uses the cold-start per-cell default x cells_count."""
+
+    doc_ids = [uuid.uuid4() for _ in range(3)]
+    cols = [
+        ColumnSpec(name="A", query="?"),
+        ColumnSpec(name="B", query="?"),
+    ]
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+    )
+    # 3 docs * 2 cols * 0.005 = 0.030
+    assert preview.estimated_cost_usd == DEFAULT_PER_CELL_USD * Decimal(6)
+
+
+@pytest.mark.unit
+async def test_execution_cost_estimated_tokens_uses_default_when_db_none() -> None:
+    """``db=None`` uses the cold-start tokens-per-cell default x cells_count."""
+
+    doc_ids = [uuid.uuid4() for _ in range(2)]
+    cols = [ColumnSpec(name="A", query="?")]
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+    )
+    assert preview.estimated_tokens == DEFAULT_TOKENS_PER_CELL * 2
+
+
+@pytest.mark.unit
+async def test_execution_cost_per_tier_breakdown_counts_default_tier() -> None:
+    """Columns without an explicit ``minimum_inference_tier`` count toward
+    the default tier bucket."""
+
+    doc_ids = [uuid.uuid4() for _ in range(4)]
+    cols = [
+        ColumnSpec(name="A", query="?"),  # default tier
+        ColumnSpec(name="B", query="?"),  # default tier
+    ]
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+    )
+    # 4 docs * 2 default-tier cols = 8 cells, all in one bucket
+    assert sum(preview.per_tier_breakdown.values()) == 8
+    assert len(preview.per_tier_breakdown) == 1
+
+
+@pytest.mark.unit
+async def test_execution_cost_per_tier_breakdown_separates_explicit_tier() -> None:
+    """Columns with explicit ``minimum_inference_tier`` get their own bucket."""
+
+    doc_ids = [uuid.uuid4() for _ in range(5)]
+    cols = [
+        ColumnSpec(name="Routine", query="?"),  # default tier
+        ColumnSpec(name="HighStakes", query="?", minimum_inference_tier=4),
+    ]
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+    )
+    # 5 cells default + 5 cells tier_4 = two buckets, each holding 5.
+    assert "tier_4" in preview.per_tier_breakdown
+    assert preview.per_tier_breakdown["tier_4"] == 5
+    # Other bucket carries the remaining 5 default cells.
+    assert sum(preview.per_tier_breakdown.values()) == 10
+
+
+@pytest.mark.unit
+async def test_execution_cost_empty_columns_yields_zero_cells() -> None:
+    """An empty column list yields zero cells / zero cost / zero tokens.
+
+    Defensive: the public entry point shouldn't crash on edge inputs;
+    the endpoint layer's request validation rejects empty inputs before
+    this layer ever sees them, but a zero-cell run should still produce
+    a well-formed response.
+    """
+
+    doc_ids = [uuid.uuid4()]
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=[],
+    )
+    assert preview.cells_count == 0
+    assert preview.estimated_cost_usd == Decimal("0")
+    assert preview.estimated_tokens == 0
+    assert preview.per_tier_breakdown == {}

--- a/api/tests/tabular/test_nodes.py
+++ b/api/tests/tabular/test_nodes.py
@@ -1,0 +1,440 @@
+"""Tabular executor node-level helpers — M3-C2.
+
+Unit tests targeting the pure functions that drive the cell-extraction
+node and the aggregation node in :mod:`app.tabular.nodes`. Full
+end-to-end executor tests (real DB + Document with chunks +
+``run_tabular_execution``) live in :mod:`tests.tabular.test_executor`.
+
+The cell-extraction LLM call is exercised with the
+:class:`_StubGateway` pattern from :mod:`tests.test_easy_playbook_extractor`
+— no live gateway, no live LLM, deterministic payloads queued per call.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from app.schemas.tabular import ColumnSpec
+from app.tabular.nodes import (
+    _assemble_rows,
+    _coerce_chunk_indices,
+    _coerce_confidence,
+    _parse_cell_response,
+    _shape_results_payload,
+    extract_cell,
+)
+
+# ---------------------------------------------------------------------------
+# Stub gateway (mirrors tests.test_easy_playbook_extractor._StubGateway)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubMessage:
+    content: str
+
+
+@dataclass
+class _StubChoice:
+    message: _StubMessage
+
+
+@dataclass
+class _StubResponse:
+    choices: list[_StubChoice]
+
+
+@dataclass
+class _StubGateway:
+    """Returns a queued list of LLM responses, one per call.
+
+    Each entry is either:
+      * ``dict`` — JSON-serialized as the LLM response content;
+      * ``str`` — returned verbatim (malformed-JSON tests);
+      * ``Exception`` — raised on the call (transport-failure tests).
+    """
+
+    payloads: list[Any] = field(default_factory=list)
+    calls_received: list[Any] = field(default_factory=list)
+
+    async def chat_completion(self, request: Any) -> _StubResponse:
+        self.calls_received.append(request)
+        if not self.payloads:
+            return _StubResponse(choices=[_StubChoice(message=_StubMessage(content=""))])
+        payload = self.payloads.pop(0)
+        if isinstance(payload, Exception):
+            raise payload
+        if isinstance(payload, str):
+            return _StubResponse(choices=[_StubChoice(message=_StubMessage(content=payload))])
+        return _StubResponse(
+            choices=[_StubChoice(message=_StubMessage(content=json.dumps(payload)))]
+        )
+
+
+def _chunk(idx: int, content: str = "chunk text") -> dict[str, Any]:
+    return {
+        "id": str(uuid.uuid4()),
+        "chunk_index": idx,
+        "content": content,
+        "char_offset_start": idx * 100,
+        "char_offset_end": idx * 100 + 50,
+        "page_start": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _parse_cell_response — leniently parse the LLM's structured JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_cell_response_valid_json() -> None:
+    """A well-formed JSON object round-trips into a dict."""
+
+    content = '{"value": "5 years", "cited_chunk_indices": [0], "confidence": "high"}'
+    parsed = _parse_cell_response(content)
+    assert parsed["value"] == "5 years"
+    assert parsed["cited_chunk_indices"] == [0]
+    assert parsed["confidence"] == "high"
+
+
+@pytest.mark.unit
+def test_parse_cell_response_strips_code_fence() -> None:
+    """A ```json …``` code-fenced response is unwrapped."""
+
+    content = '```json\n{"value": "5 years", "confidence": "high"}\n```'
+    parsed = _parse_cell_response(content)
+    assert parsed["value"] == "5 years"
+
+
+@pytest.mark.unit
+def test_parse_cell_response_malformed_returns_empty_dict() -> None:
+    """Malformed JSON returns ``{}`` — the caller treats that as failed."""
+
+    parsed = _parse_cell_response("not even close to JSON")
+    assert parsed == {}
+
+
+@pytest.mark.unit
+def test_parse_cell_response_non_object_returns_empty_dict() -> None:
+    """A JSON value that isn't an object (list, scalar) returns ``{}``."""
+
+    assert _parse_cell_response("[1, 2, 3]") == {}
+    assert _parse_cell_response("42") == {}
+    assert _parse_cell_response('"hello"') == {}
+
+
+# ---------------------------------------------------------------------------
+# _coerce_confidence — normalize to high/medium/low/failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_coerce_confidence_passes_valid_values() -> None:
+    for v in ("high", "medium", "low", "failed"):
+        assert _coerce_confidence(v) == v
+
+
+@pytest.mark.unit
+def test_coerce_confidence_defaults_to_low_for_garbage() -> None:
+    """Unknown / non-string / wrong-case values default to ``low``.
+
+    The conservative posture mirrors the playbook executor's
+    :func:`app.playbooks.nodes._coerce_confidence` — bias toward
+    low confidence on uncertainty so the operator sees the
+    weakest-signal state rather than the model's stylistic
+    self-assessment."""
+
+    assert _coerce_confidence(None) == "low"
+    assert _coerce_confidence("HIGH") == "low"
+    assert _coerce_confidence(42) == "low"
+    assert _coerce_confidence("certain") == "low"
+
+
+# ---------------------------------------------------------------------------
+# _coerce_chunk_indices — filter to valid 0-based ints inside the chunk count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_coerce_chunk_indices_keeps_valid_ints() -> None:
+    assert _coerce_chunk_indices([0, 2, 4], n_chunks=5) == [0, 2, 4]
+
+
+@pytest.mark.unit
+def test_coerce_chunk_indices_filters_out_of_range() -> None:
+    """Indices >= n_chunks or < 0 are dropped silently."""
+
+    assert _coerce_chunk_indices([0, 5, -1, 7], n_chunks=3) == [0]
+
+
+@pytest.mark.unit
+def test_coerce_chunk_indices_skips_non_ints() -> None:
+    assert _coerce_chunk_indices([0, "1", None, 2.5, 3], n_chunks=5) == [0, 3]
+
+
+@pytest.mark.unit
+def test_coerce_chunk_indices_non_list_returns_empty() -> None:
+    assert _coerce_chunk_indices(None, n_chunks=5) == []
+    assert _coerce_chunk_indices("not a list", n_chunks=5) == []
+    assert _coerce_chunk_indices(42, n_chunks=5) == []
+
+
+# ---------------------------------------------------------------------------
+# extract_cell — single-cell extraction against a stub gateway
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_extract_cell_returns_value_and_chunk_ids_on_happy_path() -> None:
+    """A well-formed LLM response populates value + cited chunk IDs."""
+
+    chunks = [_chunk(0, "Term: 5 years"), _chunk(1, "Other text")]
+    gateway = _StubGateway(
+        payloads=[
+            {
+                "value": "5 years",
+                "cited_chunk_indices": [0],
+                "confidence": "high",
+                "justification": "stated explicitly",
+            }
+        ]
+    )
+
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="Sample NDA",
+        chunks=chunks,
+        column=ColumnSpec(name="Term", query="What is the term?"),
+    )
+
+    assert cell["value"] == "5 years"
+    assert cell["confidence"] == "high"
+    assert cell["cited_chunk_ids"] == [chunks[0]["id"]]
+
+
+@pytest.mark.unit
+async def test_extract_cell_tags_request_with_tabular_extraction_purpose() -> None:
+    """The cell node sets ``lq_ai_purpose='tabular_extraction'`` on every
+    gateway call so M2-E2's per-purpose cost calibration sees the new
+    traffic and the cost estimator's rolling average can converge."""
+
+    gateway = _StubGateway(payloads=[{"value": "x", "confidence": "high"}])
+    await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="doc",
+        chunks=[_chunk(0)],
+        column=ColumnSpec(name="A", query="?"),
+    )
+    assert len(gateway.calls_received) == 1
+    request = gateway.calls_received[0]
+    assert request.lq_ai_purpose == "tabular_extraction"
+
+
+@pytest.mark.unit
+async def test_extract_cell_forwards_minimum_inference_tier_override() -> None:
+    """Per-column ``minimum_inference_tier`` override is forwarded to
+    the gateway's tier-floor enforcement (Decision C-1)."""
+
+    gateway = _StubGateway(payloads=[{"value": "x", "confidence": "high"}])
+    await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="doc",
+        chunks=[_chunk(0)],
+        column=ColumnSpec(name="HighStakes", query="?", minimum_inference_tier=4),
+    )
+    request = gateway.calls_received[0]
+    assert request.minimum_inference_tier == 4
+
+
+@pytest.mark.unit
+async def test_extract_cell_marks_failed_on_gateway_error() -> None:
+    """Any gateway exception lands as ``confidence='failed'`` + ``error``
+    populated (Decision C-10)."""
+
+    gateway = _StubGateway(payloads=[RuntimeError("provider down")])
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="doc",
+        chunks=[_chunk(0)],
+        column=ColumnSpec(name="A", query="?"),
+    )
+    assert cell["confidence"] == "failed"
+    assert cell["value"] is None
+    assert cell["error"] is not None and "provider down" in cell["error"]
+
+
+@pytest.mark.unit
+async def test_extract_cell_marks_failed_on_empty_value() -> None:
+    """An LLM response with no ``value`` field marks the cell as failed.
+
+    Per Decision C-10, "could not extract" is a distinct UI state from
+    "extracted but unverified" — the cell node treats missing value as
+    the former."""
+
+    gateway = _StubGateway(payloads=[{"confidence": "high", "cited_chunk_indices": []}])
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="doc",
+        chunks=[_chunk(0)],
+        column=ColumnSpec(name="A", query="?"),
+    )
+    assert cell["confidence"] == "failed"
+    assert cell["value"] is None
+
+
+@pytest.mark.unit
+async def test_extract_cell_with_no_chunks_marks_failed() -> None:
+    """A cell with no retrieved chunks short-circuits to failed without
+    a gateway call — extracting from an empty corpus is undefined."""
+
+    gateway = _StubGateway()
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="doc",
+        chunks=[],
+        column=ColumnSpec(name="A", query="?"),
+    )
+    assert cell["confidence"] == "failed"
+    assert gateway.calls_received == []
+
+
+# ---------------------------------------------------------------------------
+# _assemble_rows + _shape_results_payload — aggregation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assemble_rows_groups_cells_by_document_in_order() -> None:
+    """Rows are emitted in ``document_ids`` order (matches operator
+    selection); cells keyed by column name within each row."""
+
+    doc_a = uuid.uuid4()
+    doc_b = uuid.uuid4()
+    per_cell_results = [
+        {
+            "document_id": str(doc_a),
+            "column_name": "Term",
+            "value": "5y",
+            "cited_chunk_ids": [],
+            "confidence": "high",
+            "tier_used": 2,
+            "cost_usd": "0.0030",
+            "error": None,
+        },
+        {
+            "document_id": str(doc_b),
+            "column_name": "Term",
+            "value": "3y",
+            "cited_chunk_ids": [],
+            "confidence": "high",
+            "tier_used": 2,
+            "cost_usd": "0.0040",
+            "error": None,
+        },
+        {
+            "document_id": str(doc_a),
+            "column_name": "Survival",
+            "value": "perpetual",
+            "cited_chunk_ids": [],
+            "confidence": "medium",
+            "tier_used": 2,
+            "cost_usd": "0.0030",
+            "error": None,
+        },
+    ]
+    documents = [
+        {"id": str(doc_a), "name": "NDA A"},
+        {"id": str(doc_b), "name": "NDA B"},
+    ]
+
+    rows = _assemble_rows(per_cell_results, documents)
+
+    # Two rows, in documents order.
+    assert len(rows) == 2
+    assert rows[0]["document_id"] == str(doc_a)
+    assert rows[0]["document_name"] == "NDA A"
+    assert rows[1]["document_id"] == str(doc_b)
+
+    # Doc A has both columns; Doc B has just Term.
+    assert set(rows[0]["cells"].keys()) == {"Term", "Survival"}
+    assert rows[0]["cells"]["Term"]["value"] == "5y"
+    assert rows[0]["cells"]["Survival"]["value"] == "perpetual"
+    assert rows[1]["cells"]["Term"]["value"] == "3y"
+
+
+@pytest.mark.unit
+def test_shape_results_payload_includes_schema_version_and_rows() -> None:
+    """The persisted JSONB shape carries a schema-version stamp + rows +
+    a summary so the result view can decode it without re-deriving."""
+
+    doc = uuid.uuid4()
+    per_cell_results = [
+        {
+            "document_id": str(doc),
+            "column_name": "Term",
+            "value": "5y",
+            "cited_chunk_ids": [],
+            "confidence": "high",
+            "tier_used": 2,
+            "cost_usd": "0.0030",
+            "error": None,
+        }
+    ]
+    documents = [{"id": str(doc), "name": "NDA A"}]
+
+    payload = _shape_results_payload(per_cell_results, documents)
+
+    assert "schema_version" in payload
+    assert payload["schema_version"].startswith("m3-c2")
+    assert "rows" in payload
+    assert len(payload["rows"]) == 1
+    assert "summary" in payload
+    assert payload["summary"]["total_cells"] == 1
+    assert payload["summary"]["failed_cells"] == 0
+
+
+@pytest.mark.unit
+def test_shape_results_payload_counts_failed_cells() -> None:
+    """Summary surfaces failed-cell count so the result-view banner can
+    flag partial-success runs."""
+
+    doc = uuid.uuid4()
+    per_cell_results = [
+        {
+            "document_id": str(doc),
+            "column_name": "A",
+            "value": "ok",
+            "cited_chunk_ids": [],
+            "confidence": "high",
+            "tier_used": 2,
+            "cost_usd": "0.0030",
+            "error": None,
+        },
+        {
+            "document_id": str(doc),
+            "column_name": "B",
+            "value": None,
+            "cited_chunk_ids": [],
+            "confidence": "failed",
+            "tier_used": None,
+            "cost_usd": "0",
+            "error": "no chunks retrieved",
+        },
+    ]
+    documents = [{"id": str(doc), "name": "NDA A"}]
+
+    payload = _shape_results_payload(per_cell_results, documents)
+    assert payload["summary"]["total_cells"] == 2
+    assert payload["summary"]["failed_cells"] == 1

--- a/api/tests/tabular/test_worker.py
+++ b/api/tests/tabular/test_worker.py
@@ -1,0 +1,75 @@
+"""Worker-side tests for the M3-C2 Tabular execution pipeline.
+
+The :func:`tabular_execution_job` worker function dispatches to
+:func:`app.tabular.executor.run_tabular_execution`. The expensive
+pieces (LangGraph workflow + per-cell LLM dispatch) are mocked at the
+import-site level so the worker's *orchestration* is tested without
+re-running executor logic (which has its own coverage via
+:mod:`tests.tabular.test_nodes`).
+
+Verifies the load-bearing wiring:
+
+* Function name + queue constants are stable (the
+  ``M3A6_QUEUE_NAME → M3_PLAYBOOK_QUEUE_NAME`` rename keeps the alias).
+* The worker is registered in :class:`WorkerSettings.functions`.
+* The enqueue helper exists on the API-side queue module.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.workers import arq_setup, queue
+
+# ---------------------------------------------------------------------------
+# Queue + worker registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_tabular_job_name_is_stable() -> None:
+    """The ARQ function name is the contract between API and worker;
+    pinning it here makes a rename a deliberate breaking change."""
+
+    assert queue.TABULAR_JOB_NAME == "tabular_execution_job"
+
+
+@pytest.mark.unit
+def test_m3_playbook_queue_name_replaces_m3a6() -> None:
+    """Decision C-3: rename ``M3A6_QUEUE_NAME → M3_PLAYBOOK_QUEUE_NAME``
+    so the queue describes its workload (Easy Playbook + Tabular share
+    it) instead of an obsolete task code."""
+
+    assert arq_setup.M3_PLAYBOOK_QUEUE_NAME == "arq:m3a6"
+    assert queue.M3_PLAYBOOK_QUEUE_NAME == "arq:m3a6"
+
+
+@pytest.mark.unit
+def test_m3a6_queue_name_backward_compat_alias() -> None:
+    """The old constant stays exported as an alias for one release so
+    in-flight deploys / external callers aren't broken (prep doc
+    risk row 6)."""
+
+    assert arq_setup.M3A6_QUEUE_NAME == arq_setup.M3_PLAYBOOK_QUEUE_NAME
+    assert queue.M3A6_QUEUE_NAME == queue.M3_PLAYBOOK_QUEUE_NAME
+
+
+@pytest.mark.unit
+def test_worker_registers_tabular_execution_job() -> None:
+    """``WorkerSettings.functions`` must include ``tabular_execution_job``
+    or the ARQ worker would receive jobs whose function name it doesn't
+    register and reject them."""
+
+    from app.workers.tabular_worker import tabular_execution_job
+
+    assert tabular_execution_job in arq_setup.WorkerSettings.functions
+
+
+@pytest.mark.unit
+def test_worker_still_registers_easy_playbook_job() -> None:
+    """The rename must NOT drop the Easy Playbook function from
+    ``WorkerSettings.functions`` (regression guard)."""
+
+    from app.workers.easy_playbook_worker import easy_playbook_generation_job
+
+    assert easy_playbook_generation_job in arq_setup.WorkerSettings.functions

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -192,6 +192,15 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("DELETE", "/api/v1/playbooks/{playbook_id}"),
     ("POST", "/api/v1/playbooks/easy"),
     ("GET", "/api/v1/playbooks/easy/{generation_id}"),
+    # M3-C2 — Tabular / Multi-Document Review surface (PRD §3.14).
+    # Six method-tuples across five unique paths (cancel is a
+    # sub-resource of /executions/{id}).
+    ("POST", "/api/v1/tabular/preview-cost"),
+    ("POST", "/api/v1/tabular/execute"),
+    ("GET", "/api/v1/tabular/executions"),
+    ("GET", "/api/v1/tabular/executions/{execution_id}"),
+    ("DELETE", "/api/v1/tabular/executions/{execution_id}"),
+    ("POST", "/api/v1/tabular/executions/{execution_id}/cancel"),
     # M3-B1 — Word add-in admin manifest generation
     ("GET", "/api/v1/admin/word-addin/manifest"),
     # M3-B8 — Word add-in version handshake (unauthenticated)

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -140,6 +140,12 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/chats/{chat_id}/receipts",
         # Wave D.1 T6 — chat receipts JSONL export
         "/api/v1/chats/{chat_id}/receipts/export.jsonl",
+        # M3-C2 — Tabular / Multi-Document Review surface
+        "/api/v1/tabular/preview-cost",
+        "/api/v1/tabular/execute",
+        "/api/v1/tabular/executions",
+        "/api/v1/tabular/executions/{execution_id}",
+        "/api/v1/tabular/executions/{execution_id}/cancel",
     }
 )
 

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -187,7 +187,12 @@ async def test_openapi_paths_match_sketch() -> None:
     #   (POST /playbooks/easy + GET /playbooks/easy/{id}).
     # + M3-B1's /admin/word-addin/manifest.
     # + M3-B8's /word-addin/version.
-    assert len(actual) == 83
+    # + M3-C2's five NEW paths for the Tabular surface
+    #   (/tabular/preview-cost, /tabular/execute, /tabular/executions,
+    #    /tabular/executions/{id}, /tabular/executions/{id}/cancel).
+    #   DELETE on /executions/{id} shares the GET path so it adds zero
+    #   new paths here; the method-tuple count is in test_endpoints.py.
+    assert len(actual) == 88
 
 
 @pytest.mark.unit

--- a/api/tests/test_skill_table_mode.py
+++ b/api/tests/test_skill_table_mode.py
@@ -1,0 +1,252 @@
+"""Unit tests for M3-C1 — ``output_format: table`` Skill mode.
+
+Covers the new ``ColumnSpec`` model + the ``columns`` field on
+``LQAIFrontmatter`` + the resolved-summary plumbing.
+
+The loader-side WARNING when ``output_format == 'table'`` but
+``columns`` is missing is covered in ``test_skills.py`` (loader
+integration); this file owns the pure schema layer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# ColumnSpec — the per-column definition
+# ---------------------------------------------------------------------------
+
+
+class TestColumnSpec:
+    def test_accepts_name_and_query_minimally(self) -> None:
+        """Minimal happy path: a column needs a ``name`` and a ``query``."""
+
+        from app.skills.schema import ColumnSpec
+
+        col = ColumnSpec(name="Term Length", query="What is the term length of this NDA?")
+
+        assert col.name == "Term Length"
+        assert col.query == "What is the term length of this NDA?"
+        assert col.ensemble_verification is None
+        assert col.minimum_inference_tier is None
+
+    def test_accepts_per_column_overrides(self) -> None:
+        """Per-column ``ensemble_verification`` + ``minimum_inference_tier``
+        override the skill-level fields when present."""
+
+        from app.skills.schema import ColumnSpec
+
+        col = ColumnSpec(
+            name="Indemnification",
+            query="Summarize the indemnification clause.",
+            ensemble_verification=True,
+            minimum_inference_tier=4,
+        )
+
+        assert col.ensemble_verification is True
+        assert col.minimum_inference_tier == 4
+
+    def test_rejects_missing_name(self) -> None:
+        """``name`` is required — the grid header has to come from somewhere."""
+
+        from pydantic import ValidationError
+
+        from app.skills.schema import ColumnSpec
+
+        with pytest.raises(ValidationError):
+            ColumnSpec(query="Some query")  # type: ignore[call-arg]
+
+    def test_rejects_missing_query(self) -> None:
+        """``query`` is required — the per-row prompt has to be specified."""
+
+        from pydantic import ValidationError
+
+        from app.skills.schema import ColumnSpec
+
+        with pytest.raises(ValidationError):
+            ColumnSpec(name="Some Column")  # type: ignore[call-arg]
+
+    def test_rejects_inference_tier_out_of_range(self) -> None:
+        """``minimum_inference_tier`` mirrors the skill-level constraint:
+        1 ≤ tier ≤ 5."""
+
+        from pydantic import ValidationError
+
+        from app.skills.schema import ColumnSpec
+
+        with pytest.raises(ValidationError):
+            ColumnSpec(name="X", query="Y", minimum_inference_tier=0)
+
+        with pytest.raises(ValidationError):
+            ColumnSpec(name="X", query="Y", minimum_inference_tier=6)
+
+
+# ---------------------------------------------------------------------------
+# LQAIFrontmatter — the lq_ai: block gains a columns field
+# ---------------------------------------------------------------------------
+
+
+class TestLQAIFrontmatterColumns:
+    def test_columns_defaults_to_none(self) -> None:
+        """Absent ``columns`` field is None (existing report-mode skills
+        unaffected)."""
+
+        from app.skills.schema import LQAIFrontmatter
+
+        fm = LQAIFrontmatter()
+
+        assert fm.columns is None
+
+    def test_columns_parses_list_of_specs(self) -> None:
+        """``columns`` accepts a list of ColumnSpec-shaped dicts."""
+
+        from app.skills.schema import LQAIFrontmatter
+
+        fm = LQAIFrontmatter(
+            output_format="table",
+            columns=[
+                {"name": "Term", "query": "What is the term?"},
+                {"name": "Survival", "query": "What is the survival period?"},
+            ],
+        )
+
+        assert fm.output_format == "table"
+        assert fm.columns is not None
+        assert len(fm.columns) == 2
+        assert fm.columns[0].name == "Term"
+        assert fm.columns[1].name == "Survival"
+
+    def test_report_mode_can_carry_columns_field_without_effect(self) -> None:
+        """A skill author iterating between modes can pre-write ``columns``
+        on a report skill; the field is accepted but unused at parse time."""
+
+        from app.skills.schema import LQAIFrontmatter
+
+        fm = LQAIFrontmatter(
+            output_format="report",
+            columns=[{"name": "X", "query": "Y"}],
+        )
+
+        assert fm.output_format == "report"
+        assert fm.columns is not None  # Parsed but downstream ignores it.
+
+
+# ---------------------------------------------------------------------------
+# SkillFrontmatter — end-to-end frontmatter parse of a table-mode skill
+# ---------------------------------------------------------------------------
+
+
+class TestSkillFrontmatterTableMode:
+    def test_full_table_skill_parses(self) -> None:
+        """Realistic table-mode skill frontmatter parses cleanly."""
+
+        from app.skills.schema import SkillFrontmatter
+
+        raw = {
+            "name": "contract-snapshot",
+            "description": "Extract a snapshot of key terms across N contracts.",
+            "lq_ai": {
+                "title": "Contract Snapshot",
+                "version": "1.0.0",
+                "output_format": "table",
+                "tags": ["table", "due-diligence"],
+                "columns": [
+                    {"name": "Term", "query": "What is the term length?"},
+                    {
+                        "name": "Survival",
+                        "query": "What survives termination?",
+                        "ensemble_verification": True,
+                        "minimum_inference_tier": 4,
+                    },
+                ],
+            },
+        }
+
+        fm = SkillFrontmatter.model_validate(raw)
+
+        assert fm.name == "contract-snapshot"
+        assert fm.lq_ai.output_format == "table"
+        assert fm.lq_ai.columns is not None
+        assert len(fm.lq_ai.columns) == 2
+        assert fm.lq_ai.columns[1].ensemble_verification is True
+        assert fm.lq_ai.columns[1].minimum_inference_tier == 4
+
+
+# ---------------------------------------------------------------------------
+# Cross-field validation — table mode requires non-empty columns
+# ---------------------------------------------------------------------------
+
+
+class TestTableModeRequiresColumns:
+    """``output_format: table`` without ``columns`` is a malformed skill.
+
+    The loader catches the ValidationError and turns it into a
+    LoaderError → WARNING → skip (same path as any other malformed
+    frontmatter). Reflects Decision C-1: table-mode-without-columns
+    cannot produce a grid, so the skill is rejected at load time
+    rather than silently failing at execution.
+    """
+
+    def test_table_mode_without_columns_raises(self) -> None:
+        from pydantic import ValidationError
+
+        from app.skills.schema import LQAIFrontmatter
+
+        with pytest.raises(ValidationError):
+            LQAIFrontmatter(output_format="table")
+
+    def test_table_mode_with_empty_columns_raises(self) -> None:
+        from pydantic import ValidationError
+
+        from app.skills.schema import LQAIFrontmatter
+
+        with pytest.raises(ValidationError):
+            LQAIFrontmatter(output_format="table", columns=[])
+
+    def test_non_table_mode_without_columns_is_fine(self) -> None:
+        """The 'every existing skill keeps working' assertion — no existing
+        skill has ``columns`` set, and switching the validator on must
+        not break them."""
+
+        from app.skills.schema import LQAIFrontmatter
+
+        # Original corpus shape — no output_format, no columns.
+        LQAIFrontmatter()
+
+        # Common corpus shapes — non-table output_format, no columns.
+        LQAIFrontmatter(output_format="report")
+        LQAIFrontmatter(output_format="markdown")
+        LQAIFrontmatter(output_format="redline")
+        LQAIFrontmatter(output_format="structured_checklist")
+
+
+# ---------------------------------------------------------------------------
+# derive_summary — columns shouldn't leak into the summary surface
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveSummaryTableMode:
+    def test_summary_carries_output_format_table(self) -> None:
+        """The SkillSummary (list-endpoint shape) surfaces ``output_format``
+        so the UI can render a 'table' badge, but columns themselves only
+        appear on the Skill detail."""
+
+        from app.skills.schema import SkillFrontmatter, derive_summary
+
+        fm = SkillFrontmatter.model_validate(
+            {
+                "name": "contract-snapshot",
+                "description": "Snapshot of key terms.",
+                "lq_ai": {
+                    "output_format": "table",
+                    "columns": [{"name": "Term", "query": "What is the term?"}],
+                },
+            }
+        )
+
+        summary = derive_summary("contract-snapshot", fm)
+
+        assert summary.output_format == "table"
+        # SkillSummary intentionally does NOT include columns — columns are
+        # a detail-page concern.
+        assert not hasattr(summary, "columns")

--- a/docs/M3-IMPLEMENTATION-PLAN.md
+++ b/docs/M3-IMPLEMENTATION-PLAN.md
@@ -578,7 +578,7 @@ Tabular Review is the second consumer of the LangGraph runtime landed in Phase A
 - For `output_format: table` skills, frontmatter adds:
   - `columns: [{name: str, query: str, ensemble_verification: bool}]` — each column is a per-row extraction query; ensemble is optionally on by default for high-stakes columns.
 - Update `docs/skill-authoring-guide.md` and [PRD §3.4](PRD.md#34-skill-service) to document the `table` mode.
-- Update the skill-schema validator in `api/app/skills/validators.py` to enforce the new fields.
+- Extend the skill-schema validator in `api/app/skills/schema.py` (existing module; no new `validators.py`) to enforce the new fields via a Pydantic `model_validator` on `LQAIFrontmatter`.
 - Authoring conventions: a `table`-mode skill cannot specify `output_format` and `report`-mode output in the same skill — they are mutually exclusive.
 
 **Dependencies:** Phase 0 + Phase A (LangGraph runtime).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -566,13 +566,16 @@ inputs:
     - jurisdiction
     - perspective  # "discloser"|"recipient"|"mutual"
 lq_ai:
-  output_format: report   # "report" | "table" | "issue_list" (table reserved for §3.14 Tabular Review)
+  output_format: report   # "report" | "table" | "issue_list" | "redline" | "markdown"
   minimum_inference_tier: 2   # optional; if set, skill refuses to run below this tier (per §3.13)
   is_organization_profile: false   # optional; true marks this skill as the singleton Org Profile (per §3.12)
+  # `columns:` required when output_format == "table" (M3-C1; see below).
 ---
 ```
 
 The `lq_ai:` namespace fields are the project-specific extensions to the agentskills.io standard frontmatter. Skills authored against the open standard work without them; the LQ.AI application uses them when present. See §3.13 for the inference-tier model and §3.14 for the tabular output mode.
+
+**Table mode (M3-C1).** When `output_format: table`, the frontmatter MUST carry a `columns: [{name, query, ensemble_verification?, minimum_inference_tier?}]` list. Each column is a per-row extraction query the Tabular Review LangGraph workflow (§3.14) dispatches against each document in the operator's selected set. The per-column overrides shadow the skill-level `ensemble_verification` and `minimum_inference_tier` — high-stakes columns can demand Tier 4+ or ensemble verification while routine columns inherit cheaper defaults. The skill loader rejects malformed table skills at load time (missing or empty `columns`); see [`docs/skill-authoring-guide.md`](skill-authoring-guide.md#table-mode-skills) for the worked example and the reference skill at [`skills/contract-snapshot/SKILL.md`](../skills/contract-snapshot/SKILL.md).
 
 *Skill chaining.* When multiple skills are attached, their `SKILL.md` instructions are concatenated in the order attached, with clear delimiters. The model is instructed to apply all skills.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -3922,6 +3922,34 @@ When new deferred items are identified during development, ongoing skill authori
 
 This section is mutable across PRD versions; updates do not require a PRD version bump unless they change priority on P1 items.
 
+#### DE-296 — Tabular Review document-source surface: Project-scoped + free-pick (deferred from M3-C3)
+
+**Priority:** P2 (discoverability / convenience; KB-scoped picker covers the v0.3.0 happy path) · **Effort:** M (Project picker reuses existing endpoints; free-pick requires a new backend list-files endpoint plus pagination/search frontend)
+
+**Context:** The M3 Phase C prep doc Decision C-7 specified three document sources for the Tabular Review wizard's Step 1 — KB-scoped, Project-scoped, and free-pick from the operator's library. At the M3-C3 implementation kickoff (2026-05-22), the wizard scoped to **KB-scoped only** for v0.3.0 to keep the surface tight. The Project + free-pick sources are deferred here.
+
+Rationale for scoping down: (a) the existing `PlaybookExecuteModal` already proves the KB-scoped picker pattern, so M3-C3 reuses a known-good UX rather than inventing two new ones; (b) the backend `api/app/api/files.py` surface has no `GET /api/v1/files` list endpoint today (only `POST`, `GET /{id}`, `GET /{id}/content`, `DELETE /{id}`), so free-pick would require new backend work beyond M3-C3's frontend scope; (c) the 5-NDA × 4-column happy path in the Phase C prep doc lives in a single KB, which the KB-scoped picker handles natively.
+
+**Specific scope:**
+
+*Project-scoped source (~30 min frontend work, no backend changes):*
+1. Add a "Project" radio/tab alongside "Knowledge base" in the wizard's Step 1.
+2. When selected, list the caller's projects via `listProjects()`; on project selection, list its files via the existing project file endpoints (mirrors the matter-files surface).
+3. Multi-select up to `TABULAR_MAX_DOCS` files; sum across all selected sources counts toward the cap.
+
+*Free-pick source (~1-2 hr frontend + backend work):*
+1. New backend `GET /api/v1/files` endpoint paginated + searchable by filename. Returns files where `owner_id == caller` (admins see all). Soft-deleted excluded.
+2. Frontend `listFiles({ page, search })` in `web/src/lib/lq-ai/api/files.ts` with the new endpoint client + 4-6 unit tests.
+3. Wizard adds a "Files" radio/tab with paginated search-and-select UX.
+
+**Acceptance criteria:**
+
+- Operator can pick documents from any combination of KB / Project / Files sources within a single tabular run.
+- Total selected document count is enforced against `TABULAR_MAX_DOCS` server-side (already true) and surfaced in the wizard's running count.
+- Files without a `document_id` (parse-pending) are visually marked as disabled across all three sources.
+
+**When to ship:** Bundle into the v0.3.1 quickstart-corpus-expansion patch alongside the DPA / MSA-Commercial-Purchase sample corpora (already DE-tracked per [`project_lq_ai_status.md`](#) memory). Project source on its own is a 30-min lift and may justify its own micro-PR if a Tabular operator surfaces the need before v0.3.1.
+
 ---
 
 ## 10. Appendices

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -3950,6 +3950,54 @@ Rationale for scoping down: (a) the existing `PlaybookExecuteModal` already prov
 
 **When to ship:** Bundle into the v0.3.1 quickstart-corpus-expansion patch alongside the DPA / MSA-Commercial-Purchase sample corpora (already DE-tracked per [`project_lq_ai_status.md`](#) memory). Project source on its own is a 30-min lift and may justify its own micro-PR if a Tabular operator surfaces the need before v0.3.1.
 
+#### DE-297 — Table-mode skill authoring UI in `/skills/new` (column editor) (deferred from M3-C3)
+
+**Priority:** P2 (operators can fork built-in reference skills via filesystem; in-app authoring is convenience, not capability) · **Effort:** M (a structured column editor with per-column query / `ensemble_verification` / `minimum_inference_tier` fields, save-back-to-user-scope flow)
+
+**Context:** M3-C3 ships three built-in reference table-mode skills (`contract-snapshot`, `nda-snapshot`, `msa-snapshot`) plus the runtime path that consumes their `lq_ai.columns` array. The `/skills/new` authoring surface, however, was built for markdown / structured / structured_checklist `output_format` modes — it has no column-editor UI and no awareness of the table-mode shape. Operators who want a custom table-mode skill today must either fork a built-in on the filesystem (engineer-friendly, not lawyer-friendly) or hand-author YAML in `frontmatter_extra` (worse). The wizard's "Switch to ad-hoc mode" path covers the one-off case but does not let the operator save the column spec for reuse.
+
+The M3-C3 surface explicitly scoped column-editor UI out of Phase C to keep the substrate-and-wizard work focused. The Skills page "Reference table-mode skills" section added in M3-C3 (showing built-in `output_format: table` skills) is the discoverability half of the story; in-app authoring is the creation half.
+
+**Specific scope:**
+
+1. `/skills/new` detects when the operator sets `output_format: table` (via a new mode selector at the top of the editor) and swaps the body editor for a structured column list.
+2. Each column row exposes: name (free text), query (multi-line textarea), `ensemble_verification` (checkbox), `minimum_inference_tier` (1–5 dropdown). Reorder via drag-handle.
+3. "Add column" / "Remove column" controls; minimum-one-column validation matching the backend's constraint on `lq_ai.columns`.
+4. Save path persists to `user_skills` with `frontmatter_extra.output_format = 'table'` and `frontmatter_extra.columns = [...]`; the registry's user-skill loader honors these fields on hydration (already implemented for built-ins; user-scope hydration path needs a small additive change).
+5. `/skills/[id]/edit` mirrors the same editor for table-mode user skills.
+6. Cypress E2E that walks "Create table-mode skill from /skills/new → pick it in Tabular Review wizard → run → verify it executed with the right columns".
+
+**Acceptance criteria:**
+
+- An in-house lawyer with no engineering help can create a custom table-mode skill, save it, and pick it from the Tabular Review wizard's Step-2 dropdown.
+- The created skill survives a SIGHUP / container restart (i.e. it persists in the DB, not just the in-memory registry).
+- Editing an existing table-mode skill preserves column ordering and per-column flags.
+- The editor refuses to save a column with an empty query (matches backend validation) and surfaces the error inline rather than via a generic 400.
+
+**When to ship:** v0.4 (the first post-M3 cycle that touches the Skills surface). The work is bounded but spans both the Skill Creator surface (D8 / D8.1c) and the registry's user-skill hydration path; it pairs naturally with whatever additional Skill Creator polish that cycle picks up.
+
+#### DE-298 — Tabular Review built-ins browser polish on `/skills` page (deferred from M3-C3)
+
+**Priority:** P3 (convenience polish; the current Skills-page "Reference table-mode skills" section is enough for v0.3.0 discoverability) · **Effort:** S
+
+**Context:** M3-C3 surfaces built-in table-mode skills via a small "Reference table-mode skills" section above the user-skills table on `/skills`. The section is unfiltered, unsorted beyond alphabetical-by-slug, and has no detail view. As the catalog of built-in table-mode skills grows (each new domain — DPA, employment agreements, vendor MSAs, etc. — may add one), the section will benefit from richer affordances.
+
+**Specific scope:**
+
+1. **Filter on `/skills` page**: a chip-row above the user-skills table with options "All / Table / Markdown / Structured / Checklist", filtering both the built-in section and the user-skill rows by `output_format`. Defaults to "All".
+2. **Sort by recently-used**: within each `output_format` bucket, surface skills the caller has executed recently (via `messages.applied_skills`, analogous to the autocomplete recents logic at `api/app/api/skills.py` lines 553+).
+3. **Skill detail page for built-ins**: a `/skills/[slug]` view that handles built-ins (today only user-scope rows have an edit page). The detail view shows the column spec, trigger examples, and a "Use in Tabular Review" CTA that pre-fills the wizard's Step-2 with the skill selected.
+4. **In-wizard "View skill" link**: when the operator selects a table-mode skill in the Tabular Review wizard, surface a small "View columns" link that opens the same detail page in a new tab.
+
+**Acceptance criteria:**
+
+- Filter chip persists across navigation (URL query param or localStorage).
+- Sort-by-recently-used reflects per-user execution history, not global popularity.
+- Skill detail page is read-only for built-ins (no edit affordance — built-ins are filesystem-canonical) but exposes a "Fork to my skills" button that pre-populates `/skills/new` with the built-in's column spec for tuning. (Pairs with DE-297's authoring UI.)
+- Wizard's "View columns" link works for both built-in and user-scope table-mode skills.
+
+**When to ship:** When the built-in table-mode catalog reaches ~5 skills (the threshold at which a flat list becomes noisy). Likely v0.4 or v0.5 as a Skills-surface polish PR.
+
 ---
 
 ## 10. Appendices

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -2537,6 +2537,174 @@ paths:
         '401':
           description: Not authenticated.
 
+  # M3-C2 — Tabular / Multi-Document Review surface (PRD §3.14).
+  /api/v1/tabular/preview-cost:
+    post:
+      tags: [tabular]
+      summary: Preview the cost of a proposed tabular execution (M3-C2)
+      description: |
+        Synchronous cost preview — no execution row is created. The UI
+        calls this before showing the confirmation modal so the
+        operator sees the cell-count + estimated cost + per-tier
+        breakdown (Phase C prep doc Decision C-5).
+
+        Either ``skill_name`` or ``columns`` is required (not both).
+        The estimator uses a rolling-average over recent
+        ``purpose='tabular_extraction'`` routing-log rows; cold-start
+        deployments see the conservative default per-cell cost until
+        enough calibration data accumulates.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/TabularPreviewCostRequest'}
+      responses:
+        '200':
+          description: Cost preview.
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/TabularPreviewCostResponse'}
+        '400':
+          description: Both ``skill_name`` and ``columns`` provided, or skill has no columns.
+        '404':
+          description: ``skill_name`` not found in the live skill registry.
+        '422':
+          description: Validation error (empty ``document_ids``, malformed column spec, etc.).
+        '401':
+          description: Not authenticated.
+
+  /api/v1/tabular/execute:
+    post:
+      tags: [tabular]
+      summary: Start a tabular execution (M3-C2)
+      description: |
+        Kicks off a tabular execution against the supplied document
+        corpus. Creates a ``TabularExecution`` row at
+        ``status='pending'`` and enqueues the ARQ worker job on the
+        shared playbook queue (per Decision C-3 — same queue as Easy
+        Playbook). Returns 202 immediately; the result view polls
+        ``GET /api/v1/tabular/executions/{id}`` until status reaches
+        a terminal value.
+
+        Authorization: caller must own every document in
+        ``document_ids`` (admins bypass). Cross-user / missing /
+        soft-deleted documents collapse into 404.
+
+        Execution completion does NOT mean every cell is correct —
+        the result view's per-cell citation drawer is where the
+        user-attorney validates extractions before relying on them.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/TabularExecutionCreate'}
+      responses:
+        '202':
+          description: Execution scheduled; row created at status `pending`.
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/TabularExecution'}
+        '400':
+          description: Both ``skill_name`` and ``columns`` provided, or skill has no columns.
+        '404':
+          description: One or more documents not found / not authorized, or skill not found.
+        '422':
+          description: Validation error.
+        '401':
+          description: Not authenticated.
+
+  /api/v1/tabular/executions:
+    get:
+      tags: [tabular]
+      summary: List the caller's tabular executions (M3-C2)
+      description: |
+        Returns the caller's tabular executions in recent-first order.
+        Soft-deleted rows are excluded. Admins see all rows; non-admins
+        see only their own.
+      parameters:
+        - in: query
+          name: limit
+          schema: {type: integer, default: 50, minimum: 1, maximum: 200}
+          description: Maximum rows to return; default 50.
+      responses:
+        '200':
+          description: List of tabular execution summaries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/TabularExecutionSummary'}
+        '401':
+          description: Not authenticated.
+
+  /api/v1/tabular/executions/{execution_id}:
+    parameters:
+      - in: path
+        name: execution_id
+        required: true
+        schema: {type: string, format: uuid}
+    get:
+      tags: [tabular]
+      summary: Get a tabular execution by id (M3-C2)
+      description: |
+        Returns the full execution — status, results grid, costs,
+        timing. Caller must be the row's user OR an admin; cross-user
+        / missing / soft-deleted rows return 404.
+      responses:
+        '200':
+          description: Current execution row.
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/TabularExecution'}
+        '404':
+          description: Execution not found or not authorized.
+        '401':
+          description: Not authenticated.
+    delete:
+      tags: [tabular]
+      summary: Soft-delete a tabular execution (M3-C2)
+      description: |
+        Sets ``deleted_at`` to now. Soft-deleted rows are invisible
+        to list / get / cancel endpoints; subsequent operations
+        return 404.
+      responses:
+        '204':
+          description: Soft-deleted.
+        '404':
+          description: Execution not found or already deleted.
+        '401':
+          description: Not authenticated.
+
+  /api/v1/tabular/executions/{execution_id}/cancel:
+    parameters:
+      - in: path
+        name: execution_id
+        required: true
+        schema: {type: string, format: uuid}
+    post:
+      tags: [tabular]
+      summary: Cancel a pending or running tabular execution (M3-C2)
+      description: |
+        Sets status to ``cancelled`` and ``completed_at`` to now.
+        The worker's per-cell loop checks the row status at each
+        cell-iteration boundary; on cancellation it stops accepting
+        new cells and the aggregate node writes whatever partial
+        results landed. Terminal rows (``completed`` / ``failed`` /
+        ``cancelled``) return 409 — operators wanting a clean re-run
+        start a new execution via ``POST /tabular/execute``.
+      responses:
+        '200':
+          description: Cancellation accepted; row updated.
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/TabularExecution'}
+        '404':
+          description: Execution not found or not authorized.
+        '409':
+          description: Execution already in a terminal status.
+        '401':
+          description: Not authenticated.
+
   /api/v1/playbooks/{playbook_id}/execute:
     parameters:
       - in: path
@@ -3584,6 +3752,162 @@ components:
           type: string
           format: date-time
           nullable: true
+
+    # M3-C2 — Tabular / Multi-Document Review wire shapes (PRD §3.14).
+    TabularPreviewCostRequest:
+      type: object
+      required: [document_ids]
+      description: |
+        Request body for ``POST /api/v1/tabular/preview-cost``. Either
+        ``skill_name`` or ``columns`` must be supplied (not both).
+      properties:
+        document_ids:
+          type: array
+          minItems: 1
+          items: {type: string, format: uuid}
+        skill_name:
+          type: string
+          nullable: true
+          description: Name of a registered ``output_format: table`` skill.
+        columns:
+          type: array
+          nullable: true
+          items: {$ref: '#/components/schemas/ColumnSpec'}
+          description: Ad-hoc column spec (alternative to ``skill_name``).
+
+    TabularPreviewCostResponse:
+      type: object
+      required: [cells_count, estimated_tokens, estimated_cost_usd, per_tier_breakdown]
+      properties:
+        cells_count:
+          type: integer
+          description: ``len(document_ids) * len(columns)``.
+        estimated_tokens:
+          type: integer
+          description: Per-cell token average x cells_count.
+        estimated_cost_usd:
+          type: string
+          description: |
+            Per-cell rolling-average cost x cells_count, serialized as
+            a JSON string to preserve decimal precision.
+        per_tier_breakdown:
+          type: object
+          additionalProperties: {type: integer}
+          description: |
+            Map of tier label (``tier_1`` / ``tier_2`` / ... or
+            ``default``) to cell count routed at that tier. Columns
+            without an explicit ``minimum_inference_tier`` count in
+            the ``default`` bucket.
+
+    TabularExecutionCreate:
+      type: object
+      required: [document_ids]
+      description: |
+        Request body for ``POST /api/v1/tabular/execute``. Either
+        ``skill_name`` or ``columns`` must be supplied (not both).
+        ``confirmed_cost_usd`` echoes the preview value so the row
+        carries an audit trail of the operator confirming a specific
+        cost ceiling.
+      properties:
+        document_ids:
+          type: array
+          minItems: 1
+          items: {type: string, format: uuid}
+        skill_name: {type: string, nullable: true}
+        columns:
+          type: array
+          nullable: true
+          items: {$ref: '#/components/schemas/ColumnSpec'}
+        confirmed_cost_usd:
+          type: string
+          nullable: true
+          description: |
+            Operator-confirmed cost from the preview endpoint. Persisted
+            to ``tabular_executions.cost_estimate_usd``.
+
+    TabularExecution:
+      type: object
+      required: [id, status, document_ids, columns, created_at]
+      description: |
+        One row from the ``tabular_executions`` table. Lifecycle:
+        ``pending → running → completed | failed | cancelled``.
+        ``results`` is populated by the aggregate node on ``completed``;
+        ``error_text`` is populated on ``failed``. Soft-deleted rows
+        (``deleted_at`` non-null) are invisible to list / detail
+        endpoints.
+      properties:
+        id: {type: string, format: uuid}
+        user_id: {type: string, format: uuid, nullable: true}
+        parent_execution_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: |
+            Non-null on bulk-op sibling rows (Phase C prep doc Decision
+            C-9). Bulk ops spawn siblings rather than mutating the
+            original grid, preserving auditability.
+        skill_name:
+          type: string
+          nullable: true
+          description: |
+            Source skill name; ``null`` for ad-hoc executions where the
+            operator typed columns directly in the wizard.
+        status:
+          type: string
+          enum: [pending, running, completed, failed, cancelled]
+        document_ids:
+          type: array
+          items: {type: string, format: uuid}
+        columns:
+          type: array
+          items: {$ref: '#/components/schemas/ColumnSpec'}
+        results:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: |
+            Assembled grid shape with rows + per-cell results. Shape is
+            versioned via ``schema_version`` (currently ``m3-c2-v1``).
+        cost_estimate_usd:
+          type: string
+          nullable: true
+        cost_actual_usd:
+          type: string
+          nullable: true
+        error_text:
+          type: string
+          nullable: true
+        created_at: {type: string, format: date-time}
+        started_at: {type: string, format: date-time, nullable: true}
+        completed_at: {type: string, format: date-time, nullable: true}
+
+    TabularExecutionSummary:
+      type: object
+      required:
+        - id
+        - status
+        - document_count
+        - column_count
+        - created_at
+      description: |
+        Compact projection used by the list endpoint. Drops the
+        (potentially large) ``results`` payload — operators fetch the
+        full execution row when they open one.
+      properties:
+        id: {type: string, format: uuid}
+        user_id: {type: string, format: uuid, nullable: true}
+        parent_execution_id: {type: string, format: uuid, nullable: true}
+        skill_name: {type: string, nullable: true}
+        status:
+          type: string
+          enum: [pending, running, completed, failed, cancelled]
+        document_count: {type: integer}
+        column_count: {type: integer}
+        cost_estimate_usd: {type: string, nullable: true}
+        cost_actual_usd: {type: string, nullable: true}
+        created_at: {type: string, format: date-time}
+        completed_at: {type: string, format: date-time, nullable: true}
+
     AdminUserRow:
       type: object
       required: [id, email, role, is_admin, mfa_enabled, must_change_password, created_at]

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -4189,6 +4189,36 @@ components:
             Skill's documented output format (e.g., ``report``, ``markdown``,
             ``structured_checklist``, ``redline``). Free-form per the corpus.
 
+    # M3-C1 — column definition for output_format: table skills.
+    ColumnSpec:
+      type: object
+      required: [name, query]
+      description: >-
+        One column in an ``output_format: table`` skill (M3-C1). The
+        Tabular Review workflow (M3-C2) runs each ``(document, column)``
+        cell as a Citation-Engine-grounded extraction.
+      properties:
+        name: {type: string, description: "Grid column header."}
+        query:
+          type: string
+          description: >-
+            Per-row extraction prompt instantiated against each document.
+        ensemble_verification:
+          type: boolean
+          nullable: true
+          description: >-
+            Per-column override of the skill-level ``ensemble_verification``
+            field. ``true`` routes this column's cells through Stage 4 of
+            the Citation Engine cascade.
+        minimum_inference_tier:
+          type: integer
+          minimum: 1
+          maximum: 5
+          nullable: true
+          description: >-
+            Per-column override of the skill-level tier floor. High-stakes
+            columns can demand Tier 4+ while routine columns route Tier 1.
+
     Skill:
       allOf:
         - $ref: '#/components/schemas/SkillSummary'
@@ -4225,6 +4255,16 @@ components:
                 properties:
                   path: {type: string}
                   content: {type: string}
+            columns:
+              type: array
+              nullable: true
+              description: >-
+                M3-C1 — column definitions for ``output_format: table``
+                skills. ``null`` for non-table skills. The validator
+                rejects ``output_format: table`` skills that lack a
+                non-empty ``columns`` list at load time.
+              items:
+                $ref: '#/components/schemas/ColumnSpec'
 
     # Wave A — Skill inputs (form schema for the skill-input-form pattern).
     SkillInputDef:

--- a/docs/skill-authoring-guide.md
+++ b/docs/skill-authoring-guide.md
@@ -90,6 +90,36 @@ lq_ai:
 - **`lq_ai.use_organization_profile`** — defaults to `true`. Set to `false` only for skills that should run independent of organization-specific context (rare).
 - **`lq_ai.is_organization_profile`** — set to `true` only for the singleton Organization Profile skill. Every other skill leaves this `false` or omits it.
 - **`lq_ai.self_improvement`** — defaults to `false` for v1.0.0 skills. Self-improvement is a deferred enhancement; v1.0.0 skills are stable artifacts under semver, not learning systems.
+- **`lq_ai.columns`** — required when `output_format: table`; ignored otherwise. List of `{name, query, ensemble_verification?, minimum_inference_tier?}` specs. See [Table-mode skills](#table-mode-skills) below.
+
+### Table-mode skills
+
+Setting `output_format: table` opts the skill into the Tabular / Multi-Document Review surface (M3-C, see [PRD §3.14](PRD.md#314-tabular--multi-document-review-m3)). A table-mode skill produces a row-per-document × column-per-spec grid; each cell is a Citation-Engine-grounded extraction. The frontmatter needs a `columns` block:
+
+```yaml
+output_format: table
+columns:
+  - name: Term
+    query: What is the term length of this agreement?
+  - name: Survival
+    query: What confidentiality obligations survive termination?
+    ensemble_verification: true   # cell-level override
+  - name: Governing Law
+    query: What jurisdiction governs this agreement?
+    minimum_inference_tier: 3     # cell-level override
+```
+
+**Required per column:** `name` (the grid header) + `query` (the per-row prompt instantiated against each document).
+
+**Optional per column:** `ensemble_verification` and `minimum_inference_tier` override the skill-level fields. Use the overrides sparingly — high-stakes columns (e.g., survival periods, indemnification caps) benefit from the extra rigor of Stage 4 ensemble verification or a Tier 4+ floor; routine columns should inherit the skill defaults to keep cost predictable.
+
+**Constraints:**
+
+- `columns` must be non-empty when `output_format: table`. The skill loader rejects malformed table skills at load time (WARNING in container logs, skill skipped).
+- Every cell is a string in v0.3.0; column types (number / date / boolean) are a deferred enhancement filed at Phase C close if user-attorney walkthrough surfaces the need.
+- Bulk operations (M3-C4) run on top of a tabular execution's grid — they don't change the column spec; they spawn sibling executions.
+
+The reference skill at [`skills/contract-snapshot/SKILL.md`](../skills/contract-snapshot/SKILL.md) demonstrates the four-column NDA grid (Term / Survival / Carveouts / Governing Law) with two per-column overrides — fork it as a starting point for your own contract types.
 
 ### Tag conventions
 

--- a/docs/superpowers/plans/2026-05-21-m3-phase-c-tabular-review.md
+++ b/docs/superpowers/plans/2026-05-21-m3-phase-c-tabular-review.md
@@ -1,0 +1,203 @@
+# M3 Phase C — Tabular / Multi-Document Review — Prep Notes
+
+> **Scope:** Phase C in full — M3-C1 (`output_format: table` Skill mode) + M3-C2 (Tabular LangGraph workflow + execution endpoints + migration 0036) + M3-C3 (tabular UI surface + per-cell citation drawer) + M3-C4 (bulk operations + XLSX/CSV export). Per [PRD §3.14](../../PRD.md#314-tabular--multi-document-review-m3) and [M3 Plan §C](../../M3-IMPLEMENTATION-PLAN.md#phase-c--tabular--multi-document-review-week-6).
+>
+> **Branch:** `m3-phase-c-tabular-review` off `main` at `fa62142` (post-PR-#61 reconciliation; M3-A6 Easy Playbook wizard now on `main`).
+>
+> **Goal at Phase C close:** an LQ.AI operator can select N documents (KB / Project / free pick) + M columns (from a saved `output_format: table` skill or an ad-hoc column spec), see a cost preview, confirm, watch the grid populate progressively as cells complete, click any cell to open the existing M2-C2 citation drawer for that source, then export the grid as XLSX (each cell carrying its citation as a Excel comment) or CSV (citations flattened into a `citation_links` column). The Tabular workflow runs as a LangGraph executor inside `api/` and dispatches each `(document, column)` cell through the existing Citation Engine cascade. The grid is a first-class persisted artifact (`tabular_executions` table) so re-opening the result a week later still works.
+
+---
+
+## Design decisions locked at Phase C kickoff (2026-05-21)
+
+| # | Decision | Choice | Why | DE if redirected |
+|---|---|---|---|---|
+| **C-1** | `output_format: table` Skill frontmatter shape | **`lq_ai.output_format: table` + a sibling `lq_ai.columns: [{name, query, ensemble_verification?, minimum_inference_tier?}]` list.** Each column is one extraction-per-row spec. `name` is the column header in the grid. `query` is the per-row prompt (instantiated against each document). Per-column `ensemble_verification` overrides the skill-level field (M2-D1 cascade). Per-column `minimum_inference_tier` (1–5) overrides the skill-level tier floor — high-stakes columns can demand Tier 4+ while routine columns route Tier 1. **No column types in v0.3.0 — every cell is a string** (Excel-side typing is the operator's affair; file DE if a typed-grid surface emerges as need). The validator additions live in `api/app/skills/schema.py` (NOT a new `validators.py` — the M3 plan's reference at §M3-C1 is a doc nit to fix in this PR). | Aligns with the existing permissive frontmatter substrate (`SkillFrontmatter` allows extras + `LQAIFrontmatter` already supports `output_format` + `ensemble_verification` + `minimum_inference_tier`). Adding `columns` as a new optional field is additive — no breakage for `report`-mode skills. Per-column tier-floor override is the practical win Tabular needs that single-skill `minimum_inference_tier` can't express; this is the structural change the existing `lq_ai` block is one frontmatter field away from supporting. | DE-XXX: "Typed column outputs (number / date / boolean) for Tabular Review" — file at Phase C close if any user-attorney walkthrough surfaces the need. |
+| **C-2** | Per-cell citation surface | **Hybrid: small confidence-chip in each cell (matches M2-C2's chat 5-state visual) + click-anywhere-in-cell opens the existing citation side-drawer.** Cell renders `{value}` with the chip rendered right-aligned. Failed extraction renders as italic `not found` with a `verify` affordance (the same chip set, just routed to the "click to see why" state). | Reuses M2-C2's full citation rendering substrate (`web/src/lib/lq-ai/components/CitationChip.svelte` + the drawer) — no new component. Keeps the grid dense (the chip is ~20×16 px). The grid stays scannable visually while the depth-of-citation surface is one click away. Matches PRD §3.14's "Cells link to the cited chunk(s) in the source document" requirement literally. | None — single-decision; if the chip+drawer pairing turns out wrong in user testing, the change is local to the grid component. |
+| **C-3** | Execution boundary: sync vs ARQ | **Always ARQ on the existing `arq:m3a6` queue** (no new queue). The `arq-worker` container's `WorkerSettings.functions` list gains `tabular_execution_job`. Even the smallest tabular run (5 docs × 4 cols = 20 cells × ~5 sec/cell = ~100 sec) exceeds reasonable HTTP timeout windows; the 200×10 = 2000-cell case is hours. ARQ + status-poll is the only honest shape. **Reuses `arq:m3a6` rather than a new `arq:m3c` queue** — both job types (Easy Playbook generation + Tabular execution) share the same worker container, share the same worker concurrency budget, and benefit from being deployable as a single sister-of-`ingest-worker` service. The queue constant is renamed `M3A6_QUEUE_NAME → M3_PLAYBOOK_QUEUE_NAME` aliased to its old name for backward compatibility on in-flight jobs. | Two arq containers per deployment would just double the operational surface for no isolation win — the workloads are bursty in different shapes (Easy Playbook = 1–10 docs over ~10 min; Tabular = up to 2000 cells over hours), but neither saturates a worker for long enough to deserve isolation. If we see queue contention in production, splitting is a follow-on `arq:m3-tabular` queue is trivial. | DE-XXX (file at Phase C close if needed): "Dedicated arq queue for tabular executions if Easy Playbook + Tabular contention becomes measurable." |
+| **C-4** | XLSX library | **`openpyxl` ≥ 3.1.0 added as a new `api/pyproject.toml` dependency.** Pinned to a minor range. CSV uses the stdlib `csv` module (no new dep). | Canonical Python XLSX library; mature, MIT-licensed; supports cell-level comments (the load-bearing feature for the "citation as Excel comment" requirement in M3-C4 / PRD §3.14). Alternatives reviewed: `xlsxwriter` (write-only; can't read for round-trip tests), `pandas.to_excel` (drags in pandas as a dep for the wrong reason). Per CLAUDE.md "don't add libs without justification": XLSX export is a load-bearing user surface (legal teams live in Excel) and rolling our own XLSX writer is not viable. SBOM impact: 1 new direct dep, no transitive surprises. | DE-XXX if openpyxl's footprint becomes painful: "Replace openpyxl with a leaner XLSX writer." Unlikely. |
+| **C-5** | Cost-preview UX | **Modal-confirm-before-execute matching M3-A4's `PlaybookExecuteModal.svelte` pattern.** Modal shows: documents-count, columns-count, cells = docs × cols, estimated tokens (per-cell average × cells), estimated cost in USD (using M2-E2's per-purpose rolling-average cost), per-tier breakdown if some columns demand Tier 4+. **Big "Run" button is gated** behind a checkbox "I understand this will cost approximately $X.XX." for runs above $1.00; for runs below $1.00, the checkbox is hidden (no friction on small runs). | Matches the existing playbook execution flow operators already know; introduces the gate only where the cost matters (the $1 threshold mirrors the heuristic Kevin used for M3-A4 PR review — most operator runs are well below, so the friction lands only on the 200×10 case). The cost estimator code path lives in a new `api/app/tabular/cost.py` that mirrors `app/citation/cost.py`'s rolling-average pattern. | None — single-decision. The threshold is tunable via deployment config later. |
+| **C-6** | Migration sequence | **`api/alembic/versions/0036_tabular_executions.py`** — next number after M3-A6's 0035. Schema: `tabular_executions (id uuid PK, user_id uuid FK, status enum('pending','running','completed','failed','cancelled'), document_ids JSONB NOT NULL, skill_id uuid NULL FK skills.id, columns JSONB NOT NULL, results JSONB NULL, cost_estimate_usd numeric NULL, cost_actual_usd numeric NULL, error_text text NULL, created_at, started_at NULL, completed_at NULL)`. Includes a partial index `(user_id, created_at DESC)` for the list endpoint, and a foreign-key cascade on `documents.id` deletion (cascade `documents` references via the JSONB array is non-trivial; cell results carry document_id but the user_id-scoped query is the load-bearing index). | The schema is more elaborate than the M3 plan's sketch because tabular executions need cost reconciliation (estimate vs actual), status transitions, and error capture — same fields the Citation Engine cascade already needs. The `columns` JSONB stores the resolved spec (either the skill's `lq_ai.columns` snapshot at execution start, or the ad-hoc spec the operator typed) so re-rendering the grid a week later is honest about what was actually run, not what the skill currently says. | None — schema design; tunable in M4. |
+| **C-7** | Document selection sources | **KB-scoped + Project-scoped + free-pick (select individual files from the operator's library), in that order in the UI.** Multi-select up to 200 documents per execution (matches the PRD §3.14 risk-row 7 ceiling; runs above 200 are blocked at the form with a clear "Tabular runs are capped at 200 documents — split your selection or contact your admin to lift the cap" message). The 200-cap is a deployment-config knob `LQ_AI_TABULAR_MAX_DOCS=200`. | Three sources is the natural reach because LQ.AI already has all three primitives. The 200-cap is conservative for v0.3.0 — 200 × 10 columns is already a 2000-cell run that takes hours; lifting the cap is a deployment-config change, not code. Document this in the cost-preview UX. | DE-XXX if any operator hits the 200-cap and wants it lifted with sub-deployment-config granularity: "Per-user / per-project tabular cap overrides." |
+| **C-8** | PR strategy | **Single PR (M3-C1 + M3-C2 + M3-C3 + M3-C4 all together)** mirroring Phase B's PR #59 pattern. Branch is `m3-phase-c-tabular-review` per this prep doc; opens against `main`. Live verification against the running dev stack + fresh-install Docker rebuild + reviewing-attorney walkthrough land before the PR is opened. | The four tasks are tightly coupled: M3-C1's schema is what M3-C2 reads; M3-C2's results shape is what M3-C3 renders; M3-C4 reads M3-C2's persisted grid + uses M3-C3's selection model. Splitting introduces churn (each split PR would need its own contract docs + stub the next surface in). Single PR is reviewable as one feature shipped end-to-end. Risk hedge: if the PR grows beyond ~5K LOC, split is reconsidered at end of M3-C2 (the natural seam). | None — single-decision; split fallback documented. |
+| **C-9** | Bulk-ops result shape (M3-C4) | **Each bulk op spawns a SIBLING `tabular_executions` row with `parent_execution_id` FK** (new column added in migration 0036). "Redline column N in all rows" runs a fresh `output_format: report` skill against each row's source document with the column-N value as context; results land as a new sibling execution rendered as a column-of-redlines tab on the original grid view. "Summarize column N" runs the configured summary skill once over all column-N values; result is a single Markdown report rendered as a "Summary of column N" tab. **Bulk ops do NOT mutate the original grid** (immutability matters for citation provenance + re-render correctness). | The sibling-row pattern preserves the original grid's auditability — an operator can always answer "what exactly did the Tabular run produce on 2026-05-22?" without worrying about subsequent bulk ops having overwritten cells. The tab-on-the-grid-view UX (rather than a separate page per bulk op) keeps the operator in their reading flow. | None — single-decision. |
+| **C-10** | Failed-cell rendering | **Italic `not found` text + amber-chip in cell + drawer-on-click shows the error reason (model error / no citation found / cell rejected by Citation Engine).** Matches the PRD §3.14 "never as a confident wrong answer" requirement. Tabular workflow's per-cell try/except catches at the cell node and writes `{"value": None, "error": str, "confidence": "failed"}` to that cell's JSONB. Grid renderer detects `confidence: "failed"` and switches to the italic-not-found render. | The Citation Engine's 5-state UI doesn't have a "no citation" state explicitly — its weakest signal is the red `unverified` chip. For Tabular, failure modes are different (the cell can't even produce a value, not just fail to verify it). Amber + italic is a visually distinct state that doesn't conflict with the citation chips. | None — single-decision; if user testing shows the amber state confuses, the chip color is one CSS variable change. |
+
+---
+
+## Per-task scope (compact; M3 plan §C is canonical for the full text)
+
+### Task M3-C1 — `output_format: table` Skill mode (~6–8 hr)
+
+**Files to touch:**
+- `api/app/skills/schema.py` — extend `LQAIFrontmatter` with `columns: list[ColumnSpec] | None = None`. New `ColumnSpec` Pydantic model with fields per Decision C-1 (`name`, `query`, optional `ensemble_verification`, optional `minimum_inference_tier`). Validation logic: when `output_format == "table"`, `columns` must be non-empty (else raise); when `output_format != "table"`, `columns` may be present but is ignored (so a skill author can pre-write the column spec while iterating on output mode).
+- `api/app/skills/loader.py` (if needed) — propagate `columns` through to `SkillSummary` (existing `output_format` field already covers the mode signal; the column spec itself only needs to flow through to the `Skill` detail shape).
+- `docs/skill-authoring-guide.md` — add a "Table-mode skills" section with worked example + acceptance criteria.
+- `docs/api/backend-openapi.yaml` — extend `Skill` schema with `columns` field on the detail response.
+- `docs/PRD.md` §3.4 — add a paragraph on the `table` mode pointing at the authoring guide.
+- `api/tests/test_skills.py` (or new `test_skill_table_mode.py`) — unit tests: valid table skill, missing-columns table skill (raises), columns on a report skill (ignored), per-column overrides cascade correctly.
+- Optional: one example `output_format: table` skill landed under `skills/` as the canonical reference for community contributors. Suggested: `skills/contract-snapshot/SKILL.md` with 4 columns (`Term`, `Survival`, `Carveouts`, `Governing Law`) — exactly the 4 columns the M3-C2 acceptance scenario uses against the 5-NDA corpus.
+
+**Verification:**
+- `pytest -k table_mode` green.
+- Existing report-mode skills unaffected (full suite green).
+- Schema validator rejects `output_format: table` with no `columns` field at skill-load time (WARNING log + skill skipped, mirrors existing pattern in `loader.py`).
+
+---
+
+### Task M3-C2 — Tabular LangGraph workflow + endpoints + migration (~12–16 hr)
+
+**New module `api/app/tabular/`:**
+- `__init__.py`
+- `executor.py` — LangGraph workflow:
+  - **Input state:** `TabularExecutionInput(execution_id, document_ids, columns, user_id, skill_id?)`
+  - **Cell node:** for each `(document, column)` pair, run the column's `query` as a Citation-Engine-grounded extraction. Returns `{value: str, citations: [Citation], confidence: high|medium|low|failed, tier_used: int, cost_usd: float, error: str|None}`.
+  - **Aggregation node:** assemble cell results into `results: {rows: [{document_id, document_name, cells: {column_name: CellResult}}]}` JSONB.
+  - **Status transitions:** `pending → running → completed | failed | cancelled`.
+- `nodes.py` — extraction-per-cell + aggregation node implementations.
+- `cost.py` — per-purpose rolling-average cost estimator (mirrors `app/citation/cost.py`), used by the cost-preview endpoint.
+- `repository.py` (optional, depends on whether we reuse existing `app/repositories/` pattern) — CRUD on `tabular_executions`.
+
+**API endpoints (`api/app/api/tabular.py`):**
+- `POST /api/v1/tabular/preview-cost` — request: `{document_ids, columns, skill_id?}` → response: `{cells_count, estimated_tokens, estimated_cost_usd, per_tier_breakdown}`. Synchronous (cost-preview is fast).
+- `POST /api/v1/tabular/execute` — request: same as preview + `confirmed_cost_usd` (echo of the preview value so we have audit trail of the operator confirming a specific cost) → response: 202 + `{tabular_execution_id, status: "pending"}`.
+- `GET /api/v1/tabular/executions` — list user's tabular executions (paginated, recent-first).
+- `GET /api/v1/tabular/executions/{id}` — full state + grid results.
+- `DELETE /api/v1/tabular/executions/{id}` — soft delete (sets `deleted_at` — new column added in migration 0036 alongside the table; matches the M3-A6 pattern for playbooks).
+- `POST /api/v1/tabular/executions/{id}/cancel` — sets status to `cancelled`; the worker honors this on the next cell-iteration check.
+
+**Worker `api/app/workers/tabular_worker.py`:**
+- `tabular_execution_job(ctx, execution_id: str)` — load execution row, dispatch to `executor.run()`, persist results, transition status.
+- Registered in `app.workers.arq_setup.WorkerSettings.functions` alongside `noop_job` + `easy_playbook_generation_job`.
+- `app/workers/queue.py` gains `enqueue_tabular_execution_job(...)`.
+
+**Migration `0036_tabular_executions.py`** per Decision C-6 schema.
+
+**Verification:**
+- 5 NDAs × 4 columns (Term, Survival, Carveouts, Governing Law) executes end-to-end against the dev stack; grid populates; each cell carries citations.
+- Failed-cell path: ask "what is the dispute-resolution forum" against an NDA that doesn't have one; cell renders as `not found` with amber chip per Decision C-10.
+- Cost preview before execution matches actual within 10% (matches M2-E2's rolling-average accuracy band).
+- Concurrent execution: 2 tabular runs by the same user don't interfere; the arq-worker dispatches both fairly via its existing concurrency budget.
+
+---
+
+### Task M3-C3 — Tabular UI surface (~10–14 hr)
+
+**New SvelteKit routes under `web/src/routes/lq-ai/tabular/`:**
+- `+page.svelte` — list of the user's tabular executions (recent-first; "Start new tabular review" CTA at top).
+- `new/+page.svelte` — the four-step wizard:
+  1. **Documents step** — three-tab selector (KB / Project / Files) per Decision C-7; multi-select up to 200; shows running count + estimated cell count.
+  2. **Columns step** — choose from saved `output_format: table` skills (dropdown showing `name + description + columns-preview`) OR define ad-hoc columns (table widget: name + query + per-column ensemble/tier overrides).
+  3. **Cost preview step** — modal-style step matching `PlaybookExecuteModal.svelte`; renders the cost-preview endpoint's response per Decision C-5.
+  4. **Confirm + execute** — POST to `/tabular/execute`; redirects to the result view with `tabular_execution_id`.
+- `[id]/+page.svelte` — the result view:
+  - Status banner (pending / running with progress bar / completed / failed / cancelled).
+  - Sticky-first-column + sticky-first-row grid renderer (CSS `position: sticky`).
+  - Per-cell: value + confidence chip per Decision C-2; click anywhere on cell opens the existing M2-C2 `CitationDrawer.svelte` with the cell's citations.
+  - Bulk-ops menu (M3-C4 — see next task).
+  - Export menu (XLSX / CSV — M3-C4).
+
+**New shared components:**
+- `web/src/lib/lq-ai/components/TabularGrid.svelte` — the sticky grid renderer; takes `results` JSONB shape.
+- `web/src/lib/lq-ai/components/TabularCell.svelte` — single cell, with chip + click-handler that opens the citation drawer.
+- `web/src/lib/lq-ai/components/TabularCostPreviewModal.svelte` — extends the playbook execute modal pattern.
+- `web/src/lib/lq-ai/api/tabular.ts` — API client (matches `playbooks.ts` shape: types + fetch helpers + error mapping).
+- `web/src/lib/lq-ai/types.ts` — extend with `TabularExecution`, `CellResult`, `ColumnSpec`.
+
+**Cypress E2E `web/cypress/e2e/m3-c-tabular-review.cy.ts`:**
+- 8-step happy path: open `/lq-ai/tabular/new` → pick 5 sample NDAs from the M3-A6 `Sample NDAs (for testing)` KB (if seeded — see DE-285; else from free-pick) → choose the `contract-snapshot` example skill from C-1 → click "Preview cost" → click "Confirm and run" → wait for status `completed` (intercept the poll; mock the worker via response stub for test determinism) → assert grid renders with 5 rows × 4 cols → click a cell → assert citation drawer opens with the right document.
+
+**Verification:**
+- Cypress E2E green (happy path).
+- Visual review on a 30×5 grid: scroll performance OK, sticky headers behave correctly.
+- Cell-to-citation linkage works for all three cell states (verified / partial / failed).
+
+---
+
+### Task M3-C4 — Bulk ops + XLSX/CSV export (~8–10 hr)
+
+**Bulk ops (per Decision C-9):**
+- New endpoint `POST /api/v1/tabular/executions/{id}/bulk-op` — request: `{op: 'redline' | 'summarize', column_name: str, skill_id_override?: str}` → response: 202 + `{sibling_execution_id}`.
+- Worker: `bulk_op_job` enqueued onto the same `arq:m3a6` queue.
+- The sibling execution writes back to `tabular_executions` with `parent_execution_id` set (column added in migration 0036).
+- UI: result view's bulk-ops menu surfaces "Redline column …" + "Summarize column …" with column dropdown; submitting kicks off the bulk op and adds a new tab next to the main grid view.
+
+**Export (per Decision C-4):**
+- New endpoint `GET /api/v1/tabular/executions/{id}/export?format=xlsx|csv` — streams the file with `Content-Disposition: attachment`.
+- XLSX path (`openpyxl`):
+  - First row: column names + a hidden "_document_id" column for re-import-ability.
+  - Each cell carries the value; if the cell has a citation, the cell gets an Excel comment with the citation's source snippet + a clickable URL pointing at `{deployment_origin}/lq-ai/documents/{document_id}#chunk-{chunk_id}`.
+  - Failed cells render as italic empty cells with a "not found" comment.
+- CSV path (`csv` stdlib):
+  - Each cell's value goes in the value cell; a sibling `{column_name}_citation_url` column carries the citation URL when present.
+  - Failed cells: empty value + `not found` in the citation_url column.
+
+**Verification:**
+- XLSX opens cleanly in Excel desktop (Windows + macOS), Numbers (macOS), Google Sheets.
+- CSV round-trips through `pandas.read_csv()` (one-off check; pandas does NOT get added as a project dep).
+- Excel comments resolve when clicked (manual: open in Excel, click a cell with citation, comment popup shows the snippet + URL is clickable).
+
+---
+
+## PR strategy
+
+Per Decision C-8:
+
+- **PR #N (C1 + C2 + C3 + C4):** Single Phase C PR against `main`. Final state is "operator can run a 5-NDA × 4-column tabular review end-to-end, export XLSX, run a bulk redline on one column." Branch is `m3-phase-c-tabular-review`. Reviewing-attorney walkthrough against real-world contracts happens before the PR opens (M3 plan §3 risk row mention).
+- **Split fallback:** if implementation grows beyond ~5K LOC by end of M3-C2, split into PR #N (C1 + C2) + PR #N+1 (C3 + C4) at the natural seam (C2 is the backend-complete state; C3 + C4 are the UI + export layer).
+
+---
+
+## Effort estimate
+
+| Task | Hours | Notes |
+|---|---|---|
+| M3-C1 — `output_format: table` Skill mode | 6–8 | Schema extension + tests + docs + 1 example skill |
+| M3-C2 — LangGraph workflow + endpoints + migration | 12–16 | The largest task; new module, new worker, new migration, 6 endpoints |
+| M3-C3 — UI surface | 10–14 | 5 new routes / components + Cypress E2E + sticky-grid renderer |
+| M3-C4 — Bulk ops + XLSX/CSV export | 8–10 | New endpoint + worker + openpyxl integration |
+| **Phase C total** | **36–48** | Matches M3 plan §C estimate; no upward revision at kickoff |
+
+Plus ~2–4 hr for the reviewing-attorney walkthrough and pre-PR fresh-install verification.
+
+---
+
+## Risk register
+
+| # | Risk | Mitigation |
+|---|---|---|
+| 1 | LangGraph workflow concurrency saturates the `arq-worker` container | Worker concurrency is configurable; ship default `max_jobs=4`; document in `docker-compose.yml` comment. Per-cell extraction is the bursty part — bounded by the gateway's per-tier concurrency cap anyway. |
+| 2 | Cost-preview accuracy drifts as cells fan out | Use M2-E2's rolling-average cost per-purpose tag. New `purpose='tabular_extraction'` tag added at the cell-node level so future estimates calibrate against actuals. Surface estimate ± 10% in the preview text. |
+| 3 | Per-cell citation drawer integration breaks on cell-source-document mismatch | Each cell's citation list carries `document_id` explicitly; the drawer reuses the M2-C2 source-doc resolver; integration test pins this. |
+| 4 | XLSX with 2000 cells × Excel comments is slow to generate | Streaming write via `openpyxl.Workbook` + `write_only=True` mode; benchmark a 200×10 grid generation before PR opens; if >30 sec, file DE for async export generation (sibling job pattern). |
+| 5 | Reviewing-attorney walkthrough surfaces tabular-specific UX issues | Calendar the walkthrough at the M3-C3 verification step (not the final pre-PR check); fix surfaces from the walkthrough during M3-C4 if scoped, defer to follow-on DE if not. |
+| 6 | The `M3A6_QUEUE_NAME → M3_PLAYBOOK_QUEUE_NAME` rename breaks in-flight Easy Playbook jobs at deploy | Keep the old constant aliased for one release; document in the M3-A6 worker file; the queue string stays `arq:m3a6` so on-the-wire compatibility is preserved. |
+
+---
+
+## What's NOT in scope for Phase C
+
+Stated explicitly so a future reader can verify scope was held:
+
+- **No Phase D / E work.** Phase D (Slack/Teams plumbing) opens after Phase C lands cleanly.
+- **No M4 work.** The Autonomous Layer + Contract Repository design discussions stay parked.
+- **No typed columns.** Decision C-1 keeps every cell as a string; typed-grid is a Phase C-close DE candidate.
+- **No tabular skill marketplace surface.** The new `output_format: table` example skill ships, but the wider community-skill discovery UX stays out of scope.
+- **No tabular re-run / re-execute affordance.** Operators wanting to re-run with the same spec start a new execution from the result view's "Re-run as new execution" button (one-line UI affordance; counts as part of M3-C3 not a separate task).
+- **No per-cell manual edit / annotation.** Cells are read-only — they're an auditable artifact of what the model produced. Operators export to Excel for editing.
+
+---
+
+## Sequenced next steps (this session and the next)
+
+1. Commit this prep doc to `m3-phase-c-tabular-review` (this session).
+2. M3-C1 implementation: schema extension + tests + docs + one example skill (next session).
+3. M3-C2 implementation: tabular module + worker + migration + endpoints.
+4. M3-C3 implementation: UI routes + components + Cypress E2E.
+5. M3-C4 implementation: bulk ops + XLSX/CSV export.
+6. Pre-PR: fresh-install Docker rebuild + reviewing-attorney walkthrough + ruff format AND ruff check AND mypy strict on gateway AND full pytest battery.
+7. Open PR against `main` once everything green.
+
+---
+
+*Locked at 2026-05-21 by the maintainer track (Kevin + Claude Opus 4.7). Decisions are revisitable mid-phase only if a discovered constraint forces a change; otherwise hold to keep Phase C bounded.*

--- a/skills/contract-snapshot/SKILL.md
+++ b/skills/contract-snapshot/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: contract-snapshot
+description: Use when the user wants to compare the same handful of terms across N contracts side-by-side in a grid — what is the term, survival period, carveouts, and governing law in each of these 5 NDAs? Returns a row-per-document × column-per-question grid with citations per cell. Reference skill for the M3-C output_format - table mode; intended as a starting point for operators to fork and tune for their own contract types.
+lq_ai:
+  title: Contract Snapshot
+  version: 1.0.0
+  author: LegalQuants
+  tags: [contracts, due-diligence, tabular, snapshot]
+  jurisdiction: agnostic
+  trigger_examples:
+    - "compare the term length and governing law across these NDAs"
+    - "show me a side-by-side of these 5 contracts on key terms"
+    - "I want a grid of these contracts' material terms"
+  output_format: table
+  ensemble_verification: false
+  minimum_inference_tier: 2
+  columns:
+    - name: Term
+      query: |
+        What is the term length of this agreement? Quote the operative
+        clause exactly and surface the duration in plain language
+        (e.g., "3 years from the Effective Date"). If the agreement
+        is open-ended or runs until termination, say so.
+    - name: Survival
+      query: |
+        What confidentiality or other obligations survive termination
+        or expiration of this agreement? Quote the survival clause
+        if one exists. If no survival period is specified, return
+        "not specified" (do not infer a default).
+      ensemble_verification: true
+    - name: Carveouts
+      query: |
+        What carveouts to the confidentiality obligation does this
+        agreement permit (e.g., already-known information, independently
+        developed, required by law)? List each carveout as a bullet
+        with a quoted phrase from the agreement.
+    - name: Governing Law
+      query: |
+        What jurisdiction governs this agreement, and which courts
+        have venue for disputes? Quote the governing-law and
+        forum-selection clauses verbatim.
+      minimum_inference_tier: 3
+---
+
+# Contract Snapshot
+
+A reference skill for the M3-C `output_format: table` mode. Produces a side-by-side grid of the same questions across N contracts — the in-house lawyer's "compare clauses across N agreements" workflow. Each cell carries a citation back to the source document, and failed extractions render as `not found` rather than confidently-wrong text.
+
+## When this skill applies
+
+Apply when the user wants to compare a small number of well-defined questions across a corpus of similar contracts:
+
+- "What is the term, survival, and governing law across these 5 NDAs we're tracking?"
+- "Pull out the payment terms, IP ownership, and termination triggers across these 10 MSAs."
+- "For my Q3 portfolio review, I need a grid of these 30 vendor contracts' liability caps."
+
+Do not apply this skill to:
+
+- Single-document review — use the appropriate document-specific skill (`nda-review`, `msa-review-saas`, etc.).
+- Free-form chat against contracts — that's the regular Chat surface.
+- Tasks where the questions aren't well-defined upfront — the column queries must be specific enough to extract from each row's source document; vague queries produce poor cells.
+
+## Inputs
+
+The skill takes a set of documents (selected via the Tabular Review UI from a Knowledge Base, a Project, or a free file selection). The four columns above run as Citation Engine-grounded extractions against each document.
+
+To adapt this skill for a different contract type (e.g., MSAs), fork the skill and rewrite the four column queries. Keep them short, specific, and quote-asking — the Citation Engine works best when the model is encouraged to quote rather than paraphrase.
+
+## Per-column overrides
+
+This skill demonstrates the two per-column overrides M3-C1 supports:
+
+- **`ensemble_verification: true`** on the Survival column. Survival is the load-bearing economic term in confidentiality agreements (a 3-year confidentiality term with a 10-year survival is very different from one with no survival), so cells in this column run through Stage 4 of the Citation Engine cascade — three judges debating whether the cell value is faithful to its citation. Higher cost, higher confidence.
+- **`minimum_inference_tier: 3`** on the Governing Law column. The skill-level floor is Tier 2 (commercial inference). Governing-law extraction is the column most likely to surface counterintuitive answers (e.g., a contract drafted under California law but with a Delaware forum-selection clause); routing this column to Tier 3+ avoids the cheapest models' tendency to collapse the two into one answer.
+
+Other columns inherit the skill-level `ensemble_verification: false` and `minimum_inference_tier: 2` defaults — appropriate for the lower-stakes, more-extractive Term and Carveouts columns.
+
+## Output format and downstream surfaces
+
+The grid renders in the Tabular Review UI (`/lq-ai/tabular/`) with sticky-first-row and sticky-first-column. Each cell shows the extracted value + a small confidence chip; click anywhere on the cell to open the existing M2-C2 citation drawer with the source document highlighted at the cited chunk.
+
+From the result view, operators can:
+
+- **Export the grid as XLSX** — each cell carries its citation as an Excel comment with a clickable link back to the deployment.
+- **Export as CSV** — citations are flattened to sibling `{column_name}_citation_url` columns.
+- **Run a bulk operation** — e.g., "Redline the Survival column in all rows" runs the `nda-review` skill against each row's source document with the survival value as context.
+
+## Disclaimer (per Decision F)
+
+This skill is a **starting point**, not a vetted template. The four columns are appropriate for many NDAs but won't be right for every corpus. Before relying on the output of a Tabular Review run on this skill, the user-attorney should:
+
+1. Review the column queries — do they match the questions you actually want answered for this corpus?
+2. Spot-check at least one cell per column against the source document — does the extraction faithfully represent the source?
+3. Treat any `not found` cell as a signal to investigate, not as definitive evidence that the clause is absent.
+
+The output is a draft for an in-house lawyer to validate, not a final compliance artifact.
+
+## Fork and tune
+
+This skill is intentionally minimal so operators can fork it as a starting point:
+
+```yaml
+# skills/my-org/msa-snapshot/SKILL.md (operator's fork)
+output_format: table
+columns:
+  - name: Payment Terms
+    query: What are the payment terms (frequency, days-to-pay, late-fee provisions)?
+  - name: IP Ownership
+    query: Who owns IP created during the engagement (work-for-hire, license-back, joint)?
+  - name: Termination
+    query: List each termination right (for cause, for convenience, notice periods).
+  # ... more columns
+```
+
+The Tabular UI accepts both saved skills (like this one) and ad-hoc column specs entered directly in the wizard's column step.

--- a/skills/msa-snapshot/SKILL.md
+++ b/skills/msa-snapshot/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: msa-snapshot
+description: >-
+  Use when the user wants to compare the substantive commercial terms across N
+  master services agreements side-by-side — term and renewal, payment terms,
+  limitation of liability, and indemnification posture across each agreement.
+  Returns a row-per-document × column-per-question grid with citations per
+  cell. MSA-tuned reference skill for the M3-C `output_format - table` mode;
+  intended as a fork-and-tune starting point for operators reviewing MSA
+  portfolios.
+lq_ai:
+  title: MSA Snapshot
+  version: 1.0.0
+  author: LegalQuants
+  tags: [msa, commercial, due-diligence, tabular, snapshot]
+  jurisdiction: agnostic
+  trigger_examples:
+    - "compare the liability caps and payment terms across these MSAs"
+    - "what are the renewal triggers in each of these 5 vendor MSAs?"
+    - "show me a grid of indemnification posture across these agreements"
+  output_format: table
+  ensemble_verification: false
+  minimum_inference_tier: 2
+  columns:
+    - name: Term + Renewal
+      query: |
+        What is the initial term of this agreement and how does it
+        renew? Quote the operative clause. Identify: (a) initial term
+        length, (b) renewal mechanism (auto-renew, mutual written
+        consent, etc.), (c) notice period required to prevent renewal,
+        and (d) cap on total renewals if any. If the agreement is
+        perpetual or terminates only for cause, say so explicitly.
+    - name: Payment Terms
+      query: |
+        What are the payment terms? Quote the operative clause.
+        Identify: (a) net payment days (e.g., Net 30, Net 60), (b)
+        late-fee or interest provisions, (c) right-to-suspend-services
+        triggers for non-payment, (d) whether disputed amounts can be
+        withheld, and (e) currency. Quote each verbatim. Do not infer
+        defaults if any element is silent.
+      ensemble_verification: true
+    - name: Limitation of Liability
+      query: |
+        What is the cap on liability? Quote the limitation-of-liability
+        clause. Identify: (a) the cap amount or formula (e.g., "fees
+        paid in the prior 12 months"), (b) any carveouts that uncap
+        liability (e.g., indemnification obligations, confidentiality
+        breaches, gross negligence, willful misconduct), and (c)
+        whether the cap is mutual or one-way. Quote the carveouts
+        verbatim — they are the most negotiated piece of this clause.
+      minimum_inference_tier: 3
+    - name: Indemnification
+      query: |
+        What indemnification obligations does each party owe? Quote the
+        indemnification clauses. Identify for each direction: (a)
+        scope (IP infringement, breach of confidentiality, third-party
+        claims arising from negligence, etc.), (b) whether the
+        indemnifying party controls the defense, (c) any procedural
+        prerequisites (prompt notice, cooperation), and (d) whether
+        the indemnifying party's obligations survive termination.
+        Flag whether the indemnification is one-way (vendor-favorable
+        or customer-favorable) or mutual.
+      minimum_inference_tier: 3
+---
+
+# MSA Snapshot
+
+A reference skill for the M3-C `output_format: table` mode, tuned for master services agreement portfolios. Produces a side-by-side grid of MSA-specific commercial terms across N agreements — the in-house lawyer's "compare these vendor MSAs" or "diligence these target MSAs" workflow. Each cell carries a citation back to the source document; failed extractions render as `not found` rather than confidently-wrong text.
+
+## When this skill applies
+
+Apply when the user has a portfolio of MSAs and wants to see how key commercial terms compare across them. Examples:
+
+- "Pull liability caps, indemnification, and payment terms across these 8 vendor MSAs before our renewal cycle."
+- "For this acquisition diligence, show me the renewal trigger and termination posture across the target's top 15 MSAs."
+- "Compare the liability carveouts across our SaaS MSAs vs. our commercial-purchase MSAs."
+
+Do not apply this skill to:
+
+- Single-MSA review — use `msa-review-saas` or `msa-review-commercial-purchase` for one document at a time.
+- General contract comparison across mixed types — use `contract-snapshot` for the general Term/Survival/Carveouts/Governing-Law grid.
+- NDA portfolios — use `nda-snapshot` for NDA-specific columns (Confidential Information definition, permitted recipients, etc.).
+
+## Pairing with the synthetic corpus
+
+This skill ships paired with the synthetic MSA corpus in `docs/quickstart/sample-msas/` (5 MSAs with varying commercial terms). Operators trying LQ.AI for the first time can attach those 5 PDFs to a Knowledge Base and run this skill to see the tabular workflow end-to-end without committing real documents to the system.
+
+## Fork-and-tune notes
+
+The four columns here cover the highest-frequency MSA comparison questions for in-house counsel doing portfolio review or diligence. They do not overlap with the general `contract-snapshot` columns (Term, Survival, Carveouts, Governing Law) — operators wanting both can run the two skills in sequence.
+
+When forking for your own MSA template / counterparty patterns, common modifications include:
+
+- Adding a **Termination for Convenience** column if your business cares about exit flexibility (notice period + fee structure).
+- Adding a **SLA / Service Levels** column for SaaS-heavy MSA portfolios (credit structure + measurement period).
+- Adding a **Data Processing** column if you need to compare DPA references and data-residency commitments across vendors.
+- Replacing the **Indemnification** column with a narrower **IP Indemnification** column if that is the only indemnification scope you care about.
+- Bumping `minimum_inference_tier` to 3 on all columns for high-stakes diligence work.
+
+The **Limitation of Liability** and **Indemnification** columns default to `minimum_inference_tier: 3` because these clauses are dense, fragmented across the document, and most prone to silent extraction errors. The carveouts in particular are the most-negotiated piece of an MSA — surfacing them inaccurately is worse than surfacing them not-at-all.
+
+## Output expectations
+
+For each document × column cell:
+
+- A quoted phrase or short paragraph from the source document, anchored by character offsets to enable the citation modal.
+- A brief plain-language summary when the operative clause spans multiple paragraphs.
+- An explicit "one-way (vendor-favorable)" / "one-way (customer-favorable)" / "mutual" tag where the column asks about directionality (e.g., Indemnification).
+- `not found` when the requested term is genuinely absent from the document (not when extraction failed — those surface as a parse error in the cell footer).

--- a/skills/nda-snapshot/SKILL.md
+++ b/skills/nda-snapshot/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: nda-snapshot
+description: >-
+  Use when the user wants to compare the substantive NDA-specific terms across
+  N non-disclosure agreements side-by-side — the definition of Confidential
+  Information, permitted recipients, return/destruction obligation, and
+  remedies clause across each agreement. Returns a row-per-document ×
+  column-per-question grid with citations per cell. NDA-tuned reference skill
+  for the M3-C `output_format - table` mode; intended as a fork-and-tune
+  starting point for operators reviewing NDA portfolios.
+lq_ai:
+  title: NDA Snapshot
+  version: 1.0.0
+  author: LegalQuants
+  tags: [nda, confidentiality, due-diligence, tabular, snapshot]
+  jurisdiction: agnostic
+  trigger_examples:
+    - "compare the confidentiality scope and return obligations across these NDAs"
+    - "what's the definition of Confidential Information in each of these 5 agreements?"
+    - "show me a grid of permitted recipients and remedies across these NDAs"
+  output_format: table
+  ensemble_verification: false
+  minimum_inference_tier: 2
+  columns:
+    - name: Confidential Information
+      query: |
+        How does this agreement define "Confidential Information"? Quote
+        the operative definition verbatim. Note any explicit carveouts
+        embedded in the definition itself (e.g., "excluding information
+        that is publicly available…"). If the definition is unusually
+        narrow or unusually broad, flag that in a short trailing note.
+    - name: Permitted Recipients
+      query: |
+        Who is the recipient permitted to disclose Confidential
+        Information to? Quote the permitted-recipients clause. Identify
+        whether the recipient must impose written confidentiality
+        obligations on those downstream recipients, and whether the
+        recipient remains liable for their breach. If the clause is
+        silent on downstream obligations, say so explicitly — do not
+        infer a default.
+      ensemble_verification: true
+    - name: Return / Destruction
+      query: |
+        On termination or upon request, must the recipient return or
+        destroy Confidential Information? Quote the operative clause.
+        Identify: (a) trigger (termination, written request, expiry),
+        (b) timing (number of days), (c) whether destruction
+        certification is required, and (d) any carveouts for archival
+        or legally-required retention. If the clause is silent on any
+        of these, say "not specified" rather than infer.
+    - name: Remedies
+      query: |
+        What remedies does the agreement provide for breach? Quote the
+        remedies clause. Identify whether injunctive relief is
+        explicitly available (and whether the parties agree damages
+        would be inadequate), whether attorneys' fees shift to the
+        prevailing party, and whether monetary damages are capped or
+        uncapped. Quote relevant phrases verbatim.
+      minimum_inference_tier: 3
+---
+
+# NDA Snapshot
+
+A reference skill for the M3-C `output_format: table` mode, tuned for non-disclosure agreement portfolios. Produces a side-by-side grid of NDA-specific terms across N agreements — the in-house lawyer's "compare these NDAs we have with vendors / counterparties / candidates" workflow. Each cell carries a citation back to the source document; failed extractions render as `not found` rather than confidently-wrong text.
+
+## When this skill applies
+
+Apply when the user has a portfolio of NDAs and wants to see how key substantive terms compare across them. Examples:
+
+- "I have NDAs with our top 20 vendors — show me how the definition of Confidential Information varies and where the carveouts are tightest."
+- "Compare the return/destruction obligations across these 10 candidate NDAs before we standardize our template."
+- "What remedies are available across the 5 mutual NDAs in this M&A diligence box?"
+
+Do not apply this skill to:
+
+- Single-NDA review — use `nda-review` for one document at a time.
+- General contract comparison across mixed types — use `contract-snapshot` for the general Term/Survival/Carveouts/Governing-Law grid.
+- Free-form Q&A about an NDA — that's the regular Chat surface.
+
+## Pairing with the synthetic corpus
+
+This skill ships paired with the synthetic NDA corpus in `docs/quickstart/sample-ndas/` (5 mutual NDAs with varying terms). Operators trying LQ.AI for the first time can attach those 5 PDFs to a Knowledge Base and run this skill to see the tabular workflow end-to-end without committing real documents to the system.
+
+## Fork-and-tune notes
+
+The four columns here are deliberately NDA-specific — they don't overlap with the general `contract-snapshot` columns (Term, Survival, Carveouts, Governing Law). Operators who want both can run the two skills in sequence, or fork this skill and add a Term/Governing-Law column for a combined view.
+
+When forking for your own NDA template / counterparty patterns, common modifications include:
+
+- Adding a **Term** column if you care about NDA duration (often 2–5 years).
+- Adding a **Notice of Compelled Disclosure** column if you negotiate that provision frequently.
+- Replacing the **Permitted Recipients** column with a narrower **Affiliate Permission** column if your business has a specific affiliate-sharing pattern.
+- Bumping `minimum_inference_tier` to 3 on all columns if you need higher-fidelity extraction for high-stakes deals.
+
+The four columns chosen here reflect the questions a junior associate or paralegal would most often be asked to extract during NDA portfolio review — they are the highest-frequency, highest-value comparison points across typical mutual-NDA practice.
+
+## Output expectations
+
+For each document × column cell:
+
+- A quoted phrase or short paragraph from the source document, anchored by character offsets to enable the citation modal.
+- A brief plain-language summary when the operative clause is long or convoluted.
+- `not found` when the requested term is genuinely absent from the document (not when extraction failed — those surface as a parse error in the cell footer).

--- a/web/cypress/e2e/m3-c-tabular-review.cy.ts
+++ b/web/cypress/e2e/m3-c-tabular-review.cy.ts
@@ -1,0 +1,340 @@
+/**
+ * M3-C3 — Tabular Review UI happy path.
+ *
+ * Covers the full operator flow:
+ *
+ *   1. Login → redirect to /lq-ai
+ *   2. /lq-ai/tabular → empty list + "Start new tabular review" CTA
+ *   3. Click CTA → /lq-ai/tabular/new (4-step wizard)
+ *   4. Step 1 (Documents): pick KB → multi-select 5 files
+ *   5. Step 1 Next → Step 2 (Columns)
+ *   6. Step 2: pick the contract-snapshot table-mode skill
+ *   7. Step 2 Next → Step 3 (Cost preview); intercept fires
+ *   8. Step 3 Next → Step 4 (Confirm); cost below $1 so no checkbox gate
+ *   9. Step 4 Run → POST /tabular/execute → redirect to /lq-ai/tabular/[id]
+ *   10. First poll → pending banner
+ *   11. Second poll (3s later) → completed grid (5 rows × 4 cols = 20 cells)
+ *   12. Click a populated cell → citation modal opens
+ *   13. Close the modal
+ *
+ * All API responses are mocked via cy.intercept so the spec runs against
+ * a live SvelteKit dev server (`docker compose up -d`) without requiring
+ * any particular database state. Mocked shapes mirror the wire shapes in
+ * `api/app/schemas/tabular.py`.
+ *
+ * Run:
+ *   docker compose up -d
+ *   cd web && npx cypress run --spec 'cypress/e2e/m3-c-tabular-review.cy.ts'
+ */
+
+/// <reference types="cypress" />
+
+const EXECUTION_ID = 'tex-1';
+const KB_ID = 'kb-1';
+const SKILL_NAME = 'contract-snapshot';
+
+const FILE_IDS = ['f1', 'f2', 'f3', 'f4', 'f5'];
+const DOC_IDS = ['d1', 'd2', 'd3', 'd4', 'd5'];
+const COLUMN_NAMES = ['Term', 'Survival', 'Carveouts', 'Governing Law'];
+
+const mockUser = {
+	id: 'u1',
+	email: 'admin@lq.ai',
+	display_name: 'Admin',
+	is_admin: true,
+	role: 'admin' as const,
+	mfa_enabled: false,
+	must_change_password: false,
+	created_at: '2026-01-01T00:00:00Z'
+};
+
+const mockKnowledgeBase = {
+	id: KB_ID,
+	name: 'Sample NDAs',
+	description: null,
+	owner_id: 'u1',
+	project_id: null,
+	hybrid_alpha: 0.5,
+	file_count: 5,
+	chunk_count: 25,
+	archived_at: null,
+	created_at: '2026-05-22T00:00:00Z',
+	updated_at: '2026-05-22T00:00:00Z'
+};
+
+const mockKbFiles = FILE_IDS.map((id, i) => ({
+	id,
+	owner_id: 'u1',
+	project_id: null,
+	filename: `sample-nda-${i + 1}.pdf`,
+	mime_type: 'application/pdf',
+	size_bytes: 1024,
+	hash_sha256: `hash-${i}`,
+	ingestion_status: 'ready' as const,
+	ingest_status: 'ok' as const,
+	document_id: DOC_IDS[i],
+	page_count: 4,
+	character_count: 2000,
+	created_at: '2026-05-22T00:00:00Z',
+	attached_at: '2026-05-22T00:00:00Z'
+}));
+
+const mockSkills = [
+	{
+		name: SKILL_NAME,
+		version: '1.0.0',
+		scope: 'builtin' as const,
+		title: 'Contract Snapshot',
+		description: '4-column NDA snapshot: Term / Survival / Carveouts / Governing Law.',
+		output_format: 'table'
+	},
+	{
+		name: 'nda-review',
+		version: '1.0.0',
+		scope: 'builtin' as const,
+		title: 'NDA Review',
+		description: 'Standard NDA review playbook.',
+		output_format: 'report' // should be filtered out of the table-mode dropdown
+	}
+];
+
+const mockPreviewResponse = {
+	cells_count: 20,
+	estimated_tokens: 12000,
+	estimated_cost_usd: '0.0500',
+	per_tier_breakdown: { tier_2: 20 }
+};
+
+const mockExecutionPending = {
+	id: EXECUTION_ID,
+	user_id: 'u1',
+	parent_execution_id: null,
+	skill_name: SKILL_NAME,
+	status: 'pending' as const,
+	document_ids: DOC_IDS,
+	columns: COLUMN_NAMES.map((name) => ({ name, query: `What is the ${name}?` })),
+	results: null,
+	cost_estimate_usd: '0.0500',
+	cost_actual_usd: null,
+	error_text: null,
+	created_at: '2026-05-22T15:00:00Z',
+	started_at: null,
+	completed_at: null
+};
+
+const mockExecutionCompleted = {
+	...mockExecutionPending,
+	status: 'completed' as const,
+	started_at: '2026-05-22T15:00:05Z',
+	completed_at: '2026-05-22T15:01:35Z',
+	cost_actual_usd: '0.0480',
+	results: {
+		rows: DOC_IDS.map((docId, i) => ({
+			document_id: docId,
+			document_name: `sample-nda-${i + 1}.pdf`,
+			cells: Object.fromEntries(
+				COLUMN_NAMES.map((col, j) => [
+					col,
+					{
+						value: j === 2 && i === 1 ? null : `value-${i}-${j}`, // (Carveouts, NDA 2) → failed
+						citations:
+							j === 2 && i === 1
+								? []
+								: [
+										{
+											citation_id: `cite-${i}-${j}`,
+											document_id: docId,
+											chunk_id: `chunk-${i}-${j}`,
+											confidence: (['high', 'medium', 'low'] as const)[j % 3]
+										}
+									],
+						confidence:
+							j === 2 && i === 1 ? ('failed' as const) : (['high', 'medium', 'low'] as const)[j % 3],
+						tier_used: j === 2 && i === 1 ? null : 2,
+						cost_usd: '0.0024',
+						error: j === 2 && i === 1 ? 'no citation found' : null
+					}
+				])
+			)
+		}))
+	}
+};
+
+describe('M3-C3 — Tabular Review happy path', () => {
+	beforeEach(() => {
+		// --- Login + post-login gate ------------------------------------------
+		cy.intercept('POST', '**/api/v1/auth/login', {
+			statusCode: 200,
+			body: {
+				access_token: 'fake-token',
+				token_type: 'Bearer',
+				expires_in: 3600,
+				user: mockUser
+			}
+		}).as('login');
+
+		cy.intercept('GET', '**/api/v1/users/me', { statusCode: 200, body: mockUser }).as('getMe');
+		cy.intercept('GET', '**/api/v1/admin/bootstrap-status', {
+			statusCode: 200,
+			body: { default_password_active: false, logs_hint: '' }
+		}).as('bootstrapStatus');
+		cy.intercept('GET', '**/api/v1/users/me/preferences', {
+			statusCode: 200,
+			body: {
+				reasoning_visibility: 'on_request',
+				featured_tools: 'inline',
+				workspace_layout: 'three_pane',
+				trust_pills: 'labels',
+				provenance_pills: 'collapsed'
+			}
+		}).as('getPreferences');
+		cy.intercept('GET', '**/api/v1/projects**', { statusCode: 200, body: [] }).as('listProjects');
+		cy.intercept('GET', '**/api/v1/chats**', {
+			statusCode: 200,
+			body: { items: [], next_cursor: null }
+		}).as('listChats');
+		cy.intercept('GET', '**/api/v1/user-skills**', { statusCode: 200, body: [] }).as(
+			'listUserSkills'
+		);
+		cy.intercept('GET', '**/api/v1/saved-prompts**', { statusCode: 200, body: [] }).as(
+			'listSavedPrompts'
+		);
+		cy.intercept('GET', '**/api/v1/teams**', { statusCode: 200, body: [] }).as('listTeams');
+
+		// --- Skills (Step 2 dropdown filters to table-mode) -------------------
+		cy.intercept('GET', '**/api/v1/skills**', { statusCode: 200, body: mockSkills }).as(
+			'listSkills'
+		);
+
+		// --- Tabular endpoints ------------------------------------------------
+		cy.intercept('GET', '**/api/v1/tabular/executions', { statusCode: 200, body: [] }).as(
+			'listTabular'
+		);
+
+		cy.intercept('GET', '**/api/v1/knowledge-bases**', {
+			statusCode: 200,
+			body: [mockKnowledgeBase]
+		}).as('listKbs');
+
+		cy.intercept('GET', `**/api/v1/knowledge-bases/${KB_ID}/files**`, {
+			statusCode: 200,
+			body: mockKbFiles
+		}).as('listKbFiles');
+
+		cy.intercept('POST', '**/api/v1/tabular/preview-cost', {
+			statusCode: 200,
+			body: mockPreviewResponse
+		}).as('previewCost');
+
+		cy.intercept('POST', '**/api/v1/tabular/execute', {
+			statusCode: 202,
+			body: mockExecutionPending
+		}).as('executeTabular');
+
+		// First poll → pending, every subsequent poll → completed.
+		let pollCount = 0;
+		cy.intercept('GET', `**/api/v1/tabular/executions/${EXECUTION_ID}`, (req) => {
+			pollCount += 1;
+			req.reply({
+				statusCode: 200,
+				body: pollCount === 1 ? mockExecutionPending : mockExecutionCompleted
+			});
+		}).as('pollTabular');
+	});
+
+	it('login → empty list → wizard 4 steps → execute → poll twice → completed grid → cell click opens citation modal', () => {
+		// 1. Login + dashboard hop.
+		cy.visit('/lq-ai/login');
+		cy.get('[data-testid="lq-ai-login-email"]').type('admin@lq.ai');
+		cy.get('[data-testid="lq-ai-login-password"]').type('password');
+		cy.get('[data-testid="lq-ai-login-submit"]').click();
+		cy.wait('@login');
+		cy.url({ timeout: 15000 }).should('not.include', '/login');
+
+		// 2. Navigate to /lq-ai/tabular — empty list.
+		cy.visit('/lq-ai/tabular');
+		cy.wait('@listTabular');
+		cy.get('[data-testid="lq-tabular-empty"]').should('be.visible');
+
+		// 3. Click "Start new tabular review" CTA → /lq-ai/tabular/new.
+		cy.get('[data-testid="lq-tabular-new-cta"]').click();
+		cy.url().should('include', '/lq-ai/tabular/new');
+
+		// Wait for the parallel mount fetches to land.
+		cy.wait('@listKbs');
+		cy.wait('@listSkills');
+
+		// 4. Step 1: pick KB → 5 file checkboxes → multi-select all 5.
+		cy.get('[data-testid="lq-tabwiz-steps"]')
+			.find('[data-step="documents"][data-active="true"]')
+			.should('exist');
+		cy.get('[data-testid="lq-tabwiz-kb-select"]').select(KB_ID);
+		cy.wait('@listKbFiles');
+		cy.get('[data-testid="lq-tabwiz-files"]').should('be.visible');
+		cy.get('[data-testid="lq-tabwiz-file-checkbox"]').should('have.length', 5);
+		cy.get('[data-testid="lq-tabwiz-file-checkbox"]').each(($el) => {
+			cy.wrap($el).check();
+		});
+		cy.get('[data-testid="lq-tabwiz-doc-count"]').should('contain', '5');
+
+		// 5. Step 1 → Step 2.
+		cy.get('[data-testid="lq-tabwiz-next"]').should('not.be.disabled').click();
+		cy.get('[data-testid="lq-tabwiz-steps"]')
+			.find('[data-step="columns"][data-active="true"]')
+			.should('exist');
+
+		// 6. Step 2: skills already loaded; pick contract-snapshot.
+		//    Sanity: the dropdown should only contain table-mode skills (1
+		//    entry), NOT the nda-review report-mode skill from the mock.
+		cy.get('[data-testid="lq-tabwiz-skill-select"]').find('option').should('have.length', 2);
+		cy.get('[data-testid="lq-tabwiz-skill-select"]').select(SKILL_NAME);
+
+		// 7. Step 2 → Step 3 (preview fetched).
+		cy.get('[data-testid="lq-tabwiz-next"]').should('not.be.disabled').click();
+		cy.wait('@previewCost');
+		cy.get('[data-testid="lq-tabwiz-steps"]')
+			.find('[data-step="preview"][data-active="true"]')
+			.should('exist');
+		cy.get('[data-testid="lq-tabwiz-preview-cells"]').should('contain', '20');
+		cy.get('[data-testid="lq-tabwiz-preview-cost"]').should('contain', '$0.05');
+
+		// 8. Step 3 → Step 4 — cost below $1, no confirmation gate.
+		cy.get('[data-testid="lq-tabwiz-next"]').should('not.be.disabled').click();
+		cy.get('[data-testid="lq-tabwiz-steps"]')
+			.find('[data-step="confirm"][data-active="true"]')
+			.should('exist');
+		cy.get('[data-testid="lq-tabwiz-confirm-gate"]').should('not.exist');
+
+		// 9. Run → POST /tabular/execute → redirect to result.
+		cy.get('[data-testid="lq-tabwiz-next"]').should('not.be.disabled').click();
+		cy.wait('@executeTabular');
+		cy.url({ timeout: 10000 }).should('include', `/lq-ai/tabular/${EXECUTION_ID}`);
+
+		// 10. First poll → pending banner.
+		cy.wait('@pollTabular');
+		cy.get('[data-testid="lq-tabres-status"]', { timeout: 10000 }).should('contain', 'Pending');
+
+		// 11. Second poll (3s later) → completed; grid renders 5 rows.
+		cy.wait('@pollTabular');
+		cy.get('[data-testid="lq-tabres-status"]', { timeout: 10000 }).should('contain', 'Completed');
+		cy.get('[data-testid="lq-tabgrid"]').should('be.visible');
+		cy.get('[data-testid="lq-tabgrid-row"]').should('have.length', 5);
+		cy.get('[data-testid="lq-tabgrid-header"]').should('have.length', 4);
+
+		// Failed cell (Carveouts × sample-nda-2.pdf) should render italic
+		// "not found".
+		cy.get('[data-testid="lq-tabcell-failed"]').should('have.length', 1);
+		cy.get('[data-testid="lq-tabcell-failed"]').should('contain', 'not found');
+
+		// 12. Click a populated cell → citation modal opens.
+		cy.get('[data-testid="lq-tabcell"][data-state!="empty"][data-state!="failed"]')
+			.first()
+			.click();
+		cy.get('[data-testid="lq-tabcm"]').should('be.visible');
+		cy.get('[data-testid="lq-tabcm-citations"]').should('be.visible');
+
+		// 13. Close the modal (× button).
+		cy.get('[data-testid="lq-tabcm-close"]').click();
+		cy.get('[data-testid="lq-tabcm"]').should('not.exist');
+	});
+});

--- a/web/src/lib/lq-ai/__tests__/TopTabBar.test.ts
+++ b/web/src/lib/lq-ai/__tests__/TopTabBar.test.ts
@@ -5,18 +5,49 @@ describe('TopTabBar.visibleTabsFor', () => {
   const admin: TopTabBarUser = { id: '1', email: 'a@x', is_admin: true,  must_change_password: false };
   const member: TopTabBarUser = { id: '2', email: 'm@x', is_admin: false, must_change_password: false };
 
-  it('returns eight tabs for a non-admin user (admin hidden, playbooks added in M3-A4)', () => {
+  it('returns nine tabs for a non-admin user (admin hidden, tabular added in M3-C3)', () => {
     const ids = visibleTabsFor(member).map((t) => t.id);
-    expect(ids).toEqual(['home', 'chats', 'matters', 'skills', 'knowledge', 'playbooks', 'saved-prompts', 'learn']);
+    expect(ids).toEqual([
+      'home',
+      'chats',
+      'matters',
+      'skills',
+      'knowledge',
+      'playbooks',
+      'tabular',
+      'saved-prompts',
+      'learn'
+    ]);
   });
 
-  it('returns nine tabs for an admin user (playbooks added in M3-A4)', () => {
+  it('returns ten tabs for an admin user (tabular added in M3-C3)', () => {
     const ids = visibleTabsFor(admin).map((t) => t.id);
-    expect(ids).toEqual(['home', 'chats', 'matters', 'skills', 'knowledge', 'playbooks', 'saved-prompts', 'learn', 'admin']);
+    expect(ids).toEqual([
+      'home',
+      'chats',
+      'matters',
+      'skills',
+      'knowledge',
+      'playbooks',
+      'tabular',
+      'saved-prompts',
+      'learn',
+      'admin'
+    ]);
   });
 
-  it('returns eight tabs for null user (treats as non-admin, playbooks added in M3-A4)', () => {
+  it('returns nine tabs for null user (treats as non-admin, tabular added in M3-C3)', () => {
     const ids = visibleTabsFor(null).map((t) => t.id);
-    expect(ids).toEqual(['home', 'chats', 'matters', 'skills', 'knowledge', 'playbooks', 'saved-prompts', 'learn']);
+    expect(ids).toEqual([
+      'home',
+      'chats',
+      'matters',
+      'skills',
+      'knowledge',
+      'playbooks',
+      'tabular',
+      'saved-prompts',
+      'learn'
+    ]);
   });
 });

--- a/web/src/lib/lq-ai/__tests__/tabs.test.ts
+++ b/web/src/lib/lq-ai/__tests__/tabs.test.ts
@@ -5,9 +5,20 @@ describe('tabs', () => {
   const adminUser: User = { id: '1', email: 'a@x.io', is_admin: true, must_change_password: false, role: 'admin' };
   const memberUser: User = { id: '2', email: 'm@x.io', is_admin: false, must_change_password: false, role: 'member' };
 
-  it('defines eight core tabs plus admin (playbooks added in M3-A4)', () => {
+  it('defines nine core tabs plus admin (tabular added in M3-C3)', () => {
     const ids = TABS.map((t) => t.id);
-    expect(ids).toEqual(['home', 'chats', 'matters', 'skills', 'knowledge', 'playbooks', 'saved-prompts', 'learn', 'admin']);
+    expect(ids).toEqual([
+      'home',
+      'chats',
+      'matters',
+      'skills',
+      'knowledge',
+      'playbooks',
+      'tabular',
+      'saved-prompts',
+      'learn',
+      'admin'
+    ]);
   });
 
   it('hides admin tab for non-admin users', () => {
@@ -16,10 +27,29 @@ describe('tabs', () => {
   });
 
   it('shows core tabs to all users', () => {
-    for (const id of ['home', 'chats', 'matters', 'skills', 'knowledge', 'playbooks', 'saved-prompts'] as TabId[]) {
+    for (const id of [
+      'home',
+      'chats',
+      'matters',
+      'skills',
+      'knowledge',
+      'playbooks',
+      'tabular',
+      'saved-prompts'
+    ] as TabId[]) {
       expect(isTabVisible(id, memberUser)).toBe(true);
       expect(isTabVisible(id, adminUser)).toBe(true);
     }
+  });
+
+  it('marks tabular tab as available (M3-C3)', () => {
+    expect(isTabAvailable('tabular')).toBe(true);
+  });
+
+  it('activeTabFor recognises /lq-ai/tabular subroutes', () => {
+    expect(activeTabFor('/lq-ai/tabular')).toBe('tabular');
+    expect(activeTabFor('/lq-ai/tabular/new')).toBe('tabular');
+    expect(activeTabFor('/lq-ai/tabular/abc-123')).toBe('tabular');
   });
 
   it('marks every M1 tab as available (last placeholder closed)', () => {

--- a/web/src/lib/lq-ai/api/__tests__/tabular.test.ts
+++ b/web/src/lib/lq-ai/api/__tests__/tabular.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for the tabular API client (M3-C3).
+ *
+ * Mocks ``globalThis.fetch`` so the calls don't escape the test runner.
+ * Mirrors the playbooks-api test shape: regressions in the shared
+ * ``apiRequest`` helper (auth header attachment, URL encoding, error
+ * translation) surface here too.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+	previewTabularCost,
+	executeTabular,
+	listTabularExecutions,
+	getTabularExecution,
+	deleteTabularExecution,
+	cancelTabularExecution
+} from '../tabular';
+
+function jsonResponseLike(status: number, body: unknown) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		headers: {
+			get: (name: string) => (name.toLowerCase() === 'content-type' ? 'application/json' : null)
+		},
+		json: async () => body
+	};
+}
+
+describe('tabular API client', () => {
+	const fetchMock = vi.fn();
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+		fetchMock.mockReset();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it('previewTabularCost POSTs /api/v1/tabular/preview-cost with the body', async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponseLike(200, {
+				cells_count: 20,
+				estimated_tokens: 12000,
+				estimated_cost_usd: '0.0500',
+				per_tier_breakdown: { tier_2: 16, tier_4: 4 }
+			})
+		);
+		const preview = await previewTabularCost({
+			document_ids: ['d1', 'd2', 'd3', 'd4', 'd5'],
+			skill_name: 'contract-snapshot'
+		});
+		expect(preview.cells_count).toBe(20);
+		expect(preview.estimated_cost_usd).toBe('0.0500');
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(String(url)).toContain('/tabular/preview-cost');
+		expect(init.method).toBe('POST');
+		const body = JSON.parse(String(init.body));
+		expect(body.document_ids).toHaveLength(5);
+		expect(body.skill_name).toBe('contract-snapshot');
+	});
+
+	it('previewTabularCost supports ad-hoc columns instead of skill_name', async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponseLike(200, {
+				cells_count: 4,
+				estimated_tokens: 2400,
+				estimated_cost_usd: '0.0100',
+				per_tier_breakdown: { tier_2: 4 }
+			})
+		);
+		await previewTabularCost({
+			document_ids: ['d1'],
+			columns: [
+				{ name: 'Term', query: 'What is the term of this NDA?' },
+				{
+					name: 'Survival',
+					query: 'How long does the obligation survive?',
+					minimum_inference_tier: 4
+				}
+			]
+		});
+		const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+		expect(body.columns).toHaveLength(2);
+		expect(body.columns[1].minimum_inference_tier).toBe(4);
+		expect(body.skill_name).toBeUndefined();
+	});
+
+	it('executeTabular POSTs /api/v1/tabular/execute and returns 202 + execution row', async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponseLike(202, {
+				id: 'tex-1',
+				user_id: 'u1',
+				parent_execution_id: null,
+				skill_name: 'contract-snapshot',
+				status: 'pending',
+				document_ids: ['d1', 'd2', 'd3', 'd4', 'd5'],
+				columns: [{ name: 'Term', query: 'What is the term?' }],
+				results: null,
+				cost_estimate_usd: '0.0500',
+				cost_actual_usd: null,
+				error_text: null,
+				created_at: '2026-05-22T15:00:00Z',
+				started_at: null,
+				completed_at: null
+			})
+		);
+		const exec = await executeTabular({
+			document_ids: ['d1', 'd2', 'd3', 'd4', 'd5'],
+			skill_name: 'contract-snapshot',
+			confirmed_cost_usd: '0.0500'
+		});
+		expect(exec.id).toBe('tex-1');
+		expect(exec.status).toBe('pending');
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(String(url)).toContain('/tabular/execute');
+		expect(init.method).toBe('POST');
+		const body = JSON.parse(String(init.body));
+		expect(body.confirmed_cost_usd).toBe('0.0500');
+	});
+
+	it('listTabularExecutions GETs /api/v1/tabular/executions', async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponseLike(200, [
+				{
+					id: 'tex-1',
+					user_id: 'u1',
+					parent_execution_id: null,
+					skill_name: 'contract-snapshot',
+					status: 'completed',
+					document_count: 5,
+					column_count: 4,
+					cost_estimate_usd: '0.0500',
+					cost_actual_usd: '0.0480',
+					created_at: '2026-05-22T15:00:00Z',
+					completed_at: '2026-05-22T15:02:00Z'
+				}
+			])
+		);
+		const rows = await listTabularExecutions();
+		expect(rows).toHaveLength(1);
+		expect(rows[0].document_count).toBe(5);
+		expect(rows[0].column_count).toBe(4);
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit | undefined];
+		expect(String(url)).toMatch(/\/tabular\/executions$/);
+		expect(init?.method ?? 'GET').toBe('GET');
+	});
+
+	it('getTabularExecution GETs /api/v1/tabular/executions/{id}', async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponseLike(200, {
+				id: 'tex-1',
+				user_id: 'u1',
+				parent_execution_id: null,
+				skill_name: 'contract-snapshot',
+				status: 'completed',
+				document_ids: ['d1', 'd2'],
+				columns: [{ name: 'Term', query: 'What is the term?' }],
+				results: {
+					rows: [
+						{
+							document_id: 'd1',
+							document_name: 'NDA Acme.pdf',
+							cells: {
+								Term: {
+									value: '3 years',
+									citations: [],
+									confidence: 'high',
+									tier_used: 2,
+									cost_usd: '0.0050',
+									error: null
+								}
+							}
+						}
+					]
+				},
+				cost_estimate_usd: '0.0500',
+				cost_actual_usd: '0.0480',
+				error_text: null,
+				created_at: '2026-05-22T15:00:00Z',
+				started_at: '2026-05-22T15:00:05Z',
+				completed_at: '2026-05-22T15:02:00Z'
+			})
+		);
+		const exec = await getTabularExecution('tex-1');
+		expect(exec.status).toBe('completed');
+		expect(exec.results?.rows).toHaveLength(1);
+		expect(exec.results?.rows[0].cells.Term.value).toBe('3 years');
+		expect(String(fetchMock.mock.calls[0][0])).toContain('/tabular/executions/tex-1');
+	});
+
+	it('deleteTabularExecution calls DELETE /api/v1/tabular/executions/{id} and returns void on 204', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			status: 204,
+			headers: { get: () => null },
+			json: async () => undefined
+		});
+		await deleteTabularExecution('tex-1');
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(String(url)).toContain('/tabular/executions/tex-1');
+		expect(init.method).toBe('DELETE');
+	});
+
+	it('cancelTabularExecution POSTs /api/v1/tabular/executions/{id}/cancel and returns updated execution', async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponseLike(200, {
+				id: 'tex-1',
+				user_id: 'u1',
+				parent_execution_id: null,
+				skill_name: 'contract-snapshot',
+				status: 'cancelled',
+				document_ids: ['d1'],
+				columns: [{ name: 'Term', query: 'What is the term?' }],
+				results: null,
+				cost_estimate_usd: '0.0500',
+				cost_actual_usd: null,
+				error_text: null,
+				created_at: '2026-05-22T15:00:00Z',
+				started_at: '2026-05-22T15:00:05Z',
+				completed_at: '2026-05-22T15:00:30Z'
+			})
+		);
+		const exec = await cancelTabularExecution('tex-1');
+		expect(exec.status).toBe('cancelled');
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(String(url)).toContain('/tabular/executions/tex-1/cancel');
+		expect(init.method).toBe('POST');
+	});
+
+	it('getTabularExecution url-encodes IDs that contain reserved characters', async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponseLike(200, {
+				id: 'weird/id',
+				user_id: null,
+				parent_execution_id: null,
+				skill_name: null,
+				status: 'failed',
+				document_ids: [],
+				columns: [],
+				results: null,
+				cost_estimate_usd: null,
+				cost_actual_usd: null,
+				error_text: 'whatever',
+				created_at: '2026-05-22T15:00:00Z',
+				started_at: null,
+				completed_at: null
+			})
+		);
+		await getTabularExecution('weird/id');
+		const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+		// '/' inside the id segment must be percent-encoded to '%2F'.
+		expect(String(url)).toContain('/tabular/executions/weird%2Fid');
+	});
+});

--- a/web/src/lib/lq-ai/api/tabular.ts
+++ b/web/src/lib/lq-ai/api/tabular.ts
@@ -1,0 +1,89 @@
+/**
+ * /api/v1/tabular — preview / execute / list / detail / delete / cancel
+ * helpers for the Tabular / Multi-Document Review surface (M3-C2 / M3-C3).
+ *
+ * Wraps the six endpoints in `api/app/api/tabular.py`. Mirrors
+ * `playbooks.ts` exactly: uses `apiRequest` for auth-header attachment,
+ * refresh-on-401, and structured error translation. The shapes come
+ * from the backend Pydantic surface in `api/app/schemas/tabular.py`.
+ */
+import { apiRequest } from './client';
+import type {
+	TabularExecution,
+	TabularExecutionCreate,
+	TabularExecutionSummary,
+	TabularPreviewCostRequest,
+	TabularPreviewCostResponse
+} from '../types';
+
+/**
+ * POST /api/v1/tabular/preview-cost — synchronous cost preview; no
+ * execution row is created. Called by the wizard's Step 3 before
+ * showing the confirmation modal (Decision C-5).
+ */
+export async function previewTabularCost(
+	body: TabularPreviewCostRequest
+): Promise<TabularPreviewCostResponse> {
+	return apiRequest<TabularPreviewCostResponse>('/tabular/preview-cost', {
+		method: 'POST',
+		body: body as unknown as Record<string, unknown>
+	});
+}
+
+/**
+ * POST /api/v1/tabular/execute — kick off a tabular execution.
+ * Returns 202 + the row at `status='pending'`. Poll
+ * {@link getTabularExecution} until status reaches a terminal state
+ * (`completed` / `failed` / `cancelled`).
+ */
+export async function executeTabular(
+	body: TabularExecutionCreate
+): Promise<TabularExecution> {
+	return apiRequest<TabularExecution>('/tabular/execute', {
+		method: 'POST',
+		body: body as unknown as Record<string, unknown>
+	});
+}
+
+/**
+ * GET /api/v1/tabular/executions — list the caller's tabular
+ * executions (recent-first, soft-deleted excluded). Returns a
+ * paginated-on-the-backend slice as plain array.
+ */
+export async function listTabularExecutions(): Promise<TabularExecutionSummary[]> {
+	return apiRequest<TabularExecutionSummary[]>('/tabular/executions');
+}
+
+/**
+ * GET /api/v1/tabular/executions/{id} — full execution row including
+ * the (potentially large) `results` payload once status is terminal.
+ */
+export async function getTabularExecution(executionId: string): Promise<TabularExecution> {
+	return apiRequest<TabularExecution>(
+		`/tabular/executions/${encodeURIComponent(executionId)}`
+	);
+}
+
+/**
+ * DELETE /api/v1/tabular/executions/{id} — soft-delete (sets
+ * `deleted_at`). Already-deleted rows return 404.
+ */
+export async function deleteTabularExecution(executionId: string): Promise<void> {
+	await apiRequest<void>(`/tabular/executions/${encodeURIComponent(executionId)}`, {
+		method: 'DELETE'
+	});
+}
+
+/**
+ * POST /api/v1/tabular/executions/{id}/cancel — set status to
+ * `cancelled`; the worker's per-cell loop honors this at the next
+ * cell-iteration boundary. Already-terminal rows return 409.
+ */
+export async function cancelTabularExecution(
+	executionId: string
+): Promise<TabularExecution> {
+	return apiRequest<TabularExecution>(
+		`/tabular/executions/${encodeURIComponent(executionId)}/cancel`,
+		{ method: 'POST' }
+	);
+}

--- a/web/src/lib/lq-ai/components/ComingSoonModal.svelte
+++ b/web/src/lib/lq-ai/components/ComingSoonModal.svelte
@@ -13,6 +13,7 @@
     skills: 'Skills',
     knowledge: 'Knowledge',
     playbooks: 'Playbooks',
+    tabular: 'Tabular Review',
     'saved-prompts': 'Saved Prompts',
     learn: 'Learn',
     admin: 'Admin'

--- a/web/src/lib/lq-ai/components/FeaturedToolsRow.svelte
+++ b/web/src/lib/lq-ai/components/FeaturedToolsRow.svelte
@@ -37,6 +37,14 @@
 			href: '/lq-ai/playbooks'
 		},
 		{
+			id: 'tabular',
+			title: 'Tabular Review',
+			icon: '📊',
+			description: 'Run a column spec across multiple documents — every cell grounded by the Citation Engine.',
+			cta: 'Start',
+			href: '/lq-ai/tabular'
+		},
+		{
 			id: 'apply-skill',
 			title: 'Apply a Skill',
 			icon: '▶',

--- a/web/src/lib/lq-ai/components/TabularCell.svelte
+++ b/web/src/lib/lq-ai/components/TabularCell.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	/**
+	 * Single tabular cell — M3-C3 sub-phase 4.
+	 *
+	 * Renders the cell value + a confidence chip (right-aligned). Click
+	 * dispatches `open` so the result-view parent can pop the citation
+	 * modal for this cell (Decision C-2: hybrid chip + click surface).
+	 * Failed cells (Decision C-10) render italic "not found" + amber
+	 * chip; visually distinct from the Citation Engine's red unverified.
+	 */
+	import { createEventDispatcher } from 'svelte';
+
+	import type { TabularCellConfidence, TabularCellResult } from '$lib/lq-ai/types';
+
+	type CellRenderState = 'empty' | 'failed' | 'high' | 'medium' | 'low';
+
+	function cellRenderState(c: TabularCellResult | undefined): CellRenderState {
+		if (c === undefined) return 'empty';
+		return c.confidence;
+	}
+
+	function confidenceChipLabel(confidence: TabularCellConfidence): string {
+		switch (confidence) {
+			case 'high':
+				return 'High';
+			case 'medium':
+				return 'Med';
+			case 'low':
+				return 'Low';
+			case 'failed':
+				return 'Failed';
+		}
+	}
+
+	export let cell: TabularCellResult | undefined;
+	/**
+	 * Optional metadata — only used for the dispatched `open` event so
+	 * the parent's citation modal can show a header like
+	 * `<column> — <document>`.
+	 */
+	export let documentName: string = '';
+	export let columnName: string = '';
+
+	const dispatch = createEventDispatcher<{ open: { documentName: string; columnName: string } }>();
+
+	$: state = cellRenderState(cell) as CellRenderState;
+	$: clickable = state !== 'empty';
+
+	function handleClick(): void {
+		if (!clickable) return;
+		dispatch('open', { documentName, columnName });
+	}
+
+	function handleKey(e: KeyboardEvent): void {
+		if (!clickable) return;
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			handleClick();
+		}
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<!-- role + tabindex are gated together on `clickable`; the static
+     analyzer flags the dynamic tabindex without seeing the role guard. -->
+<div
+	class="lq-tabcell"
+	data-state={state}
+	data-testid="lq-tabcell"
+	data-document-name={documentName}
+	data-column-name={columnName}
+	role={clickable ? 'button' : undefined}
+	tabindex={clickable ? 0 : undefined}
+	on:click={handleClick}
+	on:keydown={handleKey}
+>
+	{#if state === 'empty'}
+		<span class="lq-tabcell__placeholder" aria-label="not yet computed">…</span>
+	{:else if state === 'failed'}
+		<span class="lq-tabcell__failed" data-testid="lq-tabcell-failed">not found</span>
+	{:else}
+		<span class="lq-tabcell__value" data-testid="lq-tabcell-value">{cell?.value ?? ''}</span>
+	{/if}
+
+	{#if cell && state !== 'empty'}
+		<span
+			class="lq-tabcell__chip"
+			data-confidence={cell.confidence}
+			data-testid="lq-tabcell-chip"
+			aria-label={`Confidence: ${confidenceChipLabel(cell.confidence)}`}
+		>
+			{confidenceChipLabel(cell.confidence)}
+		</span>
+	{/if}
+</div>
+
+<style>
+	.lq-tabcell {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		padding: 0.5rem 0.625rem;
+		min-height: 2.5rem;
+		font-size: 0.875rem;
+		color: var(--lq-text);
+		background: var(--lq-surface);
+		border: 1px solid transparent;
+		cursor: default;
+	}
+	.lq-tabcell[role='button'] {
+		cursor: pointer;
+	}
+	.lq-tabcell[role='button']:hover {
+		background: var(--lq-inset);
+	}
+	.lq-tabcell[role='button']:focus-visible {
+		outline: 2px solid var(--lq-accent, #4f46e5);
+		outline-offset: -2px;
+	}
+	.lq-tabcell__placeholder {
+		color: var(--lq-text-secondary);
+	}
+	.lq-tabcell__value {
+		flex: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.lq-tabcell__failed {
+		flex: 1;
+		font-style: italic;
+		color: var(--lq-text-secondary);
+	}
+	.lq-tabcell__chip {
+		flex-shrink: 0;
+		display: inline-block;
+		padding: 0.0625rem 0.375rem;
+		border-radius: 999px;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		text-transform: uppercase;
+	}
+	.lq-tabcell__chip[data-confidence='high'] {
+		background: var(--lq-success-soft, #dcfce7);
+		color: var(--lq-success, #166534);
+	}
+	.lq-tabcell__chip[data-confidence='medium'] {
+		background: var(--lq-inset, #e5e7eb);
+		color: var(--lq-text, #1f2937);
+	}
+	.lq-tabcell__chip[data-confidence='low'] {
+		background: var(--lq-warning-soft, #fef3c7);
+		color: var(--lq-warning, #92400e);
+	}
+	.lq-tabcell__chip[data-confidence='failed'] {
+		/* Amber per Decision C-10 — distinct from Citation Engine's red
+		   unverified state. */
+		background: var(--lq-warning-soft, #fef3c7);
+		color: var(--lq-warning, #92400e);
+		border: 1px solid var(--lq-warning, #92400e);
+	}
+</style>

--- a/web/src/lib/lq-ai/components/TabularCitationModal.svelte
+++ b/web/src/lib/lq-ai/components/TabularCitationModal.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+	/**
+	 * Citation modal for a tabular grid cell — M3-C3 sub-phase 4.
+	 *
+	 * Decision C-2 said "reuse the existing M2-C2 citation drawer" but
+	 * that drawer doesn't actually exist in the codebase — M2-C2 only
+	 * ships a chip-list with tooltips (`M2Citations.svelte`) wired to
+	 * chat content markers. Tabular cells need a different surface
+	 * because the citation list is data-bound (no inline content
+	 * markers to find), so M3-C3 introduces this purpose-built modal:
+	 * a small popover showing the cell value + confidence + error
+	 * (if any) + the citations attached to the cell.
+	 *
+	 * Per session-start AskUserQuestion (Cell citations decision).
+	 */
+	import { createEventDispatcher } from 'svelte';
+
+	import type { TabularCellResult } from '$lib/lq-ai/types';
+
+	export let documentName: string;
+	export let columnName: string;
+	export let cell: TabularCellResult;
+
+	const dispatch = createEventDispatcher<{ close: void }>();
+
+	function close(): void {
+		dispatch('close');
+	}
+
+	function handleBackdropKey(e: KeyboardEvent): void {
+		if (e.key === 'Escape') close();
+	}
+</script>
+
+<svelte:window on:keydown={handleBackdropKey} />
+
+<div class="lq-tabcm__backdrop" on:click={close} on:keydown role="presentation">
+	<!-- Dialog content stops propagation so clicks inside don't close. -->
+	<div
+		class="lq-tabcm"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="lq-tabcm-title"
+		tabindex="-1"
+		data-testid="lq-tabcm"
+		on:click|stopPropagation
+		on:keydown|stopPropagation
+	>
+		<header class="lq-tabcm__header">
+			<div>
+				<div class="lq-tabcm__column" id="lq-tabcm-title">{columnName}</div>
+				<div class="lq-tabcm__document">{documentName}</div>
+			</div>
+			<button
+				type="button"
+				class="lq-tabcm__close"
+				data-testid="lq-tabcm-close"
+				on:click={close}
+				aria-label="Close citations">×</button
+			>
+		</header>
+
+		<section class="lq-tabcm__body">
+			{#if cell.confidence === 'failed'}
+				<p class="lq-tabcm__failed">
+					<strong>Not found.</strong> Extraction failed for this cell.
+				</p>
+				{#if cell.error}
+					<pre class="lq-tabcm__error" data-testid="lq-tabcm-error">{cell.error}</pre>
+				{/if}
+			{:else}
+				<dl class="lq-tabcm__meta">
+					<div>
+						<dt>Value</dt>
+						<dd data-testid="lq-tabcm-value">{cell.value ?? '—'}</dd>
+					</div>
+					<div>
+						<dt>Confidence</dt>
+						<dd data-confidence={cell.confidence}>{cell.confidence}</dd>
+					</div>
+					{#if cell.tier_used !== null && cell.tier_used !== undefined}
+						<div>
+							<dt>Tier</dt>
+							<dd>Tier {cell.tier_used}</dd>
+						</div>
+					{/if}
+				</dl>
+			{/if}
+
+			<h3 class="lq-tabcm__cite-header">Citations</h3>
+			{#if cell.citations.length === 0}
+				<p class="lq-tabcm__empty">
+					{cell.confidence === 'failed'
+						? 'The cell errored before producing a citation.'
+						: 'No citations were attached to this cell.'}
+				</p>
+			{:else}
+				<ul class="lq-tabcm__cites" data-testid="lq-tabcm-citations">
+					{#each cell.citations as cite (cite.citation_id)}
+						<li class="lq-tabcm__cite" data-confidence={cite.confidence}>
+							<div class="lq-tabcm__cite-id">
+								<span class="lq-tabcm__cite-chip" data-confidence={cite.confidence}
+									>{cite.confidence}</span
+								>
+								<code>{cite.citation_id}</code>
+							</div>
+							<div class="lq-tabcm__cite-meta">
+								<span>Document: <code>{cite.document_id}</code></span>
+								{#if cite.chunk_id}
+									<span>· Chunk: <code>{cite.chunk_id}</code></span>
+								{/if}
+							</div>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+	</div>
+</div>
+
+<style>
+	.lq-tabcm__backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(15, 23, 42, 0.55);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+		padding: 1.5rem;
+	}
+	.lq-tabcm {
+		max-width: 36rem;
+		width: 100%;
+		max-height: calc(100vh - 3rem);
+		overflow-y: auto;
+		background: var(--lq-surface);
+		border: 1px solid var(--lq-border);
+		border-radius: 0.5rem;
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+	}
+	.lq-tabcm__header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		padding: 1rem 1.25rem;
+		border-bottom: 1px solid var(--lq-border);
+	}
+	.lq-tabcm__column {
+		font-weight: 600;
+		font-size: 1rem;
+	}
+	.lq-tabcm__document {
+		font-size: 0.8125rem;
+		color: var(--lq-text-secondary);
+		margin-top: 0.25rem;
+	}
+	.lq-tabcm__close {
+		background: none;
+		border: none;
+		font-size: 1.5rem;
+		color: var(--lq-text-secondary);
+		cursor: pointer;
+		line-height: 1;
+		padding: 0;
+	}
+	.lq-tabcm__body {
+		padding: 1.25rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+	.lq-tabcm__failed {
+		padding: 0.75rem 1rem;
+		background: var(--lq-warning-soft, #fef3c7);
+		border: 1px solid var(--lq-warning-border, var(--lq-border));
+		border-radius: 0.375rem;
+		margin: 0;
+	}
+	.lq-tabcm__error {
+		margin: 0.5rem 0 0;
+		padding: 0.5rem 0.75rem;
+		background: var(--lq-inset);
+		border-radius: 0.25rem;
+		font-size: 0.8125rem;
+		white-space: pre-wrap;
+		max-height: 8rem;
+		overflow: auto;
+	}
+	.lq-tabcm__meta {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 0.75rem;
+		margin: 0;
+	}
+	.lq-tabcm__meta dt {
+		font-size: 0.6875rem;
+		color: var(--lq-text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+	.lq-tabcm__meta dd {
+		margin: 0.25rem 0 0;
+		font-size: 0.875rem;
+		font-weight: 500;
+	}
+	.lq-tabcm__cite-header {
+		margin: 0;
+		font-size: 0.875rem;
+		text-transform: uppercase;
+		color: var(--lq-text-secondary);
+		letter-spacing: 0.04em;
+	}
+	.lq-tabcm__empty {
+		margin: 0;
+		color: var(--lq-text-secondary);
+		font-size: 0.875rem;
+	}
+	.lq-tabcm__cites {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.lq-tabcm__cite {
+		padding: 0.5rem 0.75rem;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.375rem;
+		background: var(--lq-inset);
+	}
+	.lq-tabcm__cite-id {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.8125rem;
+	}
+	.lq-tabcm__cite-chip {
+		padding: 0.0625rem 0.375rem;
+		border-radius: 999px;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.02em;
+		background: var(--lq-surface);
+	}
+	.lq-tabcm__cite-meta {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		margin-top: 0.25rem;
+		font-size: 0.75rem;
+		color: var(--lq-text-secondary);
+	}
+	.lq-tabcm__cite-meta code,
+	.lq-tabcm__cite-id code {
+		font-family: 'Menlo', 'Monaco', monospace;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/TabularGrid.svelte
+++ b/web/src/lib/lq-ai/components/TabularGrid.svelte
@@ -1,0 +1,169 @@
+<script context="module" lang="ts">
+	import type { TabularCellResult } from '$lib/lq-ai/types';
+
+	export interface CellOpenEvent {
+		documentId: string;
+		documentName: string;
+		columnName: string;
+		cell: TabularCellResult | undefined;
+	}
+</script>
+
+<script lang="ts">
+	/**
+	 * Tabular results grid — M3-C3 sub-phase 4.
+	 *
+	 * Renders the M × N grid as a single semantic <table> with sticky
+	 * first column (document name) + sticky first row (column headers)
+	 * via CSS `position: sticky`. Each cell is a `<TabularCell>` that
+	 * dispatches `open` on click; this component re-dispatches with the
+	 * full `CellOpenEvent` carrying the cell + its document / column
+	 * coordinates so the parent's citation modal has everything it
+	 * needs to render.
+	 */
+	import { createEventDispatcher } from 'svelte';
+
+	import type {
+		TabularColumnSpec,
+		TabularResults
+	} from '$lib/lq-ai/types';
+	import TabularCell from './TabularCell.svelte';
+
+	export let results: TabularResults | null;
+	export let columns: TabularColumnSpec[];
+	/**
+	 * The execution's `document_ids` order — used to render rows for
+	 * documents the worker hasn't filled yet (status='running'). Each
+	 * id maps via `documentNameById[id]` to the row label; cells that
+	 * haven't been produced yet render as `state='empty'`.
+	 */
+	export let documentIds: string[];
+	export let documentNameById: Record<string, string>;
+
+	const dispatch = createEventDispatcher<{ open: CellOpenEvent }>();
+
+	// Build a documentId → row.cells map so the renderer can render
+	// in document_ids order without depending on the row ordering the
+	// backend returns.
+	$: rowByDocId = (() => {
+		const m: Record<string, TabularResults['rows'][number]> = {};
+		for (const r of results?.rows ?? []) {
+			m[r.document_id] = r;
+		}
+		return m;
+	})();
+
+	function handleCellOpen(
+		event: CustomEvent<{ documentName: string; columnName: string }>,
+		documentId: string,
+		cell: TabularCellResult | undefined
+	): void {
+		dispatch('open', {
+			documentId,
+			documentName: event.detail.documentName,
+			columnName: event.detail.columnName,
+			cell
+		});
+	}
+</script>
+
+<div class="lq-tabgrid__scroll" data-testid="lq-tabgrid">
+	<table class="lq-tabgrid">
+		<thead>
+			<tr>
+				<th scope="col" class="lq-tabgrid__corner lq-tabgrid__sticky-col">Document</th>
+				{#each columns as col (col.name)}
+					<th
+						scope="col"
+						class="lq-tabgrid__sticky-row"
+						data-testid="lq-tabgrid-header"
+						data-column-name={col.name}
+					>
+						{col.name}
+					</th>
+				{/each}
+			</tr>
+		</thead>
+		<tbody>
+			{#each documentIds as docId (docId)}
+				{@const row = rowByDocId[docId]}
+				{@const name = documentNameById[docId] ?? docId}
+				<tr data-testid="lq-tabgrid-row" data-document-id={docId}>
+					<th
+						scope="row"
+						class="lq-tabgrid__sticky-col"
+						data-testid="lq-tabgrid-row-label"
+					>
+						{name}
+					</th>
+					{#each columns as col (col.name)}
+						{@const cell = row?.cells[col.name]}
+						<td class="lq-tabgrid__cell">
+							<TabularCell
+								{cell}
+								documentName={name}
+								columnName={col.name}
+								on:open={(e) => handleCellOpen(e, docId, cell)}
+							/>
+						</td>
+					{/each}
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>
+
+<style>
+	.lq-tabgrid__scroll {
+		max-height: 32rem;
+		overflow: auto;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.5rem;
+		background: var(--lq-surface);
+	}
+	.lq-tabgrid {
+		border-collapse: separate;
+		border-spacing: 0;
+		min-width: 100%;
+	}
+	.lq-tabgrid th,
+	.lq-tabgrid td {
+		padding: 0;
+		border-bottom: 1px solid var(--lq-border);
+		border-right: 1px solid var(--lq-border);
+		vertical-align: top;
+	}
+	.lq-tabgrid thead th {
+		padding: 0.625rem 0.75rem;
+		font-weight: 600;
+		font-size: 0.8125rem;
+		text-align: left;
+		background: var(--lq-inset);
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+	}
+	.lq-tabgrid__sticky-row {
+		position: sticky;
+		top: 0;
+		z-index: 2;
+	}
+	.lq-tabgrid__sticky-col {
+		position: sticky;
+		left: 0;
+		z-index: 1;
+		background: var(--lq-surface);
+		font-weight: 600;
+		padding: 0.625rem 0.75rem;
+		min-width: 12rem;
+	}
+	.lq-tabgrid__corner {
+		z-index: 3;
+		background: var(--lq-inset);
+	}
+	.lq-tabgrid__cell {
+		min-width: 14rem;
+	}
+	.lq-tabgrid tbody tr:nth-child(even) .lq-tabgrid__sticky-col {
+		background: var(--lq-inset);
+	}
+</style>

--- a/web/src/lib/lq-ai/tabs.ts
+++ b/web/src/lib/lq-ai/tabs.ts
@@ -17,6 +17,7 @@ export type TabId =
   | 'skills'
   | 'knowledge'
   | 'playbooks'
+  | 'tabular'
   | 'saved-prompts'
   | 'learn'
   | 'admin';
@@ -47,6 +48,7 @@ export const TABS: readonly TabDef[] = [
   { id: 'skills',        label: 'Skills',        icon: '🛠️', route: '/lq-ai/skills',         available: true },
   { id: 'knowledge',     label: 'Knowledge',     icon: '📎', route: '/lq-ai/knowledge',      available: true },
   { id: 'playbooks',     label: 'Playbooks',     icon: '📋', route: '/lq-ai/playbooks',      available: true },
+  { id: 'tabular',       label: 'Tabular',       icon: '📊', route: '/lq-ai/tabular',        available: true },
   { id: 'saved-prompts', label: 'Saved Prompts', icon: '📌', route: '/lq-ai/saved-prompts',  available: true },
   { id: 'learn',         label: 'Learn',         icon: '📖', route: '/lq-ai/learn',           available: true },
   { id: 'admin',         label: 'Admin',         icon: '🛡',  route: '/lq-ai/admin/audit-log', adminOnly: true, available: true }

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -1015,3 +1015,184 @@ export interface EasyPlaybookGeneration {
 	error_message?: string | null;
 	created_at: string;
 }
+
+// ----- Tabular / Multi-Document Review (M3-C2 / M3-C3) -----
+
+/**
+ * Lifecycle states for a `TabularExecution`. Matches the backend
+ * `Literal["pending","running","completed","failed","cancelled"]`
+ * (migration 0036's CHECK constraint on `tabular_executions.status`).
+ * Note: this enum carries a `cancelled` state that the M3-A4 playbook
+ * execution surface does NOT have — tabular runs can be hours long, so
+ * cancellation matters.
+ */
+export type TabularExecutionStatus =
+	| 'pending'
+	| 'running'
+	| 'completed'
+	| 'failed'
+	| 'cancelled';
+
+/**
+ * Per-cell confidence from the Citation Engine cascade. `failed` is
+ * the Decision C-10 state for cells where extraction itself errored —
+ * distinct from the Citation Engine's red `unverified` state on a
+ * non-tabular surface.
+ */
+export type TabularCellConfidence = 'high' | 'medium' | 'low' | 'failed';
+
+/**
+ * One column in a tabular execution's column spec. Mirrors the
+ * backend `ColumnSpec` Pydantic shape (and the skill-side
+ * `lq_ai.columns` frontmatter entry from M3-C1).
+ *
+ * - `ensemble_verification` overrides the skill-level field (M2-D1
+ *   ensemble cascade).
+ * - `minimum_inference_tier` (1-5) overrides the skill-level tier
+ *   floor — high-stakes columns can demand Tier 4+ while routine
+ *   columns route Tier 1.
+ */
+export interface TabularColumnSpec {
+	name: string;
+	query: string;
+	ensemble_verification?: boolean | null;
+	minimum_inference_tier?: number | null;
+}
+
+/**
+ * Lightweight citation projection used inside `TabularCellResult`.
+ * Distinct from the existing `Citation` interface above — the
+ * grid-cell surface only needs the IDs + confidence to render the chip
+ * and route a click to the existing M2-C2 citation drawer.
+ */
+export interface TabularCitation {
+	citation_id: string;
+	document_id: string;
+	chunk_id?: string | null;
+	confidence: TabularCellConfidence;
+}
+
+/**
+ * One cell in the grid. Failed extraction renders as `confidence:
+ * 'failed'` + `error` populated (Decision C-10). Successful
+ * extractions carry the extracted `value` plus the citation list the
+ * Citation Engine grounded it against.
+ *
+ * Decimal-typed fields (`cost_usd`) come over the wire as JSON
+ * strings because the backend uses `Decimal` for monetary precision.
+ */
+export interface TabularCellResult {
+	value: string | null;
+	citations: TabularCitation[];
+	confidence: TabularCellConfidence;
+	tier_used?: number | null;
+	cost_usd?: string | null;
+	error?: string | null;
+}
+
+/**
+ * One row in the tabular grid — all cells for a single document.
+ * Rows are returned in the order of the execution's `document_ids`
+ * array (NOT sorted by document name), so the grid matches the
+ * operator's selection order.
+ */
+export interface TabularRow {
+	document_id: string;
+	document_name: string;
+	cells: Record<string, TabularCellResult>;
+}
+
+/**
+ * Aggregated grid shape persisted in `tabular_executions.results`
+ * once status is `completed`.
+ */
+export interface TabularResults {
+	rows: TabularRow[];
+}
+
+/**
+ * Full execution row returned by every `/api/v1/tabular/executions`
+ * endpoint. The `results` payload is only populated once status is
+ * terminal (`completed`); pending / running rows return `null`.
+ *
+ * Note `error_text` not `error` — matches the migration 0036 column
+ * name + the backend Pydantic field, sidestepping a collision with
+ * the bare `error` field on `PlaybookExecution`.
+ */
+export interface TabularExecution {
+	id: string;
+	user_id: string | null;
+	parent_execution_id: string | null;
+	skill_name: string | null;
+	status: TabularExecutionStatus;
+	document_ids: string[];
+	columns: TabularColumnSpec[];
+	results: TabularResults | null;
+	cost_estimate_usd: string | null;
+	cost_actual_usd: string | null;
+	error_text: string | null;
+	created_at: string;
+	started_at: string | null;
+	completed_at: string | null;
+}
+
+/**
+ * Compact list-shape returned by `GET /api/v1/tabular/executions`.
+ * Drops the (potentially large) `results` payload — operators fetch
+ * the full execution row only when they open one.
+ */
+export interface TabularExecutionSummary {
+	id: string;
+	user_id: string | null;
+	parent_execution_id: string | null;
+	skill_name: string | null;
+	status: TabularExecutionStatus;
+	document_count: number;
+	column_count: number;
+	cost_estimate_usd: string | null;
+	cost_actual_usd: string | null;
+	created_at: string;
+	completed_at: string | null;
+}
+
+/**
+ * Request body for `POST /api/v1/tabular/execute`. Either
+ * `skill_name` (resolved at execution start to snapshot the skill's
+ * `lq_ai.columns`) OR `columns` (ad-hoc spec) is required.
+ *
+ * `confirmed_cost_usd` is the echo of the
+ * `POST /api/v1/tabular/preview-cost` response value; persisting it
+ * gives an audit trail of the operator confirming a specific cost
+ * ceiling before kickoff.
+ */
+export interface TabularExecutionCreate {
+	document_ids: string[];
+	skill_name?: string | null;
+	columns?: TabularColumnSpec[] | null;
+	confirmed_cost_usd?: string | null;
+}
+
+/**
+ * Request body for `POST /api/v1/tabular/preview-cost`. Same shape
+ * as `TabularExecutionCreate` minus the `confirmed_cost_usd` echo —
+ * preview is the operation that produces the cost; confirmation
+ * echoes it back on the subsequent execute call.
+ */
+export interface TabularPreviewCostRequest {
+	document_ids: string[];
+	skill_name?: string | null;
+	columns?: TabularColumnSpec[] | null;
+}
+
+/**
+ * Response from `POST /api/v1/tabular/preview-cost`. The UI uses
+ * `estimated_cost_usd` to decide whether to render the
+ * confirmation-checkbox gate (Decision C-5: gate above $1.00, no
+ * friction below).
+ */
+export interface TabularPreviewCostResponse {
+	cells_count: number;
+	estimated_tokens: number;
+	estimated_cost_usd: string;
+	per_tier_breakdown: Record<string, number>;
+}

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -1126,6 +1126,15 @@ export interface TabularExecution {
 	skill_name: string | null;
 	status: TabularExecutionStatus;
 	document_ids: string[];
+	/**
+	 * Filenames in the same order as `document_ids` — joined from
+	 * `documents → files.filename` at response build time. Lets the
+	 * grid render human-readable headers from execution creation,
+	 * before any row is populated by the worker. Missing entries
+	 * (file soft-deleted between create and fetch) surface as the
+	 * empty string.
+	 */
+	document_names: string[];
 	columns: TabularColumnSpec[];
 	results: TabularResults | null;
 	cost_estimate_usd: string | null;

--- a/web/src/routes/lq-ai/skills/+page.svelte
+++ b/web/src/routes/lq-ai/skills/+page.svelte
@@ -21,6 +21,7 @@
 
 	let rows: UserSkill[] = [];
 	let builtinSlugs = new Set<string>();
+	let builtinTableSkills: SkillSummary[] = [];
 	let teamNamesById = new Map<string, string>();
 	let loading = false;
 	let listError: string | null = null;
@@ -37,6 +38,12 @@
 			]);
 			rows = mine;
 			builtinSlugs = new Set(builtins.map((s: SkillSummary) => s.name));
+			// Surface built-in table-mode reference skills (M3-C3) so
+			// operators can discover them; /skills only shows user-scope
+			// skills by default and otherwise these would be invisible.
+			builtinTableSkills = builtins
+				.filter((s: SkillSummary) => s.output_format === 'table')
+				.sort((a: SkillSummary, b: SkillSummary) => a.name.localeCompare(b.name));
 			teamNamesById = new Map(
 				(myTeams as TeamSummary[]).map((t) => [t.id, t.name])
 			);
@@ -122,6 +129,38 @@
 		>
 			{actionError}
 		</div>
+	{/if}
+
+	{#if !loading && builtinTableSkills.length > 0}
+		<section class="mb-6" data-testid="lq-ai-builtin-table-skills">
+			<h2 class="lq-text-h4 mb-2">Reference table-mode skills</h2>
+			<p class="lq-text-caption mb-3" style="color: var(--lq-text-secondary);">
+				Built-in skills with <code>output_format: table</code> — usable from the
+				<a href="/lq-ai/tabular/new" class="lq-link">Tabular Review wizard</a>'s
+				skill picker. Paired with the synthetic corpus in
+				<code>docs/quickstart/</code> for first-run exploration.
+			</p>
+			<ul class="lq-table-skill-list">
+				{#each builtinTableSkills as s (s.name)}
+					<li class="lq-table-skill-card" data-testid="lq-ai-builtin-table-skill">
+						<div class="flex items-start justify-between gap-3">
+							<div class="min-w-0">
+								<div class="flex items-center gap-2 flex-wrap">
+									<span class="font-medium lq-text-body">{s.title ?? s.name}</span>
+									<span data-testid="lq-ai-table-badge">
+										<TrustPill variant="tier" label="Table" />
+									</span>
+								</div>
+								<code class="lq-text-caption font-mono" style="color: var(--lq-text-secondary);">{s.name}</code>
+								{#if s.description}
+									<p class="lq-text-caption mt-1 line-clamp-2" style="color: var(--lq-text-tertiary);">{s.description}</p>
+								{/if}
+							</div>
+						</div>
+					</li>
+				{/each}
+			</ul>
+		</section>
 	{/if}
 
 	{#if loading}
@@ -217,6 +256,20 @@
 </div>
 
 <style>
+	.lq-table-skill-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		gap: 0.5rem;
+	}
+	.lq-table-skill-card {
+		padding: 0.75rem;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.5rem;
+		background: var(--lq-surface);
+	}
 	.lq-btn-primary {
 		background: var(--lq-accent);
 		color: white;

--- a/web/src/routes/lq-ai/tabular/+page.svelte
+++ b/web/src/routes/lq-ai/tabular/+page.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+
+	import { listTabularExecutions } from '$lib/lq-ai/api/tabular';
+	import { LQAIApiError } from '$lib/lq-ai/api/client';
+	import type { TabularExecutionSummary } from '$lib/lq-ai/types';
+
+	import {
+		sortTabularExecutionsByCreatedDesc,
+		formatTabularStatus,
+		formatCellCount,
+		formatCostUsd,
+		skillNameDisplay
+	} from './page-helpers';
+
+	let executions: TabularExecutionSummary[] = [];
+	let loading = false;
+	let listError: string | null = null;
+
+	async function load(): Promise<void> {
+		loading = true;
+		listError = null;
+		try {
+			const fetched = await listTabularExecutions();
+			executions = sortTabularExecutionsByCreatedDesc(fetched);
+		} catch (err) {
+			listError = err instanceof LQAIApiError ? err.message : 'Failed to load tabular executions.';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function open(id: string): void {
+		goto(`/lq-ai/tabular/${id}`);
+	}
+
+	function startNew(): void {
+		goto('/lq-ai/tabular/new');
+	}
+
+	function formatCreatedAt(iso: string): string {
+		// e.g. "May 22, 2026 · 3:00 PM" — short and locale-aware.
+		const d = new Date(iso);
+		if (Number.isNaN(d.getTime())) return iso;
+		const date = d.toLocaleDateString(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		});
+		const time = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+		return `${date} · ${time}`;
+	}
+
+	function costColumn(row: TabularExecutionSummary): string {
+		return row.status === 'completed'
+			? formatCostUsd(row.cost_actual_usd)
+			: formatCostUsd(row.cost_estimate_usd);
+	}
+
+	onMount(load);
+</script>
+
+<svelte:head>
+	<title>Tabular Review · LQ.AI</title>
+</svelte:head>
+
+<section class="lq-tabular-page">
+	<header class="lq-tabular-page__header">
+		<div class="lq-tabular-page__heading">
+			<h1>Tabular Review</h1>
+			<button
+				type="button"
+				class="lq-tabular-page__cta"
+				data-testid="lq-tabular-new-cta"
+				on:click={startNew}
+			>
+				Start new tabular review
+			</button>
+		</div>
+		<p class="lq-tabular-page__subtitle">
+			Run a table-mode skill or an ad-hoc column spec across multiple documents. Each cell is
+			grounded by the Citation Engine; click any cell in the result view to see the source
+			passage.
+		</p>
+	</header>
+
+	{#if loading}
+		<div class="lq-tabular-page__state" data-testid="lq-tabular-loading">Loading…</div>
+	{:else if listError}
+		<div class="lq-tabular-page__error" role="alert" data-testid="lq-tabular-error">
+			{listError}
+		</div>
+	{:else if executions.length === 0}
+		<div class="lq-tabular-page__empty" data-testid="lq-tabular-empty">
+			<p class="lq-tabular-page__empty-title">No tabular reviews yet.</p>
+			<p class="lq-tabular-page__empty-body">
+				Start your first one by selecting a set of documents and choosing a column spec — either
+				from a saved table-mode skill or by typing the columns inline.
+			</p>
+		</div>
+	{:else}
+		<table class="lq-tabular-table" data-testid="lq-tabular-table">
+			<thead>
+				<tr>
+					<th scope="col">Skill</th>
+					<th scope="col" class="lq-tabular-table__compact">Scope</th>
+					<th scope="col" class="lq-tabular-table__compact">Cost</th>
+					<th scope="col" class="lq-tabular-table__compact">Status</th>
+					<th scope="col" class="lq-tabular-table__compact">Created</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each executions as row (row.id)}
+					<tr
+						data-testid="lq-tabular-row"
+						data-execution-id={row.id}
+						on:click={() => open(row.id)}
+						on:keydown={(e) => {
+							if (e.key === 'Enter' || e.key === ' ') {
+								e.preventDefault();
+								open(row.id);
+							}
+						}}
+						tabindex="0"
+						role="link"
+					>
+						<td class="lq-tabular-table__skill">{skillNameDisplay(row.skill_name)}</td>
+						<td class="lq-tabular-table__compact"
+							>{formatCellCount(row.document_count, row.column_count)}</td
+						>
+						<td class="lq-tabular-table__compact">{costColumn(row)}</td>
+						<td class="lq-tabular-table__compact">
+							<span
+								class="lq-tabular-table__status"
+								data-status={row.status}
+								data-testid="lq-tabular-row-status"
+							>
+								{formatTabularStatus(row.status)}
+							</span>
+						</td>
+						<td class="lq-tabular-table__compact">{formatCreatedAt(row.created_at)}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	{/if}
+</section>
+
+<style>
+	.lq-tabular-page {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+		max-width: 64rem;
+		margin: 0 auto;
+		padding: 1.5rem;
+	}
+	.lq-tabular-page__heading {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		margin-bottom: 0.5rem;
+	}
+	.lq-tabular-page__header h1 {
+		margin: 0;
+		font-size: 1.5rem;
+	}
+	.lq-tabular-page__cta {
+		padding: 0.5rem 0.875rem;
+		background: var(--lq-accent, #4f46e5);
+		color: var(--lq-on-accent, #ffffff);
+		border: none;
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+	}
+	.lq-tabular-page__cta:hover {
+		opacity: 0.9;
+	}
+	.lq-tabular-page__subtitle {
+		margin: 0;
+		color: var(--lq-text-secondary);
+	}
+	.lq-tabular-page__state,
+	.lq-tabular-page__error,
+	.lq-tabular-page__empty {
+		padding: 1.5rem;
+		text-align: center;
+		color: var(--lq-text-secondary);
+		background: var(--lq-inset);
+		border-radius: 0.5rem;
+	}
+	.lq-tabular-page__error {
+		color: var(--lq-error);
+		background: var(--lq-error-soft, var(--lq-inset));
+		border: 1px solid var(--lq-error-border, var(--lq-border));
+	}
+	.lq-tabular-page__empty-title {
+		margin: 0 0 0.5rem;
+		font-weight: 600;
+		color: var(--lq-text);
+	}
+	.lq-tabular-page__empty-body {
+		margin: 0;
+	}
+	.lq-tabular-table {
+		width: 100%;
+		border-collapse: collapse;
+		background: var(--lq-surface);
+		border: 1px solid var(--lq-border);
+		border-radius: 0.5rem;
+		overflow: hidden;
+	}
+	.lq-tabular-table th,
+	.lq-tabular-table td {
+		padding: 0.75rem 1rem;
+		text-align: left;
+		border-bottom: 1px solid var(--lq-border);
+	}
+	.lq-tabular-table tbody tr {
+		cursor: pointer;
+	}
+	.lq-tabular-table tbody tr:hover {
+		background: var(--lq-inset);
+	}
+	.lq-tabular-table tbody tr:last-child td {
+		border-bottom: none;
+	}
+	.lq-tabular-table__skill {
+		font-weight: 600;
+	}
+	.lq-tabular-table__compact {
+		width: 1%;
+		white-space: nowrap;
+		vertical-align: top;
+	}
+	.lq-tabular-table__status {
+		display: inline-block;
+		padding: 0.125rem 0.5rem;
+		border-radius: 999px;
+		font-size: 0.8125rem;
+		font-weight: 500;
+		background: var(--lq-inset);
+	}
+	.lq-tabular-table__status[data-status='completed'] {
+		background: var(--lq-success-soft, var(--lq-inset));
+		color: var(--lq-success, inherit);
+	}
+	.lq-tabular-table__status[data-status='failed'] {
+		background: var(--lq-error-soft, var(--lq-inset));
+		color: var(--lq-error, inherit);
+	}
+	.lq-tabular-table__status[data-status='cancelled'] {
+		background: var(--lq-inset);
+		color: var(--lq-text-secondary);
+	}
+	.lq-tabular-table__status[data-status='running'],
+	.lq-tabular-table__status[data-status='pending'] {
+		background: var(--lq-warning-soft, var(--lq-inset));
+		color: var(--lq-warning, inherit);
+	}
+</style>

--- a/web/src/routes/lq-ai/tabular/[id]/+page.svelte
+++ b/web/src/routes/lq-ai/tabular/[id]/+page.svelte
@@ -1,0 +1,347 @@
+<script lang="ts">
+	import { onDestroy, onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+
+	import { getTabularExecution, cancelTabularExecution } from '$lib/lq-ai/api/tabular';
+	import { LQAIApiError } from '$lib/lq-ai/api/client';
+	import TabularGrid from '$lib/lq-ai/components/TabularGrid.svelte';
+	import TabularCitationModal from '$lib/lq-ai/components/TabularCitationModal.svelte';
+	import type {
+		TabularCellResult,
+		TabularExecution
+	} from '$lib/lq-ai/types';
+
+	import {
+		isTerminalStatus,
+		progressFraction,
+		formatProgress,
+		TABULAR_POLL_INTERVAL_MS
+	} from './page-helpers';
+	import { formatTabularStatus, formatCostUsd, skillNameDisplay } from '../page-helpers';
+
+	let execution: TabularExecution | null = null;
+	let loading = true;
+	let loadError: string | null = null;
+	let pollTimer: ReturnType<typeof setTimeout> | null = null;
+	let cancelling = false;
+
+	// Citation modal state.
+	interface OpenCellState {
+		documentName: string;
+		columnName: string;
+		cell: TabularCellResult;
+	}
+	let openCell: OpenCellState | null = null;
+
+	$: executionId = $page.params.id;
+	$: docCount = execution?.document_ids.length ?? 0;
+	$: colCount = execution?.columns.length ?? 0;
+	$: fraction = execution
+		? progressFraction(execution.status, execution.results, docCount, colCount)
+		: 0;
+	// Map document_id -> document_name from the populated rows. Rows
+	// that haven't been written yet leave the entry undefined; the
+	// grid falls back to rendering the raw UUID as the row label
+	// until the worker writes the row.
+	$: documentNameById = (() => {
+		const m: Record<string, string> = {};
+		for (const row of execution?.results?.rows ?? []) {
+			m[row.document_id] = row.document_name;
+		}
+		return m;
+	})();
+
+	async function loadOnce(): Promise<void> {
+		if (!executionId) return;
+		loadError = null;
+		try {
+			const exec = await getTabularExecution(executionId);
+			execution = exec;
+			scheduleNextPoll();
+		} catch (err) {
+			loadError = err instanceof LQAIApiError ? err.message : 'Failed to load tabular execution.';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function scheduleNextPoll(): void {
+		if (!execution) return;
+		if (isTerminalStatus(execution.status)) {
+			if (pollTimer) {
+				clearTimeout(pollTimer);
+				pollTimer = null;
+			}
+			return;
+		}
+		if (pollTimer) clearTimeout(pollTimer);
+		pollTimer = setTimeout(loadOnce, TABULAR_POLL_INTERVAL_MS);
+	}
+
+	async function cancelRun(): Promise<void> {
+		if (!execution || isTerminalStatus(execution.status)) return;
+		cancelling = true;
+		try {
+			execution = await cancelTabularExecution(execution.id);
+		} catch (err) {
+			loadError = err instanceof LQAIApiError ? err.message : 'Failed to cancel.';
+		} finally {
+			cancelling = false;
+		}
+	}
+
+	function handleCellOpen(event: CustomEvent<{
+		documentId: string;
+		documentName: string;
+		columnName: string;
+		cell: TabularCellResult | undefined;
+	}>): void {
+		const { documentName, columnName, cell } = event.detail;
+		if (!cell) return;
+		openCell = { documentName, columnName, cell };
+	}
+
+	function closeCellModal(): void {
+		openCell = null;
+	}
+
+	onMount(loadOnce);
+	onDestroy(() => {
+		if (pollTimer) clearTimeout(pollTimer);
+	});
+</script>
+
+<svelte:head>
+	<title>Tabular result · LQ.AI</title>
+</svelte:head>
+
+<section class="lq-tabres">
+	{#if loading && !execution}
+		<div class="lq-tabres__state" data-testid="lq-tabres-loading">Loading…</div>
+	{:else if loadError && !execution}
+		<div class="lq-tabres__error" role="alert" data-testid="lq-tabres-error">{loadError}</div>
+	{:else if execution}
+		<header class="lq-tabres__header">
+			<div>
+				<h1>Tabular result</h1>
+				<p class="lq-tabres__sub">
+					<strong>{skillNameDisplay(execution.skill_name)}</strong>
+					· {docCount} docs × {colCount} cols
+				</p>
+			</div>
+			<div class="lq-tabres__actions">
+				<button
+					type="button"
+					class="lq-tabres__rerun"
+					data-testid="lq-tabres-rerun"
+					on:click={() => goto('/lq-ai/tabular/new')}>Re-run as new execution</button
+				>
+			</div>
+		</header>
+
+		<!-- Status banner -->
+		<div
+			class="lq-tabres__banner"
+			data-status={execution.status}
+			data-testid="lq-tabres-banner"
+		>
+			<div class="lq-tabres__banner-row">
+				<span class="lq-tabres__banner-label">Status:</span>
+				<span class="lq-tabres__banner-status" data-testid="lq-tabres-status">
+					{formatTabularStatus(execution.status)}
+				</span>
+				{#if !isTerminalStatus(execution.status)}
+					<button
+						type="button"
+						class="lq-tabres__cancel"
+						data-testid="lq-tabres-cancel"
+						on:click={cancelRun}
+						disabled={cancelling}
+					>
+						{cancelling ? 'Cancelling…' : 'Cancel'}
+					</button>
+				{/if}
+				{#if execution.status === 'completed'}
+					<span class="lq-tabres__banner-cost" data-testid="lq-tabres-cost">
+						{formatCostUsd(execution.cost_actual_usd)} actual
+						{#if execution.cost_estimate_usd}
+							(est. {formatCostUsd(execution.cost_estimate_usd)})
+						{/if}
+					</span>
+				{/if}
+			</div>
+			{#if !isTerminalStatus(execution.status)}
+				<div
+					class="lq-tabres__progress"
+					data-testid="lq-tabres-progress"
+					role="progressbar"
+					aria-valuemin="0"
+					aria-valuemax="100"
+					aria-valuenow={Math.round(fraction * 100)}
+				>
+					<div class="lq-tabres__progress-bar" style="width: {fraction * 100}%"></div>
+					<span class="lq-tabres__progress-text">{formatProgress(fraction)}</span>
+				</div>
+			{/if}
+			{#if execution.error_text}
+				<pre class="lq-tabres__banner-error" data-testid="lq-tabres-error-text"
+					>{execution.error_text}</pre
+				>
+			{/if}
+		</div>
+
+		{#if execution.columns.length > 0 && execution.document_ids.length > 0}
+			<TabularGrid
+				results={execution.results}
+				columns={execution.columns}
+				documentIds={execution.document_ids}
+				{documentNameById}
+				on:open={handleCellOpen}
+			/>
+		{:else}
+			<div class="lq-tabres__state">No grid to render (empty execution).</div>
+		{/if}
+	{/if}
+
+	{#if openCell}
+		<TabularCitationModal
+			documentName={openCell.documentName}
+			columnName={openCell.columnName}
+			cell={openCell.cell}
+			on:close={closeCellModal}
+		/>
+	{/if}
+</section>
+
+<style>
+	.lq-tabres {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+		max-width: 80rem;
+		margin: 0 auto;
+		padding: 1.5rem;
+	}
+	.lq-tabres__header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+	.lq-tabres__header h1 {
+		margin: 0;
+		font-size: 1.5rem;
+	}
+	.lq-tabres__sub {
+		margin: 0.25rem 0 0;
+		color: var(--lq-text-secondary);
+		font-size: 0.875rem;
+	}
+	.lq-tabres__rerun {
+		padding: 0.5rem 0.75rem;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.375rem;
+		background: var(--lq-surface);
+		font-size: 0.875rem;
+		cursor: pointer;
+	}
+	.lq-tabres__banner {
+		padding: 0.875rem 1rem;
+		background: var(--lq-inset);
+		border-radius: 0.5rem;
+		border: 1px solid var(--lq-border);
+	}
+	.lq-tabres__banner[data-status='completed'] {
+		background: var(--lq-success-soft, var(--lq-inset));
+		border-color: var(--lq-success-border, var(--lq-border));
+	}
+	.lq-tabres__banner[data-status='failed'] {
+		background: var(--lq-error-soft, var(--lq-inset));
+		border-color: var(--lq-error-border, var(--lq-border));
+	}
+	.lq-tabres__banner[data-status='cancelled'] {
+		background: var(--lq-inset);
+		border-color: var(--lq-border);
+	}
+	.lq-tabres__banner-row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+	.lq-tabres__banner-label {
+		font-size: 0.75rem;
+		color: var(--lq-text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+	.lq-tabres__banner-status {
+		font-weight: 600;
+	}
+	.lq-tabres__banner-cost {
+		margin-left: auto;
+		font-size: 0.8125rem;
+		color: var(--lq-text-secondary);
+	}
+	.lq-tabres__cancel {
+		padding: 0.25rem 0.625rem;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.25rem;
+		background: var(--lq-surface);
+		font-size: 0.75rem;
+		cursor: pointer;
+	}
+	.lq-tabres__cancel:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.lq-tabres__progress {
+		position: relative;
+		height: 1.25rem;
+		margin-top: 0.5rem;
+		background: var(--lq-surface);
+		border-radius: 999px;
+		border: 1px solid var(--lq-border);
+		overflow: hidden;
+	}
+	.lq-tabres__progress-bar {
+		height: 100%;
+		background: var(--lq-accent, #4f46e5);
+		transition: width 0.3s ease-out;
+	}
+	.lq-tabres__progress-text {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--lq-text);
+		mix-blend-mode: difference;
+	}
+	.lq-tabres__banner-error {
+		margin: 0.625rem 0 0;
+		padding: 0.5rem 0.75rem;
+		background: var(--lq-surface);
+		border-radius: 0.25rem;
+		font-size: 0.8125rem;
+		white-space: pre-wrap;
+		max-height: 6rem;
+		overflow: auto;
+	}
+	.lq-tabres__state {
+		padding: 1.5rem;
+		text-align: center;
+		color: var(--lq-text-secondary);
+		background: var(--lq-inset);
+		border-radius: 0.5rem;
+	}
+	.lq-tabres__error {
+		padding: 0.875rem;
+		background: var(--lq-error-soft, var(--lq-inset));
+		border: 1px solid var(--lq-error-border, var(--lq-border));
+		border-radius: 0.375rem;
+		color: var(--lq-error, inherit);
+	}
+</style>

--- a/web/src/routes/lq-ai/tabular/[id]/+page.svelte
+++ b/web/src/routes/lq-ai/tabular/[id]/+page.svelte
@@ -40,14 +40,24 @@
 	$: fraction = execution
 		? progressFraction(execution.status, execution.results, docCount, colCount)
 		: 0;
-	// Map document_id -> document_name from the populated rows. Rows
-	// that haven't been written yet leave the entry undefined; the
-	// grid falls back to rendering the raw UUID as the row label
-	// until the worker writes the row.
+	// Map document_id -> document_name. Primary source: the parallel
+	// `document_names` array on the execution (populated at every
+	// response build by joining documents → files.filename) so the
+	// grid renders human-readable headers from the moment the
+	// execution is created, before any row is written. Falls back to
+	// row.document_name (worker-written) for older executions that
+	// pre-date the document_names field.
 	$: documentNameById = (() => {
 		const m: Record<string, string> = {};
+		if (execution?.document_ids && execution?.document_names) {
+			const ids = execution.document_ids;
+			const names = execution.document_names;
+			for (let i = 0; i < ids.length; i++) {
+				if (names[i]) m[ids[i]] = names[i];
+			}
+		}
 		for (const row of execution?.results?.rows ?? []) {
-			m[row.document_id] = row.document_name;
+			if (!m[row.document_id]) m[row.document_id] = row.document_name;
 		}
 		return m;
 	})();

--- a/web/src/routes/lq-ai/tabular/[id]/__tests__/page-helpers.test.ts
+++ b/web/src/routes/lq-ai/tabular/[id]/__tests__/page-helpers.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure-helper tests for the Tabular result view (M3-C3 sub-phase 4).
+ *
+ * The Svelte +page.svelte holds rendering + the polling timer; these
+ * helpers carry the deterministic decisions (terminal? progress
+ * fraction? cell-render-state classification?) so the polling
+ * machinery is testable without a browser.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	isTerminalStatus,
+	progressFraction,
+	formatProgress,
+	cellRenderState,
+	confidenceChipLabel,
+	TABULAR_POLL_INTERVAL_MS
+} from '../page-helpers';
+import type { TabularCellResult, TabularResults } from '$lib/lq-ai/types';
+
+function cell(over: Partial<TabularCellResult> = {}): TabularCellResult {
+	return {
+		value: '3 years',
+		citations: [],
+		confidence: 'high',
+		tier_used: 2,
+		cost_usd: '0.0050',
+		error: null,
+		...over
+	};
+}
+
+describe('tabular result page-helpers', () => {
+	describe('TABULAR_POLL_INTERVAL_MS', () => {
+		it('matches the M3-A4 playbook execution view (3s)', () => {
+			expect(TABULAR_POLL_INTERVAL_MS).toBe(3000);
+		});
+	});
+
+	describe('isTerminalStatus', () => {
+		it('is true for completed / failed / cancelled', () => {
+			expect(isTerminalStatus('completed')).toBe(true);
+			expect(isTerminalStatus('failed')).toBe(true);
+			expect(isTerminalStatus('cancelled')).toBe(true);
+		});
+
+		it('is false for pending / running', () => {
+			expect(isTerminalStatus('pending')).toBe(false);
+			expect(isTerminalStatus('running')).toBe(false);
+		});
+	});
+
+	describe('progressFraction', () => {
+		it('returns 1 when results are null but status is completed', () => {
+			expect(progressFraction('completed', null, 5, 4)).toBe(1);
+		});
+
+		it('returns 0 when results are null and not terminal', () => {
+			expect(progressFraction('pending', null, 5, 4)).toBe(0);
+			expect(progressFraction('running', null, 5, 4)).toBe(0);
+		});
+
+		it('returns the populated-cell fraction during running', () => {
+			const results: TabularResults = {
+				rows: [
+					{
+						document_id: 'd1',
+						document_name: 'NDA 1',
+						cells: { Term: cell(), Survival: cell() }
+					},
+					{
+						document_id: 'd2',
+						document_name: 'NDA 2',
+						cells: { Term: cell() }
+					}
+				]
+			};
+			// 3 populated cells out of 2 docs × 2 columns = 4 expected
+			expect(progressFraction('running', results, 2, 2)).toBe(0.75);
+		});
+
+		it('caps at 1', () => {
+			const results: TabularResults = {
+				rows: [
+					{
+						document_id: 'd1',
+						document_name: 'NDA 1',
+						cells: { Term: cell(), Survival: cell(), Extra: cell() }
+					}
+				]
+			};
+			expect(progressFraction('running', results, 1, 2)).toBeLessThanOrEqual(1);
+		});
+	});
+
+	describe('formatProgress', () => {
+		it('renders 75% style', () => {
+			expect(formatProgress(0.75)).toBe('75%');
+			expect(formatProgress(0)).toBe('0%');
+			expect(formatProgress(1)).toBe('100%');
+		});
+
+		it('rounds to integer percent', () => {
+			expect(formatProgress(0.5555)).toBe('56%');
+			expect(formatProgress(0.123)).toBe('12%');
+		});
+	});
+
+	describe('cellRenderState', () => {
+		it('returns "empty" when the cell is undefined (not yet computed)', () => {
+			expect(cellRenderState(undefined)).toBe('empty');
+		});
+
+		it('returns "failed" for confidence=failed cells', () => {
+			expect(cellRenderState(cell({ confidence: 'failed', value: null, error: 'boom' }))).toBe(
+				'failed'
+			);
+		});
+
+		it('returns "high" / "medium" / "low" mirroring the cell confidence', () => {
+			expect(cellRenderState(cell({ confidence: 'high' }))).toBe('high');
+			expect(cellRenderState(cell({ confidence: 'medium' }))).toBe('medium');
+			expect(cellRenderState(cell({ confidence: 'low' }))).toBe('low');
+		});
+	});
+
+	describe('confidenceChipLabel', () => {
+		it('renders short human-readable labels', () => {
+			expect(confidenceChipLabel('high')).toBe('High');
+			expect(confidenceChipLabel('medium')).toBe('Med');
+			expect(confidenceChipLabel('low')).toBe('Low');
+			expect(confidenceChipLabel('failed')).toBe('Failed');
+		});
+	});
+});

--- a/web/src/routes/lq-ai/tabular/[id]/page-helpers.ts
+++ b/web/src/routes/lq-ai/tabular/[id]/page-helpers.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure helpers for the Tabular result view (`/lq-ai/tabular/[id]`).
+ *
+ * The +page.svelte holds the imperative polling + rendering; these
+ * functions hold the deterministic decisions so the polling
+ * machinery + progress display are testable without a browser
+ * (mirrors the M3-A4 playbook-executions/page-helpers.ts pattern).
+ *
+ * Constants:
+ * - `TABULAR_POLL_INTERVAL_MS` = 3000 — matches the M3-A4 playbook
+ *   execution view's 3-second poll. Tabular runs are much longer
+ *   (potentially hours), so the choice trades server load for grid
+ *   freshness; 3s is the existing accepted default.
+ */
+import type {
+	TabularCellConfidence,
+	TabularCellResult,
+	TabularExecutionStatus,
+	TabularResults
+} from '$lib/lq-ai/types';
+
+export const TABULAR_POLL_INTERVAL_MS = 3000;
+
+/** Status the worker won't change without external operator action. */
+export function isTerminalStatus(status: TabularExecutionStatus): boolean {
+	return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
+
+/**
+ * Fraction of the grid that has been populated, in [0, 1]. The result
+ * view's progress bar binds to this on running rows; the completed
+ * state always returns 1 (the grid is full by definition).
+ */
+export function progressFraction(
+	status: TabularExecutionStatus,
+	results: TabularResults | null,
+	documentCount: number,
+	columnCount: number
+): number {
+	if (status === 'completed') return 1;
+	if (!results) return 0;
+	const expected = documentCount * columnCount;
+	if (expected <= 0) return 0;
+	let populated = 0;
+	for (const row of results.rows) {
+		populated += Object.keys(row.cells).length;
+	}
+	return Math.min(1, populated / expected);
+}
+
+/** Render a 0..1 fraction as `'N%'` with integer rounding. */
+export function formatProgress(fraction: number): string {
+	return `${Math.round(fraction * 100)}%`;
+}
+
+/**
+ * Discriminator for the cell renderer:
+ * - `'empty'` → cell hasn't been populated yet (still running).
+ * - `'failed'` → extraction errored (Decision C-10: italic "not
+ *   found" + amber chip).
+ * - `'high' | 'medium' | 'low'` → Citation Engine confidence; chip
+ *   colour comes from this.
+ */
+export type CellRenderState = 'empty' | 'failed' | 'high' | 'medium' | 'low';
+
+export function cellRenderState(cell: TabularCellResult | undefined): CellRenderState {
+	if (cell === undefined) return 'empty';
+	return cell.confidence;
+}
+
+/** Short human-readable label for a confidence chip. */
+export function confidenceChipLabel(confidence: TabularCellConfidence): string {
+	switch (confidence) {
+		case 'high':
+			return 'High';
+		case 'medium':
+			return 'Med';
+		case 'low':
+			return 'Low';
+		case 'failed':
+			return 'Failed';
+	}
+}

--- a/web/src/routes/lq-ai/tabular/__tests__/page-helpers.test.ts
+++ b/web/src/routes/lq-ai/tabular/__tests__/page-helpers.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure-helper tests for the /lq-ai/tabular list-page helpers (M3-C3).
+ *
+ * Mirrors the playbooks page-helpers test shape: helpers extracted to a
+ * sibling `.ts` so vitest can exercise them without the svelte
+ * transformer.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	sortTabularExecutionsByCreatedDesc,
+	formatTabularStatus,
+	formatCellCount,
+	formatCostUsd,
+	skillNameDisplay
+} from '../page-helpers';
+import type { TabularExecutionSummary } from '$lib/lq-ai/types';
+
+function summary(over: Partial<TabularExecutionSummary> = {}): TabularExecutionSummary {
+	return {
+		id: 'tex-x',
+		user_id: 'u1',
+		parent_execution_id: null,
+		skill_name: 'contract-snapshot',
+		status: 'completed',
+		document_count: 5,
+		column_count: 4,
+		cost_estimate_usd: '0.0500',
+		cost_actual_usd: '0.0480',
+		created_at: '2026-05-22T15:00:00Z',
+		completed_at: '2026-05-22T15:02:00Z',
+		...over
+	};
+}
+
+describe('tabular page-helpers', () => {
+	describe('sortTabularExecutionsByCreatedDesc', () => {
+		it('returns newest first by created_at', () => {
+			const rows = [
+				summary({ id: 'a', created_at: '2026-05-20T10:00:00Z' }),
+				summary({ id: 'b', created_at: '2026-05-22T10:00:00Z' }),
+				summary({ id: 'c', created_at: '2026-05-21T10:00:00Z' })
+			];
+			const sorted = sortTabularExecutionsByCreatedDesc(rows);
+			expect(sorted.map((r) => r.id)).toEqual(['b', 'c', 'a']);
+		});
+
+		it('does not mutate the input array', () => {
+			const rows = [
+				summary({ id: 'a', created_at: '2026-05-20T10:00:00Z' }),
+				summary({ id: 'b', created_at: '2026-05-22T10:00:00Z' })
+			];
+			const before = rows.map((r) => r.id);
+			sortTabularExecutionsByCreatedDesc(rows);
+			expect(rows.map((r) => r.id)).toEqual(before);
+		});
+	});
+
+	describe('formatTabularStatus', () => {
+		it('renders human-friendly labels for each status', () => {
+			expect(formatTabularStatus('pending')).toBe('Pending');
+			expect(formatTabularStatus('running')).toBe('Running');
+			expect(formatTabularStatus('completed')).toBe('Completed');
+			expect(formatTabularStatus('failed')).toBe('Failed');
+			expect(formatTabularStatus('cancelled')).toBe('Cancelled');
+		});
+	});
+
+	describe('formatCellCount', () => {
+		it('renders docs × cols = cells', () => {
+			expect(formatCellCount(5, 4)).toBe('5 docs × 4 cols = 20 cells');
+		});
+
+		it('singularises correctly', () => {
+			expect(formatCellCount(1, 1)).toBe('1 doc × 1 col = 1 cell');
+			expect(formatCellCount(1, 4)).toBe('1 doc × 4 cols = 4 cells');
+			expect(formatCellCount(5, 1)).toBe('5 docs × 1 col = 5 cells');
+		});
+	});
+
+	describe('formatCostUsd', () => {
+		it('renders cost as $0.XX style', () => {
+			expect(formatCostUsd('0.0500')).toBe('$0.05');
+			expect(formatCostUsd('1.2345')).toBe('$1.23');
+			expect(formatCostUsd('0.0001')).toBe('$0.00');
+			expect(formatCostUsd('12.50')).toBe('$12.50');
+		});
+
+		it('renders null / empty as em-dash', () => {
+			expect(formatCostUsd(null)).toBe('—');
+			expect(formatCostUsd('')).toBe('—');
+		});
+
+		it('renders an invalid number defensively as em-dash', () => {
+			expect(formatCostUsd('not a number')).toBe('—');
+		});
+	});
+
+	describe('skillNameDisplay', () => {
+		it('returns the skill name when set', () => {
+			expect(skillNameDisplay('contract-snapshot')).toBe('contract-snapshot');
+		});
+
+		it('returns "Ad-hoc" when null', () => {
+			expect(skillNameDisplay(null)).toBe('Ad-hoc');
+		});
+	});
+});

--- a/web/src/routes/lq-ai/tabular/new/+page.svelte
+++ b/web/src/routes/lq-ai/tabular/new/+page.svelte
@@ -203,8 +203,14 @@
 
 	// --- Step navigation ----------------------------------------------------
 
-	function canAdvanceFrom(step: WizardStep): boolean {
-		switch (step) {
+	// Reactive — referencing the dependent state directly so Svelte's
+	// compiler tracks `documentIds`, `columnsState`, `preview`, etc.
+	// A previous `canAdvanceFrom(step)` helper hid those deps inside a
+	// function call; Svelte does not trace into function bodies, so the
+	// button's `disabled` binding never re-evaluated when the selection
+	// changed and the Next button stayed disabled (DE-XXX, M3-C3).
+	$: canAdvance = ((): boolean => {
+		switch (currentStep) {
 			case 'documents':
 				return validateDocumentsStep(documentIds) === null;
 			case 'columns':
@@ -214,7 +220,7 @@
 			case 'confirm':
 				return !gateRequiresConfirmation || confirmationChecked;
 		}
-	}
+	})();
 
 	async function advance(): Promise<void> {
 		stepError = null;
@@ -378,9 +384,13 @@
 					<div class="lq-tabwiz__error" role="alert">{skillsError}</div>
 				{:else if allTableSkills.length === 0}
 					<div class="lq-tabwiz__state">
-						No table-mode skills are installed. Switch to ad-hoc mode to define columns inline,
-						or import a table-mode skill from the
-						<a href="/lq-ai/skills">Skills page</a>.
+						No table-mode skills are available. Switch to ad-hoc mode to define columns inline.
+						Reference table-mode skills (e.g.
+						<code>contract-snapshot</code>) ship as built-ins — see the
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/docs/skill-authoring-guide.md">
+							skill authoring guide
+						</a>
+						to add your own.
 					</div>
 				{:else}
 					<label class="lq-tabwiz__field">
@@ -543,7 +553,7 @@
 			class="lq-tabwiz__next"
 			data-testid="lq-tabwiz-next"
 			on:click={advance}
-			disabled={!canAdvanceFrom(currentStep) || submitting}
+			disabled={!canAdvance || submitting}
 		>
 			{#if isLastStep(currentStep)}
 				{submitting ? 'Starting…' : 'Run'}

--- a/web/src/routes/lq-ai/tabular/new/+page.svelte
+++ b/web/src/routes/lq-ai/tabular/new/+page.svelte
@@ -1,0 +1,812 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+
+	import { LQAIApiError } from '$lib/lq-ai/api/client';
+	import {
+		listKnowledgeBases,
+		listKnowledgeBaseFiles
+	} from '$lib/lq-ai/api/knowledgeBases';
+	import { listSkills } from '$lib/lq-ai/api/skills';
+	import { previewTabularCost, executeTabular } from '$lib/lq-ai/api/tabular';
+	import type {
+		KnowledgeBase,
+		KnowledgeBaseFile,
+		SkillSummary,
+		TabularColumnSpec,
+		TabularPreviewCostResponse
+	} from '$lib/lq-ai/types';
+
+	import {
+		type WizardStep,
+		stepIndex,
+		nextStep,
+		prevStep,
+		isFirstStep,
+		isLastStep,
+		validateDocumentsStep,
+		validateColumnsStep,
+		requiresCostConfirmation,
+		buildPreviewRequest,
+		buildExecuteRequest,
+		TABULAR_MAX_DOCS,
+		COST_CONFIRMATION_THRESHOLD_USD
+	} from './page-helpers';
+	import { formatCellCount, formatCostUsd } from '../page-helpers';
+
+	// --- Wizard state -------------------------------------------------------
+
+	let currentStep: WizardStep = 'documents';
+	let stepError: string | null = null;
+	let submitError: string | null = null;
+
+	const stepLabels: Record<WizardStep, string> = {
+		documents: 'Documents',
+		columns: 'Columns',
+		preview: 'Cost preview',
+		confirm: 'Confirm & run'
+	};
+
+	// --- Step 1: Documents (KB-scoped picker) -------------------------------
+	// Decision C-7: KB / Project / free-pick — KB-only ships in v0.3.0; the
+	// other two sources are deferred (filed at Phase C close).
+
+	let kbs: KnowledgeBase[] = [];
+	let kbFiles: KnowledgeBaseFile[] = [];
+	let selectedKbId: string | null = null;
+	let kbLoading = false;
+	let filesLoading = false;
+	let kbError: string | null = null;
+
+	let selectedFiles: Map<string, KnowledgeBaseFile> = new Map();
+	$: documentIds = [...selectedFiles.values()]
+		.map((f) => f.document_id ?? null)
+		.filter((id): id is string => id !== null);
+
+	async function loadKBs(): Promise<void> {
+		kbLoading = true;
+		kbError = null;
+		try {
+			kbs = await listKnowledgeBases();
+		} catch (err) {
+			kbError = err instanceof LQAIApiError ? err.message : 'Failed to load knowledge bases.';
+		} finally {
+			kbLoading = false;
+		}
+	}
+
+	async function onSelectKb(kbId: string): Promise<void> {
+		selectedKbId = kbId;
+		filesLoading = true;
+		kbError = null;
+		try {
+			kbFiles = await listKnowledgeBaseFiles(kbId);
+		} catch (err) {
+			kbError = err instanceof LQAIApiError ? err.message : 'Failed to load KB files.';
+		} finally {
+			filesLoading = false;
+		}
+	}
+
+	function toggleFile(file: KnowledgeBaseFile): void {
+		const next = new Map(selectedFiles);
+		if (next.has(file.id)) {
+			next.delete(file.id);
+		} else {
+			// Only files with a document_id are usable — the C5 parse pipeline
+			// needs to have produced a documents row before tabular extraction
+			// can attach to it.
+			if (file.document_id) {
+				next.set(file.id, file);
+			}
+		}
+		selectedFiles = next;
+	}
+
+	// --- Step 2: Columns (saved skill OR ad-hoc) ----------------------------
+
+	type ColumnsMode = 'skill' | 'adhoc';
+	let columnsMode: ColumnsMode = 'skill';
+	let allTableSkills: SkillSummary[] = [];
+	let selectedSkillName: string | null = null;
+	let skillsLoading = false;
+	let skillsError: string | null = null;
+	let adhocColumns: TabularColumnSpec[] = [{ name: '', query: '' }];
+
+	async function loadTableSkills(): Promise<void> {
+		skillsLoading = true;
+		skillsError = null;
+		try {
+			const all = await listSkills();
+			allTableSkills = all.filter((s) => s.output_format === 'table');
+			// Pre-select the first available skill so the dropdown isn't
+			// stuck on "Choose..." when only one is present.
+			if (allTableSkills.length === 1 && !selectedSkillName) {
+				selectedSkillName = allTableSkills[0].name;
+			}
+		} catch (err) {
+			skillsError = err instanceof LQAIApiError ? err.message : 'Failed to load skills.';
+		} finally {
+			skillsLoading = false;
+		}
+	}
+
+	function addAdhocColumn(): void {
+		adhocColumns = [...adhocColumns, { name: '', query: '' }];
+	}
+
+	function removeAdhocColumn(idx: number): void {
+		adhocColumns = adhocColumns.filter((_, i) => i !== idx);
+		if (adhocColumns.length === 0) {
+			adhocColumns = [{ name: '', query: '' }];
+		}
+	}
+
+	function updateAdhocColumn(idx: number, patch: Partial<TabularColumnSpec>): void {
+		adhocColumns = adhocColumns.map((col, i) => (i === idx ? { ...col, ...patch } : col));
+	}
+
+	$: columnsState = {
+		skillName: columnsMode === 'skill' ? selectedSkillName : null,
+		columns: columnsMode === 'adhoc' ? adhocColumns.filter((c) => c.name.trim() || c.query.trim()) : []
+	};
+
+	// --- Step 3: Cost preview ----------------------------------------------
+
+	let preview: TabularPreviewCostResponse | null = null;
+	let previewLoading = false;
+	let previewError: string | null = null;
+	$: gateRequiresConfirmation = preview ? requiresCostConfirmation(preview.estimated_cost_usd) : false;
+	let confirmationChecked = false;
+
+	async function fetchPreview(): Promise<void> {
+		preview = null;
+		previewError = null;
+		previewLoading = true;
+		try {
+			const body = buildPreviewRequest({
+				documentIds,
+				skillName: columnsState.skillName,
+				columns: columnsState.columns
+			});
+			preview = await previewTabularCost(body);
+		} catch (err) {
+			previewError = err instanceof LQAIApiError ? err.message : 'Failed to load cost preview.';
+		} finally {
+			previewLoading = false;
+		}
+	}
+
+	// --- Step 4: Confirm + execute ------------------------------------------
+
+	let submitting = false;
+
+	async function executeAndRedirect(): Promise<void> {
+		if (!preview) return;
+		submitError = null;
+		submitting = true;
+		try {
+			const body = buildExecuteRequest({
+				documentIds,
+				skillName: columnsState.skillName,
+				columns: columnsState.columns,
+				confirmedCostUsd: preview.estimated_cost_usd
+			});
+			const exec = await executeTabular(body);
+			goto(`/lq-ai/tabular/${exec.id}`);
+		} catch (err) {
+			submitError = err instanceof LQAIApiError ? err.message : 'Failed to start tabular run.';
+		} finally {
+			submitting = false;
+		}
+	}
+
+	// --- Step navigation ----------------------------------------------------
+
+	function canAdvanceFrom(step: WizardStep): boolean {
+		switch (step) {
+			case 'documents':
+				return validateDocumentsStep(documentIds) === null;
+			case 'columns':
+				return validateColumnsStep(columnsState) === null;
+			case 'preview':
+				return preview !== null && !previewLoading;
+			case 'confirm':
+				return !gateRequiresConfirmation || confirmationChecked;
+		}
+	}
+
+	async function advance(): Promise<void> {
+		stepError = null;
+		switch (currentStep) {
+			case 'documents': {
+				const err = validateDocumentsStep(documentIds);
+				if (err) {
+					stepError = err;
+					return;
+				}
+				currentStep = nextStep(currentStep);
+				return;
+			}
+			case 'columns': {
+				const err = validateColumnsStep(columnsState);
+				if (err) {
+					stepError = err;
+					return;
+				}
+				currentStep = nextStep(currentStep);
+				await fetchPreview();
+				return;
+			}
+			case 'preview':
+				if (!preview) return;
+				currentStep = nextStep(currentStep);
+				return;
+			case 'confirm':
+				await executeAndRedirect();
+				return;
+		}
+	}
+
+	function retreat(): void {
+		stepError = null;
+		if (!isFirstStep(currentStep)) {
+			currentStep = prevStep(currentStep);
+		}
+	}
+
+	onMount(async () => {
+		await Promise.all([loadKBs(), loadTableSkills()]);
+	});
+</script>
+
+<svelte:head>
+	<title>New Tabular Review · LQ.AI</title>
+</svelte:head>
+
+<section class="lq-tabwiz">
+	<header class="lq-tabwiz__header">
+		<h1>New Tabular Review</h1>
+		<p class="lq-tabwiz__subtitle">
+			Run a column spec across multiple documents. Each cell is grounded by the Citation Engine.
+		</p>
+	</header>
+
+	<!-- Step indicator -->
+	<ol class="lq-tabwiz__steps" aria-label="Wizard steps" data-testid="lq-tabwiz-steps">
+		{#each ['documents', 'columns', 'preview', 'confirm'] as step (step)}
+			{@const stepWiz = step as WizardStep}
+			{@const idx = stepIndex(stepWiz)}
+			{@const curIdx = stepIndex(currentStep)}
+			<li
+				class="lq-tabwiz__step"
+				data-active={stepWiz === currentStep}
+				data-done={idx < curIdx}
+				data-testid="lq-tabwiz-step-pill"
+				data-step={stepWiz}
+			>
+				<span class="lq-tabwiz__step-num">{idx + 1}</span>
+				<span class="lq-tabwiz__step-label">{stepLabels[stepWiz]}</span>
+			</li>
+		{/each}
+	</ol>
+
+	<div class="lq-tabwiz__body" data-testid="lq-tabwiz-body" data-current-step={currentStep}>
+		{#if currentStep === 'documents'}
+			<!-- ---------------- Step 1: Documents ---------------- -->
+			<h2>Pick documents</h2>
+			<p class="lq-tabwiz__hint">
+				Up to {TABULAR_MAX_DOCS} documents. Currently selected:
+				<strong data-testid="lq-tabwiz-doc-count">{documentIds.length}</strong>.
+			</p>
+
+			{#if kbLoading}
+				<div class="lq-tabwiz__state">Loading knowledge bases…</div>
+			{:else if kbError}
+				<div class="lq-tabwiz__error" role="alert">{kbError}</div>
+			{:else if kbs.length === 0}
+				<div class="lq-tabwiz__state">
+					You don't have any knowledge bases yet. Create one from
+					<a href="/lq-ai/knowledge">Knowledge</a> to enable tabular review.
+				</div>
+			{:else}
+				<label class="lq-tabwiz__field">
+					<span>Knowledge base</span>
+					<select
+						data-testid="lq-tabwiz-kb-select"
+						bind:value={selectedKbId}
+						on:change={(e) => onSelectKb((e.target as HTMLSelectElement).value)}
+					>
+						<option value={null} disabled>Choose a KB…</option>
+						{#each kbs as kb (kb.id)}
+							<option value={kb.id}>{kb.name}</option>
+						{/each}
+					</select>
+				</label>
+
+				{#if selectedKbId}
+					{#if filesLoading}
+						<div class="lq-tabwiz__state">Loading files…</div>
+					{:else if kbFiles.length === 0}
+						<div class="lq-tabwiz__state">No files in this KB.</div>
+					{:else}
+						<ul class="lq-tabwiz__files" data-testid="lq-tabwiz-files">
+							{#each kbFiles as f (f.id)}
+								<li>
+									<label class="lq-tabwiz__file" data-disabled={!f.document_id}>
+										<input
+											type="checkbox"
+											data-testid="lq-tabwiz-file-checkbox"
+											data-file-id={f.id}
+											disabled={!f.document_id}
+											checked={selectedFiles.has(f.id)}
+											on:change={() => toggleFile(f)}
+										/>
+										<span class="lq-tabwiz__file-name">{f.filename}</span>
+										{#if !f.document_id}
+											<span class="lq-tabwiz__file-warn">Not yet parsed</span>
+										{/if}
+									</label>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				{/if}
+			{/if}
+		{:else if currentStep === 'columns'}
+			<!-- ---------------- Step 2: Columns ---------------- -->
+			<h2>Define columns</h2>
+			<p class="lq-tabwiz__hint">
+				Pick a saved table-mode skill or define columns inline.
+			</p>
+
+			<fieldset class="lq-tabwiz__mode" data-testid="lq-tabwiz-columns-mode">
+				<label>
+					<input type="radio" value="skill" bind:group={columnsMode} />
+					Saved skill
+				</label>
+				<label>
+					<input type="radio" value="adhoc" bind:group={columnsMode} />
+					Ad-hoc columns
+				</label>
+			</fieldset>
+
+			{#if columnsMode === 'skill'}
+				{#if skillsLoading}
+					<div class="lq-tabwiz__state">Loading skills…</div>
+				{:else if skillsError}
+					<div class="lq-tabwiz__error" role="alert">{skillsError}</div>
+				{:else if allTableSkills.length === 0}
+					<div class="lq-tabwiz__state">
+						No table-mode skills are installed. Switch to ad-hoc mode to define columns inline,
+						or import a table-mode skill from the
+						<a href="/lq-ai/skills">Skills page</a>.
+					</div>
+				{:else}
+					<label class="lq-tabwiz__field">
+						<span>Table-mode skill</span>
+						<select bind:value={selectedSkillName} data-testid="lq-tabwiz-skill-select">
+							<option value={null} disabled>Choose…</option>
+							{#each allTableSkills as s (s.name)}
+								<option value={s.name}>{s.title} ({s.name})</option>
+							{/each}
+						</select>
+					</label>
+					{#if selectedSkillName}
+						{@const s = allTableSkills.find((sk) => sk.name === selectedSkillName)}
+						{#if s?.description}
+							<p class="lq-tabwiz__skill-desc">{s.description}</p>
+						{/if}
+					{/if}
+				{/if}
+			{:else}
+				<table class="lq-tabwiz__adhoc" data-testid="lq-tabwiz-adhoc-table">
+					<thead>
+						<tr>
+							<th>Name</th>
+							<th>Query</th>
+							<th class="lq-tabwiz__adhoc-actions">&nbsp;</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each adhocColumns as col, idx (idx)}
+							<tr data-testid="lq-tabwiz-adhoc-row">
+								<td>
+									<input
+										type="text"
+										placeholder="e.g. Term"
+										value={col.name}
+										on:input={(e) =>
+											updateAdhocColumn(idx, {
+												name: (e.target as HTMLInputElement).value
+											})}
+									/>
+								</td>
+								<td>
+									<input
+										type="text"
+										placeholder="e.g. What is the term of this agreement?"
+										value={col.query}
+										on:input={(e) =>
+											updateAdhocColumn(idx, {
+												query: (e.target as HTMLInputElement).value
+											})}
+									/>
+								</td>
+								<td class="lq-tabwiz__adhoc-actions">
+									<button
+										type="button"
+										class="lq-tabwiz__adhoc-remove"
+										on:click={() => removeAdhocColumn(idx)}
+										aria-label="Remove column">×</button
+									>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+				<button
+					type="button"
+					class="lq-tabwiz__adhoc-add"
+					data-testid="lq-tabwiz-adhoc-add"
+					on:click={addAdhocColumn}>+ Add column</button
+				>
+			{/if}
+		{:else if currentStep === 'preview'}
+			<!-- ---------------- Step 3: Cost preview ---------------- -->
+			<h2>Cost preview</h2>
+
+			{#if previewLoading}
+				<div class="lq-tabwiz__state">Computing cost preview…</div>
+			{:else if previewError}
+				<div class="lq-tabwiz__error" role="alert">{previewError}</div>
+				<button type="button" on:click={fetchPreview}>Retry preview</button>
+			{:else if preview}
+				<dl class="lq-tabwiz__preview" data-testid="lq-tabwiz-preview">
+					<div>
+						<dt>Cells</dt>
+						<dd data-testid="lq-tabwiz-preview-cells">{preview.cells_count}</dd>
+					</div>
+					<div>
+						<dt>Estimated tokens</dt>
+						<dd>{preview.estimated_tokens.toLocaleString()}</dd>
+					</div>
+					<div>
+						<dt>Estimated cost</dt>
+						<dd data-testid="lq-tabwiz-preview-cost">
+							{formatCostUsd(preview.estimated_cost_usd)}
+						</dd>
+					</div>
+				</dl>
+
+				{#if Object.keys(preview.per_tier_breakdown).length > 0}
+					<details class="lq-tabwiz__tier-detail">
+						<summary>Per-tier breakdown</summary>
+						<ul>
+							{#each Object.entries(preview.per_tier_breakdown) as [tier, count] (tier)}
+								<li><strong>{tier}:</strong> {count} cells</li>
+							{/each}
+						</ul>
+					</details>
+				{/if}
+			{/if}
+		{:else if currentStep === 'confirm'}
+			<!-- ---------------- Step 4: Confirm + execute ---------------- -->
+			<h2>Confirm and run</h2>
+
+			{#if preview}
+				<p>
+					About to run
+					<strong>{formatCellCount(documentIds.length, preview.cells_count / documentIds.length)}</strong>
+					at an estimated cost of
+					<strong>{formatCostUsd(preview.estimated_cost_usd)}</strong>.
+				</p>
+
+				{#if gateRequiresConfirmation}
+					<label class="lq-tabwiz__gate" data-testid="lq-tabwiz-confirm-gate">
+						<input
+							type="checkbox"
+							bind:checked={confirmationChecked}
+							data-testid="lq-tabwiz-confirm-checkbox"
+						/>
+						I understand this will cost approximately
+						{formatCostUsd(preview.estimated_cost_usd)} and is at or above the
+						{formatCostUsd(String(COST_CONFIRMATION_THRESHOLD_USD))} confirmation threshold.
+					</label>
+				{/if}
+
+				{#if submitError}
+					<div class="lq-tabwiz__error" role="alert">{submitError}</div>
+				{/if}
+			{/if}
+		{/if}
+
+		{#if stepError}
+			<div class="lq-tabwiz__error" role="alert" data-testid="lq-tabwiz-step-error">
+				{stepError}
+			</div>
+		{/if}
+	</div>
+
+	<footer class="lq-tabwiz__nav">
+		<button
+			type="button"
+			class="lq-tabwiz__back"
+			data-testid="lq-tabwiz-back"
+			on:click={retreat}
+			disabled={isFirstStep(currentStep) || submitting}
+		>
+			Back
+		</button>
+		<button
+			type="button"
+			class="lq-tabwiz__next"
+			data-testid="lq-tabwiz-next"
+			on:click={advance}
+			disabled={!canAdvanceFrom(currentStep) || submitting}
+		>
+			{#if isLastStep(currentStep)}
+				{submitting ? 'Starting…' : 'Run'}
+			{:else}
+				Next
+			{/if}
+		</button>
+	</footer>
+</section>
+
+<style>
+	.lq-tabwiz {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+		max-width: 56rem;
+		margin: 0 auto;
+		padding: 1.5rem;
+	}
+	.lq-tabwiz__header h1 {
+		margin: 0;
+		font-size: 1.5rem;
+	}
+	.lq-tabwiz__subtitle {
+		margin: 0.25rem 0 0;
+		color: var(--lq-text-secondary);
+	}
+	.lq-tabwiz__steps {
+		display: flex;
+		gap: 0.5rem;
+		padding: 0;
+		margin: 0;
+		list-style: none;
+	}
+	.lq-tabwiz__step {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.625rem 0.875rem;
+		background: var(--lq-inset);
+		border-radius: 0.5rem;
+		font-size: 0.875rem;
+		color: var(--lq-text-secondary);
+	}
+	.lq-tabwiz__step[data-active='true'] {
+		background: var(--lq-accent-soft, var(--lq-inset));
+		color: var(--lq-text);
+		font-weight: 500;
+		border: 1px solid var(--lq-accent, var(--lq-border));
+	}
+	.lq-tabwiz__step[data-done='true'] {
+		opacity: 0.85;
+	}
+	.lq-tabwiz__step-num {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.5rem;
+		height: 1.5rem;
+		border-radius: 999px;
+		background: var(--lq-surface);
+		font-weight: 600;
+		font-size: 0.8125rem;
+	}
+	.lq-tabwiz__body {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		min-height: 18rem;
+		padding: 1.25rem;
+		background: var(--lq-surface);
+		border: 1px solid var(--lq-border);
+		border-radius: 0.5rem;
+	}
+	.lq-tabwiz__body h2 {
+		margin: 0;
+		font-size: 1.125rem;
+	}
+	.lq-tabwiz__hint {
+		margin: 0;
+		color: var(--lq-text-secondary);
+	}
+	.lq-tabwiz__field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+	.lq-tabwiz__field select {
+		padding: 0.5rem 0.625rem;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.375rem;
+		background: var(--lq-surface);
+		color: var(--lq-text);
+	}
+	.lq-tabwiz__files {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		max-height: 24rem;
+		overflow-y: auto;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.375rem;
+	}
+	.lq-tabwiz__files li {
+		border-bottom: 1px solid var(--lq-border);
+	}
+	.lq-tabwiz__files li:last-child {
+		border-bottom: none;
+	}
+	.lq-tabwiz__file {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		padding: 0.625rem 0.875rem;
+		cursor: pointer;
+	}
+	.lq-tabwiz__file[data-disabled='true'] {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.lq-tabwiz__file-warn {
+		font-size: 0.75rem;
+		color: var(--lq-warning, var(--lq-text-secondary));
+		margin-left: auto;
+	}
+	.lq-tabwiz__mode {
+		border: none;
+		padding: 0;
+		display: flex;
+		gap: 1rem;
+	}
+	.lq-tabwiz__mode label {
+		display: flex;
+		gap: 0.375rem;
+		align-items: center;
+		cursor: pointer;
+	}
+	.lq-tabwiz__skill-desc {
+		margin: 0.25rem 0 0;
+		color: var(--lq-text-secondary);
+		font-size: 0.875rem;
+	}
+	.lq-tabwiz__adhoc {
+		width: 100%;
+		border-collapse: collapse;
+		background: var(--lq-surface);
+	}
+	.lq-tabwiz__adhoc th,
+	.lq-tabwiz__adhoc td {
+		padding: 0.5rem;
+		border-bottom: 1px solid var(--lq-border);
+		vertical-align: top;
+	}
+	.lq-tabwiz__adhoc input {
+		width: 100%;
+		padding: 0.375rem 0.5rem;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.25rem;
+		background: var(--lq-surface);
+		color: var(--lq-text);
+	}
+	.lq-tabwiz__adhoc-actions {
+		width: 2rem;
+		text-align: center;
+	}
+	.lq-tabwiz__adhoc-remove {
+		background: none;
+		border: none;
+		font-size: 1.25rem;
+		color: var(--lq-text-secondary);
+		cursor: pointer;
+	}
+	.lq-tabwiz__adhoc-add {
+		align-self: flex-start;
+		padding: 0.375rem 0.625rem;
+		background: var(--lq-inset);
+		border: 1px solid var(--lq-border);
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		cursor: pointer;
+	}
+	.lq-tabwiz__preview {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 1rem;
+	}
+	.lq-tabwiz__preview > div {
+		padding: 0.875rem;
+		background: var(--lq-inset);
+		border-radius: 0.5rem;
+	}
+	.lq-tabwiz__preview dt {
+		font-size: 0.75rem;
+		color: var(--lq-text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+	.lq-tabwiz__preview dd {
+		margin: 0.25rem 0 0;
+		font-size: 1.25rem;
+		font-weight: 600;
+	}
+	.lq-tabwiz__tier-detail {
+		padding: 0.625rem 0.875rem;
+		background: var(--lq-inset);
+		border-radius: 0.375rem;
+	}
+	.lq-tabwiz__tier-detail summary {
+		cursor: pointer;
+		font-size: 0.875rem;
+	}
+	.lq-tabwiz__tier-detail ul {
+		margin: 0.5rem 0 0;
+		padding-left: 1.25rem;
+	}
+	.lq-tabwiz__gate {
+		display: flex;
+		gap: 0.5rem;
+		padding: 0.875rem;
+		background: var(--lq-warning-soft, var(--lq-inset));
+		border: 1px solid var(--lq-warning-border, var(--lq-border));
+		border-radius: 0.375rem;
+		cursor: pointer;
+		font-size: 0.875rem;
+	}
+	.lq-tabwiz__state {
+		padding: 1rem;
+		background: var(--lq-inset);
+		border-radius: 0.375rem;
+		color: var(--lq-text-secondary);
+		text-align: center;
+	}
+	.lq-tabwiz__error {
+		padding: 0.875rem;
+		background: var(--lq-error-soft, var(--lq-inset));
+		border: 1px solid var(--lq-error-border, var(--lq-border));
+		border-radius: 0.375rem;
+		color: var(--lq-error, inherit);
+	}
+	.lq-tabwiz__nav {
+		display: flex;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+	.lq-tabwiz__back,
+	.lq-tabwiz__next {
+		padding: 0.5rem 1rem;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		background: var(--lq-surface);
+	}
+	.lq-tabwiz__next {
+		background: var(--lq-accent, #4f46e5);
+		color: var(--lq-on-accent, #ffffff);
+		border-color: transparent;
+	}
+	.lq-tabwiz__next:disabled,
+	.lq-tabwiz__back:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/web/src/routes/lq-ai/tabular/new/__tests__/page-helpers.test.ts
+++ b/web/src/routes/lq-ai/tabular/new/__tests__/page-helpers.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Pure-helper tests for the Tabular Review wizard (M3-C3).
+ *
+ * The wizard is a single-route, four-step flow (per session-start
+ * AskUserQuestion + prep-doc Decision C-5/C-7). These helpers carry the
+ * deterministic state-machine + validation + request-builder logic so
+ * the Svelte +page.svelte stays presentational and the gating logic is
+ * test-covered without a browser.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	type WizardStep,
+	stepIndex,
+	nextStep,
+	prevStep,
+	isFirstStep,
+	isLastStep,
+	validateDocumentsStep,
+	validateColumnsStep,
+	requiresCostConfirmation,
+	buildPreviewRequest,
+	buildExecuteRequest,
+	TABULAR_MAX_DOCS,
+	COST_CONFIRMATION_THRESHOLD_USD
+} from '../page-helpers';
+import type { TabularColumnSpec } from '$lib/lq-ai/types';
+
+describe('tabular wizard page-helpers', () => {
+	describe('step transitions', () => {
+		it('orders the four steps documents → columns → preview → confirm', () => {
+			expect(stepIndex('documents')).toBe(0);
+			expect(stepIndex('columns')).toBe(1);
+			expect(stepIndex('preview')).toBe(2);
+			expect(stepIndex('confirm')).toBe(3);
+		});
+
+		it('nextStep advances; lastStep returns itself', () => {
+			expect(nextStep('documents')).toBe('columns');
+			expect(nextStep('columns')).toBe('preview');
+			expect(nextStep('preview')).toBe('confirm');
+			expect(nextStep('confirm')).toBe('confirm');
+		});
+
+		it('prevStep retreats; firstStep returns itself', () => {
+			expect(prevStep('confirm')).toBe('preview');
+			expect(prevStep('preview')).toBe('columns');
+			expect(prevStep('columns')).toBe('documents');
+			expect(prevStep('documents')).toBe('documents');
+		});
+
+		it('isFirstStep / isLastStep recognise the boundary', () => {
+			const all: WizardStep[] = ['documents', 'columns', 'preview', 'confirm'];
+			expect(all.filter(isFirstStep)).toEqual(['documents']);
+			expect(all.filter(isLastStep)).toEqual(['confirm']);
+		});
+	});
+
+	describe('TABULAR_MAX_DOCS', () => {
+		it('exposes the 200-document cap from Decision C-7', () => {
+			expect(TABULAR_MAX_DOCS).toBe(200);
+		});
+	});
+
+	describe('COST_CONFIRMATION_THRESHOLD_USD', () => {
+		it('exposes the $1.00 threshold from Decision C-5', () => {
+			expect(COST_CONFIRMATION_THRESHOLD_USD).toBe(1.0);
+		});
+	});
+
+	describe('validateDocumentsStep', () => {
+		it('returns an error when zero documents are selected', () => {
+			expect(validateDocumentsStep([])).toMatch(/select at least one document/i);
+		});
+
+		it('returns null when one document is selected', () => {
+			expect(validateDocumentsStep(['d1'])).toBeNull();
+		});
+
+		it('returns null when fewer than the cap are selected', () => {
+			expect(validateDocumentsStep(new Array(200).fill('d'))).toBeNull();
+		});
+
+		it('returns an error message naming the 200-cap when exceeded', () => {
+			const err = validateDocumentsStep(new Array(201).fill('d'));
+			expect(err).toMatch(/200/);
+		});
+	});
+
+	describe('validateColumnsStep', () => {
+		it('returns null when a skill_name is set', () => {
+			expect(validateColumnsStep({ skillName: 'contract-snapshot', columns: [] })).toBeNull();
+		});
+
+		it('returns null when at least one ad-hoc column is fully populated', () => {
+			expect(
+				validateColumnsStep({
+					skillName: null,
+					columns: [{ name: 'Term', query: 'What is the term?' }]
+				})
+			).toBeNull();
+		});
+
+		it('returns an error when neither skill nor columns are set', () => {
+			expect(validateColumnsStep({ skillName: null, columns: [] })).toMatch(
+				/choose a skill or define at least one column/i
+			);
+		});
+
+		it('rejects ad-hoc columns missing a name or query', () => {
+			expect(
+				validateColumnsStep({
+					skillName: null,
+					columns: [{ name: '', query: 'q' }]
+				})
+			).toMatch(/name and query/i);
+			expect(
+				validateColumnsStep({
+					skillName: null,
+					columns: [{ name: 'Term', query: '' }]
+				})
+			).toMatch(/name and query/i);
+		});
+
+		it('rejects duplicate column names (case-insensitive)', () => {
+			expect(
+				validateColumnsStep({
+					skillName: null,
+					columns: [
+						{ name: 'Term', query: 'a' },
+						{ name: 'term', query: 'b' }
+					]
+				})
+			).toMatch(/duplicate column name/i);
+		});
+	});
+
+	describe('requiresCostConfirmation', () => {
+		it('returns true above the $1.00 threshold', () => {
+			expect(requiresCostConfirmation('1.01')).toBe(true);
+			expect(requiresCostConfirmation('5.0000')).toBe(true);
+		});
+
+		it('returns true at exactly the threshold', () => {
+			expect(requiresCostConfirmation('1.00')).toBe(true);
+		});
+
+		it('returns false below the threshold', () => {
+			expect(requiresCostConfirmation('0.99')).toBe(false);
+			expect(requiresCostConfirmation('0.00')).toBe(false);
+		});
+
+		it('returns false defensively on invalid input', () => {
+			expect(requiresCostConfirmation('not a number')).toBe(false);
+		});
+	});
+
+	describe('buildPreviewRequest', () => {
+		it('uses skill_name when supplied; omits columns', () => {
+			const req = buildPreviewRequest({
+				documentIds: ['d1', 'd2'],
+				skillName: 'contract-snapshot',
+				columns: []
+			});
+			expect(req).toEqual({
+				document_ids: ['d1', 'd2'],
+				skill_name: 'contract-snapshot'
+			});
+		});
+
+		it('uses columns when no skill_name; omits skill_name', () => {
+			const cols: TabularColumnSpec[] = [{ name: 'Term', query: 'What is the term?' }];
+			const req = buildPreviewRequest({
+				documentIds: ['d1'],
+				skillName: null,
+				columns: cols
+			});
+			expect(req).toEqual({
+				document_ids: ['d1'],
+				columns: cols
+			});
+		});
+	});
+
+	describe('buildExecuteRequest', () => {
+		it('echoes the confirmed_cost_usd alongside skill_name', () => {
+			const req = buildExecuteRequest({
+				documentIds: ['d1'],
+				skillName: 'contract-snapshot',
+				columns: [],
+				confirmedCostUsd: '0.0500'
+			});
+			expect(req).toEqual({
+				document_ids: ['d1'],
+				skill_name: 'contract-snapshot',
+				confirmed_cost_usd: '0.0500'
+			});
+		});
+
+		it('echoes the confirmed_cost_usd alongside ad-hoc columns', () => {
+			const cols: TabularColumnSpec[] = [{ name: 'Term', query: 'What is the term?' }];
+			const req = buildExecuteRequest({
+				documentIds: ['d1'],
+				skillName: null,
+				columns: cols,
+				confirmedCostUsd: '0.0100'
+			});
+			expect(req).toEqual({
+				document_ids: ['d1'],
+				columns: cols,
+				confirmed_cost_usd: '0.0100'
+			});
+		});
+	});
+});

--- a/web/src/routes/lq-ai/tabular/new/page-helpers.ts
+++ b/web/src/routes/lq-ai/tabular/new/page-helpers.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure helpers for the Tabular Review wizard (`/lq-ai/tabular/new`).
+ *
+ * The Svelte +page.svelte holds rendering + imperative state; these
+ * functions hold the deterministic state-machine + validation +
+ * request-builder logic so the wizard's gating behaviour is tested
+ * without spinning up a browser (matches the M3-A4 playbooks pattern).
+ *
+ * Constants:
+ * - `TABULAR_MAX_DOCS` = 200 — Decision C-7's deployment cap.
+ *   The backend enforces this too (LQ_AI_TABULAR_MAX_DOCS); the wizard
+ *   surfaces it at the form level to avoid a server round-trip on
+ *   obvious over-selection.
+ * - `COST_CONFIRMATION_THRESHOLD_USD` = $1.00 — Decision C-5's gate.
+ *   At or above this estimated cost, the operator must tick the
+ *   confirmation checkbox before the wizard's final "Run" button arms.
+ */
+import type {
+	TabularColumnSpec,
+	TabularExecutionCreate,
+	TabularPreviewCostRequest
+} from '$lib/lq-ai/types';
+
+export type WizardStep = 'documents' | 'columns' | 'preview' | 'confirm';
+
+const STEP_ORDER: WizardStep[] = ['documents', 'columns', 'preview', 'confirm'];
+
+export const TABULAR_MAX_DOCS = 200;
+export const COST_CONFIRMATION_THRESHOLD_USD = 1.0;
+
+/** Zero-indexed position of a step in the ordered wizard. */
+export function stepIndex(step: WizardStep): number {
+	return STEP_ORDER.indexOf(step);
+}
+
+/** Advance to the next step; the last step returns itself. */
+export function nextStep(step: WizardStep): WizardStep {
+	const i = stepIndex(step);
+	return i < STEP_ORDER.length - 1 ? STEP_ORDER[i + 1] : step;
+}
+
+/** Retreat to the previous step; the first step returns itself. */
+export function prevStep(step: WizardStep): WizardStep {
+	const i = stepIndex(step);
+	return i > 0 ? STEP_ORDER[i - 1] : step;
+}
+
+export function isFirstStep(step: WizardStep): boolean {
+	return stepIndex(step) === 0;
+}
+
+export function isLastStep(step: WizardStep): boolean {
+	return stepIndex(step) === STEP_ORDER.length - 1;
+}
+
+/**
+ * Validate the documents step. Returns an operator-facing error string
+ * OR `null` when the selection is valid.
+ */
+export function validateDocumentsStep(documentIds: string[]): string | null {
+	if (documentIds.length === 0) {
+		return 'Select at least one document.';
+	}
+	if (documentIds.length > TABULAR_MAX_DOCS) {
+		return `Tabular runs are capped at ${TABULAR_MAX_DOCS} documents — split your selection or contact your admin to lift the cap.`;
+	}
+	return null;
+}
+
+interface ColumnsStepInput {
+	skillName: string | null;
+	columns: TabularColumnSpec[];
+}
+
+/**
+ * Validate the columns step. Either a saved skill OR at least one
+ * fully-populated ad-hoc column is required. Per Decision C-1 every
+ * column has a name + query; duplicate column names break the grid's
+ * header keying and are rejected before we round-trip to the server.
+ */
+export function validateColumnsStep(input: ColumnsStepInput): string | null {
+	if (input.skillName && input.skillName.trim().length > 0) {
+		return null;
+	}
+	if (input.columns.length === 0) {
+		return 'Choose a skill or define at least one column.';
+	}
+	for (const col of input.columns) {
+		if (!col.name.trim() || !col.query.trim()) {
+			return 'Every column needs a name and query.';
+		}
+	}
+	const seen = new Set<string>();
+	for (const col of input.columns) {
+		const key = col.name.trim().toLowerCase();
+		if (seen.has(key)) {
+			return `Duplicate column name: ${col.name.trim()}.`;
+		}
+		seen.add(key);
+	}
+	return null;
+}
+
+/**
+ * Decision C-5: gate the final "Run" button behind a confirmation
+ * checkbox at or above $1.00 estimated cost. Below that, the operator
+ * sees no friction. Defensive on non-numeric strings — pre-fetch /
+ * fetch-failure states render as no-gate.
+ */
+export function requiresCostConfirmation(estimatedCostUsd: string): boolean {
+	const n = Number(estimatedCostUsd);
+	if (!Number.isFinite(n)) return false;
+	return n >= COST_CONFIRMATION_THRESHOLD_USD;
+}
+
+interface RequestBuilderInput {
+	documentIds: string[];
+	skillName: string | null;
+	columns: TabularColumnSpec[];
+}
+
+/**
+ * Build the body for `POST /api/v1/tabular/preview-cost`. Backend
+ * accepts either `skill_name` OR `columns`; we omit the unused side
+ * so the wire payload stays tight.
+ */
+export function buildPreviewRequest(input: RequestBuilderInput): TabularPreviewCostRequest {
+	if (input.skillName && input.skillName.trim().length > 0) {
+		return {
+			document_ids: input.documentIds,
+			skill_name: input.skillName
+		};
+	}
+	return {
+		document_ids: input.documentIds,
+		columns: input.columns
+	};
+}
+
+interface ExecuteBuilderInput extends RequestBuilderInput {
+	confirmedCostUsd: string;
+}
+
+/**
+ * Build the body for `POST /api/v1/tabular/execute`. The
+ * `confirmed_cost_usd` is the echo of the preview response so the
+ * server can persist an audit trail of the operator confirming a
+ * specific cost ceiling before kickoff.
+ */
+export function buildExecuteRequest(input: ExecuteBuilderInput): TabularExecutionCreate {
+	if (input.skillName && input.skillName.trim().length > 0) {
+		return {
+			document_ids: input.documentIds,
+			skill_name: input.skillName,
+			confirmed_cost_usd: input.confirmedCostUsd
+		};
+	}
+	return {
+		document_ids: input.documentIds,
+		columns: input.columns,
+		confirmed_cost_usd: input.confirmedCostUsd
+	};
+}

--- a/web/src/routes/lq-ai/tabular/page-helpers.ts
+++ b/web/src/routes/lq-ai/tabular/page-helpers.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure helpers for the `/lq-ai/tabular` list page (M3-C3), extracted to
+ * a sibling `.ts` file so vitest can exercise them without the svelte
+ * transformer (mirrors the M3-A4 playbooks page-helpers pattern).
+ */
+import type {
+	TabularExecutionStatus,
+	TabularExecutionSummary
+} from '$lib/lq-ai/types';
+
+/**
+ * Returns a new array sorted newest-first by `created_at` (ISO-8601
+ * lexical comparison — safe because the strings are timezone-Z normal).
+ */
+export function sortTabularExecutionsByCreatedDesc(
+	rows: TabularExecutionSummary[]
+): TabularExecutionSummary[] {
+	return [...rows].sort((a, b) => (a.created_at > b.created_at ? -1 : a.created_at < b.created_at ? 1 : 0));
+}
+
+/** Human-friendly label for the status enum (title-case English). */
+export function formatTabularStatus(status: TabularExecutionStatus): string {
+	switch (status) {
+		case 'pending':
+			return 'Pending';
+		case 'running':
+			return 'Running';
+		case 'completed':
+			return 'Completed';
+		case 'failed':
+			return 'Failed';
+		case 'cancelled':
+			return 'Cancelled';
+	}
+}
+
+/**
+ * `5 docs × 4 cols = 20 cells` style string — handles singular /
+ * plural for docs, cols, cells independently.
+ */
+export function formatCellCount(documentCount: number, columnCount: number): string {
+	const cells = documentCount * columnCount;
+	const docs = `${documentCount} ${documentCount === 1 ? 'doc' : 'docs'}`;
+	const cols = `${columnCount} ${columnCount === 1 ? 'col' : 'cols'}`;
+	const cellsStr = `${cells} ${cells === 1 ? 'cell' : 'cells'}`;
+	return `${docs} × ${cols} = ${cellsStr}`;
+}
+
+/**
+ * Render a USD decimal-string as `$X.YY`. Null / empty / non-numeric
+ * inputs return `—` so the list view stays readable when cost columns
+ * are unset (pre-execute previews never persist; pending runs haven't
+ * settled actual cost yet).
+ */
+export function formatCostUsd(value: string | null): string {
+	if (value === null || value === '') return '—';
+	const n = Number(value);
+	if (!Number.isFinite(n)) return '—';
+	return `$${n.toFixed(2)}`;
+}
+
+/**
+ * Display label for the `skill_name` column. Ad-hoc executions (no
+ * skill bound) render as the literal "Ad-hoc" — keeps the list
+ * scannable without mixing nulls into a string column.
+ */
+export function skillNameDisplay(skillName: string | null): string {
+	return skillName ?? 'Ad-hoc';
+}


### PR DESCRIPTION
**Draft — opened early for CI feedback.** This PR will land all four Phase C tasks (M3-C1 through M3-C4) per Decision C-8 (single PR; see `docs/superpowers/plans/2026-05-21-m3-phase-c-tabular-review.md`). Will mark ready-for-review once M3-C4 verification + reviewing-attorney walkthrough complete.

## Status

* **M3-C1 — `output_format: table` Skill mode** — ✓ shipped at `b3e1b82`
* **M3-C2 — Tabular LangGraph workflow + endpoints + migration 0036** — pending
* **M3-C3 — Tabular UI surface** — pending
* **M3-C4 — Bulk ops + XLSX/CSV export** — pending

## M3-C1 substance (this commit)

* New `ColumnSpec` Pydantic model + `LQAIFrontmatter.columns` field
* Cross-field `model_validator` enforces `output_format: table` requires non-empty `columns`
* 13 unit tests (TDD-driven; all green locally)
* Reference skill `skills/contract-snapshot/SKILL.md` (4-col NDA grid — Term / Survival / Carveouts / Governing Law; demonstrates both per-column overrides)
* Loader smoke verified end-to-end against the real `skills/` directory (12 skills load including new one)
* Docs: `docs/skill-authoring-guide.md` Table-mode section + `docs/PRD.md` §3.4 paragraph + `docs/api/backend-openapi.yaml` ColumnSpec schema + `docs/M3-IMPLEMENTATION-PLAN.md` doc nit fix (`validators.py` → `schema.py`)

## Phase C design decisions (from prep doc `ad11040`)

10 decisions locked at kickoff covering frontmatter shape, citation surface, sync-vs-ARQ execution boundary, XLSX library choice, cost-preview UX, migration sequence, document selection sources, PR strategy, bulk-ops shape, and failed-cell rendering. See `docs/superpowers/plans/2026-05-21-m3-phase-c-tabular-review.md` for full rationale.

## Test plan (final, when PR moves out of draft)

- [ ] CI passes (ruff format + ruff check + mypy + pytest on api/, gateway/, web)
- [ ] Fresh-install Docker rebuild verifies end-to-end tabular flow
- [ ] Reviewing-attorney walkthrough against real-world contracts
- [ ] Cypress E2E for tabular review (M3-C3)
- [ ] XLSX export round-trip verified in Excel desktop + Numbers + Google Sheets
- [ ] CSV round-trip via pandas.read_csv

🤖 Generated with [Claude Code](https://claude.com/claude-code)