### PR TITLE
M3-D4 — admin intake-bridges shell (list + soft-delete for Slack + Teams)

### DIFF
--- a/api/app/api/__init__.py
+++ b/api/app/api/__init__.py
@@ -24,6 +24,7 @@ from fastapi import APIRouter, Depends
 
 from app.api import (
     admin,
+    admin_intake_bridges,
     auth,
     bootstrap,
     chat_receipts,
@@ -104,6 +105,11 @@ api_router.include_router(enhance_prompt.router, dependencies=_active)
 api_router.include_router(inference.router, dependencies=_active)
 api_router.include_router(inference_override.router, dependencies=_active)
 api_router.include_router(admin.router, dependencies=_active)
+# M3-D4: admin intake-bridges surface (list + soft-delete for Slack
+# workspaces + Teams tenants). Admin-gated at handler level via the
+# AdminUser dependency; mounted under the `_active` group so the
+# bearer-token + must-change-password gates fire first.
+api_router.include_router(admin_intake_bridges.router, dependencies=_active)
 # M3-A2: Playbook executor — two endpoints under different prefixes
 # (``/playbooks/{id}/execute`` and ``/playbook-executions/{id}``) so
 # they live alongside the M3-A4 list/CRUD endpoints in the same module.

--- a/api/app/api/admin_intake_bridges.py
+++ b/api/app/api/admin_intake_bridges.py
@@ -1,0 +1,157 @@
+"""Admin intake-bridges surface — M3-D4.
+
+Backs the SvelteKit admin page at ``/lq-ai/admin/intake-bridges``
+(M3-D4 frontend). Operators see what's currently connected and can
+soft-delete a bridge install (which causes the next OAuth re-install
+flow on that workspace/tenant to revive the row with fresh
+credentials per the M3-D1/M3-D3 upsert semantics).
+
+Surface (M3 scope — plumbing only):
+
+* ``GET    /api/v1/admin/intake-bridges`` — list connected
+  Slack workspaces + Teams tenants (live, non-soft-deleted only).
+* ``DELETE /api/v1/admin/intake-bridges/slack/{workspace_id}``
+  — soft-delete a Slack workspace.
+* ``DELETE /api/v1/admin/intake-bridges/teams/{tenant_id}``
+  — soft-delete a Teams tenant.
+
+The "configure quick-ask skill" dropdown UI and the ``/lq``
+invocation audit-log surface land with DE-288's slash-command work;
+no API endpoints for those are needed at v0.3.0 because there's no
+slash-command behavior to configure yet.
+
+Auth posture: every endpoint here stacks on ``ActiveUser`` (bearer +
+must-change-password gate, mounted at the router level in
+:mod:`app.api`) PLUS the ``AdminUser`` dependency at handler level.
+Non-admin authenticated users see 403 with ``code="forbidden"``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import AdminUser
+from app.db.session import get_db
+from app.errors import NotFound
+from app.models.slack_workspace import SlackWorkspace
+from app.models.teams_tenant import TeamsTenant
+from app.schemas.intake_bridges import (
+    IntakeBridgesList,
+    SlackWorkspaceSummary,
+    TeamsTenantSummary,
+)
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/intake-bridges", tags=["admin-intake-bridges"])
+
+
+@router.get("", response_model=IntakeBridgesList)
+async def list_intake_bridges(
+    _admin: AdminUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> IntakeBridgesList:
+    """Return live (non-soft-deleted) Slack workspaces + Teams tenants.
+
+    Sorted by ``installed_at DESC`` within each section so the most
+    recently connected bridge surfaces first.
+    """
+
+    slack_rows = (
+        (
+            await db.execute(
+                select(SlackWorkspace)
+                .where(SlackWorkspace.deleted_at.is_(None))
+                .order_by(SlackWorkspace.installed_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    teams_rows = (
+        (
+            await db.execute(
+                select(TeamsTenant)
+                .where(TeamsTenant.deleted_at.is_(None))
+                .order_by(TeamsTenant.installed_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    return IntakeBridgesList(
+        slack_workspaces=[SlackWorkspaceSummary.model_validate(row) for row in slack_rows],
+        teams_tenants=[TeamsTenantSummary.model_validate(row) for row in teams_rows],
+    )
+
+
+@router.delete(
+    "/slack/{workspace_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def soft_delete_slack_workspace(
+    _admin: AdminUser,
+    workspace_id: uuid.UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Soft-delete a Slack workspace by api-side id.
+
+    Sets ``deleted_at`` to now. The row stays in the DB so a re-install
+    via the slack-bridge OAuth flow revives it in place (per the
+    M3-D1 upsert semantics) rather than losing the install history.
+
+    ``response_class=Response`` + explicit ``Response(status_code=204)``
+    is the M3-C2 pattern — without it, FastAPI's default JSONResponse
+    fails the import-time "204 must not have body" assertion and
+    blows up the whole test suite at collection.
+    """
+
+    row = (
+        await db.execute(select(SlackWorkspace).where(SlackWorkspace.id == workspace_id))
+    ).scalar_one_or_none()
+    if row is None or row.deleted_at is not None:
+        raise NotFound(
+            message="Slack workspace not found or already disconnected.",
+            details={"workspace_id": str(workspace_id)},
+        )
+    row.deleted_at = datetime.now(tz=UTC)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete(
+    "/teams/{tenant_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def soft_delete_teams_tenant(
+    _admin: AdminUser,
+    tenant_id: uuid.UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Soft-delete a Teams tenant by api-side id.
+
+    Same posture as ``soft_delete_slack_workspace`` — the row stays so
+    a re-install via the teams-bridge OAuth flow revives it in place.
+    """
+
+    row = (
+        await db.execute(select(TeamsTenant).where(TeamsTenant.id == tenant_id))
+    ).scalar_one_or_none()
+    if row is None or row.deleted_at is not None:
+        raise NotFound(
+            message="Teams tenant not found or already disconnected.",
+            details={"tenant_id": str(tenant_id)},
+        )
+    row.deleted_at = datetime.now(tz=UTC)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/schemas/intake_bridges.py
+++ b/api/app/schemas/intake_bridges.py
@@ -1,0 +1,48 @@
+"""Pydantic wire shapes for the admin intake-bridges surface — M3-D4.
+
+Used by ``GET /api/v1/admin/intake-bridges`` to surface what's
+currently connected in the LQ.AI admin UI. The shapes are deliberately
+section-split (slack_workspaces + teams_tenants) rather than a single
+polymorphic list because the UI renders two distinct sections
+(per [M3-D4 plan](../../docs/M3-IMPLEMENTATION-PLAN.md#task-m3-d4--bot-configuration-in-lqai-admin-ui))
+and a section-split shape lets the client render directly without
+discriminator-key gymnastics.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SlackWorkspaceSummary(BaseModel):
+    """One live Slack workspace install for the admin list."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    team_id: str
+    team_name: str
+    installer_slack_user_id: str
+    installed_at: datetime
+
+
+class TeamsTenantSummary(BaseModel):
+    """One live Teams tenant install for the admin list."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    tenant_id: str
+    tenant_name: str
+    installer_oid: str
+    installed_at: datetime
+
+
+class IntakeBridgesList(BaseModel):
+    """Section-split response for the admin intake-bridges list."""
+
+    slack_workspaces: list[SlackWorkspaceSummary]
+    teams_tenants: list[TeamsTenantSummary]

--- a/api/tests/test_admin_intake_bridges.py
+++ b/api/tests/test_admin_intake_bridges.py
@@ -1,0 +1,323 @@
+"""Integration tests for M3-D4's admin intake-bridges surface.
+
+Covers:
+
+* ``GET /api/v1/admin/intake-bridges`` — returns live (non-soft-
+  deleted) Slack workspaces + Teams tenants, sorted by
+  ``installed_at DESC`` within each section.
+* ``DELETE /api/v1/admin/intake-bridges/slack/{workspace_id}`` —
+  soft-deletes the row; subsequent GET excludes it.
+* ``DELETE /api/v1/admin/intake-bridges/teams/{tenant_id}`` — same.
+* Admin gate — non-admin user → 403.
+* 404 paths — deleting an already-soft-deleted row or a nonexistent
+  id returns 404.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.main import app
+from app.models.slack_workspace import SlackWorkspace
+from app.models.teams_tenant import TeamsTenant
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+async def _make_user(
+    db_session: AsyncSession,
+    *,
+    email: str,
+    is_admin: bool,
+) -> tuple[User, str]:
+    """Insert a user + return the user + a bearer token for them."""
+    user = User(
+        id=uuid.uuid4(),
+        email=email,
+        hashed_password=hash_password("test-password-123"),
+        is_admin=is_admin,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    token = create_access_token(user_id=user.id, email=user.email, is_admin=user.is_admin)
+    return user, token
+
+
+@pytest_asyncio.fixture
+async def admin_client(db_session: AsyncSession) -> AsyncIterator[tuple[AsyncClient, str]]:
+    _user, token = await _make_user(
+        db_session,
+        email="admin-intake@example.com",
+        is_admin=True,
+    )
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, token
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def member_client(db_session: AsyncSession) -> AsyncIterator[tuple[AsyncClient, str]]:
+    _user, token = await _make_user(
+        db_session,
+        email="member-intake@example.com",
+        is_admin=False,
+    )
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, token
+    app.dependency_overrides.pop(get_db, None)
+
+
+async def _insert_slack(
+    db_session: AsyncSession,
+    *,
+    team_id: str,
+    deleted: bool = False,
+) -> SlackWorkspace:
+    row = SlackWorkspace(
+        team_id=team_id,
+        team_name=f"Workspace {team_id}",
+        bot_token_encrypted=b"opaque-ciphertext",
+        bot_user_id=f"U-bot-{team_id}",
+        installer_slack_user_id=f"U-installer-{team_id}",
+        scope="commands,chat:write",
+    )
+    if deleted:
+        row.deleted_at = datetime.now(tz=UTC)
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+    return row
+
+
+async def _insert_teams(
+    db_session: AsyncSession,
+    *,
+    tenant_id: str,
+    deleted: bool = False,
+) -> TeamsTenant:
+    row = TeamsTenant(
+        tenant_id=tenant_id,
+        tenant_name=f"Tenant {tenant_id}",
+        installer_oid=f"oid-{tenant_id}",
+    )
+    if deleted:
+        row.deleted_at = datetime.now(tz=UTC)
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/intake-bridges
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_list_returns_live_slack_and_teams_rows(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    ac, token = admin_client
+    await _insert_slack(db_session, team_id="T-alpha")
+    await _insert_slack(db_session, team_id="T-beta")
+    await _insert_teams(db_session, tenant_id="00000000-0000-0000-0000-bbbbbbbbbbbb")
+
+    res = await ac.get(
+        "/api/v1/admin/intake-bridges",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert len(body["slack_workspaces"]) == 2
+    assert len(body["teams_tenants"]) == 1
+    slack_team_ids = {row["team_id"] for row in body["slack_workspaces"]}
+    assert slack_team_ids == {"T-alpha", "T-beta"}
+
+
+@pytest.mark.integration
+async def test_list_excludes_soft_deleted_rows(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    ac, token = admin_client
+    await _insert_slack(db_session, team_id="T-live")
+    await _insert_slack(db_session, team_id="T-dead", deleted=True)
+    await _insert_teams(db_session, tenant_id="00000000-0000-0000-0000-cccccccccccc")
+    await _insert_teams(
+        db_session,
+        tenant_id="00000000-0000-0000-0000-dddddddddddd",
+        deleted=True,
+    )
+
+    res = await ac.get(
+        "/api/v1/admin/intake-bridges",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert [row["team_id"] for row in body["slack_workspaces"]] == ["T-live"]
+    assert [row["tenant_id"] for row in body["teams_tenants"]] == [
+        "00000000-0000-0000-0000-cccccccccccc"
+    ]
+
+
+@pytest.mark.integration
+async def test_list_sorts_by_installed_at_desc(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    """The list endpoint sorts by installed_at DESC.
+
+    Both rows are inserted back-to-back so the server-default
+    ``now()`` may return the same microsecond for both; force a real
+    delta by stamping ``installed_at`` manually before commit.
+    """
+    ac, token = admin_client
+    older = await _insert_slack(db_session, team_id="T-older")
+    newer = await _insert_slack(db_session, team_id="T-newer")
+    older.installed_at = datetime(2026, 1, 1, tzinfo=UTC)
+    newer.installed_at = datetime(2026, 2, 1, tzinfo=UTC)
+    await db_session.commit()
+
+    res = await ac.get(
+        "/api/v1/admin/intake-bridges",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    body = res.json()
+    assert [row["team_id"] for row in body["slack_workspaces"]] == ["T-newer", "T-older"]
+
+
+@pytest.mark.integration
+async def test_list_returns_403_for_non_admin(
+    member_client: tuple[AsyncClient, str],
+) -> None:
+    ac, token = member_client
+    res = await ac.get(
+        "/api/v1/admin/intake-bridges",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /admin/intake-bridges/slack/{workspace_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_delete_slack_soft_deletes_row(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    ac, token = admin_client
+    row = await _insert_slack(db_session, team_id="T-delete-me")
+
+    res = await ac.delete(
+        f"/api/v1/admin/intake-bridges/slack/{row.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 204
+    assert res.content == b""
+
+    await db_session.refresh(row)
+    assert row.deleted_at is not None
+
+
+@pytest.mark.integration
+async def test_delete_slack_returns_404_for_already_deleted(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    ac, token = admin_client
+    row = await _insert_slack(db_session, team_id="T-already-dead", deleted=True)
+
+    res = await ac.delete(
+        f"/api/v1/admin/intake-bridges/slack/{row.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.integration
+async def test_delete_slack_returns_404_for_missing_row(
+    admin_client: tuple[AsyncClient, str],
+) -> None:
+    ac, token = admin_client
+    res = await ac.delete(
+        f"/api/v1/admin/intake-bridges/slack/{uuid.uuid4()}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.integration
+async def test_delete_slack_returns_403_for_non_admin(
+    member_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    ac, token = member_client
+    row = await _insert_slack(db_session, team_id="T-member-cant-delete")
+    res = await ac.delete(
+        f"/api/v1/admin/intake-bridges/slack/{row.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
+
+    # And the row is unchanged.
+    await db_session.refresh(row)
+    assert row.deleted_at is None
+
+
+# ---------------------------------------------------------------------------
+# DELETE /admin/intake-bridges/teams/{tenant_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_delete_teams_soft_deletes_row(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+) -> None:
+    ac, token = admin_client
+    row = await _insert_teams(db_session, tenant_id="00000000-0000-0000-0000-eeeeeeeeeeee")
+
+    res = await ac.delete(
+        f"/api/v1/admin/intake-bridges/teams/{row.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 204
+    await db_session.refresh(row)
+    assert row.deleted_at is not None
+
+
+@pytest.mark.integration
+async def test_delete_teams_returns_404_for_missing_row(
+    admin_client: tuple[AsyncClient, str],
+) -> None:
+    ac, token = admin_client
+    res = await ac.delete(
+        f"/api/v1/admin/intake-bridges/teams/{uuid.uuid4()}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 404

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -64,6 +64,9 @@ _PARAM_VALUES: dict[str, str] = {
     "playbook_id": _DUMMY_UUID,
     "execution_id": _DUMMY_UUID,
     "generation_id": _DUMMY_UUID,
+    # M3-D4 — admin intake-bridges surface
+    "workspace_id": _DUMMY_UUID,
+    "tenant_id": _DUMMY_UUID,
 }
 
 
@@ -211,6 +214,10 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("POST", "/api/v1/integrations/slack/workspaces"),
     # M3-D3 — teams-bridge persistence surface (bridge-token bearer auth)
     ("POST", "/api/v1/integrations/teams/tenants"),
+    # M3-D4 — admin intake-bridges surface
+    ("GET", "/api/v1/admin/intake-bridges"),
+    ("DELETE", "/api/v1/admin/intake-bridges/slack/{workspace_id}"),
+    ("DELETE", "/api/v1/admin/intake-bridges/teams/{tenant_id}"),
     # D4 — Organization Profile singleton
     ("GET", "/api/v1/organization-profile"),
     ("PUT", "/api/v1/organization-profile"),

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -152,6 +152,10 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/integrations/slack/workspaces",
         # M3-D3 — teams-bridge persistence surface (bearer-token, no user)
         "/api/v1/integrations/teams/tenants",
+        # M3-D4 — admin intake-bridges surface (admin-only)
+        "/api/v1/admin/intake-bridges",
+        "/api/v1/admin/intake-bridges/slack/{workspace_id}",
+        "/api/v1/admin/intake-bridges/teams/{tenant_id}",
     }
 )
 
@@ -212,7 +216,10 @@ async def test_openapi_paths_match_sketch() -> None:
     # + M3-D3's one NEW path for the teams-bridge persistence surface
     #   (POST /integrations/teams/tenants). Same posture as M3-D1's
     #   slack equivalent.
-    assert len(actual) == 91
+    # + M3-D4's three NEW paths for the admin intake-bridges surface
+    #   (GET /admin/intake-bridges, DELETE /admin/intake-bridges/slack/{id},
+    #   DELETE /admin/intake-bridges/teams/{id}). Admin-only.
+    assert len(actual) == 94
 
 
 @pytest.mark.unit

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -3532,6 +3532,82 @@ paths:
         '500':
           description: Operator has not configured `LQ_AI_BRIDGE_TOKEN` on the api
 
+  # ============================================================
+  # M3-D4 — admin intake-bridges surface
+  # ============================================================
+
+  /api/v1/admin/intake-bridges:
+    get:
+      tags: [admin-intake-bridges]
+      summary: List live Slack + Teams installs for the admin UI (M3-D4)
+      description: |
+        Returns non-soft-deleted Slack workspaces and Teams tenants,
+        sorted by `installed_at DESC` within each section. Admin-only.
+        Backs the SvelteKit admin page at `/lq-ai/admin/intake-bridges`.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Live install list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntakeBridgesList'
+        '401':
+          description: Not authenticated
+        '403':
+          description: Authenticated but not an admin
+
+  /api/v1/admin/intake-bridges/slack/{workspace_id}:
+    delete:
+      tags: [admin-intake-bridges]
+      summary: Soft-delete a Slack workspace install (M3-D4)
+      description: |
+        Sets `deleted_at` to now. The row stays in the DB so a
+        re-install via the slack-bridge OAuth flow revives it in
+        place per the M3-D1 upsert semantics; the install history
+        is preserved across disconnect/reconnect cycles.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: workspace_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '204':
+          description: Soft-deleted
+        '401':
+          description: Not authenticated
+        '403':
+          description: Authenticated but not an admin
+        '404':
+          description: Workspace not found or already disconnected
+
+  /api/v1/admin/intake-bridges/teams/{tenant_id}:
+    delete:
+      tags: [admin-intake-bridges]
+      summary: Soft-delete a Microsoft 365 tenant install (M3-D4)
+      description: |
+        Same posture as the Slack endpoint above — soft-delete with
+        revivable row.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: tenant_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '204':
+          description: Soft-deleted
+        '401':
+          description: Not authenticated
+        '403':
+          description: Authenticated but not an admin
+        '404':
+          description: Tenant not found or already disconnected
+
 # ============================================================
 # COMPONENTS
 # ============================================================
@@ -3682,6 +3758,61 @@ components:
           type: string
           format: date-time
           description: Original install timestamp. NOT moved by upsert.
+
+    SlackWorkspaceSummary:
+      type: object
+      description: |
+        One live Slack workspace row in the admin intake-bridges list
+        (M3-D4). The wire shape mirrors the model row minus the bot
+        token ciphertext (which the admin UI has no business seeing).
+      required:
+        - id
+        - team_id
+        - team_name
+        - installer_slack_user_id
+        - installed_at
+      properties:
+        id: { type: string, format: uuid }
+        team_id: { type: string }
+        team_name: { type: string }
+        installer_slack_user_id: { type: string }
+        installed_at: { type: string, format: date-time }
+
+    TeamsTenantSummary:
+      type: object
+      description: |
+        One live Microsoft 365 tenant row in the admin intake-bridges
+        list (M3-D4). Mirrors the model row.
+      required:
+        - id
+        - tenant_id
+        - tenant_name
+        - installer_oid
+        - installed_at
+      properties:
+        id: { type: string, format: uuid }
+        tenant_id: { type: string }
+        tenant_name: { type: string }
+        installer_oid: { type: string }
+        installed_at: { type: string, format: date-time }
+
+    IntakeBridgesList:
+      type: object
+      description: |
+        Section-split response for `GET /api/v1/admin/intake-bridges`.
+        Separate sections (rather than a single polymorphic list) so
+        the SvelteKit admin page renders two distinct sections without
+        client-side discriminator-key gymnastics.
+      required:
+        - slack_workspaces
+        - teams_tenants
+      properties:
+        slack_workspaces:
+          type: array
+          items: { $ref: '#/components/schemas/SlackWorkspaceSummary' }
+        teams_tenants:
+          type: array
+          items: { $ref: '#/components/schemas/TeamsTenantSummary' }
 
     SlackWorkspaceResponse:
       type: object

--- a/web/src/lib/lq-ai/api/index.ts
+++ b/web/src/lib/lq-ai/api/index.ts
@@ -18,6 +18,7 @@ export * as projectKnowledgeBasesApi from './projectKnowledgeBases';
 export * as modelsApi from './models';
 export * as adminApi from './admin';
 export * as auditLogApi from './auditLog';
+export * as intakeBridgesApi from './intakeBridges';
 export * as savedPromptsApi from './savedPrompts';
 export * as userSkillsApi from './userSkills';
 export * as teamsApi from './teams';

--- a/web/src/lib/lq-ai/api/intakeBridges.ts
+++ b/web/src/lib/lq-ai/api/intakeBridges.ts
@@ -1,0 +1,51 @@
+/**
+ * Admin intake-bridges API client — M3-D4.
+ *
+ * Surface:
+ *
+ *   - GET    /api/v1/admin/intake-bridges           — list live installs
+ *   - DELETE /api/v1/admin/intake-bridges/slack/{id} — soft-delete
+ *   - DELETE /api/v1/admin/intake-bridges/teams/{id} — soft-delete
+ *
+ * All endpoints are admin-gated server-side; non-admin users get a
+ * 403 which `apiRequest` surfaces as a typed `ForbiddenError` the
+ * admin page catches and renders inline.
+ */
+import { apiRequest } from './client';
+
+export interface SlackWorkspaceSummary {
+	id: string;
+	team_id: string;
+	team_name: string;
+	installer_slack_user_id: string;
+	installed_at: string;
+}
+
+export interface TeamsTenantSummary {
+	id: string;
+	tenant_id: string;
+	tenant_name: string;
+	installer_oid: string;
+	installed_at: string;
+}
+
+export interface IntakeBridgesList {
+	slack_workspaces: SlackWorkspaceSummary[];
+	teams_tenants: TeamsTenantSummary[];
+}
+
+export async function listIntakeBridges(): Promise<IntakeBridgesList> {
+	return apiRequest<IntakeBridgesList>('/admin/intake-bridges', { method: 'GET' });
+}
+
+export async function deleteSlackWorkspace(workspaceId: string): Promise<void> {
+	await apiRequest<void>(`/admin/intake-bridges/slack/${workspaceId}`, {
+		method: 'DELETE'
+	});
+}
+
+export async function deleteTeamsTenant(tenantId: string): Promise<void> {
+	await apiRequest<void>(`/admin/intake-bridges/teams/${tenantId}`, {
+		method: 'DELETE'
+	});
+}

--- a/web/src/routes/lq-ai/admin/+layout.svelte
+++ b/web/src/routes/lq-ai/admin/+layout.svelte
@@ -7,6 +7,7 @@
 		{ href: '/lq-ai/admin/audit-log', label: 'Audit log' },
 		{ href: '/lq-ai/admin/models', label: 'Models' },
 		{ href: '/lq-ai/admin/word-addin', label: 'Word add-in' },
+		{ href: '/lq-ai/admin/intake-bridges', label: 'Intake bridges' },
 		{ href: '/lq-ai/admin/developer', label: 'Developer Support' }
 	];
 </script>

--- a/web/src/routes/lq-ai/admin/intake-bridges/+page.svelte
+++ b/web/src/routes/lq-ai/admin/intake-bridges/+page.svelte
@@ -1,0 +1,500 @@
+<script lang="ts">
+	/**
+	 * /lq-ai/admin/intake-bridges — M3-D4 admin shell for Slack + Teams installs.
+	 *
+	 * Surfaces what's currently connected (live, non-soft-deleted) and lets
+	 * an admin trigger install (opens the bridge's OAuth flow in a new tab)
+	 * or uninstall (soft-deletes the row server-side).
+	 *
+	 * The "configure quick-ask skill" dropdown UI + audit-log shell are
+	 * intentionally visible-but-disabled at v0.3.0 with a tooltip pointing
+	 * at DE-288 (slash-command surface deferred to M4 / community
+	 * contribution). Surfacing them now keeps the admin UI from churning
+	 * when the slash-command surface eventually lands.
+	 */
+	import { onMount } from 'svelte';
+
+	import { intakeBridgesApi } from '$lib/lq-ai/api';
+	import { LQAIApiError } from '$lib/lq-ai/api/client';
+	import type {
+		IntakeBridgesList,
+		SlackWorkspaceSummary,
+		TeamsTenantSummary
+	} from '$lib/lq-ai/api/intakeBridges';
+	import {
+		buildSlackInstallUrl,
+		buildTeamsInstallUrl,
+		deriveSectionsView,
+		formatInstalledAt,
+		slackDisplayName,
+		teamsDisplayName
+	} from './page-helpers';
+
+	let list: IntakeBridgesList | null = null;
+	let loading = false;
+	let listError: string | null = null;
+	let actionError: string | null = null;
+	let actionSuccess: string | null = null;
+	let pendingDeleteId: string | null = null;
+
+	// The bridge install URLs are documented; admins typically front the
+	// bridges behind their reverse proxy. These fields let an admin
+	// override the deployment default for the click-through. They're
+	// hints, not config — the actual URL is whatever the operator
+	// configured as LQ_AI_BRIDGE_PUBLIC_URL / LQ_AI_TEAMS_BRIDGE_PUBLIC_URL.
+	let slackBridgePublicUrl = '';
+	let teamsBridgePublicUrl = '';
+
+	$: sectionsView = deriveSectionsView(list);
+
+	onMount(load);
+
+	async function load(): Promise<void> {
+		loading = true;
+		listError = null;
+		try {
+			list = await intakeBridgesApi.listIntakeBridges();
+		} catch (err) {
+			if (err instanceof LQAIApiError && err.status === 403) {
+				listError = 'You need admin access to view intake bridges.';
+			} else {
+				listError = err instanceof Error ? err.message : String(err);
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function uninstallSlack(row: SlackWorkspaceSummary): Promise<void> {
+		const confirmed = confirm(
+			`Disconnect Slack workspace "${slackDisplayName(row)}"? The bot ` +
+				`will stop responding immediately. Re-install via OAuth restores ` +
+				`the row in place (the install history is preserved).`
+		);
+		if (!confirmed) return;
+		pendingDeleteId = row.id;
+		actionError = null;
+		actionSuccess = null;
+		try {
+			await intakeBridgesApi.deleteSlackWorkspace(row.id);
+			actionSuccess = `Disconnected Slack workspace "${slackDisplayName(row)}".`;
+			await load();
+		} catch (err) {
+			actionError = err instanceof Error ? err.message : String(err);
+		} finally {
+			pendingDeleteId = null;
+		}
+	}
+
+	async function uninstallTeams(row: TeamsTenantSummary): Promise<void> {
+		const confirmed = confirm(
+			`Disconnect Microsoft 365 tenant "${teamsDisplayName(row)}"? The bot ` +
+				`will stop responding immediately. Re-install via OAuth restores ` +
+				`the row in place.`
+		);
+		if (!confirmed) return;
+		pendingDeleteId = row.id;
+		actionError = null;
+		actionSuccess = null;
+		try {
+			await intakeBridgesApi.deleteTeamsTenant(row.id);
+			actionSuccess = `Disconnected Microsoft 365 tenant "${teamsDisplayName(row)}".`;
+			await load();
+		} catch (err) {
+			actionError = err instanceof Error ? err.message : String(err);
+		} finally {
+			pendingDeleteId = null;
+		}
+	}
+
+	function openSlackInstall(): void {
+		if (!slackBridgePublicUrl.trim()) {
+			actionError = 'Set the Slack bridge public URL to open the OAuth flow.';
+			return;
+		}
+		actionError = null;
+		const url = buildSlackInstallUrl(slackBridgePublicUrl.trim());
+		window.open(url, '_blank', 'noopener,noreferrer');
+	}
+
+	function openTeamsInstall(): void {
+		if (!teamsBridgePublicUrl.trim()) {
+			actionError = 'Set the Teams bridge public URL to open the OAuth flow.';
+			return;
+		}
+		actionError = null;
+		const url = buildTeamsInstallUrl(teamsBridgePublicUrl.trim());
+		window.open(url, '_blank', 'noopener,noreferrer');
+	}
+</script>
+
+<div class="intake-bridges-page">
+	<header class="page-header">
+		<h1 class="lq-text-page-h">Intake bridges</h1>
+		<p class="page-intro">
+			Connect Slack workspaces and Microsoft Teams tenants to this LQ.AI deployment. The slash
+			command surface (<code>/lq</code> and <code>/lq ask</code>) is descoped to M4 / community
+			contribution per
+			<a
+				href="https://github.com/LegalQuants/lq-ai/blob/main/docs/PRD.md#de-288--slackteams-lq-slash-command--quick-skill-flow--deferred-to-m4--community-contribution"
+				target="_blank"
+				rel="noopener noreferrer">DE-288</a
+			>. At v0.3.0 the bridges are installable + OAuth-bound; the bot is otherwise inert until
+			DE-288 ships.
+		</p>
+	</header>
+
+	{#if listError}
+		<div class="error-banner" role="alert">{listError}</div>
+	{/if}
+	{#if actionError}
+		<div class="error-banner" role="alert">{actionError}</div>
+	{/if}
+	{#if actionSuccess}
+		<div class="success-banner" role="status">{actionSuccess}</div>
+	{/if}
+
+	{#if loading && list === null}
+		<p class="loading">Loading intake bridges…</p>
+	{/if}
+
+	<!-- ============================================================ -->
+	<!-- Slack section                                                -->
+	<!-- ============================================================ -->
+
+	<section class="bridge-section" aria-label="Slack">
+		<div class="bridge-section-head">
+			<h2 class="bridge-section-title">Slack</h2>
+		</div>
+
+		<div class="install-row">
+			<label for="slack-public-url" class="install-label">
+				Slack bridge public URL
+				<input
+					id="slack-public-url"
+					type="url"
+					placeholder="https://lqai.example.com/slack"
+					bind:value={slackBridgePublicUrl}
+					class="install-input"
+				/>
+			</label>
+			<button
+				type="button"
+				class="install-button"
+				on:click={openSlackInstall}
+				disabled={!slackBridgePublicUrl.trim()}
+			>
+				Open Slack install →
+			</button>
+		</div>
+
+		{#if sectionsView.slackEmpty && !loading}
+			<p class="empty-state">No Slack workspaces connected yet.</p>
+		{/if}
+
+		{#if list && list.slack_workspaces.length > 0}
+			<table class="bridge-table">
+				<thead>
+					<tr>
+						<th>Workspace</th>
+						<th>Slack team id</th>
+						<th>Installed</th>
+						<th>Linked users</th>
+						<th>Quick-ask skill</th>
+						<th class="bridge-table-actions">Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each list.slack_workspaces as row (row.id)}
+						<tr>
+							<td>{slackDisplayName(row)}</td>
+							<td><code>{row.team_id}</code></td>
+							<td>{formatInstalledAt(row.installed_at)}</td>
+							<td><span class="muted">— (DE-288)</span></td>
+							<td>
+								<select
+									disabled
+									aria-disabled="true"
+									title="Quick-ask skill picker lands with DE-288's slash-command surface."
+								>
+									<option>— deferred to DE-288 —</option>
+								</select>
+							</td>
+							<td class="bridge-table-actions">
+								<button
+									type="button"
+									class="action-button danger"
+									on:click={() => uninstallSlack(row)}
+									disabled={pendingDeleteId === row.id}
+								>
+									{pendingDeleteId === row.id ? 'Disconnecting…' : 'Disconnect'}
+								</button>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
+	</section>
+
+	<!-- ============================================================ -->
+	<!-- Teams section                                                -->
+	<!-- ============================================================ -->
+
+	<section class="bridge-section" aria-label="Microsoft Teams">
+		<div class="bridge-section-head">
+			<h2 class="bridge-section-title">Microsoft Teams</h2>
+		</div>
+
+		<div class="install-row">
+			<label for="teams-public-url" class="install-label">
+				Teams bridge public URL
+				<input
+					id="teams-public-url"
+					type="url"
+					placeholder="https://lqai.example.com/teams"
+					bind:value={teamsBridgePublicUrl}
+					class="install-input"
+				/>
+			</label>
+			<button
+				type="button"
+				class="install-button"
+				on:click={openTeamsInstall}
+				disabled={!teamsBridgePublicUrl.trim()}
+			>
+				Open Teams install →
+			</button>
+		</div>
+
+		{#if sectionsView.teamsEmpty && !loading}
+			<p class="empty-state">No Microsoft 365 tenants connected yet.</p>
+		{/if}
+
+		{#if list && list.teams_tenants.length > 0}
+			<table class="bridge-table">
+				<thead>
+					<tr>
+						<th>Tenant</th>
+						<th>Tenant id</th>
+						<th>Installed</th>
+						<th>Linked users</th>
+						<th>Quick-ask skill</th>
+						<th class="bridge-table-actions">Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each list.teams_tenants as row (row.id)}
+						<tr>
+							<td>{teamsDisplayName(row)}</td>
+							<td><code>{row.tenant_id}</code></td>
+							<td>{formatInstalledAt(row.installed_at)}</td>
+							<td><span class="muted">— (DE-288)</span></td>
+							<td>
+								<select
+									disabled
+									aria-disabled="true"
+									title="Quick-ask skill picker lands with DE-288's slash-command surface."
+								>
+									<option>— deferred to DE-288 —</option>
+								</select>
+							</td>
+							<td class="bridge-table-actions">
+								<button
+									type="button"
+									class="action-button danger"
+									on:click={() => uninstallTeams(row)}
+									disabled={pendingDeleteId === row.id}
+								>
+									{pendingDeleteId === row.id ? 'Disconnecting…' : 'Disconnect'}
+								</button>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
+	</section>
+
+	<!-- ============================================================ -->
+	<!-- Audit-log shell                                              -->
+	<!-- ============================================================ -->
+
+	<section class="bridge-section" aria-label="Recent /lq invocations">
+		<div class="bridge-section-head">
+			<h2 class="bridge-section-title">Recent <code>/lq</code> invocations</h2>
+		</div>
+		<p class="empty-state">
+			Slash-command invocations will appear here once
+			<a
+				href="https://github.com/LegalQuants/lq-ai/blob/main/docs/PRD.md#de-288--slackteams-lq-slash-command--quick-skill-flow--deferred-to-m4--community-contribution"
+				target="_blank"
+				rel="noopener noreferrer">DE-288</a
+			> lands.
+		</p>
+	</section>
+</div>
+
+<style>
+	.intake-bridges-page {
+		padding: var(--lq-space-5);
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-5);
+	}
+
+	.page-header {
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-2);
+	}
+
+	.page-intro {
+		color: var(--lq-text-secondary);
+		max-width: 60rem;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	.error-banner {
+		padding: var(--lq-space-3) var(--lq-space-4);
+		background: var(--lq-error-bg, #fee);
+		color: var(--lq-error-text, #800);
+		border-radius: 6px;
+		border: 1px solid var(--lq-error-border, #fbb);
+	}
+
+	.success-banner {
+		padding: var(--lq-space-3) var(--lq-space-4);
+		background: var(--lq-success-bg, #efe);
+		color: var(--lq-success-text, #060);
+		border-radius: 6px;
+		border: 1px solid var(--lq-success-border, #bfb);
+	}
+
+	.loading {
+		color: var(--lq-text-secondary);
+		padding: var(--lq-space-3);
+	}
+
+	.bridge-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-3);
+		padding: var(--lq-space-4);
+		border: 1px solid var(--lq-border);
+		border-radius: 8px;
+		background: var(--lq-surface);
+	}
+
+	.bridge-section-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+	}
+
+	.bridge-section-title {
+		margin: 0;
+		font-size: 18px;
+		font-weight: 600;
+	}
+
+	.install-row {
+		display: flex;
+		gap: var(--lq-space-3);
+		align-items: flex-end;
+		flex-wrap: wrap;
+	}
+
+	.install-label {
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-1);
+		flex: 1;
+		min-width: 20rem;
+		font-size: 13px;
+		color: var(--lq-text-secondary);
+	}
+
+	.install-input {
+		padding: var(--lq-space-2) var(--lq-space-3);
+		border: 1px solid var(--lq-border);
+		border-radius: 6px;
+		background: var(--lq-bg, #fff);
+		font-size: 14px;
+	}
+
+	.install-button {
+		padding: var(--lq-space-2) var(--lq-space-4);
+		background: var(--lq-accent);
+		color: white;
+		border: none;
+		border-radius: 6px;
+		font-size: 14px;
+		font-weight: 500;
+		cursor: pointer;
+	}
+
+	.install-button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.empty-state {
+		color: var(--lq-text-secondary);
+		font-style: italic;
+		margin: 0;
+	}
+
+	.bridge-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 14px;
+	}
+
+	.bridge-table th,
+	.bridge-table td {
+		text-align: left;
+		padding: var(--lq-space-2) var(--lq-space-3);
+		border-bottom: 1px solid var(--lq-border);
+	}
+
+	.bridge-table th {
+		font-weight: 600;
+		color: var(--lq-text-secondary);
+		font-size: 12px;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.bridge-table-actions {
+		text-align: right;
+		width: 1px;
+		white-space: nowrap;
+	}
+
+	.action-button {
+		padding: var(--lq-space-1) var(--lq-space-3);
+		border-radius: 6px;
+		font-size: 13px;
+		cursor: pointer;
+		border: 1px solid var(--lq-border);
+		background: transparent;
+		color: var(--lq-text);
+	}
+
+	.action-button.danger {
+		color: var(--lq-error-text, #b00);
+		border-color: var(--lq-error-border, #fbb);
+	}
+
+	.action-button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.muted {
+		color: var(--lq-text-secondary);
+		font-style: italic;
+	}
+</style>

--- a/web/src/routes/lq-ai/admin/intake-bridges/__tests__/page-helpers.test.ts
+++ b/web/src/routes/lq-ai/admin/intake-bridges/__tests__/page-helpers.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Pure-helper tests for the M3-D4 admin intake-bridges page.
+ *
+ * The helpers are extracted into a sibling `page-helpers.ts` so vitest
+ * can exercise them without the svelte transformer.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type {
+	IntakeBridgesList,
+	SlackWorkspaceSummary,
+	TeamsTenantSummary
+} from '$lib/lq-ai/api/intakeBridges';
+import {
+	buildSlackInstallUrl,
+	buildTeamsInstallUrl,
+	deriveSectionsView,
+	formatInstalledAt,
+	slackDisplayName,
+	teamsDisplayName
+} from '../page-helpers';
+
+function slackRow(over: Partial<SlackWorkspaceSummary> = {}): SlackWorkspaceSummary {
+	return {
+		id: '00000000-0000-0000-0000-000000000001',
+		team_id: 'T01',
+		team_name: 'Acme Legal',
+		installer_slack_user_id: 'U-installer',
+		installed_at: '2026-01-01T00:00:00Z',
+		...over
+	};
+}
+
+function teamsRow(over: Partial<TeamsTenantSummary> = {}): TeamsTenantSummary {
+	return {
+		id: '00000000-0000-0000-0000-000000000002',
+		tenant_id: '00000000-0000-0000-0000-aaaaaaaaaaaa',
+		tenant_name: 'Acme Legal LLP',
+		installer_oid: 'oid-fixture',
+		installed_at: '2026-01-01T00:00:00Z',
+		...over
+	};
+}
+
+describe('deriveSectionsView', () => {
+	it('returns all-empty when the list is null (loading state)', () => {
+		const v = deriveSectionsView(null);
+		expect(v).toEqual({
+			slackInstalled: false,
+			teamsInstalled: false,
+			slackEmpty: false,
+			teamsEmpty: false
+		});
+	});
+
+	it('reports both empty when no bridges connected', () => {
+		const list: IntakeBridgesList = { slack_workspaces: [], teams_tenants: [] };
+		expect(deriveSectionsView(list)).toEqual({
+			slackInstalled: false,
+			teamsInstalled: false,
+			slackEmpty: true,
+			teamsEmpty: true
+		});
+	});
+
+	it('reports slack installed when at least one workspace exists', () => {
+		const list: IntakeBridgesList = {
+			slack_workspaces: [slackRow()],
+			teams_tenants: []
+		};
+		const v = deriveSectionsView(list);
+		expect(v.slackInstalled).toBe(true);
+		expect(v.slackEmpty).toBe(false);
+		expect(v.teamsEmpty).toBe(true);
+	});
+
+	it('reports teams installed when at least one tenant exists', () => {
+		const list: IntakeBridgesList = {
+			slack_workspaces: [],
+			teams_tenants: [teamsRow()]
+		};
+		const v = deriveSectionsView(list);
+		expect(v.teamsInstalled).toBe(true);
+		expect(v.teamsEmpty).toBe(false);
+		expect(v.slackEmpty).toBe(true);
+	});
+});
+
+describe('buildSlackInstallUrl', () => {
+	it('appends /slack/oauth/install with no trailing slash', () => {
+		expect(buildSlackInstallUrl('https://lqai.example.com/slack')).toBe(
+			'https://lqai.example.com/slack/slack/oauth/install'
+		);
+	});
+
+	it('trims a trailing slash before appending', () => {
+		expect(buildSlackInstallUrl('https://lqai.example.com/slack/')).toBe(
+			'https://lqai.example.com/slack/slack/oauth/install'
+		);
+	});
+});
+
+describe('buildTeamsInstallUrl', () => {
+	it('appends /teams/oauth/install', () => {
+		expect(buildTeamsInstallUrl('https://lqai.example.com/teams')).toBe(
+			'https://lqai.example.com/teams/teams/oauth/install'
+		);
+	});
+
+	it('trims a trailing slash before appending', () => {
+		expect(buildTeamsInstallUrl('https://lqai.example.com/teams/')).toBe(
+			'https://lqai.example.com/teams/teams/oauth/install'
+		);
+	});
+});
+
+describe('formatInstalledAt', () => {
+	const now = new Date('2026-05-23T12:00:00Z');
+
+	it('returns "just now" for installs under an hour old', () => {
+		expect(formatInstalledAt('2026-05-23T11:30:00Z', now)).toBe('just now');
+	});
+
+	it('returns "N hours ago" for installs within today', () => {
+		expect(formatInstalledAt('2026-05-23T08:00:00Z', now)).toBe('4 hours ago');
+	});
+
+	it('returns "1 hour ago" with singular for exactly one hour', () => {
+		expect(formatInstalledAt('2026-05-23T11:00:00Z', now)).toBe('1 hour ago');
+	});
+
+	it('returns "N days ago" for installs within two weeks', () => {
+		expect(formatInstalledAt('2026-05-20T12:00:00Z', now)).toBe('3 days ago');
+	});
+
+	it('returns "1 day ago" with singular for exactly one day', () => {
+		expect(formatInstalledAt('2026-05-22T12:00:00Z', now)).toBe('1 day ago');
+	});
+
+	it('returns ISO date for installs older than two weeks', () => {
+		expect(formatInstalledAt('2026-01-15T08:00:00Z', now)).toBe('2026-01-15');
+	});
+
+	it('returns the input verbatim when not parseable', () => {
+		expect(formatInstalledAt('not-a-date', now)).toBe('not-a-date');
+	});
+});
+
+describe('slackDisplayName', () => {
+	it('prefers team_name when non-empty', () => {
+		expect(slackDisplayName(slackRow({ team_name: 'Acme', team_id: 'T01' }))).toBe('Acme');
+	});
+
+	it('falls back to team_id when team_name is empty', () => {
+		expect(slackDisplayName(slackRow({ team_name: '', team_id: 'T01' }))).toBe('T01');
+	});
+
+	it('falls back to team_id when team_name is whitespace', () => {
+		expect(slackDisplayName(slackRow({ team_name: '   ', team_id: 'T01' }))).toBe('T01');
+	});
+});
+
+describe('teamsDisplayName', () => {
+	it('prefers tenant_name when non-empty', () => {
+		expect(teamsDisplayName(teamsRow({ tenant_name: 'Acme LLP', tenant_id: 'tid' }))).toBe(
+			'Acme LLP'
+		);
+	});
+
+	it('falls back to tenant_id when tenant_name is empty', () => {
+		expect(teamsDisplayName(teamsRow({ tenant_name: '', tenant_id: 'tid' }))).toBe('tid');
+	});
+});

--- a/web/src/routes/lq-ai/admin/intake-bridges/page-helpers.ts
+++ b/web/src/routes/lq-ai/admin/intake-bridges/page-helpers.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure helpers for the M3-D4 admin intake-bridges page.
+ *
+ * Extracted out of `+page.svelte` so vitest can exercise them without a
+ * SvelteKit runtime. The helpers cover:
+ *
+ *   - formatting `installed_at` ISO strings into a short relative form
+ *   - deciding which bridge sections render their "empty state"
+ *   - building the install-redirect URL operators click through to start
+ *     the OAuth flow on each bridge service
+ */
+
+import type {
+	IntakeBridgesList,
+	SlackWorkspaceSummary,
+	TeamsTenantSummary
+} from '$lib/lq-ai/api/intakeBridges';
+
+export interface BridgeSectionsView {
+	slackInstalled: boolean;
+	teamsInstalled: boolean;
+	slackEmpty: boolean;
+	teamsEmpty: boolean;
+}
+
+/** Decide which sections render their empty-state copy. */
+export function deriveSectionsView(list: IntakeBridgesList | null): BridgeSectionsView {
+	if (list === null) {
+		return { slackInstalled: false, teamsInstalled: false, slackEmpty: false, teamsEmpty: false };
+	}
+	const slackInstalled = list.slack_workspaces.length > 0;
+	const teamsInstalled = list.teams_tenants.length > 0;
+	return {
+		slackInstalled,
+		teamsInstalled,
+		slackEmpty: !slackInstalled,
+		teamsEmpty: !teamsInstalled
+	};
+}
+
+/** Build the slack-bridge install URL the operator clicks through. */
+export function buildSlackInstallUrl(slackBridgePublicUrl: string): string {
+	return `${trimTrailingSlash(slackBridgePublicUrl)}/slack/oauth/install`;
+}
+
+/** Build the teams-bridge install URL the operator clicks through. */
+export function buildTeamsInstallUrl(teamsBridgePublicUrl: string): string {
+	return `${trimTrailingSlash(teamsBridgePublicUrl)}/teams/oauth/install`;
+}
+
+function trimTrailingSlash(s: string): string {
+	return s.endsWith('/') ? s.slice(0, -1) : s;
+}
+
+/** Short "2 days ago" / "2026-01-15" formatter for installed_at. */
+export function formatInstalledAt(iso: string, now: Date = new Date()): string {
+	const installed = new Date(iso);
+	if (Number.isNaN(installed.getTime())) {
+		return iso;
+	}
+	const deltaMs = now.getTime() - installed.getTime();
+	const deltaHours = Math.floor(deltaMs / (60 * 60 * 1000));
+	if (deltaHours < 1) return 'just now';
+	if (deltaHours < 24) return `${deltaHours} hour${deltaHours === 1 ? '' : 's'} ago`;
+	const deltaDays = Math.floor(deltaHours / 24);
+	if (deltaDays < 14) return `${deltaDays} day${deltaDays === 1 ? '' : 's'} ago`;
+	// > 2 weeks: render YYYY-MM-DD
+	return installed.toISOString().slice(0, 10);
+}
+
+/** Display-name picker — gives the UI a non-empty string for either bridge. */
+export function slackDisplayName(row: SlackWorkspaceSummary): string {
+	return row.team_name.trim() || row.team_id;
+}
+
+export function teamsDisplayName(row: TeamsTenantSummary): string {
+	return row.tenant_name.trim() || row.tenant_id;
+}


### PR DESCRIPTION
## Summary

Closes M3-D4 plumbing — operators see what's currently connected and can disconnect installs from the LQ.AI admin UI without env-var edits or redeploys. The slash-command surface (DE-288) lands later; its UI hooks (quick-ask skill picker + audit-log section) are visible-but-disabled with tooltips pointing at DE-288.

## What's in the diff

* **Backend (`api/`)**: new admin router `app/api/admin_intake_bridges.py` with `GET /admin/intake-bridges` + `DELETE /admin/intake-bridges/{slack,teams}/{id}`. Pydantic schemas in `app/schemas/intake_bridges.py`. Section-split response (slack_workspaces + teams_tenants), soft-delete (revivable per M3-D1/M3-D3 upsert), admin-gated. Both DELETEs use the M3-C2 `response_class=Response` pattern (preserved as code comment).
* **Frontend (`web/`)**: `intakeBridgesApi` client + admin page at `/lq-ai/admin/intake-bridges` with two sections (Slack + Teams), each surfacing live installs in a table with relative-time install date, disconnect button, and visible-but-disabled quick-ask-skill picker (DE-288 tooltip). Empty `/lq` audit-log shell at the bottom.
* **Layout nav**: new "Intake bridges" link between Word add-in and Developer Support.
* **OpenAPI sketch + 3 schemas**: documented for the operator-facing surface.

## Local verification

| Surface | Result |
|---|---|
| api venv: ruff format/check, mypy app/ | clean |
| api venv: test_admin_intake_bridges.py (10/10) | pass |
| api venv: test_openapi paths_match_sketch + test_endpoints route_inventory | pass |
| web: vitest src/routes/lq-ai/admin/intake-bridges/__tests__/ (20/20) | pass |
| web: svelte-check on new files | clean (only pre-existing OWUI errors elsewhere) |

## Test plan

- [ ] CI green on API + Gateway + Web jobs
- [ ] Reviewer eyeballs the SvelteKit page in browser (run the stack, log in as admin, visit /lq-ai/admin/intake-bridges, confirm empty state + "Open install" buttons disabled when URL fields are blank)
- [ ] Reviewer confirms the disabled quick-ask-skill dropdowns surface their DE-288 tooltip
- [ ] Reviewer confirms the admin gate by trying as a non-admin user → should see "You need admin access" inline

## What's NOT in this PR (deferred):

- Linked-users count column — depends on per-user identity binding (DE-288)
- Quick-ask skill picker behavior — disabled with DE-288 tooltip
- `/lq` invocation audit-log filter UI — empty shell today, wires up with DE-288
- Cypress E2E — folds into M3-E1's pre-tag verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)