### PR TITLE
fix(m3-e1): surface tabular citations + document names; bump version

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI backend API service."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"

--- a/api/app/schemas/tabular.py
+++ b/api/app/schemas/tabular.py
@@ -24,7 +24,17 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# Deterministic namespace for synthesizing a tabular cell's ``citation_id``
+# from its ``chunk_id``. The tabular executor persists raw ``cited_chunk_ids``
+# (chunk references); the read-side surface (M3-C4) models structured
+# ``Citation`` objects keyed by ``citation_id``. Until the executor mints
+# real Citation-Engine rows (deferred — see PRD §9), we derive a stable,
+# display-only ``citation_id = uuid5(NS, chunk_id)`` so the same chunk always
+# maps to the same id. The citation drawer is display-only and never resolves
+# this id against the Citation Engine, so a synthetic id is safe.
+_TABULAR_CITATION_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_DNS, "tabular-citation.lq.ai")
 
 TabularExecutionStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
 """Lifecycle states for a :class:`TabularExecution`. Matches the CHECK
@@ -129,6 +139,47 @@ class TabularRow(BaseModel):
     cells: dict[str, CellResult]
     """Map of column name -> CellResult. Keys match the column names
     declared in the execution's column spec."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _synthesize_cell_citations(cls, data: object) -> object:
+        """Build display ``citations`` from each cell's persisted
+        ``cited_chunk_ids``.
+
+        The executor persists raw chunk references (``cited_chunk_ids``)
+        rather than structured citations. Without this, the read-side
+        ``CellResult.citations`` would always be empty even though the
+        grounding chunks are recorded. We project each chunk id into a
+        ``Citation`` using the row's ``document_id`` (the citation's
+        source document), the cell's ``confidence``, and a deterministic
+        synthetic ``citation_id``. Cells that already carry ``citations``
+        (e.g., a future executor emitting real Citation-Engine rows) pass
+        through untouched.
+        """
+
+        if not isinstance(data, dict):
+            return data
+        document_id = data.get("document_id")
+        cells = data.get("cells")
+        if document_id is None or not isinstance(cells, dict):
+            return data
+        for cell in cells.values():
+            if not isinstance(cell, dict) or cell.get("citations"):
+                continue
+            chunk_ids = cell.get("cited_chunk_ids")
+            if not isinstance(chunk_ids, list) or not chunk_ids:
+                continue
+            confidence = cell.get("confidence")
+            cell["citations"] = [
+                {
+                    "citation_id": str(uuid.uuid5(_TABULAR_CITATION_NAMESPACE, str(chunk_id))),
+                    "document_id": str(document_id),
+                    "chunk_id": str(chunk_id),
+                    "confidence": confidence,
+                }
+                for chunk_id in chunk_ids
+            ]
+        return data
 
 
 class TabularResults(BaseModel):

--- a/api/app/tabular/nodes.py
+++ b/api/app/tabular/nodes.py
@@ -43,6 +43,7 @@ from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.document import Document, DocumentChunk
+from app.models.file import File
 from app.models.tabular import TabularExecution
 from app.schemas.gateway import ChatCompletionMessage, ChatCompletionRequest
 from app.schemas.tabular import ColumnSpec
