### PR TITLE
fix(ci): authenticate to GHCR in the Release SBOM job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,18 @@ jobs:
             echo "tag=dryrun-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           fi
 
+      # syft pulls the just-pushed image from GHCR, which is private — without
+      # an authenticated docker login the pull fails with `UNAUTHORIZED` and the
+      # SBOM step errors out (the build-and-push and sign jobs already log in;
+      # this job was missing the equivalent step). packages:read on this job is
+      # sufficient for the pull.
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate SBOM (SPDX JSON)
         uses: anchore/sbom-action@v0
         with:


### PR DESCRIPTION
## What

The `Release` workflow went red on the `v0.3.0` tag. **Build/push succeeded** (the v0.3.0 images are on ghcr); the failure is the **`sbom` job** — `anchore/sbom-action` (syft) scans the just-pushed `ghcr.io/legalquants/lq-ai-<svc>:<tag>` image but the job never logged in to GHCR, so the pull failed:

```
ERROR could not determine source: ... UNAUTHORIZED: authentication required
```

The `build-and-push` and `sign` jobs both have a `docker/login-action` step; the `sbom` job was missing it. This is the **first release tag since the SBOM/provenance/cosign (OpenSSF T1–T3) steps landed**, which is why it didn't surface at v0.2.0.

## Fix
Add a `Login to GHCR` step to the `sbom` job (mirrors the `sign` job). `packages: read` on the job is sufficient for the pull.

## Notes
- The workflow does **not** create a GitHub Release object — that's a separate manual step (which is why Releases still shows v0.2.0). Handling that separately.
- Tag-triggered runs use the workflow file from the tagged commit, so getting a green run *for v0.3.0 specifically* would require moving the tag onto a commit that includes this fix — calling that out for a decision rather than doing it unilaterally.

> Touches `.github/workflows/**` — security-gated.

Refs DE-290

🤖 Generated with [Claude Code](https://claude.com/claude-code)