### PR TITLE
M3-D3 — teams-bridge service + Microsoft OAuth + backend persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -332,3 +332,30 @@ LQ_AI_BACKEND_URL=
 # bridge through their reverse proxy.
 SLACK_BRIDGE_BIND_ADDR=
 SLACK_BRIDGE_HOST_PORT=
+
+# ============================================================
+# M3-D3 — teams-bridge integration
+# ============================================================
+#
+# Mirrors the slack-bridge posture for Microsoft Teams. Gated by the
+# `teams` Compose profile. LQ_AI_BRIDGE_TOKEN above is REUSED for
+# teams-bridge → api auth per M3-D3 decision #2 (same bearer for both
+# bridges). Unlike Slack, Teams has NO per-tenant bot token to encrypt
+# — the bot uses operator-supplied APP-LEVEL credentials below.
+
+# Microsoft-side credentials (from operator's Azure AD multi-tenant
+# app registration; see teams-bridge/README.md for the registration
+# walk-through).
+MICROSOFT_APP_ID=
+MICROSOFT_APP_PASSWORD=
+
+# Externally reachable base URL of the teams-bridge — Microsoft uses
+# this to construct the OAuth callback URL. Operators typically front
+# this with their reverse proxy (e.g. https://lqai.example.com/teams).
+LQ_AI_TEAMS_BRIDGE_PUBLIC_URL=
+
+# Optional host-side bind for the teams-bridge port (defaults to
+# 127.0.0.1:8003).
+TEAMS_BRIDGE_BIND_ADDR=
+TEAMS_BRIDGE_HOST_PORT=
+LQ_AI_TEAMS_BRIDGE_LOG_LEVEL=

--- a/api/alembic/versions/0038_teams_tenants.py
+++ b/api/alembic/versions/0038_teams_tenants.py
@@ -1,0 +1,86 @@
+"""create teams_tenants table — M3-D3
+
+Persists Microsoft 365 tenant records produced by the ``teams-bridge``
+OAuth install flow. Unlike Slack (which issues per-workspace bot
+tokens), Microsoft Teams uses **app-level bot credentials** — the bot
+authenticates to the Bot Framework with the operator's single
+``MICROSOFT_APP_ID`` + ``MICROSOFT_APP_PASSWORD`` regardless of which
+tenant it's running in. So there's no per-tenant bot token to encrypt;
+this table only persists the identity-binding fields the admin UI
+(M3-D4) needs to surface "the bot is installed in tenant X".
+
+Decision M3-D3-1 (encryption key): reuse ``LQ_AI_BRIDGE_MASTER_KEY``
+from M3-D1 — same bridge threat model. (And in this milestone we don't
+actually encrypt anything for Teams; the column is left for future
+per-user-refresh-token storage when M4 lands the on-behalf-of flow.)
+
+Decision M3-D3-2 (re-install semantics): upsert on ``tenant_id``.
+Re-install in the same M365 tenant replaces ``tenant_name`` +
+``installer_oid`` and revives ``deleted_at``.
+
+Decision M3-D3-4 (tenancy): the bridge runs as a multi-tenant
+Microsoft identity platform app, so one Azure AD app registration can
+host installs from any tenant. This table can carry rows for many
+tenants concurrently.
+
+Schema
+------
+
+* ``id`` — UUID PK.
+* ``tenant_id`` — Microsoft tenant id (the M365 directory's GUID);
+  unique. The natural key from Microsoft's side.
+* ``tenant_name`` — display name at install time. Best-effort —
+  Microsoft Graph returns the org's ``displayName`` field on the
+  consent response. NOT auto-refreshed if the tenant is renamed.
+* ``installer_oid`` — M365 ``oid`` claim of the admin who completed
+  consent. Audit-only — does not grant LQ.AI permissions.
+* ``installed_at`` — install timestamp (defaults to ``now()``).
+* ``deleted_at`` — soft-delete; matches the
+  ``slack_workspaces.deleted_at`` posture from migration 0037.
+
+Revision ID: 0038
+Revises: 0037
+Create Date: 2026-05-22
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0038"
+down_revision = "0037"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "teams_tenants",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("tenant_name", sa.Text(), nullable=False),
+        sa.Column("installer_oid", sa.Text(), nullable=False),
+        sa.Column(
+            "installed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "deleted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.UniqueConstraint("tenant_id", name="uq_teams_tenants_tenant_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("teams_tenants")

--- a/api/app/api/__init__.py
+++ b/api/app/api/__init__.py
@@ -33,6 +33,7 @@ from app.api import (
     inference,
     inference_override,
     integrations_slack,
+    integrations_teams,
     internal,
     knowledge_bases,
     models,
@@ -70,6 +71,12 @@ api_router.include_router(internal.router)
 # the user-token gate. Mounted without `_active` deliberately: the
 # bridge is a service-to-service caller with no user context.
 api_router.include_router(integrations_slack.router)
+
+# M3-D3: teams-bridge → api persistence surface. Same auth posture as
+# the slack-bridge endpoint (shared LQ_AI_BRIDGE_TOKEN bearer); no
+# per-tenant secrets persisted because Teams uses app-level bot
+# credentials (one MICROSOFT_APP_ID per deployment).
+api_router.include_router(integrations_teams.router)
 
 # M3-B8 — Word add-in version handshake. Unauthenticated: the task pane
 # calls this on mount BEFORE the user has signed in, so an out-of-date

--- a/api/app/api/dependencies.py
+++ b/api/app/api/dependencies.py
@@ -16,17 +16,22 @@ first needed (admin endpoints land later — see C7, D3, D4, D5, D6, D7).
 
 from __future__ import annotations
 
+import logging
+import secrets
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import Settings, get_settings
 from app.db.session import get_db
-from app.errors import PasswordChangeRequired
+from app.errors import InternalError, PasswordChangeRequired, Unauthorized
 from app.models.user import User
 from app.security.jwt import decode_access_token
+
+log = logging.getLogger(__name__)
 
 # tokenUrl is the documented login endpoint (per the OpenAPI sketch).
 # auto_error=True so a missing Authorization header raises 401 directly;
@@ -193,3 +198,53 @@ this in place of ``ActiveUser`` so the role gate fires before any
 business logic runs. Admin-only endpoints continue to use
 ``AdminUser``; pure-read endpoints stay on ``ActiveUser``.
 """
+
+
+# ---------------------------------------------------------------------------
+# M3-D1 / M3-D3 — bridge bearer auth (service-to-service, no user)
+# ---------------------------------------------------------------------------
+
+
+def require_bridge_auth(
+    settings: Annotated[Settings, Depends(get_settings)],
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+) -> None:
+    """Constant-time match the ``Authorization: Bearer …`` token against
+    :envvar:`LQ_AI_BRIDGE_TOKEN`.
+
+    Shared by every bridge → api persistence endpoint
+    (`/api/v1/integrations/slack/workspaces`,
+    `/api/v1/integrations/teams/tenants`, future bridges) because all
+    bridges authenticate to the api with the same shared secret per
+    M3-D1 decision #3.
+
+    Raises:
+      * :class:`InternalError` (500) when ``LQ_AI_BRIDGE_TOKEN`` is
+        unset on the api — accepting bridge traffic with no enforced
+        secret would silently break the trust contract.
+      * :class:`Unauthorized` (401) on missing, malformed, or
+        non-matching bearer.
+    """
+
+    expected = settings.lq_ai_bridge_token
+    if not expected:
+        log.error(
+            "LQ_AI_BRIDGE_TOKEN is not set on the api/ service; refusing "
+            "bridge traffic. Set the env var and restart."
+        )
+        raise InternalError(
+            message=(
+                "Bridge authentication is not configured on the backend. "
+                "Operator must set LQ_AI_BRIDGE_TOKEN."
+            ),
+        )
+
+    presented = ""
+    if authorization and authorization.startswith("Bearer "):
+        presented = authorization[len("Bearer ") :].strip()
+
+    if not presented or not secrets.compare_digest(presented, expected):
+        raise Unauthorized(
+            message="Invalid or missing bridge bearer token.",
+            details={"header": "Authorization"},
+        )

--- a/api/app/api/integrations_slack.py
+++ b/api/app/api/integrations_slack.py
@@ -27,16 +27,15 @@ its secret surface stays minimal.
 from __future__ import annotations
 
 import logging
-import secrets
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.dependencies import require_bridge_auth
 from app.config import Settings, get_settings
 from app.db.session import get_db
-from app.errors import InternalError, Unauthorized
 from app.models.slack_workspace import SlackWorkspace
 from app.schemas.slack_workspace import SlackWorkspaceCreate, SlackWorkspaceResponse
 from app.security.encryption import BridgeTokenEncryptor
@@ -44,44 +43,6 @@ from app.security.encryption import BridgeTokenEncryptor
 log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/integrations/slack", tags=["integrations-slack"])
