### PR TITLE
feat(m3-close): implement admin anonymization-config GET (replace 501 stub)

### DIFF
--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -34,7 +34,7 @@ info:
       GET  /admin/v1/usage                (admin.py — 501 stub)
       GET  /admin/v1/tier-config          (admin.py — live)
       PATCH /admin/v1/tier-config         (admin.py — live)
-      GET  /admin/v1/anonymization-config (admin.py — 501 stub)
+      GET  /admin/v1/anonymization-config (admin.py — live)
       GET  /admin/v1/config               (admin.py — live)
       GET  /admin/v1/aliases              (admin.py — live)
       POST /admin/v1/aliases              (admin.py — live)
@@ -504,11 +504,11 @@ paths:
       tags: [admin]
       summary: Get current anonymization configuration (M2)
       description: |
-        M1 status: route exists in code (gateway/app/api/admin.py:270-282)
-        but returns 501 — the anonymization middleware is not running. The
-        config schema loads via gateway.yaml but is not enforced. Full
-        implementation lands with the M2 anonymization middleware (PRD §4.7).
-        See docs/HONEST-STATE.md §3.2.
+        Returns the loaded anonymization block from gateway.yaml — `enabled`,
+        `apply_at_tiers`, and the pass-through keys (`entity_types`, etc.).
+        The M2 anonymization middleware shipped and runs (pre/post
+        pseudonymization wired in gateway/app/main.py; PRD §4.7), so this read
+        surface reflects the live config. See docs/HONEST-STATE.md §3.2.
       responses:
         '200':
           description: Anonymization configuration
@@ -516,14 +516,17 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                properties:
+                  anonymization:
+                    type: object
+                    additionalProperties: true
     patch:
       tags: [admin]
       summary: Partial update to anonymization configuration (M2)
       description: |
-        M1 status: NOT yet in code — this PATCH route does not exist in
-        gateway/app/api/admin.py at M1. The GET returns 501; the PATCH
-        lands with the M2 anonymization middleware alongside it.
+        Status: the PATCH (write) surface is NOT yet in code — only the GET
+        (read) surface is live in gateway/app/api/admin.py. The write path
+        lands with the anonymization admin UI.
         Admin-only. Audited. Updates take effect for new requests immediately.
       requestBody:
         required: true

--- a/gateway.yaml.example
+++ b/gateway.yaml.example
@@ -368,7 +368,7 @@ rate_limits:
 # Tier 1 (local) inference where there's no benefit.
 
 anonymization:
-  enabled: false  # M2 feature; false until M2 ships
+  enabled: false  # M2 middleware shipped + runs; off by default — opt in per deployment
 
   # Apply when:
   # - The request's routed tier is in apply_at_tiers, AND

--- a/gateway/app/api/admin.py
+++ b/gateway/app/api/admin.py
@@ -11,7 +11,7 @@ Surface (current):
 * ``GET    /admin/v1/tier-config``            — tier policy block (A3)
 * ``GET    /admin/v1/providers/health``       — 501 stub
 * ``GET    /admin/v1/usage``                  — 501 stub
-* ``GET    /admin/v1/anonymization-config``   — 501 stub (M2)
+* ``GET    /admin/v1/anonymization-config``   — loaded anonymization block (M2)
 
 Auth: every endpoint here is gated by
 :func:`app.api.dependencies.make_require_gateway_key` — the same shared
@@ -270,18 +270,18 @@ async def patch_tier_config(
 
 
 @router.get("/anonymization-config")
-async def get_anonymization_config(request: Request) -> JSONResponse:
-    """Anonymization config — M2 feature; A3 returns 501."""
+async def get_anonymization_config(request: Request) -> dict[str, Any]:
+    """Return the loaded ``anonymization`` block from ``gateway.yaml``.
 
-    return _not_implemented(
-        message=(
-            "Anonymization configuration is an M2 feature. The "
-            "``anonymization`` block in gateway.yaml loads today but is not "
-            "yet enforced; this admin surface lands with the M2 anonymization "
-            "middleware (PRD §4.7)."
-        ),
-        next_task="M2 — anonymization middleware (PRD §4.7)",
-    )
+    The M2 middleware shipped and runs (pre/post pseudonymization wired in
+    :mod:`app.main`; PRD §4.7), so this read surface exposes the live config
+    instead of a 501. ``enabled`` and ``apply_at_tiers`` are typed; the
+    remaining keys (``entity_types`` etc.) pass through under ``extra="allow"``
+    and are echoed verbatim.
+    """
+
+    cfg = _config(request)
+    return {"anonymization": cfg.anonymization.model_dump(mode="json")}
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/tests/test_admin.py
+++ b/gateway/tests/test_admin.py
@@ -43,9 +43,21 @@ async def test_usage_returns_501(client: AsyncClient) -> None:
 
 
 @pytest.mark.unit
-async def test_anonymization_config_returns_501(client: AsyncClient) -> None:
+async def test_anonymization_config_returns_loaded_block(client: AsyncClient) -> None:
+    """Loaded ``anonymization`` block is exposed verbatim under /admin/v1.
+
+    The M2 middleware shipped and runs; this read surface reflects the
+    live config rather than the old 501 stub.
+    """
+
     response = await client.get("/admin/v1/anonymization-config")
-    assert response.status_code == 501
+
+    assert response.status_code == 200
     body = response.json()
-    assert body["error"]["code"] == "not_implemented"
-    assert "M2" in body["error"]["details"]["next_task"]
+    anonymization = body["anonymization"]
+
+    # Values from gateway.yaml.example
+    assert anonymization["enabled"] is False
+    assert anonymization["apply_at_tiers"] == [3, 4, 5]
+    # Passthrough keys (AnonymizationConfig has extra="allow") survive round-trip.
+    assert "person_name" in anonymization["entity_types"]


### PR DESCRIPTION
## What

`GET /admin/v1/anonymization-config` returned **501** with a now-false message ("Anonymization configuration is an M2 feature… not yet enforced") — even though the M2 anonymization middleware **shipped and runs** (`app.state.anonymizer` wired in `gateway/app/main.py:269`; PRD §4.7).

That stale 501 was the transparency drift flagged for M3-close, and the false-inference target the `data-residency.html` Learn viz pointed at "to verify" anonymization wasn't running. This implements the real read surface.

## How

Mirrors `GET /admin/v1/tier-config`:
```python
cfg = _config(request)
return {"anonymization": cfg.anonymization.model_dump(mode="json")}
```
`enabled` + `apply_at_tiers` are typed; passthrough keys (`entity_types`, …) echo verbatim under `extra="allow"`.

## Tests (TDD)

Replaced `test_anonymization_config_returns_501` with `test_anonymization_config_returns_loaded_block` — watched it fail (501 ≠ 200), then pass.
- Gateway suite: **485 passed / 1 skipped** (matches baseline)
- `ruff format --check`, `ruff check`, `mypy --strict` all clean

## Docs
- `gateway-openapi.yaml`: GET description + 200 schema updated; PATCH cross-reference corrected (the PATCH **write** surface is still unimplemented — read-only here).
- `gateway.yaml.example`: fixed the stale `# … until M2 ships` comment (comment only — the `enabled: false` default is unchanged; enabling is a per-deployment decision, not flipped here).

## Scope note
Read (GET) surface only. The PATCH write surface + admin UI remain unbuilt; if you want those tracked, I can file a DE.

> ⚠️ Touches `gateway/**` — security-gated per CODEOWNERS.

Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)