### PR TITLE
docs(claude): add DELETE-204 FastAPI pitfall + fix recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,29 @@ Before implementing a task, read:
 3. The relevant DB schema section if the task touches the database.
 4. Any existing implementation in the same area (don't rebuild what exists).
 
+### Common pitfalls (catch at write-time, not test-time)
+
+A few traps that have bitten this codebase more than once. Each has a fix recipe; follow it the first time and the bug never surfaces in your branch.
+
+**`DELETE` endpoints returning `204 No Content`** — FastAPI's default `JSONResponse` is body-emitting and asserts at import time when `status_code=204`. The assertion (`Status code 204 must not have a response body`) fires during test collection, collapsing the whole test suite — not just the new endpoint's tests. Recurred between M3-C2 (fix in commit `c613c43`) and M3-D4 because the recipe lived only in code comments.
+
+Recipe:
+
+```python
+from fastapi import Response, status
+
+@router.delete(
+    "/things/{thing_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,                       # critical — overrides default JSONResponse
+)
+async def soft_delete_thing(...) -> Response:
+    ...
+    return Response(status_code=status.HTTP_204_NO_CONTENT)  # explicit empty return
+```
+
+Both `response_class=Response` AND the explicit `return Response(...)` are required. Omitting either resurfaces the assertion.
+
 ### Surface ideas as DE-XXX
 
 When a useful idea surfaces that is out of scope for the current task, file it as a deferred enhancement (DE-XXX) in PRD §9. Do not expand the task to incorporate the idea; preserve the focus, defer the idea.


### PR DESCRIPTION
## Summary

- Adds a new **Common pitfalls (catch at write-time, not test-time)** subsection to `CLAUDE.md` under "What good agent behavior looks like", right after "Read before writing".
- First entry documents the `DELETE` endpoint + `status_code=204` + default `JSONResponse` collision that asserts at import time and collapses the whole test suite at collection.
- Includes the fix recipe (`response_class=Response` + explicit `return Response(status_code=204)`) so future contributors avoid the trap at write-time.

## Why

The bug bit M3-C2 (fix in commit `c613c43`) and recurred in M3-D4 because the recipe lived only in code comments inside `app/api/admin_intake_bridges.py`. Surfacing it in `CLAUDE.md` — the orientation doc every agent and human reads first — closes the recurrence loop before M3-E1 fresh-install verify and before M3-F starts adding new endpoints.

## Test plan

- [ ] CI is docs-only (no behavioral change); `markdownlint` / link-check workflows should pass without intervention.
- [ ] Spot-check rendered Markdown on the PR page — code-fence + bold formatting renders cleanly.
- [ ] Confirm no other section header collides with the new "Common pitfalls" header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)