### PR TITLE
feat(tabular): honor per-column ensemble_verification (Donna #6)

### DIFF
--- a/api/app/api/tabular.py
+++ b/api/app/api/tabular.py
@@ -62,6 +62,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import ActiveUser
 from app.audit import audit_action
+from app.clients.gateway import GatewayClient, get_gateway_client
 from app.db.session import get_db
 from app.models.document import Document, DocumentChunk
 from app.models.tabular import TabularExecution
@@ -219,6 +220,7 @@ async def preview_tabular_cost(
     request: Request,
     user: ActiveUser,
     db: Annotated[AsyncSession, Depends(get_db)],
+    gateway: Annotated[GatewayClient, Depends(get_gateway_client)],
 ) -> TabularPreviewCostResponse:
     """Synchronous cost preview — no execution row is created.
 
@@ -227,6 +229,15 @@ async def preview_tabular_cost(
     breakdown (Decision C-5). The estimator's rolling average
     (M2-E2 pattern) caches per ~5 minutes in-process; rapid re-previews
     during column-spec editing don't thrash the DB.
+
+    Ensemble columns preview higher (Donna #6): the estimator adds one
+    ensemble-pass cost (N judge calls) per ensemble cell. We fetch the
+    gateway's resolved ensemble config so the premium reflects the
+    deployment's actual judge models + default; the config is
+    process-cached and ``get_citation_engine_ensemble_config`` already
+    returns ``None`` on any gateway error / unreachable, so an
+    unconfigured or down gateway simply yields no premium (graceful
+    degrade — the preview stays a non-fatal pre-flight).
 
     Authorization is the router-level ``get_active_user`` gate — any
     authenticated caller may preview costs against their own document
@@ -242,10 +253,16 @@ async def preview_tabular_cost(
         ad_hoc=body.columns,
     )
 
+    # ``columns`` is the RESOLVED spec (skill-level ensemble fallback
+    # already baked in by ``_resolve_columns``); the estimator only needs
+    # to apply the column-value-or-deployment-default resolution on top.
+    ensemble_config = await gateway.get_citation_engine_ensemble_config()
+
     return await estimate_tabular_execution_cost(
         db,
         document_ids=list(body.document_ids),
         columns=columns,
+        ensemble_config=ensemble_config,
     )
 
 

--- a/api/app/api/tabular.py
+++ b/api/app/api/tabular.py
@@ -153,7 +153,19 @@ def _resolve_columns(
         # Re-validate through the wire-side ColumnSpec so any
         # skill-side fields the wire schema doesn't honor are
         # stripped consistently.
-        return skill_name, [ColumnSpec.model_validate(col.model_dump()) for col in skill_columns]
+        resolved = [ColumnSpec.model_validate(col.model_dump()) for col in skill_columns]
+        # Bake the skill-level ensemble_verification fallback into each
+        # column at this single resolution point (Decision C-1
+        # snapshotting posture) so both preview-cost and execute see a
+        # consistent snapshot. A column that didn't declare its own
+        # value (None) inherits the skill-level value; an explicit
+        # True/False per column is left untouched.
+        skill_ensemble = record.frontmatter.lq_ai.ensemble_verification
+        if skill_ensemble is not None:
+            for col in resolved:
+                if col.ensemble_verification is None:
+                    col.ensemble_verification = skill_ensemble
+        return skill_name, resolved
 
     # ad_hoc branch — the request-validation min_length=1 on columns
     # in TabularExecutionCreate already covers the empty case.

--- a/api/app/schemas/tabular.py
+++ b/api/app/schemas/tabular.py
@@ -266,15 +266,43 @@ class TabularPreviewCostResponse(BaseModel):
 
     The UI uses ``estimated_cost_usd`` to decide whether to render
     the confirmation-checkbox gate (Decision C-5: gate above $1.00,
-    no friction below)."""
+    no friction below).
+
+    Ensemble columns cost more (Donna #6). When a column's effective
+    ``ensemble_verification`` flag is true, each of its cells runs one
+    Stage-4 ensemble pass (N judge-model calls) on top of the base
+    extraction. ``estimated_cost_usd`` is the TOTAL — base extraction
+    plus the ensemble premium — so the operator's confirmation reflects
+    the real spend. ``ensemble_premium_usd`` and ``ensemble_cells_count``
+    surface that premium explicitly."""
 
     cells_count: int
     estimated_tokens: int
+    """Extraction tokens only. EXCLUDES ensemble judge-call tokens, whose
+    cost is captured in ``ensemble_premium_usd`` — so this token figure
+    and ``estimated_cost_usd`` are intentionally asymmetric (the dollar
+    figure includes ensemble spend; the token figure does not)."""
+
     estimated_cost_usd: Decimal
+    """Total estimated cost: base extraction (``per_cell_cost x
+    cells_count``) plus ``ensemble_premium_usd``."""
+
     per_tier_breakdown: dict[str, int]
     """Map of tier name (e.g., ``"tier_2"``) -> cell count routed
     at that tier. Lets the operator see "20 cells at Tier 2,
     4 cells at Tier 4 for the high-stakes columns."""
+
+    ensemble_cells_count: int = 0
+    """Number of cells that will run ensemble verification — the count
+    of cells whose column has an effective ``ensemble_verification`` of
+    true (``n_docs x ensemble_column_count``). Zero when no column is
+    ensemble-verified or the gateway has no ensemble configured."""
+
+    ensemble_premium_usd: Decimal = Decimal("0")
+    """The ensemble judge-call cost included in ``estimated_cost_usd``.
+    Equals ``n_judges x per-judge-cost x ensemble_cells_count`` — one
+    ensemble pass (N parallel judge calls) per ensemble cell. Zero when
+    no cell is ensemble-verified."""
 
 
 class TabularExecutionResponse(BaseModel):

--- a/api/app/schemas/tabular.py
+++ b/api/app/schemas/tabular.py
@@ -116,6 +116,14 @@ class Citation(BaseModel):
     """The cited chunk's full ``document_chunks.content``. The frontend
     locates / highlights the cited span within this text."""
 
+    verification_method: str | None = None
+    """The Citation-Engine verification method backing this citation
+    (Donna #6), e.g. ``ensemble_strict`` / ``ensemble_majority``.
+    Mirrors the parent cell's ``verification_method`` onto each citation
+    so the navigable UI can badge the ensemble-verified state per
+    citation. ``None`` when the column isn't ensemble-verified or
+    verification didn't confirm the value."""
+
 
 class CellResult(BaseModel):
     """One cell in the tabular grid.
@@ -146,6 +154,12 @@ class CellResult(BaseModel):
     """Error message when ``confidence='failed'``. Populated by the
     cell node's try/except (model error, no citation found,
     Citation Engine rejection)."""
+
+    verification_method: str | None = None
+    """The Citation-Engine verification method for the cell (Donna #6),
+    e.g. ``ensemble_strict`` / ``ensemble_majority``. ``None`` when the
+    column isn't ensemble-verified or verification didn't confirm the
+    value (a verification miss never fails the cell)."""
 
 
 class TabularRow(BaseModel):
@@ -193,12 +207,14 @@ class TabularRow(BaseModel):
             if not isinstance(chunk_ids, list) or not chunk_ids:
                 continue
             confidence = cell.get("confidence")
+            verification_method = cell.get("verification_method")
             cell["citations"] = [
                 {
                     "citation_id": str(uuid.uuid5(_TABULAR_CITATION_NAMESPACE, str(chunk_id))),
                     "document_id": str(document_id),
                     "chunk_id": str(chunk_id),
                     "confidence": confidence,
+                    "verification_method": verification_method,
                 }
                 for chunk_id in chunk_ids
             ]

--- a/api/app/tabular/cost.py
+++ b/api/app/tabular/cost.py
@@ -61,6 +61,8 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.citation.cost import estimate_judge_call_cost_usd
+from app.clients.gateway import EnsembleConfig
 from app.models.inference import InferenceRoutingLog
 from app.schemas.tabular import ColumnSpec, TabularPreviewCostResponse
 
@@ -167,6 +169,7 @@ async def estimate_tabular_execution_cost(
     *,
     document_ids: list[UUID],
     columns: list[ColumnSpec],
+    ensemble_config: EnsembleConfig | None = None,
 ) -> TabularPreviewCostResponse:
     """Compute the full cost-preview payload for one tabular execution.
 
@@ -175,12 +178,42 @@ async def estimate_tabular_execution_cost(
     cell count; bucketizes cells by ``minimum_inference_tier`` for
     the ``per_tier_breakdown`` informational field.
 
+    Ensemble premium (Donna #6)
+    ---------------------------
+
+    When ``ensemble_config`` is supplied and a column's effective
+    ``ensemble_verification`` flag is true, each of that column's cells
+    runs one Stage-4 ensemble pass — N parallel judge-model calls. The
+    premium per ensemble cell is
+    ``sum(estimate_judge_call_cost_usd(db, judge_model=m) for m in
+    ensemble_config.judge_models)`` — the SAME per-model rolling-average
+    primitive the chat-send cost pre-flight uses
+    (:func:`app.citation.cost.estimate_judge_call_cost_usd`), so the
+    tabular preview and the chat budget agree on judge costs. Total
+    premium = that per-pass cost x the number of ensemble cells, where
+    the ensemble-cell count is ``n_docs x (count of columns whose
+    effective flag is true)``. ``estimated_cost_usd`` returned here is
+    the TOTAL: base extraction + premium.
+
+    Effective per-column flag mirrors the executor's Task-1 resolution:
+    the column's own value when set, else the deployment default
+    (``ensemble_config.default_enabled``) when an ensemble is configured,
+    else false. Skill-level inheritance already happened upstream in
+    ``_resolve_columns``, so a remaining ``None`` here means "inherit
+    deployment default". A column only contributes premium when its
+    effective flag is true AND ``ensemble_config is not None`` (the
+    gateway must have an ensemble to run).
+
+    ``db=None`` keeps working: the judge estimator returns its cold-start
+    default, so ensemble columns still preview a non-zero (conservative)
+    premium.
+
     Edge case: an empty column list yields a zero-cell preview with
-    zero cost / zero tokens / empty breakdown. The endpoint layer's
-    request validation rejects this before it reaches the estimator
-    (``min_length=1`` on ``columns`` in the request schema), but the
-    estimator is defensive about edge inputs so callers building
-    previews internally don't crash on empty drafts.
+    zero cost / zero tokens / empty breakdown / zero ensemble fields.
+    The endpoint layer's request validation rejects this before it
+    reaches the estimator (``min_length=1`` on ``columns`` in the
+    request schema), but the estimator is defensive about edge inputs
+    so callers building previews internally don't crash on empty drafts.
     """
 
     cells_count = len(document_ids) * len(columns)
@@ -191,11 +224,13 @@ async def estimate_tabular_execution_cost(
             estimated_tokens=0,
             estimated_cost_usd=Decimal("0"),
             per_tier_breakdown={},
+            ensemble_cells_count=0,
+            ensemble_premium_usd=Decimal("0"),
         )
 
     per_cell_cost, per_cell_tokens = await _estimate_per_cell_metrics(db)
 
-    estimated_cost = per_cell_cost * Decimal(cells_count)
+    base_cost = per_cell_cost * Decimal(cells_count)
     estimated_tokens = per_cell_tokens * cells_count
 
     per_tier_breakdown = _bucketize_cells_by_tier(
@@ -203,12 +238,48 @@ async def estimate_tabular_execution_cost(
         columns=columns,
     )
 
+    ensemble_column_count = sum(1 for col in columns if _column_runs_ensemble(col, ensemble_config))
+    ensemble_cells_count = len(document_ids) * ensemble_column_count
+
+    ensemble_premium = Decimal("0")
+    if ensemble_config is not None and ensemble_cells_count > 0:
+        per_pass_cost = sum(
+            [
+                await estimate_judge_call_cost_usd(db, judge_model=model)
+                for model in ensemble_config.judge_models
+            ],
+            Decimal("0"),
+        )
+        ensemble_premium = per_pass_cost * Decimal(ensemble_cells_count)
+
     return TabularPreviewCostResponse(
         cells_count=cells_count,
         estimated_tokens=estimated_tokens,
-        estimated_cost_usd=estimated_cost,
+        estimated_cost_usd=base_cost + ensemble_premium,
         per_tier_breakdown=per_tier_breakdown,
+        ensemble_cells_count=ensemble_cells_count,
+        ensemble_premium_usd=ensemble_premium,
     )
+
+
+def _column_runs_ensemble(
+    column: ColumnSpec,
+    ensemble_config: EnsembleConfig | None,
+) -> bool:
+    """Resolve a column's effective ``ensemble_verification`` flag.
+
+    Mirrors Task-1's executor resolution: the column's explicit value
+    wins; a ``None`` falls back to the deployment default
+    (``ensemble_config.default_enabled``). A column can only actually run
+    an ensemble when the gateway has one configured, so this returns
+    false whenever ``ensemble_config is None`` regardless of the flag.
+    """
+
+    if ensemble_config is None:
+        return False
+    if column.ensemble_verification is not None:
+        return column.ensemble_verification
+    return ensemble_config.default_enabled
 
 
 def invalidate_cache() -> None:

--- a/api/app/tabular/nodes.py
+++ b/api/app/tabular/nodes.py
@@ -35,6 +35,7 @@ import json
 import logging
 import uuid
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
@@ -42,6 +43,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.citation.verification import verify
 from app.models.document import Document, DocumentChunk
 from app.models.file import File
 from app.models.tabular import TabularExecution
@@ -52,9 +54,42 @@ from app.tabular.cost import TABULAR_EXTRACTION_PURPOSE
 from app.tabular.state import TabularExecutionState
 
 if TYPE_CHECKING:
-    from app.clients.gateway import GatewayClient
+    from app.clients.gateway import EnsembleConfig, GatewayClient
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Cell-verification candidate / document stubs (Donna #6)
+# ---------------------------------------------------------------------------
+#
+# The Citation Engine's :func:`app.citation.verification.verify` reads a
+# candidate (the "claim") and a document (the "source") via duck-typed
+# protocols. For a tabular cell the claim is the extracted value and the
+# source is the concatenated cited-chunk text. We mint these minimal
+# stubs (mirroring ``tests/citation/test_ensemble.py``'s
+# ``_StubCandidate`` / ``_StubDocument``) rather than load a real
+# Document row — the cell's grounding evidence is the chunk text already
+# in hand, and the synthetic ids only feed a trace-span attribute.
+
+
+# Not ``frozen`` — the verifier's ``_CandidateProtocol`` /
+# ``_DocumentProtocol`` declare settable attributes, so a frozen
+# (read-only) dataclass fails the structural-subtype check. ``slots``
+# keeps them lightweight; we never mutate them after construction.
+@dataclass(slots=True)
+class _CellVerifyCandidate:
+    source_offset_start: int
+    source_offset_end: int
+    source_text: str
+    source_document_id: uuid.UUID
+
+
+@dataclass(slots=True)
+class _CellVerifyDocument:
+    id: uuid.UUID
+    normalized_content: str
+    was_ocrd: bool = False
 
 
 # Top-k chunks retrieved per cell. Bounded so the per-cell LLM context
@@ -188,10 +223,36 @@ def make_extract_cells_node(
 
         per_cell_results: list[dict[str, Any]] = []
 
+        # Resolve the gateway's Stage-4 ensemble config ONCE for the whole
+        # run (the lookup is process-cached). Per column we then decide
+        # the effective flag: explicit per-column value wins; None falls
+        # back to the gateway's deployment default. ``verify_ensemble_config``
+        # is the gateway config when this column should actually run
+        # ensemble AND the gateway has ensemble configured — else None.
+        #
+        # Cost posture (intentional): tabular ensemble verification runs one
+        # ensemble pass per cell and is NOT bounded by a mid-run per-message
+        # cost cap the way the chat path is (``_resolve_ensemble_config`` in
+        # ``api/app/api/chats.py`` falls back to a single judge once an
+        # estimate exceeds ``max_cost_per_message_usd``). Instead, tabular
+        # gates cost up-front: ``POST /api/v1/tabular/preview-cost`` surfaces
+        # the ensemble premium and the operator confirms ``confirmed_cost_usd``
+        # before the run starts (Decision C-5 cost-confirmation gate). A future
+        # mid-run / per-cell ensemble cost ceiling is deferred as DE-331.
+        ensemble_config = await gateway.get_citation_engine_ensemble_config()
+
         tracer = get_tracer()
         for document in documents:
             document_id = uuid.UUID(document["id"])
             for column in columns:
+                effective = (
+                    column.ensemble_verification
+                    if column.ensemble_verification is not None
+                    else (ensemble_config.default_enabled if ensemble_config is not None else False)
+                )
+                verify_ensemble_config = (
+                    ensemble_config if (effective and ensemble_config is not None) else None
+                )
                 with tracer.start_as_current_span("tabular.cell") as cell_span:
                     record_attributes(
                         cell_span,
@@ -212,6 +273,7 @@ def make_extract_cells_node(
                         document_name=document["name"],
                         chunks=chunks,
                         column=column,
+                        verify_ensemble_config=verify_ensemble_config,
                     )
                     cell["document_id"] = str(document_id)
                     cell["column_name"] = column.name
@@ -229,6 +291,7 @@ async def extract_cell(
     document_name: str,
     chunks: list[dict[str, Any]],
     column: ColumnSpec,
+    verify_ensemble_config: EnsembleConfig | None = None,
 ) -> dict[str, Any]:
     """Run one cell extraction; return a cell-result dict.
 
@@ -299,9 +362,32 @@ async def extract_cell(
         n_chunks=len(chunks),
     )
     cited_chunk_ids = [chunks[i]["id"] for i in cited_indices]
+    value = value.strip()
+
+    # Stage-4 ensemble verification (Donna #6). When this column should
+    # run ensemble (config supplied) and the cell has grounding chunks,
+    # run ONE ensemble pass over the concatenation of ALL cited chunks:
+    # the "claim" is the extracted value, the "source" is the cited
+    # chunk text. Stages 1-2 usually MISS (a short value rarely equals
+    # the long concatenation), so Stage 4 fires. Note: a near-verbatim
+    # single-chunk value CAN legitimately hit Stage 1 (``exact_match``) or
+    # Stage 2 (``fuzz.ratio`` >= 95, ``tolerant_match``) — that surfaces a
+    # ``verification_method`` of ``exact_match``/``tolerant_match`` instead
+    # of an ``ensemble_*`` value, which is a STRONGER verification, not an
+    # error. A verification failure must NEVER fail the cell or alter its
+    # value/confidence/citations, so the whole pass is defensively wrapped.
+    verification_method: str | None = None
+    if verify_ensemble_config is not None and cited_chunk_ids:
+        verification_method = await _verify_cell_ensemble(
+            gateway=gateway,
+            value=value,
+            chunks=chunks,
+            cited_chunk_ids=cited_chunk_ids,
+            ensemble_config=verify_ensemble_config,
+        )
 
     return {
-        "value": value.strip(),
+        "value": value,
         "cited_chunk_ids": cited_chunk_ids,
         "confidence": confidence,
         "tier_used": column.minimum_inference_tier,
@@ -311,7 +397,59 @@ async def extract_cell(
         # rolling-average converges off the routing log either way.
         "cost_usd": "0",
         "error": None,
+        "verification_method": verification_method,
     }
+
+
+async def _verify_cell_ensemble(
+    *,
+    gateway: GatewayClient,
+    value: str,
+    chunks: list[dict[str, Any]],
+    cited_chunk_ids: list[str],
+    ensemble_config: EnsembleConfig,
+) -> str | None:
+    """Run one Stage-4 ensemble verify pass for a tabular cell.
+
+    Concatenates ALL cited chunks' content as the source and the
+    extracted ``value`` as the claim, then dispatches through
+    :func:`app.citation.verification.verify`. Returns the method string
+    (e.g. ``ensemble_strict``) when the ensemble verified the value, else
+    ``None``. Any exception degrades to ``None`` — a verification failure
+    is never a cell failure.
+    """
+
+    try:
+        cited_set = set(cited_chunk_ids)
+        concat = "\n---\n".join(chunk["content"] for chunk in chunks if chunk["id"] in cited_set)
+        # Deterministic synthetic ids — used only for a trace-span
+        # attribute, so a stable uuid5 off the primary chunk id is
+        # preferred over uuid4.
+        synthetic_id = uuid.uuid5(uuid.NAMESPACE_DNS, cited_chunk_ids[0])
+        candidate = _CellVerifyCandidate(
+            source_offset_start=0,
+            source_offset_end=len(concat),
+            source_text=value,
+            source_document_id=synthetic_id,
+        )
+        document = _CellVerifyDocument(id=synthetic_id, normalized_content=concat)
+        result = await verify(
+            candidate,
+            document,
+            gateway=gateway,
+            ensemble_config=ensemble_config,
+        )
+        return result.method if result.verified else None
+    except Exception as exc:
+        logger.warning(
+            "tabular extract_cell ensemble verification error: %s",
+            exc,
+            extra={
+                "event": "tabular_extract_cell_verify_error",
+                "error_type": type(exc).__name__,
+            },
+        )
+        return None
 
 
 def _failed_cell(reason: str) -> dict[str, Any]:
@@ -322,6 +460,7 @@ def _failed_cell(reason: str) -> dict[str, Any]:
         "tier_used": None,
         "cost_usd": "0",
         "error": reason,
+        "verification_method": None,
     }
 
 
@@ -504,7 +643,15 @@ def _assemble_rows(
 
 def _strip_state_keys(cell: dict[str, Any]) -> dict[str, Any]:
     """Project the in-flight cell shape down to the persisted shape."""
-    keys = ("value", "cited_chunk_ids", "confidence", "tier_used", "cost_usd", "error")
+    keys = (
+        "value",
+        "cited_chunk_ids",
+        "confidence",
+        "tier_used",
+        "cost_usd",
+        "error",
+        "verification_method",
+    )
     return {key: cell.get(key) for key in keys}
 
 

--- a/api/app/tabular/state.py
+++ b/api/app/tabular/state.py
@@ -66,6 +66,10 @@ class _CellResultState(TypedDict, total=False):
     tier_used: int | None
     cost_usd: str  # Decimal as string for JSON serializability
     error: str | None
+    # Citation-Engine verification method for the cell (Donna #6), e.g.
+    # ``ensemble_strict`` / ``ensemble_majority``. None when the column
+    # isn't ensemble-verified or verification didn't confirm the value.
+    verification_method: str | None
 
 
 class TabularExecutionState(TypedDict, total=False):

--- a/api/tests/tabular/test_cost.py
+++ b/api/tests/tabular/test_cost.py
@@ -29,6 +29,8 @@ from decimal import Decimal
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.citation.cost import DEFAULT_PER_JUDGE_USD, invalidate_cache as invalidate_judge_cache
+from app.clients.gateway import EnsembleConfig
 from app.models.inference import InferenceRoutingLog
 from app.schemas.tabular import ColumnSpec
 from app.tabular.cost import (
@@ -43,10 +45,34 @@ from app.tabular.cost import (
 
 @pytest.fixture(autouse=True)
 def _clean_cache() -> None:
-    """Reset the in-process cache between tests so cached values from
-    one test don't leak into the next."""
+    """Reset both in-process caches between tests so cached values from
+    one test don't leak into the next: the tabular per-cell cache and
+    the judge-cost cache (the ensemble premium reuses the latter)."""
 
     invalidate_cache()
+    invalidate_judge_cache()
+
+
+def _ensemble_config(
+    *,
+    default_enabled: bool = False,
+    judge_models: tuple[str, ...] = ("a", "b", "c"),
+) -> EnsembleConfig:
+    """Build an :class:`EnsembleConfig` for premium-cost assertions.
+
+    The aggregation_rule / max_cost / envelope_tier fields don't affect
+    the cost preview (the preview always counts one ensemble pass per
+    ensemble cell); only ``default_enabled`` and ``judge_models`` matter
+    here, so they get sensible fixed values.
+    """
+
+    return EnsembleConfig(
+        default_enabled=default_enabled,
+        judge_models=judge_models,
+        aggregation_rule="strict",
+        max_cost_per_message_usd=1.0,
+        envelope_tier=3,
+    )
 
 
 def _tabular_row(
@@ -373,3 +399,183 @@ async def test_execution_cost_empty_columns_yields_zero_cells() -> None:
     assert preview.estimated_cost_usd == Decimal("0")
     assert preview.estimated_tokens == 0
     assert preview.per_tier_breakdown == {}
+    # New ensemble fields default to zero on the empty edge case.
+    assert preview.ensemble_cells_count == 0
+    assert preview.ensemble_premium_usd == Decimal("0")
+
+
+# --- estimate_tabular_execution_cost: ensemble premium (Donna #6) -----------
+
+
+@pytest.mark.unit
+async def test_execution_cost_ensemble_column_previews_higher() -> None:
+    """An ensemble column previews HIGHER than the same shape without
+    ensemble config — the premium is one ensemble pass (N judge calls)
+    per ensemble cell, on top of the extraction rate."""
+
+    doc_ids = [uuid.uuid4() for _ in range(4)]
+    cols = [ColumnSpec(name="A", query="?", ensemble_verification=True)]
+    config = _ensemble_config(judge_models=("a", "b", "c"))
+
+    # Baseline: same columns, no ensemble config wired → no premium.
+    base = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+    )
+
+    invalidate_cache()
+    invalidate_judge_cache()
+
+    premium_preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+        ensemble_config=config,
+    )
+
+    assert premium_preview.estimated_cost_usd > base.estimated_cost_usd
+    # 4 docs * 1 ensemble column = 4 ensemble cells.
+    assert premium_preview.ensemble_cells_count == 4
+    assert premium_preview.ensemble_premium_usd > Decimal("0")
+    # db=None → each judge call costs the cold-start default; one pass is
+    # 3 judges, applied per ensemble cell.
+    expected_premium = DEFAULT_PER_JUDGE_USD * Decimal(3) * Decimal(4)
+    assert premium_preview.ensemble_premium_usd == expected_premium
+    # estimated_cost_usd is the TOTAL: base extraction + premium.
+    assert premium_preview.estimated_cost_usd == base.estimated_cost_usd + expected_premium
+
+
+@pytest.mark.unit
+async def test_execution_cost_no_ensemble_config_adds_no_premium() -> None:
+    """``ensemble_config=None`` → no premium even if a column has
+    ``ensemble_verification=True`` (can't run an ensemble the gateway
+    hasn't configured)."""
+
+    doc_ids = [uuid.uuid4() for _ in range(3)]
+    cols = [ColumnSpec(name="A", query="?", ensemble_verification=True)]
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+        ensemble_config=None,
+    )
+
+    assert preview.ensemble_cells_count == 0
+    assert preview.ensemble_premium_usd == Decimal("0")
+    # estimated_cost equals the pure extraction base (3 * 1 * default).
+    assert preview.estimated_cost_usd == DEFAULT_PER_CELL_USD * Decimal(3)
+
+
+@pytest.mark.unit
+async def test_execution_cost_mixed_columns_counts_only_ensemble_cells() -> None:
+    """A mix of one ensemble + one non-ensemble column charges the
+    premium only against the ensemble cells (n_docs * 1, not * 2)."""
+
+    doc_ids = [uuid.uuid4() for _ in range(5)]
+    cols = [
+        ColumnSpec(name="Ensemble", query="?", ensemble_verification=True),
+        ColumnSpec(name="Plain", query="?", ensemble_verification=False),
+    ]
+    config = _ensemble_config(judge_models=("a", "b"))
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+        ensemble_config=config,
+    )
+
+    # 5 docs * 1 ensemble column = 5 ensemble cells (the plain column
+    # contributes 0 to the ensemble count).
+    assert preview.ensemble_cells_count == 5
+    expected_premium = DEFAULT_PER_JUDGE_USD * Decimal(2) * Decimal(5)
+    assert preview.ensemble_premium_usd == expected_premium
+
+
+@pytest.mark.unit
+async def test_execution_cost_deployment_default_activates_null_column() -> None:
+    """A column with ``ensemble_verification=None`` inherits the
+    deployment default: ``default_enabled=True`` → counts as ensemble."""
+
+    doc_ids = [uuid.uuid4() for _ in range(3)]
+    cols = [ColumnSpec(name="A", query="?")]  # ensemble_verification defaults to None
+    config = _ensemble_config(default_enabled=True, judge_models=("a", "b"))
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+        ensemble_config=config,
+    )
+
+    assert preview.ensemble_cells_count == 3
+    assert preview.ensemble_premium_usd == DEFAULT_PER_JUDGE_USD * Decimal(2) * Decimal(3)
+
+
+@pytest.mark.unit
+async def test_execution_cost_deployment_default_off_null_column_no_premium() -> None:
+    """A column with ``ensemble_verification=None`` and
+    ``default_enabled=False`` → no premium."""
+
+    doc_ids = [uuid.uuid4() for _ in range(3)]
+    cols = [ColumnSpec(name="A", query="?")]
+    config = _ensemble_config(default_enabled=False, judge_models=("a", "b"))
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+        ensemble_config=config,
+    )
+
+    assert preview.ensemble_cells_count == 0
+    assert preview.ensemble_premium_usd == Decimal("0")
+
+
+@pytest.mark.unit
+async def test_execution_cost_empty_judge_models_yields_zero_premium() -> None:
+    """An ``EnsembleConfig`` with ``judge_models=()`` (empty tuple) and an
+    ensemble column → ``ensemble_premium_usd == Decimal("0")`` cleanly.
+
+    The premium is a sum over the judge models; an empty tuple sums to
+    zero rather than crashing. This path can't arise via the gateway
+    (it rejects empty judge_models), but ``estimate_tabular_execution_cost``
+    is a public function, so this pins the empty-judges behavior: zero
+    premium, no error.
+    """
+
+    doc_ids = [uuid.uuid4() for _ in range(3)]
+    cols = [ColumnSpec(name="A", query="?", ensemble_verification=True)]
+    config = _ensemble_config(judge_models=())
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+        ensemble_config=config,
+    )
+
+    # Empty judge_models → zero premium (sum over zero judges = 0).
+    assert preview.ensemble_premium_usd == Decimal("0")
+
+
+@pytest.mark.unit
+async def test_execution_cost_explicit_false_overrides_deployment_default() -> None:
+    """An explicit ``ensemble_verification=False`` wins over
+    ``default_enabled=True`` — no premium for that column."""
+
+    doc_ids = [uuid.uuid4() for _ in range(3)]
+    cols = [ColumnSpec(name="A", query="?", ensemble_verification=False)]
+    config = _ensemble_config(default_enabled=True, judge_models=("a", "b"))
+
+    preview = await estimate_tabular_execution_cost(
+        None,
+        document_ids=doc_ids,
+        columns=cols,
+        ensemble_config=config,
+    )
+
+    assert preview.ensemble_cells_count == 0
+    assert preview.ensemble_premium_usd == Decimal("0")

--- a/api/tests/tabular/test_ensemble_verification_integration.py
+++ b/api/tests/tabular/test_ensemble_verification_integration.py
@@ -1,0 +1,300 @@
+"""End-to-end acceptance test for per-column tabular ensemble verification
+(Donna #6, part 3).
+
+Acceptance: in a completed execution, an ensemble column's cells carry an
+``ensemble_*`` verification signal while a non-ensemble column on the same run
+does not.
+
+Where the Task-1 unit tests drove ``extract_cell`` directly with an explicit
+``verify_ensemble_config``, this exercises the FULL wiring:
+``run_tabular_execution`` → ``make_extract_cells_node`` resolving each column's
+*effective* ``ensemble_verification`` flag AND fetching the ensemble config from
+the (stub) gateway → the Stage-4 ensemble verify pass → the persisted
+``results`` JSON → the read-path projection that surfaces
+``verification_method`` on each cell's citations.
+
+The stub gateway is content-sniffing (branches on the request rather than
+relying on call ordering): a judge call (``lq_ai_purpose == 'judge_paraphrase'``)
+returns a "yes" verdict; any other call returns the extraction JSON. That keeps
+the stub robust to the executor's ``for document: for column:`` walk regardless
+of how many extraction / judge calls each cell makes.
+
+Harness: ``@pytest.mark.integration`` — requires Postgres (the session-scoped
+``db_session`` fixture from conftest auto-migrates the throwaway pgvector DB).
+Mirrors the seeding pattern from :mod:`tests.tabular.test_executor_spans`.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.clients.gateway import EnsembleConfig
+from app.models.document import Document, DocumentChunk
+from app.models.file import File as FileModel
+from app.models.tabular import TabularExecution
+from app.models.user import User
+from app.security import hash_password
+from app.tabular.executor import run_tabular_execution
+
+# ---------------------------------------------------------------------------
+# Stub gateway response shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubMessage:
+    content: str
+
+
+@dataclass
+class _StubChoice:
+    message: _StubMessage
+
+
+@dataclass
+class _StubResponse:
+    choices: list[_StubChoice]
+
+
+_EXTRACTION_PAYLOAD = {
+    "value": "3 years",
+    "cited_chunk_indices": [0],
+    "confidence": "high",
+    "justification": "The clause states 'three (3) years'.",
+}
+
+_JUDGE_PAYLOAD = {
+    "verdict": "yes",
+    "confidence": "high",
+    "justification": "The source supports the claim.",
+}
+
+
+@dataclass
+class _StubGateway:
+    """Content-sniffing stub.
+
+    A judge call (``lq_ai_purpose == 'judge_paraphrase'``) returns a "yes"
+    verdict; every other call returns the extraction JSON. Records how many
+    judge calls were issued so the test can assert the non-ensemble column
+    made none of them.
+    """
+
+    judge_calls: int = 0
+    extraction_calls: int = 0
+
+    async def chat_completion(
+        self, request: Any, *, request_id: str | None = None
+    ) -> _StubResponse:
+        if getattr(request, "lq_ai_purpose", None) == "judge_paraphrase":
+            self.judge_calls += 1
+            payload = _JUDGE_PAYLOAD
+        else:
+            self.extraction_calls += 1
+            payload = _EXTRACTION_PAYLOAD
+        return _StubResponse(
+            choices=[_StubChoice(message=_StubMessage(content=json.dumps(payload)))]
+        )
+
+    async def get_citation_engine_ensemble_config(self) -> EnsembleConfig:
+        return EnsembleConfig(
+            default_enabled=False,
+            judge_models=("j1", "j2", "j3"),
+            aggregation_rule="strict",
+            max_cost_per_message_usd=10.0,
+            envelope_tier=3,
+        )
+
+
+# ---------------------------------------------------------------------------
+# DB helpers (mirror tests.tabular.test_executor_spans)
+# ---------------------------------------------------------------------------
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        email=f"u-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_doc(db: AsyncSession, *, owner: User, text: str) -> Document:
+    f = FileModel(
+        owner_id=owner.id,
+        filename=f"tab-ens-{uuid.uuid4().hex[:6]}.pdf",
+        mime_type="application/pdf",
+        size_bytes=1024,
+        hash_sha256="f" * 64,
+        storage_path=f"tab-ens/{uuid.uuid4()}",
+        ingestion_status="ready",
+    )
+    db.add(f)
+    await db.flush()
+    doc = Document(
+        file_id=f.id,
+        parser="pymupdf-only",
+        parser_version="pymupdf=1.27",
+        page_count=1,
+        character_count=len(text),
+        normalized_content=text,
+        was_ocrd=False,
+    )
+    db.add(doc)
+    await db.flush()
+    chunk = DocumentChunk(
+        document_id=doc.id,
+        chunk_index=0,
+        content=text,
+        page_start=1,
+        page_end=1,
+        char_offset_start=0,
+        char_offset_end=len(text),
+    )
+    db.add(chunk)
+    await db.flush()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Acceptance test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_per_column_ensemble_gating_end_to_end(db_session: AsyncSession) -> None:
+    """One ensemble + one non-ensemble column on the same run.
+
+    Proves (through the executor/node wiring, not a direct ``extract_cell``
+    call):
+
+    * persisted ``results``: the ensemble column's cell carries
+      ``verification_method == 'ensemble_strict'``; the non-ensemble column's
+      cell carries no verification signal (``None``). Both cells still have
+      their ``value`` + ``cited_chunk_ids``.
+    * read path: each ensemble cell citation carries
+      ``verification_method == 'ensemble_strict'`` while the non-ensemble
+      cell's citations carry ``None``.
+    * the non-ensemble column issued NO judge calls.
+    """
+
+    owner = await _make_user(db_session)
+    doc_text = (
+        "The initial term of this Agreement shall be three (3) years "
+        "commencing on the Effective Date."
+    )
+    doc = await _make_doc(db_session, owner=owner, text=doc_text)
+
+    # Column order matters: the executor walks for document: for column:.
+    # A = ensemble (1 extraction + 3 judge calls), B = non-ensemble
+    # (1 extraction, 0 judge calls).
+    columns = [
+        {
+            "name": "A",
+            "query": "contract term duration",
+            "minimum_inference_tier": None,
+            "ensemble_verification": True,
+        },
+        {
+            "name": "B",
+            "query": "contract term duration",
+            "minimum_inference_tier": None,
+            "ensemble_verification": False,
+        },
+    ]
+
+    execution = TabularExecution(
+        document_ids=[doc.id],
+        columns=columns,
+        status="pending",
+    )
+    db_session.add(execution)
+    await db_session.flush()
+
+    execution_id = execution.id
+
+    gateway = _StubGateway()
+    await run_tabular_execution(
+        db_session,
+        execution_id=execution_id,
+        gateway=gateway,  # type: ignore[arg-type]
+    )
+
+    # --- persisted-results assertion ---------------------------------------
+    # The aggregate node commits (expiring ``execution``); reload a fresh row.
+    refreshed = (
+        await db_session.execute(
+            select(TabularExecution).where(TabularExecution.id == execution_id)
+        )
+    ).scalar_one()
+
+    assert refreshed.status == "completed", f"unexpected status: {refreshed.status!r}"
+    results = refreshed.results
+    assert results is not None
+    rows = results["rows"]
+    assert len(rows) == 1
+    cells = rows[0]["cells"]
+
+    ensemble_cell = cells["A"]
+    plain_cell = cells["B"]
+
+    # Ensemble column → ensemble_strict; both cells still extracted a value
+    # with grounding chunks.
+    assert ensemble_cell["verification_method"] == "ensemble_strict", (
+        f"ensemble cell verification_method: {ensemble_cell['verification_method']!r}"
+    )
+    assert ensemble_cell["value"] == "3 years"
+    assert ensemble_cell["cited_chunk_ids"], "ensemble cell lost its cited_chunk_ids"
+
+    # Non-ensemble column → no verification signal.
+    assert plain_cell.get("verification_method") is None, (
+        f"non-ensemble cell carried a verification signal: "
+        f"{plain_cell.get('verification_method')!r}"
+    )
+    assert plain_cell["value"] == "3 years"
+    assert plain_cell["cited_chunk_ids"], "non-ensemble cell lost its cited_chunk_ids"
+
+    # The non-ensemble column must not have issued judge calls. One ensemble
+    # cell x 3 judge models = exactly 3 judge calls total.
+    assert gateway.judge_calls == 3, (
+        f"expected exactly 3 judge calls (1 ensemble cell x 3 judges); got {gateway.judge_calls}"
+    )
+
+    # --- read-path assertion -----------------------------------------------
+    # Build the response through the SAME projection the GET endpoint uses
+    # (_to_response synthesizes citations + mirrors verification_method;
+    # _enrich_cell_citations resolves navigation fields without disturbing it).
+    from app.api.tabular import _enrich_cell_citations, _to_response
+
+    response = await _to_response(db_session, refreshed)
+    await _enrich_cell_citations(db_session, response)
+
+    assert response.results is not None
+    resp_row = response.results.rows[0]
+    resp_ensemble = resp_row.cells["A"]
+    resp_plain = resp_row.cells["B"]
+
+    assert resp_ensemble.citations, "ensemble cell produced no citations on read path"
+    for citation in resp_ensemble.citations:
+        assert citation.verification_method == "ensemble_strict", (
+            f"ensemble citation verification_method: {citation.verification_method!r}"
+        )
+
+    assert resp_plain.citations, "non-ensemble cell produced no citations on read path"
+    for citation in resp_plain.citations:
+        assert citation.verification_method is None, (
+            f"non-ensemble citation carried a verification signal: {citation.verification_method!r}"
+        )

--- a/api/tests/tabular/test_executor_spans.py
+++ b/api/tests/tabular/test_executor_spans.py
@@ -85,6 +85,11 @@ class _StubGateway:
             choices=[_StubChoice(message=_StubMessage(content=json.dumps(payload)))]
         )
 
+    async def get_citation_engine_ensemble_config(self) -> None:
+        # No ensemble configured in this span-tracing test; cells run the
+        # plain (non-ensemble) extraction path.
+        return None
+
 
 # ---------------------------------------------------------------------------
 # DB helpers

--- a/api/tests/tabular/test_nodes.py
+++ b/api/tests/tabular/test_nodes.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import pytest
 
+from app.clients.gateway import EnsembleConfig
 from app.schemas.tabular import ColumnSpec
 from app.tabular.nodes import (
     _assemble_rows,
@@ -308,6 +309,225 @@ async def test_extract_cell_with_no_chunks_marks_failed() -> None:
     )
     assert cell["confidence"] == "failed"
     assert gateway.calls_received == []
+
+
+# ---------------------------------------------------------------------------
+# extract_cell — Stage-4 ensemble verification (Donna #6)
+# ---------------------------------------------------------------------------
+
+
+def _ensemble_config(
+    *,
+    n: int = 3,
+    aggregation_rule: str = "strict",
+    default_enabled: bool = True,
+) -> EnsembleConfig:
+    """Build a real (frozen) :class:`EnsembleConfig` for the cell-verify path."""
+
+    return EnsembleConfig(
+        default_enabled=default_enabled,
+        judge_models=tuple(f"judge-{i}" for i in range(n)),
+        aggregation_rule=aggregation_rule,  # type: ignore[arg-type]
+        max_cost_per_message_usd=0.05,
+        envelope_tier=3,
+    )
+
+
+def _extraction_payload(value: str = "Delaware") -> dict[str, Any]:
+    return {
+        "value": value,
+        "cited_chunk_indices": [0],
+        "confidence": "high",
+        "justification": "stated explicitly",
+    }
+
+
+def _judge_payload(verdict: str) -> dict[str, Any]:
+    return {"verdict": verdict, "confidence": "high", "justification": "test"}
+
+
+@pytest.mark.unit
+async def test_extract_cell_ensemble_strict_all_yes_sets_method() -> None:
+    """Ensemble config + all judges 'yes' under strict → method='ensemble_strict'.
+
+    The gateway is called once for extraction, then once per judge model
+    (verify runs Stage 1+2 first — they miss because the short value never
+    equals the concatenated chunk text — then dispatches Stage 4).
+    """
+
+    cfg = _ensemble_config(n=3, aggregation_rule="strict")
+    chunks = [_chunk(0, "Governing law is the State of Delaware."), _chunk(1, "Other")]
+    gateway = _StubGateway(
+        payloads=[
+            _extraction_payload("Delaware"),
+            _judge_payload("yes"),
+            _judge_payload("yes"),
+            _judge_payload("yes"),
+        ]
+    )
+
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="NDA",
+        chunks=chunks,
+        column=ColumnSpec(name="Governing Law", query="What is the governing law?"),
+        verify_ensemble_config=cfg,
+    )
+
+    assert cell["value"] == "Delaware"
+    assert cell["cited_chunk_ids"] == [chunks[0]["id"]]
+    assert cell["verification_method"] == "ensemble_strict"
+    # 1 extraction + 3 judge calls.
+    assert len(gateway.calls_received) == 4
+
+
+@pytest.mark.unit
+async def test_extract_cell_no_ensemble_config_leaves_method_none() -> None:
+    """No ensemble config → verification_method is None; gateway called once."""
+
+    gateway = _StubGateway(payloads=[_extraction_payload("Delaware")])
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="NDA",
+        chunks=[_chunk(0, "Delaware text")],
+        column=ColumnSpec(name="Governing Law", query="?"),
+    )
+
+    assert cell["value"] == "Delaware"
+    assert cell["verification_method"] is None
+    # Extraction only — no judge calls.
+    assert len(gateway.calls_received) == 1
+
+
+@pytest.mark.unit
+async def test_extract_cell_ensemble_strict_dissent_misses() -> None:
+    """Strict rule + a judge 'no' → ensemble MISS → verification_method None,
+    but the cell still returns its extracted value (verify failure is not
+    a cell failure)."""
+
+    cfg = _ensemble_config(n=3, aggregation_rule="strict")
+    gateway = _StubGateway(
+        payloads=[
+            _extraction_payload("Delaware"),
+            _judge_payload("yes"),
+            _judge_payload("no"),
+            _judge_payload("yes"),
+        ]
+    )
+
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="NDA",
+        chunks=[_chunk(0, "Governing law is the State of Delaware.")],
+        column=ColumnSpec(name="Governing Law", query="?"),
+        verify_ensemble_config=cfg,
+    )
+
+    assert cell["value"] == "Delaware"
+    assert cell["confidence"] == "high"
+    assert cell["verification_method"] is None
+
+
+@pytest.mark.unit
+async def test_extract_cell_ensemble_judge_failure_keeps_value() -> None:
+    """A judge raising / malformed JSON degrades to MISS (verify is robust);
+    verification_method is None and the cell value is intact (no crash)."""
+
+    cfg = _ensemble_config(n=2, aggregation_rule="strict")
+    gateway = _StubGateway(
+        payloads=[
+            _extraction_payload("Delaware"),
+            RuntimeError("judge down"),
+            "not valid json",
+        ]
+    )
+
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="NDA",
+        chunks=[_chunk(0, "Governing law is the State of Delaware.")],
+        column=ColumnSpec(name="Governing Law", query="?"),
+        verify_ensemble_config=cfg,
+    )
+
+    assert cell["value"] == "Delaware"
+    assert cell["verification_method"] is None
+
+
+@pytest.mark.unit
+async def test_extract_cell_ensemble_on_but_no_cited_chunks_skips_verify() -> None:
+    """Ensemble config supplied, but the model cites no (valid) chunk →
+    ``verification_method`` stays None and the gateway is called exactly
+    once (extraction only). The ``and cited_chunk_ids`` guard in
+    ``extract_cell`` skips the verify pass when there is nothing to ground
+    the value against, so no judge calls fire."""
+
+    cfg = _ensemble_config(n=3, aggregation_rule="strict")
+    # Model returns a value but cites no chunk indices — nothing to verify.
+    gateway = _StubGateway(
+        payloads=[
+            {
+                "value": "Delaware",
+                "cited_chunk_indices": [],
+                "confidence": "high",
+                "justification": "no grounding",
+            }
+        ]
+    )
+
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="NDA",
+        chunks=[_chunk(0, "Governing law is the State of Delaware.")],
+        column=ColumnSpec(name="Governing Law", query="?"),
+        verify_ensemble_config=cfg,
+    )
+
+    assert cell["value"] == "Delaware"
+    assert cell["cited_chunk_ids"] == []
+    assert cell["verification_method"] is None
+    # Extraction only — the empty-citation guard skips all judge calls.
+    assert len(gateway.calls_received) == 1
+
+
+@pytest.mark.unit
+async def test_extract_cell_ensemble_majority_sets_method() -> None:
+    """Majority rule + a verified majority of judges → method='ensemble_majority'.
+
+    Exercises the majority aggregation branch through the tabular path
+    (the strict branch is covered above). With n=3 and two 'yes' verdicts,
+    the strict-majority rule (> n/2) is satisfied and the result verifies
+    even though one judge dissented."""
+
+    cfg = _ensemble_config(n=3, aggregation_rule="majority")
+    chunks = [_chunk(0, "Governing law is the State of Delaware."), _chunk(1, "Other")]
+    gateway = _StubGateway(
+        payloads=[
+            _extraction_payload("Delaware"),
+            _judge_payload("yes"),
+            _judge_payload("no"),
+            _judge_payload("yes"),
+        ]
+    )
+
+    cell = await extract_cell(
+        gateway=gateway,  # type: ignore[arg-type]
+        judge_model="smart",
+        document_name="NDA",
+        chunks=chunks,
+        column=ColumnSpec(name="Governing Law", query="What is the governing law?"),
+        verify_ensemble_config=cfg,
+    )
+
+    assert cell["value"] == "Delaware"
+    assert cell["verification_method"] == "ensemble_majority"
+    # 1 extraction + 3 judge calls.
+    assert len(gateway.calls_received) == 4
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/tabular/test_nodes.py
+++ b/api/tests/tabular/test_nodes.py
@@ -380,6 +380,12 @@ async def test_extract_cell_ensemble_strict_all_yes_sets_method() -> None:
     assert cell["verification_method"] == "ensemble_strict"
     # 1 extraction + 3 judge calls.
     assert len(gateway.calls_received) == 4
+    # The ensemble pass must judge ONLY the cited chunk (index 0), never the
+    # uncited chunk ("Other") — the verify document is the concatenation of
+    # *cited* chunks, not all retrieved chunks. Inspect a judge call's source.
+    judge_source = gateway.calls_received[1].messages[1].content
+    assert "Delaware" in judge_source
+    assert "Other" not in judge_source
 
 
 @pytest.mark.unit

--- a/api/tests/tabular/test_schemas.py
+++ b/api/tests/tabular/test_schemas.py
@@ -27,6 +27,7 @@ def _persisted_cell(
     cited_chunk_ids: list[str],
     confidence: str,
     error: str | None = None,
+    verification_method: str | None = None,
 ) -> dict[str, object]:
     """Mirror the exact JSONB shape the executor persists per cell."""
     return {
@@ -36,6 +37,7 @@ def _persisted_cell(
         "tier_used": None,
         "cost_usd": "0",
         "error": error,
+        "verification_method": verification_method,
     }
 
 
@@ -82,6 +84,60 @@ def test_synthesized_citation_id_is_deterministic() -> None:
     first = TabularRow.model_validate(payload).cells["Col"].citations[0].citation_id
     second = TabularRow.model_validate(payload).cells["Col"].citations[0].citation_id
     assert first == second
+
+
+def test_synthesized_citation_carries_verification_method() -> None:
+    """A cell carrying ``verification_method`` mirrors it onto each
+    synthesized citation (Donna #6) so the navigable UI can badge the
+    ensemble-verified state per citation."""
+    document_id = uuid.uuid4()
+    chunk_a = uuid.uuid4()
+    chunk_b = uuid.uuid4()
+    row = TabularRow.model_validate(
+        {
+            "document_id": str(document_id),
+            "document_name": "nda-1.pdf",
+            "cells": {
+                "Governing Law": _persisted_cell(
+                    value="Delaware",
+                    cited_chunk_ids=[str(chunk_a), str(chunk_b)],
+                    confidence="high",
+                    verification_method="ensemble_strict",
+                ),
+            },
+        }
+    )
+
+    cell = row.cells["Governing Law"]
+    assert cell.verification_method == "ensemble_strict"
+    assert len(cell.citations) == 2
+    assert all(c.verification_method == "ensemble_strict" for c in cell.citations)
+
+
+def test_synthesized_citation_verification_method_none_when_absent() -> None:
+    """A non-ensemble cell (verification_method None) yields citations with
+    ``verification_method is None``."""
+    document_id = uuid.uuid4()
+    chunk = uuid.uuid4()
+    row = TabularRow.model_validate(
+        {
+            "document_id": str(document_id),
+            "document_name": "nda-1.pdf",
+            "cells": {
+                "Term": _persisted_cell(
+                    value="3 years",
+                    cited_chunk_ids=[str(chunk)],
+                    confidence="high",
+                    verification_method=None,
+                ),
+            },
+        }
+    )
+
+    cell = row.cells["Term"]
+    assert cell.verification_method is None
+    assert len(cell.citations) == 1
+    assert cell.citations[0].verification_method is None
 
 
 def test_failed_cell_with_no_chunks_yields_no_citations() -> None:

--- a/api/tests/test_tabular_endpoints.py
+++ b/api/tests/test_tabular_endpoints.py
@@ -25,6 +25,8 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.citation.cost import invalidate_cache as invalidate_judge_cache
+from app.clients.gateway import EnsembleConfig, get_gateway_client
 from app.db.session import get_db
 from app.main import app
 from app.models.document import Document, DocumentChunk
@@ -32,6 +34,7 @@ from app.models.file import File as FileModel
 from app.models.tabular import TabularExecution
 from app.models.user import User
 from app.security import create_access_token, hash_password
+from app.tabular import cost as tabular_cost
 
 
 def _override_get_db(db_session: AsyncSession):
@@ -319,3 +322,89 @@ async def test_get_execution_batches_across_two_documents(
     assert cit_b["source_file_id"] == str(doc_b.file_id)
     assert cit_b["source_page"] == 5
     assert cit_b["source_text"] == "bravo source text"
+
+
+# --- preview-cost: ensemble premium surface (Donna #6) ----------------------
+
+
+class _StubGateway:
+    """Minimal gateway stub for preview-cost — only the ensemble-config
+    accessor the endpoint touches is implemented."""
+
+    def __init__(self, ensemble_config: EnsembleConfig | None) -> None:
+        self._ensemble_config = ensemble_config
+
+    async def get_citation_engine_ensemble_config(self) -> EnsembleConfig | None:
+        return self._ensemble_config
+
+
+@pytest.mark.asyncio
+async def test_preview_cost_no_ensemble_config_back_compat(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """With no ensemble configured, the new fields are present and zero —
+    the back-compat shape the UI relies on when the gateway has no
+    ensemble. (The premium math itself is unit-tested in
+    tests/tabular/test_cost.py.)"""
+
+    user = await _make_user(db_session)
+    app.dependency_overrides[get_gateway_client] = lambda: _StubGateway(None)
+    tabular_cost.invalidate_cache()
+    invalidate_judge_cache()
+    try:
+        resp = await client.post(
+            "/api/v1/tabular/preview-cost",
+            headers=_bearer(user),
+            json={
+                "document_ids": [str(uuid.uuid4()) for _ in range(2)],
+                "columns": [
+                    {"name": "A", "query": "?", "ensemble_verification": True},
+                ],
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_gateway_client, None)
+
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["ensemble_cells_count"] == 0
+    assert payload["ensemble_premium_usd"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_preview_cost_ensemble_premium_applied(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An ensemble-verified column drives a positive premium through the
+    endpoint when the gateway returns an ensemble config."""
+
+    user = await _make_user(db_session)
+    config = EnsembleConfig(
+        default_enabled=False,
+        judge_models=("a", "b", "c"),
+        aggregation_rule="strict",
+        max_cost_per_message_usd=1.0,
+        envelope_tier=3,
+    )
+    app.dependency_overrides[get_gateway_client] = lambda: _StubGateway(config)
+    tabular_cost.invalidate_cache()
+    invalidate_judge_cache()
+    try:
+        resp = await client.post(
+            "/api/v1/tabular/preview-cost",
+            headers=_bearer(user),
+            json={
+                "document_ids": [str(uuid.uuid4()) for _ in range(3)],
+                "columns": [
+                    {"name": "A", "query": "?", "ensemble_verification": True},
+                ],
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_gateway_client, None)
+
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    # 3 docs * 1 ensemble column = 3 ensemble cells.
+    assert payload["ensemble_cells_count"] == 3
+    assert float(payload["ensemble_premium_usd"]) > 0

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4471,6 +4471,18 @@ Two bulk operations as originally written in the M3-C4 spec:
 
 ---
 
+#### DE-331 — Mid-run ensemble verification cost ceiling for Tabular Review
+
+**Priority:** P3 · **Effort:** M
+
+**Context:** Tabular ensemble verification (Donna #6) runs one Stage-4 ensemble `verify()` pass per cell when a column's effective `ensemble_verification` flag is true, fanning out N parallel judge calls per cell across the up-to-200×10 cell grid. Unlike the chat-send path — which runs a per-message cost pre-flight (`_resolve_ensemble_config` in `api/app/api/chats.py`) and falls back to a single judge when the estimate exceeds `citation_engine.ensemble_verification.max_cost_per_message_usd` — the tabular executor has no mid-run cost ceiling. Cost is instead gated up-front: `POST /api/v1/tabular/preview-cost` surfaces the ensemble premium and the operator confirms `confirmed_cost_usd` before kickoff (Decision C-5). That up-front gate is sufficient for the v1 acceptance, but a long run whose live judge costs drift above the estimate will not self-throttle the way chat does.
+
+**Specific scope:** Add an in-loop ensemble cost ceiling to the tabular extraction node — e.g. track cumulative judge spend against `confirmed_cost_usd` (or a dedicated cap) and degrade ensemble cells to no-verify (or single-judge) once the ceiling is hit, mirroring the chat path's `max_cost_per_message_usd` fallback. Receipt the degradation so the result view can show "ensemble verification halted at cost ceiling" rather than silently dropping verification.
+
+**When to ship:** When operators run large ensemble-heavy tabular grids in production and the up-front estimate proves insufficient as the sole guardrail.
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -5085,6 +5085,22 @@ components:
             ``default``) to cell count routed at that tier. Columns
             without an explicit ``minimum_inference_tier`` count in
             the ``default`` bucket.
+        ensemble_cells_count:
+          type: integer
+          description: |
+            Number of cells that will run ensemble Citation-Engine
+            verification (``len(document_ids) * ensemble-column count``).
+            ``0`` when no column is ensemble-verified.
+        ensemble_premium_usd:
+          type: string
+          description: |
+            The ensemble judge-call cost included in
+            ``estimated_cost_usd`` (= ``n_judges * per-judge-cost *
+            ensemble_cells_count``), serialized as a JSON string to
+            preserve decimal precision. ``"0"`` when no column is
+            ensemble-verified. Note that ``estimated_cost_usd`` is the
+            TOTAL (base extraction + this premium); ``estimated_tokens``
+            is extraction-only and excludes judge tokens.
 
     TabularExecutionCreate:
       type: object
@@ -5163,12 +5179,23 @@ components:
             Assembled grid shape with rows + per-cell results. Shape is
             versioned via ``schema_version`` (currently ``m3-c2-v1``).
 
+            Each cell result also carries ``verification_method``
+            (string, nullable) — the per-cell ensemble Citation-Engine
+            verification outcome (``ensemble_strict`` /
+            ``ensemble_majority``), or ``null`` when the cell's column is
+            not ensemble-verified or verification did not confirm support.
+
             Each cell carries a ``citations`` array. A tabular cell
             ``Citation`` is distinct from the chat ``Citation`` schema; it
             has: ``citation_id`` (uuid; deterministic display-only id —
             DE-309), ``document_id`` (uuid; the source ``documents.id``),
             ``chunk_id`` (uuid, nullable; the cited ``document_chunks.id``),
-            and ``confidence`` (one of ``high|medium|low|failed``).
+            and ``confidence`` (one of ``high|medium|low|failed``). Each
+            citation additionally carries ``verification_method`` (string,
+            nullable) — the Citation-Engine verification method
+            (``ensemble_strict`` / ``ensemble_majority``), or ``null`` when
+            the cell's column is not ensemble-verified or verification did
+            not confirm support. It is mirrored from the cell-level value.
 
             On ``GET /api/v1/tabular/executions/{id}`` (only) each citation
             is additionally enriched at read time so the frontend can open


### PR DESCRIPTION
Honor per-column `ensemble_verification` on Tabular Review — wires Citation-Engine **ensemble** verification into the tabular cell path for the first time (tabular ran no Citation-Engine verification before today; this overlaps DE-309). Donna ask #6.

## What changes
1. **Verification wiring** (`api/app/tabular/nodes.py`) — when a column's *effective* `ensemble_verification` flag is true, each cell runs **one Stage-4 ensemble `verify()` pass** over the concatenation of its **cited** chunks. The result `verification_method` (`ensemble_strict` / `ensemble_majority`, or `None`) is persisted on the cell and mirrored onto each cell `Citation`. Reuses `app.citation.verification.verify(..., ensemble_config=...)` + `GatewayClient.get_citation_engine_ensemble_config()` (mirrors the chat-send path at `chats.py:1872`); **no** gateway `ChatCompletionRequest` change. Non-ensemble columns are unchanged (no judge calls). Per-cell error isolation: a judge failure degrades to `verification_method=None` and never fails the cell.
2. **Cost premium** (`api/app/tabular/cost.py`, `preview-cost`) — ensemble columns now preview **higher**: per ensemble cell, add one ensemble pass (`n_judges × per-judge-cost`, reusing `estimate_judge_call_cost_usd`, the same primitive the chat budget pre-flight uses). New `TabularPreviewCostResponse` fields `ensemble_cells_count` + `ensemble_premium_usd`; `estimated_cost_usd` is now base extraction + premium.
3. **Contract** (`docs/api/backend-openapi.yaml`) — documents `verification_method` on the cell + citation (in the `results` prose; the tabular result tree still has no named components — pre-existing DE-330) and the two new preview-cost fields. `test_openapi` path count unchanged (114; no new route).

## Design decisions (locked at kickoff, confirmed against the judge prompt)
- **Claim/source mapping:** `candidate.source_text` = the cell **value**; `document.normalized_content` = the **concatenated cited chunks**; offsets span `(0, len)` so Stages 1–2 (exact/tolerant) miss and Stage 4 (ensemble) fires — the judges affirm "do these chunks support this value?", exactly Stage-4 semantics.
- **One pass per cell over all cited chunks** (not per-chunk, not primary-only): cheapest sufficient option, uses all grounding evidence, and makes the cost premium exactly `n_judges × per-judge-cost` per ensemble cell.
- **Effective flag precedence:** column value → skill-level `lq_ai.ensemble_verification` (baked into the snapshot at `_resolve_columns`, the existing C-1 snapshotting point) → deployment `default_enabled`. Resolved identically at preview and execute (no cost-honesty divergence).
- **Cost posture:** tabular ensemble cost is gated **up-front** via preview-cost + `confirmed_cost_usd` (Decision C-5), not by a mid-run per-message cap like chat. A mid-run/per-cell ceiling is deferred as **DE-331** (filed in PRD §9).
- No migration (rides the results JSON, like `cited_chunk_ids`). `skill_name` XOR `columns` contract and `minimum_inference_tier` unchanged.

## Acceptance (Donna's) — covered by `test_ensemble_verification_integration.py`
A completed execution with one ensemble + one non-ensemble column → ensemble cells carry `ensemble_strict`, non-ensemble cells carry no signal (`None`), surfaced through the read path's citations; preview-cost returns a higher estimate for ensemble columns.

## Donna integration note
`TabularPreviewCostResponse` gains typed fields (`gen:api` will emit them). The cell/citation `verification_method` rides the free-form `results` blob (documented in prose) — like the #5 `source_*` fields, `gen:api` won't emit it typed until DE-330 formalizes the tabular result components.

## Tests / gates
`ruff format --check` + `ruff check` + `mypy app` clean. 204 passed across tabular + citation + endpoints + openapi + endpoint-scaffold suites (throwaway pgvector DB; judge gateway mocked like `tests/citation/test_ensemble.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)