### PR TITLE
fix(compose): unblock default install — bridge vars use ${VAR:-} not ${VAR:?} (DE-305, #92)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -430,13 +430,13 @@ services:
         condition: service_healthy
     environment:
       # Slack-side credentials (operator obtains from Slack App admin UI)
-      SLACK_CLIENT_ID: ${SLACK_CLIENT_ID:?SLACK_CLIENT_ID is required when slack profile is enabled}
-      SLACK_CLIENT_SECRET: ${SLACK_CLIENT_SECRET:?SLACK_CLIENT_SECRET is required when slack profile is enabled}
-      SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:?SLACK_SIGNING_SECRET is required when slack profile is enabled}
+      SLACK_CLIENT_ID: ${SLACK_CLIENT_ID:-}
+      SLACK_CLIENT_SECRET: ${SLACK_CLIENT_SECRET:-}
+      SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:-}
       # LQ.AI-side coordinates
       LQ_AI_BACKEND_URL: ${LQ_AI_BACKEND_URL:-http://api:8000}
-      LQ_AI_BRIDGE_TOKEN: ${LQ_AI_BRIDGE_TOKEN:?LQ_AI_BRIDGE_TOKEN is required when slack profile is enabled}
-      LQ_AI_BRIDGE_PUBLIC_URL: ${LQ_AI_BRIDGE_PUBLIC_URL:?LQ_AI_BRIDGE_PUBLIC_URL is required when slack profile is enabled}
+      LQ_AI_BRIDGE_TOKEN: ${LQ_AI_BRIDGE_TOKEN:-}
+      LQ_AI_BRIDGE_PUBLIC_URL: ${LQ_AI_BRIDGE_PUBLIC_URL:-}
       # Observability (opt-in)
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-lq-ai-slack-bridge}
@@ -473,12 +473,12 @@ services:
         condition: service_healthy
     environment:
       # Microsoft-side credentials (Azure AD multi-tenant app)
-      MICROSOFT_APP_ID: ${MICROSOFT_APP_ID:?MICROSOFT_APP_ID is required when teams profile is enabled}
-      MICROSOFT_APP_PASSWORD: ${MICROSOFT_APP_PASSWORD:?MICROSOFT_APP_PASSWORD is required when teams profile is enabled}
+      MICROSOFT_APP_ID: ${MICROSOFT_APP_ID:-}
+      MICROSOFT_APP_PASSWORD: ${MICROSOFT_APP_PASSWORD:-}
       # LQ.AI-side coordinates
       LQ_AI_BACKEND_URL: ${LQ_AI_BACKEND_URL:-http://api:8000}
-      LQ_AI_BRIDGE_TOKEN: ${LQ_AI_BRIDGE_TOKEN:?LQ_AI_BRIDGE_TOKEN is required when teams profile is enabled}
-      LQ_AI_TEAMS_BRIDGE_PUBLIC_URL: ${LQ_AI_TEAMS_BRIDGE_PUBLIC_URL:?LQ_AI_TEAMS_BRIDGE_PUBLIC_URL is required when teams profile is enabled}
+      LQ_AI_BRIDGE_TOKEN: ${LQ_AI_BRIDGE_TOKEN:-}
+      LQ_AI_TEAMS_BRIDGE_PUBLIC_URL: ${LQ_AI_TEAMS_BRIDGE_PUBLIC_URL:-}
       # Observability (opt-in)
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-lq-ai-teams-bridge}

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4143,6 +4143,8 @@ Two bulk operations as originally written in the M3-C4 spec:
 
 #### DE-305 — Bridge env vars use `${VAR:?}` and break all Compose commands when unset (M3-E1 finding F1)
 
+**Status:** ✅ RESOLVED (2026-05-24) — independently reported by a community contributor as [issue #92](https://github.com/LegalQuants/lq-ai/issues/92). Fix: the 8 opt-in bridge vars in `docker-compose.yml` changed from `${VAR:?msg}` to `${VAR:-}` (the 4 core secrets keep `${VAR:?}`); the "required when the profile is active" guarantee moved into each bridge's `Settings` via a `field_validator` that rejects empty/whitespace credentials at startup (runs only when the profile is active). A default `docker compose up` with only the 4 core vars now succeeds. Regression tests: `slack-bridge/tests/test_config.py`, `teams-bridge/tests/test_config.py`.
+
 **Priority:** P2 (degrades the fresh-install / non-bridge-operator experience) · **Effort:** S (~1–2 hr)
 
 **Context:** Surfaced during M3-E1 fresh-install verification. `docker-compose.yml` declares the slack-bridge and teams-bridge env vars (`LQ_AI_BRIDGE_TOKEN`, `SLACK_CLIENT_ID`, `MICROSOFT_APP_ID`, etc.) with the required-error `${VAR:?msg}` interpolation form. Docker Compose interpolates **every** service definition at parse time regardless of the active `--profile`, so any `docker compose` command (`up`, `down`, `config`, `ps`) fails with `"required variable LQ_AI_BRIDGE_TOKEN is missing a value"` for an operator who has not set the bridge vars — **even one who never enables the `slack`/`teams` profiles.** This directly contradicts `.env.example` (~L297-300): "Operators who don't use Slack can leave all of the variables below unset."

--- a/slack-bridge/app/config.py
+++ b/slack-bridge/app/config.py
@@ -24,7 +24,7 @@ PRD §5.7's "no telemetry by default" promise) and the log level
 
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import Field, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -85,6 +85,32 @@ class Settings(BaseSettings):
         default="INFO",
         description="Python logging level for the bridge process.",
     )
