### PR TITLE
M3-D1 (DRAFT, ~half) — slack-bridge service scaffold + OAuth handlers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -289,3 +289,46 @@ LQ_AI_DOCLING_ENABLED=true
 # when possible; offsets stay character-precise either way.
 LQ_AI_CHUNK_TARGET_CHARS=2000
 LQ_AI_CHUNK_OVERLAP_CHARS=200
+
+# ============================================================
+# M3-D1 — slack-bridge integration
+# ============================================================
+#
+# The slack-bridge is an OPT-IN service gated by the `slack` Compose
+# profile. Operators who don't use Slack can leave all of the
+# variables below unset; the api refuses any inbound bridge traffic
+# with HTTP 500 in that state (rather than running open). Bring up
+# the bridge with: `docker compose --profile slack up -d slack-bridge`.
+
+# Slack-side credentials (from the operator's Slack App admin UI;
+# see slack-bridge/manifest.yml for the App manifest).
+SLACK_CLIENT_ID=
+SLACK_CLIENT_SECRET=
+SLACK_SIGNING_SECRET=
+
+# Shared bearer token the slack-bridge presents on its POSTs to
+# /api/v1/integrations/slack/workspaces. The api validates with the
+# same env var. Constant-time matched. Generate any sufficiently long
+# random string, e.g. `python -c 'import secrets; print(secrets.token_urlsafe(48))'`.
+LQ_AI_BRIDGE_TOKEN=
+
+# urlsafe-base64 Fernet master key used to encrypt Slack bot tokens
+# at rest in slack_workspaces.bot_token_encrypted. Distinct from
+# LQ_AI_GATEWAY_MASTER_KEY on purpose — different threat models. Mint
+# with `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'`.
+LQ_AI_BRIDGE_MASTER_KEY=
+
+# Externally reachable base URL of the slack-bridge — Slack uses this
+# to construct the OAuth callback URL. Operators typically front this
+# with their reverse proxy (e.g. https://lqai.example.com/slack).
+LQ_AI_BRIDGE_PUBLIC_URL=
+
+# Optional override of where the bridge dials the api inside the
+# compose network. Defaults to http://api:8000 (the in-network DNS).
+LQ_AI_BACKEND_URL=
+
+# Optional host-side bind for the slack-bridge port (defaults to
+# 127.0.0.1:8002). Most deployments leave this alone and reach the
+# bridge through their reverse proxy.
+SLACK_BRIDGE_BIND_ADDR=
+SLACK_BRIDGE_HOST_PORT=

--- a/api/alembic/versions/0037_slack_workspaces.py
+++ b/api/alembic/versions/0037_slack_workspaces.py
@@ -1,0 +1,100 @@
+"""create slack_workspaces table — M3-D1
+
+Persists Slack workspace records produced by the ``slack-bridge`` OAuth
+install flow. The bridge service runs the OAuth dance with Slack, then
+POSTs the resulting workspace tuple to
+``POST /api/v1/integrations/slack/workspaces`` (this milestone's new
+endpoint). The api persists the row with the bot token encrypted at
+rest under :envvar:`LQ_AI_BRIDGE_MASTER_KEY` (separate from the
+gateway's provider-key master key — different threat models).
+
+Decision M3-D1-1 (encryption key): dedicated
+:envvar:`LQ_AI_BRIDGE_MASTER_KEY`, not shared with the gateway.
+Slack bot tokens enable bot impersonation; provider keys enable
+inference routing. Different blast radii → different keys.
+
+Decision M3-D1-2 (re-install semantics): the persistence endpoint
+upserts on ``team_id`` (Slack rotates bot tokens on re-install). The
+unique constraint here enforces "one live row per Slack workspace";
+the endpoint's upsert path replaces ``bot_token_encrypted`` +
+``installer_slack_user_id`` + ``scope`` + revives ``deleted_at`` if
+the row was soft-deleted.
+
+Schema
+------
+
+* ``id`` — UUID PK.
+* ``team_id`` — Slack workspace id (T0123456...); unique. The natural
+  key from Slack's side; what the upsert path conflicts on.
+* ``team_name`` — Slack workspace display name. Snapshotted at install
+  time; not auto-refreshed if the operator renames the workspace.
+* ``bot_token_encrypted`` — bytea; Fernet-wrapped bot user OAuth token
+  (``xoxb-...``). Decrypted in-memory only when the bridge needs to
+  post a reply.
+* ``bot_user_id`` — Slack user id of the bot user the install created
+  (U0123456...). Used by the bridge to recognize self-mentions and
+  attribute audit events to the bot rather than a human.
+* ``installer_slack_user_id`` — Slack user id of the operator who
+  clicked install. Audit-only — does not grant any LQ.AI permissions.
+* ``scope`` — comma-separated scope list Slack returned (e.g.,
+  ``"commands,chat:write"``). Stored verbatim so an operator can
+  audit what the workspace consented to.
+* ``installed_at`` — install timestamp (defaults to ``now()``).
+* ``deleted_at`` — soft-delete; matches the
+  ``playbooks.deleted_at`` posture from migration 0034. Upsert
+  revives the row by setting back to NULL.
+
+Indexes
+-------
+
+* ``team_id`` — covered by the unique constraint; no separate index.
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-05-22
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "slack_workspaces",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("team_id", sa.Text(), nullable=False),
+        sa.Column("team_name", sa.Text(), nullable=False),
+        sa.Column("bot_token_encrypted", sa.LargeBinary(), nullable=False),
+        sa.Column("bot_user_id", sa.Text(), nullable=False),
+        sa.Column("installer_slack_user_id", sa.Text(), nullable=False),
+        sa.Column("scope", sa.Text(), nullable=False),
+        sa.Column(
+            "installed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "deleted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.UniqueConstraint("team_id", name="uq_slack_workspaces_team_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("slack_workspaces")

--- a/api/app/api/__init__.py
+++ b/api/app/api/__init__.py
@@ -32,6 +32,7 @@ from app.api import (
     files,
     inference,
     inference_override,
+    integrations_slack,
     internal,
     knowledge_bases,
     models,
@@ -63,6 +64,12 @@ api_router.include_router(bootstrap.router)
 # shared X-LQ-AI-Gateway-Key header per ADR 0006, NOT by the user-token
 # gate. Mounted without `_active` deliberately: the gateway has no user.
 api_router.include_router(internal.router)
+
+# M3-D1: slack-bridge → api persistence surface. Authenticated by the
+# shared LQ_AI_BRIDGE_TOKEN bearer header at the handler level, NOT by
+# the user-token gate. Mounted without `_active` deliberately: the
+# bridge is a service-to-service caller with no user context.
+api_router.include_router(integrations_slack.router)
 
 # M3-B8 — Word add-in version handshake. Unauthenticated: the task pane
 # calls this on mount BEFORE the user has signed in, so an out-of-date

--- a/api/app/api/integrations_slack.py
+++ b/api/app/api/integrations_slack.py
@@ -1,0 +1,146 @@
+"""Bridge persistence surface for Slack workspace records — M3-D1.
+
+The slack-bridge service runs the OAuth dance with Slack then POSTs the
+resulting workspace tuple here. The bridge authenticates with a shared
+bearer token (``LQ_AI_BRIDGE_TOKEN``) — NOT a user JWT, because the
+bridge is a service-to-service caller with no user context.
+
+The router is mounted WITHOUT the ``_active`` user gate (parallels
+:mod:`app.api.internal` which is also a service-to-service surface).
+Auth happens per-handler via :func:`require_bridge_auth`.
+
+Decision M3-D1-2 (re-install semantics): the POST endpoint upserts on
+``team_id``. Slack rotates bot tokens on re-install, so an existing
+row's ``bot_token_encrypted`` + ``installer_slack_user_id`` + ``scope``
+are replaced; a soft-deleted row (``deleted_at IS NOT NULL``) is
+revived.
+
+Decision M3-D1-1 (encryption key): the bot token is encrypted under
+:envvar:`LQ_AI_BRIDGE_MASTER_KEY` (NOT the gateway's master key) before
+persistence.
+
+Decision M3-D1-3 (token storage): ``LQ_AI_BRIDGE_TOKEN`` lives in the
+api's :class:`Settings` only — the gateway has no Slack-bridge role so
+its secret surface stays minimal.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import Settings, get_settings
+from app.db.session import get_db
+from app.errors import InternalError, Unauthorized
+from app.models.slack_workspace import SlackWorkspace
+from app.schemas.slack_workspace import SlackWorkspaceCreate, SlackWorkspaceResponse
+from app.security.encryption import BridgeTokenEncryptor
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/integrations/slack", tags=["integrations-slack"])
+
+
+def require_bridge_auth(
+    settings: Annotated[Settings, Depends(get_settings)],
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+) -> None:
+    """Constant-time match the ``Authorization: Bearer …`` token.
+
+    Raises:
+      * :class:`InternalError` (500) if ``LQ_AI_BRIDGE_TOKEN`` is unset
+        on the api — accepting bridge traffic with no enforced secret
+        would silently break the trust contract.
+      * :class:`Unauthorized` (401) on missing, malformed, or
+        non-matching bearer.
+    """
+
+    expected = settings.lq_ai_bridge_token
+    if not expected:
+        log.error(
+            "LQ_AI_BRIDGE_TOKEN is not set on the api/ service; refusing "
+            "slack-bridge traffic. Set the env var and restart."
+        )
+        raise InternalError(
+            message=(
+                "Bridge authentication is not configured on the backend. "
+                "Operator must set LQ_AI_BRIDGE_TOKEN."
+            ),
+        )
+
+    presented = ""
+    if authorization and authorization.startswith("Bearer "):
+        presented = authorization[len("Bearer ") :].strip()
+
+    if not presented or not secrets.compare_digest(presented, expected):
+        raise Unauthorized(
+            message="Invalid or missing bridge bearer token.",
+            details={"header": "Authorization"},
+        )
+
+
+@router.post(
+    "/workspaces",
+    response_model=SlackWorkspaceResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_bridge_auth)],
+)
+async def upsert_slack_workspace(
+    body: SlackWorkspaceCreate,
+    settings: Annotated[Settings, Depends(get_settings)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> SlackWorkspaceResponse:
+    """Persist (or upsert) the workspace record from the bridge.
+
+    Upserts on ``team_id``. On conflict:
+      * ``team_name`` is refreshed from the request body (operator may
+        have renamed the workspace in Slack).
+      * ``bot_token_encrypted`` is replaced (Slack rotates tokens on
+        re-install).
+      * ``bot_user_id`` is refreshed (Slack may have issued a new bot
+        user across the re-install).
+      * ``installer_slack_user_id`` is refreshed (a different operator
+        may be reinstalling).
+      * ``scope`` is replaced (consent may have changed).
+      * ``deleted_at`` is set back to NULL (re-install revives soft-
+        deleted rows).
+      * ``installed_at`` stays at the original install time; the
+        re-install does not reset the audit timestamp. Operators can
+        infer re-install activity from the bot-token ciphertext
+        changing without the install timestamp moving.
+    """
+
+    encryptor = BridgeTokenEncryptor(master_key=settings.lq_ai_bridge_master_key or None)
+    bot_token_encrypted = encryptor.encrypt(body.bot_token)
+
+    existing = (
+        await db.execute(select(SlackWorkspace).where(SlackWorkspace.team_id == body.team_id))
+    ).scalar_one_or_none()
+
+    if existing is None:
+        workspace = SlackWorkspace(
+            team_id=body.team_id,
+            team_name=body.team_name,
+            bot_token_encrypted=bot_token_encrypted,
+            bot_user_id=body.bot_user_id,
+            installer_slack_user_id=body.installer_slack_user_id,
+            scope=body.scope,
+        )
+        db.add(workspace)
+    else:
+        existing.team_name = body.team_name
+        existing.bot_token_encrypted = bot_token_encrypted
+        existing.bot_user_id = body.bot_user_id
+        existing.installer_slack_user_id = body.installer_slack_user_id
+        existing.scope = body.scope
+        existing.deleted_at = None
+        workspace = existing
+
+    await db.commit()
+    await db.refresh(workspace)
+    return SlackWorkspaceResponse.model_validate(workspace)

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -286,6 +286,31 @@ class Settings(BaseSettings):
         ),
     )
 
