### PR TITLE
Attached-file content injection — MessageCreate.file_ids Part B

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -1353,8 +1353,14 @@ async def send_message(
             project_id=chat.project_id,
             request=request,
             details={
+                # All validated file_ids forwarded this turn, vs. the count
+                # whose extracted text was actually injected as document
+                # context (a file with no parsed text yet is attached but
+                # contributes nothing) — kept as distinct fields so Receipts
+                # don't conflate "attached" with "reached the model".
                 "file_ids": list(effective_file_ids),
-                "file_count": len(attached_file_contexts),
+                "attached_count": len(effective_file_ids),
+                "injected_count": len(attached_file_contexts),
             },
         )
         await db.commit()

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -275,6 +275,69 @@ async def _validate_owned_file_ids(
     return [str(fid) for fid in parsed]
 
 
+async def _load_attached_file_contexts(
+    db: AsyncSession,
+    file_ids: list[str],
+    owner_id: uuid.UUID,
+) -> list[tuple[str, str]]:
+    """Load ``(filename, content)`` for per-message attached files, in caller order.
+
+    The text is :attr:`Document.normalized_content` (the canonical
+    PyMuPDF character stream) joined ``File → Document`` on
+    ``Document.file_id == File.id``. The query is **owner-scoped**
+    (``owner_id == ... AND deleted_at IS NULL``) as defense in depth —
+    even though :func:`_validate_owned_file_ids` has already validated
+    ownership upstream, this read re-asserts the boundary rather than
+    trusting the caller-supplied ids.
+
+    Files are returned in the order their ids appear in ``file_ids``
+    (deduped, first-seen). A file with **no Document row yet** (ingestion
+    pending or failed) or with empty ``normalized_content`` is OMITTED
+    from the result — it was validly attached, it just has no extractable
+    text to inject. This is graceful, not an error: the send still
+    proceeds, the file simply contributes no document-context block.
+
+    Empty input returns an empty list without a DB round-trip.
+    """
+
+    if not file_ids:
+        return []
+
+    parsed: list[uuid.UUID] = []
+    seen: set[uuid.UUID] = set()
+    for raw in file_ids:
+        try:
+            fid = uuid.UUID(raw)
+        except (ValueError, AttributeError):
+            # Upstream validation already 404s malformed ids; if a bad id
+            # reaches here it simply contributes no context.
+            continue
+        if fid not in seen:
+            seen.add(fid)
+            parsed.append(fid)
+
+    stmt = (
+        select(File.id, File.filename, Document.normalized_content)
+        .join(Document, Document.file_id == File.id)
+        .where(
+            File.id.in_(parsed),
+            File.owner_id == owner_id,
+            File.deleted_at.is_(None),
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+    by_id: dict[uuid.UUID, tuple[str, str]] = {}
+    for row in rows:
+        fid, filename, content = row[0], row[1], row[2]
+        # Omit files with no extractable text (empty / whitespace-only).
+        if content and content.strip():
+            by_id[fid] = (filename, content)
+
+    # Preserve caller-supplied order; files without a Document or with no
+    # text simply don't appear in ``by_id`` and are skipped.
+    return [by_id[fid] for fid in parsed if fid in by_id]
+
+
 async def _message_count(db: AsyncSession, chat_id: uuid.UUID) -> int:
     """Return the count of messages for a chat (single COUNT(*) query)."""
 
@@ -920,6 +983,37 @@ def _format_retrieval_context_block(
     return "\n".join(lines).rstrip()
 
 
+def _format_attached_files_block(files: list[tuple[str, str]]) -> str:
+    """Render per-message attached files as a Markdown system-message block.
+
+    Mirrors :func:`_format_retrieval_context_block`'s style: a header line
+    so the LLM recognizes the block as attached document context, then one
+    ``### {filename}`` section per file with the file's extracted text
+    verbatim. The block is injected as a ``system`` message marked
+    ``lq_ai_skip_anonymization=True`` so the content stays verbatim to the
+    provider (Decision M2-1 — attached files are document content, like
+    retrieved KB documents, and the model needs intact source text).
+
+    Callers must only pass files that actually produced text; this helper
+    does not filter (the empty-text omission happens in
+    :func:`_load_attached_file_contexts`).
+    """
+
+    lines: list[str] = [
+        "## Attached documents for this turn",
+        "",
+        "Documents the user attached to this message. Treat them as "
+        "primary source material for the user's question.",
+        "",
+    ]
+    for filename, content in files:
+        lines.append(f"### {filename}")
+        lines.append("")
+        lines.append(content)
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
 # ---------------------------------------------------------------------------
 # Messages: post (the keystone)
 # ---------------------------------------------------------------------------
@@ -1222,6 +1316,49 @@ async def send_message(
             },
         )
         await db.commit()
+
+    # Part B — inject per-message attached-file content as a verbatim
+    # document-context system message, mirroring the KB-retrieval block
+    # above. ``effective_file_ids`` are already ownership-validated;
+    # ``_load_attached_file_contexts`` re-asserts the owner scope (defense
+    # in depth) and returns ``(filename, content)`` per file that has
+    # extractable text. Files with no Document yet (ingestion pending /
+    # failed) or empty content are omitted gracefully — no block, no
+    # error. Decision M2-1: attached files are document content, so the
+    # injected message opts out of anonymization (verbatim to provider),
+    # exactly like the retrieval block. Injecting here — before the final
+    # ``user`` turn and at the single ``gw_messages`` build site — covers
+    # both the streaming and non-streaming dispatch paths.
+    attached_file_contexts = await _load_attached_file_contexts(
+        db, list(effective_file_ids), user.id
+    )
+    if attached_file_contexts:
+        attached_block = _format_attached_files_block(attached_file_contexts)
+        gw_messages.append(
+            ChatCompletionMessage(
+                role="system",
+                content=attached_block,
+                lq_ai_skip_anonymization=True,
+            )
+        )
+        # Audit row mirroring inference.kb_chunks_retrieved — committed on
+        # its own boundary so Receipts records that file content was
+        # attached regardless of the downstream gateway-call outcome.
+        await audit_action(
+            db,
+            user_id=user.id,
+            action="inference.message_files_attached",
+            resource_type="chat",
+            resource_id=str(cid),
+            project_id=chat.project_id,
+            request=request,
+            details={
+                "file_ids": list(effective_file_ids),
+                "file_count": len(attached_file_contexts),
+            },
+        )
+        await db.commit()
+
     gw_messages.append(ChatCompletionMessage(role="user", content=effective_content))
 
     # Build the gateway request. C3 still sends a single-turn request

--- a/api/tests/test_chats_skills_forwarding.py
+++ b/api/tests/test_chats_skills_forwarding.py
@@ -814,4 +814,5 @@ async def test_attached_file_writes_audit_row(
     assert row.user_id == db_user.id
     assert row.details is not None
     assert row.details["file_ids"] == [str(f.id)]
-    assert row.details["file_count"] == 1
+    assert row.details["attached_count"] == 1
+    assert row.details["injected_count"] == 1

--- a/api/tests/test_chats_skills_forwarding.py
+++ b/api/tests/test_chats_skills_forwarding.py
@@ -24,12 +24,15 @@ import pytest
 import pytest_asyncio
 import respx
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.clients.gateway import GatewayClient, set_gateway_client
 from app.db.session import get_db
 from app.main import app
+from app.models.audit import AuditLog
 from app.models.chat import Chat
+from app.models.document import Document
 from app.models.file import File
 from app.models.user import User
 from app.security import create_access_token, hash_password
@@ -114,6 +117,32 @@ async def _make_file(
         deleted_at=(_dt.datetime.now(tz=_dt.UTC) if deleted else None),
     )
     db_session.add(f)
+    await db_session.flush()
+    return f
+
+
+async def _make_file_with_document(
+    db_session: AsyncSession,
+    owner: User,
+    *,
+    filename: str = "contract.pdf",
+    content: str = "This Agreement is governed by Delaware law.",
+) -> File:
+    """Insert a ``files`` row plus its joined ``documents`` row with text.
+
+    Part B fetches ``Document.normalized_content`` joined File→Document to
+    build the attached-files context block. Passing ``content=""`` produces
+    a Document with no extractable text (the graceful-omit case).
+    """
+
+    f = await _make_file(db_session, owner)
+    f.filename = filename
+    doc = Document(
+        file_id=f.id,
+        parser="pymupdf",
+        normalized_content=content,
+    )
+    db_session.add(doc)
     await db_session.flush()
     return f
 
@@ -546,3 +575,243 @@ async def test_file_ids_echoed_on_streaming_complete_frame(
     complete = [e for e in events if e["type"] == "complete"]
     assert len(complete) == 1
     assert complete[0]["applied_file_ids"] == [str(f.id)]
+
+
+# --- Part B: attached-file content injection --------------------------------
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_attached_file_content_injected_as_system_message_non_streaming(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """A file WITH document text injects a verbatim system message (M2-1)."""
+
+    f = await _make_file_with_document(
+        db_session,
+        db_user,
+        filename="nda.pdf",
+        content="The receiving party shall not disclose Confidential Information.",
+    )
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "summarize this", "model": "smart", "file_ids": [str(f.id)]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    sent = _json.loads(route.calls[0].request.read())
+    messages = sent["messages"]
+    # system attached-docs block + user turn.
+    assert len(messages) == 2, messages
+    sys_msg = messages[0]
+    assert sys_msg["role"] == "system"
+    assert "Attached documents for this turn" in sys_msg["content"]
+    assert "nda.pdf" in sys_msg["content"]
+    assert "The receiving party shall not disclose Confidential Information." in sys_msg["content"]
+    # Decision M2-1: attached document content stays verbatim to the provider.
+    assert sys_msg["lq_ai_skip_anonymization"] is True
+    # User turn is still last, unchanged.
+    assert messages[-1] == {
+        "role": "user",
+        "content": "summarize this",
+        "lq_ai_skip_anonymization": False,
+    }
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_attached_file_content_injected_streaming(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """The same injection feeds the streaming path (single gw_request build)."""
+
+    f = await _make_file_with_document(
+        db_session,
+        db_user,
+        filename="msa.pdf",
+        content="Term and termination provisions apply.",
+    )
+    body = _stream_chunk("done") + "data: [DONE]\n\n"
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    token = _bearer_for(db_user)
+
+    async with client.stream(
+        "POST",
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "review", "stream": True, "file_ids": [str(f.id)]},
+        headers={"Authorization": f"Bearer {token}"},
+    ) as resp:
+        assert resp.status_code == 200
+        async for _line in resp.aiter_lines():
+            pass
+
+    sent = _json.loads(route.calls[0].request.read())
+    messages = sent["messages"]
+    sys_msgs = [m for m in messages if m["role"] == "system"]
+    assert len(sys_msgs) == 1
+    assert "msa.pdf" in sys_msgs[0]["content"]
+    assert "Term and termination provisions apply." in sys_msgs[0]["content"]
+    assert sys_msgs[0]["lq_ai_skip_anonymization"] is True
+    assert messages[-1]["role"] == "user"
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_two_attached_files_both_present_in_order(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """Two files → both contents in one block, in caller-supplied order."""
+
+    f1 = await _make_file_with_document(
+        db_session, db_user, filename="first.pdf", content="ALPHA clause body."
+    )
+    f2 = await _make_file_with_document(
+        db_session, db_user, filename="second.pdf", content="BRAVO clause body."
+    )
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={
+            "content": "compare these",
+            "model": "smart",
+            "file_ids": [str(f1.id), str(f2.id)],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    sent = _json.loads(route.calls[0].request.read())
+    sys_content = next(m["content"] for m in sent["messages"] if m["role"] == "system")
+    assert "ALPHA clause body." in sys_content
+    assert "BRAVO clause body." in sys_content
+    # Order preserved: first.pdf section precedes second.pdf section.
+    assert sys_content.index("first.pdf") < sys_content.index("second.pdf")
+    assert sys_content.index("ALPHA") < sys_content.index("BRAVO")
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_attached_file_without_text_is_omitted_gracefully(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """A file with an empty Document produces no block; request still succeeds."""
+
+    f = await _make_file_with_document(db_session, db_user, content="")
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "summarize", "model": "smart", "file_ids": [str(f.id)]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    sent = _json.loads(route.calls[0].request.read())
+    # file_ids still forwarded (Part A contract) but no attached-docs block.
+    assert sent["lq_ai_file_ids"] == [str(f.id)]
+    assert sent["messages"] == [
+        {"role": "user", "content": "summarize", "lq_ai_skip_anonymization": False}
+    ]
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_attached_file_with_no_document_is_omitted_gracefully(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """A validly-attached file with NO Document row yet → no block, no crash."""
+
+    f = await _make_file(db_session, db_user)  # no Document created
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "summarize", "model": "smart", "file_ids": [str(f.id)]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    sent = _json.loads(route.calls[0].request.read())
+    assert sent["messages"] == [
+        {"role": "user", "content": "summarize", "lq_ai_skip_anonymization": False}
+    ]
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_no_file_ids_means_no_attached_docs_block(client: AsyncClient, db_user: User) -> None:
+    """Omitted file_ids: back-compat, no attached-docs system message."""
+
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "hi", "model": "smart"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    sent = _json.loads(route.calls[0].request.read())
+    assert sent["messages"] == [
+        {"role": "user", "content": "hi", "lq_ai_skip_anonymization": False}
+    ]
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_attached_file_writes_audit_row(
+    client: AsyncClient, db_user: User, db_session: AsyncSession
+) -> None:
+    """A file with content writes an inference.message_files_attached audit row."""
+
+    f = await _make_file_with_document(
+        db_session, db_user, filename="deed.pdf", content="Grantor conveys to Grantee."
+    )
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    response = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "summarize", "model": "smart", "file_ids": [str(f.id)]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.action == "inference.message_files_attached",
+                    AuditLog.resource_id == _DUMMY_CHAT_ID,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.resource_type == "chat"
+    assert row.user_id == db_user.id
+    assert row.details is not None
+    assert row.details["file_ids"] == [str(f.id)]
+    assert row.details["file_count"] == 1


### PR DESCRIPTION
## Attached-file content injection — `MessageCreate.file_ids` Part B

**Donna #2 Part B (completes #2).** Part A (#116) added the backend channel (validate/forward/echo); this makes the attached file content actually reach the model. **api-only** — mirrors the existing KB-retrieval-context injection, so no gateway/security-boundary change.

### What it does
- Fetches each validated file's extracted text (`Document.normalized_content`, joined `File→Document`, owner-scoped defense-in-depth) in caller order.
- Injects a `## Attached documents for this turn` **system** message with **`lq_ai_skip_anonymization=True`** — verbatim to the provider, per **Decision M2-1** (attached files are document content, like retrieved KB docs). The user turn stays last.
- One build site feeds both streaming + non-streaming.
- Files with no parsed text yet are **omitted gracefully** (no error, no empty block).
- Audit row `inference.message_files_attached` with `file_ids` + `attached_count` (all forwarded) + `injected_count` (those whose text reached the model) — distinct fields so Receipts don't conflate the two.

### Scope / honesty
- **No schema/endpoint/migration/OpenAPI change** (the `file_ids` field shipped in Part A); `test_openapi` stays 114 paths.
- Verbatim treatment is the deliberate, confirmed privacy decision (M2-1) — file content is **not** pseudonymized before the provider, same as retrieved KB documents.

### Tests & verification
- Tests (stream + non-stream): content present in a `system` message with `lq_ai_skip_anonymization=True`; two-file ordering; no-text file omitted gracefully (empty-Document + no-Document cases); back-compat; audit row shape.
- ruff + mypy clean; `test_chats_skills_forwarding.py` 21 passed against a throwaway pgvector DB (dev DB untouched).