@@ -84,17 +85,24 @@ def make_load_documents_node(
     """Build the load-documents node bound to a DB session."""
 
     async def load_documents_node(state: TabularExecutionState) -> dict[str, Any]:
-        stmt = select(Document).where(Document.id.in_(document_ids))
-        rows = (await db.execute(stmt)).scalars().all()
-        by_id = {row.id: row for row in rows}
+        # Join the parent File for the operator-facing filename — the
+        # display name for the grid's row label. The Document row itself
+        # carries no filename (it lives on files.filename), so without
+        # the join the row label falls back to the document UUID.
+        stmt = (
+            select(Document.id, File.filename)
+            .join(File, Document.file_id == File.id)
+            .where(Document.id.in_(document_ids))
+        )
+        by_id = {row.id: row.filename for row in (await db.execute(stmt)).all()}
 
         # Preserve the operator's selection order (matches the playbook
         # easy_playbook_worker's _load_documents helper); missing rows
         # are silently skipped.
         documents: list[dict[str, str]] = []
         for did in document_ids:
-            row = by_id.get(did)
-            if row is None:
+            filename = by_id.get(did)
+            if filename is None:
                 logger.info(
                     "tabular_executor.load_documents: document missing; skipping",
                     extra={
@@ -105,28 +113,14 @@ def make_load_documents_node(
                 continue
             documents.append(
                 {
-                    "id": str(row.id),
-                    "name": _document_display_name(row),
+                    "id": str(did),
+                    "name": filename,
                 }
             )
 
         return {"documents": documents}
 
     return load_documents_node
-
-
-def _document_display_name(document: Document) -> str:
-    """Best-effort display name for a Document.
-
-    Tries ``original_filename`` (the operator-uploaded name) first, then
-    falls back to the row id. Matches the existing UI convention in
-    the playbook execution-view renderer.
-    """
-
-    name = getattr(document, "original_filename", None) or getattr(document, "name", None)
-    if name:
-        return str(name)
-    return str(document.id)
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/tabular/test_schemas.py
+++ b/api/tests/tabular/test_schemas.py
@@ -1,0 +1,167 @@
+"""Tabular wire-schema read-side transforms — M3-C2 / M3-E1.
+
+Regression coverage for the citation read-side projection (F6, found in
+the M3-E1 fresh-install verification): the executor persists each cell's
+grounding chunks as raw ``cited_chunk_ids: list[str]``, but the API/UI
+surface models structured ``Citation`` objects under ``citations``.
+Without the :class:`TabularRow` ``model_validator`` that bridges the two,
+``CellResult.citations`` deserialized empty on every cell even though the
+grounding chunks were recorded — the citation drawer showed nothing.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.schemas.tabular import (
+    _TABULAR_CITATION_NAMESPACE,
+    CellResult,
+    TabularResults,
+    TabularRow,
+)
+
+
+def _persisted_cell(
+    *,
+    value: str | None,
+    cited_chunk_ids: list[str],
+    confidence: str,
+    error: str | None = None,
+) -> dict[str, object]:
+    """Mirror the exact JSONB shape the executor persists per cell."""
+    return {
+        "value": value,
+        "cited_chunk_ids": cited_chunk_ids,
+        "confidence": confidence,
+        "tier_used": None,
+        "cost_usd": "0",
+        "error": error,
+    }
+
+
+def test_tabular_row_synthesizes_citations_from_cited_chunk_ids() -> None:
+    document_id = uuid.uuid4()
+    chunk_a = uuid.uuid4()
+    chunk_b = uuid.uuid4()
+    row = TabularRow.model_validate(
+        {
+            "document_id": str(document_id),
+            "document_name": "nda-1-acme-beta.pdf",
+            "cells": {
+                "Term": _persisted_cell(
+                    value="3 years",
+                    cited_chunk_ids=[str(chunk_a), str(chunk_b)],
+                    confidence="high",
+                ),
+            },
+        }
+    )
+
+    cell = row.cells["Term"]
+    assert len(cell.citations) == 2
+    cite_a, cite_b = cell.citations
+    assert cite_a.document_id == document_id
+    assert cite_a.chunk_id == chunk_a
+    assert cite_a.confidence == "high"
+    # citation_id is deterministic: uuid5(NS, chunk_id) so the same chunk
+    # always maps to the same display id.
+    assert cite_a.citation_id == uuid.uuid5(_TABULAR_CITATION_NAMESPACE, str(chunk_a))
+    assert cite_b.chunk_id == chunk_b
+
+
+def test_synthesized_citation_id_is_deterministic() -> None:
+    document_id = uuid.uuid4()
+    chunk = uuid.uuid4()
+    payload = {
+        "document_id": str(document_id),
+        "document_name": "x.pdf",
+        "cells": {
+            "Col": _persisted_cell(value="v", cited_chunk_ids=[str(chunk)], confidence="medium")
+        },
+    }
+    first = TabularRow.model_validate(payload).cells["Col"].citations[0].citation_id
+    second = TabularRow.model_validate(payload).cells["Col"].citations[0].citation_id
+    assert first == second
+
+
+def test_failed_cell_with_no_chunks_yields_no_citations() -> None:
+    row = TabularRow.model_validate(
+        {
+            "document_id": str(uuid.uuid4()),
+            "document_name": "x.pdf",
+            "cells": {
+                "Col": _persisted_cell(
+                    value=None,
+                    cited_chunk_ids=[],
+                    confidence="failed",
+                    error="no chunks retrieved",
+                ),
+            },
+        }
+    )
+    assert row.cells["Col"].citations == []
+
+
+def test_cell_already_carrying_citations_passes_through_untouched() -> None:
+    """A future executor that emits real Citation objects must not be
+    double-projected away by the chunk-id bridge."""
+    document_id = uuid.uuid4()
+    citation_id = uuid.uuid4()
+    chunk = uuid.uuid4()
+    row = TabularRow.model_validate(
+        {
+            "document_id": str(document_id),
+            "document_name": "x.pdf",
+            "cells": {
+                "Col": {
+                    "value": "v",
+                    "cited_chunk_ids": [str(uuid.uuid4())],  # should be ignored
+                    "citations": [
+                        {
+                            "citation_id": str(citation_id),
+                            "document_id": str(document_id),
+                            "chunk_id": str(chunk),
+                            "confidence": "high",
+                        }
+                    ],
+                    "confidence": "high",
+                    "tier_used": 4,
+                    "cost_usd": "0.01",
+                    "error": None,
+                },
+            },
+        }
+    )
+    cell = row.cells["Col"]
+    assert len(cell.citations) == 1
+    assert cell.citations[0].citation_id == citation_id
+    assert cell.citations[0].chunk_id == chunk
+
+
+def test_full_results_payload_round_trip_surfaces_citations() -> None:
+    """The API read path: TabularResults.model_validate over the persisted
+    JSONB must surface citations on every grounded cell."""
+    document_id = uuid.uuid4()
+    chunk = uuid.uuid4()
+    results = TabularResults.model_validate(
+        {
+            "schema_version": 1,
+            "rows": [
+                {
+                    "document_id": str(document_id),
+                    "document_name": "nda-1.pdf",
+                    "cells": {
+                        "Governing Law": _persisted_cell(
+                            value="Delaware",
+                            cited_chunk_ids=[str(chunk)],
+                            confidence="high",
+                        ),
+                    },
+                }
+            ],
+            "summary": {"total_cells": 1, "failed_cells": 0},
+        }
+    )
+    cell: CellResult = results.rows[0].cells["Governing Law"]
+    assert len(cell.citations) == 1
+    assert cell.citations[0].chunk_id == chunk

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -2705,6 +2705,55 @@ paths:
         '401':
           description: Not authenticated.
 
+  /api/v1/tabular/executions/{execution_id}/export:
+    parameters:
+      - in: path
+        name: execution_id
+        required: true
+        schema: {type: string, format: uuid}
+    get:
+      tags: [tabular]
+      summary: Export a completed tabular grid as XLSX or CSV (M3-C4a)
+      description: |
+        Streams the tabular grid in the requested format. Both formats
+        carry the document column (leftmost) plus one column per declared
+        column spec, in spec order. Cells with ``confidence='failed'``
+        render as ``"(failed)"`` so operators can spot gaps.
+
+        Citation surfacing differs by format:
+
+        * **XLSX** — each grid cell with at least one citation carries an
+          openpyxl cell ``Comment`` listing the citation ids + confidences
+          (up to 5 per comment; the cell retains the full count). Operators
+          hover any cell in Excel / Numbers / Google Sheets to see sources.
+        * **CSV** — a trailing ``citation_links`` column per row carries a
+          semicolon-separated list of ``"<column_name>:<citation_id>"``
+          pairs across the row's cells; empty when no cell had citations.
+
+        The execution must be in ``status='completed'`` — pending /
+        running / cancelled / failed rows return 409 (partial grids would
+        mislead downstream consumers).
+      parameters:
+        - in: query
+          name: format
+          required: false
+          schema: {type: string, enum: [xlsx, csv], default: xlsx}
+          description: Export format. `xlsx` carries citations as cell comments; `csv` flattens them into a `citation_links` column.
+      responses:
+        '200':
+          description: Streaming export; `Content-Type` matches the format.
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema: {type: string, format: binary}
+            text/csv:
+              schema: {type: string, format: binary}
+        '404':
+          description: Execution not found or not authorized.
+        '409':
+          description: Execution not in a terminal `completed` status — cannot export.
+        '401':
+          description: Not authenticated.
+
   /api/v1/playbooks/{playbook_id}/execute:
     parameters:
       - in: path


### PR DESCRIPTION
## Summary

Fixes four read-side/metadata defects surfaced during **M3-E1 fresh-install verification** (the pre-v0.3.0 tag pass). None require migrations or executor changes.

- **F6 — tabular citations never reached the API/UI.** The executor persists grounding chunks as raw `cited_chunk_ids: list[str]`, but the read-side `CellResult` models structured `Citation` objects under `citations`, with no bridge. So `citations` deserialized **empty on every cell** even though the chunks were recorded — the citation drawer (a core M3-C4 feature) showed nothing. Adds a `TabularRow` `model_validator(before)` projecting each `cited_chunk_id` into a `Citation` (row `document_id` + cell `confidence` + deterministic display-only `citation_id = uuid5(NS, chunk_id)`). Cells already carrying real citations pass through untouched. **Both the API response and the XLSX/CSV export pick this up.**
- **F7 — row `document_name` showed the document UUID, not the filename.** The load-documents node read `original_filename`/`name` off the `Document` row (which has neither) and fell back to the id. Now joins the parent `File` for `files.filename`.
- **F3 — `app.__version__` was still `0.1.0`**, never bumped through v0.2.0, so the M3-B8 Word handshake reported a stale `deployment_version`. Bumped to `0.3.0`.
- **F8 — OpenAPI sketch** now documents the M3-C4a `GET /tabular/executions/{id}/export` endpoint (xlsx|csv), which M3-C4a omitted.

## Deferred (PRD §9, filed separately)

- Real Citation-Engine-backed provenance for tabular cells (resolvable `citation_id` rather than synthetic) — the F6 fix is a display-only bridge.
- Single-source-of-truth for `__version__` so it stops drifting (F3 root cause).

## Verification

Verified live on a fresh `~/Code/lq-ai` stack (full cold build, all profiles):
- Existing execution citations **surface post-fix** (read-side transform retro-applies to already-persisted `cited_chunk_ids`).
- Fresh execution shows `document_name: nda-1-acme-beta.pdf` + 2 citations per grounded cell.
- CSV `citation_links` column populated on all 5 rows (was empty).
- `ruff format --check` + `ruff check` clean on all changed files.

## Test plan

- [ ] CI: ruff + mypy + pytest (new `api/tests/tabular/test_schemas.py` — 5 regression cases covering the citation projection, determinism, failed-cell, pass-through, and full results round-trip).
- [ ] Reviewer: confirm the synthetic `citation_id` approach is acceptable for v0.3.0 (display-only; never resolved against the Citation Engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs M3-E1.