### PR TITLE
docs(m3-close): fix stale Learn-viz status claims (transparency audit)

### DIFF
--- a/web/static/learn/playgrounds/data-residency.html
+++ b/web/static/learn/playgrounds/data-residency.html
@@ -1066,7 +1066,7 @@ function renderOutput() {
 
   const privacyHonest = `
     <div class="warn">
-      <strong>Anonymization Layer (M2, not yet running):</strong> The PRD describes entity substitution on the request path — swapping named entities for stable placeholders before they leave the deployment. In M1, the config slot exists but the middleware does not run. Read <a class="file" href="${REPO}docs/HONEST-STATE.md" target="_blank" rel="noopener">docs/HONEST-STATE.md §3.2</a> and <a class="file" href="${REPO}gateway/app/api/admin.py" target="_blank" rel="noopener">gateway/app/api/admin.py:270-282</a> (returns 501) to verify.
+      <strong>Anonymization Layer (M2 — running):</strong> Entity substitution runs on the request path — named entities are swapped for stable pseudonyms before the payload leaves the deployment, and the response is rehydrated inside the deployment (wired at <a class="file" href="${REPO}gateway/app/main.py" target="_blank" rel="noopener">gateway/app/main.py</a>). Honest caveat: Presidio default-recognizer recall/precision on a legal corpus is empirically unmeasured — see <a class="file" href="${REPO}docs/security/anonymization.md#whats-validated-vs-whats-unvalidated" target="_blank" rel="noopener">anonymization.md</a> and DE-282 for the risk framing.
     </div>`;
 
   verifyHtml += gatewayBoundary + networkTopology + privacyHonest;
@@ -1102,7 +1102,7 @@ function renderOutput() {
 
   describeHtml += `<p><strong>No phone-home, analytics, or telemetry.</strong> Verify: <a class="file" href="${REPO}docker-compose.yml" target="_blank" rel="noopener">docker-compose.yml</a> defines no analytics services. The <a class="file" href="${REPO}gateway/app/router.py" target="_blank" rel="noopener">gateway/app/router.py</a> makes no calls except to the configured inference providers. The web bundle is served from the self-hosted container — no CDN fonts or scripts in an air-gapped deployment.</p>`;
 
-  describeHtml += `<p style="color:var(--api);font-size:11px"><strong>M2 note:</strong> The Anonymization Layer (PRD §4.7) will add entity substitution on the request path. In M1 it is not running — the config slot exists but the middleware is absent. See <a class="file" href="${REPO}docs/HONEST-STATE.md" target="_blank" rel="noopener">HONEST-STATE.md §3.2</a>.</p>`;
+  describeHtml += `<p style="color:var(--api);font-size:11px"><strong>Anonymization note:</strong> The Anonymization Layer (PRD §4.7) performs entity substitution on the request path and is running as of M2 (<a class="file" href="${REPO}gateway/app/main.py" target="_blank" rel="noopener">gateway/app/main.py</a>). For non-privileged chats the model sees pseudonyms; the mapping back to originals stays inside the deployment. See <a class="file" href="${REPO}docs/HONEST-STATE.md" target="_blank" rel="noopener">HONEST-STATE.md §3.2</a>.</p>`;
 
   if (state.selectedNode) {
     const n = findNode(state.selectedNode);

--- a/web/static/learn/playgrounds/skill-composition.html
+++ b/web/static/learn/playgrounds/skill-composition.html
@@ -694,7 +694,7 @@ const ORG_PROFILE_PLACEHOLDER = `# Organization Profile
 
 This section is populated by the deployment's Organization Profile — a singleton skill set by the operator at the deployment level that provides organization-wide voice, jurisdiction defaults, and institutional context for all downstream skills.
 
-The Organization Profile slot ships in M2 per the roadmap. It is not active in the current M1 deployment.`;
+The Organization Profile shipped in M2 and is active — an operator-configured singleton. This demo shows it unconfigured (the placeholder above).`;
 
 const USER_SKILL_CONTENT = `# Skill: company-style-guide (User skill)
 [Hypothetical user-authored skill — illustrating how user skills compose alongside built-in skills]
@@ -919,7 +919,7 @@ function renderPrompt() {
 
     const noteSpan = document.createElement('div');
     noteSpan.style.cssText = 'padding: 4px 14px 6px; font-size: 10px; color: var(--providers); font-family: -apple-system, sans-serif; background: var(--prompt-bg);';
-    noteSpan.textContent = 'Organization Profile — ships in M2, not active in M1. Shown here as a placeholder.';
+    noteSpan.textContent = 'Organization Profile — shipped in M2; an operator-configured singleton. Shown here as an unconfigured placeholder.';
     container.appendChild(noteSpan);
 
     const { element: orgEl, bodyText: orgText } = makeSection({
@@ -1097,7 +1097,7 @@ function renderOutput() {
     describeHtml += `<p style="margin-top:8px"><strong>Transparency:</strong> Every built-in skill body is open-source. Click any GitHub link in the "Verify in source" tab to read exactly what the skill instructs the model to do. If you don't like what a skill does, you can fork it — the full corpus is at <a class="file" href="https://github.com/LegalQuants/lq-ai/tree/main/skills" target="_blank" rel="noopener">github.com/LegalQuants/lq-ai/tree/main/skills</a> and the authoring guide at <a class="file" href="${REPO}docs/skill-authoring-guide.md" target="_blank" rel="noopener">docs/skill-authoring-guide.md</a>.</p>`;
 
     if (state.includeOrgProfile) {
-      describeHtml += `<p style="margin-top:8px;padding:8px;border-left:2px solid var(--providers);background:rgba(253,164,175,0.06)"><strong>Organization Profile note:</strong> This is an M2 feature, not active in the current M1 deployment. When shipped, the Organization Profile is a singleton skill set by the operator at the deployment level — it provides org-wide voice, default jurisdiction, and institutional context that shapes every downstream skill. It is the first section of the assembled prompt, rendered before any attached skills. <a class="file" href="${REPO}docs/PRD.md" target="_blank" rel="noopener">PRD §3.12</a></p>`;
+      describeHtml += `<p style="margin-top:8px;padding:8px;border-left:2px solid var(--providers);background:rgba(253,164,175,0.06)"><strong>Organization Profile note:</strong> This is an M2 feature, active in the current deployment. The Organization Profile is a singleton skill set by the operator at the deployment level — it provides org-wide voice, default jurisdiction, and institutional context that shapes every downstream skill. It is the first section of the assembled prompt, rendered before any attached skills. <a class="file" href="${REPO}docs/PRD.md" target="_blank" rel="noopener">PRD §3.12</a></p>`;
     }
 
     if (state.includeUserSkill) {


### PR DESCRIPTION
## What

M3-close transparency audit of all 12 `web/static/learn/playgrounds/*.html` "How it Works" visualizations for stale M1/M2-era status claims.

A viz that **underclaims** shipped work (says a feature "isn't running" when it ships and runs) is a transparency violation — exactly as bad as overclaiming, per the project's founding principle.

## Findings

**5 false claims in 2 files. The other 10 viz are clean** and correctly cite real PRD §9 deferrals (DE-287/295/309/312).

Two root causes, both underclaiming shipped work:

| File | Was | Now |
|---|---|---|
| `data-residency.html` (×2) | "Anonymization Layer (M2, not yet running)… the middleware is absent", cited admin 501 as proof | "M2 — running"; points at `gateway/app/main.py` + keeps the genuine still-true caveat (Presidio legal-corpus recall/precision unmeasured, DE-282); dropped the 501 reference |
| `skill-composition.html` (×3) | Organization Profile "not active in the current M1 deployment" | Shipped in M2 + active; shown unconfigured in the demo |

## Evidence
- Anonymization middleware runs: `gateway/app/main.py:269` wires `app.state.anonymizer = Anonymizer()`; confirmed by `docs/HONEST-STATE.md §3.2`.
- Organization Profile shipped: `api/app/models/organization_profile.py`, `api/app/api/organization_profile.py`, `docs/db-schema.md` singleton index.

## Notes
- The admin `get_anonymization_config` 501 stub (the false-inference target) is being fixed separately (implement the real endpoint).
- Surgical diff: 5 string replacements, template literals verified balanced.

Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)