### PR TITLE
chore(release): bump version 0.3.0 → 0.3.1 for the v0.3.1 patch

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI backend API service."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/gateway/app/__init__.py
+++ b/gateway/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI Inference Gateway."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
Bumps `api/app/__init__.py` + `gateway/app/__init__.py` `__version__` to **0.3.1** for the v0.3.1 patch release (DE-305 / #92 — the bridge `${VAR:?}` default-install blocker, fixed in #96).

No api/gateway app-code change in the patch; both bump so they self-report the release version. Single-source-of-truth fix remains DE-311.

## Follow-up
Once this merges, I'll cut the **v0.3.1** annotated tag on the new `main` HEAD (the Release workflow runs green → images + SBOM + cosign signatures) and mirror the tag to Tucuxi — same flow as v0.3.0.