+
+    @field_validator(
+        "slack_client_id",
+        "slack_client_secret",
+        "slack_signing_secret",
+        "lq_ai_bridge_token",
+        "lq_ai_bridge_public_url",
+    )
+    @classmethod
+    def _required_when_slack_enabled(cls, value: str, info: ValidationInfo) -> str:
+        """Reject empty operator credentials at bridge startup.
+
+        These vars use the ``${VAR:-}`` (empty-default) form in
+        ``docker-compose.yml`` so a default ``docker compose up`` with the
+        ``slack`` profile inactive does not abort at interpolation time
+        (DE-305 — Compose interpolates every service before profile
+        filtering). The "required when the profile is active" guarantee
+        moves here: the bridge only constructs ``Settings`` when its
+        container starts (i.e. when the ``slack`` profile is enabled), so
+        an empty value fails fast with a clear message instead of starting
+        a broken bridge that only errors later at OAuth time.
+        """
+
+        if not value or not value.strip():
+            raise ValueError(f"{info.field_name} is required when the slack profile is enabled")
+        return value
 
 
 _settings: Settings | None = None

--- a/slack-bridge/tests/test_config.py
+++ b/slack-bridge/tests/test_config.py
@@ -1,0 +1,56 @@
+"""Tests for the slack-bridge Settings validator (DE-305).
+
+The bridge env vars use the ``${VAR:-}`` (empty-default) form in
+docker-compose.yml so a default ``docker compose up`` with the ``slack``
+profile inactive does not abort at interpolation time. The
+"required when the profile is active" guarantee moves into ``Settings``:
+the bridge only constructs ``Settings`` when its container starts (profile
+enabled), so an empty required credential must fail fast at startup.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+_VALID = {
+    "slack_client_id": "cid",
+    "slack_client_secret": "csecret",
+    "slack_signing_secret": "ssecret",
+    "lq_ai_backend_url": "http://api:8000",
+    "lq_ai_bridge_token": "token",
+    "lq_ai_bridge_public_url": "https://bridge.example.com",
+}
+
+
+def test_valid_settings_construct() -> None:
+    settings = Settings(**_VALID)
+    assert settings.slack_client_id == "cid"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "slack_client_id",
+        "slack_client_secret",
+        "slack_signing_secret",
+        "lq_ai_bridge_token",
+        "lq_ai_bridge_public_url",
+    ],
+)
+def test_empty_required_field_rejected(field: str) -> None:
+    """An empty operator credential fails fast with a clear message."""
+
+    bad = {**_VALID, field: ""}
+    with pytest.raises(ValidationError) as exc:
+        Settings(**bad)
+    assert "required when the slack profile is enabled" in str(exc.value)
+
+
+def test_whitespace_only_required_field_rejected() -> None:
+    bad = {**_VALID, "slack_client_id": "   "}
+    with pytest.raises(ValidationError) as exc:
+        Settings(**bad)
+    assert "slack_client_id is required when the slack profile is enabled" in str(exc.value)

--- a/teams-bridge/app/config.py
+++ b/teams-bridge/app/config.py
@@ -24,7 +24,7 @@ PRD §5.7's "no telemetry by default" promise) and the log level
 
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import Field, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -82,6 +82,31 @@ class Settings(BaseSettings):
         default="INFO",
         description="Python logging level for the bridge process.",
     )
+
+    @field_validator(
+        "microsoft_app_id",
+        "microsoft_app_password",
+        "lq_ai_bridge_token",
+        "lq_ai_teams_bridge_public_url",
+    )
+    @classmethod
+    def _required_when_teams_enabled(cls, value: str, info: ValidationInfo) -> str:
+        """Reject empty operator credentials at bridge startup.
+
+        These vars use the ``${VAR:-}`` (empty-default) form in
+        ``docker-compose.yml`` so a default ``docker compose up`` with the
+        ``teams`` profile inactive does not abort at interpolation time
+        (DE-305 — Compose interpolates every service before profile
+        filtering). The "required when the profile is active" guarantee
+        moves here: the bridge only constructs ``Settings`` when its
+        container starts (i.e. when the ``teams`` profile is enabled), so
+        an empty value fails fast with a clear message instead of starting
+        a broken bridge that only errors later at OAuth time.
+        """
+
+        if not value or not value.strip():
+            raise ValueError(f"{info.field_name} is required when the teams profile is enabled")
+        return value
 
 
 _settings: Settings | None = None

--- a/teams-bridge/tests/test_config.py
+++ b/teams-bridge/tests/test_config.py
@@ -1,0 +1,54 @@
+"""Tests for the teams-bridge Settings validator (DE-305).
+
+The bridge env vars use the ``${VAR:-}`` (empty-default) form in
+docker-compose.yml so a default ``docker compose up`` with the ``teams``
+profile inactive does not abort at interpolation time. The
+"required when the profile is active" guarantee moves into ``Settings``:
+the bridge only constructs ``Settings`` when its container starts (profile
+enabled), so an empty required credential must fail fast at startup.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+_VALID = {
+    "microsoft_app_id": "app-id",
+    "microsoft_app_password": "app-password",
+    "lq_ai_backend_url": "http://api:8000",
+    "lq_ai_bridge_token": "token",
+    "lq_ai_teams_bridge_public_url": "https://teams-bridge.example.com",
+}
+
+
+def test_valid_settings_construct() -> None:
+    settings = Settings(**_VALID)
+    assert settings.microsoft_app_id == "app-id"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "microsoft_app_id",
+        "microsoft_app_password",
+        "lq_ai_bridge_token",
+        "lq_ai_teams_bridge_public_url",
+    ],
+)
+def test_empty_required_field_rejected(field: str) -> None:
+    """An empty operator credential fails fast with a clear message."""
+
+    bad = {**_VALID, field: ""}
+    with pytest.raises(ValidationError) as exc:
+        Settings(**bad)
+    assert "required when the teams profile is enabled" in str(exc.value)
+
+
+def test_whitespace_only_required_field_rejected() -> None:
+    bad = {**_VALID, "microsoft_app_id": "   "}
+    with pytest.raises(ValidationError) as exc:
+        Settings(**bad)
+    assert "microsoft_app_id is required when the teams profile is enabled" in str(exc.value)


