### PR TITLE
Navigable tabular cell citations (read-side source resolution)

### DIFF
--- a/api/app/api/tabular.py
+++ b/api/app/api/tabular.py
@@ -63,7 +63,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies import ActiveUser
 from app.audit import audit_action
 from app.db.session import get_db
-from app.models.document import Document
+from app.models.document import Document, DocumentChunk
 from app.models.tabular import TabularExecution
 from app.schemas.tabular import (
     Citation,
@@ -376,7 +376,9 @@ async def get_tabular_execution(
     """
 
     row = await _load_caller_execution(db, execution_id=execution_id, user=user)
-    return await _to_response(db, row)
+    response = await _to_response(db, row)
+    await _enrich_cell_citations(db, response)
+    return response
 
 
 @router.delete(
@@ -741,6 +743,68 @@ async def _to_response(db: AsyncSession, row: TabularExecution) -> TabularExecut
             "completed_at": row.completed_at,
         }
     )
+
+
+async def _enrich_cell_citations(db: AsyncSession, response: TabularExecutionResponse) -> None:
+    """Make tabular cell citations navigable by resolving their source.
+
+    The schema-level ``_synthesize_cell_citations`` validator builds each
+    :class:`Citation` purely from the cell's persisted ``cited_chunk_ids``
+    (real ``document_chunks.id`` UUIDs) with no DB access, so it can only
+    set ``document_id`` (a ``documents.id``) — not enough for the frontend
+    to navigate (its doc panel keys off ``files.id``). Here, where a DB
+    session is available, we enrich every cell citation in place with
+    ``source_file_id`` (``documents.file_id``), ``source_page``
+    (``document_chunks.page_start``), and ``source_text``
+    (``document_chunks.content``).
+
+    Resolution is batched — two ``IN`` queries total regardless of grid
+    size (no N+1): one over every cited chunk id across the whole grid,
+    then one over the documents those chunks belong to. Citations whose
+    ``chunk_id`` is missing (stale / hard-deleted chunk) are left with the
+    navigation fields unset rather than crashing.
+    """
+
+    if response.results is None:
+        return
+
+    all_citations: list[Citation] = [
+        citation
+        for tab_row in response.results.rows
+        for cell in tab_row.cells.values()
+        for citation in cell.citations
+    ]
+    chunk_ids = {c.chunk_id for c in all_citations if c.chunk_id is not None}
+    if not chunk_ids:
+        return
+
+    # Query 1: chunk id -> (document_id, page_start, content).
+    chunk_stmt = select(
+        DocumentChunk.id,
+        DocumentChunk.document_id,
+        DocumentChunk.page_start,
+        DocumentChunk.content,
+    ).where(DocumentChunk.id.in_(chunk_ids))
+    chunk_rows = (await db.execute(chunk_stmt)).all()
+    chunk_by_id = {cr.id: (cr.document_id, cr.page_start, cr.content) for cr in chunk_rows}
+
+    # Query 2: document id -> file_id.
+    document_ids = {doc_id for (doc_id, _page, _content) in chunk_by_id.values()}
+    file_by_document: dict[uuid.UUID, uuid.UUID] = {}
+    if document_ids:
+        doc_stmt = select(Document.id, Document.file_id).where(Document.id.in_(document_ids))
+        file_by_document = {dr.id: dr.file_id for dr in (await db.execute(doc_stmt)).all()}
+
+    for citation in all_citations:
+        if citation.chunk_id is None:
+            continue
+        resolved = chunk_by_id.get(citation.chunk_id)
+        if resolved is None:
+            continue  # stale chunk reference — leave navigation fields unset.
+        doc_id, page_start, content = resolved
+        citation.source_file_id = file_by_document.get(doc_id)
+        citation.source_page = page_start
+        citation.source_text = content
 
 
 def _to_summary(row: TabularExecution) -> TabularExecutionSummary:

--- a/api/app/schemas/tabular.py
+++ b/api/app/schemas/tabular.py
@@ -93,6 +93,29 @@ class Citation(BaseModel):
 
     confidence: CellConfidence
 
+    # --- Navigation fields (Donna) ----------------------------------------
+    # Resolved at read time in ``GET /tabular/executions/{id}`` so the
+    # frontend can open the cited source in its doc panel (same UX as chat
+    # citations). They are optional + default ``None`` so the schema-level
+    # ``_synthesize_cell_citations`` validator (no DB access) and the
+    # XLSX/CSV export paths (which only read ``citation_id``) keep building
+    # this model unchanged; the endpoint handler populates them via batched
+    # lookups against ``documents`` and ``document_chunks``.
+    source_file_id: uuid.UUID | None = None
+    """The ``documents.file_id`` of the citation's source document. The
+    critical missing piece for navigation: cells reference a
+    ``documents.id`` (via ``document_id``), but the frontend's doc panel
+    keys off ``files.id``. ``None`` until resolved (or when the backing
+    chunk row is missing / stale)."""
+
+    source_page: int | None = None
+    """The cited chunk's ``document_chunks.page_start``. Nullable because
+    some chunks have no clean page assignment (best-effort page mapping)."""
+
+    source_text: str | None = None
+    """The cited chunk's full ``document_chunks.content``. The frontend
+    locates / highlights the cited span within this text."""
+
 
 class CellResult(BaseModel):
     """One cell in the tabular grid.

--- a/api/tests/test_tabular_endpoints.py
+++ b/api/tests/test_tabular_endpoints.py
@@ -1,0 +1,321 @@
+"""HTTP-level tests for navigable tabular cell citations (Donna).
+
+Exercises ``GET /api/v1/tabular/executions/{id}`` read-time enrichment:
+each synthesized cell ``Citation`` (built from the persisted
+``cited_chunk_ids``) is enriched with ``source_file_id``
+(``documents.file_id``), ``source_page`` (``document_chunks.page_start``),
+and ``source_text`` (``document_chunks.content``) so the frontend can open
+the cited source in its doc panel.
+
+Key property under test: enrichment happens at serialization time. The
+execution rows are inserted directly with the pre-change persisted shape
+(``cited_chunk_ids`` only — no navigation fields stored), simulating a
+pre-feature execution; the response must still carry the navigation fields
+with no migration / backfill / re-run.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.main import app
+from app.models.document import Document, DocumentChunk
+from app.models.file import File as FileModel
+from app.models.tabular import TabularExecution
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+async def _make_user(db: AsyncSession) -> User:
+    u = User(
+        email=f"u-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(u)
+    await db.flush()
+    return u
+
+
+def _bearer(user: User) -> dict[str, str]:
+    return {
+        "Authorization": (
+            f"Bearer {create_access_token(user.id, user.email, is_admin=user.is_admin)}"
+        )
+    }
+
+
+async def _make_doc_with_chunk(
+    db: AsyncSession,
+    *,
+    owner: User,
+    content: str,
+    page_start: int | None,
+) -> tuple[Document, DocumentChunk]:
+    """Seed a File + Document(file_id) + one DocumentChunk."""
+
+    f = FileModel(
+        owner_id=owner.id,
+        filename=f"doc-{uuid.uuid4().hex[:6]}.pdf",
+        mime_type="application/pdf",
+        size_bytes=1024,
+        hash_sha256=uuid.uuid4().hex + uuid.uuid4().hex,
+        storage_path=f"tabular-citation-fixture/{uuid.uuid4()}",
+        ingestion_status="ready",
+    )
+    db.add(f)
+    await db.flush()
+    doc = Document(
+        file_id=f.id,
+        parser="pymupdf-only",
+        parser_version="pymupdf=1.27",
+        page_count=3,
+        character_count=len(content),
+        normalized_content=content,
+        was_ocrd=False,
+    )
+    db.add(doc)
+    await db.flush()
+    chunk = DocumentChunk(
+        document_id=doc.id,
+        chunk_index=0,
+        content=content,
+        page_start=page_start,
+        page_end=page_start,
+        char_offset_start=0,
+        char_offset_end=len(content),
+    )
+    db.add(chunk)
+    await db.flush()
+    return doc, chunk
+
+
+async def _insert_execution(
+    db: AsyncSession,
+    *,
+    owner: User,
+    document_ids: list[uuid.UUID],
+    rows: list[dict[str, Any]],
+) -> TabularExecution:
+    """Insert a completed execution row directly in the pre-change shape.
+
+    ``results.rows[*].cells[*]`` carry only the persisted keys (notably
+    ``cited_chunk_ids``) — no navigation fields — so the test proves
+    enrichment happens at read time, not via stored data.
+    """
+
+    execution = TabularExecution(
+        user_id=owner.id,
+        skill_name=None,
+        status="completed",
+        document_ids=document_ids,
+        columns=[{"name": "Term", "query": "What is the term?"}],
+        results={"schema_version": "m3-c2-v1", "rows": rows},
+    )
+    db.add(execution)
+    await db.flush()
+    return execution
+
+
+@pytest.mark.integration
+async def test_get_execution_enriches_citations_with_navigable_source(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    user = await _make_user(db_session)
+    content = "The term of this Agreement is three (3) years from the Effective Date."
+    doc, chunk = await _make_doc_with_chunk(db_session, owner=user, content=content, page_start=2)
+    execution = await _insert_execution(
+        db_session,
+        owner=user,
+        document_ids=[doc.id],
+        rows=[
+            {
+                "document_id": str(doc.id),
+                "document_name": "nda.pdf",
+                "cells": {
+                    "Term": {
+                        "value": "3 years",
+                        "cited_chunk_ids": [str(chunk.id)],
+                        "confidence": "high",
+                        "tier_used": 2,
+                    }
+                },
+            }
+        ],
+    )
+
+    resp = await client.get(f"/api/v1/tabular/executions/{execution.id}", headers=_bearer(user))
+    assert resp.status_code == 200, resp.text
+    cell = resp.json()["results"]["rows"][0]["cells"]["Term"]
+    citations = cell["citations"]
+    assert len(citations) == 1
+    cit = citations[0]
+
+    # Existing display-only fields still present.
+    assert cit["document_id"] == str(doc.id)
+    assert cit["chunk_id"] == str(chunk.id)
+    assert cit["citation_id"]  # synthetic deterministic id
+
+    # Navigation fields resolved at read time.
+    assert cit["source_file_id"] == str(doc.file_id)
+    assert cit["source_page"] == 2
+    assert cit["source_text"] == content
+
+    # The referenced file actually exists.
+    file_row = await db_session.get(FileModel, doc.file_id)
+    assert file_row is not None
+
+
+@pytest.mark.integration
+async def test_get_execution_empty_cited_chunk_ids_yields_no_citations(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Back-compat: a cell with no cited chunks → empty citations, no error."""
+
+    user = await _make_user(db_session)
+    doc, _chunk = await _make_doc_with_chunk(
+        db_session, owner=user, content="irrelevant", page_start=1
+    )
+    execution = await _insert_execution(
+        db_session,
+        owner=user,
+        document_ids=[doc.id],
+        rows=[
+            {
+                "document_id": str(doc.id),
+                "document_name": "nda.pdf",
+                "cells": {
+                    "Term": {
+                        "value": None,
+                        "cited_chunk_ids": [],
+                        "confidence": "failed",
+                        "error": "no citation found",
+                    }
+                },
+            }
+        ],
+    )
+
+    resp = await client.get(f"/api/v1/tabular/executions/{execution.id}", headers=_bearer(user))
+    assert resp.status_code == 200, resp.text
+    cell = resp.json()["results"]["rows"][0]["cells"]["Term"]
+    assert cell["citations"] == []
+
+
+@pytest.mark.integration
+async def test_get_execution_stale_chunk_id_leaves_nav_fields_null(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A cited chunk id with no backing row → nav fields stay null, no crash."""
+
+    user = await _make_user(db_session)
+    doc, _chunk = await _make_doc_with_chunk(
+        db_session, owner=user, content="present", page_start=1
+    )
+    stale_chunk_id = uuid.uuid4()  # never inserted
+    execution = await _insert_execution(
+        db_session,
+        owner=user,
+        document_ids=[doc.id],
+        rows=[
+            {
+                "document_id": str(doc.id),
+                "document_name": "nda.pdf",
+                "cells": {
+                    "Term": {
+                        "value": "x",
+                        "cited_chunk_ids": [str(stale_chunk_id)],
+                        "confidence": "low",
+                    }
+                },
+            }
+        ],
+    )
+
+    resp = await client.get(f"/api/v1/tabular/executions/{execution.id}", headers=_bearer(user))
+    assert resp.status_code == 200, resp.text
+    cit = resp.json()["results"]["rows"][0]["cells"]["Term"]["citations"][0]
+    assert cit["chunk_id"] == str(stale_chunk_id)
+    assert cit["source_file_id"] is None
+    assert cit["source_page"] is None
+    assert cit["source_text"] is None
+
+
+@pytest.mark.integration
+async def test_get_execution_batches_across_two_documents(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A cell citing two chunks across two documents resolves each correctly.
+
+    Proves the batched chunk + document IN-queries map each citation to
+    the right file / page / text (no cross-contamination).
+    """
+
+    user = await _make_user(db_session)
+    doc_a, chunk_a = await _make_doc_with_chunk(
+        db_session, owner=user, content="alpha source text", page_start=1
+    )
+    doc_b, chunk_b = await _make_doc_with_chunk(
+        db_session, owner=user, content="bravo source text", page_start=5
+    )
+    # Row is for doc_a; its cell cites a chunk from doc_a AND doc_b.
+    execution = await _insert_execution(
+        db_session,
+        owner=user,
+        document_ids=[doc_a.id, doc_b.id],
+        rows=[
+            {
+                "document_id": str(doc_a.id),
+                "document_name": "a.pdf",
+                "cells": {
+                    "Term": {
+                        "value": "cross-doc",
+                        "cited_chunk_ids": [str(chunk_a.id), str(chunk_b.id)],
+                        "confidence": "high",
+                    }
+                },
+            }
+        ],
+    )
+
+    resp = await client.get(f"/api/v1/tabular/executions/{execution.id}", headers=_bearer(user))
+    assert resp.status_code == 200, resp.text
+    citations = resp.json()["results"]["rows"][0]["cells"]["Term"]["citations"]
+    by_chunk = {c["chunk_id"]: c for c in citations}
+
+    cit_a = by_chunk[str(chunk_a.id)]
+    assert cit_a["source_file_id"] == str(doc_a.file_id)
+    assert cit_a["source_page"] == 1
+    assert cit_a["source_text"] == "alpha source text"
+
+    cit_b = by_chunk[str(chunk_b.id)]
+    assert cit_b["source_file_id"] == str(doc_b.file_id)
+    assert cit_b["source_page"] == 5
+    assert cit_b["source_text"] == "bravo source text"

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4459,6 +4459,18 @@ Two bulk operations as originally written in the M3-C4 spec:
 
 ---
 
+#### DE-330 — Formalize the tabular `results` OpenAPI schema (typed cell/citation components)
+
+**Priority:** P3 · **Effort:** M · **Good first issue** (community-suitable)
+
+**Context:** The tabular execution detail (`GET /api/v1/tabular/executions/{id}`) returns `results` as a free-form `type: object, additionalProperties: true` in `docs/api/backend-openapi.yaml` — the grid's rows/cells/citations have no named OpenAPI components. So a generated client (Donna's `npm run gen:api`) sees `results` as an opaque object and emits no typed fields for cell results or their citations, even though the runtime JSON is well-structured. This surfaced when adding navigable-citation fields (`source_file_id` / `source_page` / `source_text`) to the tabular cell `Citation`: the new fields are present at runtime and documented in the `results` description, but cannot be expressed as typed properties without restructuring the whole `results` tree. The existing tabular-cell citation fields (`citation_id`, `document_id`, `chunk_id`, `confidence`) are already untyped for the same reason — this is a pre-existing gap, not introduced by the navigable-citations change.
+
+**Specific scope:** Introduce named components for the tabular result tree — e.g. `TabularResults` / `TabularRow` / `TabularCellResult` / `TabularCitation` — mirroring the actual serialized shape in `api/app/schemas/tabular.py` (including the navigable-citation fields), and `$ref` them from the execution-detail response instead of `additionalProperties: true`. Keep `api/tests/test_openapi.py` green (the path count is unchanged; this is schema-component work, not new paths). The frontend can then generate typed cell/citation models and drop any hand-written shims.
+
+**When to ship:** When typed tabular results would meaningfully reduce frontend shim code; safe community pickup (contract-only, no runtime behavior change).
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -5162,6 +5162,31 @@ components:
           description: |
             Assembled grid shape with rows + per-cell results. Shape is
             versioned via ``schema_version`` (currently ``m3-c2-v1``).
+
+            Each cell carries a ``citations`` array. A tabular cell
+            ``Citation`` is distinct from the chat ``Citation`` schema; it
+            has: ``citation_id`` (uuid; deterministic display-only id —
+            DE-309), ``document_id`` (uuid; the source ``documents.id``),
+            ``chunk_id`` (uuid, nullable; the cited ``document_chunks.id``),
+            and ``confidence`` (one of ``high|medium|low|failed``).
+
+            On ``GET /api/v1/tabular/executions/{id}`` (only) each citation
+            is additionally enriched at read time so the frontend can open
+            the cited source in its doc panel (same UX as chat citations):
+
+            - ``source_file_id`` (uuid, nullable): the source document's
+              ``documents.file_id`` — the ``files.id`` the doc panel keys
+              off. ``null`` when the backing chunk row is missing/stale.
+            - ``source_page`` (integer, nullable): the cited chunk's
+              ``document_chunks.page_start`` (nullable — best-effort page
+              assignment).
+            - ``source_text`` (string, nullable): the cited chunk's full
+              ``document_chunks.content`` (the frontend locates/highlights
+              the cited span within it).
+
+            These three fields are resolved via two batched ``IN`` queries
+            (chunks, then documents) — no N+1 — and are ``null`` on the
+            list/export paths, which do not enrich.
         cost_estimate_usd:
           type: string
           nullable: true


### PR DESCRIPTION
## Navigable tabular cell citations (read-side)

**Donna upstream request — navigable provenance on tabular cell citations.** Read-time enrichment only (NOT the deferred DE-309 Citation-Engine minting). Lets the frontend open a tabular cell's cited source in its doc panel, same UX as chat citations.

### What it does
- Adds three optional fields to the tabular cell `Citation` (`api/app/schemas/tabular.py`): `source_file_id` (← `documents.file_id` — the critical missing piece), `source_page` (← `document_chunks.page_start`), `source_text` (← `document_chunks.content`). Existing `document_id` / `chunk_id` / `confidence` / synthetic `citation_id` preserved.
- Populates them at serialization time in `GET /api/v1/tabular/executions/{id}` (the schema-level synthesis validator has no DB access), via **two batched IN-queries per execution** (all chunk ids, then their document ids) — **no N+1**, regardless of grid size.
- `cited_chunk_ids` are already real `document_chunks` UUIDs, so **existing executions get navigable citations** — no migration, no backfill, no re-runs.

### Scope / honesty
- **No migration, no new endpoint/path** (`test_openapi` stays 114). Enrichment is detail-endpoint only — list + XLSX/CSV export leave the fields `None`. `cost_actual_usd` (DE-310) untouched. DE-309 minting stays deferred.
- **Contract note for Donna:** the tabular `results` object is `additionalProperties: true` (no named cell/citation OpenAPI component — pre-existing across the whole tabular result tree), so the new fields are documented in the `results` description and present in the **runtime JSON**, but `gen:api` won't emit typed `source_*` properties yet. Formalizing the tabular result schema is filed as **DE-330** (follow-up).

### Tests & verification
- New `test_tabular_endpoints.py`: happy path (`source_file_id == doc.file_id` + file exists, `source_page == chunk.page_start`, `source_text == chunk.content`); **read-side proof** (execution inserted with the pre-change shape — enrichment happens at read time, no backfill); empty `cited_chunk_ids` back-compat; stale chunk_id → `None`, no crash; batching across 2 documents. Existing tabular schema/export tests still green.
- ruff + mypy clean; `test_openapi` 114; tabular suites pass against a throwaway pgvector DB (dev DB untouched).
