### PR TITLE
fix(chat-receipts): surface anonymization_applied + message_id in inference detail

### DIFF
--- a/api/app/api/chat_receipts.py
+++ b/api/app/api/chat_receipts.py
@@ -74,7 +74,10 @@ class ReceiptEvent(BaseModel):
         "``messages`` (+ denorm ``applied_skills``), "
         "``inference_routing_log``, and ``audit_log`` into one "
         "timestamp-ordered stream. Owner-of-chat or admin only. "
-        "Filter with ``?event_kinds=message,audit`` etc."
+        "Filter with ``?event_kinds=message,audit`` etc. "
+        "Inference/error event ``detail`` includes ``anonymization_applied`` "
+        "(bool — the source of truth for the UI's anonymization indicator) and "
+        "``message_id`` (the assistant message the indicator pins to; may be null)."
     ),
 )
 async def get_chat_receipts(
@@ -200,6 +203,11 @@ async def get_chat_receipts(
                             "latency_ms": log.latency_ms,
                             "refused": log.refused,
                             "refusal_reason": log.refusal_reason,
+                            # anonymization_applied is the source of truth for the
+                            # UI's anonymization indicator; message_id pins the
+                            # indicator to the right assistant message bubble.
+                            "anonymization_applied": log.anonymization_applied,
+                            "message_id": str(log.message_id) if log.message_id else None,
                         },
                     )
                 )

--- a/api/tests/test_chat_receipts.py
+++ b/api/tests/test_chat_receipts.py
@@ -260,6 +260,56 @@ async def test_receipts_inference_refused_renders_as_error(
     assert error_events[0]["detail"]["refused"] is True
 
 
+async def test_receipts_inference_detail_includes_anonymization_and_message_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    owner_user: User,
+) -> None:
+    """The inference event's detail surfaces ``anonymization_applied`` (the UI
+    indicator's source of truth) and the assistant ``message_id`` (so the
+    frontend can pin the indicator to the right message bubble)."""
+    chat = Chat(owner_id=owner_user.id, title="anon chat")
+    db_session.add(chat)
+    await db_session.flush()
+    ai_msg = Message(
+        chat_id=chat.id,
+        role="assistant",
+        kind="ai",
+        content="Hi there",
+        applied_skills=[],
+        created_at=datetime.now(tz=UTC),
+    )
+    db_session.add(ai_msg)
+    await db_session.flush()
+    log = InferenceRoutingLog(
+        chat_id=chat.id,
+        message_id=ai_msg.id,
+        routed_provider="anthropic",
+        routed_model="claude-opus-4-7",
+        routed_inference_tier=2,
+        refused=False,
+        anonymization_applied=True,
+        timestamp=datetime.now(tz=UTC),
+    )
+    db_session.add(log)
+    await db_session.flush()
+
+    response = await client.get(
+        f"/api/v1/chats/{chat.id}/receipts",
+        headers=_h(owner_user),
+    )
+    assert response.status_code == 200, response.text
+    events = response.json()
+    inference_events = [e for e in events if e["kind"] == "inference"]
+    assert len(inference_events) == 1
+    detail = inference_events[0]["detail"]
+    # anonymization_applied is a real bool (not a string/None) — the indicator
+    # reads it directly.
+    assert detail["anonymization_applied"] is True
+    # message_id pins the indicator to the assistant message bubble.
+    assert detail["message_id"] == str(ai_msg.id)
+
+
 # ----------------------------------------------------------------
 # Wave D.1 T6 — JSONL export sibling route
 # ----------------------------------------------------------------


### PR DESCRIPTION
## What

`get_chat_receipts` builds an `inference`/`error` event whose `detail` dict (in `api/app/api/chat_receipts.py`) omitted two fields that **already exist as columns** on `InferenceRoutingLog`:

```python
"anonymization_applied": log.anonymization_applied,
"message_id": str(log.message_id) if log.message_id else None,
```

Both the `inference` and `error` branches share the one `detail` dict, so a single edit covers both.

## Why

- **`anonymization_applied`** is the source of truth for the UI's anonymization indicator (whether the request was pseudonymized before leaving for the provider).
- **`message_id`** lets the frontend pin that indicator to the correct assistant message bubble.

## Scope

- `detail` is `additionalProperties: true`, so **no OpenAPI schema change** — only the endpoint `description` is updated to document the two fields.
- Regression test (`test_receipts_inference_detail_includes_anonymization_and_message_id`) asserts the inference event's `detail` carries a **boolean** `anonymization_applied` and the assistant `message_id`.

## Verification

`pytest tests/test_chat_receipts.py -q` → **11 passed**; `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)