### PR TITLE
chore(gateway): bump __version__ 0.1.0 → 0.3.0 for v0.3.0

### DIFF
--- a/gateway/app/__init__.py
+++ b/gateway/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI Inference Gateway."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
## What

The gateway version string was never bumped alongside the api (which moved to `0.3.0` in M3-E1 / #80). At the `v0.3.0` tag, the **gateway service self-reports `0.1.0`** in its startup log and OpenAPI `version` field. This bumps it to match.

The real fix (single source of truth across services) remains **DE-311**.

## Follow-up
Once this merges, the `v0.3.0` tag will be moved to the new `main` HEAD so the gateway reports `0.3.0` within the release.

> Touches `gateway/**` — security-gated. It's a one-character version-string change with no security surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)