### PR DESCRIPTION
Fixes #92 (tracked internally as **DE-305**).

## Problem
Docker Compose interpolates **every** service definition before applying `--profile` filtering, so the profile-gated `slack-bridge`/`teams-bridge` env vars declared with the required-error `${VAR:?msg}` form aborted a plain `docker compose up` — even for operators who never enable those profiles:

```
error while interpolating services.slack-bridge.environment.SLACK_CLIENT_ID: required variable SLACK_CLIENT_ID is missing a value
```

This contradicted `.env.example` (the bridge vars are documented as leave-blank-if-unused) and broke the README Quick Start for every fresh install. Reported independently — with an excellent, precise diagnosis — by @legalinnovationaggregator-coder.

## Fix
- **`docker-compose.yml`:** the 8 opt-in bridge vars change `${VAR:?…}` → `${VAR:-}`. The 4 core secrets (`POSTGRES_PASSWORD`, `MINIO_ROOT_PASSWORD`, `LQ_AI_GATEWAY_KEY`, `JWT_SECRET`) keep `${VAR:?}`.
- **The "required when the profile is active" guarantee moves into each bridge's `Settings`** via a `field_validator` that rejects empty/whitespace credentials. It runs only when the bridge container starts (profile enabled) and preserves the exact `"X is required when the <slack|teams> profile is enabled"` message — fail-fast at startup beats a bridge that boots broken and only errors at OAuth time. (This is precisely the reporter's suggested approach.)
- **Regression tests:** `slack-bridge/tests/test_config.py` (7), `teams-bridge/tests/test_config.py` (6).

## Verification
- `docker compose --env-file <only 4 core vars> config` → **succeeds** with no `--profile` (the exact reported scenario).
- `docker compose --profile slack config` → still resolves `slack-bridge` (empty default, caught by the startup validator).
- Both new test suites pass; `ruff format`/`ruff check` clean.

> Touches `docker-compose.yml` + the bridge services. The bridge suites aren't in the main CI matrix (like the repo-root `tests/`), so the new config tests run locally / on demand.

Closes #92