### PR TITLE
Expose deletion_scheduled_at on GET /users/me (Donna P1.4)

### DIFF
--- a/api/app/api/auth.py
+++ b/api/app/api/auth.py
@@ -108,6 +108,11 @@ class UserPublic(BaseModel):
     provenance_pills: str = "always"
     created_at: datetime
     last_login_at: datetime | None = None
+    # GDPR Article 17 grace-period delete: non-null while a deletion is
+    # pending (set by POST /users/me/delete, cleared by .../delete/cancel).
+    # Surfaced here so a user's own session can render a "deletion pending —
+    # cancel by <date>" state on load (Donna P1.4), not just the admin view.
+    deletion_scheduled_at: datetime | None = None
 
     @classmethod
     def from_user(cls, user: User) -> UserPublic:
@@ -126,6 +131,7 @@ class UserPublic(BaseModel):
             provenance_pills=getattr(user, "provenance_pills", "always"),
             created_at=user.created_at,
             last_login_at=user.last_login_at,
+            deletion_scheduled_at=user.deletion_scheduled_at,
         )
 
 

--- a/api/tests/test_user_deletion.py
+++ b/api/tests/test_user_deletion.py
@@ -111,6 +111,35 @@ async def test_delete_schedules_deletion_and_revokes_sessions(
 
 
 @pytest.mark.integration
+async def test_users_me_exposes_deletion_scheduled_at(
+    client: AsyncClient, db_session: AsyncSession, seed_user: User
+) -> None:
+    """GET /users/me surfaces deletion_scheduled_at (Donna P1.4).
+
+    A user's own session must be able to tell on load whether a deletion is
+    pending — the field is null before scheduling and carries the scheduled
+    timestamp after, matching the POST /users/me/delete response.
+    """
+    # Before any deletion: field present and null.
+    before = await client.get("/api/v1/users/me", headers=_bearer(seed_user))
+    assert before.status_code == 200, before.text
+    assert "deletion_scheduled_at" in before.json()
+    assert before.json()["deletion_scheduled_at"] is None
+
+    # Schedule a deletion.
+    sched = await client.post("/api/v1/users/me/delete", headers=_bearer(seed_user))
+    assert sched.status_code == 202, sched.text
+    scheduled_at = sched.json()["scheduled_deletion_at"]
+
+    # /users/me now reflects the pending-deletion timestamp.
+    after = await client.get("/api/v1/users/me", headers=_bearer(seed_user))
+    assert after.status_code == 200, after.text
+    exposed = after.json()["deletion_scheduled_at"]
+    assert exposed is not None
+    assert datetime.fromisoformat(exposed) == datetime.fromisoformat(scheduled_at)
+
+
+@pytest.mark.integration
 async def test_delete_is_idempotent(
     client: AsyncClient, db_session: AsyncSession, seed_user: User
 ) -> None:

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -5778,6 +5778,9 @@ components:
             by default) vs. ``collapsed`` (hidden until expanded).
         created_at: {type: string, format: date-time}
         last_login_at: {type: string, format: date-time, nullable: true}
+        deletion_scheduled_at:
+          {type: string, format: date-time, nullable: true,
+           description: "Non-null while a GDPR Article 17 grace-period deletion is pending (set by POST /users/me/delete, cleared by .../delete/cancel)."}
 
     UserPreferences:
       type: object


### PR DESCRIPTION
Donna relay item **P1.4**. Surfaces the GDPR grace-period deletion timestamp on `UserPublic` (the schema `GET /users/me`, login, and refresh return) — today it lives only on the admin-only `AdminUserRow`, so a user's own session can't tell on load that a deletion is pending. Read-only echo of the existing `users.deletion_scheduled_at` column.

- `api/app/api/auth.py`: `deletion_scheduled_at: datetime | None` on `UserPublic` + `from_user`.
- `docs/api/backend-openapi.yaml`: field added to the `User` schema (nullable date-time).
- Test: `GET /users/me` → field null before scheduling, equals the POST /delete timestamp after.
- **No migration, no new path** (test_openapi stays 114). ruff + mypy clean; deletion/auth/profile/openapi suites 36 passed against a throwaway pgvector DB.