### PR TITLE
MessageCreate.file_ids — per-message file attachment (backend channel)

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -82,6 +82,7 @@ from app.knowledge.embed import DEFAULT_EMBEDDING_MODEL, request_embedding_vecto
 from app.knowledge.retrieval import HybridSearchResult, hybrid_search
 from app.models.chat import Chat, Message, MessageCitation
 from app.models.document import Document
+from app.models.file import File
 from app.models.inference import InferenceRoutingLog
 from app.models.knowledge import KnowledgeBase
 from app.models.project import Project
@@ -212,6 +213,66 @@ async def _load_visible_chat(
             details={"chat_id": str(chat_id)},
         )
     return row
+
+
+async def _validate_owned_file_ids(
+    db: AsyncSession,
+    file_ids: list[str],
+    owner_id: uuid.UUID,
+) -> list[str]:
+    """Validate caller-owned, non-deleted file ids for per-message attach.
+
+    Mirrors :func:`app.api.files._load_visible_file`'s ownership posture:
+    each id must parse as a UUID and resolve to a non-soft-deleted
+    ``files`` row owned by ``owner_id``. Any id that is malformed,
+    nonexistent, soft-deleted, or owned by another user raises
+    :class:`NotFound` (404) — **id-probing-safe**: a foreign file is
+    indistinguishable from a nonexistent one, so the caller can't probe
+    for the existence of files they don't own (per CLAUDE.md
+    information-leakage avoidance + the C4 file-ownership brief).
+
+    Returns the validated ids as strings (deduped, order-preserving) for
+    forwarding to the gateway as ``lq_ai_file_ids``. Empty input returns
+    an empty list without a DB round-trip — the back-compatible no-op
+    path.
+    """
+
+    if not file_ids:
+        return []
+
+    # Parse + dedupe while preserving first-seen order. A malformed id is
+    # a 404 (not a 422) so it's indistinguishable from "not yours" — the
+    # caller learns nothing about which ids exist.
+    parsed: list[uuid.UUID] = []
+    seen: set[uuid.UUID] = set()
+    for raw in file_ids:
+        try:
+            fid = uuid.UUID(raw)
+        except (ValueError, AttributeError) as exc:
+            raise NotFound(
+                f"File {raw} not found.",
+                details={"file_id": str(raw)},
+            ) from exc
+        if fid not in seen:
+            seen.add(fid)
+            parsed.append(fid)
+
+    # Single SELECT for all ids, scoped to owner + not-deleted. Any id
+    # that doesn't come back is 404'd (the loop above already deduped).
+    stmt = select(File.id).where(
+        File.id.in_(parsed),
+        File.owner_id == owner_id,
+        File.deleted_at.is_(None),
+    )
+    found = set((await db.execute(stmt)).scalars().all())
+    for fid in parsed:
+        if fid not in found:
+            raise NotFound(
+                f"File {fid} not found.",
+                details={"file_id": str(fid)},
+            )
+
+    return [str(fid) for fid in parsed]
 
 
 async def _message_count(db: AsyncSession, chat_id: uuid.UUID) -> int:
