### PR TITLE
DE-328 — skill_inputs reach non-templated skills (gateway assembler)

### DIFF
--- a/gateway/app/skills/assembler.py
+++ b/gateway/app/skills/assembler.py
@@ -81,7 +81,12 @@ _SKILL_SEPARATOR: Final[str] = "\n\n---\n\n"
 _PREPEND_SEPARATOR: Final[str] = "\n\n---\n\n## Operator system instructions\n\n"
 
 
-def interpolate(template: str, bindings: dict[str, Any]) -> str:
+def interpolate(
+    template: str,
+    bindings: dict[str, Any],
+    *,
+    consumed: set[str] | None = None,
+) -> str:
     """Substitute ``{{name}}`` placeholders with values from ``bindings``.
 
     Unknown variables are left in place. Non-string values are
@@ -90,11 +95,21 @@ def interpolate(template: str, bindings: dict[str, Any]) -> str:
     * ``interpolate("hello {{name}}", {"name": "Ada"}) == "hello Ada"``
     * ``interpolate("hello {{name}}", {})              == "hello {{name}}"``
     * ``interpolate("hi", {"unused": "x"})             == "hi"``
+
+    Optional out-param ``consumed``: if a mutable set is passed, every
+    binding key that was actually substituted by a ``{{placeholder}}``
+    is added to it. This lets callers (DE-328) detect which bound
+    inputs the template never referenced so they can surface them
+    elsewhere instead of silently dropping them. The return value and
+    substitution behavior are unchanged whether or not ``consumed`` is
+    passed — existing callers that omit it are unaffected.
     """
 
     def _replace(match: re.Match[str]) -> str:
         var = match.group(1)
         if var in bindings:
+            if consumed is not None:
+                consumed.add(var)
             value = bindings[var]
             if value is None:
                 return ""
@@ -219,8 +234,13 @@ def _render_skill(skill: Skill, *, inputs: dict[str, Any]) -> _AssembledSkill:
     if skill.description:
         parts.append(skill.description)
 
+    # Track which bound input keys are actually consumed by a
+    # ``{{placeholder}}`` across the body and every reference file, so
+    # we can surface the leftovers (DE-328) rather than dropping them.
+    consumed: set[str] = set()
+
     # Body markdown — apply substitution to the body text.
-    body = interpolate(skill.content_md or "", inputs)
+    body = interpolate(skill.content_md or "", inputs, consumed=consumed)
     parts.append(body.strip("\n"))
 
     # Reference files — appended verbatim with clear delimiters so the
@@ -230,8 +250,28 @@ def _render_skill(skill: Skill, *, inputs: dict[str, Any]) -> _AssembledSkill:
     # that says "for {{counterparty}} ..."); permissive substitution
     # is the right default.
     for ref in skill.reference_files:
-        ref_body = interpolate(ref.content or "", inputs)
+        ref_body = interpolate(ref.content or "", inputs, consumed=consumed)
         parts.append(f"## Reference: {ref.path}\n\n{ref_body.strip()}\n")
+
+    # DE-328 (Option A) — surface caller-bound inputs that no
+    # ``{{placeholder}}`` consumed. None of the built-in skill bodies use
+    # ``{{}}`` tokens, so without this the collected inputs (jurisdiction,
+    # audience, text, …) would vanish before reaching the model. We append
+    # a single labelled block per skill listing each leftover input whose
+    # value is non-empty. Insertion order of ``inputs`` is preserved.
+    # Templated skills whose inputs are all consumed get no block (no
+    # duplication); a skill with no leftover inputs gets no block.
+    leftover = [k for k in inputs if k not in consumed]
+    leftover_lines: list[str] = []
+    for key in leftover:
+        value = inputs[key]
+        if value is None or value == "":
+            continue
+        leftover_lines.append(f"- {key}: {value!s}")
+    if leftover_lines:
+        display = skill.title or skill.name
+        block = f"### Provided inputs for {display}\n\n" + "\n".join(leftover_lines)
+        parts.append(block)
 
     return _AssembledSkill(name=skill.name, text="\n\n".join(parts).strip())
 

--- a/gateway/tests/test_skill_assembler.py
+++ b/gateway/tests/test_skill_assembler.py
@@ -249,6 +249,116 @@ def test_assemble_includes_reference_files_in_separate_blocks() -> None:
     assert "ref b" in out
 
 
