### PR TITLE
feat(m3-f3): OTel deployment recipes + observability.md + OTel-eval playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Inference Gateway:  http://localhost:8001/docs
 
 After login you land on the LQ.AI home. Three good starting points:
 
-- Click **Learn** in the top bar to take the interactive tour — six playgrounds walk through the architecture, the request lifecycle, the tier system, what the model sees, where your data lives, and how to author a skill. This is the fastest orientation for both evaluators and new contributors. (`http://localhost:3000/lq-ai/learn`)
+- Click **Learn** in the top bar to take the interactive tour — eleven playgrounds walk through the architecture, the request lifecycle, the tier system, what the model sees, where your data lives, and how to author a skill. This is the fastest orientation for both evaluators and new contributors. (`http://localhost:3000/lq-ai/learn`)
 - Click **Skills** to browse the 10 built-in skills. Each is inspectable: click any skill to read the `SKILL.md` driving it.
 - Click **+ New matter** to create your first project workspace and attach a document to try a skill against.
 
@@ -274,13 +274,13 @@ The trust model for a self-hosted, open-source project is that every claim termi
 - **Inference Gateway:** `gateway/app/router.py` — the only egress point, the security boundary, the place where routing decisions are made and logged.
 - **Audit log writer:** `api/app/audit.py` — what gets written to the `audit_log` table, and for which actions.
 - **Honest catalog:** [`docs/HONEST-STATE.md`](docs/HONEST-STATE.md) — the shipped-vs-deferred table with a verification path for every row. If you find a discrepancy between this document and the code, the code is canonical.
-- **Interactive architecture tour:** Navigate to `http://localhost:3000/lq-ai/learn` after logging in. The six playgrounds each point at the relevant source files for that topic.
+- **Interactive architecture tour:** Navigate to `http://localhost:3000/lq-ai/learn` after logging in. The eleven playgrounds each point at the relevant source files for that topic.
 
 ---
 
 ### First steps after login
 