@@ -925,6 +986,15 @@ async def send_message(
     # must explicitly unarchive (PATCH archived=false) before posting.
     chat = await _load_visible_chat(db, cid, user.id, include_archived=False)
 
+    # Donna — validate caller-owned ``file_ids`` before anything is
+    # persisted or dispatched. Ownership is enforced id-probing-safe
+    # (404 on foreign / nonexistent / soft-deleted, indistinguishable
+    # from one another) so the caller can't enumerate file ids they
+    # don't own. Validated ids forward to the gateway as
+    # ``lq_ai_file_ids`` and echo back as ``applied_file_ids``. Empty /
+    # omitted is a no-op (no DB round-trip) — back-compatible.
+    effective_file_ids = await _validate_owned_file_ids(db, payload.file_ids, user.id)
+
     # Wave D.2 Task 3.0 — merge legacy ``skills`` with new
     # ``attached_skills``. Each ``attached_skills`` entry is XOR'd at
     # schema time: ``slug`` entries roll into the legacy slug path
@@ -1176,6 +1246,7 @@ async def send_message(
         lq_ai_skills=list(effective_skills),
         lq_ai_skill_inputs=dict(effective_skill_inputs),
         lq_ai_inline_skills=list(inline_skill_refs),
+        lq_ai_file_ids=list(effective_file_ids),
         lq_ai_project_minimum_inference_tier=project_floor,
         lq_ai_privileged=project_privileged,
     )
@@ -1929,6 +2000,7 @@ async def _non_streaming_response(
         routed_provider=response.routed_provider,
         cost_estimate=response.cost_estimate,
         applied_skills=applied_skills,
+        applied_file_ids=list(request.lq_ai_file_ids),
         attached_skill_names=list(attached_skill_names or []),
         slash_unresolved=slash_unresolved,
     )
@@ -2146,6 +2218,10 @@ async def _stream_response(
                     "created_at": datetime.now(tz=UTC).isoformat(),
                 },
                 "applied_skills": last_applied_skills or [],
+                # Donna — echo the validated, caller-owned file ids that
+                # were forwarded to the gateway for this turn (mirrors
+                # ``applied_skills``; turn-scoped, not persisted).
+                "applied_file_ids": list(request.lq_ai_file_ids),
                 "citations": [],
                 "routed_inference_tier": last_tier,
                 "routed_provider": last_provider,

--- a/api/app/schemas/chats.py
+++ b/api/app/schemas/chats.py
@@ -83,6 +83,16 @@ path attaches exactly one skill, the wizard tryout attaches exactly
 one, and even an "attach multiple skills to a chat" UX rarely exceeds
 a handful. Requests with more than 16 attachments 422 at schema time."""
 
+MESSAGE_FILE_IDS_MAX_LEN: int = 16
+"""Donna — hard cap on ``MessageCreateRequest.file_ids``.
+
+Each id triggers an ownership-validation SELECT and forwards document
+context to the gateway for one turn. Without a cap, a single message
+could attach thousands of file ids — workload-multiplication DoS
+available to any authenticated user. 16 matches
+:data:`ATTACHED_SKILLS_MAX_LEN`; realistic per-turn document context is
+a handful of files. Requests over the cap 422 at schema time."""
+
 KNOWN_ATTACHED_SKILL_SOURCES: frozenset[str] = frozenset(
     {"slash", "wizard-tryout", "tryit-tab", "capture", "manual"}
 )
@@ -381,7 +391,35 @@ class MessageCreateRequest(BaseModel):
     """C2: per-skill input bindings, keyed by skill name. Forwarded as
     ``lq_ai_skill_inputs``. Per-attachment ``inputs`` on
     ``attached_skills`` entries are merged into this map at handler
-    time (the per-attachment value wins on key collision)."""
+    time (the per-attachment value wins on key collision).
+
+    Note on the ``file_ids`` interaction: ``skill_inputs`` values are
+    plain scalars interpolated into the skill body via ``{{name}}``
+    substitution (ADR 0006 / the gateway's ``skills/assembler.py``).
+    There is **no** ``type:"file"`` binding that resolves a ``file_id``
+    to document content today — passing a file UUID as a skill-input
+    value would interpolate the literal UUID string, not the file's
+    text. To attach document context for a turn, use the separate
+    :attr:`file_ids` channel below, not ``skill_inputs``."""
+
+    file_ids: list[str] = Field(default_factory=list, max_length=MESSAGE_FILE_IDS_MAX_LEN)
+    """Donna: caller-owned file UUIDs supplying ephemeral, per-message
+    document context for this one chat turn. Distinct from KB attach
+    (which is project-scoped and persistent): these ids bind document
+    context to a single send and are not stored on the chat.
+
+    Each id is validated server-side to exist and be owned by the
+    caller (id-probing-safe: a foreign or unknown id 404s exactly like
+    ``GET /files/{id}``). Validated ids are forwarded to the gateway as
+    ``lq_ai_file_ids`` alongside ``lq_ai_skills`` and echoed back as
+    ``applied_file_ids`` on the response / SSE ``complete`` frame.
+
+    This is a **separate channel from** ``skill_inputs``: file_ids are
+    NOT bound to a skill file-input via ``skill_inputs`` (no
+    ``type:"file"`` binding is wired — see the ``skill_inputs`` note
+    above). Populate ``file_ids`` for document context; populate
+    ``skill_inputs`` for scalar skill parameters. Omitted / empty is
+    fully back-compatible (pre-existing wire shape unchanged)."""
 
     stream: bool = False
     """Whether to stream the response as SSE. ``False`` returns a single
@@ -523,6 +561,15 @@ class MessagePostResponse(BaseModel):
     routed_provider: str | None = None
     cost_estimate: float | None = None
     applied_skills: list[str] = Field(default_factory=list)
+    applied_file_ids: list[str] = Field(default_factory=list)
+    """Donna: caller-owned file ids that were validated and forwarded to
+    the gateway as ``lq_ai_file_ids`` for this turn — the echo of
+    :attr:`MessageCreateRequest.file_ids`. Mirrors how ``applied_skills``
+    is echoed, but turn-scoped: there is no ``messages.file_ids`` column,
+    so this surfaces only on the send response (and the SSE ``complete``
+    frame), not on rows read back via ``GET /chats/{id}/messages``. Empty
+    when no file_ids were attached."""
+
     attached_skill_names: list[str] = Field(default_factory=list)
     """Wave D.2 Task 2.7 — slugs the send-time slash fallback attached
     on the caller's behalf. Distinct from ``applied_skills`` (the
@@ -562,6 +609,7 @@ __all__ = [
     "KNOWN_ATTACHED_SKILL_SOURCES",
     "LIST_LIMIT_DEFAULT",
     "LIST_LIMIT_MAX",
+    "MESSAGE_FILE_IDS_MAX_LEN",
     "TITLE_MAX_LEN",
     "AttachedSkillRef",
     "ChatCreateRequest",

--- a/api/app/schemas/gateway.py
+++ b/api/app/schemas/gateway.py
@@ -153,8 +153,9 @@ class ChatCompletionRequest(BaseModel):
     lq_ai_file_ids: list[str] = Field(default_factory=list, max_length=16)
     """Donna: caller-owned file UUIDs supplying ephemeral per-message
     document context for this turn. The backend validates ownership
-    (id-probing-safe 404) before forwarding; the gateway consumes these
-    as the document-context channel for the send. Distinct from
+    (id-probing-safe 404) before forwarding; this is the channel the
+    gateway will consume as document context (gateway-side consumption
+    is a follow-up — see DE for file-content injection). Distinct from
     ``lq_ai_skills`` (the prompt-assembly channel) and from KB attach
     (project-scoped, persistent). Empty list (default) preserves the
     pre-existing wire shape exactly. Capped server-side at the same

--- a/api/app/schemas/gateway.py
+++ b/api/app/schemas/gateway.py
@@ -150,6 +150,16 @@ class ChatCompletionRequest(BaseModel):
     lq_ai_skill_inputs: dict[str, dict[str, Any]] = Field(default_factory=dict)
     """Per-skill input bindings, keyed by skill name."""
 
+    lq_ai_file_ids: list[str] = Field(default_factory=list, max_length=16)
+    """Donna: caller-owned file UUIDs supplying ephemeral per-message
+    document context for this turn. The backend validates ownership
+    (id-probing-safe 404) before forwarding; the gateway consumes these
+    as the document-context channel for the send. Distinct from
+    ``lq_ai_skills`` (the prompt-assembly channel) and from KB attach
+    (project-scoped, persistent). Empty list (default) preserves the
+    pre-existing wire shape exactly. Capped server-side at the same
+    bound as the request schema's ``file_ids``."""
+
     lq_ai_inline_skills: list[InlineSkillRef] = Field(default_factory=list, max_length=16)
     """Wave D.2 Task 3.0: inline-body skills the gateway assembles
     without a catalogue fetch. Mirrors

--- a/api/tests/test_chats_skills_forwarding.py
+++ b/api/tests/test_chats_skills_forwarding.py
@@ -30,6 +30,7 @@ from app.clients.gateway import GatewayClient, set_gateway_client
 from app.db.session import get_db
 from app.main import app
 from app.models.chat import Chat
+from app.models.file import File
 from app.models.user import User
 from app.security import create_access_token, hash_password
 
@@ -91,6 +92,30 @@ async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
 
 def _bearer_for(user: User) -> str:
     return create_access_token(user.id, user.email, is_admin=user.is_admin)
+
+
+async def _make_file(
+    db_session: AsyncSession,
+    owner: User,
+    *,
+    deleted: bool = False,
+) -> File:
+    """Insert a minimal ``files`` row owned by ``owner``."""
+    import datetime as _dt
+
+    f = File(
+        owner_id=owner.id,
+        filename="contract.pdf",
+        mime_type="application/pdf",
+        size_bytes=1234,
+        hash_sha256="0" * 64,
+        storage_path=str(uuid.uuid4()),
+        ingestion_status="ready",
+        deleted_at=(_dt.datetime.now(tz=_dt.UTC) if deleted else None),
+    )
+    db_session.add(f)
+    await db_session.flush()
+    return f
 
 
 def _success_payload(
@@ -336,3 +361,188 @@ async def test_skill_input_missing_propagates_to_400(client: AsyncClient, db_use
     body = response.json()
     assert body["detail"]["code"] == "skill_input_missing"
     assert "alpha.document" in body["detail"]["details"]["missing"]
+
+
+# --- file_ids: per-message document context (Donna) -------------------------
+
+
+def _stream_chunk(content: str) -> str:
+    chunk = {
+        "id": "chatcmpl-stream",
+        "object": "chat.completion.chunk",
+        "created": 1_700_000_000,
+        "model": "claude-sonnet-4-6",
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant", "content": content}, "finish_reason": None}
+        ],
+        "routed_inference_tier": 3,
+        "routed_provider": "anthropic-prod",
+    }
+    return f"data: {_json.dumps(chunk)}\n\n"
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_file_ids_forwarded_and_echoed_non_streaming(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """Caller-owned file_ids forward as lq_ai_file_ids and echo back."""
+
+    f = await _make_file(db_session, db_user)
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "summarize this", "model": "smart", "file_ids": [str(f.id)]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    sent = _json.loads(route.calls[0].request.read())
+    assert sent["lq_ai_file_ids"] == [str(f.id)]
+    body = response.json()
+    assert body["applied_file_ids"] == [str(f.id)]
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_file_ids_foreign_owner_404(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """A file owned by another user 404s without leaking existence; no gateway call."""
+
+    other = User(
+        email=f"other-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Other",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(other)
+    await db_session.flush()
+    foreign = await _make_file(db_session, other)
+
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "summarize this", "model": "smart", "file_ids": [str(foreign.id)]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 404
+    # The gateway is never reached when validation fails.
+    assert not route.called
+    # The 404 detail carries only the id the caller already sent — no
+    # owner / existence signal that distinguishes "not yours" from
+    # "doesn't exist".
+    body = response.json()
+    assert body["detail"]["details"]["file_id"] == str(foreign.id)
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_file_ids_nonexistent_404(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """An unknown UUID 404s identically to a foreign file (id-probing-safe)."""
+
+    ghost = str(uuid.uuid4())
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "hi", "model": "smart", "file_ids": [ghost]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 404
+    assert not route.called
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_file_ids_soft_deleted_404(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """A soft-deleted file owned by the caller still 404s."""
+
+    f = await _make_file(db_session, db_user, deleted=True)
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "hi", "model": "smart", "file_ids": [str(f.id)]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 404
+    assert not route.called
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_no_file_ids_means_empty_extension_field(client: AsyncClient, db_user: User) -> None:
+    """Omitted file_ids is back-compatible: empty/absent lq_ai_file_ids, empty echo."""
+
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "hi", "model": "smart"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    sent = _json.loads(route.calls[0].request.read())
+    # exclude_none/exclude_default serialization may drop the empty list.
+    assert sent.get("lq_ai_file_ids", []) == []
+    assert response.json()["applied_file_ids"] == []
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_file_ids_echoed_on_streaming_complete_frame(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """The streaming `complete` SSE frame echoes applied_file_ids."""
+
+    f = await _make_file(db_session, db_user)
+    body = _stream_chunk("done") + "data: [DONE]\n\n"
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    token = _bearer_for(db_user)
+
+    events: list[dict[str, object]] = []
+    async with client.stream(
+        "POST",
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "summarize", "stream": True, "file_ids": [str(f.id)]},
+        headers={"Authorization": f"Bearer {token}"},
+    ) as resp:
+        assert resp.status_code == 200
+        async for line in resp.aiter_lines():
+            line = line.strip()
+            if not line or line == "data: [DONE]":
+                if line == "data: [DONE]":
+                    break
+                continue
+            events.append(_json.loads(line[len("data:") :].strip()))
+
+    complete = [e for e in events if e["type"] == "complete"]
+    assert len(complete) == 1
+    assert complete[0]["applied_file_ids"] == [str(f.id)]

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -6033,6 +6033,31 @@ components:
             that the skill's frontmatter declares but the bindings
             don't provide cause a 400 with `code=skill_input_missing`.
 
+            Values are plain scalars interpolated into the skill body via
+            `{{name}}` substitution (ADR 0006). There is NO `type:"file"`
+            binding: passing a file UUID here interpolates the literal
+            UUID string, not the file's document text. For per-turn
+            document context use the separate `file_ids` channel below —
+            `skill_inputs` and `file_ids` are distinct; a `file_id` is
+            NOT bindable to a skill file-input via `skill_inputs`.
+        file_ids:
+          type: array
+          maxItems: 16
+          items: {type: string, format: uuid}
+          description: |
+            Donna: caller-owned file UUIDs supplying ephemeral,
+            per-message document context for this one chat turn.
+            Distinct from KB attach (project-scoped, persistent) and
+            from `skill_inputs` (scalar skill params — see the note
+            above; no `type:"file"` binding is wired). Each id is
+            validated server-side to exist and be owned by the caller;
+            a foreign, unknown, or soft-deleted id returns 404
+            (id-probing-safe — indistinguishable from "not found").
+            Validated ids are forwarded to the gateway as `lq_ai_file_ids`
+            alongside `lq_ai_skills` and echoed back as `applied_file_ids`
+            on the response / SSE `complete` frame. Capped at 16 entries.
+            Omitted / empty is back-compatible.
+
     MessagePostResponse:
       type: object
       required: [message, citations]
@@ -6069,6 +6094,17 @@ components:
           description: |
             C2: skills that were successfully assembled into the prompt
             for this request. Empty when no skills were attached.
+        applied_file_ids:
+          type: array
+          items: {type: string, format: uuid}
+          description: |
+            Donna: caller-owned file ids that were validated and
+            forwarded to the gateway as `lq_ai_file_ids` for this turn —
+            the echo of `MessageCreate.file_ids` (mirrors
+            `applied_skills`). Turn-scoped: there is no
+            `messages.file_ids` column, so this surfaces only on the send
+            response (and the SSE `complete` frame), not on rows read
+            back via `GET /chats/{id}/messages`. Empty when none attached.
 
     MessageStreamEvent:
       oneOf:
@@ -6136,6 +6172,14 @@ components:
           description: |
             C2: skills that were successfully assembled into the prompt
             for this request. Empty when no skills were attached.
+        applied_file_ids:
+          type: array
+          items: {type: string, format: uuid}
+          description: |
+            Donna: caller-owned file ids forwarded to the gateway as
+            `lq_ai_file_ids` for this turn — the echo of
+            `MessageCreate.file_ids` (mirrors `applied_skills`).
+            Turn-scoped; not persisted. Empty when none attached.
         routed_inference_tier:
           type: integer
           enum: [1,2,3,4,5]


### PR DESCRIPTION
## `MessageCreate.file_ids` — per-message file attachment (backend channel)

**Donna backend ask #2 of 3 — Part A (backend channel).** A follow-up PR (Part B) will teach the gateway to consume the channel (fetch file text + inject as document context through anonymization); this PR is the backend plumbing only.

### What it does
- `MessageCreate.file_ids: list[str]` (optional, ≤16) — caller-owned file UUIDs for ephemeral, per-turn document context (distinct from KB attach, which is project-scoped + persistent).
- Send handler validates each id is caller-owned/existing **before** dispatch (both streaming + non-streaming), **id-probing-safe**: foreign / nonexistent / malformed / soft-deleted all collapse to `404` with no existence leakage (mirrors `_load_visible_file`).
- Forwards validated ids to the gateway as `lq_ai_file_ids` alongside `lq_ai_skills`, and **echoes** applied ids as `applied_file_ids` on the message response + the SSE `complete` frame (mirrors `applied_skills`).
- Documents the `skill_inputs type:"file"` interaction: **separate channel** — a file_id is NOT bindable via `skill_inputs` (those are scalar `{{}}` substitutions), so Donna should populate `file_ids` for document context.

### Honest scope
The gateway does **not** yet consume `lq_ai_file_ids` — so file content does not reach the model until Part B lands. The contract wording says "forwarded … will be consumed", not that the assistant already reads it. No new endpoint, **no migration / no persisted column** (the echo is turn-scoped, request-derived).

### Tests & verification
- 6 new tests (stream + non-stream): valid→2xx + forwarded payload + echoed; foreign/nonexistent/soft-deleted→404 (gateway never called, no leakage); omitted/empty→back-compat.
- `test_openapi.py` path count unchanged (114; no new path). ruff + mypy clean; full chats/forwarding suites green against a throwaway DB (dev DB untouched).