+# --- DE-328: unconsumed inputs surfaced as a labelled block ------------------
+
+
+@pytest.mark.unit
+def test_assemble_surfaces_unconsumed_inputs_for_non_templated_skill() -> None:
+    """A non-templated body (no ``{{}}``) must not silently drop bound inputs.
+
+    None of the built-in skills use ``{{placeholder}}`` tokens, so without
+    DE-328 (Option A) the caller-bound inputs vanish before reaching the
+    model. The assembled prompt must carry each leftover input's name AND
+    value under a "Provided inputs" block.
+    """
+
+    skill = Skill(
+        name="comms-improver",
+        title="Comms Improver",
+        content_md="Improve the writing. No placeholders here.",
+        content_yaml="name: comms-improver\n",
+    )
+    out = assemble_skill_prompt(
+        [skill],
+        skill_inputs={
+            "comms-improver": {
+                "audience": "executives",
+                "text": "Our Q3 results",
+            }
+        },
+    )
+    assert "### Provided inputs for Comms Improver" in out
+    assert "audience" in out
+    assert "executives" in out
+    assert "text" in out
+    assert "Our Q3 results" in out
+
+
+@pytest.mark.unit
+def test_assemble_does_not_duplicate_consumed_templated_inputs() -> None:
+    """An input consumed by ``{{}}`` is substituted in-body, not re-listed.
+
+    A templated skill whose inputs are all consumed must get NO "Provided
+    inputs" block, so the value isn't duplicated (once in-body, once in the
+    block).
+    """
+
+    skill = Skill(
+        name="alpha",
+        title="Alpha",
+        content_md="Review {{document}} carefully.",
+        content_yaml="name: alpha\n",
+    )
+    out = assemble_skill_prompt(
+        [skill],
+        skill_inputs={"alpha": {"document": "the NDA"}},
+    )
+    assert "Review the NDA carefully." in out
+    assert "Provided inputs" not in out
+
+
+@pytest.mark.unit
+def test_assemble_block_only_lists_unconsumed_inputs() -> None:
+    """Mixed case: consumed inputs substitute in-body; only leftovers list."""
+
+    skill = Skill(
+        name="alpha",
+        title="Alpha",
+        content_md="Review {{document}} now.",
+        content_yaml="name: alpha\n",
+    )
+    out = assemble_skill_prompt(
+        [skill],
+        skill_inputs={"alpha": {"document": "the NDA", "audience": "the board"}},
+    )
+    assert "Review the NDA now." in out
+    assert "### Provided inputs for Alpha" in out
+    assert "audience" in out
+    assert "the board" in out
+    # The consumed input is not duplicated in the block.
+    assert out.count("the NDA") == 1
+
+
+@pytest.mark.unit
+def test_assemble_omits_empty_value_inputs_from_block() -> None:
+    """Leftover inputs whose value is None/empty-string are not listed."""
+
+    skill = Skill(
+        name="alpha",
+        title="Alpha",
+        content_md="No placeholders.",
+        content_yaml="name: alpha\n",
+    )
+    out = assemble_skill_prompt(
+        [skill],
+        skill_inputs={"alpha": {"audience": "execs", "blank": "", "missing": None}},
+    )
+    assert "### Provided inputs for Alpha" in out
+    assert "audience: execs" in out
+    assert "blank" not in out
+    assert "missing" not in out
+
+
+@pytest.mark.unit
+def test_interpolate_records_consumed_keys() -> None:
+    """The optional ``consumed`` out-param tracks substituted keys only."""
+
+    consumed: set[str] = set()
+    out = interpolate("hi {{name}}", {"name": "Ada", "unused": "x"}, consumed=consumed)
+    assert out == "hi Ada"
+    assert consumed == {"name"}
+
+
 @pytest.mark.unit
 def test_assemble_concatenates_multiple_skills_with_separator() -> None:
     a = _basic_skill("alpha", body="Alpha body")

--- a/gateway/tests/test_skill_assembler.py
+++ b/gateway/tests/test_skill_assembler.py
@@ -360,6 +360,76 @@ def test_interpolate_records_consumed_keys() -> None:
 
 
 @pytest.mark.unit