-**The Learn page is the guided tour.** New users and procurement evaluators start at `http://localhost:3000/lq-ai/learn`. Six interactive playgrounds walk through the architecture, the full request lifecycle, the five-tier inference model, what the model actually sees (and what it doesn't), where data lives, and how to author your own skill. Each playground links to the relevant source file.
+**The Learn page is the guided tour.** New users and procurement evaluators start at `http://localhost:3000/lq-ai/learn`. Eleven interactive playgrounds walk through the architecture, the full request lifecycle, the five-tier inference model, what the model actually sees (and what it doesn't), where data lives, and how to author your own skill. Each playground links to the relevant source file.
 
 **The honest catalog.** [`docs/HONEST-STATE.md`](docs/HONEST-STATE.md) names what is shipped, what is deferred, and how to verify each. We publish this because the verification path for an open-source product terminates in code, not in claims. If anything in this README is inconsistent with what the code does, please [open an issue](https://github.com/LegalQuants/lq-ai/issues) — the code is canonical.
 
@@ -460,6 +460,7 @@ For security disclosures, see [`SECURITY.md`](SECURITY.md). The disclosure proce
 
 - [Product Requirements Document](docs/PRD.md) — the canonical specification (v0.2).
 - [`docs/HONEST-STATE.md`](docs/HONEST-STATE.md) — shipped-vs-deferred catalog with verification paths for every claim.
+- [`docs/observability.md`](docs/observability.md) — OpenTelemetry traces/metrics, deployment recipes, operator guide.
 - [`docs/contribute/EASIEST-CONTRIBUTIONS.md`](docs/contribute/EASIEST-CONTRIBUTIONS.md) — curated short-cycle contributions with mini-PRDs.
 - [`docs/skill-authoring-guide.md`](docs/skill-authoring-guide.md) — how to write a high-quality skill.
 - [`docs/playbook-authoring-guide.md`](docs/playbook-authoring-guide.md) — how to write a Playbook.

--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -1,0 +1,22 @@
+# LQ.AI — Observability Deployment Recipes
+
+LQ.AI emits OTLP traces from the API and Gateway services and exposes Prometheus metrics on `/metrics`. By default, no telemetry leaves the deployment — the services start cleanly without a collector, and span data is silently dropped until you wire a backend (per [PRD §5.7](../../docs/PRD.md#57-no-telemetry-by-default)). These recipes wire that backend. If you prefer to configure a collector yourself, setting `OTEL_EXPORTER_OTLP_ENDPOINT` in your `.env` is sufficient; the recipes here are for operators who want a ready-made setup.
+
+For the full operator guide — signal inventory, span names, attribute schema, sampling guidance, and dashboard reference — see [docs/observability.md](../../docs/observability.md) (note: this file is added in the M3-F3 release alongside these recipes).
+
+---
+
+## Choose a recipe
+
+| Situation | Recipe |
+|---|---|
+| You are starting fresh and want a self-hosted observability stack with no third-party SaaS. You want traces in Tempo, logs in Loki, metrics in Prometheus, and a Grafana dashboard — all running alongside the main stack in Docker. | [`grafana-tempo-loki/`](grafana-tempo-loki/) |
+| You already run Honeycomb, Datadog, Lightstep, Splunk, or any other OTLP-compatible backend, and you just need a collector that forwards LQ.AI's spans to it. You don't want Grafana or Tempo locally. | [`otel-collector-standalone/`](otel-collector-standalone/) |
+
+Both recipes are Docker Compose overlays. They add services and set `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318` on the api and gateway containers. The base stack (`docker-compose.yml` in the repo root) is unchanged; the overlay is merged at startup with the `-f` flag.
+
+---
+
+## Switching between recipes
+
+Run `docker compose down` before switching overlays; the collector service name is the same (`otel-collector`) in both recipes, and having both active simultaneously is not a supported configuration.

--- a/deploy/observability/grafana-tempo-loki/.env.example
+++ b/deploy/observability/grafana-tempo-loki/.env.example
@@ -1,0 +1,21 @@
+# Environment variables for the LQ.AI observability overlay
+# Copy relevant vars into your repo-root .env before bringing up the stack.
+#
+# Usage:
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f deploy/observability/grafana-tempo-loki/docker-compose.observability.yml \
+#     up -d
+
+# Grafana admin password.  Change before exposing Grafana outside localhost.
+GF_SECURITY_ADMIN_PASSWORD=admin
+
+# Host port Grafana binds on.  Default 3001 avoids collision with the web service (3000).
+GRAFANA_HOST_PORT=3001
+
+# OTLP trace sampler.
+# Development default: sample every trace (parentbased_always_on).
+# Production recommendation: parentbased_traceidratio + OTEL_TRACES_SAMPLER_ARG=0.1
+#   to sample ~10% of root traces while preserving complete child spans.
+OTEL_TRACES_SAMPLER=parentbased_always_on
+# OTEL_TRACES_SAMPLER_ARG=0.1   # Uncomment for production ratio sampling

--- a/deploy/observability/grafana-tempo-loki/README.md
+++ b/deploy/observability/grafana-tempo-loki/README.md
@@ -1,0 +1,126 @@
+# Observability recipe: Grafana + Tempo + Loki + Prometheus
+
+This recipe adds a self-hosted observability backend alongside the main LQ.AI stack. It provisions:
+
+- **OpenTelemetry Collector** — receives OTLP traces from the api and gateway; forwards to Tempo.
+- **Grafana Tempo** — trace storage and query backend.
+- **Grafana Loki** — log aggregation (ready for future log-shipping; not auto-populated today).
+- **Prometheus** — scrapes `/metrics` from api (`:8000`) and gateway (`:8001`).
+- **Grafana** — unified query and dashboard UI on host port `3001`.
+
+## When to use this recipe
+
+Use this recipe when you want a complete, self-hosted observability stack with no third-party SaaS dependency. If you already have Honeycomb, Datadog, or Lightstep, use [`../otel-collector-standalone/`](../otel-collector-standalone/) instead.
+
+## Prerequisites
+
+- Docker Desktop (or Docker Engine 24+) installed and running.
+- The base LQ.AI stack able to start: `docker compose up -d` from the repo root should reach a healthy state before you add this overlay. See [docs/quickstart.md](../../../docs/quickstart.md) for the base-stack setup walkthrough.
+
+> **First-run image pull:** bringing this overlay up for the first time pulls the Collector, Tempo, Loki, Prometheus, and Grafana images. Combined, these are several hundred MB. On a reasonable connection this adds 2–5 minutes to the first startup. Subsequent runs reuse cached images and add seconds.
+
+---
+
+## Run command
+
+Run from the **repo root**:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f deploy/observability/grafana-tempo-loki/docker-compose.observability.yml \
+  up -d
+```
+
+### Environment variables
+
+Copy the relevant variables from `.env.example` into your repo-root `.env` before bringing the stack up:
+
+```bash
+# Grafana admin password — change this before exposing Grafana outside localhost.
+GF_SECURITY_ADMIN_PASSWORD=admin
+
+# Host port for Grafana. Default 3001 avoids collision with the web service on 3000.
+GRAFANA_HOST_PORT=3001
+```
+
+The overlay reads these from the repo-root `.env` via Compose's standard env-file loading. You do not need to copy the `.env.example` file itself — copy only the variable lines you want to override.
+
+---
+
+## 15-minute "verify a trace" walkthrough
+
+### Step 1 — Confirm the stack is up
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f deploy/observability/grafana-tempo-loki/docker-compose.observability.yml \
+  ps
+```
+
+All services should show `running`. The `otel-collector`, `tempo`, `loki`, `prometheus`, and `grafana` services are new; `api` and `gateway` are the base-stack services with OTLP export now enabled.
+
+### Step 2 — Send a request to generate a trace
+
+The easiest path is to open the web UI at `http://localhost:3000`, log in, and send a chat message. Any chat-send request causes the api to call the gateway, which calls the configured provider — that round-trip produces the `api → gateway → provider` span tree that includes the M3-F domain spans (`inference.dispatch`, `skill.execute`, etc.).
+
+Alternatively, use the API directly. The chat-send endpoint requires a valid JWT. Obtain a token by following the authentication steps in [docs/quickstart.md](../../../docs/quickstart.md), then:
+
+```bash
+curl -s -X POST http://localhost:8000/api/v1/chats/{chat_id}/messages \
+  -H "Authorization: Bearer <your-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Summarize the key obligations in this NDA.", "model": "smart"}'
+```
+
+Replace `{chat_id}` with an existing chat ID from your session and `<your-token>` with the JWT from the quickstart auth flow. Do not fabricate tokens — the endpoint will reject them with `401`.
+
+### Step 3 — Open Grafana and find the trace
+
+1. Navigate to `http://localhost:3001`.
+2. Anonymous viewer access is enabled; you can browse dashboards without logging in. To use Explore or change settings, log in as `admin` with the password from your `.env` (default: `admin`).
+3. In the left sidebar, click **Explore**.
+4. In the datasource dropdown at the top, select **Tempo**.
+5. Switch to the **Search** tab.
+6. Filter by **Service Name**: `lq-ai-gateway` (or `lq-ai-api`).
+7. Optionally filter by **Span Name**: `inference.dispatch` to isolate the gateway's per-call dispatch span.
+8. Click **Run query**. Recent traces appear in the results table.
+9. Click a trace ID to open the span waterfall. You should see the `lq-ai-api → lq-ai-gateway → provider` tree with the F2 domain spans as children.
+
+### Step 4 — Check the metrics dashboard
+
+In the left sidebar, click **Dashboards**. The provisioned **LQ.AI** dashboard is pre-loaded and shows the Prometheus-scraped metric panels (request rate, latency percentiles, error rate) for the api and gateway services.
+
+---
+
+## Sampling
+
+The default sampler is `parentbased_always_on` — every trace is recorded. This is appropriate for development and low-traffic staging.
+
+For production, set the following in your repo-root `.env`:
+
+```bash
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.1   # ~10% of root traces; complete child spans are always kept
+```
+
+Then restart the api and gateway containers (`docker compose up -d api gateway`) for the change to take effect.
+
+---
+
+## Switching to an external backend
+
+If you later move to Honeycomb, Datadog, or another managed backend, bring this stack down and switch to the standalone collector recipe:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f deploy/observability/grafana-tempo-loki/docker-compose.observability.yml \
+  down
+
+# Then follow the instructions in:
+# deploy/observability/otel-collector-standalone/README.md
+```
+
+Named volumes (`tempo-data`, `loki-data`, `prom-data`, `grafana-data`) persist across restarts but are removed by `docker compose down -v`. Historical trace data does not migrate to a new backend.

--- a/deploy/observability/grafana-tempo-loki/docker-compose.observability.yml
+++ b/deploy/observability/grafana-tempo-loki/docker-compose.observability.yml
@@ -1,0 +1,107 @@
+# LQ.AI — Observability overlay: OpenTelemetry Collector + Tempo + Loki + Prometheus + Grafana
+#
+# Usage (from repo root):
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f deploy/observability/grafana-tempo-loki/docker-compose.observability.yml \
+#     up -d
+#
+# This overlay is additive. It:
+#   - Adds the observability stack (otel-collector, tempo, loki, prometheus, grafana).
+#   - Overrides api and gateway to enable OTLP export to the in-network collector.
+#   Compose merges environment maps, so base-service env vars are preserved.
+#
+# See deploy/observability/grafana-tempo-loki/.env.example for tunable vars.
+
+name: lq-ai
+
+services:
+  # ============================================================
+  # Override existing services — enable OTLP export
+  # ============================================================
+
+  api:
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_SERVICE_NAME: lq-ai-api
+      OTEL_TRACES_SAMPLER: ${OTEL_TRACES_SAMPLER:-parentbased_always_on}
+
+  gateway:
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_SERVICE_NAME: lq-ai-gateway
+      OTEL_TRACES_SAMPLER: ${OTEL_TRACES_SAMPLER:-parentbased_always_on}
+
+  # ============================================================
+  # Observability backend
+  # ============================================================
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.109.0
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./deploy/observability/grafana-tempo-loki/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      # Expose on the internal network only — no host binding needed for in-stack use.
+      # 4317 = gRPC, 4318 = HTTP/protobuf.  Both are exposed so operators can also
+      # forward host-side instrumented processes without changing the config.
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+    depends_on:
+      - tempo
+    restart: unless-stopped
+
+  tempo:
+    image: grafana/tempo:2.6.1
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./deploy/observability/grafana-tempo-loki/tempo.yaml:/etc/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:3.2.1
+    command: ["-config.file=/etc/loki/loki.yaml"]
+    volumes:
+      - ./deploy/observability/grafana-tempo-loki/loki.yaml:/etc/loki/loki.yaml:ro
+      - loki-data:/loki
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    volumes:
+      - ./deploy/observability/grafana-tempo-loki/prometheus.yaml:/etc/prometheus/prometheus.yml:ro
+      - prom-data:/prometheus
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.2.2
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD:-admin}
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    volumes:
+      - ./deploy/observability/grafana-tempo-loki/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "${GRAFANA_HOST_PORT:-3001}:3000"
+    depends_on:
+      - tempo
+      - loki
+      - prometheus
+    restart: unless-stopped
+
+# ============================================================
+# Named volumes for observability backend persistence
+# ============================================================
+
+volumes:
+  tempo-data:
+  loki-data:
+  prom-data:
+  grafana-data:

--- a/deploy/observability/grafana-tempo-loki/grafana/provisioning/dashboards/dashboards.yaml
+++ b/deploy/observability/grafana-tempo-loki/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+# Grafana dashboard provisioning for LQ.AI
+# Points the file provider at the directory that holds the dashboard JSON files.
+
+apiVersion: 1
+
+providers:
+  - name: lq-ai
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/deploy/observability/grafana-tempo-loki/grafana/provisioning/dashboards/lq-ai.json
+++ b/deploy/observability/grafana-tempo-loki/grafana/provisioning/dashboards/lq-ai.json
@@ -1,0 +1,301 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "LQ.AI — Inference Gateway and API observability (Prometheus metrics)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (tier) (rate(lq_ai_gateway_inference_requests_total[5m]))",
+          "legendFormat": "tier={{tier}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway tier mix",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, route) (rate(lq_ai_gateway_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "route={{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "p99 HTTP latency by route (gateway)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (job) (rate(lq_ai_gateway_http_requests_total{status=~\"5..\"}[5m])) / sum by (job) (rate(lq_ai_gateway_http_requests_total[5m]))",
+          "legendFormat": "gateway 5xx rate",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (job) (rate(lq_ai_api_http_requests_total{status=~\"5..\"}[5m])) / sum by (job) (rate(lq_ai_api_http_requests_total[5m]))",
+          "legendFormat": "api 5xx rate",
+          "refId": "B"
+        }
+      ],
+      "title": "Error rate by service (5xx)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["lq-ai", "observability"],
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "LQ.AI — Observability",
+  "uid": "lq-ai-observability",
+  "version": 1
+}

--- a/deploy/observability/grafana-tempo-loki/grafana/provisioning/datasources/lq-ai.yaml
+++ b/deploy/observability/grafana-tempo-loki/grafana/provisioning/datasources/lq-ai.yaml
@@ -1,0 +1,37 @@
+# Grafana datasource provisioning for LQ.AI
+# Automatically configures Tempo, Loki, and Prometheus on container start.
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    access: proxy
+    jsonData:
+      timeInterval: "15s"
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    url: http://tempo:3200
+    access: proxy
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: "-1m"
+        spanEndTimeShift: "1m"
+        filterByTraceID: true
+        filterBySpanID: false
+      lokiSearch:
+        datasourceUid: loki
+      serviceMap:
+        datasourceUid: prometheus
+
+  - name: Loki
+    type: loki
+    uid: loki
+    url: http://loki:3100
+    access: proxy

--- a/deploy/observability/grafana-tempo-loki/loki.yaml
+++ b/deploy/observability/grafana-tempo-loki/loki.yaml
@@ -1,0 +1,54 @@
+# Grafana Loki 3.2.x — minimal single-binary configuration for LQ.AI
+#
+# Runs in monolithic mode (all components in a single process).
+# Storage is local filesystem backed by the `loki-data` Docker volume.
+# For production, switch to S3-compatible object storage (e.g. MinIO —
+# which is already in the LQ.AI compose stack) and configure ruler/compactor.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  allow_structured_metadata: true
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# Required for single-binary: disables the memberlist ring
+# used by horizontally-scaled Loki deployments.
+memberlist:
+  abort_if_cluster_join_fails: false

--- a/deploy/observability/grafana-tempo-loki/otel-collector-config.yaml
+++ b/deploy/observability/grafana-tempo-loki/otel-collector-config.yaml
@@ -1,0 +1,34 @@
+# OpenTelemetry Collector configuration for LQ.AI
+#
+# Receiver: OTLP over HTTP (4318) and gRPC (4317).
+# Processors: batch (buffer before export to reduce round-trips).
+# Exporters: Tempo for traces (via gRPC OTLP).
+#
+# NOTE: Metrics are NOT routed through the collector.
+# Prometheus scrapes /metrics directly from api:8000 and gateway:8001
+# (see prometheus.yaml).  Routing Prometheus metrics through the collector
+# would add an unnecessary hop and complicate label fidelity.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo]

--- a/deploy/observability/grafana-tempo-loki/prometheus.yaml
+++ b/deploy/observability/grafana-tempo-loki/prometheus.yaml
@@ -1,0 +1,24 @@
+# Prometheus configuration for LQ.AI
+#
+# Scrapes /metrics from the API and Inference Gateway services.
+# Metric names (authoritative — from PRD / CLAUDE.md):
+#   lq_ai_api_http_requests_total         (labels: method, route, status)
+#   lq_ai_api_http_request_duration_seconds (labels: method, route, status)
+#   lq_ai_gateway_http_requests_total      (labels: method, route, status)
+#   lq_ai_gateway_http_request_duration_seconds (labels: method, route, status)
+#   lq_ai_gateway_inference_requests_total (labels: provider, tier, outcome)
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: lq-ai-api
+    static_configs:
+      - targets: ["api:8000"]
+    metrics_path: /metrics
+
+  - job_name: lq-ai-gateway
+    static_configs:
+      - targets: ["gateway:8001"]
+    metrics_path: /metrics

--- a/deploy/observability/grafana-tempo-loki/tempo.yaml
+++ b/deploy/observability/grafana-tempo-loki/tempo.yaml
@@ -1,0 +1,46 @@
+# Grafana Tempo 2.6.x — minimal single-binary configuration for LQ.AI
+#
+# Runs in monolithic mode (all components in a single process).
+# Storage is local filesystem backed by the `tempo-data` Docker volume.
+# For production, switch storage.trace.backend to s3/gcs/azure and
+# configure the block/wal paths accordingly.
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          # Listens on 4317 (standard OTLP gRPC port).
+          # The otel-collector's otlp/tempo exporter targets this.
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 48h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/blocks
+    wal:
+      path: /var/tempo/wal
+
+# Metrics-generator disabled in this minimal config.
+# Enable in production to derive RED metrics from traces.
+metrics_generator:
+  storage:
+    path: /var/tempo/generator/wal
+
+# Required for single-binary mode: disables the ring-based
+# memberlist that multi-binary deployments use.
+memberlist:
+  abort_if_cluster_join_fails: false

--- a/deploy/observability/otel-collector-standalone/.env.example
+++ b/deploy/observability/otel-collector-standalone/.env.example
@@ -1,0 +1,42 @@
+# LQ.AI — otel-collector-standalone environment variables
+#
+# Copy to .env in the repo root (or export in your shell) before bringing
+# up the standalone collector overlay.  Only the vars relevant to your
+# chosen backend are required.
+#
+# Usage:
+#   cp deploy/observability/otel-collector-standalone/.env.example .env
+#   # Edit .env, then:
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f deploy/observability/otel-collector-standalone/docker-compose.observability.yml \
+#     up -d
+
+# ------------------------------------------------------------
+# Honeycomb
+# Obtain at: https://ui.honeycomb.io/account
+# ------------------------------------------------------------
+# HONEYCOMB_API_KEY=
+
+# ------------------------------------------------------------
+# Datadog
+# DD_SITE: datadoghq.com (US1), datadoghq.eu (EU), us3.datadoghq.com, etc.
+# ------------------------------------------------------------
+# DD_API_KEY=
+# DD_SITE=datadoghq.com
+
+# ------------------------------------------------------------
+# Lightstep (ServiceNow Cloud Observability)
+# Obtain at: https://app.lightstep.com/[your-project]/settings/access-tokens
+# ------------------------------------------------------------
+# LS_ACCESS_TOKEN=
+
+# ------------------------------------------------------------
+# Sampling — applies to all backends.
+# parentbased_always_on: sample every trace (good for dev/staging).
+# parentbased_traceidratio: probabilistic; set OTEL_TRACES_SAMPLER_ARG=0.1
+#   for 10% sampling (recommended for production to control ingestion cost).
+# ------------------------------------------------------------
+OTEL_TRACES_SAMPLER=parentbased_always_on
+# OTEL_TRACES_SAMPLER=parentbased_traceidratio
+# OTEL_TRACES_SAMPLER_ARG=0.1

--- a/deploy/observability/otel-collector-standalone/README.md
+++ b/deploy/observability/otel-collector-standalone/README.md
@@ -1,0 +1,157 @@
+# Observability recipe: standalone OpenTelemetry Collector
+
+This recipe adds only an OpenTelemetry Collector to the LQ.AI stack. It does not bundle Grafana, Tempo, Loki, or Prometheus. Use it when you already have a tracing backend — Honeycomb, Datadog, Lightstep, or any OTLP-compatible endpoint — and want to forward LQ.AI's spans there with minimal additional Docker surface.
+
+If you don't have an existing backend and want a self-hosted stack, use [`../grafana-tempo-loki/`](../grafana-tempo-loki/) instead.
+
+---
+
+## Run command
+
+Run from the **repo root**:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f deploy/observability/otel-collector-standalone/docker-compose.observability.yml \
+  up -d
+```
+
+Before bringing the stack up, configure your backend in `otel-collector-config.yaml` and set the relevant env vars in your repo-root `.env` (instructions below).
+
+---
+
+## Configuring your backend
+
+Open `deploy/observability/otel-collector-standalone/otel-collector-config.yaml`. The file ships with the `debug` exporter active and all backend-specific exporter blocks commented out. The `debug` exporter logs span summaries to the collector's stdout — useful as a smoke test before wiring your real backend:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f deploy/observability/otel-collector-standalone/docker-compose.observability.yml \
+  logs otel-collector
+```
+
+If traces are flowing you will see lines like `Traces #0` with resource and span summaries. Once confirmed, wire your backend using the instructions for your provider below.
+
+---
+
+### Honeycomb
+
+1. **Uncomment** the `otlp/honeycomb` exporter block in `otel-collector-config.yaml`:
+
+   ```yaml
+   otlp/honeycomb:
+     endpoint: api.honeycomb.io:443
+     headers:
+       x-honeycomb-team: ${HONEYCOMB_API_KEY}
+     tls:
+       insecure: false
+   ```
+
+2. **Update the pipeline** — change the `traces` pipeline's `exporters` line from `[debug]` to `[otlp/honeycomb]` (or `[debug, otlp/honeycomb]` to keep stdout logging while validating):
+
+   ```yaml
+   service:
+     pipelines:
+       traces:
+         receivers: [otlp]
+         processors: [batch]
+         exporters: [otlp/honeycomb]
+   ```
+
+3. **Set the env var** in your repo-root `.env`:
+
+   ```bash
+   HONEYCOMB_API_KEY=<your-key>   # obtain at https://ui.honeycomb.io/account
+   ```
+
+4. Restart the collector: `docker compose -f docker-compose.yml -f deploy/observability/otel-collector-standalone/docker-compose.observability.yml up -d otel-collector`.
+
+---
+
+### Datadog
+
+1. **Uncomment** the `datadog` exporter block in `otel-collector-config.yaml`:
+
+   ```yaml
+   datadog:
+     api:
+       key: ${DD_API_KEY}
+       site: ${DD_SITE:-datadoghq.com}
+   ```
+
+2. **Update the pipeline** — change `exporters: [debug]` to `exporters: [datadog]` (or `[debug, datadog]`):
+
+   ```yaml
+   service:
+     pipelines:
+       traces:
+         receivers: [otlp]
+         processors: [batch]
+         exporters: [datadog]
+   ```
+
+3. **Set the env vars** in your repo-root `.env`:
+
+   ```bash
+   DD_API_KEY=<your-key>
+   DD_SITE=datadoghq.com   # other values: datadoghq.eu, us3.datadoghq.com, us5.datadoghq.com
+   ```
+
+4. Restart the collector.
+
+The recipe uses the `otel/opentelemetry-collector-contrib` image, which includes the native Datadog exporter — no additional image changes are needed.
+
+---
+
+### Lightstep (ServiceNow Cloud Observability)
+
+1. **Uncomment** the `otlp/lightstep` exporter block in `otel-collector-config.yaml`:
+
+   ```yaml
+   otlp/lightstep:
+     endpoint: ingest.lightstep.com:443
+     headers:
+       lightstep-access-token: ${LS_ACCESS_TOKEN}
+     tls:
+       insecure: false
+   ```
+
+2. **Update the pipeline** — change `exporters: [debug]` to `exporters: [otlp/lightstep]` (or `[debug, otlp/lightstep]`):
+
+   ```yaml
+   service:
+     pipelines:
+       traces:
+         receivers: [otlp]
+         processors: [batch]
+         exporters: [otlp/lightstep]
+   ```
+
+3. **Set the env var** in your repo-root `.env`:
+
+   ```bash
+   LS_ACCESS_TOKEN=<your-token>   # obtain at https://app.lightstep.com/[your-project]/settings/access-tokens
+   ```
+
+4. Restart the collector.
+
+---
+
+### Other OTLP-compatible backends
+
+For any backend that accepts standard OTLP/gRPC or OTLP/HTTP, add an `otlp/<name>` exporter block following the same pattern as the Honeycomb and Lightstep blocks above, pointing at your backend's ingest endpoint. Consult your backend's documentation for the exact endpoint, port, and authentication header name.
+
+---
+
+## Sampling
+
+The default sampler is `parentbased_always_on` — every trace is recorded. For production, add the following to your repo-root `.env`:
+
+```bash
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.1   # ~10% of root traces; complete child spans are always kept
+```
+
+Then restart the api and gateway containers for the change to take effect. See [docs/observability.md](../../../docs/observability.md) for guidance on choosing a sampling rate.

--- a/deploy/observability/otel-collector-standalone/docker-compose.observability.yml
+++ b/deploy/observability/otel-collector-standalone/docker-compose.observability.yml
@@ -1,0 +1,53 @@
+# LQ.AI — Observability overlay: standalone OpenTelemetry Collector
+#
+# Usage (from repo root):
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f deploy/observability/otel-collector-standalone/docker-compose.observability.yml \
+#     up -d
+#
+# This overlay is the LEAN variant for operators who already have a tracing
+# backend (Honeycomb, Datadog, Lightstep, or any OTLP-compatible endpoint).
+# It adds only the collector; no Grafana, Tempo, Loki, or Prometheus are
+# bundled here.  Configure your backend in otel-collector-config.yaml before
+# bringing the stack up.
+#
+# Compose merges environment maps, so base-service env vars are preserved.
+#
+# See deploy/observability/otel-collector-standalone/.env.example for tunable vars.
+
+name: lq-ai
+
+services:
+  # ============================================================
+  # Override existing services — enable OTLP export to collector
+  # ============================================================
+
+  api:
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_SERVICE_NAME: lq-ai-api
+      OTEL_TRACES_SAMPLER: ${OTEL_TRACES_SAMPLER:-parentbased_always_on}
+
+  gateway:
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_SERVICE_NAME: lq-ai-gateway
+      OTEL_TRACES_SAMPLER: ${OTEL_TRACES_SAMPLER:-parentbased_always_on}
+
+  # ============================================================
+  # Standalone collector — stateless, forwards to operator backend
+  # ============================================================
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.109.0
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./deploy/observability/otel-collector-standalone/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      # Expose on loopback only — no host binding needed for in-stack use.
+      # 4317 = gRPC, 4318 = HTTP/protobuf.  Both exposed so operators can
+      # also forward host-side instrumented processes without config changes.
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+    restart: unless-stopped

--- a/deploy/observability/otel-collector-standalone/otel-collector-config.yaml
+++ b/deploy/observability/otel-collector-standalone/otel-collector-config.yaml
@@ -1,0 +1,85 @@
+# OpenTelemetry Collector configuration for LQ.AI — standalone / forward-to-backend variant
+#
+# This configuration runs out-of-the-box with the `debug` exporter so the
+# collector starts and validates cleanly.  To forward traces to your backend,
+# uncomment the relevant exporter block below and update the pipeline's
+# exporters list from [debug] to your backend (e.g. [otlp/honeycomb]).
+#
+# Receiver: OTLP over HTTP (4318) and gRPC (4317).
+# Processors: batch — buffers spans before export to reduce round-trips.
+# Exporters: debug (active, always on) + commented backend blocks.
+#
+# gRPC vs HTTP per backend:
+#   Honeycomb  — OTLP/gRPC on port 443 (TLS).
+#   Datadog    — uses the native datadog exporter (contrib image required; we use it).
+#   Lightstep  — OTLP/gRPC on port 443 (TLS).
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  # ------------------------------------------------------------------
+  # debug — ACTIVE.  Logs span summaries to collector stdout so you
+  # can confirm traces are flowing before wiring a real backend.
+  # Safe to leave enabled alongside a backend exporter.
+  # ------------------------------------------------------------------
+  debug:
+    verbosity: basic
+
+  # ------------------------------------------------------------------
+  # Honeycomb — OTLP/gRPC on port 443 with TLS.
+  # Requires env var: HONEYCOMB_API_KEY
+  # Uncomment this block, then set exporters in the pipeline to
+  # [otlp/honeycomb] (or [debug, otlp/honeycomb] to keep logging).
+  # ------------------------------------------------------------------
+  # otlp/honeycomb:
+  #   endpoint: api.honeycomb.io:443
+  #   headers:
+  #     x-honeycomb-team: ${HONEYCOMB_API_KEY}
+  #   tls:
+  #     insecure: false   # port 443 uses TLS — do NOT set insecure: true
+
+  # ------------------------------------------------------------------
+  # Datadog — uses the native datadog exporter (contrib image, which
+  # this recipe already uses).  No OTLP relay needed.
+  # Requires env vars: DD_API_KEY, DD_SITE (default: datadoghq.com)
+  # Uncomment this block, then set exporters in the pipeline to
+  # [datadog] (or [debug, datadog]).
+  # ------------------------------------------------------------------
+  # datadog:
+  #   api:
+  #     key: ${DD_API_KEY}
+  #     site: ${DD_SITE:-datadoghq.com}
+
+  # ------------------------------------------------------------------
+  # Lightstep — OTLP/gRPC on port 443 with TLS.
+  # Requires env var: LS_ACCESS_TOKEN
+  # Uncomment this block, then set exporters in the pipeline to
+  # [otlp/lightstep] (or [debug, otlp/lightstep]).
+  # ------------------------------------------------------------------
+  # otlp/lightstep:
+  #   endpoint: ingest.lightstep.com:443
+  #   headers:
+  #     lightstep-access-token: ${LS_ACCESS_TOKEN}
+  #   tls:
+  #     insecure: false   # port 443 uses TLS — do NOT set insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      # To forward to your backend, replace [debug] with your exporter, e.g.:
+      #   exporters: [otlp/honeycomb]
+      #   exporters: [datadog]
+      #   exporters: [otlp/lightstep]
+      # You can also combine: exporters: [debug, otlp/honeycomb]
+      exporters: [debug]

--- a/docs/HONEST-STATE.md
+++ b/docs/HONEST-STATE.md
@@ -259,6 +259,7 @@ The deployment story in M1 is Docker Compose plus a drafted Helm chart. The supp
 | Reverse-proxy + TLS recipes (Caddy, Traefik, nginx) | not yet | [Mini-PRD open](contribute/mini-prds/reverse-proxy-tls-deployment-recipes.md) |
 | Backup + restore tooling (`pg_dump` + MinIO snapshot wrapper) | not yet | `ls scripts/` — no backup tooling |
 | Runbooks for operational tasks | not yet | `ls docs/` — no `runbooks/` directory |
+| OpenTelemetry instrumentation (traces + metrics) | M1 baseline + M3-F domain spans | [`docs/observability.md`](observability.md) — signal inventory, span names, attribute schema; deployment recipes at [`deploy/observability/`](../deploy/observability/) |
 | SLO / SLI publication | not yet | OpenTelemetry instrumentation ships at M1; service-level objectives are deferred |
 | Public status page (for any LegalQuants-hosted artifacts) | not yet | No hosted service in M1; the project ships as software the operator runs |
 | Public postmortem template + commitment | not yet | No incidents in operator-facing infrastructure yet; the publication commitment lands with the engineering-discipline roadmap |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,298 @@
+# LQ.AI — Observability Operator Guide
+
+> **Scope:** OpenTelemetry traces, Prometheus metrics, and deployment recipes for the
+> `api` and `gateway` services. Covers what is shipped as of M3-F (M3-F1 trace
+> propagation, M3-F2 domain spans, M3-F3 recipes and this doc). What is not yet
+> shipped is listed in [§6 — What's not yet shipped](#6-whats-not-yet-shipped) with
+> links to the tracking DE entries.
+
+For the architectural context see [docs/architecture.md](architecture.md) §OBS and the
+"What the diagram doesn't show" section. For the deployment recipes see
+[deploy/observability/README.md](../deploy/observability/README.md).
+
+---
+
+## 1. Environment-variable matrix
+
+LQ.AI initializes the OTel SDK **only when at least one of the endpoint variables
+below is set.** If none are set, the services start cleanly and spans are silently
+dropped — no traces leave the deployment (per [PRD §5.7](PRD.md#57-no-telemetry-by-default)).
+Prometheus `/metrics` is always on regardless of OTel configuration.
+
+Transport is OTLP/HTTP for all signals.
+
+| Variable | Meaning | Default |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Master switch. Sets the base URL for all signals (traces + metrics when [DE-301](PRD.md#de-301--otel-meterprovider-for-metrics-export-otel-deepening-de-c) lands). OTel initializes iff this OR a per-signal endpoint is set. Example: `http://otel-collector:4318`. | unset — no OTel |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Per-signal override for traces. Takes precedence over the master endpoint for trace export. Useful when splitting traces and metrics to different backends. | unset |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Per-signal override for metrics (relevant once DE-301 lands). | unset |
+| `OTEL_SERVICE_NAME` | Resource attribute `service.name` attached to every span. | `lq-ai-api` (api service), `lq-ai-gateway` (gateway service) |
+| `OTEL_RESOURCE_ATTRIBUTES` | Arbitrary `key=value,key=value` pairs appended to the resource. Use for deployment environment, region, or cluster tags. Example: `deployment.environment=production,k8s.cluster.name=prod-east`. | unset |
+| `OTEL_TRACES_SAMPLER` | Sampler name per the OTel SDK. The SDK default is `parentbased_always_on` (sample everything). For production, use `parentbased_traceidratio` and set `OTEL_TRACES_SAMPLER_ARG=0.1` (10% head sampling). | `parentbased_always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument. For `parentbased_traceidratio`, the sampling ratio (0.0–1.0). | `1.0` |
+
+**Recommended production configuration:**
+
+```env
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+OTEL_SERVICE_NAME=lq-ai-api          # or lq-ai-gateway per service
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.1
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production
+```
+
+---
+
+## 2. What's in each signal
+
+### Traces
+
+W3C `traceparent` propagates across the full `api → gateway → provider` call chain
+(M3-F1). A single chat-send surfaces as **one end-to-end trace**, not three separate
+traces — verified by `test_trace_propagation.py` in both `api/` and `gateway/`.
+
+Beyond HTTP auto-instrumentation (FastAPI + httpx), the services emit **domain spans**
+for the high-value LQ.AI operations. These spans are no-ops when OTel is disabled.
+
+---
+
+#### `citation.verify`
+
+Wraps the full Citation Engine cascade for one citation candidate. Child spans cover
+each stage that runs.
+
+| Child span | Emitted when |
+|---|---|
+| `citation.stage.exact_match` | Always (stage 1) |
+| `citation.stage.tolerant_match` | Stage 1 misses |
+| `citation.stage.paraphrase_judge` | Stage 2 misses (single-judge path) |
+| `citation.stage.ensemble` | Ensemble path active (replaces paraphrase_judge) |
+
+**Attributes on `citation.verify`:**
+
+| Attribute | Description |
+|---|---|
+| `citation.method` | Winning stage: `exact_match`, `tolerant_match`, `paraphrase_judge`, `ensemble_strict`, or `ensemble_majority` |
+| `citation.confidence` | Float 0.0–1.0; maps to stage confidence (0.90/0.70/0.50 for the judge stages) |
+| `citation.partial` | Boolean; `true` when the source partially supports the claim |
+| `citation.tier_envelope` | Inference tier used for judge calls |
+| `document.id` | ID of the cited source document |
+
+**Additional attributes on `citation.stage.ensemble`:**
+
+| Attribute | Description |
+|---|---|
+| `citation.ensemble.n_judges` | Number of parallel judge calls |
+| `citation.ensemble.rule` | Aggregation rule: `strict` or `majority` |
+
+**Span events:**
+
+| Event | Meaning |
+|---|---|
+| `exact_match.hit` | Stage 1 short-circuit (no further stages run) |
+| `tolerant_match.hit` | Stage 2 short-circuit |
+| `ensemble.budget_fallback` | Pre-flight budget check tripped; ensemble skipped |
+
+---
+
+#### `anonymization.pre` / `anonymization.post`
+
+Emitted by the gateway anonymization middleware. `anonymization.pre` wraps the
+entity-detection + pseudonymization pass before the model call;
+`anonymization.post` wraps the rehydration pass on the response.
+
+**Attributes (both spans):**
+
+| Attribute | Description |
+|---|---|
+| `anonymization.enabled` | Boolean; `false` when the tier or project configuration skips anonymization |
+| `anonymization.skip_reason` | Present when `enabled=false`; values include `tier_below_threshold`, `privileged_project`, `retrieval_context` |
+| `anonymization.entity_count` | Integer count of entities detected (pre) or rehydrated (post) |
+| `anonymization.entity_types` | Comma-separated list of entity type labels (e.g., `PERSON,MATTER_NUMBER`). **Never raw entity values** — see [§4](#4-anonymization-and-telemetry). |
+| `anonymization.tier` | Inference tier at the time of the anonymization decision |
+
+---
+
+#### `skill.execute`
+
+One span per skill applied to the request.
+
+| Attribute | Description |
+|---|---|
+| `skill.slug` | Skill identifier (e.g., `nda-review`) |
+| `skill.version` | Skill semver |
+| `skill.author` | Skill author field from `SKILL.md` frontmatter (may be `null` for built-ins until [DE-316](PRD.md#de-316--promote-skill-author-to-the-skill--skillsummary-wire-shape-otel-deepening-skill-spans) lands) |
+| `project.id` | Matter-scoped project UUID |
+| `project.privileged` | Boolean; `true` for privileged matters |
+| `chat.id` | Chat session UUID |
+
+---
+
+#### `inference.dispatch`
+
+Emitted by the gateway on the **non-streaming** `chat_completions` path. Carries the
+post-dispatch cost and outcome data. **Note:** the streaming path does not yet emit
+this span — tracked at [DE-317](PRD.md#de-317--inferencedispatch-span-on-the-streaming-path-otel-deepening).
+
+| Attribute | Description |
+|---|---|
+| `inference.provider` | Provider name: `anthropic`, `openai`, `azure_openai`, `ollama` |
+| `inference.model` | Model ID as sent to the provider |
+| `inference.tier` | Routed inference tier (1–5) |
+| `inference.outcome` | `success`, `fallback`, or `error` |
+| `inference.tokens_in` | Prompt token count |
+| `inference.tokens_out` | Completion token count |
+| `inference.cost_usd` | Computed cost in USD at configured per-model rates |
+
+---
+
+#### `playbook.execute` / `tabular.execute`
+
+Top-level spans wrapping a full Playbook or Tabular Review execution. Each has
+per-position child spans (`playbook.position`) or per-cell child spans
+(`tabular.cell`).
+
+**Note on `playbook.position` coverage:** child spans are emitted in the `classify`
+node but not yet in the `redline` node — tracked at
+[DE-318](PRD.md#de-318--playbookposition-child-spans-on-the-redline-node-otel-deepening).
+
+---
+
+### Metrics
+
+Prometheus metrics are served by the api (`:8000/metrics`) and gateway
+(`:8001/metrics`). These endpoints are always on but are reachable only inside the
+Compose network (or wherever the operator's reverse proxy routes them) — they are
+not exposed on a public interface by default.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `lq_ai_api_http_requests_total` | Counter | `method`, `route`, `status` | Total HTTP requests handled by the api service |
+| `lq_ai_api_http_request_duration_seconds` | Histogram | `method`, `route`, `status` | Request latency distribution on the api service |
+| `lq_ai_gateway_http_requests_total` | Counter | `method`, `route`, `status` | Total HTTP requests handled by the gateway service |
+| `lq_ai_gateway_http_request_duration_seconds` | Histogram | `method`, `route`, `status` | Request latency distribution on the gateway service |
+| `lq_ai_gateway_inference_requests_total` | Counter | `provider`, `tier`, `outcome` | Inference dispatches by provider, tier, and outcome (success / fallback / error) |
+
+---
+
+### Logs
+
+Structured logs are emitted by both services. **Log-trace correlation (injecting
+`trace_id` / `span_id` into log lines) is not yet shipped** — tracked at
+[DE-300](PRD.md#de-300--log-trace-correlation-via-structured-logger-trace_id--span_id-injection-otel-deepening-de-b).
+Until DE-300 lands, pivoting from a span in Tempo or Honeycomb to the logs for that
+request requires matching on timestamp + `service.name` manually.
+
+---
+
+## 3. Deployment recipes
+
+Two ready-made Docker Compose overlays are in [`deploy/observability/`](../deploy/observability/).
+Read [`deploy/observability/README.md`](../deploy/observability/README.md) first — it explains
+how to switch between them and what each adds to the base stack.
+
+### Self-hosted: Grafana + Tempo + Loki + Prometheus
+
+**Recipe:** [`deploy/observability/grafana-tempo-loki/`](../deploy/observability/grafana-tempo-loki/)
+
+Use this when you are starting fresh and want a self-contained observability stack
+with no third-party SaaS accounts. The overlay adds Grafana, Tempo (traces),
+Loki (logs), Prometheus (metrics), and an OTel Collector — all running alongside
+the main LQ.AI Compose stack. The OTel Collector is the collection point; api and
+gateway send spans to it over OTLP/HTTP; it fans out to Tempo. Prometheus scrapes
+`/metrics` directly.
+
+Time-to-first-trace once the overlay is running: under 15 minutes with the bundled
+Grafana dashboard.
+
+### Existing backend: OTel Collector standalone
+
+**Recipe:** [`deploy/observability/otel-collector-standalone/`](../deploy/observability/otel-collector-standalone/)
+
+Use this when you already run Honeycomb, Datadog, Lightstep, Splunk, or any other
+OTLP-compatible backend and you do not want Grafana or Tempo locally. The overlay
+adds only an OTel Collector configured to forward spans to your backend. You supply
+the backend endpoint and API key via environment variables in the Collector config;
+the api and gateway are wired to the local Collector, which handles batching and
+export.
+
+---
+
+## 4. Anonymization and telemetry
+
+The Anonymization Layer (Inference Gateway; [docs/security/anonymization.md](security/anonymization.md))
+pseudonymizes sensitive entities — names, matter numbers, organization names, contact
+details — before they reach a cloud inference provider. The same posture extends to
+telemetry: **span attributes carry entity counts and type labels only, never raw
+entity values.**
+
+Concretely: if a request triggers anonymization of three person names and one matter
+number, the `anonymization.entity_count` attribute is `4` and
+`anonymization.entity_types` is `PERSON,MATTER_NUMBER`. The actual names and the
+matter number do not appear in any span attribute, span event, or metric label.
+
+This invariant is enforced by `gateway/tests/test_anonymization_observability.py`.
+
+Operators forwarding trace data to a third-party backend (Honeycomb, Datadog,
+Lightstep) receive the same guarantee: the telemetry side-channel cannot leak what
+the Anonymization Layer is designed to protect.
+
+---
+
+## 5. No telemetry by default
+
+Per [PRD §5.7](PRD.md#57-no-telemetry-by-default): until `OTEL_EXPORTER_OTLP_ENDPOINT`
+or a per-signal endpoint is set, **no traces leave the deployment.** The OTel SDK is
+present in the service images but the TracerProvider is never initialized, and spans
+are silently dropped.
+
+Prometheus `/metrics` is always on. It is served on the internal Docker network only
+(`:8000` for api, `:8001` for gateway); the operator's reverse proxy or a scrape
+configuration inside the Compose network is required to reach it. The metrics
+endpoint does not emit data to any external destination — it is a pull surface, not
+a push surface.
+
+This behavior is pinned by `tests/test_observability.py` (cross-cutting integration
+test, added alongside this doc in M3-F3).
+
+---
+
+## 6. What's not yet shipped
+
+The items below are honestly deferred. Each links to its PRD §9 tracking entry with
+the acceptance criteria and contributor profile.
+
+**OTel Deepening DEs (PRD §9, added at M3-F close):**
+
+| DE | Title | Notes |
+|---|---|---|
+| [DE-299](PRD.md#de-299--otel-instrumentation-for-sqlalchemy--arq-workers-otel-deepening-de-a) | OTel instrumentation for SQLAlchemy + ARQ workers | DB query and background-job latency are blind spots today |
+| [DE-300](PRD.md#de-300--log-trace-correlation-via-structured-logger-trace_id--span_id-injection-otel-deepening-de-b) | Log-trace correlation via structured-logger trace_id / span_id injection | Pivoting from a span to its logs requires manual timestamp correlation until this lands |
+| [DE-301](PRD.md#de-301--otel-meterprovider-for-metrics-export-otel-deepening-de-c) | OTel MeterProvider for metrics export | Metrics today go only to Prometheus; OTel-native metrics export (Honeycomb-only, Datadog APM-only) is additive |
+| [DE-302](PRD.md#de-302--reconcile-otel-with-the-openwebui-forks-inherited-telemetry-otel-deepening-de-d) | Reconcile OTel with the OpenWebUI fork's inherited telemetry | The OWUI-inherited layer runs as a parallel `service.name`; alignment or disable decision pending |
+| [DE-303](PRD.md#de-303--browser-rum-via-opentelemetry-sdk-otel-deepening-de-e) | Browser RUM via OpenTelemetry SDK | Frontend spans not yet emitted; opt-in env var + CSP review required |
+
+**Streaming coverage gaps:**
+
+| DE | Title | Notes |
+|---|---|---|
+| [DE-315](PRD.md#de-315--streaming-rehydration-per-chunk-spans-otel-deepening-anonymization) | Streaming-rehydration per-chunk spans | `StreamingRehydrator` path not yet instrumented |
+| [DE-317](PRD.md#de-317--inferencedispatch-span-on-the-streaming-path-otel-deepening) | `inference.dispatch` span on the streaming path | Non-streaming path only today |
+
+**Playbook coverage gap:**
+
+| DE | Title | Notes |
+|---|---|---|
+| [DE-318](PRD.md#de-318--playbookposition-child-spans-on-the-redline-node-otel-deepening) | `playbook.position` child spans on the redline node | Classify-node positions are spanned; redline-node positions are not |
+
+**SLO + RUM catalog (from [`docs/proposals/opentelemetry-deepening.md`](proposals/opentelemetry-deepening.md)):**
+DE-E (Browser RUM, same as DE-303 above), DE-F (Published SLO catalog), and DE-G
+(Performance regression tracking) are downstream of the shipped M3-F signals and are
+deferred to whichever milestone first makes the signal inventory stable enough to
+define meaningful targets.
+
+---
+
+*Maintained by the maintainer team. Updates land alongside observability changes. If
+a claim in this doc doesn't match the code, the code is canonical — please
+[open an issue](https://github.com/LegalQuants/lq-ai/issues).*

--- a/docs/superpowers/plans/2026-05-24-m3-f3-deploy-observability.md
+++ b/docs/superpowers/plans/2026-05-24-m3-f3-deploy-observability.md
@@ -1,0 +1,179 @@
+# M3-F3 — Deployment Recipes + `docs/observability.md` + OTel-eval Playground Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Give operators a copy-paste path from zero to "I can see a chat-send trace in Grafana" — two `deploy/observability/` recipes (self-hosted Tempo+Loki+Grafana, and standalone Collector→your-backend), an operator guide `docs/observability.md`, a "no telemetry by default" regression test, and a 4th Learn playground that visualizes the F2 trace tree.
+
+**Architecture:** The base `docker-compose.yml` already declares `OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}` (empty → off) on `api`/`gateway`. Each recipe is a compose **overlay** (`docker-compose.observability.yml`) that (a) adds the observability services and (b) sets that env var to the in-network collector, composed via `docker compose -f docker-compose.yml -f deploy/observability/<recipe>/docker-compose.observability.yml`. Transport is OTLP/HTTP (port 4318), per the locked decision. No code changes to api/gateway — F3 is config + docs + one test + one playground.
+
+**Tech Stack:** Docker Compose overlays, OpenTelemetry Collector (`otel/opentelemetry-collector-contrib`), Grafana Tempo, Grafana Loki, Grafana, Prometheus, Grafana provisioning YAML + dashboard JSON, a self-contained HTML playground (mirrors `web/static/learn/playgrounds/citation-engine-cascade.html`), pytest in the repo-root `tests/`.
+
+---
+
+## Decisions locked (carry into every task)
+
+1. **Transport:** OTLP/HTTP, collector on `:4318`. (Locked F1/F2.)
+2. **Sampler:** document `parentbased_always_on` (dev) + `parentbased_traceidratio` 0.1 (prod-ref) via `OTEL_TRACES_SAMPLER` env; **do not change any code default**.
+3. **Overlay sets the endpoint:** the recipe overlay sets `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318` on `api`+`gateway` (and bridges if trivial). Base compose stays no-telemetry-by-default.
+4. **OWUI out of scope (DE-D):** do NOT touch `web/docker-compose.otel.yaml` (the OpenWebUI-fork OTel overlay) or the `open-webui` service name. LQ.AI services are `lq-ai-api`/`lq-ai-gateway`.
+5. **No live-stack disruption during build:** the live bring-up validation (recipe 1 → see a trace in Grafana) is the real acceptance bar but bounces api/gateway with OTel ON. It is deferred to an explicit validation pass / M3-close fresh-install, NOT run silently during the build. Static `docker compose ... config` validation IS run per task.
+6. **Honesty:** `docs/observability.md` documents only what's shipped; everything not-yet (browser RUM, OTel-native metrics export, SQLAlchemy/ARQ instrumentation, log-trace correlation, SLO catalog) links to the DE entries (DE-299..303, DE-A..G, DE-315/317/318).
+
+---
+
+## File structure (all NEW unless noted)
+
+```
+deploy/observability/
+├── README.md                                         # which recipe, when
+├── grafana-tempo-loki/
+│   ├── README.md
+│   ├── docker-compose.observability.yml              # Collector + Tempo + Loki + Prometheus + Grafana; sets OTEL endpoint on api/gateway
+│   ├── otel-collector-config.yaml                    # OTLP/HTTP :4318 → Tempo (traces) + Prom (metrics scrape) ; logs path noted
+│   ├── tempo.yaml
+│   ├── loki.yaml
+│   ├── prometheus.yaml
+│   ├── grafana/provisioning/datasources/lq-ai.yaml   # Tempo + Loki + Prometheus datasources
+│   ├── grafana/provisioning/dashboards/dashboards.yaml  # provider file
+│   ├── grafana/provisioning/dashboards/lq-ai.json    # starter dashboard (tier mix, p99 by route, error rate)
+│   └── .env.example
+└── otel-collector-standalone/
+    ├── README.md                                     # Honeycomb / Datadog / Lightstep specifics
+    ├── docker-compose.observability.yml              # Collector only; sets OTEL endpoint on api/gateway
+    ├── otel-collector-config.yaml                    # OTLP/HTTP in → operator backend (commented exporters)
+    └── .env.example
+
+docs/observability.md                                 # operator guide (6 sections)
+tests/test_observability.py                           # NEW — no-telemetry-by-default contract
+web/static/learn/playgrounds/otel-eval.html           # NEW — 4th playground
+```
+
+**Modify:** `README.md` (link observability.md in Documentation section ~L462; fix stale "Six interactive playgrounds" → "Eleven"), `docs/HONEST-STATE.md` (§7 link), `web/src/routes/lq-ai/learn/how/+page.svelte` (add §11 section).
+
+---
+
+### Task 1: `grafana-tempo-loki` recipe (config files + overlay)
+
+**Files:** all under `deploy/observability/grafana-tempo-loki/` (see structure). 
+
+- [ ] **Step 1:** Write `docker-compose.observability.yml` — an overlay adding: `otel-collector` (`otel/opentelemetry-collector-contrib:0.x`, mounts `otel-collector-config.yaml`, ports 4318), `tempo` (`grafana/tempo`, mounts `tempo.yaml`), `loki` (`grafana/loki`, mounts `loki.yaml`), `prometheus` (`prom/prometheus`, mounts `prometheus.yaml`, scrapes api+gateway `/metrics`), `grafana` (`grafana/grafana`, mounts provisioning, port 3001:3000). Add an `environment:` override block on `api` and `gateway` setting `OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318` and `OTEL_SERVICE_NAME` (`lq-ai-api`/`lq-ai-gateway`). All services on the default `lq-ai` network. Use named volumes for tempo/loki/grafana data.
+- [ ] **Step 2:** Write `otel-collector-config.yaml` — `receivers.otlp.protocols.http` on `:4318`; `processors.batch`; `exporters`: `otlp/tempo` (to `tempo:4317`, tls insecure) for traces, and document that metrics come via Prometheus scrape of `/metrics` (collector need not handle metrics in recipe 1). `service.pipelines.traces` wires otlp→batch→otlp/tempo.
+- [ ] **Step 3:** Write `tempo.yaml` (minimal single-binary: local storage, otlp receiver on 4317), `loki.yaml` (minimal single-binary), `prometheus.yaml` (scrape_configs for `api:8000/metrics` + `gateway:8001/metrics`).
+- [ ] **Step 4:** Write `grafana/provisioning/datasources/lq-ai.yaml` (Tempo @ `http://tempo:3200`, Loki @ `http://loki:3100`, Prometheus @ `http://prometheus:9090`), `grafana/provisioning/dashboards/dashboards.yaml` (file provider → `/etc/grafana/provisioning/dashboards`), and `grafana/provisioning/dashboards/lq-ai.json` — 3 panels: (a) gateway tier mix = `sum by (tier) (rate(lq_ai_gateway_inference_requests_total[5m]))`; (b) p99 HTTP latency by route = `histogram_quantile(0.99, sum by (le,route) (rate(lq_ai_gateway_http_request_duration_seconds_bucket[5m])))`; (c) error rate by service = ratio of `status=~"5.."` over total from `lq_ai_*_http_requests_total`.
+- [ ] **Step 5:** Write `.env.example` (e.g., `GF_SECURITY_ADMIN_PASSWORD`, `OTEL_TRACES_SAMPLER` default note).
+- [ ] **Step 6: VALIDATE** the merged config:
+  `cd ~/Code/lq-ai && docker compose -f docker-compose.yml -f deploy/observability/grafana-tempo-loki/docker-compose.observability.yml config >/dev/null && echo CONFIG_OK`
+  Expected: `CONFIG_OK` (no YAML/merge errors). Fix any merge errors (env-required vars like LQ_AI_GATEWAY_KEY/JWT_SECRET must be present — source the repo `.env` or pass placeholders for the `config` check).
+- [ ] **Step 7: Commit** `feat(m3-f3): grafana-tempo-loki observability recipe (Collector+Tempo+Loki+Prometheus+Grafana)`.
+
+> README for this recipe is Task 3 (grouped with the overview README).
+
+---
+
+### Task 2: `otel-collector-standalone` recipe
+
+**Files:** under `deploy/observability/otel-collector-standalone/`.
+
+- [ ] **Step 1:** `docker-compose.observability.yml` — overlay adding only `otel-collector` (ports 4318) + the `OTEL_EXPORTER_OTLP_ENDPOINT`/`OTEL_SERVICE_NAME` overrides on api/gateway.
+- [ ] **Step 2:** `otel-collector-config.yaml` — OTLP/HTTP receiver on 4318, batch processor, and a `service.pipelines.traces` with the exporter left as a clearly-commented placeholder plus three commented-out exporter blocks: **Honeycomb** (`otlp` exporter to `api.honeycomb.io:443` with `x-honeycomb-team` header), **Datadog** (`datadog` exporter with `api.key`), **Lightstep** (`otlp` to `ingest.lightstep.com:443` with `lightstep-access-token`). One active no-op `debug` exporter so the config validates out of the box.
+- [ ] **Step 3:** `.env.example` (operator's backend keys, commented).
+- [ ] **Step 4: VALIDATE:** `docker compose -f docker-compose.yml -f deploy/observability/otel-collector-standalone/docker-compose.observability.yml config >/dev/null && echo CONFIG_OK`.
+- [ ] **Step 5: Commit** `feat(m3-f3): standalone OTel Collector recipe (forward to Honeycomb/Datadog/Lightstep)`.
+
+---
+
+### Task 3: `deploy/observability/README.md` + per-recipe READMEs
+
+- [ ] **Step 1:** `deploy/observability/README.md` — overview + a decision table: choose `grafana-tempo-loki` (fresh, want a self-hosted stack) vs `otel-collector-standalone` (already have Honeycomb/Datadog/etc). Link `docs/observability.md`.
+- [ ] **Step 2:** `grafana-tempo-loki/README.md` — prerequisites; the exact `docker compose -f ... -f ... up -d` command; the 15-min "verify a trace" walkthrough (`curl` a chat-send → Grafana `http://localhost:3001` → Explore → Tempo → search by trace ID); how to switch sampler via `OTEL_TRACES_SAMPLER`.
+- [ ] **Step 3:** `otel-collector-standalone/README.md` — when to use; uncomment-your-backend instructions for Honeycomb, Datadog, Lightstep specifically; the run command.
+- [ ] **Step 4: Commit** `docs(m3-f3): observability recipe READMEs + decision guide`.
+
+---
+
+### Task 4: `docs/observability.md` operator guide + links
+
+- [ ] **Step 1:** Write `docs/observability.md` covering the six required sections:
+  1. **Env-var matrix** — `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, per-signal `OTEL_EXPORTER_OTLP_{TRACES,METRICS}_ENDPOINT`, `OTEL_TRACES_SAMPLER` (+ default `parentbased_always_on`, recommended prod `parentbased_traceidratio`=0.1). Note the trigger: OTel initializes iff one of the endpoint vars is set.
+  2. **Per-signal inventory** — Traces: the F2 domain spans (`citation.verify`+stages, `anonymization.pre/.post`, `skill.execute`, `inference.dispatch`, `playbook.execute`/`tabular.execute`+children) with the filterable attributes. Metrics: `lq_ai_api_http_requests_total`, `lq_ai_api_http_request_duration_seconds`, `lq_ai_gateway_http_requests_total`, `lq_ai_gateway_http_request_duration_seconds`, `lq_ai_gateway_inference_requests_total` (one line each + labels). Logs: link forward to DE (log-trace correlation not yet shipped).
+  3. **Two reference recipes** — when to choose each; link the recipe dirs.
+  4. **Anonymization + telemetry** — span attributes carry counts/types only, never raw PII (the F2 guarantee); link `docs/security/anonymization.md`. Same anonymization posture for trace data sent to third-party backends.
+  5. **No telemetry by default** — restate PRD §5.7; `/metrics` is on but only reachable inside the compose network.
+  6. **What's not yet shipped** — link DE-299..303, DE-315/317/318, and the proposal's DE-A..G (browser RUM, OTel-native metrics, SQLAlchemy/ARQ, log correlation, SLO catalog).
+- [ ] **Step 2:** Link `docs/observability.md` from `README.md` Documentation section (~L462) AND fix the stale "Six interactive playgrounds" → "Eleven" in "First steps after login".
+- [ ] **Step 3:** Link it from `docs/HONEST-STATE.md` §7 (Operational state) — add an "Observability / OpenTelemetry" row or sentence pointing at the guide + recipes.
+- [ ] **Step 4: Commit** `docs(m3-f3): docs/observability.md operator guide + README/HONEST-STATE links`.
+
+---
+
+### Task 5: "No telemetry by default" regression test
+
+**Files:** Create `tests/test_observability.py` (repo-root cross-cutting tests).
+
+- [ ] **Step 1: Write the test** — mirror `tests/test_error_code_contract.py`'s sys.path module-loading pattern to import BOTH `api/app/observability.py` and `gateway/app/observability.py`, then assert the contract:
+
+```python
+@pytest.mark.unit
+def test_no_telemetry_by_default_api(api_observability) -> None:
+    assert api_observability._otel_enabled(env={}) is False
+
+@pytest.mark.unit
+def test_no_telemetry_by_default_gateway(gateway_observability) -> None:
+    assert gateway_observability._otel_enabled(env={}) is False
+
+@pytest.mark.unit
+@pytest.mark.parametrize("var", [
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+])
+def test_any_otlp_endpoint_enables(api_observability, gateway_observability, var) -> None:
+    assert api_observability._otel_enabled(env={var: "http://collector:4318"}) is True
+    assert gateway_observability._otel_enabled(env={var: "http://collector:4318"}) is True
+```
+
+(Use module-scoped fixtures loading each `app.observability` via importlib + sys.path, like `test_error_code_contract.py`. Confirm `_otel_enabled` accepts an `env` kwarg — it does in both modules.)
+
+- [ ] **Step 2: Run** (from repo root, with the api venv which has pytest):
+  `cd ~/Code/lq-ai && api/.venv/bin/python -m pytest tests/test_observability.py -q` — expect green. (If sys.path loading needs both `api` and `gateway` importable, follow exactly what `test_error_code_contract.py` does.)
+- [ ] **Step 3: Note** in the PR description that CI does not currently run the repo-root `tests/` dir (only api/gateway/web) — flag whether to add a CI job as a follow-up DE (CI changes are CODEOWNERS-gated).
+- [ ] **Step 4: Commit** `test(m3-f3): pin no-telemetry-by-default across api + gateway`.
+
+---
+
+### Task 6: OTel-eval Learn playground + page wiring
+
+**Files:** Create `web/static/learn/playgrounds/otel-eval.html`; modify `web/src/routes/lq-ai/learn/how/+page.svelte`.
+
+- [ ] **Step 1: Build `otel-eval.html`** — a self-contained single HTML file MIRRORING `citation-engine-cascade.html`'s shell (same `:root` CSS variables / dark theme / two-column controls+preview layout / header with source links; copy that file's `<style>` scaffold and adapt). Content: an **annotated trace tree** for one chat-send showing the real F2 span hierarchy — root HTTP span → `inference.dispatch` (with provider/model/tier/tokens/cost/outcome attrs) → `citation.verify` → `citation.stage.*` children; plus `anonymization.pre/.post`, `skill.execute`, and (toggle) `playbook.execute`/`tabular.execute` with per-position/cell children. Controls let the user toggle scenarios (cache hit vs ensemble; anonymization on/off; playbook vs chat) and the tree + attribute panels update. Include the **5 operator questions** answered by the trace (why slow / how much did it cost / did anonymization run / which provider+model per tier / citation-cascade outcome distribution), each pointing at the span+attribute that answers it. Include sample **TraceQL / LogQL / PromQL** snippets and a side-by-side "attributes that appear vs. attributes that never appear (raw PII)" panel reinforcing the anonymization guarantee. All client-side; no network calls.
+- [ ] **Step 2: Wire §11** into `+page.svelte` after the word-addin section (~L543), mirroring the section template exactly: `<section ... data-testid="lq-ai-learn-how-section-otel-eval">`, `<h2>11. Seeing it all at once: the observability trace</h2>`, a 2–3 sentence description, the `<iframe src="/learn/playgrounds/otel-eval.html" ... height:900px>`, and the `lq-playground-foot` with Open-full-screen + source links (`docs/observability.md`, `api/app/observability_helpers.py`).
+- [ ] **Step 3: Verify** the web bundle builds (don't break the page): `cd web && <pkg-mgr> run check` or the project's svelte-check/lint if quick; otherwise confirm the iframe path + static file exist and the +page.svelte parses (no Svelte syntax error). Note in the PR that a visual smoke (rebuild `web`, open `/lq-ai/learn/how` §11) is pending.
+- [ ] **Step 4: Commit** `feat(m3-f3): OTel-eval Learn playground (§11) — annotated trace tree + operator questions`.
+
+---
+
+### Task 7: Final validation + verification
+
+- [ ] **Step 1:** Re-run BOTH recipe `docker compose ... config` validations (Task 1 Step 6, Task 2 Step 4) from a clean shell with repo `.env` sourced → both `CONFIG_OK`.
+- [ ] **Step 2:** `cd ~/Code/lq-ai && api/.venv/bin/python -m pytest tests/test_observability.py -q` → green.
+- [ ] **Step 3:** Confirm no api/gateway code changed in F3 (`git diff --stat origin/main...HEAD` should show only `deploy/`, `docs/`, `tests/`, `web/`, and the plan) — F3 is config/docs/test/web only.
+- [ ] **Step 4: Live bring-up (DEFERRED — operator/maintainer decision):** Document in the PR that the "bring up recipe 1, send a chat, see the trace in Grafana within 15 min" acceptance check + the dashboard "shows live data" check are pending a live validation pass (they require running api/gateway with OTel ON, which bounces the dev stack). Recommend running them at M3-close fresh-install verification. Do NOT run silently.
+- [ ] **Step 5:** Open PR (PR-3 of the OTel phase). Rebase onto main first if #86 (F2) has merged.
+
+---
+
+## Self-review
+
+**Spec coverage (proposal PR-3 acceptance):**
+- `deploy/observability/` with both subdirs → Tasks 1–3. ✓
+- Merged `docker compose ... config` validates → Task 1 Step 6 + Task 2 Step 4 + Task 7. ✓
+- `docs/observability.md` six sections + README + HONEST-STATE links → Task 4. ✓
+- "No telemetry by default" test in `tests/test_observability.py` → Task 5. ✓
+- Starter Grafana dashboard (3 panels) → Task 1 Step 4. ✓
+- Standalone recipe covers Honeycomb/Datadog/Lightstep → Task 2 Step 2 + Task 3 Step 3. ✓
+- 4th OTel-eval playground + §11 wiring (handoff addition) → Task 6. ✓
+- "see a trace in 15 min" + "dashboard shows live data" → **deferred live validation, Task 7 Step 4** (honest: needs OTel-on bring-up; not run silently). ⚠ documented.
+
+**Decisions explicit:** transport, sampler, overlay-sets-endpoint, OWUI-out-of-scope, no-live-disruption, honesty-links — all in the Decisions section.
+
+**Risks:** (1) Grafana dashboard PromQL must match the real metric/label names (Task 1 Step 4 uses the confirmed names). (2) Collector/Tempo/Loki image versions — pin to recent stable tags; `config` validation only checks compose syntax, not image pulls. (3) The root `tests/` dir isn't in CI — flagged in Task 5 Step 3.

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,137 @@
+"""Cross-subsystem no-telemetry-by-default contract test (M3-F3).
+
+Per PRD §5.7, both ``api/`` and ``gateway/`` guarantee that OTel export
+is **off by default** — it activates only when the operator sets one of
+three well-known OTLP env vars.  This file pins that contract across
+both sides so a future change to either observability module surfaces
+here before landing in production.
+
+What's verified:
+
+1. ``_otel_enabled(env={})`` is ``False`` — no env vars, no telemetry.
+2. Each of the three trigger vars individually enables telemetry.
+3. Setting a trigger var to an empty string does **not** enable telemetry
+   (empty string ≠ set).
+
+The module-loading technique mirrors :mod:`test_error_code_contract`
+exactly: clear ``app`` / ``app.*`` from ``sys.modules``, insert the
+target subsystem dir at position 0, then use ``importlib.import_module``.
+Module-scoped fixtures load each side once per test session.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+API_DIR = REPO_ROOT / "api"
+GATEWAY_DIR = REPO_ROOT / "gateway"
+
+# The three OTLP env vars that trigger OTel (per both observability modules).
+TRIGGER_VARS: list[str] = [
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+]
+
+
+def _load_subsystem_observability(subsystem_dir: Path) -> ModuleType:
+    """Load ``<subsystem>/app/observability.py`` as a fresh module instance.
+
+    Follows the identical technique used by ``_load_subsystem_errors`` in
+    :mod:`test_error_code_contract`: evict any cached ``app`` / ``app.*``
+    module from :data:`sys.modules` before loading so the two subsystems'
+    ``observability`` modules do not clobber each other on the shared
+    package name ``app``.
+    """
+
+    # Evict cached app namespace — ensures next import binds against
+    # subsystem_dir/app/ rather than a previously-cached copy.
+    for mod_name in list(sys.modules):
+        if mod_name == "app" or mod_name.startswith("app."):
+            del sys.modules[mod_name]
+
+    # Put the subsystem dir at the front so its app/ wins.
+    str_dir = str(subsystem_dir)
+    sys.path.insert(0, str_dir)
+    try:
+        module = importlib.import_module("app.observability")
+        return module
+    finally:
+        # Leave sys.path mutated — consistent with test_error_code_contract.
+        # The next load will insert at position 0 and the right module wins.
+        pass
+
+
+@pytest.fixture(scope="module")
+def api_obs() -> ModuleType:
+    """Load ``api/app/observability.py``."""
+    return _load_subsystem_observability(API_DIR)
+
+
+@pytest.fixture(scope="module")
+def gateway_obs() -> ModuleType:
+    """Load ``gateway/app/observability.py``.
+
+    Runs after ``api_obs`` (which left ``app`` cached against api/).
+    The load helper evicts the cache before binding against gateway/.
+    """
+    return _load_subsystem_observability(GATEWAY_DIR)
+
+
+# ---------------------------------------------------------------------------
+# 1. No telemetry by default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_no_telemetry_by_default_api(api_obs: ModuleType) -> None:
+    """api/_otel_enabled returns False when env is empty."""
+    assert api_obs._otel_enabled(env={}) is False
+
+
+@pytest.mark.unit
+def test_no_telemetry_by_default_gateway(gateway_obs: ModuleType) -> None:
+    """gateway/_otel_enabled returns False when env is empty."""
+    assert gateway_obs._otel_enabled(env={}) is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Each trigger var enables telemetry (parametrized)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("var", TRIGGER_VARS)
+def test_otlp_endpoint_enables_api(api_obs: ModuleType, var: str) -> None:
+    """api/_otel_enabled returns True when any trigger var is set."""
+    assert api_obs._otel_enabled(env={var: "http://collector:4318"}) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("var", TRIGGER_VARS)
+def test_otlp_endpoint_enables_gateway(gateway_obs: ModuleType, var: str) -> None:
+    """gateway/_otel_enabled returns True when any trigger var is set."""
+    assert gateway_obs._otel_enabled(env={var: "http://collector:4318"}) is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty string does not count as "set"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_empty_endpoint_value_stays_disabled_api(api_obs: ModuleType) -> None:
+    """api/_otel_enabled treats an empty-string value as unset."""
+    assert api_obs._otel_enabled(env={"OTEL_EXPORTER_OTLP_ENDPOINT": ""}) is False
+
+
+@pytest.mark.unit
+def test_empty_endpoint_value_stays_disabled_gateway(gateway_obs: ModuleType) -> None:
+    """gateway/_otel_enabled treats an empty-string value as unset."""
+    assert gateway_obs._otel_enabled(env={"OTEL_EXPORTER_OTLP_ENDPOINT": ""}) is False

--- a/web/src/routes/lq-ai/learn/how/+page.svelte
+++ b/web/src/routes/lq-ai/learn/how/+page.svelte
@@ -21,10 +21,10 @@
 		<a href="/lq-ai/learn" class="lq-back-link">← Learn</a>
 		<h1 class="lq-text-page-h">How It Works</h1>
 		<p class="lq-text-body lq-page-intro">
-			Ten interactive surfaces. Together they tell the story of how LQ.AI works from request to
-			response — the engine, its boundaries, and the M3 capability surfaces built on top. Each
-			playground links to the source files that implement what it shows — if a visualization makes a
-			claim, the linked file is where you verify it.
+			Eleven interactive surfaces. Together they tell the story of how LQ.AI works from request to
+			response — the engine, its boundaries, the M3 capability surfaces built on top, and the
+			observability trace that ties them together. Each playground links to the source files that
+			implement what it shows — if a visualization makes a claim, the linked file is where you verify it.
 		</p>
 	</header>
 
@@ -537,6 +537,58 @@
 						class="lq-link"
 						target="_blank"
 						rel="noopener noreferrer">docs/word-addin.md</a
+					>
+				</span>
+			</div>
+		</section>
+
+		<p class="lq-transition lq-text-body">
+			Every chat-send, playbook run, and tabular extraction emits a distributed trace. The final
+			playground makes the full span hierarchy visible — from the HTTP boundary at the api down
+			through inference dispatch, anonymization, and citation verification — so operators can answer
+			latency, cost, and data-handling questions from a single trace view.
+		</p>
+
+		<!-- 11: OTel trace visualizer -->
+		<section class="lq-how-section" data-testid="lq-ai-learn-how-section-otel-eval">
+			<h2 class="lq-section-h">11. Seeing it all at once: the observability trace</h2>
+			<p class="lq-text-body">
+				Every chat-send is one OpenTelemetry trace spanning api → gateway → provider, with domain
+				spans for citation verification, anonymization, skill dispatch, and inference carrying counts
+				and types only — never raw entity values, prompt text, or response content. This playground
+				lets you toggle the citation path, anonymization state, workflow type, and provider tier to
+				see how the span tree changes, and shows which span attribute answers each of the five
+				questions an operator is most likely to ask in production.
+			</p>
+			<div class="lq-playground-wrap">
+				<iframe
+					src="/learn/playgrounds/otel-eval.html"
+					title="OTel trace — chat-send end to end"
+					loading="lazy"
+					data-testid="learn-playground-otel-eval"
+					style="width: 100%; height: 900px; border: 1px solid var(--lq-border, #e5e7eb); border-radius: 8px;"
+				></iframe>
+			</div>
+			<div class="lq-playground-foot">
+				<a
+					href="/learn/playgrounds/otel-eval.html"
+					class="lq-link lq-fullscreen-link"
+					target="_blank"
+					rel="noopener noreferrer">Open full-screen ↗</a
+				>
+				<span class="lq-source-ref">
+					Source:
+					<a
+						href="https://github.com/LegalQuants/lq-ai/blob/main/docs/observability.md"
+						class="lq-link"
+						target="_blank"
+						rel="noopener noreferrer">docs/observability.md</a
+					>;
+					<a
+						href="https://github.com/LegalQuants/lq-ai/blob/main/api/app/observability_helpers.py"
+						class="lq-link"
+						target="_blank"
+						rel="noopener noreferrer">api/app/observability_helpers.py</a
 					>
 				</span>
 			</div>

--- a/web/static/learn/playgrounds/otel-eval.html
+++ b/web/static/learn/playgrounds/otel-eval.html
@@ -1,0 +1,1023 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LQ.AI — OTel Trace: chat-send end to end</title>
+<style>
+  :root {
+    --bg: #0c0f14;
+    --bg-elev: #151a23;
+    --bg-elev-2: #1d242f;
+    --border: #2a3340;
+    --border-hover: #3a4555;
+    --text: #e6ebf3;
+    --text-dim: #8a96a8;
+    --text-faint: #5a6578;
+    --accent: #7dd3fc;
+    --accent-dim: #38bdf8;
+    --verified: #86efac;
+    --verified-bg: rgba(134,239,172,0.08);
+    --verified-border: rgba(134,239,172,0.3);
+    --partial: #fcd34d;
+    --partial-bg: rgba(252,211,77,0.08);
+    --partial-border: rgba(252,211,77,0.3);
+    --unverified: #f87171;
+    --unverified-bg: rgba(248,113,113,0.08);
+    --unverified-border: rgba(248,113,113,0.3);
+    --pending: #5a6578;
+    --pending-bg: rgba(90,101,120,0.08);
+    --pending-border: rgba(90,101,120,0.25);
+    --shadow: rgba(0,0,0,0.4);
+    --span-api: rgba(125,211,252,0.12);
+    --span-gateway: rgba(134,239,172,0.10);
+    --span-provider: rgba(252,211,77,0.08);
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    height: 100vh;
+    overflow: hidden;
+  }
+  .app { display: grid; grid-template-rows: auto 1fr; height: 100vh; }
+  header {
+    padding: 12px 20px;
+    background: var(--bg-elev);
+    border-bottom: 1px solid var(--border);
+    display: flex; align-items: center; gap: 16px;
+  }
+  header h1 { margin: 0; font-size: 15px; font-weight: 600; letter-spacing: 0.01em; }
+  header .subtitle { color: var(--text-dim); font-size: 13px; }
+  header .spacer { flex: 1; }
+  header a {
+    color: var(--accent); text-decoration: none; font-size: 12px;
+    border: 1px solid var(--border); padding: 4px 10px; border-radius: 4px;
+  }
+  header a:hover { border-color: var(--border-hover); background: var(--bg-elev-2); }
+
+  .main { display: grid; grid-template-columns: 360px 1fr; overflow: hidden; }
+  .controls {
+    background: var(--bg-elev);
+    border-right: 1px solid var(--border);
+    padding: 16px; overflow-y: auto;
+  }
+  .controls h2 {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--text-dim); margin: 16px 0 8px;
+  }
+  .controls h2:first-child { margin-top: 0; }
+  .controls .hint { font-size: 11px; color: var(--text-faint); margin: 4px 0 8px; line-height: 1.4; }
+
+  .presets { display: grid; grid-template-columns: 1fr; gap: 5px; }
+  .preset-btn {
+    background: var(--bg-elev-2); border: 1px solid var(--border);
+    color: var(--text); padding: 7px 10px; border-radius: 4px;
+    cursor: pointer; font-size: 12px; text-align: left;
+    transition: all 0.1s; line-height: 1.4;
+  }
+  .preset-btn:hover { border-color: var(--border-hover); }
+  .preset-btn.active {
+    background: var(--accent); border-color: var(--accent);
+    color: var(--bg); font-weight: 600;
+  }
+  .preset-btn .preset-label { display: block; font-weight: 600; margin-bottom: 2px; }
+  .preset-btn .preset-desc { display: block; font-size: 11px; color: var(--text-dim); }
+  .preset-btn.active .preset-desc { color: rgba(12,15,20,0.7); }
+
+  .toggle {
+    display: flex; align-items: flex-start; gap: 8px;
+    padding: 8px 8px; border-radius: 4px; cursor: pointer;
+    user-select: none; transition: background 0.1s; font-size: 13px;
+  }
+  .toggle:hover { background: var(--bg-elev-2); }
+  .toggle input { margin: 3px 0 0; cursor: pointer; accent-color: var(--accent); flex-shrink: 0; }
+  .toggle .toggle-label { flex: 1; line-height: 1.4; }
+  .toggle .toggle-label span { display: block; color: var(--text-dim); font-size: 11px; margin-top: 2px; }
+
+  select {
+    width: 100%;
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 7px 10px;
+    border-radius: 4px;
+    font: 13px -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    cursor: pointer;
+  }
+  select:focus { border-color: var(--accent); outline: none; }
+
+  .preview-wrap {
+    overflow-y: auto;
+    padding: 20px;
+    background:
+      radial-gradient(circle at 20% 20%, rgba(125,211,252,0.03), transparent 55%),
+      radial-gradient(circle at 80% 80%, rgba(134,239,172,0.03), transparent 55%);
+  }
+  .preview-inner { max-width: 760px; margin: 0 auto; display: flex; flex-direction: column; gap: 20px; }
+
+  /* --- Span tree --- */
+  .tree-section { }
+  .tree-title {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--text-dim); margin: 0 0 10px;
+  }
+  .span-tree { display: flex; flex-direction: column; gap: 4px; }
+  .span-node {
+    display: flex; flex-direction: column; gap: 0;
+  }
+  .span-row {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    gap: 8px;
+    align-items: center;
+    padding: 7px 10px;
+    border-radius: 5px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: border-color 0.1s;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 12px;
+  }
+  .span-row:hover { border-color: var(--border-hover); }
+  .span-row.expanded { border-color: var(--accent-dim); }
+  .span-row.service-api { background: var(--span-api); }
+  .span-row.service-gateway { background: var(--span-gateway); }
+  .span-row.service-provider { background: var(--span-provider); }
+  .span-row.hidden-node { display: none; }
+
+  .span-indent { color: var(--text-faint); white-space: pre; font-size: 11px; }
+  .span-name { color: var(--text); font-weight: 600; }
+  .span-name .span-sub { color: var(--text-dim); font-weight: 400; font-size: 11px; margin-left: 6px; }
+  .span-kind {
+    font-size: 10px; padding: 1px 6px; border-radius: 3px;
+    border: 1px solid var(--border); color: var(--text-faint);
+    font-weight: 600; white-space: nowrap;
+  }
+  .span-kind.SERVER { color: var(--accent); border-color: rgba(125,211,252,0.3); }
+  .span-kind.CLIENT { color: var(--partial); border-color: rgba(252,211,77,0.3); }
+  .span-kind.INTERNAL { color: var(--text-faint); }
+
+  .span-dur-wrap { width: 80px; }
+  .span-dur-bar {
+    height: 6px; border-radius: 2px;
+    background: var(--border);
+    overflow: hidden;
+    margin-bottom: 2px;
+  }
+  .span-dur-fill { height: 100%; border-radius: 2px; background: var(--accent); }
+  .span-dur-label { font-size: 10px; color: var(--text-faint); text-align: right; }
+
+  .span-attrs {
+    padding: 10px 14px;
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    border-top: none;
+    border-radius: 0 0 5px 5px;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    display: none;
+  }
+  .span-attrs.open { display: block; }
+  .attr-row {
+    display: grid; grid-template-columns: 220px 1fr;
+    gap: 10px; padding: 3px 0;
+    border-bottom: 1px dashed var(--border);
+  }
+  .attr-row:last-child { border-bottom: none; }
+  .attr-k { color: var(--text-dim); }
+  .attr-v { color: var(--text); }
+  .attr-v.green { color: var(--verified); }
+  .attr-v.yellow { color: var(--partial); }
+  .attr-v.red { color: var(--unverified); }
+  .attr-event {
+    display: flex; align-items: center; gap: 6px;
+    padding: 4px 0; font-size: 11px;
+    color: var(--accent); border-bottom: 1px dashed var(--border);
+  }
+  .attr-event:last-child { border-bottom: none; }
+  .attr-event-label { font-weight: 600; }
+  .attr-section-title {
+    font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--text-faint); margin: 6px 0 3px;
+  }
+
+  /* --- Panels --- */
+  .panel {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .panel-header {
+    padding: 10px 14px;
+    background: var(--bg-elev-2);
+    border-bottom: 1px solid var(--border);
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--text-dim);
+  }
+  .panel-body { padding: 14px; }
+
+  .q-list { display: flex; flex-direction: column; gap: 10px; }
+  .q-item {
+    padding: 10px 12px;
+    border-radius: 5px;
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+  }
+  .q-item .q-text { font-size: 13px; color: var(--text); margin-bottom: 5px; font-weight: 500; }
+  .q-item .q-answer { font-size: 12px; color: var(--text-dim); }
+  .q-item .q-answer code {
+    display: inline-block;
+    background: rgba(125,211,252,0.08);
+    border: 1px solid rgba(125,211,252,0.2);
+    border-radius: 3px; padding: 0 5px;
+    color: var(--accent); font-size: 11px;
+    font-family: ui-monospace, Menlo, monospace;
+  }
+
+  .query-list { display: flex; flex-direction: column; gap: 8px; }
+  .query-item {
+    padding: 10px 12px;
+    border-radius: 5px;
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+  }
+  .query-item .q-lang {
+    font-size: 10px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.06em; color: var(--text-faint); margin-bottom: 5px;
+  }
+  .query-item .q-code {
+    font-family: ui-monospace, Menlo, monospace; font-size: 11px;
+    color: var(--accent); word-break: break-all; line-height: 1.5;
+  }
+  .query-item .q-note { font-size: 11px; color: var(--text-faint); margin-top: 5px; }
+  .query-item .copy-btn {
+    float: right; font-size: 10px; color: var(--text-faint);
+    background: none; border: 1px solid var(--border);
+    border-radius: 3px; padding: 2px 7px; cursor: pointer;
+    font-family: ui-monospace, Menlo, monospace;
+  }
+  .query-item .copy-btn:hover { color: var(--text); border-color: var(--border-hover); }
+  .query-item .copy-btn.copied { color: var(--verified); border-color: var(--verified-border); }
+
+  .attr-hygiene { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .hygiene-col { }
+  .hygiene-col-title {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.06em; margin-bottom: 8px;
+  }
+  .hygiene-col-title.green { color: var(--verified); }
+  .hygiene-col-title.red { color: var(--unverified); }
+  .hygiene-row {
+    padding: 5px 8px; border-radius: 4px;
+    font-family: ui-monospace, Menlo, monospace; font-size: 11px;
+    margin-bottom: 4px; border: 1px solid var(--border);
+    background: var(--bg-elev-2);
+  }
+  .hygiene-row.appears { color: var(--verified); border-color: var(--verified-border); }
+  .hygiene-row.never { color: var(--unverified); border-color: var(--unverified-border); }
+  .hygiene-row .hygiene-key { color: inherit; }
+  .hygiene-row .hygiene-ex { color: var(--text-faint); font-size: 10px; display: block; margin-top: 2px; }
+</style>
+</head>
+<body>
+<div class="app">
+  <header>
+    <h1>OTel trace — chat-send end to end</h1>
+    <span class="subtitle">Every chat-send is one distributed trace. Explore the span hierarchy, domain attributes, and operator questions.</span>
+    <span class="spacer"></span>
+    <a href="https://github.com/LegalQuants/lq-ai/blob/main/docs/observability.md" target="_blank">docs/observability.md</a>
+    <a href="https://github.com/LegalQuants/lq-ai/blob/main/api/app/observability_helpers.py" target="_blank">observability_helpers.py</a>
+  </header>
+  <div class="main">
+    <div class="controls">
+      <h2>Citation path</h2>
+      <p class="hint">Determines the <code>citation.verify</code> subtree shape.</p>
+      <div class="presets" id="citation-presets"></div>
+
+      <h2>Anonymization</h2>
+      <label class="toggle">
+        <input type="checkbox" id="anon-toggle" checked>
+        <div class="toggle-label">Anonymization active
+          <span>Shows anonymization.pre / .post spans + entity_count attribute. Uncheck to simulate privileged project (skip_reason = "privileged").</span>
+        </div>
+      </label>
+
+      <h2>Workflow</h2>
+      <div class="presets" id="workflow-presets"></div>
+
+      <h2>Provider / tier</h2>
+      <p class="hint">Sets attributes on the <code>inference.dispatch</code> span.</p>
+      <select id="provider-select">
+        <option value="anthropic-smart">Anthropic · claude-opus-4-7 · Tier 5 (cloud)</option>
+        <option value="anthropic-fast">Anthropic · claude-haiku-4-5 · Tier 5 (cloud)</option>
+        <option value="openai-smart">OpenAI · gpt-4o · Tier 5 (cloud)</option>
+        <option value="azure-smart">Azure OpenAI · gpt-4o · Tier 3 (private cloud)</option>
+        <option value="local-llama">Local Ollama · llama-3.3-70b · Tier 1 (on-prem)</option>
+      </select>
+    </div>
+
+    <div class="preview-wrap">
+      <div class="preview-inner">
+        <div class="tree-section">
+          <div class="tree-title">Span tree — click any span to expand attributes</div>
+          <div class="span-tree" id="span-tree"></div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">5 operator questions — which span answers each one</div>
+          <div class="panel-body">
+            <div class="q-list" id="q-list"></div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">Sample queries — TraceQL · PromQL · LogQL</div>
+          <div class="panel-body">
+            <div class="query-list" id="query-list"></div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">Attribute hygiene — what appears vs. what never appears</div>
+          <div class="panel-body">
+            <div class="attr-hygiene" id="hygiene"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+"use strict";
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const CITATION_PRESETS = [
+  {
+    id: "exact",
+    label: "Exact-match hit (fast)",
+    desc: "Stage 1 wins — short-circuit event; no tolerant/judge spans emitted.",
+    stages: ["citation.stage.exact_match"],
+    method: "exact_match",
+    confidence: 1.0,
+    partial: false,
+    shortCircuit: "exact_match.hit",
+    totalMs: 2
+  },
+  {
+    id: "ensemble",
+    label: "Ensemble (3 judges)",
+    desc: "Stages 1+2 miss; cascade goes to ensemble. 3 parallel judge spans.",
+    stages: ["citation.stage.exact_match", "citation.stage.tolerant_match", "citation.stage.ensemble"],
+    method: "ensemble_strict",
+    confidence: 0.87,
+    partial: false,
+    shortCircuit: null,
+    totalMs: 1240
+  }
+];
+
+const WORKFLOW_PRESETS = [
+  {
+    id: "chat",
+    label: "Chat",
+    desc: "Plain chat-send. One skill, one inference call.",
+    spanName: null,
+    childCount: 0,
+    totalMs: 890
+  },
+  {
+    id: "playbook",
+    label: "Playbook (30 positions)",
+    desc: "playbook.execute spans each position sequentially.",
+    spanName: "playbook.execute",
+    childCount: 30,
+    totalMs: 48200
+  },
+  {
+    id: "tabular",
+    label: "Tabular (5 docs × 4 cols)",
+    desc: "tabular.execute spans each cell in a 5 × 4 grid.",
+    spanName: "tabular.execute",
+    childCount: 20,
+    totalMs: 22400
+  }
+];
+
+const PROVIDERS = {
+  "anthropic-smart": { provider: "anthropic", model: "claude-opus-4-7", tier: 5, tokensIn: 4120, tokensOut: 387, costUsd: 0.0613, inferenceMs: 3840 },
+  "anthropic-fast":  { provider: "anthropic", model: "claude-haiku-4-5", tier: 5, tokensIn: 4120, tokensOut: 387, costUsd: 0.0031, inferenceMs: 1120 },
+  "openai-smart":    { provider: "openai",    model: "gpt-4o",           tier: 5, tokensIn: 4120, tokensOut: 387, costUsd: 0.0247, inferenceMs: 2980 },
+  "azure-smart":     { provider: "azure",     model: "gpt-4o",           tier: 3, tokensIn: 4120, tokensOut: 387, costUsd: 0.0247, inferenceMs: 3240 },
+  "local-llama":     { provider: "ollama",    model: "llama-3.3-70b",    tier: 1, tokensIn: 4120, tokensOut: 387, costUsd: 0.0000, inferenceMs: 7610 }
+};
+
+let activeCitationId = "exact";
+let activeWorkflowId = "chat";
+let anonOn = true;
+let providerKey = "anthropic-smart";
+
+// ---------------------------------------------------------------------------
+// Build span tree data
+// ---------------------------------------------------------------------------
+
+function buildTree() {
+  const prov = PROVIDERS[providerKey];
+  const cit = CITATION_PRESETS.find(c => c.id === activeCitationId);
+  const wf = WORKFLOW_PRESETS.find(w => w.id === activeWorkflowId);
+  const totalMs = wf.totalMs || (prov.inferenceMs + cit.totalMs + (anonOn ? 40 : 0) + 80);
+
+  const anon_pre_ms = anonOn ? 18 : 0;
+  const anon_post_ms = anonOn ? 7 : 0;
+
+  const nodes = [];
+
+  // Root: HTTP span (api, SERVER)
+  nodes.push({
+    id: "root",
+    indent: "",
+    connector: "",
+    name: "POST /api/v1/chats/{chat_id}/messages",
+    sub: "(api — SERVER)",
+    kind: "SERVER",
+    service: "api",
+    ms: totalMs,
+    maxMs: totalMs,
+    attrs: [
+      { k: "http.method", v: "POST" },
+      { k: "http.route", v: "/api/v1/chats/{chat_id}/messages" },
+      { k: "http.status_code", v: "200" },
+      { k: "net.peer.ip", v: "10.0.1.42" }
+    ],
+    events: []
+  });
+
+  // skill.execute (api, INTERNAL) — one per skill in slug list
+  nodes.push({
+    id: "skill",
+    indent: "   ",
+    connector: "└─ ",
+    name: "skill.execute",
+    sub: "(nda-review)",
+    kind: "INTERNAL",
+    service: "api",
+    ms: totalMs - 5,
+    maxMs: totalMs,
+    attrs: [
+      { k: "skill.slug", v: "nda-review" },
+      { k: "skill.version", v: "1.0.0" },
+      { k: "skill.author", v: "Jane Doe" },
+      { k: "project.id", v: "a7f3d2e1-..." },
+      { k: "project.privileged", v: anonOn ? "false" : "true" },
+      { k: "chat.id", v: "b91c4f08-..." }
+    ],
+    events: []
+  });
+
+  // Workflow span (only for playbook / tabular)
+  if (wf.id !== "chat") {
+    const wfMs = wf.id === "playbook" ? wf.totalMs - 60 : wf.totalMs - 40;
+    const childLabel = wf.id === "playbook" ? "position_index" : "cell_index";
+    const childAttrs = wf.id === "playbook"
+      ? [
+          { k: "playbook.id", v: "pb-nda-standard" },
+          { k: "playbook.position_count", v: "30" },
+          { k: "playbook.position_index", v: "0..29 (one span each)" },
+          { k: "playbook.position_slug", v: "governing_law" }
+        ]
+      : [
+          { k: "tabular.review_id", v: "tr-9f3a2d" },
+          { k: "tabular.doc_count", v: "5" },
+          { k: "tabular.col_count", v: "4" },
+          { k: "tabular.cell_index", v: "0..19 (one span each)" }
+        ];
+    nodes.push({
+      id: "workflow",
+      indent: "      ",
+      connector: "└─ ",
+      name: wf.id === "playbook" ? "playbook.execute" : "tabular.execute",
+      sub: wf.id === "playbook" ? "(30 positions)" : "(5 docs × 4 cols)",
+      kind: "INTERNAL",
+      service: "api",
+      ms: wfMs,
+      maxMs: totalMs,
+      attrs: wfAttrs(wf),
+      events: []
+    });
+
+    // Collapsed child spans (we show one representative + count)
+    nodes.push({
+      id: "workflow-child",
+      indent: "         ",
+      connector: "└─ ",
+      name: wf.id === "playbook" ? "playbook.position" : "tabular.cell",
+      sub: `(×${wf.childCount} spans, one shown)`,
+      kind: "INTERNAL",
+      service: "api",
+      ms: Math.round(wfMs / wf.childCount),
+      maxMs: totalMs,
+      attrs: wfChildAttrs(wf),
+      events: []
+    });
+  }
+
+  // HTTP client span: POST /v1/chat/completions (api→gateway, CLIENT)
+  nodes.push({
+    id: "http-client",
+    indent: "   ",
+    connector: "└─ ",
+    name: "POST /v1/chat/completions",
+    sub: "(api → gateway — CLIENT)",
+    kind: "CLIENT",
+    service: "api",
+    ms: prov.inferenceMs + anon_pre_ms + anon_post_ms + 12,
+    maxMs: totalMs,
+    attrs: [
+      { k: "http.method", v: "POST" },
+      { k: "http.url", v: "http://gateway:8001/v1/chat/completions" },
+      { k: "http.status_code", v: "200" }
+    ],
+    events: []
+  });
+
+  // inference.dispatch (gateway, INTERNAL)
+  nodes.push({
+    id: "inference",
+    indent: "      ",
+    connector: "└─ ",
+    name: "inference.dispatch",
+    sub: "(gateway)",
+    kind: "INTERNAL",
+    service: "gateway",
+    ms: prov.inferenceMs + anon_pre_ms + anon_post_ms,
+    maxMs: totalMs,
+    attrs: [
+      { k: "inference.provider", v: prov.provider, cls: "green" },
+      { k: "inference.model", v: prov.model },
+      { k: "inference.tier", v: String(prov.tier) },
+      { k: "inference.tokens_in", v: String(prov.tokensIn) },
+      { k: "inference.tokens_out", v: String(prov.tokensOut) },
+      { k: "inference.cost_usd", v: prov.costUsd.toFixed(4), cls: prov.costUsd === 0 ? "green" : "yellow" },
+      { k: "inference.outcome", v: "success", cls: "green" }
+    ],
+    events: []
+  });
+
+  // anonymization.pre (gateway, INTERNAL) — conditional
+  if (anonOn) {
+    nodes.push({
+      id: "anon-pre",
+      indent: "         ",
+      connector: "└─ ",
+      name: "anonymization.pre",
+      sub: "(gateway)",
+      kind: "INTERNAL",
+      service: "gateway",
+      ms: anon_pre_ms,
+      maxMs: totalMs,
+      attrs: [
+        { k: "anonymization.enabled", v: "true", cls: "green" },
+        { k: "anonymization.tier", v: String(prov.tier) },
+        { k: "anonymization.entity_count", v: "3", cls: "green" },
+        { k: "anonymization.entity_types", v: '["PERSON","ORGANIZATION","MATTER_NUMBER"]', cls: "green" }
+      ],
+      events: []
+    });
+  } else {
+    nodes.push({
+      id: "anon-pre",
+      indent: "         ",
+      connector: "└─ ",
+      name: "anonymization.pre",
+      sub: "(gateway — skipped)",
+      kind: "INTERNAL",
+      service: "gateway",
+      ms: 1,
+      maxMs: totalMs,
+      attrs: [
+        { k: "anonymization.enabled", v: "true" },
+        { k: "anonymization.tier", v: String(prov.tier) },
+        { k: "anonymization.skip_reason", v: "privileged", cls: "yellow" },
+        { k: "anonymization.entity_count", v: "0" }
+      ],
+      events: []
+    });
+  }
+
+  // (provider call — represented as a note, not a real span unless httpx instrumented)
+  nodes.push({
+    id: "provider-call",
+    indent: "         ",
+    connector: "└─ ",
+    name: "POST " + providerEndpoint(prov.provider),
+    sub: "(provider — CLIENT, httpx auto-instrumented)",
+    kind: "CLIENT",
+    service: "provider",
+    ms: prov.inferenceMs - 20,
+    maxMs: totalMs,
+    attrs: [
+      { k: "http.method", v: "POST" },
+      { k: "http.url", v: providerEndpoint(prov.provider) },
+      { k: "http.status_code", v: "200" }
+    ],
+    events: []
+  });
+
+  // anonymization.post (gateway, INTERNAL) — conditional
+  if (anonOn) {
+    nodes.push({
+      id: "anon-post",
+      indent: "         ",
+      connector: "└─ ",
+      name: "anonymization.post",
+      sub: "(gateway)",
+      kind: "INTERNAL",
+      service: "gateway",
+      ms: anon_post_ms,
+      maxMs: totalMs,
+      attrs: [
+        { k: "anonymization.entity_count", v: "3", cls: "green" },
+        { k: "anonymization.entity_types", v: '["PERSON","ORGANIZATION","MATTER_NUMBER"]' }
+      ],
+      events: []
+    });
+  } else {
+    nodes.push({
+      id: "anon-post",
+      indent: "         ",
+      connector: "└─ ",
+      name: "anonymization.post",
+      sub: "(gateway — skipped)",
+      kind: "INTERNAL",
+      service: "gateway",
+      ms: 1,
+      maxMs: totalMs,
+      attrs: [
+        { k: "anonymization.skip_reason", v: "privileged", cls: "yellow" },
+        { k: "anonymization.entity_count", v: "0" }
+      ],
+      events: []
+    });
+  }
+
+  // citation.verify (api, INTERNAL)
+  const citEvents = [];
+  if (cit.shortCircuit) citEvents.push(cit.shortCircuit);
+  const citAttrs = [
+    { k: "citation.method", v: cit.method, cls: "green" },
+    { k: "citation.confidence", v: cit.confidence.toFixed(2), cls: cit.confidence >= 0.9 ? "green" : "yellow" },
+    { k: "citation.partial", v: String(cit.partial) }
+  ];
+  nodes.push({
+    id: "citation",
+    indent: "   ",
+    connector: "└─ ",
+    name: "citation.verify",
+    sub: "(api)",
+    kind: "INTERNAL",
+    service: "api",
+    ms: cit.totalMs,
+    maxMs: totalMs,
+    attrs: citAttrs,
+    events: citEvents
+  });
+
+  // Per-stage citation spans
+  for (const stageName of cit.stages) {
+    const shortName = stageName.replace("citation.stage.", "");
+    const isEnsemble = shortName === "ensemble";
+    const isFinalStage = stageName === cit.stages[cit.stages.length - 1];
+    const stageMs = isEnsemble ? cit.totalMs - 4 : (shortName === "exact_match" ? 1 : 3);
+    const stageAttrs = [
+      { k: "citation.stage.verified", v: isFinalStage ? "true" : "false",
+        cls: isFinalStage ? "green" : "red" }
+    ];
+    if (isEnsemble) {
+      stageAttrs.push({ k: "citation.ensemble.n_judges", v: "3" });
+      stageAttrs.push({ k: "citation.ensemble.rule", v: "strict" });
+    }
+    nodes.push({
+      id: "citation-stage-" + shortName,
+      indent: "      ",
+      connector: "└─ ",
+      name: stageName,
+      sub: "",
+      kind: "INTERNAL",
+      service: "api",
+      ms: stageMs,
+      maxMs: totalMs,
+      attrs: stageAttrs,
+      events: []
+    });
+  }
+
+  return nodes;
+}
+
+function wfAttrs(wf) {
+  if (wf.id === "playbook") {
+    return [
+      { k: "playbook.id", v: "pb-nda-standard" },
+      { k: "playbook.position_count", v: "30" }
+    ];
+  }
+  return [
+    { k: "tabular.review_id", v: "tr-9f3a2d" },
+    { k: "tabular.doc_count", v: "5" },
+    { k: "tabular.col_count", v: "4" }
+  ];
+}
+
+function wfChildAttrs(wf) {
+  if (wf.id === "playbook") {
+    return [
+      { k: "playbook.position_index", v: "0" },
+      { k: "playbook.position_slug", v: "governing_law" },
+      { k: "playbook.classification", v: "DEVIATE" }
+    ];
+  }
+  return [
+    { k: "tabular.cell_row", v: "0" },
+    { k: "tabular.cell_col", v: "0" },
+    { k: "tabular.question_slug", v: "governing_law" }
+  ];
+}
+
+function providerEndpoint(p) {
+  if (p === "anthropic") return "https://api.anthropic.com/v1/messages";
+  if (p === "openai")    return "https://api.openai.com/v1/chat/completions";
+  if (p === "azure")     return "https://resource.openai.azure.com/v1/chat/completions";
+  return "http://localhost:11434/v1/chat/completions";
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+function fmtMs(ms) {
+  if (ms >= 1000) return (ms / 1000).toFixed(2) + "s";
+  return ms + "ms";
+}
+
+function escHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"})[c]);
+}
+
+function renderSpanTree(nodes) {
+  const el = document.getElementById("span-tree");
+  el.innerHTML = "";
+
+  nodes.forEach((node, i) => {
+    const nodeDiv = document.createElement("div");
+    nodeDiv.className = "span-node";
+    nodeDiv.dataset.id = node.id;
+
+    const pct = Math.max(3, Math.round((node.ms / node.maxMs) * 100));
+    const rowCls = ["span-row", "service-" + node.service].join(" ");
+
+    const attrsHtml = buildAttrsHtml(node);
+
+    nodeDiv.innerHTML = `
+      <div class="${rowCls}" data-node="${node.id}">
+        <span class="span-indent">${escHtml(node.indent + node.connector)}</span>
+        <span class="span-name">${escHtml(node.name)}<span class="span-sub">${escHtml(node.sub)}</span></span>
+        <span class="span-kind ${node.kind}">${node.kind}</span>
+        <div class="span-dur-wrap">
+          <div class="span-dur-bar"><div class="span-dur-fill" style="width:${pct}%"></div></div>
+          <div class="span-dur-label">${fmtMs(node.ms)}</div>
+        </div>
+      </div>
+      <div class="span-attrs" data-attrs="${node.id}">${attrsHtml}</div>
+    `;
+    el.appendChild(nodeDiv);
+  });
+
+  // Click to toggle attrs
+  el.querySelectorAll(".span-row").forEach(row => {
+    row.addEventListener("click", () => {
+      const id = row.dataset.node;
+      const attrsEl = el.querySelector(`[data-attrs="${id}"]`);
+      const open = attrsEl.classList.toggle("open");
+      row.classList.toggle("expanded", open);
+    });
+  });
+}
+
+function buildAttrsHtml(node) {
+  let html = "";
+  if (node.events.length > 0) {
+    html += `<div class="attr-section-title">Span events</div>`;
+    for (const ev of node.events) {
+      html += `<div class="attr-event"><span class="attr-event-label">&#9654; ${escHtml(ev)}</span></div>`;
+    }
+  }
+  if (node.attrs.length > 0) {
+    if (node.events.length > 0) html += `<div class="attr-section-title" style="margin-top:8px;">Attributes</div>`;
+    for (const a of node.attrs) {
+      const cls = a.cls ? ` class="attr-v ${a.cls}"` : ` class="attr-v"`;
+      html += `<div class="attr-row"><div class="attr-k">${escHtml(a.k)}</div><div${cls}>${escHtml(a.v)}</div></div>`;
+    }
+  }
+  if (!html) html = `<div style="color:var(--text-faint);font-size:11px;">No attributes recorded.</div>`;
+  return html;
+}
+
+function renderQuestions() {
+  const prov = PROVIDERS[providerKey];
+  const cit = CITATION_PRESETS.find(c => c.id === activeCitationId);
+  const qs = [
+    {
+      q: "Why was this slow?",
+      a: "Compare the duration bars. The longest bar is your bottleneck. For cloud providers, <code>inference.dispatch</code> dominates. For playbooks, <code>playbook.execute</code> stacks 30 sequential positions."
+    },
+    {
+      q: "How much did this inference call cost?",
+      a: `<code>inference.dispatch</code> → attribute <code>inference.cost_usd = ${prov.costUsd.toFixed(4)}</code> (provider = ${prov.provider}, model = ${prov.model}, tier = ${prov.tier}).`
+    },
+    {
+      q: "Did anonymization run? How many entities?",
+      a: anonOn
+        ? `<code>anonymization.pre</code> → <code>anonymization.entity_count = 3</code>, <code>entity_types = ["PERSON","ORGANIZATION","MATTER_NUMBER"]</code>. Anonymization fired.`
+        : `<code>anonymization.pre</code> → <code>anonymization.skip_reason = "privileged"</code>, <code>entity_count = 0</code>. Privileged project — layer bypassed.`
+    },
+    {
+      q: "Which provider + model served each tier?",
+      a: `<code>inference.dispatch</code> → <code>inference.provider = "${prov.provider}"</code>, <code>inference.model = "${prov.model}"</code>, <code>inference.tier = ${prov.tier}</code>. Filter by tier across requests to see fleet distribution.`
+    },
+    {
+      q: "What's the citation-cascade outcome distribution across requests?",
+      a: `<code>citation.verify</code> → <code>citation.method = "${cit.method}"</code> on this trace. Aggregate <code>citation.method</code> across traces with TraceQL or a PromQL counter to get distribution (exact_match / tolerant_match / paraphrase_judge / ensemble_strict).`
+    }
+  ];
+
+  const el = document.getElementById("q-list");
+  el.innerHTML = qs.map(({ q, a }) => `
+    <div class="q-item">
+      <div class="q-text">${escHtml(q)}</div>
+      <div class="q-answer">${a}</div>
+    </div>
+  `).join("");
+}
+
+function renderQueries() {
+  const prov = PROVIDERS[providerKey];
+  const queries = [
+    {
+      lang: "TraceQL (Grafana Tempo)",
+      code: `{ name = "inference.dispatch" && .inference.tier = ${prov.tier} }`,
+      note: "Find all inference calls at Tier " + prov.tier + ". Swap tier value to compare across tiers."
+    },
+    {
+      lang: "TraceQL — cost > threshold",
+      code: `{ name = "inference.dispatch" && .inference.cost_usd > 0.05 }`,
+      note: "Surface expensive calls for cost anomaly investigation."
+    },
+    {
+      lang: "TraceQL — citation method",
+      code: `{ name = "citation.verify" && .citation.method = "ensemble_strict" }`,
+      note: "Find traces where the ensemble path fired — indicates exact+tolerant both missed."
+    },
+    {
+      lang: "PromQL (Prometheus / Grafana)",
+      code: `histogram_quantile(0.99, sum by (le, route) (rate(lq_ai_gateway_http_request_duration_seconds_bucket[5m])))`,
+      note: "P99 latency per route across the gateway. Same histogram shape in lq_ai_api_* for the api service."
+    },
+    {
+      lang: "LogQL (Grafana Loki) — note",
+      code: `# Log-trace correlation is a deferred enhancement (see PRD §9).`,
+      note: "Logs and traces are emitted separately today. Correlating a Loki log line to its Tempo trace by trace_id is DE-pending. The trace_id is available in structured log fields when OTel is initialized."
+    }
+  ];
+
+  const el = document.getElementById("query-list");
+  el.innerHTML = queries.map((q, i) => `
+    <div class="query-item">
+      <div class="q-lang">${escHtml(q.lang)}</div>
+      <div style="display:flex;align-items:flex-start;gap:8px;">
+        <div class="q-code" style="flex:1;">${escHtml(q.code)}</div>
+        <button class="copy-btn" data-idx="${i}" data-code="${escHtml(q.code)}">copy</button>
+      </div>
+      <div class="q-note">${escHtml(q.note)}</div>
+    </div>
+  `).join("");
+
+  el.querySelectorAll(".copy-btn").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const code = btn.dataset.code.replace(/&amp;/g,"&").replace(/&lt;/g,"<").replace(/&gt;/g,">").replace(/&quot;/g,'"').replace(/&#39;/g,"'");
+      navigator.clipboard.writeText(code).then(() => {
+        btn.textContent = "copied";
+        btn.classList.add("copied");
+        setTimeout(() => { btn.textContent = "copy"; btn.classList.remove("copied"); }, 1500);
+      });
+    });
+  });
+}
+
+function renderHygiene() {
+  const appears = [
+    { key: "anonymization.entity_count", ex: "integer — e.g., 3" },
+    { key: "anonymization.entity_types", ex: '["PERSON","ORGANIZATION","MATTER_NUMBER"]' },
+    { key: "anonymization.skip_reason",  ex: '"privileged" | "disabled"' },
+    { key: "inference.provider",         ex: '"anthropic" | "openai" | "azure" | "ollama"' },
+    { key: "inference.model",            ex: '"claude-opus-4-7" | "gpt-4o" | ...' },
+    { key: "inference.tier",             ex: "integer 1–5" },
+    { key: "inference.tokens_in",        ex: "integer" },
+    { key: "inference.tokens_out",       ex: "integer" },
+    { key: "inference.cost_usd",         ex: "float — e.g., 0.0613" },
+    { key: "inference.outcome",          ex: '"success" | "provider_error" | "network_error"' },
+    { key: "citation.method",            ex: '"exact_match" | "tolerant_match" | "ensemble_strict"' },
+    { key: "citation.confidence",        ex: "float 0–1" },
+    { key: "skill.slug",                 ex: '"nda-review"' },
+    { key: "project.privileged",         ex: "boolean" }
+  ];
+
+  const never = [
+    { key: "raw PERSON names",          ex: "e.g., \"Alexandra Pemberton\" → NEVER in any attr" },
+    { key: "MATTER_NUMBER values",      ex: "e.g., \"MATTER-2024-0042\" → pseudonymized before dispatch" },
+    { key: "document text / content",   ex: "prompt body, source text, normalized_content" },
+    { key: "ORGANIZATION names",        ex: "client / counterparty names replaced by pseudonyms" },
+    { key: "EMAIL / PHONE values",      ex: "PII fields — count + type only" },
+    { key: "chat.message content",      ex: "user message text never in OTel attributes" },
+    { key: "skill.system_prompt",       ex: "skill prompt text — not recorded in telemetry" },
+    { key: "inference.response_text",   ex: "model response body — never in attributes" }
+  ];
+
+  const el = document.getElementById("hygiene");
+  el.innerHTML = `
+    <div class="hygiene-col">
+      <div class="hygiene-col-title green">Appears in span attributes</div>
+      ${appears.map(a => `<div class="hygiene-row appears"><span class="hygiene-key">${escHtml(a.key)}</span><span class="hygiene-ex">${escHtml(a.ex)}</span></div>`).join("")}
+    </div>
+    <div class="hygiene-col">
+      <div class="hygiene-col-title red">NEVER appears in any span attribute</div>
+      ${never.map(a => `<div class="hygiene-row never"><span class="hygiene-key">${escHtml(a.key)}</span><span class="hygiene-ex">${escHtml(a.ex)}</span></div>`).join("")}
+    </div>
+  `;
+}
+
+function render() {
+  const nodes = buildTree();
+  renderSpanTree(nodes);
+  renderQuestions();
+  renderQueries();
+  renderHygiene();
+}
+
+// ---------------------------------------------------------------------------
+// Control wiring
+// ---------------------------------------------------------------------------
+
+// Citation presets
+const citPresetsEl = document.getElementById("citation-presets");
+CITATION_PRESETS.forEach(p => {
+  const btn = document.createElement("button");
+  btn.className = "preset-btn" + (p.id === activeCitationId ? " active" : "");
+  btn.dataset.id = p.id;
+  btn.innerHTML = `<span class="preset-label">${escHtml(p.label)}</span><span class="preset-desc">${escHtml(p.desc)}</span>`;
+  btn.addEventListener("click", () => {
+    activeCitationId = p.id;
+    citPresetsEl.querySelectorAll(".preset-btn").forEach(b => b.classList.toggle("active", b.dataset.id === p.id));
+    render();
+  });
+  citPresetsEl.appendChild(btn);
+});
+
+// Workflow presets
+const wfPresetsEl = document.getElementById("workflow-presets");
+WORKFLOW_PRESETS.forEach(p => {
+  const btn = document.createElement("button");
+  btn.className = "preset-btn" + (p.id === activeWorkflowId ? " active" : "");
+  btn.dataset.id = p.id;
+  btn.innerHTML = `<span class="preset-label">${escHtml(p.label)}</span><span class="preset-desc">${escHtml(p.desc)}</span>`;
+  btn.addEventListener("click", () => {
+    activeWorkflowId = p.id;
+    wfPresetsEl.querySelectorAll(".preset-btn").forEach(b => b.classList.toggle("active", b.dataset.id === p.id));
+    render();
+  });
+  wfPresetsEl.appendChild(btn);
+});
+
+// Anon toggle
+document.getElementById("anon-toggle").addEventListener("change", e => {
+  anonOn = e.target.checked;
+  render();
+});
+
+// Provider select
+document.getElementById("provider-select").addEventListener("change", e => {
+  providerKey = e.target.value;
+  render();
+});
+
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## M3-F3 — Deployment recipes + operator guide + OTel-eval playground (PR-3, final of the OTel phase)

Plan: [`docs/superpowers/plans/2026-05-24-m3-f3-deploy-observability.md`](docs/superpowers/plans/2026-05-24-m3-f3-deploy-observability.md). Spec: [`docs/proposals/opentelemetry-deepening.md`](docs/proposals/opentelemetry-deepening.md) PR-3. Builds on F1 (#85) + F2 (#86).

Gives operators a copy-paste path from zero to "I can see a chat-send trace." **No application code changes** — config, docs, one test, one playground.

### What's here
- **`deploy/observability/grafana-tempo-loki/`** — full self-hosted stack: a compose overlay adding OTel Collector + Tempo + Loki + Prometheus + Grafana, plus collector/tempo/loki/prometheus configs, Grafana datasource + dashboard provisioning (3 panels: gateway tier mix, p99 latency by route, error rate), and `.env.example`. The overlay points api/gateway's OTLP exporter at the in-network collector.
- **`deploy/observability/otel-collector-standalone/`** — collector-only overlay for operators who already run Honeycomb / Datadog / Lightstep (commented per-backend exporter blocks; active `debug` exporter so it runs out-of-box).
- **`deploy/observability/README.md`** + per-recipe READMEs — decision guide + run commands + a 15-minute "verify a trace in Grafana" walkthrough.
- **`docs/observability.md`** — operator guide: env-var matrix, per-signal inventory (the F2 domain spans + the Prometheus metrics), the two recipes, anonymization+telemetry posture, no-telemetry-by-default, and links to every deferred enhancement. Linked from README + HONEST-STATE §7.
- **`tests/test_observability.py`** — pins "no telemetry by default" across api + gateway (10 tests).
- **`web/static/learn/playgrounds/otel-eval.html`** + Learn §11 — an interactive annotated trace tree of a chat-send showing the F2 span hierarchy, the 5 operator questions, sample TraceQL/PromQL, and an "attributes that appear vs. never appear (raw PII)" panel reinforcing the anonymization guarantee.

### Decisions locked
OTLP/HTTP transport (collector :4318); sampler documented (`parentbased_always_on` dev / `parentbased_traceidratio` 0.1 prod) via env, no code default changed; overlays set the OTLP endpoint, base compose stays no-telemetry-by-default; OWUI-fork OTel out of scope (DE-302/DE-D).

### Verified
- `docker compose -f docker-compose.yml -f deploy/observability/<recipe>/docker-compose.observability.yml config` → **valid merged config for both recipes**.
- The overlay env-merge sets `OTEL_EXPORTER_OTLP_ENDPOINT` on api/gateway while retaining base env.
- `tests/test_observability.py` → **10 passed**; existing cross-cutting contract test unaffected.
- Dashboard JSON valid, queries use the real metric names.
- §11 playground well-formed, self-contained (no external CDN/font/script), wired into the Learn page.
- **No api/gateway app code changed** (config/docs/test/web only).

### Pending validations (deferred to M3-close pre-v0.3.0 fresh-install — they require bouncing containers with OTel on)
- **Live bring-up**: recipe 1 up → send a chat → see the trace in Grafana within 15 min + dashboard shows live data (the proposal's headline acceptance).
- **§11 visual smoke**: rebuild `web`, open `/lq-ai/learn/how`, confirm the section renders (Svelte toolchain builds in Docker, not locally).

### Note
CI does not currently run the repo-root `tests/` directory (only `api/`, `gateway/`, `web/`) — so `tests/test_observability.py` won't execute in CI as-is. Adding a CI job is a CODEOWNERS-gated `.github/workflows/**` change; flagging as a possible follow-up rather than bundling it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)