### PR TITLE
PATCH /api/v1/users/me — edit own profile (display_name)

### DIFF
--- a/api/app/api/users.py
+++ b/api/app/api/users.py
@@ -27,7 +27,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -107,6 +107,55 @@ class UserPreferencesUpdate(BaseModel):
     autonomous_enabled: bool | None = None
 
 
+# Cap for ``display_name``. The ``users.display_name`` column is an
+# unbounded Postgres ``String`` (TEXT) — there is no DB length to mirror,
+# so we pick a sane application-layer cap here. 200 matches the project
+# name cap used elsewhere in the API surface (Project.name maxLength).
+_DISPLAY_NAME_MAX_LEN = 200
+
+
+class UserProfileUpdate(BaseModel):
+    """PATCH body for ``/users/me`` — edit the caller's own profile.
+
+    Currently scoped to ``display_name`` only. Email self-service editing
+    is intentionally **out of scope** for this surface: changing the login
+    email pulls in re-verification, MFA, and uniqueness concerns that are
+    auth-adjacent and warrant their own dedicated flow. ``display_name``
+    alone unblocks the editable-profile experience.
+
+    Validation (mirrors how ``UserPreferencesUpdate`` constrains its
+    fields, but for a free-text field):
+
+    * ``display_name`` is optional — omitting it means "no change".
+    * When supplied, leading/trailing whitespace is trimmed and the result
+      must be non-empty (empty or whitespace-only → 422).
+    * The trimmed value must be at most ``_DISPLAY_NAME_MAX_LEN`` chars
+      (over-length → 422).
+    * At least one updatable field must be present; since ``display_name``
+      is the only field today, an all-omitted body → 422 ("no fields to
+      update").
+    """
+
+    display_name: str | None = None
+
+    @model_validator(mode="after")
+    def _validate(self) -> UserProfileUpdate:
+        # ``display_name`` is the only updatable field; an omitted body is
+        # a no-op PATCH with nothing to do, which we reject as 422.
+        if self.display_name is None:
+            raise ValueError("no fields to update")
+
+        trimmed = self.display_name.strip()
+        if not trimmed:
+            raise ValueError("display_name must not be empty or whitespace-only")
+        if len(trimmed) > _DISPLAY_NAME_MAX_LEN:
+            raise ValueError(f"display_name must be at most {_DISPLAY_NAME_MAX_LEN} characters")
+
+        # Persist the trimmed value so callers can't smuggle padding in.
+        self.display_name = trimmed
+        return self
+
+
 class UserPreferencesResponse(BaseModel):
     """The preferences slice of the user profile.
 
@@ -143,6 +192,60 @@ async def get_me(user: CurrentUser) -> UserPublic:
     """
 
     return UserPublic.from_user(user)
