### PR TITLE
Document /v1/models alias fields to match the live gateway

### DIFF
--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -1624,10 +1624,16 @@ paths:
                         created: {type: integer}
                         owned_by: {type: string}
                         lq_ai_kind: {type: string, enum: [alias, provider_native]}
+                        # routed_inference_tier is present on provider_native rows AND on
+                        # alias rows (the tier of the alias's primary resolution).
                         routed_inference_tier: {type: integer, enum: [1, 2, 3, 4, 5]}
                         provider_type:
                           type: string
                           enum: [anthropic, openai, vertex, cohere, azure_openai, bedrock, ollama, vllm, openai_compatible]
+                        # alias rows only (absent on provider_native):
+                        lq_ai_resolves_to: {type: string}
+                        # alias rows, present only when > 0 (absent otherwise / on provider_native):
+                        lq_ai_fallback_count: {type: integer}
         '401':
           description: Missing or invalid bearer token
           content:

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -909,9 +909,11 @@ components:
           enum: [1, 2, 3, 4, 5]
           description: |
             Tier the request would land at if dispatched at this id.
-            Present on ``provider_native`` rows; omitted on aliases
-            (the alias may resolve to different providers via fallback,
-            so the tier is settled per-request, not per-alias).
+            Present on ``provider_native`` rows and on ``alias`` rows
+            (where it is the tier of the alias's *primary* resolution).
+            For an alias the tier actually applied can still differ
+            per-request if a fallback step runs, so treat it as the
+            expected/primary tier rather than a guarantee.
         provider_type:
           type: string
           enum: [anthropic, openai, vertex, cohere, azure_openai, bedrock, ollama, vllm, openai_compatible]
@@ -919,6 +921,21 @@ components:
             For ``provider_native`` rows: the provider's ``type``
             (``anthropic``, ``ollama``, …). Lets clients group rows
             under user-friendly section headers.
+        lq_ai_resolves_to:
+          type: string
+          description: |
+            ``alias`` rows only: the ``<provider_name>/<native_model>``
+            the alias resolves to today (its primary target), e.g.
+            ``"anthropic-prod/claude-opus-4-7"``. Absent on
+            ``provider_native`` rows. Optional — surfaced so a client
+            can show what an alias currently points at.
+        lq_ai_fallback_count:
+          type: integer
+          description: |
+            ``alias`` rows: how many entries are in the alias's fallback
+            chain after the primary. Present only when the alias has at
+            least one fallback (value ``> 0``); absent when there are no
+            fallbacks and on ``provider_native`` rows. Optional.
 
     AliasFallback:
       type: object

--- a/gateway/tests/test_model_discovery.py
+++ b/gateway/tests/test_model_discovery.py
@@ -687,3 +687,51 @@ def test_to_payload_includes_resolves_to_for_alias() -> None:
     payload = row.to_payload()
     assert payload["lq_ai_resolves_to"] == "anthropic-prod/claude-opus-4-7"
     assert payload["lq_ai_fallback_count"] == 2
+
+
+@pytest.mark.unit
+def test_to_payload_keys_declared_in_openapi_modelentry() -> None:
+    """Every key the live ``GET /v1/models`` emits is a declared property
+    on the ``ModelEntry`` schema in ``docs/api/gateway-openapi.yaml``.
+
+    Pins the hand-written OpenAPI sketch to the live ``to_payload`` shape so
+    the doc can't silently drift behind the gateway (the inverse of the
+    field-presence tests above, which pin the live side). This is a
+    property-*superset* check rather than ``additionalProperties: false`` on
+    the schema, so the contract still tolerates other valid runtime fields.
+    """
+    from pathlib import Path
+
+    import yaml
+
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = yaml.safe_load(
+        (repo_root / "docs" / "api" / "gateway-openapi.yaml").read_text(encoding="utf-8")
+    )
+    declared = set(spec["components"]["schemas"]["ModelEntry"]["properties"].keys())
+
+    # Both row kinds the gateway emits, with every optional field populated.
+    alias = DiscoveredModel(
+        id="smart",
+        owned_by="lq-ai-gateway",
+        lq_ai_kind="alias",
+        routed_inference_tier=4,
+        resolves_to="anthropic-prod/claude-opus-4-7",
+        fallback_count=2,
+    ).to_payload()
+    native = DiscoveredModel(
+        id="anthropic-prod/claude-opus-4-7",
+        owned_by="anthropic-prod",
+        lq_ai_kind="provider_native",
+        provider_type="anthropic",
+        routed_inference_tier=4,
+    ).to_payload()
+
+    for payload in (alias, native):
+        undeclared = set(payload) - declared
+        assert not undeclared, (
+            "GET /v1/models emits keys not declared on ModelEntry in "
+            f"docs/api/gateway-openapi.yaml: {sorted(undeclared)}"
+        )
+    # The alias-only extensions added in this doc fix are explicitly declared.
+    assert {"lq_ai_resolves_to", "lq_ai_fallback_count"} <= declared


### PR DESCRIPTION
## What

Doc-only fix requested by a downstream frontend team. The gateway's `GET /v1/models` (via `ModelDiscoverer.to_payload`, `gateway/app/model_discovery.py:142-159`) **already** returns these on alias rows, but the OpenAPI sketch didn't declare them:

```json
{ "id": "smart", "lq_ai_kind": "alias", "routed_inference_tier": 4,
  "lq_ai_resolves_to": "anthropic-prod/claude-opus-4-7", "lq_ai_fallback_count": 2 }
```

The gateway is authoritative and correct — **no behavior change**, no touch to model resolution / aliasing / discovery. Verified the live shape against `model_discovery.py` and the existing tests (`test_model_discovery.py:673-689` already pin presence-on-alias / absence-on-provider-native, matching this exact example).

## Changes

- **`gateway-openapi.yaml` `ModelEntry`**: added optional `lq_ai_resolves_to` (string) + `lq_ai_fallback_count` (integer) — present on `alias` rows, absent on `provider_native`. Corrected the `routed_inference_tier` description: it **is** present on aliases (the tier of the alias's *primary* resolution), not omitted. Description/schema only — handler untouched.
- **`backend-openapi.yaml`** `/api/v1/models` inline item schema: mirrored the two additions + the tier note (single-sourced to the gateway).
- **`test_model_discovery.py`**: a property-superset conformance test — every key the live `to_payload` emits must be a declared `ModelEntry` property — so the doc can't silently drift behind the gateway. Deliberately **not** `additionalProperties: false`, so the contract still tolerates other valid runtime fields.

All optional (not `required`); `lq_ai_fallback_count` is emitted only when `> 0`. Gateway ruff + the model-discovery suite (29 passed) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)