### PR TITLE
docs(m3-close): refresh Learn sub-pages (use/how/build) for M1–M3 reality

### DIFF
--- a/web/src/routes/lq-ai/learn/build/+page.svelte
+++ b/web/src/routes/lq-ai/learn/build/+page.svelte
@@ -160,12 +160,32 @@
 			</div>
 		</section>
 
+		<!-- 3b: Dev-facing visualizations -->
+		<section class="lq-build-section" data-testid="lq-ai-learn-build-section-dev-viz">
+			<h2 class="lq-section-h">Before you open a PR: what must pass, and how to trace it</h2>
+			<p class="lq-text-body">
+				Two interactive maps help you ship a change that merges cleanly. The test landscape shows
+				every gate a PR must clear before merge — unit, integration, end-to-end, lint, type-check,
+				and coverage — and where each one lives. The observability trace shows the OpenTelemetry
+				span tree a single chat-send produces, so you can see exactly where to add instrumentation
+				for a new surface.
+			</p>
+			<div class="lq-build-links">
+				<a href="/learn/playgrounds/test-landscape.html" class="lq-link" target="_blank" rel="noopener noreferrer">Test landscape: what must pass before merge ↗</a>
+				<span class="lq-sep">·</span>
+				<a href="/learn/playgrounds/otel-eval.html" class="lq-link" target="_blank" rel="noopener noreferrer">Observability trace explorer ↗</a>
+				<span class="lq-sep">·</span>
+				<a href="https://github.com/LegalQuants/lq-ai/blob/main/docs/observability.md" class="lq-link" target="_blank" rel="noopener noreferrer">docs/observability.md</a>
+			</div>
+		</section>
+
 		<!-- 4: Roadmap -->
 		<section class="lq-build-section" data-testid="lq-ai-learn-build-section-roadmap">
 			<h2 class="lq-section-h">The roadmap</h2>
 			<p class="lq-text-body">
-				LQ.AI follows a milestone-based roadmap. M1 ships the foundation. Each subsequent
-				milestone adds a named capability layer on top.
+				LQ.AI follows a milestone-based roadmap. M1 shipped the foundation; M2 and M3 each added a
+				named capability layer on top. M1, M2, and M3 are all shipped as of v0.3.0; M4 is the next
+				milestone.
 			</p>
 			<div class="lq-roadmap-list">
 				<div class="lq-roadmap-item lq-roadmap-item--shipped">
@@ -177,20 +197,20 @@
 						Three provider adapters: Anthropic, OpenAI, Ollama.
 					</div>
 				</div>
-				<div class="lq-roadmap-item">
-					<div class="lq-roadmap-pill lq-roadmap-pill--future">M2</div>
+				<div class="lq-roadmap-item lq-roadmap-item--shipped">
+					<div class="lq-roadmap-pill">M2</div>
 					<div>
-						<strong>Citation Engine + Anonymization Layer + Playbooks.</strong>
-						Character-level citation verification, personal-data pseudonymization
-						before inference, multi-step playbook execution. Vertex AI and AWS
-						Bedrock provider adapters.
+						<strong>Citation Engine + Anonymization Layer.</strong>
+						Character-level citation verification and personal-data pseudonymization
+						before inference, plus the Azure OpenAI provider adapter.
 					</div>
 				</div>
-				<div class="lq-roadmap-item">
-					<div class="lq-roadmap-pill lq-roadmap-pill--future">M3</div>
+				<div class="lq-roadmap-item lq-roadmap-item--shipped">
+					<div class="lq-roadmap-pill">M3</div>
 					<div>
-						<strong>Integrations.</strong> Microsoft Word add-in (Office.js), Slack/Teams
-						bridge, Tabular Review surface.
+						<strong>Capability surfaces + integrations.</strong> Playbooks, Tabular Review,
+						Slack/Teams intake bridges, OpenTelemetry observability, and the Microsoft Word
+						add-in (Office.js — plumbing only at v0.3.0; the in-pane feature surface is deferred).
 					</div>
 				</div>
 				<div class="lq-roadmap-item">

--- a/web/src/routes/lq-ai/learn/how/+page.svelte
+++ b/web/src/routes/lq-ai/learn/how/+page.svelte
@@ -1,11 +1,11 @@
 <!--
   /lq-ai/learn/how — "How It Works" visualization page.
 
-  Ten interactive playground iframes in narrative order: system map →
+  Eleven interactive playground iframes in narrative order: system map →
   request lifecycle → tier system → skill composition → citation engine →
   anonymization layer → data residency → playbook cascade → tabular review →
