### PR TITLE
feat(m3-close): test-landscape contributor playground (Learn viz)

### DIFF
--- a/web/static/learn/playgrounds/test-landscape.html
+++ b/web/static/learn/playgrounds/test-landscape.html
@@ -1,0 +1,706 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LQ.AI — Test landscape: what must pass before merge</title>
+<style>
+  :root {
+    --bg: #0c0f14;
+    --bg-elev: #151a23;
+    --bg-elev-2: #1d242f;
+    --border: #2a3340;
+    --border-hover: #3a4555;
+    --text: #e6ebf3;
+    --text-dim: #8a96a8;
+    --text-faint: #5a6578;
+    --accent: #7dd3fc;
+    --accent-dim: #38bdf8;
+    --required: #86efac;
+    --required-bg: rgba(134,239,172,0.08);
+    --required-border: rgba(134,239,172,0.3);
+    --reco: #fcd34d;
+    --reco-bg: rgba(252,211,77,0.08);
+    --reco-border: rgba(252,211,77,0.3);
+    --caveat: #f87171;
+    --caveat-bg: rgba(248,113,113,0.08);
+    --caveat-border: rgba(248,113,113,0.3);
+    --shadow: rgba(0,0,0,0.4);
+    --grp-static: rgba(125,211,252,0.10);
+    --grp-tests: rgba(134,239,172,0.09);
+    --grp-ci: rgba(196,181,253,0.10);
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    height: 100vh;
+    overflow: hidden;
+  }
+  .app { display: grid; grid-template-rows: auto 1fr; height: 100vh; }
+  header {
+    padding: 12px 20px;
+    background: var(--bg-elev);
+    border-bottom: 1px solid var(--border);
+    display: flex; align-items: center; gap: 16px;
+  }
+  header h1 { margin: 0; font-size: 15px; font-weight: 600; letter-spacing: 0.01em; }
+  header .subtitle { color: var(--text-dim); font-size: 13px; }
+  header .spacer { flex: 1; }
+  header a {
+    color: var(--accent); text-decoration: none; font-size: 12px;
+    border: 1px solid var(--border); padding: 4px 10px; border-radius: 4px;
+    white-space: nowrap;
+  }
+  header a:hover { border-color: var(--border-hover); background: var(--bg-elev-2); }
+
+  .main { display: grid; grid-template-columns: 320px 1fr; overflow: hidden; }
+  .controls {
+    background: var(--bg-elev);
+    border-right: 1px solid var(--border);
+    padding: 16px; overflow-y: auto;
+  }
+  .controls h2 {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--text-dim); margin: 16px 0 8px;
+  }
+  .controls h2:first-child { margin-top: 0; }
+  .controls .hint { font-size: 11px; color: var(--text-faint); margin: 4px 0 10px; line-height: 1.45; }
+
+  .presets { display: grid; grid-template-columns: 1fr; gap: 5px; }
+  .preset-btn {
+    background: var(--bg-elev-2); border: 1px solid var(--border);
+    color: var(--text); padding: 8px 11px; border-radius: 4px;
+    cursor: pointer; text-align: left;
+    transition: all 0.1s; line-height: 1.4;
+  }
+  .preset-btn:hover { border-color: var(--border-hover); }
+  .preset-btn.active {
+    background: var(--accent); border-color: var(--accent);
+    color: var(--bg); font-weight: 600;
+  }
+  .preset-btn .preset-label { display: flex; align-items: center; gap: 7px; font-weight: 600; font-size: 13px; margin-bottom: 2px; }
+  .preset-btn .preset-emoji { font-size: 13px; }
+  .preset-btn .preset-desc { display: block; font-size: 11px; color: var(--text-dim); }
+  .preset-btn.active .preset-desc { color: rgba(12,15,20,0.72); }
+  .preset-btn .sub-pill {
+    font-size: 9px; text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 5px; border-radius: 8px; font-weight: 700;
+    background: rgba(125,211,252,0.16); color: var(--accent);
+    margin-left: auto;
+  }
+  .preset-btn.active .sub-pill { background: rgba(12,15,20,0.18); color: var(--bg); }
+
+  .controls .footnote {
+    font-size: 10.5px; color: var(--text-faint); line-height: 1.5;
+    margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border);
+  }
+
+  .preview-wrap {
+    overflow-y: auto;
+    padding: 20px;
+    background:
+      radial-gradient(circle at 20% 20%, rgba(125,211,252,0.03), transparent 55%),
+      radial-gradient(circle at 80% 80%, rgba(134,239,172,0.03), transparent 55%);
+  }
+  .preview-inner { max-width: 820px; margin: 0 auto; display: flex; flex-direction: column; gap: 20px; }
+
+  /* --- Panels --- */
+  .panel {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .panel-header {
+    padding: 10px 14px;
+    background: var(--bg-elev-2);
+    border-bottom: 1px solid var(--border);
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--text-dim);
+    display: flex; align-items: center; gap: 10px;
+  }
+  .panel-header .ph-spacer { flex: 1; }
+  .panel-body { padding: 14px; }
+
+  .change-title {
+    font-size: 17px; font-weight: 700; color: var(--text);
+    display: flex; align-items: center; gap: 9px; text-transform: none; letter-spacing: 0;
+  }
+
+  /* --- Gate groups --- */
+  .gate-group { margin-bottom: 14px; }
+  .gate-group:last-child { margin-bottom: 0; }
+  .gate-group-title {
+    font-size: 10px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.07em; color: var(--text-faint);
+    padding: 4px 8px; border-radius: 4px; margin-bottom: 6px;
+    display: inline-block;
+  }
+  .gate-group-title.static { color: var(--accent); background: var(--grp-static); }
+  .gate-group-title.tests { color: var(--required); background: var(--grp-tests); }
+  .gate-group-title.ci { color: #c4b5fd; background: var(--grp-ci); }
+  .gate-group-title.docs { color: var(--text-dim); background: var(--bg-elev-2); }
+  .gate-group-title.process { color: var(--reco); background: var(--reco-bg); }
+
+  .gate-row {
+    padding: 8px 11px; border-radius: 5px;
+    background: var(--bg-elev-2); border: 1px solid var(--border);
+    margin-bottom: 5px;
+  }
+  .gate-row:last-child { margin-bottom: 0; }
+  .gate-row-head { display: flex; align-items: center; gap: 8px; }
+  .gate-name {
+    font-family: ui-monospace, Menlo, monospace; font-size: 12px;
+    color: var(--text); font-weight: 600;
+  }
+  .gate-badge {
+    font-size: 9px; text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; font-weight: 700; white-space: nowrap;
+  }
+  .gate-badge.required { color: var(--required); background: var(--required-bg); border: 1px solid var(--required-border); }
+  .gate-badge.reco { color: var(--reco); background: var(--reco-bg); border: 1px solid var(--reco-border); }
+  .gate-badge.spacer { flex: 1; background: none; border: none; }
+  .gate-note { font-size: 11.5px; color: var(--text-dim); margin-top: 4px; line-height: 1.45; }
+  .gate-cmd-row { display: flex; align-items: stretch; gap: 8px; margin-top: 6px; }
+  .gate-cmd {
+    flex: 1; font-family: ui-monospace, Menlo, monospace; font-size: 11px;
+    color: var(--accent); background: rgba(125,211,252,0.06);
+    border: 1px solid rgba(125,211,252,0.18); border-radius: 4px;
+    padding: 5px 8px; word-break: break-all; line-height: 1.5;
+  }
+  .copy-btn {
+    font-size: 10px; color: var(--text-faint);
+    background: none; border: 1px solid var(--border);
+    border-radius: 4px; padding: 2px 9px; cursor: pointer;
+    font-family: ui-monospace, Menlo, monospace; white-space: nowrap;
+  }
+  .copy-btn:hover { color: var(--text); border-color: var(--border-hover); }
+  .copy-btn.copied { color: var(--required); border-color: var(--required-border); }
+
+  .caveat-box {
+    margin-top: 4px;
+    background: var(--caveat-bg); border: 1px solid var(--caveat-border);
+    border-radius: 5px; padding: 9px 12px;
+  }
+  .caveat-box .caveat-title {
+    font-size: 10px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.06em; color: var(--caveat); margin-bottom: 5px;
+  }
+  .caveat-box ul { margin: 0; padding-left: 16px; }
+  .caveat-box li { font-size: 11.5px; color: var(--text-dim); margin: 3px 0; line-height: 1.45; }
+  .caveat-box code {
+    background: rgba(248,113,113,0.1); border: 1px solid rgba(248,113,113,0.2);
+    border-radius: 3px; padding: 0 4px; color: #fca5a5; font-size: 10.5px;
+    font-family: ui-monospace, Menlo, monospace;
+  }
+
+  .verify-all {
+    display: flex; align-items: center; gap: 10px;
+    margin-top: 4px; padding: 11px 14px;
+    background: var(--required-bg); border: 1px solid var(--required-border);
+    border-radius: 6px;
+  }
+  .verify-all .va-text { flex: 1; font-size: 12px; color: var(--text-dim); }
+  .verify-all .va-text strong { color: var(--required); }
+  .verify-all .copy-btn { border-color: var(--required-border); color: var(--required); }
+
+  /* --- Taxonomy reference --- */
+  .marker-grid { display: flex; flex-direction: column; gap: 6px; }
+  .marker-row {
+    display: grid; grid-template-columns: 130px 1fr; gap: 12px;
+    padding: 7px 10px; border-radius: 5px;
+    background: var(--bg-elev-2); border: 1px solid var(--border);
+  }
+  .marker-name {
+    font-family: ui-monospace, Menlo, monospace; font-size: 12px;
+    color: var(--required); font-weight: 600;
+  }
+  .marker-desc { font-size: 11.5px; color: var(--text-dim); line-height: 1.45; }
+  .marker-desc code {
+    background: rgba(125,211,252,0.08); border: 1px solid rgba(125,211,252,0.18);
+    border-radius: 3px; padding: 0 4px; color: var(--accent); font-size: 10.5px;
+    font-family: ui-monospace, Menlo, monospace;
+  }
+
+  .counts-row {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px;
+    margin-top: 12px;
+  }
+  .count-card {
+    text-align: center; padding: 10px 6px;
+    background: var(--bg-elev-2); border: 1px solid var(--border); border-radius: 6px;
+  }
+  .count-num { font-size: 20px; font-weight: 700; color: var(--accent); }
+  .count-label { font-size: 10px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2px; }
+
+  /* --- CI jobs --- */
+  .job-grid { display: flex; flex-direction: column; gap: 8px; }
+  .job-card {
+    padding: 10px 12px; border-radius: 6px;
+    background: var(--bg-elev-2); border: 1px solid var(--border);
+  }
+  .job-card.highlight { border-color: var(--accent-dim); background: rgba(125,211,252,0.06); }
+  .job-name { font-size: 12.5px; font-weight: 700; color: var(--text); margin-bottom: 4px; }
+  .job-name .job-tag {
+    font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+    color: var(--accent); background: rgba(125,211,252,0.14);
+    padding: 1px 6px; border-radius: 8px; margin-left: 6px;
+  }
+  .job-steps { display: flex; flex-wrap: wrap; gap: 5px; }
+  .job-step {
+    font-family: ui-monospace, Menlo, monospace; font-size: 10.5px;
+    color: var(--text-dim); background: var(--bg-elev);
+    border: 1px solid var(--border); border-radius: 3px; padding: 2px 7px;
+  }
+  .job-step.arrow { border: none; background: none; color: var(--text-faint); padding: 2px 0; }
+
+  .intro-note {
+    font-size: 12px; color: var(--text-dim); line-height: 1.55;
+    padding: 11px 14px; background: var(--bg-elev); border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+  .intro-note strong { color: var(--text); }
+  .intro-note code {
+    background: rgba(125,211,252,0.08); border: 1px solid rgba(125,211,252,0.18);
+    border-radius: 3px; padding: 0 4px; color: var(--accent); font-size: 11px;
+    font-family: ui-monospace, Menlo, monospace;
+  }
+</style>
+</head>
+<body>
+<div class="app">
+  <header>
+    <h1>Test landscape — what must pass before merge</h1>
+    <span class="subtitle">Pick what you're changing; see the gates your change has to clear.</span>
+    <span class="spacer"></span>
+    <a href="https://github.com/LegalQuants/lq-ai/blob/main/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a>
+    <a href="https://github.com/LegalQuants/lq-ai/blob/main/.github/workflows/ci.yml" target="_blank">ci.yml</a>
+  </header>
+  <div class="main">
+    <div class="controls">
+      <h2>What are you changing?</h2>
+      <p class="hint">CI runs all three jobs on every PR. The panel highlights the gates <em>your</em> change is responsible for keeping green.</p>
+      <div class="presets" id="change-presets"></div>
+      <p class="footnote">
+        Snapshot at <strong>v0.3.0</strong>. Counts and the change&rarr;gate mapping are illustrative
+        for orientation — the authoritative source is <code>.github/workflows/ci.yml</code>,
+        <code>CONTRIBUTING.md</code>, and <code>CLAUDE.md</code>. Local commands assume the per-package
+        dev venvs / <code>npm ci</code> described in CONTRIBUTING.
+      </p>
+    </div>
+
+    <div class="preview-wrap">
+      <div class="preview-inner">
+        <div class="panel">
+          <div class="panel-header"><span id="gates-title">Gates that must pass</span></div>
+          <div class="panel-body" id="gates-body"></div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">The test taxonomy — pytest markers + suite sizes</div>
+          <div class="panel-body">
+            <div class="marker-grid" id="marker-grid"></div>
+            <div class="counts-row" id="counts-row"></div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">What CI runs on every PR — and what it doesn't</div>
+          <div class="panel-body">
+            <div class="job-grid" id="job-grid"></div>
+            <div class="caveat-box" style="margin-top:12px;">
+              <div class="caveat-title">Not in the per-PR CI matrix — verify these yourself</div>
+              <ul>
+                <li><strong>Cypress E2E</strong> (<code>web/cypress/</code>, 16 specs) — the Web job runs svelte-check + Vitest only; Cypress runs against a deployed stack, not in the unit CI job.</li>
+                <li><strong>Repo-root <code>tests/</code></strong> (cross-cutting, e.g. <code>test_observability.py</code>, <code>test_error_code_contract.py</code>) — CI runs <code>api/</code>, <code>gateway/</code>, and <code>web/</code> only. Run root tests with <code>api/.venv/bin/python -m pytest tests/ -q</code>.</li>
+                <li><strong>Coverage gate</strong> — the 80% (api) / 90% (gateway) targets are tracked but not yet build-failing in CI (PRD §6, on the engineering-discipline roadmap).</li>
+                <li><strong><code>provider</code>-marked tests</strong> — hit a real LLM; require an API key, so they're skipped in CI. Run them locally with a key + <code>-m provider</code>.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="intro-note">
+          <strong>Two rules that apply to every change</strong> (per <code>CLAUDE.md</code>): a bug fix
+          ships with a <strong>regression test</strong> that fails before the fix, and a feature change
+          ships with the <strong>doc update</strong> that describes it (the PRD section, the OpenAPI
+          sketch, or the DB-schema doc). Tests and docs are part of the change, not a follow-up.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+"use strict";
+
+// ---------------------------------------------------------------------------
+// Data — change types → the gates each one is responsible for.
+// Illustrative orientation map; authoritative source is ci.yml + CONTRIBUTING.
+// ---------------------------------------------------------------------------
+
+const CI_JOBS = {
+  web: {
+    name: "Web", tag: "svelte-check + Vitest",
+    steps: ["npm ci", "→", "npm run check:lq-ai", "→", "npm run test:frontend -- --run"]
+  },
+  api: {
+    name: "API", tag: "ruff + mypy + pytest",
+    steps: ["ruff check api scripts", "→", "ruff format --check", "→", "mypy app", "→", "pytest -q"]
+  },
+  gateway: {
+    name: "Gateway", tag: "ruff + mypy --strict + pytest",
+    steps: ["ruff check gateway", "→", "ruff format --check", "→", "mypy app (--strict)", "→", "pytest -q"]
+  }
+};
+
+const CHANGE_TYPES = [
+  {
+    id: "api-endpoint",
+    emoji: "🔌",
+    label: "API endpoint",
+    sub: "api/",
+    desc: "New or changed FastAPI route in api/.",
+    ciJobs: ["api"],
+    coverage: "80% on api/ — CI tracks per-file; keep it from decreasing.",
+    static: [
+      { name: "ruff check", cmd: "ruff check api scripts" },
+      { name: "ruff format --check", cmd: "ruff format --check api scripts" },
+      { name: "mypy (standard)", cmd: "cd api && mypy app", note: "Type annotations required on public functions + class methods." }
+    ],
+    tests: [
+      { name: "pytest -m unit", req: true, note: "Handler logic — pure unit tests, no I/O.", cmd: 'cd api && pytest -m unit -q' },
+      { name: "pytest -m integration", req: true, note: "The endpoint against real Postgres. Conftest builds a throwaway test DB from migrations.", cmd: 'cd api && pytest -m integration -q' },
+      { name: "OpenAPI schema-conformance test", req: true, note: "New endpoints include a conformance test asserting the handler matches the sketch." }
+    ],
+    docs: [ "Update <code>docs/api/backend-openapi.yaml</code> — the endpoint shape is part of the change." ],
+    process: [],
+    caveats: []
+  },
+  {
+    id: "bug-fix",
+    emoji: "🐞",
+    label: "Bug fix",
+    sub: "any",
+    desc: "Fixing incorrect behavior anywhere in the stack.",
+    ciJobs: ["api", "gateway", "web"],
+    coverage: "No-decrease on the package you touch.",
+    static: [
+      { name: "ruff + mypy", cmd: "# run the gate set for the package you touched (api / gateway / web)" }
+    ],
+    tests: [
+      { name: "Regression test (RED → GREEN)", req: true, note: "Write a test that reproduces the bug and FAILS before your fix, then passes after. This is the contract — a fix without a regression test invites the bug back.", cmd: "# add the test in the touched package's tests/ dir, watch it fail first" }
+    ],
+    docs: [ "Update the relevant doc only if the bug was a documented-behavior mismatch." ],
+    process: [],
+    caveats: []
+  },
+  {
+    id: "gateway",
+    emoji: "🛡️",
+    label: "Gateway change",
+    sub: "gateway/",
+    desc: "Anything under gateway/ — the security boundary.",
+    ciJobs: ["gateway"],
+    coverage: "90% on gateway/ — the higher floor reflects its position in the trust path.",
+    static: [
+      { name: "ruff check", cmd: "ruff check gateway" },
+      { name: "ruff format --check", cmd: "ruff format --check gateway" },
+      { name: "mypy --strict", cmd: "cd gateway && mypy app", note: "Gateway is mypy --strict (configured in pyproject) — stricter than api/." }
+    ],
+    tests: [
+      { name: "pytest -m unit", req: true, note: "Pure unit tests, no I/O.", cmd: "cd gateway && pytest -m unit -q" },
+      { name: "pytest -m integration", req: true, note: "Hits downstream services; uses respx to stub HTTP — no DB needed.", cmd: "cd gateway && pytest -m integration -q" }
+    ],
+    docs: [
+      "Update <code>docs/api/gateway-openapi.yaml</code> if the endpoint shape changed.",
+      "Update <code>gateway.yaml.example</code> if you added a config key."
+    ],
+    process: [
+      "<strong>Security review.</strong> <code>gateway/**</code> is CODEOWNERS-gated — your PR auto-routes to security reviewers and is held until they approve."
+    ],
+    caveats: []
+  },
+  {
+    id: "migration",
+    emoji: "🗄️",
+    label: "DB migration",
+    sub: "api/ alembic",
+    desc: "A new Alembic migration / schema change.",
+    ciJobs: ["api"],
+    coverage: "80% on api/.",
+    static: [
+      { name: "ruff + mypy (api)", cmd: "ruff check api scripts && cd api && mypy app" }
+    ],
+    tests: [
+      { name: "pytest -m integration", req: true, note: "The conftest builds the test DB by running every migration — a broken or non-applying migration fails the WHOLE integration suite, not just one test.", cmd: "cd api && pytest -m integration -q" }
+    ],
+    docs: [ "Update <code>docs/db-schema.md</code> — the table/column/index change is part of the migration." ],
+    process: [
+      "<strong>Deploy note (not a CI gate).</strong> After a migration lands, rebuild every Alembic-running worker together (api + arq-worker + ingest-worker) — stale siblings crash-loop on the unknown revision."
+    ],
+    caveats: []
+  },
+  {
+    id: "frontend",
+    emoji: "🎨",
+    label: "Frontend component",
+    sub: "web/",
+    desc: "Svelte component / page in the OpenWebUI fork.",
+    ciJobs: ["web"],
+    coverage: "Vitest covers LQ.AI-owned units; no global % gate on web/.",
+    static: [
+      { name: "svelte-check (LQ.AI tsconfig)", cmd: "cd web && npm run check:lq-ai", note: "Typechecks LQ.AI-owned code against tsconfig.lq-ai.json. New files are TypeScript." }
+    ],
+    tests: [
+      { name: "Vitest (unit)", req: true, note: "Runs on the host against the source tree — no container rebuild needed.", cmd: "cd web && npm run test:frontend -- --run" },
+      { name: "Cypress E2E", req: false, note: "LQ.AI specs are prefixed wave-*. Run against a deployed stack — NOT in the per-PR CI job.", cmd: "cd web && npx cypress run" }
+    ],
+    docs: [ "Use the design-system primitives; match OpenWebUI conventions for shared components." ],
+    process: [],
+    caveats: [
+      "The Web CI job runs <code>svelte-check</code> + <code>Vitest</code> only. Cypress E2E is your responsibility to run locally / against a stack.",
+      "<code>web/</code> is not bind-mounted — a live in-browser smoke needs <code>docker compose up -d --build web</code> (the bundle needs a 4 GiB Node heap)."
+    ]
+  },
+  {
+    id: "skill",
+    emoji: "📜",
+    label: "New skill",
+    sub: "skills/",
+    desc: "A skill with legal substance (SKILL.md + references).",
+    ciJobs: ["api"],
+    coverage: "Skill-loader tests confirm the registry parses your frontmatter.",
+    static: [
+      { name: "Frontmatter validity", cmd: "cd api && pytest tests/test_skill_loader.py -q", note: "The loader rejects malformed frontmatter; table-mode skills need a columns spec." }
+    ],
+    tests: [
+      { name: "Worked example", req: true, note: "Draft at least one worked example. The skill-acceptance-test harness is a deferred contribution path (test-plan.md per skill today)." }
+    ],
+    docs: [ "Follow <code>docs/skill-authoring-guide.md</code>; the SKILL.md is the work product." ],
+    process: [
+      "<strong>Claim → Draft → Attest → Review → Merge.</strong> A practicing-attorney attestation paragraph goes in the PR description. Agents draft but do <em>not</em> attest — the human contributor is the attesting party.",
+      "Review requires a practicing attorney AND an engineer; merge only after both pass."
+    ],
+    caveats: [
+      "Skills are bind-mounted read-only into the api / worker containers — edit the SKILL.md and SIGHUP the api to reload without an image rebuild. The file still has to be committed (CI bakes the directory into the image)."
+    ]
+  },
+  {
+    id: "docs",
+    emoji: "📝",
+    label: "Docs-only",
+    sub: "docs/ · *.md",
+    desc: "Documentation, PRD, or comments — no code paths.",
+    ciJobs: [],
+    coverage: null,
+    static: [],
+    tests: [],
+    docs: [ "The lightest path — but note that docs are part of every code change, not only standalone doc PRs." ],
+    process: [],
+    caveats: [
+      "Editing an OpenAPI sketch (<code>docs/api/*.yaml</code>) is <em>not</em> docs-only — the schema-conformance tests assert it matches the live handlers, so it runs through the api/gateway pytest gate."
+    ]
+  }
+];
+
+const MARKERS = [
+  { name: "unit", desc: "Pure unit tests, no I/O. The fast inner loop. (<code>-m unit</code>)" },
+  { name: "integration", desc: "Hits Postgres/Redis/MinIO/Gateway (api) or downstream services (gateway). (<code>-m integration</code>)" },
+  { name: "provider", desc: "Hits a real LLM provider — requires an API key, so skipped in CI. (<code>-m provider</code>)" },
+  { name: "slow", desc: "Takes longer than 5s. Deselect for a fast local loop. (<code>-m \"not slow\"</code>)" },
+  { name: "e2e", desc: "End-to-end via Playwright (api marker); Cypress covers the web E2E surface separately." }
+];
+
+const COUNTS = [
+  { num: "115", label: "api pytest files" },
+  { num: "41", label: "gateway pytest files" },
+  { num: "66", label: "vitest specs" },
+  { num: "16", label: "cypress specs" }
+];
+
+let activeId = "api-endpoint";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function escHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"})[c]);
+}
+
+function decodeEntities(s) {
+  return s.replace(/&amp;/g,"&").replace(/&lt;/g,"<").replace(/&gt;/g,">").replace(/&quot;/g,'"').replace(/&#39;/g,"'");
+}
+
+function copyButton(rawCmd) {
+  return `<button class="copy-btn" data-cmd="${escHtml(rawCmd)}">copy</button>`;
+}
+
+function wireCopyButtons(scope) {
+  scope.querySelectorAll(".copy-btn").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const cmd = decodeEntities(btn.dataset.cmd);
+      navigator.clipboard.writeText(cmd).then(() => {
+        const prev = btn.textContent;
+        btn.textContent = "copied";
+        btn.classList.add("copied");
+        setTimeout(() => { btn.textContent = prev; btn.classList.remove("copied"); }, 1500);
+      });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Render — gates panel (driven by activeId)
+// ---------------------------------------------------------------------------
+
+function localVerificationSequence(ct) {
+  const cmds = [];
+  ct.static.forEach(s => { if (s.cmd && !s.cmd.trim().startsWith("#")) cmds.push(s.cmd); });
+  ct.tests.forEach(t => { if (t.req && t.cmd && !t.cmd.trim().startsWith("#")) cmds.push(t.cmd); });
+  return cmds;
+}
+
+function gateRow(g, badge) {
+  let html = `<div class="gate-row"><div class="gate-row-head">`;
+  html += `<span class="gate-name">${escHtml(g.name)}</span>`;
+  if (badge) html += `<span class="gate-badge ${badge.cls}">${escHtml(badge.text)}</span>`;
+  html += `</div>`;
+  if (g.note) html += `<div class="gate-note">${g.note}</div>`;
+  if (g.cmd) {
+    html += `<div class="gate-cmd-row"><div class="gate-cmd">${escHtml(g.cmd)}</div>${copyButton(g.cmd)}</div>`;
+  }
+  html += `</div>`;
+  return html;
+}
+
+function renderGates() {
+  const ct = CHANGE_TYPES.find(c => c.id === activeId);
+  document.getElementById("gates-title").textContent = "Gates for: " + ct.label + "  (" + ct.sub + ")";
+
+  const body = document.getElementById("gates-body");
+  let html = "";
+
+  // STATIC
+  if (ct.static.length) {
+    html += `<div class="gate-group"><div class="gate-group-title static">Static analysis</div>`;
+    ct.static.forEach(s => { html += gateRow(s, null); });
+    html += `</div>`;
+  }
+
+  // TESTS
+  if (ct.tests.length) {
+    html += `<div class="gate-group"><div class="gate-group-title tests">Tests</div>`;
+    ct.tests.forEach(t => {
+      const badge = t.req ? { cls: "required", text: "required" } : { cls: "reco", text: "recommended" };
+      html += gateRow(t, badge);
+    });
+    html += `</div>`;
+  }
+
+  // COVERAGE
+  if (ct.coverage) {
+    html += `<div class="gate-group"><div class="gate-group-title tests">Coverage</div>`;
+    html += `<div class="gate-row"><div class="gate-note" style="margin-top:0">${escHtml(ct.coverage)}</div></div>`;
+    html += `</div>`;
+  }
+
+  // CI JOBS
+  html += `<div class="gate-group"><div class="gate-group-title ci">CI job(s) your change lands in</div>`;
+  if (ct.ciJobs.length) {
+    ct.ciJobs.forEach(j => {
+      const job = CI_JOBS[j];
+      html += `<div class="gate-row"><div class="gate-row-head"><span class="gate-name">${escHtml(job.name)} job</span><span class="gate-badge spacer"></span><span style="font-size:11px;color:var(--text-faint)">${escHtml(job.tag)}</span></div></div>`;
+    });
+  } else {
+    html += `<div class="gate-row"><div class="gate-note" style="margin-top:0">No compiled CI job gates a docs-only change. (All three jobs still run, but nothing here is yours to keep green.)</div></div>`;
+  }
+  html += `</div>`;
+
+  // DOCS
+  if (ct.docs.length) {
+    html += `<div class="gate-group"><div class="gate-group-title docs">Docs (part of the change)</div>`;
+    ct.docs.forEach(d => { html += `<div class="gate-row"><div class="gate-note" style="margin-top:0">${d}</div></div>`; });
+    html += `</div>`;
+  }
+
+  // PROCESS
+  if (ct.process.length) {
+    html += `<div class="gate-group"><div class="gate-group-title process">Process</div>`;
+    ct.process.forEach(p => { html += `<div class="gate-row"><div class="gate-note" style="margin-top:0">${p}</div></div>`; });
+    html += `</div>`;
+  }
+
+  // CAVEATS
+  if (ct.caveats.length) {
+    html += `<div class="caveat-box"><div class="caveat-title">Watch out</div><ul>`;
+    ct.caveats.forEach(c => { html += `<li>${c}</li>`; });
+    html += `</ul></div>`;
+  }
+
+  // VERIFY-ALL
+  const seq = localVerificationSequence(ct);
+  if (seq.length) {
+    const joined = seq.join(" && \\\n");
+    html += `<div class="verify-all"><div class="va-text"><strong>Run it all locally</strong> before you push — the same gates CI applies, in order.</div>${copyButton(joined)}</div>`;
+  }
+
+  body.innerHTML = html;
+  wireCopyButtons(body);
+}
+
+// ---------------------------------------------------------------------------
+// Render — static reference panels (once)
+// ---------------------------------------------------------------------------
+
+function renderMarkers() {
+  document.getElementById("marker-grid").innerHTML = MARKERS.map(m =>
+    `<div class="marker-row"><div class="marker-name">${escHtml(m.name)}</div><div class="marker-desc">${m.desc}</div></div>`
+  ).join("");
+  document.getElementById("counts-row").innerHTML = COUNTS.map(c =>
+    `<div class="count-card"><div class="count-num">${escHtml(c.num)}</div><div class="count-label">${escHtml(c.label)}</div></div>`
+  ).join("");
+}
+
+function renderJobs() {
+  const ct = CHANGE_TYPES.find(c => c.id === activeId);
+  document.getElementById("job-grid").innerHTML = Object.entries(CI_JOBS).map(([id, job]) => {
+    const hl = ct.ciJobs.includes(id) ? " highlight" : "";
+    const steps = job.steps.map(s => s === "→"
+      ? `<span class="job-step arrow">→</span>`
+      : `<span class="job-step">${escHtml(s)}</span>`).join("");
+    return `<div class="job-card${hl}"><div class="job-name">${escHtml(job.name)}<span class="job-tag">${escHtml(job.tag)}</span></div><div class="job-steps">${steps}</div></div>`;
+  }).join("");
+}
+
+// ---------------------------------------------------------------------------
+// Control wiring
+// ---------------------------------------------------------------------------
+
+const presetsEl = document.getElementById("change-presets");
+CHANGE_TYPES.forEach(ct => {
+  const btn = document.createElement("button");
+  btn.className = "preset-btn" + (ct.id === activeId ? " active" : "");
+  btn.dataset.id = ct.id;
+  btn.innerHTML =
+    `<span class="preset-label"><span class="preset-emoji">${ct.emoji}</span>${escHtml(ct.label)}<span class="sub-pill">${escHtml(ct.sub)}</span></span>` +
+    `<span class="preset-desc">${escHtml(ct.desc)}</span>`;
+  btn.addEventListener("click", () => {
+    activeId = ct.id;
+    presetsEl.querySelectorAll(".preset-btn").forEach(b => b.classList.toggle("active", b.dataset.id === ct.id));
+    renderGates();
+    renderJobs();
+  });
+  presetsEl.appendChild(btn);
+});
+
+renderMarkers();
+renderGates();
+renderJobs();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

New self-contained Learn playground — `web/static/learn/playgrounds/test-landscape.html` — a **"Change → gates" explorer** for contributors, mirroring the `otel-eval.html` conventions (theme, header, controls + preview, copy buttons).

Pick a change type — **API endpoint · Bug fix · Gateway · DB migration · Frontend · New skill · Docs-only** — and see the gates it must clear:
- **Static** (ruff / ruff format / mypy — `--strict` for gateway / svelte-check)
- **Tests** (the relevant pytest markers, required vs recommended)
- **Coverage** floor (80% api / 90% gateway)
- **Which CI job** it lands in (highlighted)
- **Docs** obligations + **Process** gates (security review for `gateway/**`, attorney attestation for skills)
- A **"run it all locally"** copy-out emitting the verification command sequence

## Grounded in the real setup
- Exact CI commands lifted from `.github/workflows/ci.yml`
- The five pytest markers; suite sizes (api 115 / gateway 41 / vitest 66 / cypress 16), labeled "snapshot at v0.3.0"
- **Honest about what's *not* in the per-PR CI matrix:** Cypress E2E, the repo-root `tests/` dir, the not-yet-build-failing coverage gate, `provider`-marked tests

## Verification
- Headless-Chrome render executes the JS and populates all panels (7 change types, gate rows with real content, markers, job cards)
- `node --check` passes; all `getElementById` targets resolve

## Follow-up
Wiring this into the **How-to-Build** page (iframe embed + nav link) lands with the Learn sub-pages overhaul (next PR).

Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)