### PR TITLE
docs(lqvern): handoff — v0.4.0 shipped + Donna asks done (standby)

### DIFF
--- a/docs/LQVern/HANDOFF-2026-06-01-v0.4.0-shipped-donna-asks-done.md
+++ b/docs/LQVern/HANDOFF-2026-06-01-v0.4.0-shipped-donna-asks-done.md
@@ -1,0 +1,72 @@
+# Handoff — 2026-06-01 — v0.4.0 shipped; all Donna backend asks merged; STANDBY
+
+> **For:** the next session continuing on **`~/Code/lq-ai`** (canonical repo — NEVER `~/Desktop/lq-ai`; Bash cwd resets to `~/Desktop` between calls, so **prefix every command with `cd ~/Code/lq-ai &&`**).
+>
+> **TL;DR:** **v0.4.0 (Milestone 4) is fully shipped** and **all of Donna's backend asks (#1–3 + P1.4) are merged to `main`**. There is **no active build task** — this is a STANDBY/maintenance state. The community has the baton; Kevin may bring more small, caller-scoped Donna asks. Work the same proven loop (below).
+
+---
+
+## 1. Where things stand
+
+- **`main` HEAD = `945ad31`** on both remotes (`origin` = LegalQuants/lq-ai, `tucuxi` = Tucuxi-Inc/lq-ai mirror — kept identical). Both services report `__version__ = 0.4.0`. Migration head **0045**.
+- **v0.4.0 — M4 release: the Autonomous Layer (opt-in)** — tagged `v0.4.0` (annotated, both remotes), **GitHub Release published as Latest** (release workflow built + SBOM + Cosign-signed all 3 images). Full notes: `docs/releases/v0.4.0.md`.
+- **Live dev stack:** rebuilt on `main` (`docker compose build web && up -d web`), web healthy at `localhost:3000`, serving 0.4.0. Acceptance data preserved (do **NOT** `docker compose down -v`).
+
+### What v0.4.0 contains
+M4 Autonomous Layer (opt-in, off by default): Schedules (cron) / Watches (KB doc-arrival) / Run-now (one-off), a LangGraph phase machine doing guarded in-loop work, brakes **R4** cost cap + **R5** external halt/idle watchdog + **R6** per-phase tool limits (all receipted; R4 live-verified), surfaces Sessions/Memory/Precedents/Proposals/Notifications. Plus Phase-1 operability (Home signpost, Configure tab, cost-cap fields, readable names, Run-now UI, tabular Citation-Engine honesty) and the M4-D2 docs/Learn honesty sweep.
+
+### Donna backend asks — ALL merged to `main` (report these SHAs to Donna for `vendor/lq-ai` pin + `npm run gen:api`)
+| Ask | What | PR | SHA |
+|---|---|---|---|
+| **#1 DE-328** | `skill_inputs` reach non-templated skills (gateway assembler appends a `### Provided inputs for <skill>` block) | #115 | `396e19f` |
+| **#2 Part A** | `MessageCreate.file_ids` backend channel (validate caller-owned, forward `lq_ai_file_ids`, echo `applied_file_ids`) | #116 | `1592063` |
+| **#2 Part B** | attached-file content → model, **verbatim** (`lq_ai_skip_anonymization=True` document-context system message, per Decision M2-1) | #117 | `6dae35d` |
+| **#3** | `PATCH /api/v1/users/me` — edit own `display_name` (caller-scoped, audit `user.profile_updated`) | #118 | `e9659da` |
+| **DE-329 filed** | email self-service edit deferred + DE-328 marked resolved (docs) | #119 | `badf83d` |
+| **P1.4** | expose `deletion_scheduled_at` on `GET /users/me` (was admin-only on `AdminUserRow`); `/delete/cancel` clears it | #120 | `945ad31` |
+
+Notes for Donna: `file_ids` is a **separate channel** from `skill_inputs` (a file UUID is NOT bindable via `skill_inputs type:"file"` — those are scalar `{{}}` substitutions). `PATCH /users/me` is **display_name-only** (email edit is DE-329).
+
+---
+
+## 2. Open / deferred items
+
+- **DE-329** — self-service **email** editing on `PATCH /users/me` (deferred from ask #3). Needs a product decision on the verification/step-up model first (id-probing-safe `409` on uniqueness collision + re-verification-before-swap). PRD §9.
+- Other standing DEs are in **PRD §9** (`docs/PRD.md`) — DE-287 (Word add-in in-pane), DE-309/310 (tabular citations/telemetry), DE-319 (LangGraph 1.x), DE-320 (scanned-PDF OCR), DE-321–327, etc. These are community-pickup candidates.
+- The platform-cohesion spec's **Phases 2–5** (roadmap, recommendation-only) were intentionally NOT built.
+
+---
+
+## 3. How to work here (the proven loop — used for every Donna ask)
+
+For each small, caller-scoped, back-compatible ask:
+1. **Branch off `main`** (`git checkout -b feat/<name> main`).
+2. **Subagent-driven** (`superpowers:subagent-driven-development`): fresh implementer subagent (full task text + scene-setting context; it reads the files), then an **independent spec+quality review subagent** before the PR. Apply review fixes (a follow-up commit is fine — PRs are squash-merged).
+3. **Gates:** api → `api/.venv/bin/ruff format --check app tests && ruff check app tests && mypy app && pytest …`; gateway → `gateway/.venv/bin/{ruff,mypy --strict,pytest}`; web → `cd web && npm run check:lq-ai` (0 errors) + `npx vitest run`. Backend DB tests need a **throwaway** Postgres (see §4).
+4. **Commit** `git commit -s` + trailer `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`. **Push BOTH remotes.**
+5. **PR → `main`** via `gh`. CI runs 3 required checks (API ~12 min, Gateway ~2 min, Web ~1 min). LegalQuants `main` ruleset = **PR + linear-history (no merge commits) + 3 status checks**; `required_approving_review_count: 0` / `require_code_owner_review: false` → no GitHub-enforced approval, so **gateway/security-boundary review is Kevin's manual call** (he merged #115 himself).
+6. **Squash-merge** (`gh pr merge <n> --squash`), **preserve the feature branch** (no `--delete-branch` — branch-preservation policy). Then `git fetch origin main`, ff local `main`, **realign `tucuxi/main`** (`git push tucuxi main`). Report the merged SHA.
+
+---
+
+## 4. Hard rules (memorize — these have bitten before)
+
+- **NEVER** run host-side `alembic upgrade head` against `127.0.0.1:15432/lq_ai` — that's the live dev DB; it desyncs the running stack and crash-loops the api trio. Verify backend via a **throwaway pgvector container** instead: `docker run -d --name lqai-throwaway-pg -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=lqai_test -p 55432:5432 pgvector/pgvector:pg16`, then `export DATABASE_URL=postgresql+asyncpg://test:test@127.0.0.1:55432/lqai_test` and run pytest (conftest auto-migrates it). **Use the pgvector image, not plain postgres** (migrations create a `vector` extension). Remove the container after. ([[feedback_no_host_alembic_on_dev_db]])
+- **Do NOT `docker compose down -v`** (preserves attorney-review acceptance data: KB `9003dbc6-abf5-4f25-922b-588714f26405`, autonomous sessions incl. the R4-halted one). To refresh UI: `docker compose build web && docker compose up -d web`.
+- **DCO sign-off + the 4.7 trailer** on every commit. **Push both remotes** after each task. **Preserve merged feature branches.** ([[feedback_branch_preservation]])
+- **`web/` autonomous Svelte files are TAB-indented** — the Edit tool can corrupt tabs; if a match fails, use `perl -0777 -i` / heredoc with real tabs and verify with `cat -tn`.
+- **Two collection-time traps to remember** (both fixed, don't reintroduce): (a) `tests/test_endpoints.py` is a 501-scaffold sweep — **any fully-implemented new route must be added to `IMPLEMENTED_ROUTES`** or the whole api suite crashes at collection; (b) `alembic/env.py` now passes `disable_existing_loggers=False` so the per-session `alembic upgrade` doesn't disable `app.*` loggers (which had broken a caplog citation test). Both are the same class as the **DELETE-204** trap documented in `CLAUDE.md`.
+- **`api/tests/test_openapi.py`** pins an exact path count (currently **114**) + an `EXPECTED_PATHS` set. Adding a new endpoint bumps both; adding a field/method to an existing path does NOT.
+
+---
+
+## 5. Dev environment quick facts
+Admin `admin@lq.ai` / `AcceptTest12345!`; dashboard `localhost:3000` (web maps 3000→8080); api `:8000`, gateway `:8001`. Backend venvs: `api/.venv/bin/...` and `gateway/.venv/bin/...` (the bare `pytest` on PATH has a broken starlette). More quirks in [[reference_lq_ai_dev_quirks]]; decision-routing docs (PRD/ADRs/OpenAPI/db-schema) per `CLAUDE.md`.
+
+---
+
+## 6. Likely next work
+- More small Donna integration asks (same loop). Kevin batches them as relay items.
+- If/when a bigger piece comes (e.g. DE-329 email edit, or gateway-side work), that wants a fresh session with full context — Kevin will scope it there.
+
+*Drafted at the v0.4.0-shipped + Donna-asks-complete standby point. The contracts are `CLAUDE.md` (decision routing) + `docs/PRD.md`; this handoff is the navigation aid.*


### PR DESCRIPTION
Session handoff doc capturing the v0.4.0-shipped + all-Donna-asks-merged standby state: main `945ad31`, the merged SHAs (#1 396e19f / #2 1592063+6dae35d / #3 e9659da / P1.4 945ad31), open deferrals (DE-329), the proven per-ask PR→CI→squash loop, and the hard rules (no host-side alembic on dev DB, throwaway pgvector for tests, branch preservation, the two collection-time traps + test_openapi=114). Docs-only.