### PR TITLE
feat(m3-close): promote skill author to wire shape (DE-316)

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -1432,12 +1432,11 @@ def _emit_skill_spans(
     actual prompt assembly + inference run in the gateway under the same
     trace. ``version`` comes from :attr:`Skill.version` when the
     registry resolves the slug. ``author`` comes from
-    :attr:`Skill.author` when present — note that ``author`` lives on
-    :class:`LQAIFrontmatter` and is NOT promoted to :class:`Skill` /
-    :class:`SkillSummary` in the current schema, so it will be ``None``
-    for built-in skills until that field is added to the wire shape
-    (DE-316). ``None`` attributes are silently dropped by
-    :func:`record_attributes` per the OTel attribute-hygiene contract.
+    :attr:`Skill.author`, promoted to the wire shape from
+    :class:`LQAIFrontmatter` (DE-316); it is ``None`` only when the
+    skill's frontmatter omits ``author``. ``None`` attributes are
+    silently dropped by :func:`record_attributes` per the OTel
+    attribute-hygiene contract.
 
     No-op when ``skill_slugs`` is empty. Safe to call before or after
     ``gw_request`` construction — it does not mutate any shared state.

--- a/api/app/skills/schema.py
+++ b/api/app/skills/schema.py
@@ -207,6 +207,10 @@ class SkillSummary(BaseModel):
     ``skills/community/skills/``. User/team-scope DB-backed skills carry
     ``"user"`` or ``"team"`` respectively."""
     description: str | None = None
+    author: str | None = None
+    """Attribution string from ``lq_ai.author`` (DE-316). Promoted to the
+    wire shape so the gateway's ``skill.execute`` OTel span can record
+    ``skill.author``; ``None`` when the frontmatter omits it."""
     tags: list[str] = Field(default_factory=list)
     jurisdiction: str | None = None
     minimum_inference_tier: int | None = None
@@ -389,6 +393,7 @@ def derive_summary(
         source=source,
         title=title,
         description=frontmatter.description,
+        author=lq.author,
         tags=list(lq.tags),
         jurisdiction=lq.jurisdiction,
         minimum_inference_tier=lq.minimum_inference_tier,

--- a/api/tests/test_skill_loader.py
+++ b/api/tests/test_skill_loader.py
@@ -173,6 +173,36 @@ def test_derive_summary_defaults_when_lq_ai_sparse() -> None:
 
 
 @pytest.mark.unit
+def test_derive_summary_promotes_author() -> None:
+    """`lq_ai.author` is promoted to the SkillSummary wire shape (DE-316).
+
+    The `skill.execute` OTel span reads `skill.author`; before DE-316 it
+    was always None because `author` lived only on `LQAIFrontmatter` and
+    was never copied onto the wire shape the registry resolves.
+    """
+
+    fm = SkillFrontmatter.model_validate(
+        {
+            "name": "nda-review",
+            "description": "X.",
+            "lq_ai": {"author": "LQ.AI Core Team"},
+        }
+    )
+    summary = derive_summary("nda-review", fm)
+    assert summary.author == "LQ.AI Core Team"
+
+
+@pytest.mark.unit
+def test_derive_summary_author_none_when_absent() -> None:
+    """Sparse frontmatter leaves `author` None (dropped from the response)."""
+
+    fm = SkillFrontmatter.model_validate({"name": "x", "description": "Y."})
+    summary = derive_summary("x", fm)
+    assert summary.author is None
+    assert "author" not in filter_summary_for_response(summary)
+
+
+@pytest.mark.unit
 def test_filter_summary_drops_none_and_empty() -> None:
     """`None` values and empty tag lists are dropped from the wire shape."""
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4271,6 +4271,8 @@ Two bulk operations as originally written in the M3-C4 spec:
 
 #### DE-316 — Promote skill `author` to the `Skill` / `SkillSummary` wire shape (OTel Deepening, skill spans)
 
+**Status:** ✅ RESOLVED (M3-close). `author: str | None` added to `SkillSummary` and mapped from `lq.author` in `derive_summary()` (`api/app/skills/schema.py`); OpenAPI sketch + `_emit_skill_spans` docstring updated; `derive_summary` author-promotion regression test added. `skill.author` now populates from frontmatter automatically.
+
 **Priority:** P3 · **Effort:** XS
 
 **Context:** The M3-F2 `skill.execute` spans (`api/app/api/chats.py::_emit_skill_spans`) record `skill.author`, but `author` lives only on `LQAIFrontmatter` (`api/app/skills/schema.py`) and is NOT promoted to `SkillSummary` / `Skill` — the wire shape `SkillRegistry.get_skill()` returns. As a result `skill.author` is `None` (silently dropped) for every built-in skill. `skill.version` is unaffected (it is a real field on `SkillSummary`).

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -4951,6 +4951,12 @@ components:
         scope: {type: string, enum: [builtin, user, team]}
         title: {type: string}
         description: {type: string}
+        author:
+          type: string
+          description: >-
+            Attribution string from the skill's ``lq_ai.author`` frontmatter
+            (DE-316). Surfaced verbatim; absent when the frontmatter omits it.
+            Read by the gateway's ``skill.execute`` OTel span as ``skill.author``.
         tags: {type: array, items: {type: string}}
         jurisdiction:
           type: string


### PR DESCRIPTION
## What

Closes **DE-316**. The M3-F2 `skill.execute` OTel spans read `skill.author`, but `author` lived only on `LQAIFrontmatter` and was never promoted to the `SkillSummary` / `Skill` wire shape that `SkillRegistry.get_skill()` returns — so `skill.author` was **always None** (silently dropped) for every built-in skill.

The existing span unit test masked this by using a *fake* skill that carried `author` directly. This change makes real registry-resolved skills carry it.

## How
- Add `author: str | None = None` to `SkillSummary` (inherited by `Skill`).
- Map `lq.author` in `derive_summary()` (`api/app/skills/schema.py`).

## Tests (TDD)
- `test_derive_summary_promotes_author` — watched it fail (`'SkillSummary' object has no attribute 'author'`), then pass.
- `test_derive_summary_author_none_when_absent` — None when frontmatter omits it; dropped from the response by `filter_summary_for_response`.
- api skill suite green; `ruff` + `mypy` clean; DB-backed skill-endpoint conformance tests pass.

## Docs
- `backend-openapi.yaml` `SkillSummary`: `author` optional field.
- `_emit_skill_spans` docstring: no longer says "NOT promoted (DE-316)".
- PRD §9 DE-316 marked **RESOLVED**.

Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)