-
-
-def require_bridge_auth(
-    settings: Annotated[Settings, Depends(get_settings)],
-    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
-) -> None:
-    """Constant-time match the ``Authorization: Bearer …`` token.
-
-    Raises:
-      * :class:`InternalError` (500) if ``LQ_AI_BRIDGE_TOKEN`` is unset
-        on the api — accepting bridge traffic with no enforced secret
-        would silently break the trust contract.
-      * :class:`Unauthorized` (401) on missing, malformed, or
-        non-matching bearer.
-    """
-
-    expected = settings.lq_ai_bridge_token
-    if not expected:
-        log.error(
-            "LQ_AI_BRIDGE_TOKEN is not set on the api/ service; refusing "
-            "slack-bridge traffic. Set the env var and restart."
-        )
-        raise InternalError(
-            message=(
-                "Bridge authentication is not configured on the backend. "
-                "Operator must set LQ_AI_BRIDGE_TOKEN."
-            ),
-        )
-
-    presented = ""
-    if authorization and authorization.startswith("Bearer "):
-        presented = authorization[len("Bearer ") :].strip()
-
-    if not presented or not secrets.compare_digest(presented, expected):
-        raise Unauthorized(
-            message="Invalid or missing bridge bearer token.",
-            details={"header": "Authorization"},
-        )
 
 
 @router.post(

--- a/api/app/api/integrations_teams.py
+++ b/api/app/api/integrations_teams.py
@@ -1,0 +1,83 @@
+"""Bridge persistence surface for Microsoft Teams tenant records — M3-D3.
+
+The teams-bridge service runs the OAuth dance with Microsoft identity
+platform (multi-tenant Azure AD app) then POSTs the resulting tenant
+tuple here. Auth posture is identical to the Slack equivalent: shared
+bearer token (LQ_AI_BRIDGE_TOKEN, reused per M3-D3 decision #2) via
+the shared :func:`app.api.dependencies.require_bridge_auth` dep.
+
+Decision M3-D3-2 (re-install semantics): upsert on ``tenant_id``.
+Re-install in the same M365 tenant replaces ``tenant_name`` +
+``installer_oid`` and revives ``deleted_at``. ``installed_at`` stays
+at the original install time.
+
+Decision M3-D3-3 (auth library): teams-bridge uses raw httpx against
+Microsoft identity platform (no botbuilder SDK). This module knows
+nothing about that — it just accepts the post-consent tenant tuple.
+
+Unlike :mod:`app.api.integrations_slack`, no bot token is persisted
+here: Microsoft Teams uses operator-supplied app-level bot
+credentials (one ``MICROSOFT_APP_ID`` per deployment) not per-tenant
+tokens. Per-user refresh tokens (when M4 lands on-behalf-of flows)
+will likely add a separate ``teams_user_tokens`` table.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import require_bridge_auth
+from app.db.session import get_db
+from app.models.teams_tenant import TeamsTenant
+from app.schemas.teams_tenant import TeamsTenantCreate, TeamsTenantResponse
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/integrations/teams", tags=["integrations-teams"])
+
+
+@router.post(
+    "/tenants",
+    response_model=TeamsTenantResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_bridge_auth)],
+)
+async def upsert_teams_tenant(
+    body: TeamsTenantCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TeamsTenantResponse:
+    """Persist (or upsert) the tenant record from the teams-bridge.
+
+    Upserts on ``tenant_id``. On conflict:
+      * ``tenant_name`` refreshed (operator may have renamed the org).
+      * ``installer_oid`` refreshed (a different admin may be
+        reinstalling).
+      * ``deleted_at`` reset to NULL.
+      * ``installed_at`` stays at the original install time.
+    """
+
+    existing = (
+        await db.execute(select(TeamsTenant).where(TeamsTenant.tenant_id == body.tenant_id))
+    ).scalar_one_or_none()
+
+    if existing is None:
+        tenant = TeamsTenant(
+            tenant_id=body.tenant_id,
+            tenant_name=body.tenant_name,
+            installer_oid=body.installer_oid,
+        )
+        db.add(tenant)
+    else:
+        existing.tenant_name = body.tenant_name
+        existing.installer_oid = body.installer_oid
+        existing.deleted_at = None
+        tenant = existing
+
+    await db.commit()
+    await db.refresh(tenant)
+    return TeamsTenantResponse.model_validate(tenant)

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -25,6 +25,7 @@ from app.models.saved_prompt import SavedPrompt
 from app.models.slack_workspace import SlackWorkspace
 from app.models.tabular import TabularExecution
 from app.models.team import Team, TeamMember
+from app.models.teams_tenant import TeamsTenant
 from app.models.user import User, UserSession
 from app.models.user_export import UserExportJob
 from app.models.user_skill import UserSkill
@@ -54,6 +55,7 @@ __all__ = [
     "TabularExecution",
     "Team",
     "TeamMember",
+    "TeamsTenant",
     "User",
     "UserExportJob",
     "UserSession",

--- a/api/app/models/teams_tenant.py
+++ b/api/app/models/teams_tenant.py
@@ -1,0 +1,47 @@
+"""TeamsTenant ORM — M3-D3.
+
+Persists Microsoft 365 tenant records produced by the ``teams-bridge``
+OAuth install flow. See migration ``0038_teams_tenants.py`` for the
+table DDL.
+
+Teams uses app-level bot credentials (one ``MICROSOFT_APP_ID`` per
+deployment), so there's no per-tenant bot token to encrypt here —
+contrast :class:`app.models.slack_workspace.SlackWorkspace` which
+holds a Fernet-wrapped ``bot_token_encrypted``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class TeamsTenant(Base):
+    """One Microsoft 365 tenant connected via the teams-bridge install flow."""
+
+    __tablename__ = "teams_tenants"
+    __table_args__ = (UniqueConstraint("tenant_id", name="uq_teams_tenants_tenant_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    tenant_id: Mapped[str] = mapped_column(Text, nullable=False)
+    tenant_name: Mapped[str] = mapped_column(Text, nullable=False)
+    installer_oid: Mapped[str] = mapped_column(Text, nullable=False)
+    installed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )

--- a/api/app/schemas/teams_tenant.py
+++ b/api/app/schemas/teams_tenant.py
@@ -1,0 +1,62 @@
+"""Pydantic wire shapes for the teams-bridge persistence surface — M3-D3.
+
+The teams-bridge service runs the OAuth dance with Microsoft identity
+platform (multi-tenant Azure AD app) then POSTs the resulting tenant
+tuple to ``POST /api/v1/integrations/teams/tenants`` on the api. This
+module defines the request body (:class:`TeamsTenantCreate`) and the
+response shape (:class:`TeamsTenantResponse`).
+
+Unlike the Slack equivalent, no bot token travels here — Microsoft
+Teams uses operator-supplied app-level bot credentials (one
+``MICROSOFT_APP_ID`` per deployment) not per-tenant tokens.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TeamsTenantCreate(BaseModel):
+    """Tenant record the teams-bridge POSTs after admin consent.
+
+    Field shape matches what ``teams-bridge/app/oauth.py`` produces
+    from the ``id_token`` claims (``tid`` for tenant_id, ``oid`` for
+    installer) and the Microsoft Graph ``/organization`` lookup for
+    the display name.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    tenant_id: str = Field(
+        ...,
+        min_length=1,
+        description="Microsoft tenant id (`tid` claim — the M365 directory GUID).",
+    )
+    tenant_name: str = Field(
+        ...,
+        min_length=1,
+        description="Tenant display name at install time (from Graph /organization).",
+    )
+    installer_oid: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "M365 object id (`oid` claim) of the admin who completed consent. "
+            "Audit only — does not grant LQ.AI permissions."
+        ),
+    )
+
+
+class TeamsTenantResponse(BaseModel):
+    """Persisted-tenant response. Mirrors :class:`SlackWorkspaceResponse`."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    tenant_id: str
+    tenant_name: str
+    installer_oid: str
+    installed_at: datetime

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -209,6 +209,8 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("GET", "/api/v1/word-addin/version"),
     # M3-D1 — slack-bridge persistence surface (bridge-token bearer auth)
     ("POST", "/api/v1/integrations/slack/workspaces"),
+    # M3-D3 — teams-bridge persistence surface (bridge-token bearer auth)
+    ("POST", "/api/v1/integrations/teams/tenants"),
     # D4 — Organization Profile singleton
     ("GET", "/api/v1/organization-profile"),
     ("PUT", "/api/v1/organization-profile"),

--- a/api/tests/test_integrations_teams.py
+++ b/api/tests/test_integrations_teams.py
@@ -1,0 +1,200 @@
+"""Integration tests for M3-D3's teams-bridge persistence endpoint.
+
+Covers ``POST /api/v1/integrations/teams/tenants``:
+
+* Auth — valid bridge bearer → 201; missing → 401; wrong → 401;
+  unset operator token on the api → 500.
+* Upsert semantics — re-POSTing the same ``tenant_id`` refreshes the
+  display name + installer OID + resurrects soft-deleted rows.
+* The shared :func:`require_bridge_auth` dep is exercised through the
+  same path as Slack (M3-D1) — this test pins that Teams sees identical
+  auth behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.db.session import get_db
+from app.main import app
+from app.models.teams_tenant import TeamsTenant
+
+BRIDGE_TOKEN = "bridge-token-fixture-value"
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def configured_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LQ_AI_BRIDGE_TOKEN", BRIDGE_TOKEN)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest_asyncio.fixture
+async def client(
+    db_session: AsyncSession,
+    configured_settings: None,
+) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def unconfigured_client(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[AsyncClient]:
+    monkeypatch.delenv("LQ_AI_BRIDGE_TOKEN", raising=False)
+    get_settings.cache_clear()
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+    get_settings.cache_clear()
+
+
+def _tenant_body(**overrides: str) -> dict[str, str]:
+    base = {
+        "tenant_id": "00000000-0000-0000-0000-aaaaaaaaaaaa",
+        "tenant_name": "Acme Legal LLP",
+        "installer_oid": "00000000-0000-0000-0000-111111111111",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_post_tenants_with_valid_bearer_returns_201(client: AsyncClient) -> None:
+    res = await client.post(
+        "/api/v1/integrations/teams/tenants",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_tenant_body(),
+    )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["tenant_id"] == "00000000-0000-0000-0000-aaaaaaaaaaaa"
+    assert body["tenant_name"] == "Acme Legal LLP"
+    assert body["installer_oid"] == "00000000-0000-0000-0000-111111111111"
+
+
+@pytest.mark.integration
+async def test_post_tenants_without_bearer_returns_401(client: AsyncClient) -> None:
+    res = await client.post(
+        "/api/v1/integrations/teams/tenants",
+        json=_tenant_body(),
+    )
+    assert res.status_code == 401
+
+
+@pytest.mark.integration
+async def test_post_tenants_with_wrong_bearer_returns_401(client: AsyncClient) -> None:
+    res = await client.post(
+        "/api/v1/integrations/teams/tenants",
+        headers={"Authorization": "Bearer not-the-real-token"},
+        json=_tenant_body(),
+    )
+    assert res.status_code == 401
+
+
+@pytest.mark.integration
+async def test_post_tenants_when_bridge_token_unset_returns_500(
+    unconfigured_client: AsyncClient,
+) -> None:
+    res = await unconfigured_client.post(
+        "/api/v1/integrations/teams/tenants",
+        headers={"Authorization": "Bearer anything"},
+        json=_tenant_body(),
+    )
+    assert res.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Upsert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_post_tenants_upserts_on_tenant_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    first = await client.post(
+        "/api/v1/integrations/teams/tenants",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_tenant_body(),
+    )
+    assert first.status_code == 201
+    first_id = first.json()["id"]
+
+    second = await client.post(
+        "/api/v1/integrations/teams/tenants",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_tenant_body(
+            tenant_name="Acme Legal LLP (renamed)",
+            installer_oid="00000000-0000-0000-0000-222222222222",
+        ),
+    )
+    assert second.status_code == 201
+    assert second.json()["id"] == first_id
+    assert second.json()["tenant_name"] == "Acme Legal LLP (renamed)"
+    assert second.json()["installer_oid"] == "00000000-0000-0000-0000-222222222222"
+
+    rows = (await db_session.execute(select(TeamsTenant))).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.integration
+async def test_post_tenants_resurrects_soft_deleted_row(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    res = await client.post(
+        "/api/v1/integrations/teams/tenants",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_tenant_body(),
+    )
+    assert res.status_code == 201
+
+    row = (
+        await db_session.execute(
+            select(TeamsTenant).where(
+                TeamsTenant.tenant_id == "00000000-0000-0000-0000-aaaaaaaaaaaa"
+            )
+        )
+    ).scalar_one()
+    row.deleted_at = datetime.now(tz=UTC)
+    await db_session.commit()
+
+    revived = await client.post(
+        "/api/v1/integrations/teams/tenants",
+        headers={"Authorization": f"Bearer {BRIDGE_TOKEN}"},
+        json=_tenant_body(),
+    )
+    assert revived.status_code == 201
+
+    await db_session.refresh(row)
+    assert row.deleted_at is None

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -150,6 +150,8 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/tabular/executions/{execution_id}/export",
         # M3-D1 — slack-bridge persistence surface (bearer-token, no user)
         "/api/v1/integrations/slack/workspaces",
+        # M3-D3 — teams-bridge persistence surface (bearer-token, no user)
+        "/api/v1/integrations/teams/tenants",
     }
 )
 
@@ -207,7 +209,10 @@ async def test_openapi_paths_match_sketch() -> None:
     #   (POST /integrations/slack/workspaces). One method-tuple here;
     #   the bridge is the sole caller so additional verbs aren't needed
     #   in M3-D1 (uninstall comes in M3-D4 admin UI work).
-    assert len(actual) == 90
+    # + M3-D3's one NEW path for the teams-bridge persistence surface
+    #   (POST /integrations/teams/tenants). Same posture as M3-D1's
+    #   slack equivalent.
+    assert len(actual) == 91
 
 
 @pytest.mark.unit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -449,6 +449,48 @@ services:
       timeout: 3s
       retries: 10
 
+  teams-bridge:
+    # M3-D3 — Microsoft Teams OAuth bridge. Gated by the ``teams``
+    # profile so operators who don't use Teams don't pay the SBOM
+    # cost or run a service they have nothing to do with.
+    #
+    # Bring up with: ``docker compose --profile teams up -d teams-bridge``
+    #
+    # Credentials come from the operator's Azure AD app registration
+    # (MICROSOFT_APP_ID + MICROSOFT_APP_PASSWORD); LQ_AI_BRIDGE_TOKEN
+    # is REUSED from the slack-bridge per M3-D3 decision #2 (same
+    # bearer authenticates both bridges to the api).
+    # LQ_AI_TEAMS_BRIDGE_PUBLIC_URL is the externally reachable URL
+    # Microsoft will hit on OAuth callback — typically fronted by the
+    # operator's reverse proxy.
+    build:
+      context: ./teams-bridge
+      dockerfile: Dockerfile
+    profiles: ["teams"]
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      # Microsoft-side credentials (Azure AD multi-tenant app)
+      MICROSOFT_APP_ID: ${MICROSOFT_APP_ID:?MICROSOFT_APP_ID is required when teams profile is enabled}
+      MICROSOFT_APP_PASSWORD: ${MICROSOFT_APP_PASSWORD:?MICROSOFT_APP_PASSWORD is required when teams profile is enabled}
+      # LQ.AI-side coordinates
+      LQ_AI_BACKEND_URL: ${LQ_AI_BACKEND_URL:-http://api:8000}
+      LQ_AI_BRIDGE_TOKEN: ${LQ_AI_BRIDGE_TOKEN:?LQ_AI_BRIDGE_TOKEN is required when teams profile is enabled}
+      LQ_AI_TEAMS_BRIDGE_PUBLIC_URL: ${LQ_AI_TEAMS_BRIDGE_PUBLIC_URL:?LQ_AI_TEAMS_BRIDGE_PUBLIC_URL is required when teams profile is enabled}
+      # Observability (opt-in)
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-lq-ai-teams-bridge}
+      LQ_AI_TEAMS_BRIDGE_LOG_LEVEL: ${LQ_AI_TEAMS_BRIDGE_LOG_LEVEL:-INFO}
+    ports:
+      - "${TEAMS_BRIDGE_BIND_ADDR:-127.0.0.1}:${TEAMS_BRIDGE_HOST_PORT:-8003}:8003"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8003/healthz', timeout=2).status == 200 else 1)"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
 # ============================================================
 # Persistent volumes (PRD §6.5)
 # ============================================================

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -3493,6 +3493,45 @@ paths:
         '500':
           description: Operator has not configured `LQ_AI_BRIDGE_TOKEN` on the api
 
+  /api/v1/integrations/teams/tenants:
+    post:
+      tags: [integrations-teams]
+      summary: Persist a Microsoft 365 tenant from the teams-bridge OAuth flow (M3-D3)
+      description: |
+        Service-to-service endpoint. Authenticated by the **same**
+        `Authorization: Bearer ${LQ_AI_BRIDGE_TOKEN}` bearer as the
+        slack-bridge endpoint per M3-D3 decision #2 — one shared
+        secret authenticates every bridge → api call.
+
+        Unlike the Slack equivalent, no bot token is persisted here:
+        Microsoft Teams uses operator-supplied APP-LEVEL bot
+        credentials (one `MICROSOFT_APP_ID` per deployment) not
+        per-tenant tokens. The persisted record carries only the
+        tenant id + display name + installer object id.
+
+        Upserts on `tenant_id`. Soft-deleted rows revive on
+        re-install. `installed_at` is NOT moved by upsert (operators
+        can infer re-install activity from other field changes).
+      security:
+        - bridgeBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TeamsTenantCreate'
+      responses:
+        '201':
+          description: Persisted (or upserted) the tenant record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamsTenantResponse'
+        '401':
+          description: Missing, malformed, or non-matching bridge bearer token
+        '500':
+          description: Operator has not configured `LQ_AI_BRIDGE_TOKEN` on the api
+
 # ============================================================
 # COMPONENTS
 # ============================================================
@@ -3576,6 +3615,73 @@ components:
           minLength: 1
           description: Comma-separated scope list Slack returned.
           example: 'commands,chat:write'
+
+    TeamsTenantCreate:
+      type: object
+      description: |
+        Request body for `POST /api/v1/integrations/teams/tenants`
+        (M3-D3). Shape matches what `teams-bridge/app/oauth.py`
+        constructs from the Microsoft id_token claims (`tid`, `oid`)
+        + a best-effort Microsoft Graph `/organization` display-name
+        lookup.
+      required:
+        - tenant_id
+        - tenant_name
+        - installer_oid
+      additionalProperties: false
+      properties:
+        tenant_id:
+          type: string
+          minLength: 1
+          description: Microsoft tenant id (`tid` claim — the M365 directory GUID).
+          example: '00000000-0000-0000-0000-aaaaaaaaaaaa'
+        tenant_name:
+          type: string
+          minLength: 1
+          description: |
+            Tenant display name at install time. Best-effort from
+            Microsoft Graph `/organization`; falls back to the
+            tenant_id if Graph errors.
+          example: 'Acme Legal LLP'
+        installer_oid:
+          type: string
+          minLength: 1
+          description: |
+            M365 `oid` claim of the admin who completed consent.
+            Audit only — does not grant LQ.AI permissions.
+          example: '00000000-0000-0000-0000-111111111111'
+
+    TeamsTenantResponse:
+      type: object
+      description: |
+        Persisted-tenant response for `POST
+        /api/v1/integrations/teams/tenants`. Mirrors
+        `SlackWorkspaceResponse` minus the per-tenant bot fields
+        (Teams uses app-level credentials).
+      required:
+        - id
+        - tenant_id
+        - tenant_name
+        - installer_oid
+        - installed_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: api-side tenant row id.
+        tenant_id:
+          type: string
+          example: '00000000-0000-0000-0000-aaaaaaaaaaaa'
+        tenant_name:
+          type: string
+          example: 'Acme Legal LLP'
+        installer_oid:
+          type: string
+          example: '00000000-0000-0000-0000-111111111111'
+        installed_at:
+          type: string
+          format: date-time
+          description: Original install timestamp. NOT moved by upsert.
 
     SlackWorkspaceResponse:
       type: object

--- a/teams-bridge/Dockerfile
+++ b/teams-bridge/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.7
+
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+RUN pip install --no-cache-dir .
+
+COPY app/ ./app/
+
+EXPOSE 8003
+
+# The teams-bridge is a lightweight HTTP service — no migrations, no
+# external storage. uvicorn runs the FastAPI app directly. Operators
+# in air-gapped environments who do not use Teams should not run this
+# service at all; the docker-compose `teams` profile gates startup.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8003"]

--- a/teams-bridge/README.md
+++ b/teams-bridge/README.md
@@ -1,0 +1,84 @@
+# LQ.AI Teams Bridge (M3-D3)
+
+The Teams bridge is a small standalone service that mediates between
+Microsoft identity platform / Bot Framework and the LQ.AI backend. It
+ships with the M3 release as **plumbing-only**: the `/lq` slash-command
+surface (M3-D2's Teams parity) is descoped to M4 / community
+contribution per [PRD §9 DE-288](../docs/PRD.md#de-288--slackteams-lq-slash-command--quick-skill-flow--deferred-to-m4--community-contribution).
+
+## What it does today (v0.3.0)
+
+- Hosts the OAuth admin-consent flow at `/teams/oauth/install` →
+  Microsoft identity platform → `/teams/oauth/callback` → tenant
+  persistence in the LQ.AI api.
+- Multi-tenant Azure AD app posture per [M3-D3 decision #4](../docs/M3-IMPLEMENTATION-PLAN.md#task-m3-d3--teams-bridge-service--teams-oauth--lq-flows)
+  — one Azure AD app registration can host installs from any
+  Microsoft 365 tenant.
+- Health surface: `/healthz` (liveness) + `/readyz` (readiness —
+  checks the LQ.AI api is reachable on the configured
+  `LQ_AI_BACKEND_URL`).
+
+## What it does NOT do today
+
+- **Slash commands** — `/lq` and `/lq ask` Teams parity, per DE-288,
+  are deferred.
+- **Bot framework message handling** — the bot does not respond to
+  channel messages; it only completes the OAuth install flow.
+- **Per-user Microsoft Graph access** — the on-behalf-of flow for
+  per-user Graph queries is M4 scope (when the slash-command surface
+  lands and `/lq` needs to read mail/files on the invoker's behalf).
+- **Per-tenant bot token encryption** — Teams uses operator-supplied
+  APP-LEVEL bot credentials (one `MICROSOFT_APP_ID` +
+  `MICROSOFT_APP_PASSWORD` per deployment) not per-tenant tokens, so
+  there's nothing per-tenant to encrypt. Contrast `slack-bridge`
+  which stores `bot_token_encrypted` per workspace.
+
+## Configuration
+
+| Env var | Required | Purpose |
+|---|---|---|
+| `MICROSOFT_APP_ID` | yes | Azure AD multi-tenant app client_id (from Azure AD admin) |
+| `MICROSOFT_APP_PASSWORD` | yes | Azure AD app client secret |
+| `LQ_AI_BACKEND_URL` | yes | Base URL of the lq-ai api (e.g. `http://api:8000`) |
+| `LQ_AI_BRIDGE_TOKEN` | yes | **Reused** from slack-bridge per M3-D3 decision #2 — same shared secret authenticates both bridges to the api |
+| `LQ_AI_TEAMS_BRIDGE_PUBLIC_URL` | yes | Public base URL of the teams-bridge — used to build the OAuth `redirect_uri` Microsoft calls back to (e.g. `https://lqai.example.com/teams`) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | no | OpenTelemetry exporter — opt-in per PRD §5.7 |
+| `OTEL_SERVICE_NAME` | no | Defaults to `lq-ai-teams-bridge` |
+| `LQ_AI_TEAMS_BRIDGE_LOG_LEVEL` | no | Defaults to `INFO` |
+
+## Running locally
+
+```bash
+docker compose --profile teams up -d teams-bridge
+```
+
+The teams-bridge service ships behind the `teams` Compose profile so
+operators who do not use Teams don't pay the SBOM cost. See
+`docker-compose.yml` for the service definition.
+
+## Setting up the Azure AD multi-tenant app
+
+1. In Azure Portal → Azure Active Directory → App registrations → New
+   registration:
+   - Name: LQ.AI
+   - Supported account types: "Accounts in any organizational
+     directory (Any Azure AD directory — Multitenant)"
+   - Redirect URI (Web): `${LQ_AI_TEAMS_BRIDGE_PUBLIC_URL}/teams/oauth/callback`
+2. Copy the Application (client) ID → `MICROSOFT_APP_ID`.
+3. Certificates & secrets → New client secret → copy value →
+   `MICROSOFT_APP_PASSWORD`.
+4. API permissions → Microsoft Graph → Delegated → `User.Read` +
+   `offline_access` (already on by default). Grant admin consent for
+   your own tenant.
+5. Expose an API (optional, only if the bot needs SSO into the task
+   pane — M4 scope).
+
+## Teams app manifest
+
+The Teams app manifest at `teams-bridge/manifest.json` declares the
+Teams app metadata, valid domains, and bot id. Operators upload the
+manifest to their tenant's Teams Admin Center → Manage apps → Upload.
+
+The bot id in the manifest must match `MICROSOFT_APP_ID`. The
+manifest is templated with `${MICROSOFT_APP_ID}` placeholders the
+operator substitutes before uploading.

--- a/teams-bridge/app/__init__.py
+++ b/teams-bridge/app/__init__.py
@@ -1,0 +1,1 @@
+"""LQ.AI Microsoft Teams bridge (M3-D3)."""

--- a/teams-bridge/app/config.py
+++ b/teams-bridge/app/config.py
@@ -1,0 +1,96 @@
+"""Runtime configuration for the LQ.AI Teams Bridge.
+
+Loaded from environment variables via ``pydantic-settings`` (same
+pattern as ``api/``, ``gateway/``, and ``slack-bridge/``).
+
+The fields divide into three groups:
+
+* **Microsoft-side credentials** — ``MICROSOFT_APP_ID`` (Azure AD
+  multi-tenant app client_id) + ``MICROSOFT_APP_PASSWORD`` (client
+  secret). These come from the operator's Azure AD admin portal.
+* **LQ.AI-side coordinates** — ``LQ_AI_BACKEND_URL`` (where the api
+  is reachable from inside the bridge's network) and
+  ``LQ_AI_BRIDGE_TOKEN`` (shared bearer with slack-bridge per M3-D3
+  decision #2).
+* **Bridge public URL** — ``LQ_AI_TEAMS_BRIDGE_PUBLIC_URL`` is the
+  externally reachable base URL of this bridge. Microsoft's OAuth
+  flow needs a public callback URL; the bridge builds it by
+  appending ``/teams/oauth/callback`` to this base.
+
+All fields are required EXCEPT for the OTel exporter URL (opt-in per
+PRD §5.7's "no telemetry by default" promise) and the log level
+(defaults to INFO).
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Bridge runtime configuration."""
+
+    model_config = SettingsConfigDict(env_file=None, extra="ignore")
+
+    microsoft_app_id: str = Field(..., description="Azure AD multi-tenant app client_id.")
+    microsoft_app_password: str = Field(
+        ...,
+        description="Azure AD app client secret (sometimes called `MICROSOFT_APP_PASSWORD`).",
+    )
+
+    lq_ai_backend_url: str = Field(
+        ...,
+        description=(
+            "Base URL of the LQ.AI api as reachable from inside the "
+            "bridge's network (e.g. http://api:8000 in compose)."
+        ),
+    )
+    lq_ai_bridge_token: str = Field(
+        ...,
+        description=(
+            "Shared secret the bridge sends on every internal call to "
+            "the api. The api verifies this matches its own "
+            "LQ_AI_BRIDGE_TOKEN env var. **Reused** with slack-bridge "
+            "per M3-D3 decision #2."
+        ),
+    )
+    lq_ai_teams_bridge_public_url: str = Field(
+        ...,
+        description=(
+            "Externally reachable base URL of the teams-bridge itself. "
+            "Microsoft's OAuth flow needs this to construct the callback "
+            "URL (LQ_AI_TEAMS_BRIDGE_PUBLIC_URL + /teams/oauth/callback)."
+        ),
+    )
+
+    # Observability — opt-in per PRD §5.7.
+    otel_exporter_otlp_endpoint: str | None = Field(
+        default=None,
+        description=(
+            "OpenTelemetry collector endpoint. If unset, the bridge does "
+            "not initialise the TracerProvider — no telemetry leaves the "
+            "deployment (PRD §5.7 no-telemetry-by-default)."
+        ),
+    )
+    otel_service_name: str = Field(
+        default="lq-ai-teams-bridge",
+        description="Resource attribute reported on every span.",
+    )
+
+    log_level: str = Field(
+        default="INFO",
+        description="Python logging level for the bridge process.",
+    )
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    """Return a process-cached :class:`Settings` instance."""
+
+    global _settings
+    if _settings is None:
+        _settings = Settings()  # type: ignore[call-arg]
+    return _settings

--- a/teams-bridge/app/main.py
+++ b/teams-bridge/app/main.py
@@ -1,0 +1,99 @@
+"""LQ.AI Teams Bridge — FastAPI entry point (M3-D3).
+
+The bridge surface is intentionally tiny at v0.3.0:
+
+* ``GET  /healthz`` — liveness. Always 200 once the process is up.
+* ``GET  /readyz`` — readiness. 200 when ``LQ_AI_BACKEND_URL`` is
+  reachable; 503 otherwise.
+* ``GET  /teams/oauth/install`` — kicks off the Microsoft identity
+  platform admin-consent flow. See ``app.oauth``.
+* ``GET  /teams/oauth/callback`` — receives Microsoft's redirect
+  after the tenant admin consents.
+
+Everything else — slash commands, Bot Framework activity routing,
+per-user identity binding — is M3-D2 (descoped, see DE-288) / M3-D4
+(admin UI) / community contribution scope.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+from .config import Settings, get_settings
+from .oauth import router as oauth_router
+from .observability import init_otel
+
+log = logging.getLogger(__name__)
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Build the FastAPI application.
+
+    Factored out of module-level instantiation so tests can construct
+    isolated app instances with their own ``Settings`` overrides.
+    """
+
+    cfg = settings or get_settings()
+
+    logging.basicConfig(
+        level=cfg.log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    app = FastAPI(
+        title="LQ.AI Teams Bridge",
+        version="0.1.0",
+        description=(
+            "OAuth admin-consent + tenant persistence for the LQ.AI "
+            "Microsoft Teams integration. M3-D3 plumbing. Slash-command "
+            "surface deferred to M4 / community per DE-288."
+        ),
+    )
+
+    init_otel(cfg)
+    FastAPIInstrumentor.instrument_app(app)
+
+    app.include_router(oauth_router)
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/readyz")
+    async def readyz() -> JSONResponse:
+        """Readiness check — verifies the LQ.AI api is reachable.
+
+        The bridge is useless without the api: every OAuth callback
+        ends with a POST to the api's bridge-facing persistence
+        endpoint. If the api is down, the bridge should report
+        unready so operators see the dependency failure rather than
+        a confusing OAuth callback error.
+        """
+
+        try:
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                res = await client.get(f"{cfg.lq_ai_backend_url}/healthz")
+                if res.status_code != 200:
+                    return JSONResponse(
+                        status_code=503,
+                        content={
+                            "status": "unready",
+                            "reason": f"backend returned {res.status_code}",
+                        },
+                    )
+        except (httpx.HTTPError, OSError) as exc:
+            return JSONResponse(
+                status_code=503,
+                content={"status": "unready", "reason": f"backend unreachable: {exc}"},
+            )
+        return JSONResponse(content={"status": "ok"})
+
+    return app
+
+
+app = create_app()

--- a/teams-bridge/app/oauth.py
+++ b/teams-bridge/app/oauth.py
@@ -1,0 +1,362 @@
+"""Microsoft OAuth admin-consent + callback handlers (M3-D3).
+
+The flow:
+
+1. **Operator initiates install** by clicking a button in the LQ.AI
+   admin UI (M3-D4 work) which opens ``GET /teams/oauth/install`` on
+   the bridge.
+2. **Bridge redirects to Microsoft identity platform** with the Azure
+   AD app's ``client_id``, the scopes the bridge declares (``openid``,
+   ``profile``, ``email``, ``offline_access``, plus
+   ``https://graph.microsoft.com/User.Read`` so the bridge can fetch
+   the tenant display name from Graph), a randomly-generated ``state``
+   token (CSRF), the redirect_uri pointing back at this bridge, and
+   ``prompt=admin_consent`` so the tenant admin grants consent for
+   the whole tenant in one flow.
+3. **Admin consents in Microsoft**, Microsoft redirects to
+   ``GET /teams/oauth/callback?code=...&state=...``.
+4. **Bridge verifies the state**, exchanges the code for tokens via
+   the multi-tenant ``/common/oauth2/v2.0/token`` endpoint, decodes
+   the id_token's ``tid`` (tenant id) + ``oid`` (admin's object id)
+   claims, optionally calls Microsoft Graph ``/organization`` to
+   fetch the tenant display name, and POSTs the resulting tenant
+   record to the LQ.AI api at
+   ``POST /api/v1/integrations/teams/tenants``.
+5. **Bridge returns a simple success page** so the operator sees
+   confirmation in their browser.
+
+Decision M3-D3-3 (raw httpx, no botbuilder SDK): both the token
+exchange and the optional Graph display-name lookup are plain HTTP
+calls. The official ``botbuilder-core`` SDK adds ~15 transitive deps
+we don't need for plumbing.
+
+Decision M3-D3-4 (multi-tenant): the authorize/token endpoints use
+the ``/common/`` tenant placeholder so any Microsoft 365 tenant's
+admin can install the app under the operator's single Azure AD
+multi-tenant app registration.
+
+State tokens live in-memory in the bridge with a 10-minute TTL.
+Single-instance per deployment so an in-memory store is sufficient
+(matches the slack-bridge posture; same DE candidate).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import secrets
+import time
+import uuid
+from typing import Annotated, Any
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .config import Settings, get_settings
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/teams", tags=["teams-oauth"])
+
+
+_STATE_STORE: dict[str, float] = {}
+_STATE_TTL_SECONDS = 600  # 10 minutes
+
+
+def _gc_state_store() -> None:
+    """Best-effort cleanup of expired state tokens."""
+
+    now = time.time()
+    expired = [k for k, ts in _STATE_STORE.items() if now - ts > _STATE_TTL_SECONDS]
+    for k in expired:
+        _STATE_STORE.pop(k, None)
+
+
+# Scopes the bridge requests during admin consent. ``User.Read`` is the
+# narrowest scope that returns an access_token usable against Microsoft
+# Graph, which the bridge calls (best-effort) to fetch the tenant
+# display name for the persisted record. ``offline_access`` keeps
+# refresh-token plumbing alive for future M4 on-behalf-of flows.
+SCOPES = [
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "https://graph.microsoft.com/User.Read",
+]
+
+
+def _decode_id_token_unverified(id_token: str) -> dict[str, Any]:
+    """Base64-decode the id_token payload without signature verification.
+
+    Safe in this context because the token arrived over TLS from the
+    Microsoft token endpoint via our client_secret-authenticated POST.
+    The bridge doesn't grant any LQ.AI-side permissions based on
+    these claims — they're only used to identify which tenant + admin
+    completed the install.
+    """
+
+    try:
+        _header, payload, _sig = id_token.split(".")
+    except ValueError as exc:
+        raise ValueError("id_token is not a JWT (expected three dot-separated segments)") from exc
+    # JWT base64url has no padding; rfill with '='s before decode.
+    pad = "=" * (-len(payload) % 4)
+    decoded = base64.urlsafe_b64decode(payload + pad)
+    parsed = json.loads(decoded)
+    if not isinstance(parsed, dict):
+        raise ValueError("id_token payload did not decode to a JSON object")
+    return parsed
+
+
+@router.get("/oauth/install")
+async def oauth_install(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> RedirectResponse:
+    """Redirect the operator to Microsoft's admin-consent page."""
+
+    _gc_state_store()
+    state = secrets.token_urlsafe(32)
+    _STATE_STORE[state] = time.time()
+
+    redirect_uri = f"{settings.lq_ai_teams_bridge_public_url.rstrip('/')}/teams/oauth/callback"
+    params = {
+        "client_id": settings.microsoft_app_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "response_mode": "query",
+        "scope": " ".join(SCOPES),
+        "state": state,
+        "prompt": "admin_consent",
+    }
+    consent_url = (
+        f"https://login.microsoftonline.com/common/oauth2/v2.0/authorize?{urlencode(params)}"
+    )
+
+    log.info("teams.oauth.install_started state=%s", state[:8])
+    return RedirectResponse(url=consent_url, status_code=302)
+
+
+@router.get("/oauth/callback")
+async def oauth_callback(
+    request: Request,
+    settings: Annotated[Settings, Depends(get_settings)],
+    code: Annotated[str | None, Query(description="Authorization code from Microsoft.")] = None,
+    state: Annotated[str | None, Query(description="Round-tripped state token (CSRF).")] = None,
+    error: Annotated[str | None, Query()] = None,
+    error_description: Annotated[str | None, Query()] = None,
+) -> HTMLResponse:
+    """Handle the Microsoft identity platform OAuth callback.
+
+    Steps:
+
+    1. If ``error`` is set, render the cancellation page (admin
+       declined consent).
+    2. Verify ``state`` matches a token we issued (single-use).
+    3. POST to the multi-tenant token endpoint with
+       ``grant_type=authorization_code`` to exchange ``code`` for an
+       ``id_token`` + ``access_token`` + ``refresh_token``.
+    4. Decode the id_token (no signature verify needed — TLS + our
+       client_secret authenticated us to Microsoft).
+    5. Best-effort: call Microsoft Graph ``/organization`` to fetch
+       the tenant display name; falls back to ``tid`` if Graph errors.
+    6. POST the tenant record to the LQ.AI api with the shared
+       ``LQ_AI_BRIDGE_TOKEN`` bearer.
+    """
+
+    if error:
+        log.warning("teams.oauth.user_denied error=%s description=%s", error, error_description)
+        return HTMLResponse(
+            f"<h1>Install cancelled</h1><p>Microsoft returned: {error!r}</p>"
+            f"<p>{error_description or ''}</p>",
+            status_code=400,
+        )
+
+    _gc_state_store()
+    if state is None or _STATE_STORE.pop(state, None) is None:
+        log.warning("teams.oauth.invalid_state state=%s", (state or "")[:8])
+        raise HTTPException(
+            status_code=400,
+            detail=("invalid or expired state token — restart the install from the LQ.AI admin UI"),
+        )
+
+    if not code:
+        log.warning("teams.oauth.missing_code")
+        raise HTTPException(status_code=400, detail="missing authorization code from Microsoft")
+
+    redirect_uri = f"{settings.lq_ai_teams_bridge_public_url.rstrip('/')}/teams/oauth/callback"
+
+    token_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    token_body = {
+        "client_id": settings.microsoft_app_id,
+        "client_secret": settings.microsoft_app_password,
+        "code": code,
+        "grant_type": "authorization_code",
+        "redirect_uri": redirect_uri,
+        "scope": " ".join(SCOPES),
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as http:
+            tok_res = await http.post(
+                token_url,
+                data=token_body,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+    except httpx.HTTPError as exc:
+        log.exception("teams.oauth.token_endpoint_failed")
+        return HTMLResponse(
+            f"<h1>Install failed</h1><p>Token exchange failed: {exc!r}</p>",
+            status_code=502,
+        )
+
+    if tok_res.status_code != 200:
+        log.warning(
+            "teams.oauth.token_endpoint_rejected status=%s body=%s",
+            tok_res.status_code,
+            tok_res.text[:300],
+        )
+        return HTMLResponse(
+            f"<h1>Install failed</h1>"
+            f"<p>Microsoft token endpoint returned HTTP {tok_res.status_code}.</p>"
+            f"<pre>{tok_res.text[:500]}</pre>",
+            status_code=502,
+        )
+
+    tok_payload = tok_res.json()
+    id_token = tok_payload.get("id_token")
+    access_token = tok_payload.get("access_token")
+    if not id_token or not access_token:
+        log.error("teams.oauth.malformed_token_response payload=%s", tok_payload)
+        return HTMLResponse(
+            "<h1>Install failed</h1><p>Microsoft response missing id_token or access_token.</p>",
+            status_code=502,
+        )
+
+    try:
+        claims = _decode_id_token_unverified(id_token)
+    except ValueError as exc:
+        log.error("teams.oauth.id_token_decode_failed error=%s", exc)
+        return HTMLResponse(
+            f"<h1>Install failed</h1><p>id_token decode failed: {exc!r}</p>",
+            status_code=502,
+        )
+
+    tenant_id = claims.get("tid")
+    installer_oid = claims.get("oid")
+    if not tenant_id or not installer_oid:
+        log.error("teams.oauth.id_token_missing_claims claims_keys=%s", list(claims.keys()))
+        return HTMLResponse(
+            "<h1>Install failed</h1><p>id_token did not carry the required tid + oid claims.</p>",
+            status_code=502,
+        )
+
+    # Best-effort tenant display name via Microsoft Graph. Falls back
+    # to the tenant id if Graph errors — we'd rather persist with a
+    # placeholder name than fail the whole install on a Graph hiccup.
+    tenant_name = await _fetch_tenant_display_name(access_token) or str(tenant_id)
+
+    tenant_record = {
+        "tenant_id": str(tenant_id),
+        "tenant_name": tenant_name,
+        "installer_oid": str(installer_oid),
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as http:
+            persist_res = await http.post(
+                f"{settings.lq_ai_backend_url.rstrip('/')}/api/v1/integrations/teams/tenants",
+                headers={"Authorization": f"Bearer {settings.lq_ai_bridge_token}"},
+                json=tenant_record,
+            )
+    except httpx.HTTPError as exc:
+        log.exception("teams.oauth.api_persist_failed")
+        return HTMLResponse(
+            f"<h1>Install failed</h1><p>Could not persist to the LQ.AI backend: {exc!r}</p>",
+            status_code=502,
+        )
+
+    if persist_res.status_code not in (200, 201, 204):
+        log.warning(
+            "teams.oauth.api_persist_rejected status=%s body=%s",
+            persist_res.status_code,
+            persist_res.text[:200],
+        )
+        return HTMLResponse(
+            f"<h1>Install failed</h1><p>Backend rejected with HTTP {persist_res.status_code}.</p>",
+            status_code=502,
+        )
+
+    log.info(
+        "teams.oauth.install_completed tenant_id=%s installer_oid=%s",
+        tenant_id,
+        installer_oid,
+    )
+
+    correlation = uuid.uuid4().hex[:8]
+    body_style = "font-family: system-ui; max-width: 32rem; margin: 4rem auto; line-height: 1.5;"
+    connected_line = (
+        f"<p>Microsoft 365 tenant <strong>{tenant_name}</strong> "
+        f"is now connected to this LQ.AI deployment.</p>"
+    )
+    next_step_line = (
+        "<p>Next step: upload the Teams app manifest "
+        "(see <code>teams-bridge/manifest.json</code>) to your Teams "
+        "Admin Center, then open the LQ.AI admin UI to bind Teams "
+        "users to LQ.AI accounts (M3-D4).</p>"
+    )
+    return HTMLResponse(
+        content=f"""
+        <!doctype html>
+        <html lang="en">
+        <head><meta charset="utf-8"><title>LQ.AI Teams install complete</title></head>
+        <body style="{body_style}">
+          <h1>Install complete</h1>
+          {connected_line}
+          {next_step_line}
+          <p style="color: #888; font-size: 0.875rem;">Correlation: <code>{correlation}</code></p>
+        </body>
+        </html>
+        """,
+        status_code=200,
+    )
+
+
+async def _fetch_tenant_display_name(access_token: str) -> str | None:
+    """Best-effort Microsoft Graph lookup for the tenant displayName.
+
+    Returns ``None`` on any failure path — the caller falls back to
+    the tenant id rather than failing the whole install.
+    """
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as http:
+            res = await http.get(
+                "https://graph.microsoft.com/v1.0/organization",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+    except httpx.HTTPError as exc:
+        log.info("teams.oauth.graph_org_lookup_failed error=%s", exc)
+        return None
+
+    if res.status_code != 200:
+        log.info(
+            "teams.oauth.graph_org_lookup_rejected status=%s body=%s",
+            res.status_code,
+            res.text[:200],
+        )
+        return None
+
+    try:
+        body = res.json()
+        orgs = body.get("value") or []
+        if orgs and isinstance(orgs, list):
+            name = orgs[0].get("displayName")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+    except (ValueError, KeyError, TypeError):
+        return None
+    return None

--- a/teams-bridge/app/observability.py
+++ b/teams-bridge/app/observability.py
@@ -1,0 +1,61 @@
+"""OpenTelemetry init for the Teams Bridge.
+
+Mirrors ``slack-bridge/app/observability.py`` — opt-in via
+``OTEL_EXPORTER_OTLP_ENDPOINT``, auto-instrumentation for FastAPI +
+httpx, no metrics surface beyond what FastAPI auto-instrumentation
+produces.
+
+When M3 Phase F's domain-span work lands (per
+``docs/proposals/opentelemetry-deepening.md``), the bridge will gain
+``teams.oauth.exchange`` and ``teams.callback.verify`` spans on top
+of this substrate.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .config import Settings
+
+log = logging.getLogger(__name__)
+
+
+def init_otel(settings: Settings) -> None:
+    """Initialise OTel TracerProvider + auto-instrumentations.
+
+    No-op when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is unset (PRD §5.7
+    no-telemetry-by-default promise applies here too).
+    """
+
+    if not settings.otel_exporter_otlp_endpoint:
+        log.info(
+            "otel.disabled — OTEL_EXPORTER_OTLP_ENDPOINT unset; bridge will "
+            "emit no telemetry. Per PRD §5.7's no-telemetry-by-default."
+        )
+        return
+
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter,
+    )
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    resource = Resource.create(
+        {"service.name": settings.otel_service_name, "service.namespace": "lq-ai"}
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=settings.otel_exporter_otlp_endpoint))
+    )
+    trace.set_tracer_provider(provider)
+
+    HTTPXClientInstrumentor().instrument()
+
+    log.info(
+        "otel.initialised — exporter=%s, service.name=%s",
+        settings.otel_exporter_otlp_endpoint,
+        settings.otel_service_name,
+    )

--- a/teams-bridge/manifest.json
+++ b/teams-bridge/manifest.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.16/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.16",
+  "version": "0.1.0",
+  "id": "${MICROSOFT_APP_ID}",
+  "_comment_id": "The 'id' field is the Teams App ID. For a bot-only app it can be the same GUID as the bot id (MICROSOFT_APP_ID). Operators substitute the placeholder before uploading the manifest.",
+  "packageName": "ai.lqai.teams",
+  "developer": {
+    "name": "LegalQuants",
+    "websiteUrl": "https://lqai.example.com",
+    "privacyUrl": "https://lqai.example.com/privacy",
+    "termsOfUseUrl": "https://lqai.example.com/terms"
+  },
+  "icons": {
+    "color": "color.png",
+    "outline": "outline.png"
+  },
+  "name": {
+    "short": "LQ.AI",
+    "full": "LQ.AI for Microsoft Teams"
+  },
+  "description": {
+    "short": "In-house legal AI bridge for LQ.AI deployments.",
+    "full": "LQ.AI is a self-hosted, transparency-first AI platform for in-house legal teams. This Microsoft Teams bridge connects a tenant to one LQ.AI deployment so that future slash-command and bot surfaces can be wired up by operator and community contributors. The bot does not read silent channels — it only responds to explicit user invocations."
+  },
+  "accentColor": "#0B3A53",
+  "_comment_bots": "The slash-command surface lands with DE-288 (M4 / community). At v0.3.0 the bot is registered so the tenant install flow + identity binding work; commandLists is intentionally empty until DE-288 ships.",
+  "bots": [
+    {
+      "botId": "${MICROSOFT_APP_ID}",
+      "scopes": ["personal", "team", "groupchat"],
+      "isNotificationOnly": false,
+      "supportsCalling": false,
+      "supportsVideo": false,
+      "supportsFiles": false,
+      "commandLists": []
+    }
+  ],
+  "validDomains": [
+    "${LQ_AI_TEAMS_BRIDGE_PUBLIC_HOST}"
+  ],
+  "_comment_validDomains": "${LQ_AI_TEAMS_BRIDGE_PUBLIC_HOST} is the bare host (no scheme, no path) of the teams-bridge — e.g. 'lqai.example.com'. Operators substitute before uploading.",
+  "permissions": ["identity", "messageTeamMembers"],
+  "_comment_webApplicationInfo": "webApplicationInfo enables Azure AD SSO for future task-pane / message-extension surfaces. The resource value uses the api://-prefixed app id URI from the Azure AD app registration; operators set this when M4 SSO lands.",
+  "webApplicationInfo": {
+    "id": "${MICROSOFT_APP_ID}",
+    "resource": "api://${LQ_AI_TEAMS_BRIDGE_PUBLIC_HOST}/${MICROSOFT_APP_ID}"
+  }
+}

--- a/teams-bridge/pyproject.toml
+++ b/teams-bridge/pyproject.toml
@@ -1,0 +1,84 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lq-ai-teams-bridge"
+version = "0.1.0"
+description = "LQ.AI Microsoft Teams bridge — OAuth admin consent + tenant persistence (M3-D3)"
+readme = "README.md"
+requires-python = ">=3.12"
+license = "Apache-2.0"
+authors = [{ name = "LegalQuants" }]
+
+# M3-D3 — the teams-bridge mirrors slack-bridge for Microsoft Teams.
+# It handles:
+#
+# 1. The OAuth admin-consent flow (operator clicks "Install Teams" in
+#    the LQ.AI admin UI → bridge redirects to Microsoft identity
+#    platform's multi-tenant /authorize endpoint with prompt=admin_consent
+#    → tenant admin consents → callback exchanges the code for tokens
+#    → bridge extracts tid+oid from the id_token and POSTs the tenant
+#    record to the LQ.AI api over the shared LQ_AI_BRIDGE_TOKEN bearer).
+# 2. (Future M3-D2 / community contribution) the `/lq` slash command
+#    handler for Teams. Descoped from M3 per PRD §9 DE-288.
+#
+# Unlike the Slack equivalent, the Teams bot uses operator-supplied
+# APP-LEVEL credentials (one MICROSOFT_APP_ID + MICROSOFT_APP_PASSWORD
+# per deployment) rather than per-tenant bot tokens. There is nothing
+# per-tenant to encrypt in M3-D3.
+#
+# Decision M3-D3-3 (raw httpx, no botbuilder SDK): the Microsoft
+# identity platform OAuth surface is plain HTTP; the official
+# botbuilder-core SDK adds ~15 transitive deps (msrest, msal,
+# aiohttp, botbuilder-schema, ...) we don't need for the M3-D3
+# plumbing scope. Mirrors slack-bridge's "slack-sdk only for the
+# OAuth exchange, everything else raw" posture.
+dependencies = [
+    "fastapi>=0.115,<0.137",
+    "uvicorn[standard]>=0.32,<0.48",
+    "pydantic>=2.7,<3",
+    "pydantic-settings>=2.4,<3",
+    "httpx>=0.27,<0.29",
+    # OpenTelemetry — mirrors api/ + gateway/ + slack-bridge/ so the
+    # teams-bridge participates in the M1 OTel substrate from day one.
+    # M3 Phase F adds domain spans on top.
+    "opentelemetry-api>=1.27,<2",
+    "opentelemetry-sdk>=1.27,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
+    "opentelemetry-instrumentation-fastapi>=0.48b0,<1",
+    "opentelemetry-instrumentation-httpx>=0.48b0,<1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3,<9",
+    "pytest-asyncio>=0.24,<0.25",
+    "pytest-httpx>=0.32,<0.40",
+    "ruff>=0.6,<0.14",
+    "mypy>=1.11,<2",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "SIM"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+markers = [
+    "unit: fast tests with no external deps",
+    "integration: tests against real external services or mocked equivalents",
+]

--- a/teams-bridge/tests/conftest.py
+++ b/teams-bridge/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Test fixtures for the LQ.AI Teams Bridge.
+
+``app/main.py`` constructs the FastAPI ``app`` object at module import
+time (``app = create_app()``), which calls ``Settings()`` and fails if
+the operator hasn't set the required Microsoft / LQ.AI env vars. Tests
+don't want to depend on a real Azure AD app's secrets, so this
+conftest seeds the process environment with safe fixture values
+BEFORE pytest collects any test that imports from ``app.main``.
+
+Individual tests construct their own app via ``create_app(settings=…)``
+to inject test-specific Settings; the env-var seeding here just makes
+the module-level ``app = create_app()`` line not crash on import.
+"""
+
+from __future__ import annotations
+
+import os
+
+_TEST_DEFAULTS = {
+    "MICROSOFT_APP_ID": "test-microsoft-app-id",
+    "MICROSOFT_APP_PASSWORD": "test-microsoft-app-secret",
+    "LQ_AI_BACKEND_URL": "http://api.test",
+    "LQ_AI_BRIDGE_TOKEN": "test-bridge-token",
+    "LQ_AI_TEAMS_BRIDGE_PUBLIC_URL": "https://teams-bridge.test",
+}
+
+for key, value in _TEST_DEFAULTS.items():
+    os.environ.setdefault(key, value)

--- a/teams-bridge/tests/test_oauth.py
+++ b/teams-bridge/tests/test_oauth.py
@@ -1,0 +1,325 @@
+"""OAuth admin-consent + callback handler tests for the teams-bridge (M3-D3).
+
+Covers:
+
+* ``GET /teams/oauth/install`` — generates a fresh state token, stores
+  it in the bridge's in-memory store, and redirects to the Microsoft
+  identity platform multi-tenant authorize endpoint with the right
+  ``client_id`` / ``scope`` / ``redirect_uri`` / ``state`` /
+  ``prompt=admin_consent`` query params.
+* ``GET /teams/oauth/callback`` — happy path: valid state → mocked
+  token exchange → mocked Graph display-name lookup → POST tenant
+  record to the api over the shared bridge token → success page.
+* ``GET /teams/oauth/callback`` — bad state → 400.
+* ``GET /teams/oauth/callback`` — ``error=...`` query param renders
+  the cancellation page without contacting Microsoft or the api.
+* Microsoft token endpoint returning non-200 → 502.
+* api persistence returning non-2xx → 502.
+* Graph display-name lookup failure falls back to tid (does NOT 502).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+from pytest_httpx import HTTPXMock
+
+from app import oauth as oauth_module
+from app.config import Settings, get_settings
+from app.main import create_app
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        microsoft_app_id="ms-app-id-fixture",
+        microsoft_app_password="ms-app-password-fixture",
+        lq_ai_backend_url="http://api.test",
+        lq_ai_bridge_token="bridge-token-fixture",
+        lq_ai_teams_bridge_public_url="https://teams-bridge.test",
+    )
+
+
+@pytest.fixture
+def client(settings: Settings) -> TestClient:
+    app = create_app(settings=settings)
+    app.dependency_overrides[get_settings] = lambda: settings
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state_store() -> None:
+    oauth_module._STATE_STORE.clear()
+    yield
+    oauth_module._STATE_STORE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_state(state: str = "stateA") -> str:
+    oauth_module._STATE_STORE[state] = time.time()
+    return state
+
+
+def _b64url(data: bytes) -> str:
+    """Base64-url-encode without padding (JWT convention)."""
+
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _make_id_token(claims: dict[str, Any]) -> str:
+    """Construct a JWT-shaped id_token for tests (signature ignored)."""
+
+    header = _b64url(json.dumps({"alg": "none", "typ": "JWT"}).encode())
+    payload = _b64url(json.dumps(claims).encode())
+    signature = _b64url(b"signature-not-checked")
+    return f"{header}.{payload}.{signature}"
+
+
+# ---------------------------------------------------------------------------
+# /teams/oauth/install
+# ---------------------------------------------------------------------------
+
+
+def test_install_redirects_to_microsoft_consent_with_required_params(
+    client: TestClient,
+    settings: Settings,
+) -> None:
+    res = client.get("/teams/oauth/install")
+    assert res.status_code == 302
+    location = res.headers["location"]
+
+    parsed = urlparse(location)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "login.microsoftonline.com"
+    assert parsed.path == "/common/oauth2/v2.0/authorize"
+
+    params = parse_qs(parsed.query)
+    assert params["client_id"] == [settings.microsoft_app_id]
+    assert params["response_type"] == ["code"]
+    assert params["redirect_uri"] == [
+        f"{settings.lq_ai_teams_bridge_public_url.rstrip('/')}/teams/oauth/callback"
+    ]
+    assert params["response_mode"] == ["query"]
+    assert params["prompt"] == ["admin_consent"]
+    scope_value = params["scope"][0]
+    assert "openid" in scope_value
+    assert "User.Read" in scope_value
+    state = params["state"][0]
+    assert state  # non-empty CSRF token
+    assert state in oauth_module._STATE_STORE
+
+
+def test_install_emits_distinct_state_tokens(client: TestClient) -> None:
+    states = set()
+    for _ in range(3):
+        res = client.get("/teams/oauth/install")
+        states.add(parse_qs(urlparse(res.headers["location"]).query)["state"][0])
+    assert len(states) == 3
+
+
+# ---------------------------------------------------------------------------
+# /teams/oauth/callback — happy path
+# ---------------------------------------------------------------------------
+
+
+def _add_token_endpoint_success(
+    httpx_mock: HTTPXMock,
+    *,
+    tenant_id: str = "00000000-0000-0000-0000-aaaaaaaaaaaa",
+    installer_oid: str = "00000000-0000-0000-0000-111111111111",
+    access_token: str = "graph-access-token",
+) -> None:
+    id_token = _make_id_token(
+        {"tid": tenant_id, "oid": installer_oid, "iss": "https://login.microsoftonline.com/x/v2.0"}
+    )
+    httpx_mock.add_response(
+        url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        method="POST",
+        status_code=200,
+        json={
+            "token_type": "Bearer",
+            "id_token": id_token,
+            "access_token": access_token,
+            "refresh_token": "refresh-token-fixture",
+            "expires_in": 3599,
+        },
+    )
+
+
+def _add_graph_org_success(
+    httpx_mock: HTTPXMock,
+    *,
+    display_name: str = "Acme Legal LLP",
+) -> None:
+    httpx_mock.add_response(
+        url="https://graph.microsoft.com/v1.0/organization",
+        method="GET",
+        status_code=200,
+        json={"value": [{"displayName": display_name}]},
+    )
+
+
+def test_callback_happy_path_persists_to_api_and_returns_success(
+    client: TestClient,
+    settings: Settings,
+    httpx_mock: HTTPXMock,
+) -> None:
+    state = _seed_state()
+    _add_token_endpoint_success(httpx_mock)
+    _add_graph_org_success(httpx_mock)
+    httpx_mock.add_response(
+        url=f"{settings.lq_ai_backend_url}/api/v1/integrations/teams/tenants",
+        method="POST",
+        status_code=201,
+        json={
+            "id": "00000000-0000-0000-0000-000000000999",
+            "tenant_id": "00000000-0000-0000-0000-aaaaaaaaaaaa",
+            "tenant_name": "Acme Legal LLP",
+            "installer_oid": "00000000-0000-0000-0000-111111111111",
+            "installed_at": "2026-05-22T12:00:00Z",
+        },
+    )
+
+    res = client.get(f"/teams/oauth/callback?code=auth-code&state={state}")
+    assert res.status_code == 200, res.text
+    assert "Install complete" in res.text
+    assert "Acme Legal LLP" in res.text
+
+    assert state not in oauth_module._STATE_STORE
+
+    sent_requests = httpx_mock.get_requests()
+    persist = [r for r in sent_requests if r.url.host == "api.test"]
+    assert len(persist) == 1
+    assert persist[0].headers["authorization"] == f"Bearer {settings.lq_ai_bridge_token}"
+    assert json.loads(persist[0].content) == {
+        "tenant_id": "00000000-0000-0000-0000-aaaaaaaaaaaa",
+        "tenant_name": "Acme Legal LLP",
+        "installer_oid": "00000000-0000-0000-0000-111111111111",
+    }
+
+
+def test_callback_falls_back_to_tid_when_graph_lookup_fails(
+    client: TestClient,
+    settings: Settings,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Graph hiccup must NOT fail the whole install — fall back to tid."""
+    state = _seed_state("stateFallback")
+    _add_token_endpoint_success(httpx_mock)
+    httpx_mock.add_response(
+        url="https://graph.microsoft.com/v1.0/organization",
+        method="GET",
+        status_code=503,
+        text="Graph is having a moment",
+    )
+    httpx_mock.add_response(
+        url=f"{settings.lq_ai_backend_url}/api/v1/integrations/teams/tenants",
+        method="POST",
+        status_code=201,
+        json={
+            "id": "00000000-0000-0000-0000-000000000999",
+            "tenant_id": "00000000-0000-0000-0000-aaaaaaaaaaaa",
+            "tenant_name": "00000000-0000-0000-0000-aaaaaaaaaaaa",
+            "installer_oid": "00000000-0000-0000-0000-111111111111",
+            "installed_at": "2026-05-22T12:00:00Z",
+        },
+    )
+
+    res = client.get(f"/teams/oauth/callback?code=auth-code&state={state}")
+    assert res.status_code == 200, res.text
+
+    sent_requests = httpx_mock.get_requests()
+    persist = [r for r in sent_requests if r.url.host == "api.test"]
+    body = json.loads(persist[0].content)
+    # Graph fallback: tenant_name = tenant_id
+    assert body["tenant_name"] == body["tenant_id"]
+
+
+# ---------------------------------------------------------------------------
+# /teams/oauth/callback — failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_callback_with_bad_state_returns_400(client: TestClient) -> None:
+    res = client.get("/teams/oauth/callback?code=anything&state=not-a-real-state")
+    assert res.status_code == 400
+    assert "invalid or expired state" in res.text.lower()
+
+
+def test_callback_with_error_query_param_renders_cancellation_page(
+    client: TestClient,
+) -> None:
+    res = client.get(
+        "/teams/oauth/callback?code=ignored&state=ignored"
+        "&error=access_denied&error_description=admin+declined"
+    )
+    assert res.status_code == 400
+    assert "Install cancelled" in res.text
+    assert "access_denied" in res.text
+
+
+def test_callback_with_token_endpoint_failure_returns_502(
+    client: TestClient,
+    httpx_mock: HTTPXMock,
+) -> None:
+    state = _seed_state("stateTokenFail")
+    httpx_mock.add_response(
+        url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        method="POST",
+        status_code=400,
+        json={"error": "invalid_grant", "error_description": "code expired"},
+    )
+    res = client.get(f"/teams/oauth/callback?code=bad&state={state}")
+    assert res.status_code == 502
+    assert "invalid_grant" in res.text
+
+
+def test_callback_with_api_persist_failure_returns_502(
+    client: TestClient,
+    settings: Settings,
+    httpx_mock: HTTPXMock,
+) -> None:
+    state = _seed_state("stateApiFail")
+    _add_token_endpoint_success(httpx_mock)
+    _add_graph_org_success(httpx_mock)
+    httpx_mock.add_response(
+        url=f"{settings.lq_ai_backend_url}/api/v1/integrations/teams/tenants",
+        method="POST",
+        status_code=500,
+        text="boom",
+    )
+    res = client.get(f"/teams/oauth/callback?code=auth-code&state={state}")
+    assert res.status_code == 502
+    assert "HTTP 500" in res.text
+
+
+def test_callback_with_id_token_missing_claims_returns_502(
+    client: TestClient,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """An id_token without tid/oid claims is a malformed Microsoft response."""
+    state = _seed_state("stateNoClaims")
+    id_token = _make_id_token({"sub": "irrelevant"})  # no tid, no oid
+    httpx_mock.add_response(
+        url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        method="POST",
+        status_code=200,
+        json={
+            "token_type": "Bearer",
+            "id_token": id_token,
+            "access_token": "x",
+        },
+    )
+    res = client.get(f"/teams/oauth/callback?code=auth-code&state={state}")
+    assert res.status_code == 502
+    assert "tid + oid" in res.text


### PR DESCRIPTION
## Summary

Mirrors the M3-D1 slack-bridge for Microsoft Teams. Operator installs LQ.AI in any M365 tenant via the multi-tenant Azure AD app; the tenant record persists in the api for M3-D4's admin UI to surface.

**4 architectural decisions locked at start** (handoff recommendations all ratified):

1. **Encryption key** — reuse `LQ_AI_BRIDGE_MASTER_KEY` from M3-D1 (same bridge threat model; nothing per-tenant to encrypt today since Teams uses app-level credentials)
2. **Bridge bearer** — reuse `LQ_AI_BRIDGE_TOKEN` (one rotation point for both bridges)
3. **MS Bot Framework auth** — raw httpx, no `botbuilder-core` SDK (saves ~15 transitive deps; mirrors slack-bridge's posture)
4. **Tenancy** — multi-tenant Azure AD app (one registration serves any tenant)

## What's in the diff

* **`teams-bridge/`** standalone FastAPI service on port 8003 — pyproject + Dockerfile + README + app/main + config + OAuth handler (Microsoft identity platform `/common/oauth2/v2.0/{authorize,token}` + Graph `/organization`) + OTel substrate + Teams App manifest.json
* **`api/`** — migration 0038 `teams_tenants` table + ORM + Pydantic + `POST /api/v1/integrations/teams/tenants` endpoint + 6 integration tests
* **Shared `require_bridge_auth`** lifted out of `integrations_slack.py` into `app/api/dependencies.py` so both bridges share the same constant-time `LQ_AI_BRIDGE_TOKEN` matcher
* **docker-compose** — new `slack-bridge` service under `profiles: [teams]`; required env vars marked with `:?` form
* **`docs/api/backend-openapi.yaml`** — new path + schemas (TeamsTenantCreate, TeamsTenantResponse)
* **`.env.example`** — new M3-D3 section

## Local verification

| Surface | Result |
|---|---|
| api venv: ruff format/check, mypy app/ | clean |
| api venv: test_integrations_teams (6) + test_integrations_slack (8) + test_encryption (8) | 22/22 pass |
| api venv: test_openapi paths_match_sketch + test_endpoints route_inventory | pass |
| teams-bridge venv: ruff format/check, mypy --strict | clean |
| teams-bridge venv: pytest tests/ (test_oauth.py) | 9/9 pass |
| slack-bridge venv (sanity re-check after BridgeAuth refactor) | 15/15 pass |

## Test plan

- [ ] CI green on API + Gateway + Web jobs
- [ ] Reviewer skims `app/oauth.py` for Microsoft OAuth correctness (multi-tenant common endpoint, scopes list, code exchange body shape, id_token decode safety, Graph fallback)
- [ ] Reviewer confirms shared `require_bridge_auth` refactor doesn't change Slack endpoint behavior
- [ ] Reviewer eyeballs the Teams App manifest schema against [Microsoft's v1.16 reference](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema)

## Deferred (DEs in PR description, not new):

- Identity-mapping UI (Teams email ↔ LQ.AI user) — M3-D4 admin UI scope
- On-behalf-of refresh-token storage column — M4 scope (only needed once DE-288's `/lq` surface lands)
- Teams app icons (color.png + outline.png) — operators provide own; reference icons can ship in a follow-up docs PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)