### PR TITLE
fix(ci): don't upload SBOM as a GitHub Release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,13 @@ jobs:
           artifact-name: ${{ matrix.service }}.spdx.json
           upload-artifact: true
           upload-artifact-retention: 90
+          # Do NOT attach the SBOM as a GitHub Release asset. anchore/sbom-action
+          # defaults this to true and tries the releases API when the run is on a
+          # tag — which needs `contents: write` (this job is `contents: read`) and
+          # fails with "Resource not accessible by integration" whenever a Release
+          # for the tag already exists. The SBOM is delivered as a signed cosign
+          # attestation by the `sign` job; the Actions artifact above feeds that.
+          upload-release-assets: false
 
       - name: Verify SBOM is non-empty
         run: |


### PR DESCRIPTION
## What
The `Release` workflow went red on the **v0.3.1** tag at the SBOM step (login now succeeds thanks to #95):
```
##[error]Resource not accessible by integration
```
`anchore/sbom-action` defaults `upload-release-assets: true`, so on a tag run it calls the GitHub **releases API** to attach the SBOM — which needs `contents: write`, but the `sbom` job is `contents: read`. It fails whenever a **Release for the tag already exists** (it did for v0.3.1). v0.3.0's run only went green because no published Release existed yet when its SBOM step ran — order-dependent and fragile.

## Fix
Set `upload-release-assets: false`. The SBOM is delivered as a **signed cosign attestation** by the `sign` job (fed by the Actions artifact, which still uploads), so attaching it as a release asset is unnecessary.

## v0.3.1 note
v0.3.1's images are built + pushed; only the SBOM/cosign attestations didn't complete. Once this merges, moving the v0.3.1 tag onto the post-fix HEAD gives it a green run + attestations (or we leave v0.3.1's run as-is and this covers future releases).

> Touches `.github/workflows/**` — security-gated.

Refs DE-290