+def test_assemble_input_consumed_only_in_reference_is_not_relisted() -> None:
+    """A key consumed by a ``{{}}`` in a reference file (not the body) must not
+    reappear in the "Provided inputs" block — consumed-tracking unions the body
+    and every reference file, not just the body.
+    """
+
+    skill = Skill(
+        name="alpha",
+        title="Alpha",
+        content_md="No body placeholders.",
+        content_yaml="name: alpha\n",
+        reference_files=[
+            SkillFile(
+                path="reference/note.md",
+                content="For counterparty {{counterparty}}, proceed.",
+            )
+        ],
+    )
+    out = assemble_skill_prompt(
+        [skill],
+        skill_inputs={"alpha": {"counterparty": "Acme Corp"}},
+    )
+    # Substituted in the reference...
+    assert "For counterparty Acme Corp" in out
+    # ...and therefore NOT re-listed in a Provided-inputs block.
+    assert "Provided inputs" not in out
+    assert out.count("Acme Corp") == 1
+
+
+@pytest.mark.unit
+def test_assemble_provided_inputs_blocks_do_not_bleed_across_skills() -> None:
+    """Each skill's leftover-input block lists only that skill's bindings.
+
+    ``_render_skill`` scopes ``consumed``/``inputs`` per skill, so a multi-skill
+    assemble must keep each "Provided inputs" block under its own skill section
+    with no cross-skill bleed.
+    """
+
+    alpha = Skill(
+        name="alpha",
+        title="Alpha",
+        content_md="Alpha body, no placeholders.",
+        content_yaml="name: alpha\n",
+    )
+    beta = Skill(
+        name="beta",
+        title="Beta",
+        content_md="Beta body, no placeholders.",
+        content_yaml="name: beta\n",
+    )
+    out = assemble_skill_prompt(
+        [alpha, beta],
+        skill_inputs={
+            "alpha": {"audience": "the board"},
+            "beta": {"jurisdiction": "Delaware"},
+        },
+    )
+    assert "### Provided inputs for Alpha" in out
+    assert "### Provided inputs for Beta" in out
+    # Each value appears exactly once, under its own skill's block.
+    assert out.count("the board") == 1
+    assert out.count("Delaware") == 1
+    # Alpha's block precedes Beta's, and alpha's input is above the beta divider.
+    alpha_block = out.index("### Provided inputs for Alpha")
+    beta_header = out.index("# Skill: Beta")
+    assert alpha_block < beta_header
+    assert out.index("the board") < beta_header
+
+
+@pytest.mark.unit
 def test_assemble_concatenates_multiple_skills_with_separator() -> None:
     a = _basic_skill("alpha", body="Alpha body")
     b = _basic_skill("beta", body="Beta body")


### PR DESCRIPTION
## DE-328 — `skill_inputs` reach the model for non-templated skills

**Donna backend ask #1 of 3.** Behavior-only change to the Inference Gateway. No schema/OpenAPI change.

### Problem
`MessageCreate.skill_inputs` is accepted and forwarded to the gateway as `lq_ai_skill_inputs`, but the assembler (`gateway/app/skills/assembler.py`) only substitutes `{{placeholder}}` tokens and silently drops any bound input the body never references. None of the 14 built-in `skills/*/SKILL.md` bodies are templated, so collected inputs (audience, jurisdiction, text, …) vanished before reaching the model for every built-in skill (e.g. comms-improver with `text`/`audience` bound still said "I don't see any text").

### Change (Option A)
- `interpolate(...)` gains an optional **keyword-only** `consumed: set[str] | None = None` out-param that records which binding keys a `{{placeholder}}` actually substituted. Default `None` → identical behavior; fully back-compatible (only callers are inside `assembler.py`).
- `_render_skill(...)` unions consumed keys across the body **and every reference file**, then appends each skill's *unconsumed* non-empty bound inputs as a labelled block:
  ```
  ### Provided inputs for <skill>
  - <name>: <value>
  ```
  Templated inputs (consumed by `{{}}`) are not duplicated; skills with no leftover inputs get no block; the Organization Profile path (`inputs={}`) is unaffected. Per-skill scoped — no cross-skill bleed.

### Tests (`gateway/tests/test_skill_assembler.py`, unit)
Non-templated skill surfaces name+value; templated skill not duplicated; mixed leftover-only listing; None/empty excluded; `interpolate` consumed-tracking; **+ reference-only consumption not re-listed; multi-skill block isolation**.

### Verification (local)
- gateway: `ruff format --check` + `ruff check` clean; `mypy --strict` Success (38 files); pytest **536 passed / 2 skipped**.

Contract unchanged → no `backend-openapi.yaml` edit for this one. Touches `gateway/**` (security boundary) → routed to security review per CODEOWNERS.
