### PR TITLE
docs(m4): land the approved Autonomous Layer design on main (ADR 0013 + PRD §3.10 + alignment guide)

### DIFF
--- a/docs/LQVern/HANDOFFlavernevaluation.md
+++ b/docs/LQVern/HANDOFFlavernevaluation.md
@@ -1,0 +1,267 @@
+# Session handoff — Lavern evaluation and integration into the LQ.AI roadmap
+
+> **Audience:** Claude Code running on **a different machine from the one where this work was drafted**. The originating session was a Claude Code web session (Anthropic-hosted ephemeral container) that could not push to the remote due to GitHub App permission scope. That container's local git state is unreachable from here — everything needed to continue is in this document and the accompanying `de-265.patch` file, both of which Kevin will hand to you.
+>
+> **Branch:** `claude/evaluate-lavern-integration-YMMJi` — created in the web session, **never pushed to the remote**, and the web session's container is gone. You will create the branch fresh on the receiving machine.
+>
+> **External reference:** [AnttiHero/lavern](https://github.com/AnttiHero/lavern) — Apache 2.0, TypeScript/Fastify/SQLite, open-source multi-agent legal review system.
+
+---
+
+## 0. What's already done (and how to recover it on a fresh machine)
+
+A web Claude Code session evaluated Lavern against the LQ.AI PRD and roadmap, drafted DE-265 in `docs/PRD.md`, and committed it as `4bf2c0c` on `claude/evaluate-lavern-integration-YMMJi`. The push was blocked: the git proxy returned 403 (`Permission to LegalQuants/lq-ai.git denied to Kevin-Tucuxi`) despite Kevin-Tucuxi being admin on the repo, and the GitHub MCP returned `Resource not accessible by integration` (Claude GitHub App installation scope on this repo is insufficient). Because the web session's container is ephemeral, the commit object `4bf2c0c` exists nowhere except inside that (now-discarded) container — it cannot be fetched from anywhere on the network. The substantive content of the commit travels with this handoff as `de-265.patch`.
+
+**To recover the work on the receiving machine** (which has its own clone of `legalquants/lq-ai` — or needs one):
+
+```bash
+# 1. If you don't yet have a clone on this machine:
+git clone https://github.com/legalquants/lq-ai.git
+cd lq-ai
+
+# 2. If you do, make sure you have the latest main:
+cd /path/to/lq-ai
+git fetch origin
+git checkout main
+git pull origin main
+
+# 3. Create the branch fresh, off origin/main (matches what the web session did):
+git checkout -b claude/evaluate-lavern-integration-YMMJi origin/main
+
+# 4. Apply the patch Kevin handed you alongside this document.
+#    On most systems Kevin will have downloaded it to ~/Downloads/de-265.patch
+#    or similar — adjust the path to wherever the file actually lives:
+git am ~/Downloads/de-265.patch
+
+# 5. Verify the result:
+git log --oneline -2            # should show your new commit on top of origin/main
+git diff origin/main -- docs/PRD.md | head -50
+
+# 6. Push to the remote and continue with §5 of this handoff.
+git push -u origin claude/evaluate-lavern-integration-YMMJi
+```
+
+**If `git am` fails** (e.g., because Kevin's local git identity differs from the patch's, or the patch is malformed in transit), fall back to recreating the commit manually: the full text of DE-265 is reproduced verbatim in §3 below — open `docs/PRD.md`, find the line "### How to add to this list" inside §9, paste DE-265's content immediately before that subsection (after DE-264's "**Acceptance criteria — Phase A:** …" closing line), and commit with the same message:
+
+```
+Add DE-265: Lavern as design reference for Autonomous Layer, ensemble, MCP
+```
+
+Either path lands the same final state. Then push and proceed with §5–§9 below.
+
+---
+
+## 1. What Lavern is (factual summary)
+
+From `https://github.com/AnttiHero/lavern` (README + repo metadata, observed 2026-05-20):
+
+- **License:** Apache 2.0.
+- **Stack:** TypeScript (~93% of LOC), React dashboard, Fastify API with WebSocket support, SQLite (FTS5 for full-text), Docker deploy. 1,677 tests across 105 files.
+- **Tagline:** "An agentic law firm" emphasizing evidence-based reasoning over single-pass LLM answers.
+- **Composition:**
+  - 67 specialist agent prompts (59 specialists + 8 orchestrators) coordinated through an adversarial debate protocol.
+  - Three-layer verification pipeline: evaluator gates, adversarial debate, 10-pass verification (context, clarity, accuracy, risk, …).
+  - 21 MCP tools (debate, scoring, verification, knowledge management).
+  - 9 workflow templates ranging from single-specialist consultation to full adversarial review.
+  - 5 bundled legal datasets: CUAD, MAUD, ACORD, UNFAIR-ToS, LEDGAR.
+  - Persistent "precedent board" tracking recurring patterns across documents.
+  - Mandatory human approval gates before critical findings deliver.
+- **Operating modes:**
+  - **Interactive** — web dashboard, real-time agent observation, human gates.
+  - **Clawern (autonomous)** — 30-min heartbeat monitoring, email/Telegram alerts, precedent accumulation, cost forecasting.
+  - **EU mode** — routes through Mistral instead of Anthropic.
+- **Providers:** Anthropic, Mistral (EU), local Ollama.
+- **Stated limitations** (from the README itself): no independent public benchmark; no vector/dense retrieval for knowledge search; no durable task queue; counsel deliveries range 5–10 minutes.
+
+---
+
+## 2. The strategic conclusion (and why)
+
+**Lavern is not directly integrable** into LQ.AI as code:
+
+- **Stack mismatch.** TypeScript/Fastify/SQLite vs. LQ.AI's Python/FastAPI/Postgres/SvelteKit. Apache 2.0 permits vendoring, but the integration cost is the architecture, not the license.
+- **LQ.AI's substrate is strictly stronger** for the same goals: pgvector + Postgres FTS hybrid retrieval (§3.5), char-precise deterministic citation verification (§3.3, shipped M2), Redis-backed durable task queue, OpenWebUI Pipelines framework as the autonomous substrate (§3.10).
+- **Lavern's quality claims are unvalidated** — no independent benchmark. Per LQ.AI's §1.9 conservative-posture principle, claims-by-agent-count are not adopted as quality signals.
+
+**Lavern is the closest public prior art** for several LQ.AI roadmap commitments that are currently underdesigned in the PRD:
+
+| LQ.AI section | Lavern's contribution |
+|---|---|
+| §3.10 Autonomous Layer (M4) | Clawern pipeline = working pattern for the open questions in §3.10 |
+| §3.8 Ensemble Verification (full-chat-path extension, deferred) | Debate-and-evaluator shape candidate |
+| §8.5 M5+ MCP-client subsystem | 21-tool catalog = starting categorization |
+| §3.7 Playbooks / §3.14 Tabular | Workflow-template spectrum = complexity-dial framing |
+
+**Treatment:** design reference, not dependency. Study, write up the influences as ADRs/mini-PRDs, fold concrete increments into existing M3/M4/M5+ scope. Do not import code, do not bulk-import the 67-agent prompt corpus (skill-contribution path applies per skill per §7.5).
+
+---
+
+## 3. DE-265 — the entry already drafted
+
+Committed locally as `4bf2c0c`, inserted into `docs/PRD.md` after DE-264, before the "How to add to this list" subsection of §9. **Full text below** in case the patch is unavailable:
+
+````markdown
+#### DE-265 — Lavern as design reference for the Autonomous Layer, full-path ensemble, and MCP catalog
+
+**Priority:** P2 · **Effort:** S (this entry — design study + ADRs) plus downstream impact on M3/M4/M5+ work already scoped
+
+**Context:** [AnttiHero/lavern](https://github.com/AnttiHero/lavern) is an Apache 2.0, TypeScript/React/Fastify/SQLite, open-source "agentic law firm" for document review. It ships 67 specialist agent prompts coordinated through an adversarial debate protocol, a 3-layer verification pipeline (evaluator gates + adversarial debate + 10-pass verification), 21 MCP tools, 9 workflow templates (single-specialist → full adversarial review), 5 bundled legal datasets (CUAD, MAUD, ACORD, UNFAIR-ToS, LEDGAR), a persistent "precedent board," and an autonomous mode ("Clawern") with 30-minute heartbeat monitoring, email/Telegram alerts, precedent accumulation, and cost forecasting. It supports Anthropic, Mistral (EU mode), and local Ollama.
+
+Lavern is the closest public prior art for several LQ.AI roadmap commitments that are currently underdesigned in the PRD, particularly **§3.10 Autonomous Layer (M4)**, the deferred "full chat path" extension of **§3.8 Multi-Model Ensemble Verification**, the MCP tool catalog shape implied by **§8.5 M5+ MCP-client subsystem**, and a possible "complexity dial" on **§3.7 Playbooks (M3)** and **§3.14 Tabular Review (M3)**. Studying Lavern's design choices and writing them up against ours before M3/M4 design freezes is much cheaper than re-deriving the same shape from scratch.
+
+**Stack mismatch makes direct integration uneconomical.** Lavern is TypeScript/React/Fastify/SQLite; LQ.AI is Python/FastAPI/Postgres/SvelteKit (OpenWebUI fork). Apache 2.0 permits code vendoring, but the architecture surface (sync wire formats, single-process SQLite, no vector retrieval, no durable task queue) is strictly weaker than what LQ.AI has already built or specified — re-implementing the ideas natively in the existing services is the right path. Lavern's quality claims also lack independent benchmarks; treat the design as inspiration, not as validated implementation.
+
+**Specific overlap map.**
+
+| Lavern feature | LQ.AI section | Treatment |
+|---|---|---|
+| 67 specialist agent prompts | §3.4 Skill Library | Already the model. The 67-prompt corpus is potentially seed material for community skills under `skills/community/` (DE-001, DE-219), subject to the skill-contribution path's attorney-attestation gate (§7.5 / `skills/CONTRIBUTING.md`). |
+| Adversarial debate protocol with mandatory citations | §3.3 Citation Engine (shipped M2) + §3.8 Ensemble Verification (shipped narrowly on Stage 4 of Citation Engine) | LQ.AI's deterministic substring verification and char-precise offsets are stronger than Lavern's "agents must cite or be discarded." Lavern's contribution is a candidate execution shape for the deferred "full chat path ensemble" framing flagged in §3.8 — N agents debate, an evaluator gates, the user sees the disagreement structure rather than only the reconciled answer. |
+| 10-pass verification (context, clarity, accuracy, risk, …) | §3.7 Playbooks (§3.7), §3.14 Tabular Review | Suggests a complexity dial on Playbook execution: single specialist → small panel → full adversarial. Worth scoping as an option on `POST /api/v1/playbooks/{id}/execute` rather than a separate capability. |
+| 9 workflow templates | §3.7 Playbooks | The template taxonomy (cost vs. rigor) is a useful framing for how operators choose Playbook execution modes. |
+| 21 MCP tools (debate, scoring, verification, knowledge management) | §8.5 M5+ MCP-client subsystem | Concrete prior art for tool categorization and the registration surface. Worth comparing against the MCP-client subsystem skeleton planned for M5 before that work starts. |
+| Clawern autonomous mode (30-min heartbeat, alerts, cost forecast, precedent accumulation) | §3.10 Autonomous Layer (M4) | **Highest-value overlap.** §3.10 has committed the architectural slot but explicitly deferred detailed design ("M4 territory; detailed design deferred"). Lavern's Clawern is a working pattern for several of the open questions: how the heartbeat loop interacts with cost budgets, how alerts surface across email and chat, how precedent accumulation contrasts with Project context (§3.11) and user-curated memory. |
+| Persistent precedent board | §3.10 vs. §3.11 | A third framing — system-curated cross-matter patterns visible to the user — that sits between Project context (user-curated, per-matter) and autonomous memory (system-curated, system-visible). Worth deciding explicitly whether M4 absorbs this, rejects it, or files it as a separate construct. |
+| Bundled legal datasets (CUAD/MAUD/ACORD/UNFAIR-ToS/LEDGAR) | `docs/acceptance-testing-framework.md`; DE-237 eval harness | Useful eval corpora for the Citation Engine and Playbooks, independent of Lavern's runtime. Licensing of each dataset to be verified before any bundling. |
+| EU mode (routes through Mistral) | §1.5.2 Inference Tier Spectrum + Provider Compliance Matrix | Already addressed structurally by the Tier model. Lavern's framing as a single switch is worth borrowing as UX language ("EU residency mode") even though the underlying mechanism is the same provider routing. |
+
+**Specific scope (this DE):**
+
+*Phase 1 — design study (before M4 kickoff; ~1 day of reading + writing):*
+- Read Lavern's Clawern pipeline source (TypeScript) and write `docs/adr/00XX-autonomous-layer-design-influences.md` comparing it to the §3.10 sketch — naming what LQ.AI adopts, what it adapts, and what it rejects, with the open questions in §3.10 ("Open questions") answered or explicitly punted.
+- Read Lavern's debate protocol and write a short note in §3.8 (or an ADR cross-referenced from it) on whether the "full chat path ensemble" extension should adopt the debate-and-evaluator shape; if yes, file a follow-up DE with concrete scope.
+- Read Lavern's MCP tool catalog and capture the categorization in `docs/contribute/mini-prds/mcp-client-subsystem.md` (creating that mini-PRD if it does not yet exist) so the M5 design starts with prior art rather than a blank page.
+
+*Phase 2 — feature increments (folded into existing milestones, not net-new work):*
+- **M3 — Playbook execution-mode dial (§3.7).** Add `execution_mode: "single" | "panel" | "adversarial"` to the `POST /api/v1/playbooks/{id}/execute` body, defaulting to `single`. Panel and adversarial route through the same ensemble surface §3.8 already builds on. Cost preview surfaces the mode's expected token spend per §5.5. Estimated +S work on top of M3 §3.7.
+- **M4 — Autonomous Layer informed by Clawern (§3.10).** No new line items; the existing M4 scope absorbs the Phase 1 ADR's conclusions. Particular focus areas: heartbeat-loop cost-budget integration; alert surface (email + in-app + optional webhook to align with §3.15 Slack/Teams Bridge once it ships); precedent-board vs. autonomous-memory disambiguation.
+- **M5+ — MCP catalog seeded from Lavern (§8.5).** Phase 1 ADR's tool categorization becomes the starting catalog for the MCP-client subsystem's first iteration.
+
+**What is explicitly out of scope:** direct code reuse from Lavern (stack mismatch); bulk import of the 67-agent prompt corpus (skill-contribution path applies per skill); adoption of Lavern's SQLite/Fastify/no-vector-retrieval architecture choices (strictly weaker than LQ.AI's existing substrate); marketing claims about agent counts or verification-pass counts as a quality signal in their own right (§1.9 conservative-posture principle).
+
+**Acceptance criteria — Phase 1:** the autonomous-layer ADR is merged and cross-referenced from §3.10; the §3.8 follow-up note is merged and cross-referenced from §3.8; the MCP-client mini-PRD exists and references Lavern's tool catalog. **Acceptance criteria — Phase 2:** revisit when M3/M4/M5 design freezes for each milestone.
+````
+
+---
+
+## 4. Open framing questions Kevin flagged but did not resolve
+
+When DE-265 was drafted, four framing choices were called out for Kevin to redirect or accept. **Carry these into the next session and surface them explicitly before locking in downstream work:**
+
+1. **Priority P2 vs. P1.** DE-265 is currently P2 (design study influencing existing committed milestones). If Kevin wants to signal "must-be-done-before-M4-design-freeze," it should be P1.
+2. **Effort framing.** DE itself marked S (the design study). Phase 2 increments are folded into existing M3/M4/M5+ scope without separate hour estimates. Alternative framing: split each Phase 2 increment into its own DE so the work is trackable independently of the parent milestone.
+3. **Bulk-import question on the 67-agent corpus.** Currently rejected in DE-265 as "out of scope" because the skill-contribution attestation gate (§7.5) applies per-skill. A lighter-weight alternative worth considering: bulk-port to `skills/community/lavern-port/` as a *batch* draft, with attorney attestation as a follow-up DE that gates the directory's eligibility for default-install. Decide before any port work starts.
+4. **Tone on Lavern's quality claims.** Currently called "unvalidated" verbatim from the §1.9 conservative-posture principle. Soften, keep, or sharpen — Kevin's call.
+
+---
+
+## 5. The Phase 1 deliverables (next session's work)
+
+The DE specifies three Phase 1 design-study deliverables. **Land them as separate commits on the same branch** (`claude/evaluate-lavern-integration-YMMJi`), each with its own short PR-ready commit message.
+
+### 5.1. ADR — Autonomous-layer design influences from Clawern
+
+**File:** `docs/adr/00XX-autonomous-layer-design-influences.md` (pick the next number after the highest existing in `docs/adr/`).
+
+**Source material:** read Lavern's TypeScript source for Clawern. Specifically:
+- The heartbeat loop (search the repo for `heartbeat`, `30 minute`, or the cron entrypoint).
+- Cost forecasting logic (search for `forecast`, `budget`, `cost cap`).
+- Alert dispatch (email/Telegram — search for `nodemailer`, `telegram`, `alert`).
+- Precedent-board read/write (search for `precedent` in src/ paths).
+
+**Structure the ADR as:**
+- **Context.** Restate §3.10's stated scope and open questions verbatim (the §3.10 text already names what's deferred).
+- **Decision drivers.** What §3.10 needs from the design that the current sketch doesn't yet name.
+- **Considered alternatives.** Clawern-shaped (Lavern), Temporal/Celery-shaped, naive cron-job-shaped. For each, state the costs and what §3.10's open questions look like under that shape.
+- **Decision.** What LQ.AI adopts from Clawern, what it adapts, what it rejects.
+- **Open questions remaining.** Anything §3.10 still needs to resolve before M4 design freezes.
+- **Cross-references.** Link from §3.10's "Open questions" subsection to the new ADR, and from the ADR back to §3.10 and to DE-265.
+
+**Estimated effort:** 4–6 hours including the source-read.
+
+### 5.2. §3.8 follow-up note on full-chat-path ensemble
+
+**File:** edit `docs/PRD.md` §3.8 directly, OR create `docs/adr/00XX-full-chat-path-ensemble.md` and cross-reference from §3.8.
+
+**Content:** §3.8 currently states that the "full chat path ensemble" framing is **not built** and that operators wanting it configure parallel chat sessions manually. The follow-up note evaluates whether Lavern's debate-and-evaluator shape is the right execution surface if/when LQ.AI implements the full-chat-path extension. Specifically:
+
+- Does the debate-with-citations protocol degrade gracefully in Mode 2 (local Ollama only)? §3.8's existing fallback says it degrades to "diversified prompts on the same model" — Lavern's protocol assumes multiple distinct agent personas, which may or may not work with a single local model.
+- Where does the evaluator gate live — in the gateway (where ensemble currently lives) or in the backend (where it would need to coordinate with the citation engine)?
+- What does the UI show: only the reconciled answer (current §3.8 framing) or the disagreement structure (Lavern's user-facing innovation)?
+
+**Outcome:** either land a "yes, file DE-266 with concrete scope" recommendation, or land a "no, the current §3.8 framing is sufficient and the M2 narrow scope stands" recommendation with reasoning.
+
+**Estimated effort:** 2–3 hours.
+
+### 5.3. MCP-client mini-PRD seeded from Lavern's tool catalog
+
+**File:** `docs/contribute/mini-prds/mcp-client-subsystem.md`. Create if it does not exist (`ls docs/contribute/mini-prds/` to check first; the existing mini-PRD template in that directory shows the house style).
+
+**Content:**
+- Restate §8.5's commitment that the MCP-client subsystem is the integration substrate for M5+.
+- Enumerate the categories of tools that the MCP-client subsystem needs to host, **seeded by Lavern's 21-tool catalog**. Group as: debate/coordination, scoring/evaluation, verification, knowledge management. Add LQ.AI-specific categories that Lavern doesn't have (matter-scoped retrieval, privilege flags, tier enforcement).
+- Sketch the registration surface (config? auto-discovery? explicit registration in `gateway.yaml`?).
+- Sketch the per-tool security envelope: which tier can call which tools, what audit-log fields apply, how privilege flags propagate.
+- Acceptance criteria for the mini-PRD itself: "any community contributor can read this and start work on a specific tool integration."
+
+**Estimated effort:** 3–4 hours.
+
+---
+
+## 6. Phase 2 — what folds into M3/M4/M5+ (NOT next session's work)
+
+Recorded here only so the local CC instance has full context. **Do not start Phase 2 work in the same session as Phase 1 deliverables.**
+
+- **M3 work:** add `execution_mode` field to Playbook execution. Wave-into the existing M3 plan (`docs/M3-IMPLEMENTATION-PLAN.md` — check whether Phase A/B/C/etc. has a natural slot for this, or file as a new task within M3).
+- **M4 work:** the autonomous-layer ADR's conclusions inform M4 design. M4 has not started; carry the ADR's open questions into the M4-IMPLEMENTATION-PLAN drafting (whenever that begins).
+- **M5+ work:** the MCP-client mini-PRD seeds the M5 build. M5 is community-driven per §8.5; the mini-PRD is the contributor brief.
+
+---
+
+## 7. Files in `lq-ai` the next session should read first
+
+Roughly in priority order:
+
+| Path | Why |
+|---|---|
+| `docs/PRD.md §3.10` (lines ~866–899) | Autonomous Layer scope and open questions — primary input for the ADR in §5.1 |
+| `docs/PRD.md §3.8` (lines ~792–822) | Ensemble Verification current state and the "full chat path" deferral — primary input for §5.2 |
+| `docs/PRD.md §8.5` (lines ~1848–1877) | M5+ Workflow Intelligence and MCP-client subsystem — primary input for §5.3 |
+| `docs/PRD.md §3.7` (lines ~712–790) | Playbooks (M3) — for Phase 2 M3 work |
+| `docs/PRD.md §9 DE-265` (newly added) | Self-reference; the brief for everything else |
+| `docs/PRD.md §9 DE-263, DE-264` | House style for DE entries that wrap external projects |
+| `docs/adr/` directory | House style for ADRs (pick the most recent for tone calibration) |
+| `docs/contribute/mini-prds/` directory | House style for mini-PRDs |
+| `CLAUDE.md` | Project orientation; decision-routing rules — read first if unfamiliar with the codebase |
+| `docs/HONEST-STATE.md` | What's shipped vs. deferred — useful sanity check before claiming anything about current state |
+
+---
+
+## 8. Constraints carried forward (from `CLAUDE.md`)
+
+The next session must obey these — they materially affected DE-265's framing:
+
+- **Decisions are explicit, not implicit.** If a Phase 1 deliverable surfaces an architectural decision not anchored in §3.10/§3.8/§8.5, stop and ask Kevin rather than guess.
+- **Don't expand scope.** Phase 1 deliverables are studies and ADRs, not implementation. Don't draft migration files, don't add API endpoints, don't start Phase 2 prematurely.
+- **Surface ideas as DE-XXX.** If reading Lavern's source surfaces useful adjacencies not covered by DE-265, file them as new DE entries in `docs/PRD.md §9` rather than expanding DE-265.
+- **Conservative posture extends to engineering.** Don't claim Clawern's design "works" — claim only what its source code demonstrates. The §1.9 principle and Lavern's lack of independent benchmarks both apply.
+
+---
+
+## 9. What to send Kevin back after Phase 1 lands
+
+Three deliverables on `claude/evaluate-lavern-integration-YMMJi`:
+
+1. `docs/adr/00XX-autonomous-layer-design-influences.md` (new file).
+2. `docs/PRD.md §3.8` updated, OR `docs/adr/00XX-full-chat-path-ensemble.md` (new file).
+3. `docs/contribute/mini-prds/mcp-client-subsystem.md` (new file).
+
+Plus the DE-265 commit already on the branch (`4bf2c0c`).
+
+PR title: `DE-265: Lavern design study — autonomous layer ADR, ensemble note, MCP mini-PRD`.
+
+PR body should resolve the four framing questions in §4 above (Kevin will weigh in during review if any need adjustment).
+
+---
+
+*Drafted in a Claude Code web session on 2026-05-20. Hand this document plus `de-265.patch` to a Claude Code instance on a different machine (the web session's container is gone; nothing of the work survives outside these two files). The receiving machine needs its own clone of `legalquants/lq-ai` and a GitHub identity with push access to it — see §0 for the recovery procedure.*

--- a/docs/LQVern/README.md
+++ b/docs/LQVern/README.md
@@ -1,0 +1,21 @@
+# LQVern — M4 Autonomous Layer working folder
+
+This folder collects the design + contributor material for **M4 / LQVern**: incorporating autonomous tasks (the PRD §3.10 Autonomous Layer) into LQ.AI, using [AnttiHero/lavern](https://github.com/AnttiHero/lavern)'s **Clawern** autonomous mode as a *design reference* (not a code dependency — stack mismatch; see DE-289).
+
+## Canonical design artifacts (read these in order)
+
+1. **[ADR 0013 — Autonomous Layer design influences](../adr/0013-autonomous-layer-design-influences.md)** — the gating design study. Pins single-agent v1, the api/arq executor substrate, the four primitives, the R4/R5/R6 brakes, the memory + precedent-board model, and the alignment contract. Answers §3.10's open questions.
+2. **[PRD §3.10 Autonomous Layer](../PRD.md#310-autonomous-layer-m4)** — the built-out capability spec (data model, API surface, functional requirements, alignment contract).
+3. **[agentic-flow-alignment-guide.md](agentic-flow-alignment-guide.md)** — the contributor how-to: the transparency/audit/OTel contract with pseudo-code, how to leverage the backend, and the "is my flow aligned?" checklist. **The most important doc for whoever builds this.**
+
+Still to come (via the writing-plans step, after Kevin reviews the above): the phased implementation plan, and the Learn-tab visualization spec (a new "Autonomous flow" playground + How-it-Works section + build-page "anatomy of an aligned agentic flow" viz).
+
+## Provenance / source material
+
+- **`HANDOFFlavernevaluation.md`** — the original Lavern-evaluation handoff from a prior Claude Code web session (Lavern factual summary, the strategic "design reference, not dependency" conclusion, and the original Phase-1 deliverable structure). Useful reference; some of its scope framing is now superseded by ADR 0013 + the current PRD.
+
+The work began as a "DE-265" PRD patch; that content was re-landed and renumbered on `main` as **DE-289** (expanded there with the boundary-register mapping), so the original patch is not carried here.
+
+## Status
+
+Design phase (feature branch `feat/lqvern-m4-autonomous`). The branch is intended for others to build on: the ADR + PRD build-out + alignment guide give a contributor the *what*, *why*, and *how* (including how agentic flows stay aligned with LQ.AI's transparent, auditable, OpenTelemetry-instrumented approach) before implementation begins.

--- a/docs/LQVern/agentic-flow-alignment-guide.md
+++ b/docs/LQVern/agentic-flow-alignment-guide.md
@@ -1,0 +1,203 @@
+# Building aligned agentic flows in LQ.AI (M4 / LQVern contributor guide)
+
+> **Audience:** anyone implementing an autonomous flow on the M4 Autonomous Layer (`api/app/autonomous/`). Read [ADR 0013](../adr/0013-autonomous-layer-design-influences.md) and [PRD §3.10](../PRD.md#310-autonomous-layer-m4) first — this guide is the *how*, those are the *what* and *why*.
+>
+> **The one rule this guide exists to enforce:** an autonomous agent acts without a human watching each step, so the human must be able to read, afterward, **exactly what it did and why** — and the agent must be unable to overspend, run away, or use a tool it wasn't granted in its current phase. Transparency and the brakes are not features you add at the end; they are the shape of the loop. Code that omits them is not done.
+
+---
+
+## 1. Why autonomy raises the bar
+
+LQ.AI's founding principle (PRD §1.3) is transparency: every artifact that shapes the user's experience is visible work product. For chat, that's the Skill Inspector + receipts. For an **autonomous** flow, the model takes actions the user did not individually approve — so the transparency obligation moves from "you can read the prompt" to "you can audit the **behavior**." Concretely, three surfaces are mandatory for every flow:
+
+1. **OTel domain spans** — so an operator can trace what ran, how long, what it cost, and whether the brakes fired.
+2. **A closed-enum audit trail** — so there is a durable, queryable record of every consequential action.
+3. **A human-readable per-session receipt** — so the *user* (not just the operator) can read "what the agent did and why."
+
+Plus the three brakes from the boundary-register catalog (PRD §1.8, [DE-293](../PRD.md#de-293)): **R4 cost cap**, **R5 halt switch + idle timeout**, **R6 phase-gated tool grants** — checked **before every tool call**.
+
+---
+
+## 2. The shape of an aligned flow
+
+An autonomous flow is a **LangGraph state machine** (mirroring `api/app/playbooks/executor.py`) running on the **arq-worker**, with one `autonomous_session` row as its durable state. Every tool call passes through a single chokepoint — `guarded_tool_call` — that enforces all three brakes, emits the span, and writes the audit row. **There is exactly one chokepoint on purpose:** a contributor adding a new tool gets the brakes + telemetry for free and cannot accidentally route around them.
+
+```
+arq schedule/watch trigger
+        │
+        ▼
+ create autonomous_session(user_id, max_cost_usd, phase="intake", halt_state="running")
+        │
+        ▼
+ LangGraph loop ── for each step ──▶ guarded_tool_call(session, tool, intent, params)
+        │                                   │  1. read halt_state            (R5)
+        │                                   │  2. check phase grants tool    (R6)
+        │                                   │  3. project cost vs remaining  (R4)
+        │                                   │  4. open OTel span + audit row
+        │                                   │  5. run tool (inference via gateway, retrieval, etc.)
+        │                                   │  6. record cost, outcome; close span + audit row
+        │                                   ▼
+        │                            (any check fails → halt cleanly, write partial result + reason)
+        ▼
+ emit per-session receipt; notify; persist session terminal state
+```
+
+The phases are a closed enum (`intake → analysis → drafting → ethics_review → delivery`); transitions are explicit and audited. Tool grants are declared **per phase**, so a tool available at `intake` (e.g. broad retrieval) can be stripped by `ethics_review` (ADR 0013 D3, R6).
+
+---
+
+## 3. The mandatory contract — pseudo-code
+
+> Illustrative. The authoritative patterns to copy are `api/app/playbooks/executor.py` + `nodes.py` + `state.py` (LangGraph + Pydantic-typed state), `api/app/observability_helpers.py` (`get_tracer` / `record_attributes` / `@traced`), the `audit_log` write pattern in `api/app/api/*.py`, and the M2-E2 cost estimator in `api/app/citation/cost.py`. Do not invent new helpers where these exist.
+
+```python
+# api/app/autonomous/executor.py  (illustrative)
+from app.observability_helpers import get_tracer, record_attributes
+
+tracer = get_tracer(__name__)
+
+# Closed enum — the ONLY tools a flow may call. Adding a tool = adding an enum member.
+class ToolIntent(StrEnum):
+    retrieve_chunks = "retrieve_chunks"
+    run_skill = "run_skill"
+    run_playbook = "run_playbook"
+    propose_memory = "propose_memory"
+    emit_finding = "emit_finding"
+    notify = "notify"
+
+# Per-phase grants: phase -> allowed intents (R6).
+PHASE_GRANTS: dict[Phase, set[ToolIntent]] = {
+    Phase.intake:        {ToolIntent.retrieve_chunks},
+    Phase.analysis:      {ToolIntent.retrieve_chunks, ToolIntent.run_skill, ToolIntent.run_playbook},
+    Phase.drafting:      {ToolIntent.run_skill, ToolIntent.emit_finding, ToolIntent.propose_memory},
+    Phase.ethics_review: {ToolIntent.emit_finding},          # retrieval/skills stripped here
+    Phase.delivery:      {ToolIntent.notify},
+}
+
+async def guarded_tool_call(session: AutonomousSession, intent: ToolIntent,
+                            params: ToolParams, db, gateway) -> ToolResult:
+    """The single chokepoint. Every tool call goes through here."""
+    with tracer.start_as_current_span("autonomous.tool_call") as span:
+        record_attributes(
+            span,
+            # COUNTS + TYPES ONLY — never raw entity values, never document text.
+            **{
+                "autonomous.session_id": str(session.id),
+                "autonomous.phase": session.current_phase,
+                "autonomous.tool": intent,                 # the intent, not its payload
+                "autonomous.halt_state": session.halt_state,
+            },
+        )
+
+        # R5 temporal — external halt switch, checked BEFORE the call.
+        await db.refresh(session, ["halt_state"])
+        if session.halt_state == HaltState.halt_requested:
+            session.halt_state = HaltState.halted
+            await _audit(db, session, "autonomous_session.halted", reason="external_halt")
+            raise SessionHalted(reason="external_halt")
+
+        # R6 contextual — is this tool granted in the current phase?
+        if intent not in PHASE_GRANTS[session.current_phase]:
+            await _audit(db, session, "autonomous_session.tool_call",
+                         tool=intent, outcome="tool_not_granted")
+            record_attributes(span, **{"autonomous.outcome": "tool_not_granted"})
+            raise ToolNotGranted(intent=intent, phase=session.current_phase)
+
+        # R4 economic — would this call exceed the cap? (M2-E2 estimator)
+        projected = session.cost_total_usd + estimate_tool_cost(intent, params)
+        if session.max_cost_usd is not None and projected > session.max_cost_usd:
+            session.cost_cap_reached = True
+            session.halt_state = HaltState.halted
+            await _audit(db, session, "autonomous_session.cost_cap_reached",
+                         projected_usd=float(projected))
+            record_attributes(span, **{"autonomous.outcome": "cost_cap_reached"})
+            raise CostCapReached(projected_usd=projected)
+
+        # --- run the tool ---  (inference goes through the gateway → anonymization +
+        #     citation verification apply automatically, same as playbooks)
+        await _audit(db, session, "autonomous_session.tool_call", tool=intent, outcome="started")
+        result = await _dispatch(intent, params, gateway=gateway, db=db, session=session)
+
+        session.cost_total_usd += result.cost_usd
+        record_attributes(span, **{
+            "autonomous.cost_usd": result.cost_usd,        # the real post-call cost
+            "autonomous.outcome": "success",
+        })
+        await _audit(db, session, "autonomous_session.tool_call",
+                     tool=intent, outcome="success", cost_usd=float(result.cost_usd))
+        return result
+```
+
+```python
+async def run_phase_transition(session, to_phase: Phase, db) -> None:
+    session.current_phase = to_phase
+    await _audit(db, session, "autonomous_session.phase_transition", to_phase=to_phase)
+    # idle-halt (R5): a watchdog arq job auto-transitions sessions idle past
+    # idle_halt_minutes (default 5) to paused, then halted.
+```
+
+The audit action strings are a **closed set** — `autonomous_session.{started, phase_transition, tool_call, halted, cost_cap_reached, completed}`. Don't add free-form actions; extend the enum in one place if you genuinely need a new one.
+
+---
+
+## 4. How to leverage the existing backend (don't rebuild)
+
+| You need to… | Use | Source of truth |
+|---|---|---|
+| Run the flow on a durable queue / on a cron | the **arq-worker** (the same worker playbooks/ingest run on) | `api/app/workers/`, the `arq` redis settings; cron via arq's `cron_jobs` |
+| Call a model | the **gateway client** (POST `/v1/chat/completions`) — inference through the gateway gets **anonymization + tier enforcement + cost accounting for free** | the playbook executor's gateway call path |
+| Verify a quote / ground a finding | the **Citation Engine** | `api/app/citation/verification.py` |
+| Retrieve from a KB | **pgvector + FTS hybrid retrieval** | `api/app/knowledge/` |
+| Estimate a call's cost (for R4) | the **M2-E2 rolling-average estimator** | `api/app/citation/cost.py` |
+| Emit telemetry | `get_tracer` / `record_attributes` / `@traced` (**no-op when OTel disabled**) | `api/app/observability_helpers.py` |
+| Write an audit row | the `audit_log` table + the project's audit-write helper | the `audit_action(...)` pattern in `api/app/api/*.py` |
+| Model multi-step state | **LangGraph + Pydantic-typed state** (typed transitions are LQ.AI's R3 posture) | `api/app/playbooks/{executor,nodes,state}.py` |
+
+**Inference always goes through the gateway.** Never call a provider SDK directly from `api/`. Routing through the gateway is what gives an autonomous flow the same anonymization, tier-floor enforcement, and cost accounting the chat path has — and it's why the autonomous executor lives in `api/` (the orchestration) while the gateway stays the key-holding boundary.
+
+---
+
+## 5. OpenTelemetry rules for new autonomous code
+
+The F-phase OTel work (PRD §5.4, `docs/observability.md`) is the standard. New autonomous code MUST:
+
+- **Use the helpers, never raw OTel.** `get_tracer(__name__)` + `record_attributes(span, **attrs)`. They no-op when OTel is disabled, so they're always safe to call.
+- **Span names:** `autonomous.session` (one per run, the root of the flow's subtree) and `autonomous.tool_call` (one per guarded call). Per-skill/per-playbook work invoked by a tool re-uses the existing `skill.execute` / `playbook.execute` spans — don't duplicate them.
+- **Attribute hygiene — the hard rule:** attributes carry **counts, types, IDs, costs, outcomes, enum labels** — **never raw entity values, document text, prompt bodies, or model responses.** This extends the M2 anonymization-span guarantee (enforced for the gateway by `gateway/tests/test_anonymization_observability.py`); the autonomous layer needs the equivalent guard test. If you're tempted to put the *content* of a finding in a span attribute, put its `finding_id` and `severity` instead.
+- **The brakes are observable:** `cost_usd`, `halt_state`, `phase`, and `outcome` (`success` / `tool_not_granted` / `cost_cap_reached` / `external_halt`) are span attributes so an operator can answer "did the brakes fire, and which one?" from the trace alone.
+
+---
+
+## 6. Testing expectations (the acceptance bar, from DE-293)
+
+Integration tests must exercise each brake — these are the acceptance criteria, not optional:
+
+- **R4:** a session whose projected cost exceeds its `max_cost_usd` halts with `cost_cap_reached=True` and preserves the partial result.
+- **R5:** a session that receives an external halt (`POST …/halt`) stops on its **next** tool call; an idle session auto-pauses past `idle_halt_minutes`.
+- **R6:** a session in `ethics_review` cannot invoke a tool granted only at `intake` (raises `ToolNotGranted`, audited).
+- **Privacy guard:** an autonomous-span test (mirror `test_anonymization_observability.py`) asserts no raw entity value ever lands in an `autonomous.*` attribute.
+- **Isolation:** user A's session can never read user B's memory/precedents (per-user hard isolation, §3.10 NFR).
+
+Standard project gates apply (CLAUDE.md): TDD, `ruff` + `mypy` (api standard mode), the new endpoints get unit + integration + OpenAPI-conformance tests, and the repo-root `tests/` cross-cutting suite if you add a privacy-guard contract test there.
+
+---
+
+## 7. "Is my agentic flow aligned?" — checklist
+
+Before you open the PR:
+
+- [ ] Every tool call goes through the single `guarded_tool_call` chokepoint (no tool bypasses it).
+- [ ] R4 cost cap, R5 halt-state read, R6 phase-grant check all happen **before** the tool runs.
+- [ ] `autonomous.session` + `autonomous.tool_call` spans emitted via the helpers; attributes are counts/types/IDs/costs only.
+- [ ] Closed-enum audit rows written for started / phase_transition / tool_call / halted / cost_cap_reached / completed.
+- [ ] A per-session receipt renders "what the agent did and why" (every tool call, inputs seen, cost, phase, gates) — readable by the **user**, not just the operator.
+- [ ] Inference goes through the gateway (anonymization + tier + cost), never a direct provider call.
+- [ ] Per-user isolation holds; memory writes follow *system-proposes, user-owns* (no silent writes).
+- [ ] The R4/R5/R6 + privacy-guard + isolation tests pass.
+- [ ] The Learn-tab "Autonomous flow" visualization (see the Learn-tab plan) reflects any new phase or tool so the public explainer stays honest.
+
+If every box is checked, the flow is aligned with LQ.AI's transparent, auditable posture — which is the whole point of doing autonomy this way.
+
+---
+
+*Companion docs: [ADR 0013](../adr/0013-autonomous-layer-design-influences.md) (design + decisions), [PRD §3.10](../PRD.md#310-autonomous-layer-m4) (the capability spec), [DE-293](../PRD.md#de-293) (the brakes spec), [`docs/security/boundary-registers.md`](../security/boundary-registers.md) (R4/R5/R6 definitions), [`docs/observability.md`](../observability.md) (the OTel operator guide). The implementation plan + Learn-tab viz spec follow via the writing-plans step.*

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -875,7 +875,7 @@ The scope-as-shipped is narrower than the original "ensemble runs on the whole a
 
 **M1 status:** Deferred-M4. No `autonomous_tasks`, `autonomous_schedules`, or `autonomous_watches` table exists in `api/alembic/versions/`. No per-user memory store. The architectural slot is committed; detailed M4 design is deferred. See [HONEST-STATE.md §4](HONEST-STATE.md#4-capabilities-not-yet-started-in-source).
 
-**Description.** Long-running per-user agents that observe activity, learn patterns, take proactive actions, and create skills autonomously. Runs as OpenWebUI Pipelines, off by default, opt-in per user.
+**Description.** Long-running per-user agents that observe activity, learn patterns, take proactive actions, and create skills autonomously. **Off by default, opt-in per user.** The autonomous executor runs in `api/app/autonomous/` on the existing **arq-worker** as a LangGraph state machine mirroring the Playbook executor (`api/app/playbooks/`), calling the gateway for inference exactly as playbooks do; it is **not** an OpenWebUI Pipeline (an earlier framing — superseded by [ADR 0013](adr/0013-autonomous-layer-design-influences.md), which pins the substrate). The web layer renders the dashboard and the per-session receipts; it does not run the agent loop. The detailed M4 design is pinned in **[ADR 0013 — Autonomous Layer design influences](adr/0013-autonomous-layer-design-influences.md)** (the DE-289 Phase 1 study).
 
 **User stories.**
 - As a user, I opt in to "autonomous skill suggestions"; after I review my fifth SaaS DPA, the system asks if I'd like it to draft a custom DPA Playbook based on my reviews.
@@ -884,12 +884,23 @@ The scope-as-shipped is narrower than the original "ensemble runs on the whole a
 - As a user, I see a "memory" view showing what the autonomous agent has learned about my preferences.
 
 **Functional requirements.**
-- Autonomous agents run as background pipelines, not user-facing requests.
+- Autonomous agents run as background work on the arq-worker, not as user-facing requests; lower priority than interactive use.
+- **Single-agent per session** for M4 v1 (one agent per `autonomous_session`), designed so multi-agent orchestration can extend later without redesign ([ADR 0013](adr/0013-autonomous-layer-design-influences.md) D1; the cross-agent handoff facet stays deferred under DE-294).
 - Per-user persistent memory store (separate from chat history) tracks patterns, preferences, and past actions.
-- Memory is *user-curated* — the user can view, edit, delete entries.
-- Cron scheduling for periodic tasks.
-- Notifications via email, Slack, or in-app.
-- Hard isolation between users — no cross-user memory leakage.
+- **Memory model — *system-proposes, user-owns*.** The agent observes and proposes memory entries (system-derived), but every entry is user-visible, user-editable, user-deletable, and applied only after the user keeps it; proposals surface for review rather than silent write. This resolves the prior contradiction in this section (the system derives candidates; the user holds authority and ownership). See ADR 0013 D4.
+- Cron scheduling for periodic tasks; event-triggered runs ("watches") enqueued by the ingest pipeline on document arrival.
+- Notifications via email or in-app (an optional webhook to the §3.15 Slack/Teams bridge folds in once that bridge's send-path lands; DE-312 gates it).
+- Hard isolation between users — no cross-user memory or precedent leakage.
+
+**M4 v1 capability scope (the four primitives — each spawns an `autonomous_session` the single agent runs under the R4/R5/R6 brakes):**
+- **Watches** — new documents in a watched Knowledge Base trigger a configured Playbook/skill; findings are notified.
+- **Scheduled tasks** — cron-scheduled periodic runs (e.g., a weekly compliance scan against a contract repository).
+- **Per-user memory** — the observe-and-propose preference store above.
+- **Precedent board** — system-observed patterns about *documents/clauses across matters* (recurring counterparty positions, clause-language patterns), read-mostly and user-dismissable. **Distinct** from Project context (§3.11 — user-authored, per-matter) and from per-user memory (patterns about *the user's* behavior): the precedent board is patterns about *the documents*. The agent may propose promoting a precedent into a Project's context but never writes Project context directly. See ADR 0013 D5.
+
+**Data model (new tables, all per-user, hard-isolated).** `autonomous_sessions` (run record carrying the brakes: `max_cost_usd`, `cost_total_usd`, `halt_state` enum, `current_phase`, `idle_halt_minutes` — per DE-293), `autonomous_schedules` (cron specs), `autonomous_watches` (KB-trigger configs), `autonomous_memory` (proposed/kept preference entries), `precedent_entries` (cross-matter patterns).
+
+**Alignment contract (non-optional — [ADR 0013](adr/0013-autonomous-layer-design-influences.md) D6; contributor how-to in [`docs/LQVern/agentic-flow-alignment-guide.md`](LQVern/agentic-flow-alignment-guide.md)).** Every autonomous flow, by construction: (a) emits OTel domain spans (`autonomous.session` + `autonomous.tool_call` children; attributes = cost/halt/phase/tool/outcome — **counts and types only, never raw entity values**, extending the M2 anonymization-span guarantee); (b) writes a closed-enum audit trail (`autonomous_session.{started,phase_transition,tool_call,halted,cost_cap_reached,completed}`); (c) produces a human-readable per-session receipt ("what the agent did and why" — every tool call, the inputs it saw, the cost, the phase, the gates passed), the §1.3 transparency principle applied to actions. Autonomous code that does not emit these is not done.
 
 **Boundary-register obligations for autonomous flows (M4 design surface).** The autonomous layer is the LQ.AI surface where Tier 2 of the boundary-register catalog (R4 economic, R5 temporal, R6 contextual — see §1.8 and [`docs/security/boundary-registers.md`](security/boundary-registers.md)) first attaches to running code. M4 design must discharge each: a per-session hard cost cap with halt-on-overrun and a structured `cost_cap_reached` final state (R4); an external halt switch checked before every tool call, with an idle-halt timeout that auto-transitions a paused session rather than bleeding resources (R5); per-workflow-phase tool-grant modulation that strips intake-time tools at the ethics-gate or delivery-phase boundary (R6). The implementation specification is tracked by DE-293. The design study comparing Lavern's `Clawern` pipeline (the most concrete prior art for all three Tier 2 registers) to LQ.AI's planned approach is tracked by DE-289 Phase 1; the design-influences ADR it produces is the input to the M4 implementation plan. If M4 ships *multi-agent* autonomous flows rather than only single-agent ones, the R3-for-cross-agent-handoffs facet (an `orchestrate.py`-equivalent with closed intent allowlist + typed-template prompt rendering + JSONL audit log) attaches alongside the Tier 2 work, tracked by DE-294; the single-agent vs. multi-agent pin is the first deliverable of DE-289 Phase 1.
 
@@ -897,16 +908,21 @@ The scope-as-shipped is narrower than the original "ensemble runs on the whole a
 - Autonomous activity must not interfere with interactive use; runs at lower priority.
 
 **API surface.**
-- `GET/POST /api/v1/autonomous/memory` — view and edit user memory.
+- `GET/POST /api/v1/autonomous/memory` — view, keep/edit/delete proposed and kept memory entries.
 - `GET/POST /api/v1/autonomous/schedules` — manage scheduled tasks.
 - `GET/POST /api/v1/autonomous/watches` — manage watches.
+- `GET /api/v1/autonomous/sessions` + `GET /api/v1/autonomous/sessions/{id}` — list/inspect runs (the receipt trail).
+- `POST /api/v1/autonomous/sessions/{id}/halt` — the external halt switch (R5; ADR 0013 D3).
+- `GET/POST /api/v1/autonomous/precedents` — view + dismiss precedent-board entries.
 
 **Dependencies.** All other capabilities. OpenWebUI Pipelines framework.
 
-**Open questions.**
-- This is M4 territory; detailed design deferred. The PRD commits to the capability and the architectural slot, not to the full design.
-- **Distinction from Projects (§3.11).** Autonomous-layer memory is system-curated and observed; Project context is user-curated and matter-scoped. Both serve different purposes; one informs the other. The autonomous layer can *propose* additions to a Project's context, but the user owns the Project.
-- **Forward extension to M5+ (§8.5).** The autonomous layer's memory and scheduled-pipelines substrate is the foundation on which the M5+ workflow-intelligence direction extends. M4 design choices should anticipate that extension — particularly multi-step agents that take external-side-effecting actions with human approval gates, since retrofitting that into a memory-and-watches-only autonomous layer is harder than designing for it from the start.
+**Open questions — resolved in [ADR 0013](adr/0013-autonomous-layer-design-influences.md).** The detailed design is no longer deferred; the ADR + this build-out are the design, and the M4 implementation follows the writing-plans output on the `feat/lqvern-m4-autonomous` branch. The three prior open questions resolved as:
+- **Detailed design** — pinned (single-agent v1, api/arq executor, the four primitives, the brakes, the alignment contract). ADR 0013 D1–D6.
+- **Distinction from Projects (§3.11)** — the three-way memory model (Project context vs. autonomous memory vs. precedent board). ADR 0013 D5.
+- **Forward extension to M5+ (§8.5)** — the single-agent interfaces are designed so multi-agent orchestration (DE-294) and external-side-effecting actions with approval gates extend without redesign; the memory + scheduled-pipeline substrate is the M5+ workflow-intelligence foundation. ADR 0013 D1 + open question 3.
+
+Remaining implementation-level open questions (watch-trigger plumbing, notification surface, precedent-board per-user vs per-deployment scope) are carried in ADR 0013 "Open questions remaining" for the implementation plan.
 
 ---
 

--- a/docs/adr/0013-autonomous-layer-design-influences.md
+++ b/docs/adr/0013-autonomous-layer-design-influences.md
@@ -1,0 +1,102 @@
+# ADR 0013 — Autonomous Layer design influences (M4 / LQVern)
+
+**Status:** Proposed
+**Date:** 2026-05-24
+**Owner:** M4 / LQVern kickoff (feature branch `feat/lqvern-m4-autonomous`)
+
+## Context
+
+PRD [§3.10 Autonomous Layer](../PRD.md#310-autonomous-layer-m4) commits the architectural slot for long-running per-user agents that observe activity, learn patterns, take proactive actions, and run scheduled/triggered work — but explicitly defers the detailed design ("This is M4 territory; detailed design deferred. The PRD commits to the capability and the architectural slot, not to the full design"). M4 is where **Tier 2 of the boundary-register catalog** ([§1.8](../PRD.md#18-security-posture), [`docs/security/boundary-registers.md`](../security/boundary-registers.md)) — R4 economic, R5 temporal, R6 contextual — first attaches to running code. [DE-293](../PRD.md#de-293) carries the implementation spec for those restraints; [DE-294](../PRD.md#de-294) carries cross-agent handoff validation **if** M4 ships multi-agent flows.
+
+[DE-289](../PRD.md#de-289) names [AnttiHero/lavern](https://github.com/AnttiHero/lavern) (Apache-2.0, TypeScript/Fastify/SQLite "agentic law firm") as the closest public prior art, and its **Clawern** autonomous mode as the most concrete working pattern for the §3.10 open questions and the Tier-2 brakes. This ADR is **DE-289 Phase 1**: it compares Clawern's pattern to LQ.AI's substrate, **pins the single-agent-vs-multi-agent question** (which gates DE-294 classification), answers §3.10's open questions, and is the input to the M4 implementation plan.
+
+**Provenance note.** Lavern's mechanisms cited here are as extracted in DE-289/DE-293 from Lavern's README and source-file names (`cost-tracker.ts`, `haltCheckHook`, the dynamic-permissions layer, `orchestrate.ts`). This ADR reasons about Clawern's *pattern*, not a line-by-line re-derivation; a deeper source read is available to a contributor who wants to refine a specific mechanism, but the load-bearing facts are stable and sufficient to pin the decisions below. Per the §1.9 conservative-posture principle and Lavern's own stated lack of an independent benchmark, Clawern is treated as a **design reference, not validated implementation** — we adopt shapes, not quality claims.
+
+## Decision drivers
+
+What §3.10 needs from the design that the current sketch does not yet name:
+
+1. **An execution substrate** for long-running, resumable, scheduled/triggered agent work that does not interfere with interactive use.
+2. **The Tier-2 brakes wired in, not bolted on** — a per-session cost cap (R4), an external halt switch + idle timeout (R5), and per-phase tool-grant modulation (R6), checked *before every tool call*.
+3. **A transparency/audit posture** for autonomy consistent with the rest of the product: a user must be able to read, after the fact, exactly what an agent did and why (the §1.3 transparency principle applied to actions, not just prompts).
+4. **A memory model** that resolves §3.10's internal tension (functional reqs say memory is "user-curated"; the open questions and §3.11 say it is "system-curated").
+5. **A disambiguation** of the precedent board from Project context (§3.11) and from per-user memory.
+6. **A single-agent-vs-multi-agent pin** that gates DE-294.
+
+## Considered alternatives (execution substrate)
+
+### A. Clawern-shaped, re-implemented natively on the api/arq substrate — **chosen**
+
+Clawern's pattern: a heartbeat loop wakes periodically, evaluates watched state, runs an agent that calls tools under a cost tracker (`cost-tracker.ts`, default ~$5/session), a halt hook (`haltCheckHook` — "the red button", checked before every tool call, with a ~5-minute idle auto-halt), and a dynamic-permissions layer that strips tool grants at phase boundaries (e.g., removes search/read at the ethics gate). LQ.AI **re-implements this pattern natively** in `api/app/autonomous/` as a LangGraph state machine on the existing **arq-worker**, mirroring the shipped Playbook executor (`api/app/playbooks/`).
+
+- **Cost:** new module + tables; the brakes are real engineering (DE-293).
+- **Why it wins:** LQ.AI already has every substrate piece Clawern lacks — a **durable task queue** (arq/Redis), **Postgres** for session/memory/precedent state, **pgvector + FTS** retrieval, **char-precise citation verification** (M2), the **anonymization layer** (M2), a **cost estimator** (M2-E2 rolling average), and the **gateway** as the inference boundary. The executor reuses the Playbook executor's proven LangGraph + Pydantic-typed-state pattern, so the brakes and audit attach the same way DE-292 attaches them to playbooks. Under this shape every §3.10 open question has a concrete home (below).
+
+### B. Temporal / Celery-shaped (dedicated workflow engine)
+
+A purpose-built durable-workflow engine (Temporal, or Celery beat) for the scheduling + resumability story.
+
+- **Cost:** a new heavyweight dependency and operational surface; a second queue alongside arq; SBOM + supply-chain expansion (CLAUDE.md: new deps need justification).
+- **Rejected:** arq already provides durable, Redis-backed scheduled + enqueued execution and is what the Playbook/ingest/tabular workers run on. A second engine fragments the backend for no capability we lack. Revisit only if cross-service saga orchestration becomes a requirement (not an M4 need).
+
+### C. Naive cron job (OS cron → one-shot script)
+
+- **Rejected:** no resumability, no per-session state, no place to attach the brakes/audit/OTel, no halt switch. Fails decision drivers 2 and 3 outright. Named only to reject it explicitly.
+
+> **Note on §3.10's "runs as OpenWebUI Pipelines" wording.** That phrasing predates this ADR. OpenWebUI Pipelines is a TypeScript/web-layer plugin surface; the autonomous executor's work — legal agent loops, cost/halt/phase brakes, Postgres-backed memory, citation/anonymization integration, OTel domain spans — is backend (Python) territory. This ADR supersedes the "Pipelines" framing: the executor lives in `api/`, and the PRD §3.10 build-out on this branch corrects the wording. (The web layer still renders the dashboard + receipts; it does not run the agent loop.)
+
+## Decision
+
+### D1. Single-agent for M4 v1, designed to extend — **pins DE-294**
+
+M4/LQVern v1 ships **single-agent** autonomous flows: one agent per `autonomous_session`, running the §3.10 user stories (watches, scheduled scans, skill suggestions). This **delivers every committed §3.10 user story** without the agent-to-agent handoff surface, and lets the brakes + audit + OTel substrate be proven before any multi-agent orchestration. **DE-294 stays P2/deferred** (cross-agent handoff validation attaches to whichever later milestone first ships multi-agent flows). The executor's interfaces (typed session state, closed tool-intent enum) are designed so a multi-agent orchestrator can later wrap single-agent sessions without redesign — Clawern's debate protocol is the reference for that future increment, not a v1 deliverable.
+
+### D2. Execution substrate: alternative A (api/arq, LangGraph, mirrors playbooks)
+
+`api/app/autonomous/` on the arq-worker. Scheduled work via arq's cron; event-triggered work (watches) enqueued by the existing ingest pipeline on document arrival. Inference via the gateway client, exactly as playbooks call it.
+
+### D3. The Tier-2 brakes, adopted from Clawern's shape (DE-293)
+
+| Register | Clawern reference | LQ.AI adoption |
+|---|---|---|
+| **R4 economic** | `cost-tracker.ts`, ~$5 default per-session budget | `autonomous_sessions.max_cost_usd` (deployment default in `gateway.yaml`, suggested $5), checked before every tool call against `cost_total_usd` using the M2-E2 estimator; overrun → `cost_cap_reached` terminal state + partial result preserved. **Adopt the shape and the $5 default.** |
+| **R5 temporal** | `haltCheckHook` ("red button") + ~5-min idle auto-halt | `autonomous_sessions.halt_state` (`running`/`halt_requested`/`halted`/`paused`); read before every tool call; `POST /api/v1/autonomous/sessions/{id}/halt`; idle > `idle_halt_minutes` (default 5) auto-pauses then halts. **Adopt directly.** |
+| **R6 contextual** | dynamic permissions strip tools at ethics gate / delivery | Workflows declare phases (`intake`/`analysis`/`drafting`/`ethics_review`/`delivery`) with per-phase tool grants; the executor's current-phase row gates every tool call; transitions are explicit + audited. **Adopt the shape; the phase set is LQ.AI's, not Lavern's.** |
+
+### D4. Memory model — *system-proposes, user-owns* (resolves the §3.10 tension)
+
+The agent **observes and proposes** memory entries (so the source is system-derived), but every entry is **user-visible, user-editable, user-deletable, and applied only after the user keeps it**. Default posture: proposals surface for review, not silent write. This reconciles "user-curated" (the user holds authority and ownership) with "system-curated" (the system derives the candidates). It also satisfies R-class restraint by keeping a human in the loop on what the agent is allowed to remember about them.
+
+### D5. Precedent board — *absorbed into M4 v1, distinct from the other two memory surfaces*
+
+§3.10's open "absorb / reject / separate" question is resolved as **absorb, as a distinct construct**:
+
+- **Project context (§3.11):** user-authored, per-matter, user-owned. *What this matter is.*
+- **Autonomous memory (D4):** system-observed patterns about **the user's preferences/behavior**, user-owned. *How this user likes to work.*
+- **Precedent board (this ADR):** system-observed patterns about **documents/clauses across matters** (recurring counterparty positions, clause-language patterns), read-mostly, user-dismissable. *What we keep seeing in the documents.* The agent may **propose** promoting a precedent into a Project's context but never writes Project context directly.
+
+Hard per-user isolation applies to all three (no cross-user leakage, §3.10 NFR).
+
+### D6. The transparency/audit/OTel alignment contract is non-optional
+
+Every autonomous flow, by construction, emits OTel domain spans (`autonomous.session` + `autonomous.tool_call` children, attributes = cost/halt/phase/tool/outcome, **counts and types only, never raw entity values** — the M2 anonymization-span guarantee extends here), writes a closed-enum audit trail, and produces a human-readable per-session receipt ("what the agent did and why"). This is specified for contributors in [`docs/LQVern/agentic-flow-alignment-guide.md`](../LQVern/agentic-flow-alignment-guide.md) and is the heart of keeping autonomy aligned with the §1.3 transparency principle. New autonomous code that does not emit these is not done.
+
+## §3.10 open questions — resolved
+
+- **Detailed design deferred?** No longer — this ADR + the PRD §3.10 build-out on this branch are the design. M4 implementation follows the writing-plans output.
+- **Distinction from Projects (§3.11)?** Resolved in D5 (three-way distinction).
+- **Forward extension to M5+?** D1's single-agent interfaces are designed so multi-agent orchestration (Clawern's debate protocol; DE-294) and external-side-effecting actions with approval gates extend without redesign. The memory + scheduled-pipeline substrate is the M5+ workflow-intelligence foundation per §8.5.
+
+## Open questions remaining (for the implementation plan / contributor)
+
+1. **Watch trigger plumbing:** does the ingest pipeline enqueue the autonomous session directly, or publish an event the autonomous scheduler subscribes to? (Pin in the implementation plan; the simpler direct-enqueue is the likely answer given arq.)
+2. **Notification surface:** email + in-app are committed; the optional webhook to the §3.15 Slack/Teams bridge is a fold-in once that bridge's send-path exists (DE-312 gates the bridge's E2E).
+3. **Precedent-board scope:** per-user vs per-deployment. D5 pins per-user for isolation; a per-deployment (org-shared) precedent board is a possible later option — file as a DE if it surfaces.
+
+## Cross-references
+
+- PRD [§3.10](../PRD.md#310-autonomous-layer-m4) (build-out on this branch links back here from "Open questions"), [§1.8](../PRD.md#18-security-posture), [§3.8](../PRD.md#38-multi-model-ensemble-verification), [§8.5](../PRD.md#85-mcp-client-subsystem).
+- [DE-289](../PRD.md#de-289) (this ADR is its Phase 1 deliverable), [DE-293](../PRD.md#de-293) (the R4/R5/R6 spec D3 discharges), [DE-294](../PRD.md#de-294) (deferred per D1), [DE-292](../PRD.md#de-292) (the Playbook-executor retrofit whose pattern D2 mirrors).
+- [`docs/security/boundary-registers.md`](../security/boundary-registers.md) (R4/R5/R6 flip to "shipped" when DE-293 lands).
+- [`docs/LQVern/agentic-flow-alignment-guide.md`](../LQVern/agentic-flow-alignment-guide.md) (the D6 contract, for contributors).
+- Provenance: [`docs/LQVern/HANDOFFlavernevaluation.md`](../LQVern/HANDOFFlavernevaluation.md). (This work began as a "DE-265" PRD patch, since re-landed and renumbered on `main` as DE-289.)


### PR DESCRIPTION
## What

Lands the **approved M4 / LQVern Autonomous Layer design** on `main` so the canonical PRD + ADR set stops lagging the pinned design while implementation proceeds on `feat/lqvern-m4-autonomous`.

This is a clean cherry-pick of the single design commit (`112ccd7`) — docs-only, no code.

## Why now

Per the M4 planning-session handoff §6, the design docs currently live only on the LQVern feature branch. Kevin's call: **merge the design to main now via a small docs PR** (so main's §3.10 reflects the pinned design for the months M4 takes to land), keeping `feat/lqvern-m4-autonomous` as the implementation base.

## Contents

- **`docs/adr/0013-autonomous-layer-design-influences.md`** — the design: D1 single-agent v1, D2 executor in `api/app/autonomous` on arq mirroring playbooks, D3 the R4/R5/R6 brakes, D4 memory *system-proposes/user-owns*, D5 precedent board, D6 the non-optional OTel + audit + receipt alignment contract.
- **`docs/PRD.md` §3.10 build-out** — the capability spec (data model, API surface, the alignment contract, the resolved open questions). Supersedes the stale "OpenWebUI Pipelines" framing.
- **`docs/LQVern/agentic-flow-alignment-guide.md`** — the contributor how-to with the `guarded_tool_call` chokepoint pseudo-code.
- **`docs/LQVern/README.md`** + **`docs/LQVern/HANDOFFlavernevaluation.md`** — folder guide + the provenance doc the ADR cross-references.

## Reviewer note

The cherry-pick includes **`docs/LQVern/de265.patch`**, which the LQVern README flags as **superseded** (its content is already on `main` as DE-289). It rode along in the original approved commit; I kept the cherry-pick whole to preserve the README's cross-reference rather than hand-edit the approved commit. **If you'd prefer it not on `main`, say so and I'll drop it from this branch** before merge.

The M4 implementation plan + Learn-tab viz spec are intentionally **not** in this PR — they stay on `feat/lqvern-m4-autonomous` as the implementation base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)