+    # ----- M3-D1 slack-bridge integration -----
+    # The slack-bridge runs the OAuth dance with Slack then POSTs the
+    # resulting workspace record to
+    # ``POST /api/v1/integrations/slack/workspaces``. Both secrets here
+    # live on the api ONLY (NOT on the gateway): the gateway has no
+    # role in the Slack OAuth surface, and keeping its secret surface
+    # minimal is a load-bearing posture. Different from the gateway's
+    # ``LQ_AI_GATEWAY_MASTER_KEY`` on purpose — Slack bot tokens enable
+    # bot impersonation; provider keys enable inference routing.
+    # Different blast radii → different keys.
+    lq_ai_bridge_token: str = Field(
+        default="",
+        description=(
+            "Shared bearer token the slack-bridge presents on POSTs to "
+            "/api/v1/integrations/slack/workspaces. Constant-time matched."
+        ),
+    )
+    lq_ai_bridge_master_key: str = Field(
+        default="",
+        description=(
+            "urlsafe-base64 Fernet master key used to encrypt Slack bot "
+            "tokens at rest (and any future bridge-issued secret)."
+        ),
+    )
+
     # ----- Operational -----
     log_level: LogLevel = Field(default="info", description="Log level for the api/ service.")
     lq_ai_dev_mode: bool = Field(

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.playbook import Playbook, PlaybookExecution, PlaybookPosition
 from app.models.project import Project, ProjectFile, ProjectSkill
 from app.models.project_knowledge_base import ProjectKnowledgeBase
 from app.models.saved_prompt import SavedPrompt
+from app.models.slack_workspace import SlackWorkspace
 from app.models.tabular import TabularExecution
 from app.models.team import Team, TeamMember
 from app.models.user import User, UserSession
@@ -49,6 +50,7 @@ __all__ = [
     "ProjectKnowledgeBase",
     "ProjectSkill",
     "SavedPrompt",
+    "SlackWorkspace",
     "TabularExecution",
     "Team",
     "TeamMember",

--- a/api/app/models/slack_workspace.py
+++ b/api/app/models/slack_workspace.py
@@ -1,0 +1,52 @@
+"""SlackWorkspace ORM — M3-D1.
+
+Persists Slack workspace records produced by the ``slack-bridge`` OAuth
+install flow. The bot token is stored encrypted at rest under
+:envvar:`LQ_AI_BRIDGE_MASTER_KEY` via
+:class:`app.security.encryption.BridgeTokenEncryptor`. See migration
+``0037_slack_workspaces.py`` for the table DDL.
+
+One workspace per Slack team (``team_id`` is unique). The persistence
+endpoint upserts on ``team_id`` so a re-install (Slack rotates the bot
+token) replaces the prior row's ciphertext + installer + scope and
+revives ``deleted_at`` if the workspace had been soft-deleted.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, LargeBinary, Text, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class SlackWorkspace(Base):
+    """One Slack workspace connected via the bridge OAuth install flow."""
+
+    __tablename__ = "slack_workspaces"
+    __table_args__ = (UniqueConstraint("team_id", name="uq_slack_workspaces_team_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    team_id: Mapped[str] = mapped_column(Text, nullable=False)
+    team_name: Mapped[str] = mapped_column(Text, nullable=False)
+    bot_token_encrypted: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    bot_user_id: Mapped[str] = mapped_column(Text, nullable=False)
+    installer_slack_user_id: Mapped[str] = mapped_column(Text, nullable=False)
+    scope: Mapped[str] = mapped_column(Text, nullable=False)
+    installed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )

--- a/api/app/schemas/slack_workspace.py
+++ b/api/app/schemas/slack_workspace.py
@@ -1,0 +1,69 @@
+"""Pydantic wire shapes for the slack-bridge persistence surface — M3-D1.
+
+The slack-bridge service runs the OAuth dance with Slack and POSTs the
+resulting workspace tuple to
+``POST /api/v1/integrations/slack/workspaces`` on the api. This module
+defines the request body (:class:`SlackWorkspaceCreate`) and the
+response shape (:class:`SlackWorkspaceResponse`). The bot token is
+plaintext on the wire (the request travels over the trusted in-cluster
+network with a bearer token) and encrypted before persistence.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SlackWorkspaceCreate(BaseModel):
+    """Workspace record the slack-bridge POSTs after OAuth completes.
+
+    Field shape matches what ``slack-bridge/app/oauth.py`` produces from
+    Slack's ``oauth.v2.access`` response (see lines 184-191 in that
+    file). Renames here would break the bridge → api contract.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    team_id: str = Field(..., min_length=1, description="Slack workspace id (T0...).")
+    team_name: str = Field(..., min_length=1, description="Workspace display name at install time.")
+    bot_token: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "The xoxb- bot user OAuth token Slack returned. Plaintext on the wire; "
+            "encrypted under LQ_AI_BRIDGE_MASTER_KEY before persistence."
+        ),
+    )
+    bot_user_id: str = Field(..., min_length=1, description="Slack user id of the bot user.")
+    installer_slack_user_id: str = Field(
+        ...,
+        min_length=1,
+        description="Slack user id of the operator who completed install (audit only).",
+    )
+    scope: str = Field(
+        ...,
+        min_length=1,
+        description="Comma-separated scope list Slack returned (e.g. 'commands,chat:write').",
+    )
+
+
+class SlackWorkspaceResponse(BaseModel):
+    """Persisted-workspace response. Bot token deliberately omitted.
+
+    The bridge does not need the ciphertext echoed back; the response
+    exists so the bridge can log the api-side workspace id for
+    correlation and confirm the upsert path it took.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    team_id: str
+    team_name: str
+    bot_user_id: str
+    installer_slack_user_id: str
+    scope: str
+    installed_at: datetime

--- a/api/app/security/encryption.py
+++ b/api/app/security/encryption.py
@@ -1,0 +1,112 @@
+"""Symmetric-encryption helper for at-rest secrets owned by ``api/``.
+
+The first caller is M3-D1's ``slack_workspaces`` table, where bot tokens
+are persisted encrypted under a master key the operator supplies via
+:envvar:`LQ_AI_BRIDGE_MASTER_KEY`. The intent is to mirror the gateway's
+:mod:`gateway.app.secrets` ADR-0011 pattern (Fernet authenticated
+encryption + urlsafe-base64 master key) without sharing the key
+material between services — Slack bot tokens (bot-impersonation blast
+radius) and provider API keys (inference-routing blast radius) live in
+different threat models, so they get different master keys.
+
+Operators generate the master key once with :func:`generate_master_key`
+and store it however they store other small high-value secrets — a
+password manager, a hardware token, a secrets vault. The key is read
+from the environment at adapter construction time and held in memory;
+nothing in this module persists it.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from cryptography.fernet import Fernet, InvalidToken
+
+__all__ = [
+    "BRIDGE_MASTER_KEY_ENV",
+    "BridgeEncryptionError",
+    "BridgeMasterKeyMissing",
+    "BridgeTokenEncryptor",
+    "generate_master_key",
+]
+
+
+BRIDGE_MASTER_KEY_ENV = "LQ_AI_BRIDGE_MASTER_KEY"
+"""Environment variable the api reads to bind its bridge master key.
+
+Distinct from ``LQ_AI_GATEWAY_MASTER_KEY`` on purpose — see module
+docstring."""
+
+
+class BridgeMasterKeyMissing(RuntimeError):
+    """Raised when an encrypt/decrypt is requested without a master key."""
+
+
+class BridgeEncryptionError(RuntimeError):
+    """Raised when a ciphertext cannot be decrypted with the master key.
+
+    Wrong master key vs corrupted/tampered ciphertext are indistinguishable
+    by Fernet design (AEAD rejects both with the same error).
+    """
+
+
+def generate_master_key() -> str:
+    """Generate a fresh urlsafe-base64 master key (32 bytes / 256 bits)."""
+
+    return Fernet.generate_key().decode("ascii")
+
+
+def _fernet_from(master_key: str | None) -> Fernet:
+    if not master_key:
+        raise BridgeMasterKeyMissing(
+            f"{BRIDGE_MASTER_KEY_ENV} is not set. Generate a master key with "
+            f"`python -c 'from app.security.encryption import generate_master_key; "
+            f"print(generate_master_key())'` and export it before starting the api."
+        )
+    try:
+        return Fernet(master_key.encode("ascii") if isinstance(master_key, str) else master_key)
+    except (ValueError, TypeError) as exc:
+        raise BridgeMasterKeyMissing(
+            f"{BRIDGE_MASTER_KEY_ENV} is malformed (must be urlsafe-base64 of 32 bytes): {exc}"
+        ) from exc
+
+
+@dataclass
+class BridgeTokenEncryptor:
+    """Encrypt and decrypt bridge-issued secrets (e.g., Slack bot tokens).
+
+    Constructed once per request scope from :data:`BRIDGE_MASTER_KEY_ENV`
+    via :meth:`from_environ`; tests construct directly with their own
+    master key to stay hermetic.
+
+    Both :meth:`encrypt` and :meth:`decrypt` operate on ``bytes`` on the
+    storage side (the column type is ``bytea`` so the ORM sees ``bytes``)
+    and ``str`` on the plaintext side (Slack bot tokens are ASCII).
+    """
+
+    master_key: str | None
+
+    @classmethod
+    def from_environ(cls) -> BridgeTokenEncryptor:
+        return cls(master_key=os.environ.get(BRIDGE_MASTER_KEY_ENV) or None)
+
+    def encrypt(self, plaintext: str) -> bytes:
+        """Wrap ``plaintext`` and return the Fernet token as ``bytes``."""
+
+        if not plaintext:
+            raise ValueError("encrypt() requires a non-empty plaintext")
+        fernet = _fernet_from(self.master_key)
+        return fernet.encrypt(plaintext.encode("utf-8"))
+
+    def decrypt(self, ciphertext: bytes) -> str:
+        """Unwrap ``ciphertext`` and return the plaintext string."""
+
+        fernet = _fernet_from(self.master_key)
+        try:
+            return fernet.decrypt(ciphertext).decode("utf-8")
+        except InvalidToken as exc:
+            raise BridgeEncryptionError(
+                f"bridge ciphertext does not decrypt under {BRIDGE_MASTER_KEY_ENV}. "
+                f"Wrong master key, or the token was generated with a different one."
+            ) from exc

--- a/api/tests/test_encryption.py
+++ b/api/tests/test_encryption.py
@@ -1,0 +1,74 @@
+"""Unit tests for the api-side bridge-secret encryptor (M3-D1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.security.encryption import (
+    BRIDGE_MASTER_KEY_ENV,
+    BridgeEncryptionError,
+    BridgeMasterKeyMissing,
+    BridgeTokenEncryptor,
+    generate_master_key,
+)
+
+
+@pytest.mark.unit
+def test_generate_master_key_is_fernet_compatible() -> None:
+    key = generate_master_key()
+    enc = BridgeTokenEncryptor(master_key=key)
+    ciphertext = enc.encrypt("xoxb-fake")
+    assert enc.decrypt(ciphertext) == "xoxb-fake"
+
+
+@pytest.mark.unit
+def test_encrypt_emits_distinct_ciphertexts_for_same_plaintext() -> None:
+    enc = BridgeTokenEncryptor(master_key=generate_master_key())
+    a = enc.encrypt("xoxb-fake")
+    b = enc.encrypt("xoxb-fake")
+    assert a != b
+
+
+@pytest.mark.unit
+def test_encrypt_rejects_empty_plaintext() -> None:
+    enc = BridgeTokenEncryptor(master_key=generate_master_key())
+    with pytest.raises(ValueError):
+        enc.encrypt("")
+
+
+@pytest.mark.unit
+def test_encrypt_without_master_key_raises_missing() -> None:
+    enc = BridgeTokenEncryptor(master_key=None)
+    with pytest.raises(BridgeMasterKeyMissing):
+        enc.encrypt("xoxb-fake")
+
+
+@pytest.mark.unit
+def test_decrypt_with_wrong_master_key_raises_encryption_error() -> None:
+    enc_a = BridgeTokenEncryptor(master_key=generate_master_key())
+    enc_b = BridgeTokenEncryptor(master_key=generate_master_key())
+    ciphertext = enc_a.encrypt("xoxb-fake")
+    with pytest.raises(BridgeEncryptionError):
+        enc_b.decrypt(ciphertext)
+
+
+@pytest.mark.unit
+def test_malformed_master_key_raises_missing() -> None:
+    enc = BridgeTokenEncryptor(master_key="not-a-real-fernet-key")
+    with pytest.raises(BridgeMasterKeyMissing):
+        enc.encrypt("xoxb-fake")
+
+
+@pytest.mark.unit
+def test_from_environ_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    key = generate_master_key()
+    monkeypatch.setenv(BRIDGE_MASTER_KEY_ENV, key)
+    enc = BridgeTokenEncryptor.from_environ()
+    assert enc.master_key == key
+
+
+@pytest.mark.unit
+def test_from_environ_returns_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(BRIDGE_MASTER_KEY_ENV, raising=False)
+    enc = BridgeTokenEncryptor.from_environ()
+    assert enc.master_key is None

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -205,6 +205,8 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("GET", "/api/v1/admin/word-addin/manifest"),
     # M3-B8 — Word add-in version handshake (unauthenticated)
     ("GET", "/api/v1/word-addin/version"),
+    # M3-D1 — slack-bridge persistence surface (bridge-token bearer auth)
+    ("POST", "/api/v1/integrations/slack/workspaces"),
     # D4 — Organization Profile singleton
     ("GET", "/api/v1/organization-profile"),
     ("PUT", "/api/v1/organization-profile"),

--- a/api/tests/test_integrations_slack.py
+++ b/api/tests/test_integrations_slack.py
@@ -1,0 +1,266 @@
+"""Integration tests for M3-D1's slack-bridge persistence endpoint.
+
+Covers ``POST /api/v1/integrations/slack/workspaces``:
+
+* Auth — valid bridge bearer → 201; missing → 401; wrong → 401;
+  unset operator token on the api → 500.
+* Upsert semantics — re-POSTing the same ``team_id`` replaces the
+  encrypted bot token + scope + installer; resurrects soft-deleted
+  rows; does NOT move ``installed_at``.
+* Encryption roundtrip — the persisted ``bot_token_encrypted`` value
+  decrypts under the configured master key and is NOT the plaintext.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.db.session import get_db
+from app.main import app
+from app.models.slack_workspace import SlackWorkspace
+from app.security.encryption import BridgeTokenEncryptor, generate_master_key
+
+BRIDGE_TOKEN = "bridge-token-fixture-value"
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def configured_settings(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set both bridge env vars + clear the Settings cache for the test."""
+    master_key = generate_master_key()
+    monkeypatch.setenv("LQ_AI_BRIDGE_TOKEN", BRIDGE_TOKEN)
+    monkeypatch.setenv("LQ_AI_BRIDGE_MASTER_KEY", master_key)
+    get_settings.cache_clear()
+    yield master_key
+    get_settings.cache_clear()
+
+
+@pytest_asyncio.fixture
+async def client(
+    db_session: AsyncSession,
+    configured_settings: str,
+) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def unconfigured_client(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[AsyncClient]:
+    """Client where the operator has NOT set ``LQ_AI_BRIDGE_TOKEN``."""
+    monkeypatch.delenv("LQ_AI_BRIDGE_TOKEN", raising=False)
+    monkeypatch.delenv("LQ_AI_BRIDGE_MASTER_KEY", raising=False)
+    get_settings.cache_clear()
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+    get_settings.cache_clear()
+
+
+def _workspace_body(**overrides: str) -> dict[str, str]:
+    base = {
+        "team_id": "T01234567",
+        "team_name": "Acme Legal",
+        "bot_token": "xoxb-fixture-bot-token",
+        "bot_user_id": "U99999999",
+        "installer_slack_user_id": "U11111111",
+        "scope": "commands,chat:write",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_post_workspaces_with_valid_bearer_returns_201(
+    client: AsyncClient,
+) -> None:
+    res = await client.post(
+        "/api/v1/integrations/slack/workspaces",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_workspace_body(),
+    )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["team_id"] == "T01234567"
+    assert body["team_name"] == "Acme Legal"
+    assert body["bot_user_id"] == "U99999999"
+    assert body["installer_slack_user_id"] == "U11111111"
+    assert body["scope"] == "commands,chat:write"
+    assert "bot_token" not in body  # response omits ciphertext + plaintext
+
+
+@pytest.mark.integration
+async def test_post_workspaces_without_bearer_returns_401(
+    client: AsyncClient,
+) -> None:
+    res = await client.post(
+        "/api/v1/integrations/slack/workspaces",
+        json=_workspace_body(),
+    )
+    assert res.status_code == 401
+
+
+@pytest.mark.integration
+async def test_post_workspaces_with_wrong_bearer_returns_401(
+    client: AsyncClient,
+) -> None:
+    res = await client.post(
+        "/api/v1/integrations/slack/workspaces",
+        headers={"Authorization": "Bearer not-the-real-token"},
+        json=_workspace_body(),
+    )
+    assert res.status_code == 401
+
+
+@pytest.mark.integration
+async def test_post_workspaces_when_bridge_token_unset_returns_500(
+    unconfigured_client: AsyncClient,
+) -> None:
+    """Operator misconfiguration — refuse traffic rather than running open."""
+    res = await unconfigured_client.post(
+        "/api/v1/integrations/slack/workspaces",
+        headers={"Authorization": "Bearer anything"},
+        json=_workspace_body(),
+    )
+    assert res.status_code == 500
+
+
+@pytest.mark.integration
+async def test_post_workspaces_with_malformed_authorization_header_returns_401(
+    client: AsyncClient,
+) -> None:
+    """``Authorization: bridge-token`` (no Bearer prefix) is rejected."""
+    res = await client.post(
+        "/api/v1/integrations/slack/workspaces",
+        headers={"Authorization": BRIDGE_TOKEN},
+        json=_workspace_body(),
+    )
+    assert res.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Upsert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_post_workspaces_upserts_on_team_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Re-POSTing the same team_id replaces token + scope + installer."""
+    first = await client.post(
+        "/api/v1/integrations/slack/workspaces",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_workspace_body(),
+    )
+    assert first.status_code == 201
+    first_id = first.json()["id"]
+
+    second = await client.post(
+        "/api/v1/integrations/slack/workspaces",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_workspace_body(
+            team_name="Acme Legal (renamed)",
+            bot_token="xoxb-rotated-fixture-token",
+            installer_slack_user_id="U22222222",
+            scope="commands,chat:write,channels:read",
+        ),
+    )
+    assert second.status_code == 201
+    assert second.json()["id"] == first_id  # same row
+    assert second.json()["team_name"] == "Acme Legal (renamed)"
+    assert second.json()["installer_slack_user_id"] == "U22222222"
+    assert second.json()["scope"] == "commands,chat:write,channels:read"
+
+    rows = (await db_session.execute(select(SlackWorkspace))).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.integration
+async def test_post_workspaces_resurrects_soft_deleted_row(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    res = await client.post(
+        "/api/v1/integrations/slack/workspaces",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_workspace_body(),
+    )
+    assert res.status_code == 201
+
+    row = (
+        await db_session.execute(
+            select(SlackWorkspace).where(SlackWorkspace.team_id == "T01234567")
+        )
+    ).scalar_one()
+    row.deleted_at = datetime.now(tz=UTC)
+    await db_session.commit()
+
+    revived = await client.post(
+        "/api/v1/integrations/slack/workspaces",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_workspace_body(bot_token="xoxb-after-reinstall"),
+    )
+    assert revived.status_code == 201
+
+    await db_session.refresh(row)
+    assert row.deleted_at is None
+
+
+# ---------------------------------------------------------------------------
+# Encryption roundtrip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_persisted_bot_token_is_encrypted_and_decrypts(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    configured_settings: str,
+) -> None:
+    res = await client.post(
+        "/api/v1/integrations/slack/workspaces",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_workspace_body(),
+    )
+    assert res.status_code == 201
+
+    row = (
+        await db_session.execute(
+            select(SlackWorkspace).where(SlackWorkspace.team_id == "T01234567")
+        )
+    ).scalar_one()
+
+    assert isinstance(row.bot_token_encrypted, bytes)
+    assert b"xoxb-fixture-bot-token" not in row.bot_token_encrypted
+    decrypted = BridgeTokenEncryptor(master_key=configured_settings).decrypt(
+        row.bot_token_encrypted
+    )
+    assert decrypted == "xoxb-fixture-bot-token"

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -146,6 +146,8 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/tabular/executions",
         "/api/v1/tabular/executions/{execution_id}",
         "/api/v1/tabular/executions/{execution_id}/cancel",
+        # M3-D1 — slack-bridge persistence surface (bearer-token, no user)
+        "/api/v1/integrations/slack/workspaces",
     }
 )
 
@@ -198,7 +200,11 @@ async def test_openapi_paths_match_sketch() -> None:
     #    /tabular/executions/{id}, /tabular/executions/{id}/cancel).
     #   DELETE on /executions/{id} shares the GET path so it adds zero
     #   new paths here; the method-tuple count is in test_endpoints.py.
-    assert len(actual) == 88
+    # + M3-D1's one NEW path for the slack-bridge persistence surface
+    #   (POST /integrations/slack/workspaces). One method-tuple here;
+    #   the bridge is the sole caller so additional verbs aren't needed
+    #   in M3-D1 (uninstall comes in M3-D4 admin UI work).
+    assert len(actual) == 89
 
 
 @pytest.mark.unit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,11 @@ services:
       # not mutate it (skill authoring is a host-side / human-attestation
       # workflow per CLAUDE.md "Working with skills").
       LQ_AI_SKILLS_DIR: ${LQ_AI_SKILLS_DIR:-/skills}
+      # M3-D1 slack-bridge integration. Both optional: only required for
+      # operators who enable the `slack` compose profile. The api refuses
+      # bridge traffic with 500 when either is unset.
+      LQ_AI_BRIDGE_TOKEN: ${LQ_AI_BRIDGE_TOKEN:-}
+      LQ_AI_BRIDGE_MASTER_KEY: ${LQ_AI_BRIDGE_MASTER_KEY:-}
     volumes:
       - ./skills:/skills:ro
     ports:
@@ -396,6 +401,53 @@ services:
     restart: "no"
     # Disabled in M1; placeholder so Mode 2 ops know where it goes.
     entrypoint: ["sh", "-c", "echo 'PaddleOCR-VL service lands in M2.'; sleep 1"]
+
+  # ============================================================
+  # Integration bridges (PRD §3.15 — opt-in by Compose profile)
+  # ============================================================
+
+  slack-bridge:
+    # M3-D1 — Slack OAuth + webhook bridge. Gated by the ``slack``
+    # profile so operators who don't use Slack don't pay the SBOM cost
+    # or run a service they have nothing to do with.
+    #
+    # Bring up with: ``docker compose --profile slack up -d slack-bridge``
+    #
+    # Credentials come from the operator's Slack App admin UI
+    # (SLACK_CLIENT_ID / SLACK_CLIENT_SECRET / SLACK_SIGNING_SECRET);
+    # LQ_AI_BRIDGE_TOKEN is the shared secret the bridge presents on
+    # internal calls to the api (the api validates with the same env
+    # var). LQ_AI_BRIDGE_PUBLIC_URL is the externally reachable URL
+    # Slack will hit on OAuth callback — operators typically front
+    # this with their reverse proxy.
+    build:
+      context: ./slack-bridge
+      dockerfile: Dockerfile
+    profiles: ["slack"]
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      # Slack-side credentials (operator obtains from Slack App admin UI)
+      SLACK_CLIENT_ID: ${SLACK_CLIENT_ID:?SLACK_CLIENT_ID is required when slack profile is enabled}
+      SLACK_CLIENT_SECRET: ${SLACK_CLIENT_SECRET:?SLACK_CLIENT_SECRET is required when slack profile is enabled}
+      SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:?SLACK_SIGNING_SECRET is required when slack profile is enabled}
+      # LQ.AI-side coordinates
+      LQ_AI_BACKEND_URL: ${LQ_AI_BACKEND_URL:-http://api:8000}
+      LQ_AI_BRIDGE_TOKEN: ${LQ_AI_BRIDGE_TOKEN:?LQ_AI_BRIDGE_TOKEN is required when slack profile is enabled}
+      LQ_AI_BRIDGE_PUBLIC_URL: ${LQ_AI_BRIDGE_PUBLIC_URL:?LQ_AI_BRIDGE_PUBLIC_URL is required when slack profile is enabled}
+      # Observability (opt-in)
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-lq-ai-slack-bridge}
+      LQ_AI_BRIDGE_LOG_LEVEL: ${LQ_AI_BRIDGE_LOG_LEVEL:-INFO}
+    ports:
+      - "${SLACK_BRIDGE_BIND_ADDR:-127.0.0.1}:${SLACK_BRIDGE_HOST_PORT:-8002}:8002"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8002/healthz', timeout=2).status == 200 else 1)"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
 # ============================================================
 # Persistent volumes (PRD §6.5)

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -3446,6 +3446,53 @@ paths:
         '404':
           description: Chat not found
 
+  # ============================================================
+  # M3-D1 — slack-bridge persistence surface
+  # ============================================================
+
+  /api/v1/integrations/slack/workspaces:
+    post:
+      tags: [integrations-slack]
+      summary: Persist a Slack workspace from the slack-bridge OAuth flow (M3-D1)
+      description: |
+        Service-to-service endpoint. Authenticated by a shared
+        `Authorization: Bearer ${LQ_AI_BRIDGE_TOKEN}` token (NOT a user
+        JWT) — the slack-bridge is the only intended caller.
+
+        The bridge POSTs the workspace tuple after the operator
+        completes the Slack OAuth install flow at
+        `${LQ_AI_BRIDGE_PUBLIC_URL}/slack/oauth/install`. The api
+        encrypts the bot token at rest under `LQ_AI_BRIDGE_MASTER_KEY`
+        (a separate Fernet master key from the gateway's
+        `LQ_AI_GATEWAY_MASTER_KEY` — different threat models) and
+        upserts on `team_id` so a re-install (Slack rotates bot tokens
+        on re-install) replaces the old ciphertext + scope + installer
+        in place. Soft-deleted rows revive on re-install.
+
+        500 (not 401) is the response when the operator hasn't set
+        `LQ_AI_BRIDGE_TOKEN` on the api — accepting bridge traffic
+        with no enforced secret would silently break the trust
+        contract.
+      security:
+        - bridgeBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SlackWorkspaceCreate'
+      responses:
+        '201':
+          description: Persisted (or upserted) the workspace record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SlackWorkspaceResponse'
+        '401':
+          description: Missing, malformed, or non-matching bridge bearer token
+        '500':
+          description: Operator has not configured `LQ_AI_BRIDGE_TOKEN` on the api
+
 # ============================================================
 # COMPONENTS
 # ============================================================
@@ -3466,8 +3513,110 @@ components:
         same secret is used in the reverse direction (backend → gateway)
         for incoming-request auth on the gateway's surface, though the
         gateway-side enforcement is a deferred D-phase item.
+    bridgeBearerAuth:
+      type: http
+      scheme: bearer
+      description: |
+        Shared-secret bearer token the slack-bridge service presents
+        on POSTs to `/api/v1/integrations/slack/workspaces` (M3-D1).
+        Constant-time compare against `LQ_AI_BRIDGE_TOKEN` on the
+        backend. Distinct from `gatewayKeyAuth` — the bridge and the
+        gateway have separate service identities and separate
+        threat models.
 
   schemas:
+    SlackWorkspaceCreate:
+      type: object
+      description: |
+        Request body for `POST /api/v1/integrations/slack/workspaces`
+        (M3-D1). Shape matches what `slack-bridge/app/oauth.py`
+        constructs from Slack's `oauth.v2.access` response after the
+        operator completes consent. The bridge → api contract is
+        position-coupled to this shape; renames here would break it.
+      required:
+        - team_id
+        - team_name
+        - bot_token
+        - bot_user_id
+        - installer_slack_user_id
+        - scope
+      additionalProperties: false
+      properties:
+        team_id:
+          type: string
+          minLength: 1
+          description: Slack workspace id (T0...).
+          example: 'T01234567'
+        team_name:
+          type: string
+          minLength: 1
+          description: Workspace display name at install time.
+          example: 'Acme Legal'
+        bot_token:
+          type: string
+          minLength: 1
+          description: |
+            The xoxb- bot user OAuth token Slack returned. Plaintext
+            on the wire (the request travels over the trusted
+            in-cluster network with a bridge bearer token); encrypted
+            under `LQ_AI_BRIDGE_MASTER_KEY` before persistence.
+          example: 'xoxb-...'
+        bot_user_id:
+          type: string
+          minLength: 1
+          description: Slack user id of the bot user.
+          example: 'U99BOT'
+        installer_slack_user_id:
+          type: string
+          minLength: 1
+          description: Slack user id of the operator who completed install (audit only).
+          example: 'U11INSTALLER'
+        scope:
+          type: string
+          minLength: 1
+          description: Comma-separated scope list Slack returned.
+          example: 'commands,chat:write'
+
+    SlackWorkspaceResponse:
+      type: object
+      description: |
+        Persisted-workspace response for `POST
+        /api/v1/integrations/slack/workspaces`. Bot token is
+        deliberately omitted — neither the plaintext nor the
+        ciphertext is echoed back to the bridge.
+      required:
+        - id
+        - team_id
+        - team_name
+        - bot_user_id
+        - installer_slack_user_id
+        - scope
+        - installed_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: api-side workspace row id.
+        team_id:
+          type: string
+          example: 'T01234567'
+        team_name:
+          type: string
+          example: 'Acme Legal'
+        bot_user_id:
+          type: string
+          example: 'U99BOT'
+        installer_slack_user_id:
+          type: string
+          example: 'U11INSTALLER'
+        scope:
+          type: string
+          example: 'commands,chat:write'
+        installed_at:
+          type: string
+          format: date-time
+          description: Original install timestamp. NOT moved by upsert.
+
     WordAddinVersionResponse:
       type: object
       description: |

--- a/slack-bridge/Dockerfile
+++ b/slack-bridge/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.7
+
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+RUN pip install --no-cache-dir .
+
+COPY app/ ./app/
+
+EXPOSE 8002
+
+# The slack-bridge is a lightweight HTTP service — no migrations, no
+# external storage. uvicorn runs the FastAPI app directly. Operators
+# in air-gapped environments who do not use Slack should not run this
+# service at all; the docker-compose `slack` profile gates startup.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -1,0 +1,82 @@
+# LQ.AI Slack Bridge (M3-D1)
+
+The Slack bridge is a small standalone service that mediates between Slack's
+OAuth / Events APIs and the LQ.AI backend. It ships with the M3 release as
+**plumbing-only**: the `/lq` slash command surface (M3-D2) is descoped to M4 /
+community contribution per [PRD §9 DE-288](../docs/PRD.md#de-288--slackteams-lq-slash-command--quick-skill-flow--deferred-to-m4--community-contribution).
+
+## What it does today (v0.3.0)
+
+- Hosts the OAuth install flow at `/slack/oauth/install` → Slack consent →
+  `/slack/oauth/callback` → workspace persistence in the LQ.AI api.
+- Verifies inbound Slack request signatures (`X-Slack-Signature` /
+  `X-Slack-Request-Timestamp`) on every webhook so M3-D2's slash-command
+  handler lands on a verified substrate.
+- Health surface: `/healthz` (liveness) + `/readyz` (readiness — checks the
+  LQ.AI api is reachable on the configured `LQ_AI_BACKEND_URL`).
+
+## What it does NOT do today
+
+- **Slash commands** — `/lq` and `/lq ask`, per DE-288, are deferred.
+- **Inbound message handling** — the bot does not read silent channels; it
+  only acts on user-invoked commands (when those land in M3-D2 / community).
+- **Per-user identity binding** — Slack user ↔ LQ.AI user mapping is in
+  M3-D4's admin UI scope. The bridge persists the workspace record; the
+  admin UI binds Slack identities to LQ.AI accounts.
+
+## Configuration
+
+| Env var | Required | Purpose |
+|---|---|---|
+| `SLACK_CLIENT_ID` | yes | OAuth client id (from Slack App admin UI) |
+| `SLACK_CLIENT_SECRET` | yes | OAuth client secret |
+| `SLACK_SIGNING_SECRET` | yes | Inbound webhook signature verification |
+| `LQ_AI_BACKEND_URL` | yes | Base URL of the lq-ai api (e.g. `http://api:8000`) |
+| `LQ_AI_BRIDGE_TOKEN` | yes | Shared secret the bridge sends on internal calls to the api |
+| `LQ_AI_BRIDGE_PUBLIC_URL` | yes | Public base URL of the bridge — used to build the OAuth `redirect_uri` Slack calls back to (e.g. `https://lqai.example.com/slack`) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | no | OpenTelemetry exporter — opt-in per PRD §5.7 |
+| `OTEL_SERVICE_NAME` | no | Defaults to `lq-ai-slack-bridge` |
+| `LQ_AI_BRIDGE_LOG_LEVEL` | no | Defaults to `INFO` |
+
+## Running locally
+
+```bash
+docker compose --profile slack up -d slack-bridge
+```
+
+The slack-bridge service ships behind the `slack` Compose profile so operators
+who do not use Slack don't pay the SBOM cost. See `docker-compose.yml` for the
+service definition.
+
+## Slack App configuration
+
+`manifest.yml` in this directory is the Slack App manifest. Operators install
+their own Slack App (via the [Slack App Manifest UI](https://api.slack.com/reference/manifests))
+and supply the resulting OAuth credentials via the env vars above.
+
+The manifest declares only the scopes the bridge needs today:
+- `commands` — for the future M3-D2 slash-command surface.
+- `chat:write` — so the bot can post replies in channels it is invited to.
+
+No `channels:read`, no `groups:read`, no `im:read` — the bot does **not** read
+silent channels. It only acts on explicit user-invoked commands.
+
+## Security posture
+
+- Bot tokens never persist in the bridge. They are POSTed to the LQ.AI api
+  on receipt and encrypted there (per the existing secret-management
+  conventions for provider keys).
+- The OAuth state token is held in-memory in the bridge with a 10-minute
+  TTL. A bridge restart between install start and callback invalidates the
+  flow; the operator restarts the install.
+- The internal call from bridge → api carries `LQ_AI_BRIDGE_TOKEN` as a
+  Bearer header. The api verifies it against `LQ_AI_BRIDGE_TOKEN` at every
+  bridge-facing endpoint. The token must be different from any user-facing
+  token.
+
+## Tests
+
+```bash
+cd slack-bridge
+.venv/bin/pytest tests/ -q
+```

--- a/slack-bridge/app/config.py
+++ b/slack-bridge/app/config.py
@@ -1,0 +1,104 @@
+"""Runtime configuration for the LQ.AI Slack Bridge.
+
+Loaded from environment variables via ``pydantic-settings`` (same
+pattern as ``api/`` and ``gateway/``). All Slack secrets are supplied
+by the operator; the bridge holds nothing baked into the image.
+
+The fields divide into three groups:
+
+* **Slack-side credentials** — ``SLACK_CLIENT_ID``, ``SLACK_CLIENT_SECRET``,
+  ``SLACK_SIGNING_SECRET``. These come from the operator's Slack App
+  admin UI (one Slack App per LQ.AI deployment that uses Slack).
+* **LQ.AI-side coordinates** — ``LQ_AI_BACKEND_URL`` (where the api is
+  reachable from inside the compose network) and ``LQ_AI_BRIDGE_TOKEN``
+  (shared secret for the internal bridge → api channel).
+* **Bridge public URL** — ``LQ_AI_BRIDGE_PUBLIC_URL`` is the externally
+  reachable base URL of the bridge itself (e.g. ``https://lqai.example.com/slack``).
+  Slack's OAuth flow needs a public callback URL; the bridge builds it
+  by appending ``/slack/oauth/callback`` to this base.
+
+All fields are required EXCEPT for the OTel exporter URL (opt-in per
+PRD §5.7's "no telemetry by default" promise) and the log level
+(defaults to INFO).
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Bridge runtime configuration."""
+
+    model_config = SettingsConfigDict(env_file=None, extra="ignore")
+
+    slack_client_id: str = Field(..., description="Slack App OAuth client id.")
+    slack_client_secret: str = Field(..., description="Slack App OAuth client secret.")
+    slack_signing_secret: str = Field(
+        ...,
+        description=(
+            "Slack signing secret — verifies inbound webhook requests "
+            "via the X-Slack-Signature + X-Slack-Request-Timestamp pair."
+        ),
+    )
+
+    lq_ai_backend_url: str = Field(
+        ...,
+        description=(
+            "Base URL of the LQ.AI api as reachable from inside the "
+            "bridge's network (e.g. http://api:8000 in compose)."
+        ),
+    )
+    lq_ai_bridge_token: str = Field(
+        ...,
+        description=(
+            "Shared secret the bridge sends on every internal call to "
+            "the api. The api verifies this matches its own "
+            "LQ_AI_BRIDGE_TOKEN env var at every bridge-facing endpoint."
+        ),
+    )
+    lq_ai_bridge_public_url: str = Field(
+        ...,
+        description=(
+            "Externally reachable base URL of the bridge itself. Slack's "
+            "OAuth flow needs this to construct the callback URL "
+            "(LQ_AI_BRIDGE_PUBLIC_URL + /slack/oauth/callback)."
+        ),
+    )
+
+    # Observability — opt-in per PRD §5.7.
+    otel_exporter_otlp_endpoint: str | None = Field(
+        default=None,
+        description=(
+            "OpenTelemetry collector endpoint. If unset, the bridge does "
+            "not initialise the TracerProvider — no telemetry leaves the "
+            "deployment (PRD §5.7 no-telemetry-by-default)."
+        ),
+    )
+    otel_service_name: str = Field(
+        default="lq-ai-slack-bridge",
+        description="Resource attribute reported on every span.",
+    )
+
+    log_level: str = Field(
+        default="INFO",
+        description="Python logging level for the bridge process.",
+    )
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    """Return a process-cached :class:`Settings` instance.
+
+    Cached so the env-var read happens once at process start. Tests
+    that need a different value should construct ``Settings(...)``
+    directly via the FastAPI dependency override mechanism.
+    """
+
+    global _settings
+    if _settings is None:
+        _settings = Settings()  # type: ignore[call-arg]
+    return _settings

--- a/slack-bridge/app/main.py
+++ b/slack-bridge/app/main.py
@@ -1,0 +1,146 @@
+"""LQ.AI Slack Bridge — FastAPI entry point (M3-D1).
+
+The bridge surface is intentionally tiny at v0.3.0:
+
+* ``GET  /healthz`` — liveness. Always 200 once the process is up.
+* ``GET  /readyz`` — readiness. 200 when ``LQ_AI_BACKEND_URL`` is
+  reachable; 503 otherwise. Operators wire this into their orchestrator
+  to gate traffic to the bridge.
+* ``GET  /slack/oauth/install`` — kicks off the OAuth install flow.
+  See ``app.oauth``.
+* ``GET  /slack/oauth/callback`` — receives Slack's redirect after the
+  user consents.
+* ``POST /slack/events`` — inbound webhook from Slack. At v0.3.0 the
+  bridge verifies the signature and returns 200; the handler stub is
+  the foundation M3-D2 (slash commands, descoped to M4 per DE-288)
+  will fill in.
+
+Everything else — slash commands, message handlers, per-user identity
+binding — is M3-D2 / M3-D4 / community contribution scope.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+from .config import Settings, get_settings
+from .oauth import router as oauth_router
+from .observability import init_otel
+
+log = logging.getLogger(__name__)
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Build the FastAPI application.
+
+    Factored out of module-level instantiation so tests can construct
+    isolated app instances with their own ``Settings`` overrides.
+    """
+
+    cfg = settings or get_settings()
+
+    logging.basicConfig(
+        level=cfg.log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    app = FastAPI(
+        title="LQ.AI Slack Bridge",
+        version="0.1.0",
+        description=(
+            "OAuth install + workspace persistence for the LQ.AI Slack "
+            "integration. M3-D1 plumbing. Slash-command surface deferred "
+            "to M4 / community per DE-288."
+        ),
+    )
+
+    init_otel(cfg)
+    FastAPIInstrumentor.instrument_app(app)
+
+    app.include_router(oauth_router)
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/readyz")
+    async def readyz() -> JSONResponse:
+        """Readiness check — verifies the LQ.AI api is reachable.
+
+        The bridge is useless without the api: every OAuth callback
+        ends with a POST to the api's bridge-facing persistence
+        endpoint. If the api is down, the bridge should report unready
+        so operators see the dependency failure rather than a
+        confusing OAuth callback error.
+        """
+
+        try:
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                res = await client.get(f"{cfg.lq_ai_backend_url}/healthz")
+                if res.status_code != 200:
+                    return JSONResponse(
+                        status_code=503,
+                        content={
+                            "status": "unready",
+                            "reason": f"backend returned {res.status_code}",
+                        },
+                    )
+        except (httpx.HTTPError, OSError) as exc:
+            return JSONResponse(
+                status_code=503,
+                content={"status": "unready", "reason": f"backend unreachable: {exc}"},
+            )
+        return JSONResponse(content={"status": "ok"})
+
+    @app.post("/slack/events")
+    async def slack_events(request: Request) -> dict[str, str]:
+        """Inbound webhook stub.
+
+        Verifies the Slack signature (per the Events API requirement)
+        and returns 200. The handler body is left for M3-D2 / community
+        contribution to fill in once the slash-command surface lands.
+
+        Even at v0.3.0, signature verification matters: it prevents an
+        attacker from POSTing fake events at the bridge and getting
+        any observable response. The signature check is the substrate
+        the slash-command handler will rely on.
+        """
+
+        from .signing import verify_slack_signature
+
+        body = await request.body()
+        timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
+        signature = request.headers.get("X-Slack-Signature", "")
+        if not verify_slack_signature(
+            signing_secret=cfg.slack_signing_secret,
+            timestamp=timestamp,
+            body=body,
+            signature=signature,
+        ):
+            raise HTTPException(status_code=401, detail="invalid Slack signature")
+
+        # Slack's "url_verification" handshake — Slack sends a one-off
+        # POST with `{"type":"url_verification","challenge":"..."}`
+        # when the operator configures the Events API URL. Responding
+        # with the challenge value confirms the URL belongs to the
+        # bridge.
+        try:
+            payload = await request.json()
+        except Exception:
+            payload = {}
+        if isinstance(payload, dict) and payload.get("type") == "url_verification":
+            return {"challenge": payload.get("challenge", "")}
+
+        # All other event types are a no-op at v0.3.0 — M3-D2 will
+        # extend this branch.
+        return {"status": "ok"}
+
+    return app
+
+
+app = create_app()

--- a/slack-bridge/app/oauth.py
+++ b/slack-bridge/app/oauth.py
@@ -1,0 +1,250 @@
+"""Slack OAuth install + callback handlers (M3-D1).
+
+The flow:
+
+1. **Operator initiates install** by clicking a button in the LQ.AI
+   admin UI (M3-D4 work) which opens ``GET /slack/oauth/install``
+   on the bridge.
+2. **Bridge redirects to Slack** with the App's client_id, the
+   scopes the bridge declares (``commands``, ``chat:write``), a
+   randomly-generated ``state`` token (CSRF), and the redirect_uri
+   pointing back at this bridge.
+3. **User consents in Slack**, Slack redirects to
+   ``GET /slack/oauth/callback?code=...&state=...``.
+4. **Bridge verifies the state**, exchanges the code for a bot
+   token via ``oauth.v2.access``, and POSTs the resulting workspace
+   record to the LQ.AI api at
+   ``POST /api/v1/integrations/slack/workspaces``.
+5. **Bridge returns a simple success page** so the operator sees
+   confirmation in the browser they were redirected back to. (A
+   future polish PR can return a richer page or redirect back into
+   the LQ.AI admin UI.)
+
+State tokens live in-memory in the bridge with a 10-minute TTL. The
+bridge is single-instance per deployment so an in-memory store is
+sufficient; if the bridge restarts between install initiation and
+callback, the operator restarts the install. (DE candidate: persist
+state tokens in the api so install survives bridge restarts. Filing
+implicit — surfaces if an operator hits this.)
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import time
+import uuid
+from typing import Annotated
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .config import Settings, get_settings
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/slack", tags=["slack-oauth"])
+
+
+# In-memory state token store. Keys are the random state tokens; values
+# are creation timestamps. A token is consumed (deleted) on first read
+# in the callback handler — replay protection.
+_STATE_STORE: dict[str, float] = {}
+_STATE_TTL_SECONDS = 600  # 10 minutes
+
+
+def _gc_state_store() -> None:
+    """Best-effort cleanup of expired state tokens.
+
+    Called inside the install + callback handlers; keeps the store
+    bounded without needing a background task. The store is small
+    (one entry per concurrent install flow, which is typically zero
+    or one in a given 10-minute window).
+    """
+
+    now = time.time()
+    expired = [k for k, ts in _STATE_STORE.items() if now - ts > _STATE_TTL_SECONDS]
+    for k in expired:
+        _STATE_STORE.pop(k, None)
+
+
+# Scopes the bridge requests during OAuth install. Kept narrow on
+# purpose: ``commands`` for the future slash-command surface and
+# ``chat:write`` so the bot can post replies in channels it's invited
+# to. No ``channels:read`` / ``groups:read`` / ``im:read`` — the bot
+# does NOT read silent channels.
+SCOPES = ["commands", "chat:write"]
+
+
+@router.get("/oauth/install")
+async def oauth_install(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> RedirectResponse:
+    """Redirect the operator to Slack's OAuth consent screen.
+
+    Generates a fresh state token (CSRF), stores it in the bridge's
+    in-memory store, and builds the consent URL. Slack will redirect
+    the operator back to ``/slack/oauth/callback`` after they consent.
+    """
+
+    _gc_state_store()
+    state = secrets.token_urlsafe(32)
+    _STATE_STORE[state] = time.time()
+
+    redirect_uri = f"{settings.lq_ai_bridge_public_url.rstrip('/')}/slack/oauth/callback"
+    params = {
+        "client_id": settings.slack_client_id,
+        "scope": ",".join(SCOPES),
+        "redirect_uri": redirect_uri,
+        "state": state,
+    }
+    consent_url = f"https://slack.com/oauth/v2/authorize?{urlencode(params)}"
+
+    log.info("slack.oauth.install_started state=%s", state[:8])
+    return RedirectResponse(url=consent_url, status_code=302)
+
+
+@router.get("/oauth/callback")
+async def oauth_callback(
+    request: Request,
+    settings: Annotated[Settings, Depends(get_settings)],
+    code: Annotated[str, Query(description="Authorization code from Slack.")],
+    state: Annotated[str, Query(description="Round-tripped state token (CSRF).")],
+    error: Annotated[str | None, Query()] = None,
+) -> HTMLResponse:
+    """Handle the Slack OAuth callback.
+
+    Steps:
+
+    1. Verify the ``state`` matches a token we issued (and delete it
+       — single-use).
+    2. Exchange the ``code`` for a bot token via Slack's
+       ``oauth.v2.access`` endpoint.
+    3. POST the resulting workspace record (team_id, team_name,
+       bot_token, installer_user_id) to the LQ.AI api at
+       ``/api/v1/integrations/slack/workspaces`` carrying
+       ``LQ_AI_BRIDGE_TOKEN`` as a bearer.
+    4. Return a simple HTML success page.
+
+    Any failure path returns an HTML error page rather than raising —
+    the operator is in a browser, not curl. The api-side persistence
+    failure is the most likely source of trouble (api down, token
+    encryption misconfigured); the error page surfaces the failure
+    plainly.
+    """
+
+    if error:
+        log.warning("slack.oauth.user_denied error=%s", error)
+        return HTMLResponse(
+            f"<h1>Install cancelled</h1><p>Slack returned: {error!r}</p>",
+            status_code=400,
+        )
+
+    _gc_state_store()
+    if _STATE_STORE.pop(state, None) is None:
+        log.warning("slack.oauth.invalid_state state=%s", state[:8])
+        raise HTTPException(
+            status_code=400,
+            detail=("invalid or expired state token — restart the install from the LQ.AI admin UI"),
+        )
+
+    redirect_uri = f"{settings.lq_ai_bridge_public_url.rstrip('/')}/slack/oauth/callback"
+
+    # Lazy import slack_sdk to keep the import-cost off the bridge's
+    # hot path. The SDK pulls a few transitive deps.
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    client = AsyncWebClient()
+    try:
+        token_response = await client.oauth_v2_access(
+            client_id=settings.slack_client_id,
+            client_secret=settings.slack_client_secret,
+            code=code,
+            redirect_uri=redirect_uri,
+        )
+    except Exception as exc:
+        log.exception("slack.oauth.exchange_failed")
+        return HTMLResponse(
+            f"<h1>Install failed</h1><p>Token exchange failed: {exc!r}</p>",
+            status_code=502,
+        )
+
+    if not token_response.get("ok"):
+        slack_error = token_response.get("error", "unknown")
+        log.warning("slack.oauth.exchange_not_ok error=%s", slack_error)
+        return HTMLResponse(
+            f"<h1>Install failed</h1><p>Slack returned: {slack_error}</p>",
+            status_code=502,
+        )
+
+    team = token_response.get("team") or {}
+    authed_user = token_response.get("authed_user") or {}
+    workspace = {
+        "team_id": team.get("id"),
+        "team_name": team.get("name"),
+        "bot_token": token_response.get("access_token"),
+        "bot_user_id": token_response.get("bot_user_id"),
+        "installer_slack_user_id": authed_user.get("id"),
+        "scope": token_response.get("scope"),
+    }
+
+    if not workspace["team_id"] or not workspace["bot_token"]:
+        log.error("slack.oauth.malformed_response payload=%s", token_response.data)
+        return HTMLResponse(
+            "<h1>Install failed</h1><p>Slack response missing required fields.</p>",
+            status_code=502,
+        )
+
+    # POST the workspace record to the lq-ai api for encrypted persistence.
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as http:
+            res = await http.post(
+                f"{settings.lq_ai_backend_url.rstrip('/')}/api/v1/integrations/slack/workspaces",
+                headers={"Authorization": f"Bearer {settings.lq_ai_bridge_token}"},
+                json=workspace,
+            )
+    except httpx.HTTPError as exc:
+        log.exception("slack.oauth.api_persist_failed")
+        return HTMLResponse(
+            f"<h1>Install failed</h1><p>Could not persist to the LQ.AI backend: {exc!r}</p>",
+            status_code=502,
+        )
+
+    if res.status_code not in (200, 201, 204):
+        log.warning(
+            "slack.oauth.api_persist_rejected status=%s body=%s",
+            res.status_code,
+            res.text[:200],
+        )
+        return HTMLResponse(
+            f"<h1>Install failed</h1><p>Backend rejected with HTTP {res.status_code}.</p>",
+            status_code=502,
+        )
+
+    workspace_id = workspace["team_id"]
+    log.info(
+        "slack.oauth.install_completed team_id=%s installer=%s",
+        workspace_id,
+        workspace["installer_slack_user_id"],
+    )
+
+    # Best-effort: include a correlation id for the operator to
+    # reference if they file a support ticket.
+    correlation = uuid.uuid4().hex[:8]
+    return HTMLResponse(
+        content=f"""
+        <!doctype html>
+        <html lang="en">
+        <head><meta charset="utf-8"><title>LQ.AI Slack install complete</title></head>
+        <body style="font-family: system-ui; max-width: 32rem; margin: 4rem auto; line-height: 1.5;">
+          <h1>Install complete</h1>
+          <p>Slack workspace <strong>{workspace["team_name"]}</strong> is now connected to this LQ.AI deployment.</p>
+          <p>Next step: open the LQ.AI admin UI to configure bot behavior (M3-D4) and bind Slack users to LQ.AI accounts.</p>
+          <p style="color: #888; font-size: 0.875rem;">Correlation: <code>{correlation}</code></p>
+        </body>
+        </html>
+        """,
+        status_code=200,
+    )

--- a/slack-bridge/app/observability.py
+++ b/slack-bridge/app/observability.py
@@ -1,0 +1,67 @@
+"""OpenTelemetry init for the Slack Bridge.
+
+Mirrors ``api/app/observability.py`` and ``gateway/app/observability.py``
+at the M1 substrate level: opt-in via ``OTEL_EXPORTER_OTLP_ENDPOINT``,
+auto-instrumentation for FastAPI + httpx, no metrics surface beyond
+what FastAPI auto-instrumentation produces (the bridge has no
+domain-specific Prometheus metrics today).
+
+When M3 Phase F's domain-span work (per
+``docs/proposals/opentelemetry-deepening.md``) lands, the bridge will
+gain explicit ``slack.oauth.exchange`` and ``slack.callback.verify``
+spans. The substrate here makes those additive.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .config import Settings
+
+log = logging.getLogger(__name__)
+
+
+def init_otel(settings: Settings) -> None:
+    """Initialise OTel TracerProvider + auto-instrumentations.
+
+    No-op when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is unset (PRD §5.7
+    no-telemetry-by-default promise applies here too).
+    """
+
+    if not settings.otel_exporter_otlp_endpoint:
+        log.info(
+            "otel.disabled — OTEL_EXPORTER_OTLP_ENDPOINT unset; bridge will "
+            "emit no telemetry. Per PRD §5.7's no-telemetry-by-default."
+        )
+        return
+
+    # Lazy import keeps the OTel surface out of the startup hot-path
+    # for operators who don't opt in.
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter,
+    )
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    resource = Resource.create(
+        {"service.name": settings.otel_service_name, "service.namespace": "lq-ai"}
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=settings.otel_exporter_otlp_endpoint))
+    )
+    trace.set_tracer_provider(provider)
+
+    # FastAPIInstrumentor is wired in main.py via `app.add_middleware(...)`
+    # equivalent — instrumentor pattern handles that. httpx instrumentation
+    # is process-global and only needs to be enabled once here.
+    HTTPXClientInstrumentor().instrument()
+
+    log.info(
+        "otel.initialised — exporter=%s, service.name=%s",
+        settings.otel_exporter_otlp_endpoint,
+        settings.otel_service_name,
+    )

--- a/slack-bridge/app/signing.py
+++ b/slack-bridge/app/signing.py
@@ -1,0 +1,75 @@
+"""Slack request-signature verification.
+
+Slack signs every webhook request with HMAC-SHA256 over the literal
+string ``v0:{timestamp}:{body}`` using the App's signing secret. The
+result is sent in the ``X-Slack-Signature`` header prefixed with
+``v0=``; the corresponding timestamp is in ``X-Slack-Request-Timestamp``.
+
+Verifying signatures is the substrate for every inbound webhook the
+bridge ever handles. M3-D2's slash-command handler (descoped to M4 /
+community per DE-288) will lean on this primitive. We ship it now so
+when the slash-command surface lands it sits on a verified
+foundation.
+
+Replay protection: Slack recommends rejecting any request with a
+timestamp older than 5 minutes from the current time. We enforce that
+here so the protocol-level invariant lives in one place.
+
+References:
+- https://api.slack.com/authentication/verifying-requests-from-slack
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+_MAX_AGE_SECONDS = 5 * 60
+
+
+def verify_slack_signature(
+    *,
+    signing_secret: str,
+    timestamp: str,
+    body: bytes,
+    signature: str,
+    now: int | None = None,
+) -> bool:
+    """Return True when the request's HMAC matches and the timestamp
+    is within the freshness window.
+
+    All four input types are deliberately strict:
+
+    * ``signing_secret`` — operator-supplied via ``SLACK_SIGNING_SECRET``
+      env var.
+    * ``timestamp`` — raw ``X-Slack-Request-Timestamp`` header value
+      (a Unix epoch as a string; Slack does not zero-pad).
+    * ``body`` — raw request body bytes (NOT the json-decoded form;
+      Slack signs the raw bytes).
+    * ``signature`` — the full ``X-Slack-Signature`` header including
+      the ``v0=`` prefix.
+
+    The ``now`` parameter is for testing — production code passes
+    ``None`` and the function reads the wall clock.
+
+    Returns False (not an exception) on any failure path so the caller
+    can return 401 without leaking which check failed.
+    """
+
+    if not (signing_secret and timestamp and signature and signature.startswith("v0=")):
+        return False
+
+    try:
+        ts_int = int(timestamp)
+    except ValueError:
+        return False
+
+    current = now if now is not None else int(time.time())
+    if abs(current - ts_int) > _MAX_AGE_SECONDS:
+        return False
+
+    base = f"v0:{timestamp}:".encode() + body
+    digest = hmac.new(signing_secret.encode("utf-8"), base, hashlib.sha256).hexdigest()
+    expected = f"v0={digest}"
+    return hmac.compare_digest(expected, signature)

--- a/slack-bridge/manifest.yml
+++ b/slack-bridge/manifest.yml
@@ -1,0 +1,68 @@
+# Slack App manifest for the LQ.AI Slack Bridge (M3-D1).
+#
+# Operators paste this into the Slack App admin UI at
+# https://api.slack.com/apps?new_app=1 → "From a manifest" to create
+# the LQ.AI app in their workspace, then export the resulting
+# SLACK_CLIENT_ID / SLACK_CLIENT_SECRET / SLACK_SIGNING_SECRET to
+# the slack-bridge service (see slack-bridge/README.md).
+#
+# Scopes are kept narrow on purpose — the bridge only needs to:
+#
+#   - present a future slash command (`commands`)
+#   - reply to invocations and post in invited channels (`chat:write`)
+#
+# It does NOT need `channels:read` / `groups:read` / `im:read` because
+# the bot does not read silent channels (PRD §3.15 — only acts on
+# explicit user invocations).
+#
+# The slash-command surface (M3-D2) is descoped to M4 / community per
+# DE-288, so this manifest declares no `slash_commands` block today.
+# Community contributors adding `/lq` extend this file via PR.
+#
+# `${LQ_AI_BRIDGE_PUBLIC_URL}` is a placeholder the operator replaces
+# manually before pasting into Slack — Slack's manifest UI does not
+# perform environment substitution. The bridge OAuth handler builds
+# the matching `redirect_uri` from the same env var at runtime, so the
+# values must agree.
+
+_metadata:
+  major_version: 1
+  minor_version: 1
+
+display_information:
+  name: LQ.AI
+  description: In-house legal AI — Slack bridge for LQ.AI deployments.
+  long_description: >-
+    LQ.AI is a self-hosted, transparency-first AI platform for in-house
+    legal teams. This Slack bridge connects a Slack workspace to one
+    LQ.AI deployment so that future slash-command and bot surfaces can
+    be wired up by operator and community contributors. The bot does
+    not read silent channels — it only responds to explicit user
+    invocations.
+  background_color: "#0b3a53"
+
+features:
+  bot_user:
+    display_name: LQ.AI
+    always_online: false
+
+oauth_config:
+  redirect_urls:
+    # Replace ${LQ_AI_BRIDGE_PUBLIC_URL} with the externally reachable
+    # base URL of the bridge before saving the manifest. The bridge
+    # OAuth handler builds the same URL at runtime from
+    # LQ_AI_BRIDGE_PUBLIC_URL; the two must match exactly or Slack
+    # will reject the callback.
+    - ${LQ_AI_BRIDGE_PUBLIC_URL}/slack/oauth/callback
+  scopes:
+    bot:
+      - commands
+      - chat:write
+
+settings:
+  # Slash commands + interactive components land in M3-D2 / community
+  # per DE-288. When they do, populate interactivity.request_url and
+  # add the slash_commands block above.
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/slack-bridge/pyproject.toml
+++ b/slack-bridge/pyproject.toml
@@ -1,0 +1,81 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lq-ai-slack-bridge"
+version = "0.1.0"
+description = "LQ.AI Slack bridge — OAuth install + workspace persistence (M3-D1)"
+readme = "README.md"
+requires-python = ">=3.12"
+license = "Apache-2.0"
+authors = [{ name = "LegalQuants" }]
+
+# M3-D1 — the slack-bridge is a small standalone service that mediates
+# between Slack's OAuth/Events APIs and the LQ.AI backend. It carries:
+#
+# 1. The OAuth install flow (operator clicks "Install" in the LQ.AI
+#    admin UI → bridge redirects to Slack's consent page → callback
+#    exchanges the code for a bot token → bridge POSTs the workspace
+#    record to the LQ.AI api over an internal bridge token).
+# 2. (Future M3-D2 / community contribution) the `/lq` slash command
+#    handler. Descoped from M3 per PRD §9 DE-288.
+#
+# The bridge holds NO long-lived secrets except the OAuth state token
+# (in-memory, TTL'd). Bot tokens land in the LQ.AI api's encrypted
+# storage immediately on receipt.
+dependencies = [
+    "fastapi>=0.115,<0.137",
+    "uvicorn[standard]>=0.32,<0.48",
+    "pydantic>=2.7,<3",
+    "pydantic-settings>=2.4,<3",
+    # httpx is used both inbound (in FastAPI tests via the TestClient
+    # transport) and outbound (calling the LQ.AI api to persist
+    # workspace records).
+    "httpx>=0.27,<0.29",
+    # slack-sdk: official Slack Python SDK. We use it for OAuth code
+    # exchange (`AsyncWebClient.oauth_v2_access`) and for request
+    # signature verification on inbound webhooks (the same primitive
+    # M3-D2 will use when the slash-command surface lands). Pinning
+    # the 3.x line; 4.x is not yet released.
+    "slack-sdk>=3.27,<4",
+    # OpenTelemetry — mirrors api/ + gateway/ so the bridge participates
+    # in the M1 OTel substrate from day one. The deepening work in
+    # M3 Phase F (per docs/proposals/opentelemetry-deepening.md) will
+    # add domain spans; the substrate exporters are already wired here
+    # so the bridge's traces propagate cleanly into the trace tree.
+    "opentelemetry-api>=1.27,<2",
+    "opentelemetry-sdk>=1.27,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
+    "opentelemetry-instrumentation-fastapi>=0.48b0,<1",
+    "opentelemetry-instrumentation-httpx>=0.48b0,<1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3,<9",
+    "pytest-asyncio>=0.24,<0.25",
+    "pytest-httpx>=0.32,<0.40",
+    "ruff>=0.6,<0.14",
+    "mypy>=1.11,<2",
+]
+
+[tool.setuptools.packages.find]
+include = ["app*"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/slack-bridge/pyproject.toml
+++ b/slack-bridge/pyproject.toml
@@ -39,6 +39,12 @@ dependencies = [
     # M3-D2 will use when the slash-command surface lands). Pinning
     # the 3.x line; 4.x is not yet released.
     "slack-sdk>=3.27,<4",
+    # aiohttp is a transitive runtime requirement of slack_sdk's async
+    # web client (slack_sdk.web.async_client.AsyncWebClient). slack-sdk
+    # treats it as an optional/lazy dep; we pin it explicitly because
+    # every OAuth callback uses the async client, so an unpinned
+    # missing-aiohttp is a runtime crash on first install.
+    "aiohttp>=3.10,<4",
     # OpenTelemetry — mirrors api/ + gateway/ so the bridge participates
     # in the M1 OTel substrate from day one. The deepening work in
     # M3 Phase F (per docs/proposals/opentelemetry-deepening.md) will

--- a/slack-bridge/tests/conftest.py
+++ b/slack-bridge/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Test fixtures for the LQ.AI Slack Bridge.
+
+``app/main.py`` constructs the FastAPI ``app`` object at module import time
+(``app = create_app()``), which calls ``Settings()`` and fails if the
+operator hasn't set the required Slack/LQ.AI env vars. Tests don't want
+to depend on a real Slack App's secrets, so this conftest seeds the
+process environment with safe fixture values BEFORE pytest collects any
+test that imports from ``app.main`` (which then imports
+``app.oauth``).
+
+Individual tests construct their own app via ``create_app(settings=…)``
+to inject test-specific Settings; the env-var seeding here just makes
+the module-level ``app = create_app()`` line not crash on import.
+"""
+
+from __future__ import annotations
+
+import os
+
+_TEST_DEFAULTS = {
+    "SLACK_CLIENT_ID": "test-client-id",
+    "SLACK_CLIENT_SECRET": "test-client-secret",
+    "SLACK_SIGNING_SECRET": "test-signing-secret",
+    "LQ_AI_BACKEND_URL": "http://api.test",
+    "LQ_AI_BRIDGE_TOKEN": "test-bridge-token",
+    "LQ_AI_BRIDGE_PUBLIC_URL": "https://bridge.test",
+}
+
+for key, value in _TEST_DEFAULTS.items():
+    os.environ.setdefault(key, value)

--- a/slack-bridge/tests/test_oauth.py
+++ b/slack-bridge/tests/test_oauth.py
@@ -1,0 +1,274 @@
+"""OAuth install + callback handler tests for the slack-bridge (M3-D1).
+
+Covers:
+
+* ``GET /slack/oauth/install`` — generates a fresh state token, stores
+  it in the bridge's in-memory store, and redirects to Slack's consent
+  URL with the right ``client_id`` / ``scope`` / ``redirect_uri`` /
+  ``state`` query params.
+* ``GET /slack/oauth/callback`` — happy path: valid state → mocked
+  Slack ``oauth.v2.access`` exchange → POST workspace record to the
+  api over an internal bridge token → success page.
+* ``GET /slack/oauth/callback`` — bad state → 400.
+* ``GET /slack/oauth/callback`` — ``error=...`` query param renders the
+  cancellation page without contacting Slack or the api.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+from pytest_httpx import HTTPXMock
+
+from app import oauth as oauth_module
+from app.config import Settings, get_settings
+from app.main import create_app
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        slack_client_id="A123CLIENT",
+        slack_client_secret="A123SECRET",
+        slack_signing_secret="A123SIGNING",
+        lq_ai_backend_url="http://api.test",
+        lq_ai_bridge_token="bridge-token-fixture",
+        lq_ai_bridge_public_url="https://bridge.test",
+    )
+
+
+@pytest.fixture
+def client(settings: Settings) -> TestClient:
+    """Test client wired to a fresh app instance using the test Settings.
+
+    Overrides the ``get_settings`` dependency so the oauth router
+    sees the test Settings instead of the process-cached one (which
+    is derived from the conftest's env-var defaults).
+    """
+
+    app = create_app(settings=settings)
+    app.dependency_overrides[get_settings] = lambda: settings
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state_store() -> None:
+    """Module-level _STATE_STORE leaks between tests; clear before each."""
+
+    oauth_module._STATE_STORE.clear()
+    yield
+    oauth_module._STATE_STORE.clear()
+
+
+# ---------------------------------------------------------------------------
+# /slack/oauth/install
+# ---------------------------------------------------------------------------
+
+
+def test_install_redirects_to_slack_consent_with_required_params(
+    client: TestClient,
+    settings: Settings,
+) -> None:
+    res = client.get("/slack/oauth/install")
+    assert res.status_code == 302
+    location = res.headers["location"]
+
+    parsed = urlparse(location)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "slack.com"
+    assert parsed.path == "/oauth/v2/authorize"
+
+    params = parse_qs(parsed.query)
+    assert params["client_id"] == [settings.slack_client_id]
+    assert params["scope"] == ["commands,chat:write"]
+    assert params["redirect_uri"] == [
+        f"{settings.lq_ai_bridge_public_url.rstrip('/')}/slack/oauth/callback"
+    ]
+    state = params["state"][0]
+    assert state  # non-empty CSRF token
+    assert state in oauth_module._STATE_STORE
+
+
+def test_install_emits_distinct_state_tokens(client: TestClient) -> None:
+    """Each install call mints a fresh CSRF token."""
+    states = set()
+    for _ in range(3):
+        res = client.get("/slack/oauth/install")
+        states.add(parse_qs(urlparse(res.headers["location"]).query)["state"][0])
+    assert len(states) == 3
+
+
+# ---------------------------------------------------------------------------
+# /slack/oauth/callback — happy path
+# ---------------------------------------------------------------------------
+
+
+class _StubSlackResponse:
+    """Stand-in for ``slack_sdk.web.SlackResponse`` for tests."""
+
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.data = payload
+
+    def get(self, key: str, default: object | None = None) -> object | None:
+        return self.data.get(key, default)
+
+
+class _StubAsyncWebClient:
+    """Replaces ``slack_sdk.web.async_client.AsyncWebClient`` for tests.
+
+    Captures the kwargs ``oauth_v2_access`` was called with so assertions
+    can verify the bridge passed ``client_id`` / ``client_secret`` /
+    ``code`` / ``redirect_uri`` per Slack's contract.
+    """
+
+    last_kwargs: dict[str, object] | None = None
+
+    def __init__(self, payload: dict[str, object] | None = None) -> None:
+        self._payload = payload or {
+            "ok": True,
+            "access_token": "xoxb-fake-bot-token",
+            "bot_user_id": "U99BOT",
+            "scope": "commands,chat:write",
+            "team": {"id": "T0123456", "name": "Acme Legal"},
+            "authed_user": {"id": "U11INSTALLER"},
+        }
+
+    async def oauth_v2_access(self, **kwargs: object) -> _StubSlackResponse:
+        type(self).last_kwargs = kwargs
+        return _StubSlackResponse(self._payload)
+
+
+def _seed_state(state: str = "stateA") -> str:
+    oauth_module._STATE_STORE[state] = time.time()
+    return state
+
+
+def test_callback_happy_path_persists_to_api_and_returns_success(
+    client: TestClient,
+    settings: Settings,
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _seed_state()
+    monkeypatch.setattr(
+        "slack_sdk.web.async_client.AsyncWebClient",
+        _StubAsyncWebClient,
+        raising=True,
+    )
+    httpx_mock.add_response(
+        url=f"{settings.lq_ai_backend_url}/api/v1/integrations/slack/workspaces",
+        method="POST",
+        status_code=201,
+        json={
+            "id": "00000000-0000-0000-0000-000000000001",
+            "team_id": "T0123456",
+            "team_name": "Acme Legal",
+            "bot_user_id": "U99BOT",
+            "installer_slack_user_id": "U11INSTALLER",
+            "scope": "commands,chat:write",
+            "installed_at": "2026-05-22T12:00:00Z",
+        },
+    )
+
+    res = client.get(f"/slack/oauth/callback?code=auth-code-from-slack&state={state}")
+    assert res.status_code == 200, res.text
+    assert "Install complete" in res.text
+    assert "Acme Legal" in res.text
+
+    # Confirm the bridge consumed the state token (single-use).
+    assert state not in oauth_module._STATE_STORE
+
+    # Confirm Slack code exchange was called with the right kwargs.
+    assert _StubAsyncWebClient.last_kwargs is not None
+    assert _StubAsyncWebClient.last_kwargs["code"] == "auth-code-from-slack"
+    assert _StubAsyncWebClient.last_kwargs["client_id"] == settings.slack_client_id
+    assert _StubAsyncWebClient.last_kwargs["client_secret"] == settings.slack_client_secret
+    assert _StubAsyncWebClient.last_kwargs["redirect_uri"] == (
+        f"{settings.lq_ai_bridge_public_url.rstrip('/')}/slack/oauth/callback"
+    )
+
+    # Confirm the api POST carried the bridge bearer + the expected body shape.
+    sent_requests = httpx_mock.get_requests()
+    assert len(sent_requests) == 1
+    sent = sent_requests[0]
+    assert sent.headers["authorization"] == f"Bearer {settings.lq_ai_bridge_token}"
+    assert json.loads(sent.content) == {
+        "team_id": "T0123456",
+        "team_name": "Acme Legal",
+        "bot_token": "xoxb-fake-bot-token",
+        "bot_user_id": "U99BOT",
+        "installer_slack_user_id": "U11INSTALLER",
+        "scope": "commands,chat:write",
+    }
+
+
+# ---------------------------------------------------------------------------
+# /slack/oauth/callback — failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_callback_with_bad_state_returns_400(client: TestClient) -> None:
+    """A state token we didn't issue is rejected with 400."""
+    res = client.get("/slack/oauth/callback?code=anything&state=not-a-real-state")
+    assert res.status_code == 400
+    assert "invalid or expired state" in res.text.lower()
+
+
+def test_callback_with_error_query_param_renders_cancellation_page(
+    client: TestClient,
+) -> None:
+    """``?error=access_denied`` short-circuits without touching Slack/api."""
+    res = client.get("/slack/oauth/callback?code=ignored&state=ignored&error=access_denied")
+    assert res.status_code == 400
+    assert "Install cancelled" in res.text
+    assert "access_denied" in res.text
+
+
+def test_callback_with_slack_returning_not_ok_returns_502(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If Slack's oauth.v2.access returns ok=false, the bridge surfaces 502."""
+    state = _seed_state("stateNotOk")
+
+    class _NotOkClient(_StubAsyncWebClient):
+        def __init__(self) -> None:
+            super().__init__(payload={"ok": False, "error": "invalid_code"})
+
+    monkeypatch.setattr(
+        "slack_sdk.web.async_client.AsyncWebClient",
+        _NotOkClient,
+        raising=True,
+    )
+    res = client.get(f"/slack/oauth/callback?code=bad&state={state}")
+    assert res.status_code == 502
+    assert "invalid_code" in res.text
+
+
+def test_callback_with_api_persist_failure_returns_502(
+    client: TestClient,
+    settings: Settings,
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the api rejects the persistence POST, the bridge surfaces 502."""
+    state = _seed_state("stateApiFail")
+    monkeypatch.setattr(
+        "slack_sdk.web.async_client.AsyncWebClient",
+        _StubAsyncWebClient,
+        raising=True,
+    )
+    httpx_mock.add_response(
+        url=f"{settings.lq_ai_backend_url}/api/v1/integrations/slack/workspaces",
+        method="POST",
+        status_code=500,
+        text="boom",
+    )
+
+    res = client.get(f"/slack/oauth/callback?code=auth-code&state={state}")
+    assert res.status_code == 502
+    assert "Backend rejected with HTTP 500" in res.text

--- a/slack-bridge/tests/test_signing.py
+++ b/slack-bridge/tests/test_signing.py
@@ -1,0 +1,151 @@
+"""Slack signature verification — M3-D1.
+
+Targets :func:`app.signing.verify_slack_signature` which gates every
+inbound webhook the bridge handles. The substrate matters because
+M3-D2's slash-command handler (descoped to M4 per DE-288) will lean
+on it; if signature verification ever passes a forged request, the
+slash-command surface inherits the gap.
+
+The vectors below are constructed by hand rather than copied from
+Slack's docs so the test exercises the exact HMAC computation the
+bridge runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+from app.signing import verify_slack_signature
+
+SECRET = "12345678901234567890123456789012"
+NOW = 1_700_000_000
+
+
+def _sign(secret: str, timestamp: int, body: bytes) -> str:
+    base = f"v0:{timestamp}:".encode() + body
+    digest = hmac.new(secret.encode("utf-8"), base, hashlib.sha256).hexdigest()
+    return f"v0={digest}"
+
+
+def test_valid_signature_accepts() -> None:
+    body = b'{"type":"event_callback"}'
+    sig = _sign(SECRET, NOW, body)
+    assert verify_slack_signature(
+        signing_secret=SECRET,
+        timestamp=str(NOW),
+        body=body,
+        signature=sig,
+        now=NOW,
+    )
+
+
+def test_tampered_body_rejects() -> None:
+    body = b'{"type":"event_callback"}'
+    sig = _sign(SECRET, NOW, body)
+    tampered = b'{"type":"different"}'
+    assert not verify_slack_signature(
+        signing_secret=SECRET,
+        timestamp=str(NOW),
+        body=tampered,
+        signature=sig,
+        now=NOW,
+    )
+
+
+def test_wrong_secret_rejects() -> None:
+    body = b'{"type":"event_callback"}'
+    sig = _sign(SECRET, NOW, body)
+    assert not verify_slack_signature(
+        signing_secret="x" * 32,
+        timestamp=str(NOW),
+        body=body,
+        signature=sig,
+        now=NOW,
+    )
+
+
+def test_stale_timestamp_rejects() -> None:
+    body = b'{"type":"event_callback"}'
+    stale_ts = NOW - (6 * 60)  # 6 minutes old — beyond the 5-minute window
+    sig = _sign(SECRET, stale_ts, body)
+    assert not verify_slack_signature(
+        signing_secret=SECRET,
+        timestamp=str(stale_ts),
+        body=body,
+        signature=sig,
+        now=NOW,
+    )
+
+
+def test_future_timestamp_rejects() -> None:
+    """Symmetric to the stale check — a far-future timestamp is also
+    out of the freshness window (clock skew or replay attack)."""
+
+    body = b'{"type":"event_callback"}'
+    future_ts = NOW + (6 * 60)
+    sig = _sign(SECRET, future_ts, body)
+    assert not verify_slack_signature(
+        signing_secret=SECRET,
+        timestamp=str(future_ts),
+        body=body,
+        signature=sig,
+        now=NOW,
+    )
+
+
+def test_missing_prefix_rejects() -> None:
+    """A signature without the ``v0=`` prefix is malformed."""
+
+    body = b'{"type":"event_callback"}'
+    sig = _sign(SECRET, NOW, body).removeprefix("v0=")
+    assert not verify_slack_signature(
+        signing_secret=SECRET,
+        timestamp=str(NOW),
+        body=body,
+        signature=sig,
+        now=NOW,
+    )
+
+
+def test_empty_inputs_reject() -> None:
+    """Every empty-string input should return False rather than raise."""
+
+    body = b""
+    assert not verify_slack_signature(
+        signing_secret="",
+        timestamp=str(NOW),
+        body=body,
+        signature="v0=" + "0" * 64,
+        now=NOW,
+    )
+    assert not verify_slack_signature(
+        signing_secret=SECRET,
+        timestamp="",
+        body=body,
+        signature="v0=" + "0" * 64,
+        now=NOW,
+    )
+    assert not verify_slack_signature(
+        signing_secret=SECRET,
+        timestamp=str(NOW),
+        body=body,
+        signature="",
+        now=NOW,
+    )
+
+
+def test_real_wall_clock_path() -> None:
+    """``now=None`` reads ``time.time()`` — sanity check that the
+    default path works with a freshly-signed request."""
+
+    ts = int(time.time())
+    body = b'{"type":"event_callback"}'
+    sig = _sign(SECRET, ts, body)
+    assert verify_slack_signature(
+        signing_secret=SECRET,
+        timestamp=str(ts),
+        body=body,
+        signature=sig,
+    )


### PR DESCRIPTION
## Status: DRAFT — partial M3-D1 (~6 of ~11 hr)

This PR lands the **bridge-side half** of M3-D1: the standalone slack-bridge FastAPI service with OAuth install + callback handlers + Slack signature verification + 8 unit tests. Mergeable in isolation as a self-contained service.

**Held as draft until the backend half lands:** the OAuth callback POSTs to `POST /api/v1/integrations/slack/workspaces` on the lq-ai api, which does not yet exist. Without it, installing a Slack app would 404 on persistence. The next commit(s) on this branch add the backend endpoint + migration 0037 (`slack_workspaces` table) + the Slack App manifest YAML + the docker-compose `--profile slack` entry + integration tests. Once the api endpoint lands the PR flips to ready-for-review.

## What's in this PR

- **`slack-bridge/`** — new standalone FastAPI service:
  - `pyproject.toml` — runtime deps: fastapi, uvicorn, httpx, slack-sdk, OTel substrate
  - `Dockerfile` — mirrors `gateway/` (no DB, no migrations, runs uvicorn directly on port 8002)
  - `README.md` — env-var matrix, security posture, install flow walkthrough
  - `app/main.py` — FastAPI factory with /healthz + /readyz + /slack/events stub
  - `app/config.py` — pydantic-settings Settings (3 credential groups)
  - `app/oauth.py` — install + callback handlers (state-token CSRF, 10-min TTL, narrow `commands` + `chat:write` scopes only)
  - `app/signing.py` — HMAC-SHA256 inbound webhook verification + 5-min replay window
  - `app/observability.py` — OTel substrate (TracerProvider + FastAPI + httpx auto-instrumentation, opt-in)
  - `tests/test_signing.py` — 8 tests: valid accept, tampered reject, wrong secret reject, stale/future ts reject, missing prefix reject, empty inputs reject without raising, real wall-clock sanity

## Security notes (CODEOWNERS-routed)

- Bot tokens never persist in the bridge. They POST to the LQ.AI api on receipt for encrypted persistence there.
- State tokens are in-memory with TTL; bridge restart between install start and callback invalidates the flow (operator restarts the install).
- Slack scopes are narrow on purpose: only `commands` (for the future M3-D2 slash-command surface) and `chat:write` (so the bot can post replies in channels it is invited to). The bot does **not** read silent channels.
- The internal bridge→api channel carries `LQ_AI_BRIDGE_TOKEN` as a bearer. Operator-supplied; must differ from any user-facing token.

## Test plan

- [x] Bridge unit tests: `pytest tests/` — 8/8 pass.
- [x] ruff format + ruff check + mypy --strict — all clean.
- [ ] CI: ruff + mypy + pytest in the new `Slack Bridge` workflow (to be added in a CI follow-up commit if needed; this PR may need a workflow file).
- [ ] Backend persistence endpoint lands (this branch, follow-up commit).
- [ ] OAuth callback integration test against mocked slack_sdk (this branch, follow-up commit).
- [ ] Manual E2E: install the bridge into a test Slack workspace, verify bot appears + persistence row lands in the LQ.AI api.

## Next session pickup

Per the M3-D1 task spec at `docs/M3-IMPLEMENTATION-PLAN.md` lines 682+:

1. Add `POST /api/v1/integrations/slack/workspaces` to the api — bridge-token bearer auth, persists `team_id`, encrypted `bot_token`, `team_name`, `bot_user_id`, `installer_slack_user_id`.
2. Migration 0037 — `slack_workspaces` table (uuid PK, team_id text unique, bot_token_encrypted bytea, etc.).
3. `slack-bridge/manifest.yml` — Slack App manifest declaring scopes + redirect URI.
4. `docker-compose.yml` — `slack-bridge` service under `profiles: [slack]`.
5. OAuth callback integration test with mocked `slack_sdk.AsyncWebClient`.
6. Backend endpoint test in `api/tests/test_integrations_slack.py`.

Estimated remaining effort: ~3–4 hours of focused work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)