### PR TITLE
fix(gateway): persist inference_routing_log on streamed completions

### DIFF
--- a/gateway/app/api/inference.py
+++ b/gateway/app/api/inference.py
@@ -1207,9 +1207,14 @@ async def _stream_openai_sse(
             payload = terminal.model_dump(mode="json", exclude_none=True)
             yield f"data: {json.dumps(payload, separators=(',', ':'))}\n\n".encode()
 
-    yield b"data: [DONE]\n\n"
-
     # Persist the routing-log row using the final chunk's usage block.
+    # This MUST precede the `[DONE]` yield: the api-side consumer stops
+    # iterating on `[DONE]` and closes the stream context, which cancels
+    # this generator (throws GeneratorExit at the next suspended `yield`).
+    # Anything awaited after the `[DONE]` yield never runs — so every
+    # streamed success turn would persist zero routing-log rows. The
+    # failure path above writes before its `[DONE]` for the same reason;
+    # mirror that here.
     usage = (last_chunk.usage if last_chunk is not None else None) or None
     cost = (
         estimate_cost(
@@ -1239,6 +1244,8 @@ async def _stream_openai_sse(
             purpose=_purpose_from_request(chat_request),
         )
     )
+
+    yield b"data: [DONE]\n\n"
 
 
 async def _single_error_sse(*, code: str, message: str) -> AsyncIterator[bytes]:

--- a/gateway/tests/test_inference_streaming_routing_log.py
+++ b/gateway/tests/test_inference_streaming_routing_log.py
@@ -1,0 +1,214 @@
+"""Regression: streamed chat completions must persist an inference_routing_log row.
+
+The success path of :func:`_stream_openai_sse` used to write its routing-log
+row *after* yielding ``data: [DONE]\\n\\n``. The api-side consumer
+(``GatewayClient.chat_completion_stream`` -> ``_iter_sse_chunks``) stops
+iterating the moment it sees ``[DONE]`` and closes the ``async with
+client.stream(...)`` context. Closing that context cancels this async
+generator — it throws ``GeneratorExit`` into the generator while it is
+suspended at the ``yield b"data: [DONE]\\n\\n"`` — so any ``await`` placed
+*after* that yield never runs. Result: every streamed turn (i.e. all real UI
+traffic) persisted zero routing-log rows, blanking the M2 receipts /
+anonymization transparency surfaces.
+
+This test reproduces that early-close cancellation precisely: it consumes the
+generator with ``async for`` and ``break``\\s the instant it sees the
+``[DONE]`` frame, then calls ``gen.aclose()`` (which throws ``GeneratorExit``
+exactly like the real consumer's stream-context exit). It then asserts exactly
+one routing-log row was persisted with the expected token / tier / provider /
+anonymization fields.
+
+DO NOT "simplify" this into a full-drain test (e.g. ``[f async for f in gen]``
+or reading ``response.text``). Draining the generator to completion runs the
+post-``[DONE]`` code and hides the bug — that is exactly why the pre-existing
+``test_chat_completions_streams_sse_frames`` did not catch it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from app.api.inference import _stream_openai_sse
+from app.config import CostRateEntry, GatewayConfig, ProviderConfig
+from app.providers.openai_schema import (
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
+    ChatCompletionDelta,
+    ChatCompletionRequest,
+    ChatCompletionUsage,
+)
+from app.router import ResolvedTarget
+from app.routing_log import RecordingRoutingLogWriter
+
+
+def _config() -> GatewayConfig:
+    """Minimal config; ``_stream_openai_sse`` only reads ``cost_tracking.rates``."""
+
+    provider = ProviderConfig(
+        name="anthropic-prod",
+        type="anthropic",
+        base_url="https://anthropic-prod.example.com",
+        api_key_env="ANTHROPIC_PROD_API_KEY",
+        tier=4,
+        models=["claude-opus-4-7"],
+    )
+    raw = {
+        "providers": [provider.model_dump(exclude_none=True)],
+        "model_aliases": {},
+        "cost_tracking": {
+            "rates": {
+                "anthropic-prod/claude-opus-4-7": CostRateEntry(
+                    input_per_mtok=10.0,
+                    output_per_mtok=30.0,
+                ).model_dump(exclude_none=True),
+            },
+        },
+    }
+    return GatewayConfig.model_validate(raw)
+
+
+def _target(config: GatewayConfig) -> ResolvedTarget:
+    return ResolvedTarget(
+        provider=config.providers[0],
+        native_model="claude-opus-4-7",
+        routed_inference_tier=4,
+        role="primary",
+    )
+
+
+def _chunks() -> AsyncIterator[ChatCompletionChunk]:
+    """Two chunks; the final one carries the usage block (like OpenAI/Anthropic)."""
+
+    async def gen() -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="chunk-1",
+            created=1_700_000_000,
+            model="claude-opus-4-7",
+            choices=[
+                ChatCompletionChunkChoice(
+                    index=0,
+                    delta=ChatCompletionDelta(role="assistant", content="Hello"),
+                )
+            ],
+        )
+        yield ChatCompletionChunk(
+            id="chunk-2",
+            created=1_700_000_001,
+            model="claude-opus-4-7",
+            choices=[
+                ChatCompletionChunkChoice(
+                    index=0,
+                    delta=ChatCompletionDelta(content=" world"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=ChatCompletionUsage(
+                prompt_tokens=11,
+                completion_tokens=5,
+                total_tokens=16,
+            ),
+        )
+
+    return gen()
+
+
+@pytest.mark.asyncio
+async def test_stream_persists_routing_log_on_consumer_early_close() -> None:
+    """A streamed success turn persists exactly one routing-log row.
+
+    Reproduces the real consumer's early close: break on ``[DONE]`` then
+    ``aclose()`` the generator. Before the fix this asserted ``rows == 0``
+    (the write lived after ``[DONE]`` and never ran); after the fix the
+    write precedes ``[DONE]`` so exactly one row persists.
+    """
+
+    config = _config()
+    target = _target(config)
+    recorder = RecordingRoutingLogWriter()
+    chat_request = ChatCompletionRequest(
+        model="smart",
+        messages=[{"role": "user", "content": "hi"}],  # type: ignore[list-item]
+        stream=True,
+    )
+
+    gen = _stream_openai_sse(
+        _chunks(),
+        target=target,
+        config=config,
+        chat_request=chat_request,
+        log_writer=recorder,
+        request_id="req-stream-test",
+    )
+
+    saw_done = False
+    try:
+        async for frame in gen:
+            if frame == b"data: [DONE]\n\n":
+                # Mirror the api-side consumer: stop the instant [DONE]
+                # arrives, then close the stream context.
+                saw_done = True
+                break
+    finally:
+        # Closing the stream context throws GeneratorExit into the suspended
+        # generator — exactly what the real network consumer does.
+        await gen.aclose()
+
+    assert saw_done, "stream never emitted a [DONE] frame"
+
+    assert len(recorder.rows) == 1, (
+        f"expected exactly one routing-log row, got {len(recorder.rows)} "
+        "(the success-path write must precede the [DONE] yield)"
+    )
+    row = recorder.rows[0]
+    assert row.tokens_in == 11
+    assert row.tokens_out == 5
+    assert row.routed_inference_tier == 4
+    assert row.routed_provider == "anthropic-prod"
+    assert row.routed_model == "claude-opus-4-7"
+    assert row.anonymization_applied is False
+    assert row.request_id == "req-stream-test"
+
+
+@pytest.mark.asyncio
+async def test_stream_persists_routing_log_with_anonymization_flag() -> None:
+    """anonymization_applied is True when an anon_mapper is supplied.
+
+    Note: passing ``anon_mapper`` without ``anonymizer`` skips the
+    rehydrator (no tail flush) but still records ``anonymization_applied``
+    from ``anon_mapper is not None`` — which is the field the receipts
+    surface reads.
+    """
+
+    config = _config()
+    target = _target(config)
+    recorder = RecordingRoutingLogWriter()
+    chat_request = ChatCompletionRequest(
+        model="smart",
+        messages=[{"role": "user", "content": "hi"}],  # type: ignore[list-item]
+        stream=True,
+    )
+
+    class _Mapper:
+        pass
+
+    gen = _stream_openai_sse(
+        _chunks(),
+        target=target,
+        config=config,
+        chat_request=chat_request,
+        log_writer=recorder,
+        request_id="req-stream-anon",
+        anon_mapper=_Mapper(),  # type: ignore[arg-type]
+    )
+
+    try:
+        async for frame in gen:
+            if frame == b"data: [DONE]\n\n":
+                break
+    finally:
+        await gen.aclose()
+
+    assert len(recorder.rows) == 1
+    assert recorder.rows[0].anonymization_applied is True


### PR DESCRIPTION
## Root cause

`gateway/app/api/inference.py::_stream_openai_sse` wrote the success-path `inference_routing_log` row **after** yielding `data: [DONE]\n\n`. The api-side consumer (`GatewayClient.chat_completion_stream` → `_iter_sse_chunks`) stops iterating the moment it sees `[DONE]` and closes the `async with client.stream(...)` context. Closing that context cancels the async generator — throwing `GeneratorExit` while it is suspended at the `[DONE]` yield — so the `await log_writer.write(...)` after that yield never ran.

Net effect: **every streamed turn persisted zero routing-log rows.** Since all real UI traffic streams, this blanked the M2 transparency surfaces (Receipts drawer, anonymization indicator) — tier, tokens, latency, `anonymization_applied` were all missing for streamed turns. The failure path (`except ProviderAdapterError`) already calls `_write_failure(...)` *before* its `[DONE]` yield, which is why refused/error turns logged correctly and only the success path was broken.

## The fix

Move the success-path routing-log write to **before** the `yield b"data: [DONE]\n\n"`, mirroring the failure path. No computed values or row fields changed — only ordering. Added a comment noting the write MUST precede `[DONE]` because the consumer cancels the generator on `[DONE]`.

## Regression test

`gateway/tests/test_inference_streaming_routing_log.py` calls `_stream_openai_sse` directly with a `RecordingRoutingLogWriter` (no DB), consumes the stream, `break`s the instant it sees the `[DONE]` frame, then `await gen.aclose()` — reproducing the real consumer's early-close cancellation. It asserts exactly one row persists with the expected `tokens_in`/`tokens_out`/`routed_inference_tier`/`routed_provider`/`anonymization_applied`. A second test covers the `anonymization_applied=True` path.

Confirmed red→green: against the unfixed code the test asserted `rows == 0` (write never ran); after the fix it asserts `rows == 1`. The pre-existing `test_chat_completions_streams_sse_frames` did not catch this because it reads the full `response.text`, draining the generator to completion and running the post-`[DONE]` write.

## Gates

- `pytest` — full gateway suite 528 passed, 2 skipped (DB-backed, expected without `DATABASE_URL`).
- `ruff format .` + `ruff check .` — clean.
- `mypy app` (strict) — clean, no issues in 38 source files.

Touches `gateway/**` (security boundary) — auto-routes to security reviewers per CODEOWNERS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)