-  word add-in flow. Each section has: a heading, a 2-3 sentence framing
-  paragraph, the embedded iframe, and an "Open full-screen" link.
+  word add-in flow → observability trace. Each section has: a heading, a 2-3
+  sentence framing paragraph, the embedded iframe, and an "Open full-screen" link.
 
   Iframes load the static HTML playgrounds at /learn/playgrounds/*.html
   served directly by the web container from web/static/learn/playgrounds/.

--- a/web/src/routes/lq-ai/learn/use/+page.svelte
+++ b/web/src/routes/lq-ai/learn/use/+page.svelte
@@ -1,7 +1,7 @@
 <!--
   /lq-ai/learn/use — "How to Use" feature tour.
 
-  Ten sections covering every M1 user-facing capability. Each section has:
+  Sections covering every user-facing capability across M1–M3. Each section has:
   - A heading
   - A plain-language description
   - A <details> foldout linking to the relevant source file paths, E2E
@@ -15,8 +15,9 @@
 		<a href="/lq-ai/learn" class="lq-back-link">← Learn</a>
 		<h1 class="lq-text-page-h">How to Use LQ.AI</h1>
 		<p class="lq-text-body lq-page-intro">
-			A plain-language tour of every M1 feature. Each section names the file paths and test
-			that exercise the behavior described, so you can verify any claim against the source.
+			A plain-language tour of every user-facing feature across M1–M3. Each section names the
+			file paths and test that exercise the behavior described, so you can verify any claim
+			against the source.
 		</p>
 	</header>
 
@@ -222,7 +223,7 @@
 				in the composer toolbar to open the receipts drawer. Each receipt entry shows: the
 				request timestamp, the model and provider used, the tier in effect, the full
 				assembled prompt (including any skill system prompt and KB chunks), and — when a
-				skill was invoked — "via slash command /<alias>". Receipts are read-only audit
+				skill was invoked — "via slash command /&lt;alias&gt;". Receipts are read-only audit
 				artifacts; they cannot be edited or deleted through the UI.
 			</p>
 			<details class="lq-verify">
@@ -291,12 +292,146 @@
 			</details>
 		</section>
 
+		<!-- 11 -->
+		<section class="lq-use-section" data-testid="lq-ai-learn-use-section-citations">
+			<h2 class="lq-section-h">11. Read verified citations</h2>
+			<p class="lq-text-body">
+				When a model reply quotes a source in the form <code>"&lt;quote&gt;" (Source: [N])</code>,
+				the Citation Engine verifies each quote against the cited source before it counts. Verified
+				quotes render as a green chip in the chat message; quotes the model emitted but that could
+				not be matched render as a grey <code>[unverified]</code> chip. There are four chip states —
+				verified by exact match, verified by tolerant match, verified by paraphrase judge, and
+				unverified — so you see not just whether a citation checked out but how strong the match was.
+				Click a verified chip to jump to the matched span in the source.
+			</p>
+			<details class="lq-verify">
+				<summary class="lq-verify-summary">Dig deeper / verify</summary>
+				<div class="lq-verify-body">
+					<p><strong>Source:</strong>
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/api/app/citation/verification.py" class="lq-link" target="_blank" rel="noopener noreferrer">api/app/citation/verification.py</a>
+						— four-stage cascade;
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/web/src/lib/lq-ai/components/M2Citations.svelte" class="lq-link" target="_blank" rel="noopener noreferrer">web/src/lib/lq-ai/components/M2Citations.svelte</a>
+						— chip rendering.
+					</p>
+					<p><strong>E2E test:</strong>
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/web/cypress/e2e/m2-c2-citation-states.cy.ts" class="lq-link" target="_blank" rel="noopener noreferrer">web/cypress/e2e/m2-c2-citation-states.cy.ts</a>
+					</p>
+				</div>
+			</details>
+		</section>
+
+		<!-- 12 -->
+		<section class="lq-use-section" data-testid="lq-ai-learn-use-section-playbooks">
+			<h2 class="lq-section-h">12. Run a playbook against a document</h2>
+			<p class="lq-text-body">
+				A playbook codifies your organization's standard positions on common contract issues. From
+				<a href="/lq-ai/playbooks" class="lq-link">Playbooks</a>, pick a playbook, choose the document
+				to review, preview the cost, and run it. Execution walks each position through a four-node
+				cascade — retrieve the matching clause, classify it against your standard, draft a redline
+				where it deviates, and compile the result. Each position lands on one of four verdicts so you
+				can triage at a glance. Completed runs are saved and re-openable from
+				<a href="/lq-ai/playbook-executions" class="lq-link">playbook executions</a>.
+			</p>
+			<details class="lq-verify">
+				<summary class="lq-verify-summary">Dig deeper / verify</summary>
+				<div class="lq-verify-body">
+					<p><strong>Source:</strong>
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/api/app/playbooks/nodes.py" class="lq-link" target="_blank" rel="noopener noreferrer">api/app/playbooks/nodes.py</a>
+						— cascade nodes;
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/api/app/api/playbooks.py" class="lq-link" target="_blank" rel="noopener noreferrer">api/app/api/playbooks.py</a>
+						— endpoints.
+					</p>
+					<p><strong>E2E test:</strong>
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/web/cypress/e2e/m3-a4-playbook-execution.cy.ts" class="lq-link" target="_blank" rel="noopener noreferrer">web/cypress/e2e/m3-a4-playbook-execution.cy.ts</a>
+					</p>
+					<p><strong>Audit action:</strong> <code>playbook.created</code>, <code>playbook.updated</code>, <code>playbook.deleted</code></p>
+				</div>
+			</details>
+		</section>
+
+		<!-- 13 -->
+		<section class="lq-use-section" data-testid="lq-ai-learn-use-section-tabular">
+			<h2 class="lq-section-h">13. Compare many documents in a grid</h2>
+			<p class="lq-text-body">
+				Tabular Review asks the same set of questions across a set of documents and lays the answers
+				out in a grid — one row per document, one column per question. From
+				<a href="/lq-ai/tabular" class="lq-link">Tabular Review</a>, a four-step wizard collects the
+				documents, the questions, and a cost preview, then runs the extraction. Each cell is grounded
+				in the chunks the model cited; click a cell to open its citation drawer. Finished grids export
+				to XLSX or CSV.
+			</p>
+			<details class="lq-verify">
+				<summary class="lq-verify-summary">Dig deeper / verify</summary>
+				<div class="lq-verify-body">
+					<p><strong>Source:</strong>
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/api/app/tabular/nodes.py" class="lq-link" target="_blank" rel="noopener noreferrer">api/app/tabular/nodes.py</a>
+						— extraction nodes;
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/api/app/api/tabular.py" class="lq-link" target="_blank" rel="noopener noreferrer">api/app/api/tabular.py</a>
+						— endpoints + export.
+					</p>
+					<p><strong>E2E test:</strong>
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/web/cypress/e2e/m3-c-tabular-review.cy.ts" class="lq-link" target="_blank" rel="noopener noreferrer">web/cypress/e2e/m3-c-tabular-review.cy.ts</a>
+					</p>
+					<p><strong>Audit action:</strong> <code>tabular.execution_started</code>, <code>tabular.execution_exported</code></p>
+				</div>
+			</details>
+		</section>
+
+		<!-- 14 -->
+		<section class="lq-use-section" data-testid="lq-ai-learn-use-section-word-addin">
+			<h2 class="lq-section-h">14. Word add-in (plumbing only at v0.3.0)</h2>
+			<p class="lq-text-body">
+				The Microsoft Word add-in is an Office.js task pane that installs against your own deployment.
+				At v0.3.0, only the plumbing has shipped: an admin generates a per-deployment manifest, the
+				operator sideloads the unsigned manifest (Microsoft 365 warns about the unsigned package —
+				expected), the pane completes OAuth against the deployment, and a version handshake confirms
+				compatibility. The in-pane feature surface — chat, skills, playbooks — is deferred (DE-287),
+				and a signed distribution package is community-led (DE-295). We call this out plainly rather
+				than implying the editor experience is finished.
+			</p>
+			<details class="lq-verify">
+				<summary class="lq-verify-summary">Dig deeper / verify</summary>
+				<div class="lq-verify-body">
+					<p><strong>Source:</strong>
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/api/app/api/word_addin.py" class="lq-link" target="_blank" rel="noopener noreferrer">api/app/api/word_addin.py</a>;
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/docs/word-addin.md" class="lq-link" target="_blank" rel="noopener noreferrer">docs/word-addin.md</a>
+					</p>
+					<p><strong>E2E test:</strong>
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/web/cypress/e2e/m3-b2-word-addin-oauth.cy.ts" class="lq-link" target="_blank" rel="noopener noreferrer">web/cypress/e2e/m3-b2-word-addin-oauth.cy.ts</a>
+					</p>
+				</div>
+			</details>
+		</section>
+
+		<!-- 15 -->
+		<section class="lq-use-section" data-testid="lq-ai-learn-use-section-intake-bridges">
+			<h2 class="lq-section-h">15. Intake bridges: Slack + Teams (admin)</h2>
+			<p class="lq-text-body">
+				Intake bridges let a legal team take in requests from Slack and Microsoft Teams. This is an
+				admin-facing surface: from <a href="/lq-ai/admin/intake-bridges" class="lq-link">Admin →
+				Intake bridges</a>, an administrator connects a workspace over OAuth, lists the configured
+				bridges, and soft-deletes ones that are no longer needed. The bridge services run as separate
+				deployments. Honest state: the admin shell and backend persistence have shipped; end-to-end
+				OAuth against live Slack and Teams workspaces is not yet validated in CI (DE-312).
+			</p>
+			<details class="lq-verify">
+				<summary class="lq-verify-summary">Dig deeper / verify</summary>
+				<div class="lq-verify-body">
+					<p><strong>Source:</strong>
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/api/app/api/admin_intake_bridges.py" class="lq-link" target="_blank" rel="noopener noreferrer">api/app/api/admin_intake_bridges.py</a>;
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/slack-bridge/" class="lq-link" target="_blank" rel="noopener noreferrer">slack-bridge/</a>;
+						<a href="https://github.com/LegalQuants/lq-ai/blob/main/teams-bridge/" class="lq-link" target="_blank" rel="noopener noreferrer">teams-bridge/</a>
+					</p>
+				</div>
+			</details>
+		</section>
+
 	</div>
 
 	<footer class="lq-use-footer">
 		<p class="lq-text-body">
 			<a href="/lq-ai/learn/how" class="lq-link">Want to see how this all fits together?</a>
-			— Five interactive playgrounds that show the system from request to response.
+			— Eleven interactive playgrounds that show the system from request to response.
 		</p>
 		<p class="lq-text-body">
 			For the full shipped/deferred capability catalog, read


### PR DESCRIPTION
## What

The three Learn sub-pages were written at M1 and **underclaimed the shipped M2/M3 surface** — the same transparency drift the playground-viz audit (#88) fixed, now in the prose pages.

### `use` — How to Use
- Reframed intro + footer: "every M1 feature" → M1–M3; "Five interactive playgrounds" → "Eleven" (matches what the `how` page embeds).
- **Added 5 verified sections** for post-M1 user-facing features: verified citations (Citation Engine chip states), playbooks, tabular review, the Word add-in (plumbing-only — honest about DE-287/295), admin intake bridges (honest about DE-312).
- Every new section's **Source / E2E-test / audit-action link verified against the codebase** (no invented paths; audit-action lines omitted where no such action exists).
- Fixed a latent rendering bug: `/<alias>` was parsed as a phantom element (now escaped) — cleared the file's only svelte-check warning.

### `build` — How to Build
- **Roadmap fix:** M2 and M3 were marked `--future` but are **shipped** (→ `--shipped`).
- **Accuracy corrections:** Playbooks shipped in M3-A (not M2); the M2 provider adapter that actually landed is **Azure OpenAI** — there are no `vertex.py`/`bedrock.py` adapters (config-only). M3 line now lists Playbooks/Tabular/Bridges/OTel/Word-addin.
- **Added a "before you open a PR" section** linking the test-landscape playground, the OTel trace explorer, and `docs/observability.md` — this is where the dev-facing testing + observability viz live (per the request), and it wires `test-landscape.html` into the site.

### `how` — How it Works
- Fixed the stale doc-comment count (Ten → Eleven iframes; added observability trace to the narrative). Body claims spot-checked — accurate; no §12 added (the test landscape is a contributor concern → lives on the build page).

## Verification
- **svelte-check (the CI gate): 0 errors.** No vitest/Cypress test references these pages.
- Prettier dirtiness on `use`/`how` is **pre-existing on main** (CI runs svelte-check + vitest, not Prettier) — left untouched to avoid an out-of-scope reformat.

## ⚠️ Merge ordering
The build page links to `/learn/playgrounds/test-landscape.html`, which ships in **#91** — merge #91 first (or alongside) so the link resolves. SvelteKit does not validate `href` targets, so build/CI order is unaffected.

Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)