+
+
+@router.patch(
+    "/me",
+    response_model=UserPublic,
+    summary="Update the calling user's own profile (display_name)",
+)
+async def patch_me(
+    payload: UserProfileUpdate,
+    request: Request,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> UserPublic:
+    """PATCH /api/v1/users/me — edit the caller's own profile.
+
+    Caller-scoped: mutates only the authenticated user's own row; no user
+    id is ever accepted from the path or body. Currently updates
+    ``display_name`` only (trimmed, non-empty, length-guarded by
+    ``UserProfileUpdate``). Email self-service editing is intentionally
+    out of scope (re-verification / MFA / uniqueness).
+
+    Writes a ``user.profile_updated`` audit row enumerating the changed
+    fields, mirroring ``patch_me_preferences``. Returns the updated
+    ``UserPublic`` — the same shape ``GET /users/me`` returns.
+    """
+
+    from app.models.user import User as UserORM  # local — only writer needs it
+
+    row = await db.get(UserORM, user.id)
+    if row is None:  # pragma: no cover — dependency would have already 401d
+        raise HTTPException(status_code=404, detail="user not found")
+
+    changed_fields: list[str] = []
+    # ``display_name`` is guaranteed present + trimmed + non-empty by the
+    # model validator (omitted/empty bodies 422 before we get here).
+    assert payload.display_name is not None
+    if row.display_name != payload.display_name:
+        row.display_name = payload.display_name
+        changed_fields.append("display_name")
+
+    if changed_fields:
+        await audit_action(
+            db,
+            user_id=row.id,
+            action="user.profile_updated",
+            resource_type="user",
+            resource_id=str(row.id),
+            request=request,
+            details={"fields": changed_fields},
+        )
+        await db.commit()
+        await db.refresh(row)
+
+    return UserPublic.from_user(row)
 
 
 @router.get(

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -95,6 +95,8 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("POST", "/api/v1/auth/refresh"),
     ("POST", "/api/v1/auth/logout"),
     ("GET", "/api/v1/users/me"),
+    # Donna-3 — caller-scoped profile edit (display_name)
+    ("PATCH", "/api/v1/users/me"),
     # B2 — first-run admin + forced password change
     ("POST", "/api/v1/auth/change-password"),
     # D5 — MFA enrollment + verification

--- a/api/tests/test_user_profile.py
+++ b/api/tests/test_user_profile.py
@@ -1,0 +1,187 @@
+"""Integration tests for PATCH /users/me — caller-scoped profile edit (Donna-3).
+
+Covers:
+
+* PATCH with a new ``display_name`` returns 200 with the updated
+  ``UserPublic``; a follow-up GET /users/me reflects it.
+* Whitespace around a valid name is trimmed.
+* Empty / whitespace-only ``display_name`` returns 422.
+* Empty body (no updatable fields) returns 422.
+* Over-length ``display_name`` returns 422.
+* The handler is caller-scoped — a second user's row is untouched.
+* A ``user.profile_updated`` audit row is written listing the changed fields.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.users import _DISPLAY_NAME_MAX_LEN
+from app.db.session import get_db
+from app.main import app
+from app.models import AuditLog, User
+from app.security import create_access_token, hash_password
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+async def _make_user(db_session: AsyncSession, display_name: str) -> User:
+    user = User(
+        email=f"profile-{uuid.uuid4().hex[:8]}@example.com",
+        display_name=display_name,
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def caller(db_session: AsyncSession) -> User:
+    return await _make_user(db_session, "Original Name")
+
+
+def _bearer(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.integration
+async def test_patch_me_updates_display_name(client: AsyncClient, caller: User) -> None:
+    resp = await client.patch(
+        "/api/v1/users/me",
+        headers=_bearer(caller),
+        json={"display_name": "New Name"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["display_name"] == "New Name"
+    # Returned shape is UserPublic — same id/email as the caller.
+    assert data["id"] == str(caller.id)
+    assert data["email"] == caller.email
+
+    # A follow-up GET reflects the change.
+    get_resp = await client.get("/api/v1/users/me", headers=_bearer(caller))
+    assert get_resp.status_code == 200
+    assert get_resp.json()["display_name"] == "New Name"
+
+
+@pytest.mark.integration
+async def test_patch_me_trims_whitespace(client: AsyncClient, caller: User) -> None:
+    resp = await client.patch(
+        "/api/v1/users/me",
+        headers=_bearer(caller),
+        json={"display_name": "  Padded Name  "},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == "Padded Name"
+
+
+@pytest.mark.integration
+async def test_patch_me_empty_display_name_returns_422(client: AsyncClient, caller: User) -> None:
+    resp = await client.patch(
+        "/api/v1/users/me",
+        headers=_bearer(caller),
+        json={"display_name": ""},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.integration
+async def test_patch_me_whitespace_only_display_name_returns_422(
+    client: AsyncClient, caller: User
+) -> None:
+    resp = await client.patch(
+        "/api/v1/users/me",
+        headers=_bearer(caller),
+        json={"display_name": "   "},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.integration
+async def test_patch_me_empty_body_returns_422(client: AsyncClient, caller: User) -> None:
+    resp = await client.patch(
+        "/api/v1/users/me",
+        headers=_bearer(caller),
+        json={},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.integration
+async def test_patch_me_overlong_display_name_returns_422(
+    client: AsyncClient, caller: User
+) -> None:
+    resp = await client.patch(
+        "/api/v1/users/me",
+        headers=_bearer(caller),
+        json={"display_name": "x" * (_DISPLAY_NAME_MAX_LEN + 1)},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.integration
+async def test_patch_me_is_caller_scoped(
+    client: AsyncClient, db_session: AsyncSession, caller: User
+) -> None:
+    """Updating the caller leaves a second user's row untouched."""
+    other = await _make_user(db_session, "Other Name")
+
+    resp = await client.patch(
+        "/api/v1/users/me",
+        headers=_bearer(caller),
+        json={"display_name": "Caller Renamed"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == "Caller Renamed"
+
+    await db_session.refresh(other)
+    assert other.display_name == "Other Name"
+
+
+@pytest.mark.integration
+async def test_patch_me_writes_audit_row(
+    client: AsyncClient, db_session: AsyncSession, caller: User
+) -> None:
+    resp = await client.patch(
+        "/api/v1/users/me",
+        headers=_bearer(caller),
+        json={"display_name": "Audited Name"},
+    )
+    assert resp.status_code == 200
+
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "user.profile_updated",
+                AuditLog.resource_id == str(caller.id),
+            )
+        )
+    ).scalar_one()
+    assert audit.resource_type == "user"
+    assert audit.details["fields"] == ["display_name"]

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -266,6 +266,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+    patch:
+      tags: [users]
+      summary: Update the caller's own profile (display_name)
+      description: |
+        Bearer-authenticated. Caller-scoped — updates only the
+        authenticated user's own row; no user id is accepted from the
+        path or body. Currently edits `display_name` only: the value is
+        trimmed, must be non-empty after trimming, and is length-capped
+        (200 chars). Omitting `display_name` (or sending an empty body)
+        is a 422 — there is nothing to update. Writes a
+        `user.profile_updated` audit row listing the changed fields and
+        returns the updated `User` (same shape as `GET /users/me`).
+
+        Email self-service editing is intentionally out of scope on this
+        surface — changing the login email pulls in re-verification, MFA,
+        and uniqueness concerns and warrants its own dedicated flow (a
+        future enhancement).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/UserProfileUpdate'}
+      responses:
+        '200':
+          description: Updated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '422': {description: Validation error (empty/whitespace/over-length display_name, or no fields to update)}
 
   /api/v1/users/me/export:
     post:
@@ -5804,6 +5834,27 @@ components:
           enum: [always, collapsed]
         autonomous_enabled:
           type: boolean
+
+    UserProfileUpdate:
+      type: object
+      description: |
+        PATCH body for `/api/v1/users/me`. Caller-scoped self-edit of the
+        user's own profile. Currently `display_name` only: when supplied
+        it is trimmed and must be non-empty after trimming. At least one
+        updatable field must be present (an all-omitted body is a 422).
+
+        Email self-service editing is intentionally out of scope here —
+        changing the login email pulls in re-verification, MFA, and
+        uniqueness concerns and is deferred to a dedicated flow.
+      properties:
+        display_name:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: |
+            New display name. Trimmed server-side; must be non-empty after
+            trimming. Omit to leave unchanged (but at least one field must
+            be present, so an empty body is rejected).
 
     Project:
       type: object


### PR DESCRIPTION
## `PATCH /api/v1/users/me` — edit own profile (display_name)

**Donna backend ask #3 of 3 (final).** Unblocks Donna's editable-profile slice. api-only.

### What it does
- `UserProfileUpdate { display_name?: string }` — trimmed, non-empty-after-trim required, max length 200 (the column is unbounded TEXT; 200 matches the project-name cap, documented). Empty body / no updatable field → 422; whitespace-only → 422; over-length → 422.
- `PATCH /me` handler is **caller-scoped**: the user id comes solely from the `ActiveUser` auth dependency (never path/body), updates only the caller's own row, returns the updated `UserPublic` (same shape as `GET /me`). Mirrors `patch_me_preferences`.
- Writes a `user.profile_updated` audit row (only when a field actually changed), `details={"fields": [...]}`.

### Scope / honesty
- **Email self-service editing is intentionally out of scope** (re-verification / MFA / uniqueness) — noted in the docstring + OpenAPI. display_name alone unblocks Donna; email edit will be filed as a deferred enhancement.
- **No migration** (column exists). `test_openapi` path count stays **114** (PATCH added to the existing `/users/me` path, not a new path). The new method is added to `IMPLEMENTED_ROUTES` so the 501-scaffold smoke test stays correct.
- OpenAPI: `patch:` operation added under the existing `/api/v1/users/me` path + `UserProfileUpdate` schema.

### Tests & verification
- 8 tests: update→200 + GET reflects it; whitespace trimmed; empty/whitespace-only/empty-body/over-length→422; caller-scope (second user untouched); audit row shape.
- ruff + mypy clean; `test_openapi` 114 intact; users suite 24 passed against a throwaway pgvector DB (dev DB untouched).
