### PR TITLE
feat: runtime provider API-key management (BYOK) — gateway admin + backend proxy (Donna #7)

### DIFF
--- a/api/app/api/admin.py
+++ b/api/app/api/admin.py
@@ -7,6 +7,10 @@ Surface (current):
 * ``POST   /api/v1/admin/aliases``           — create alias (D0.5)
 * ``PATCH  /api/v1/admin/aliases/{name}``    — update alias (D0.5)
 * ``DELETE /api/v1/admin/aliases/{name}``    — remove alias (D0.5)
+* ``GET    /api/v1/admin/provider-keys``     — list provider-key status (Donna #7)
+* ``POST   /api/v1/admin/provider-keys``     — set/replace runtime key (Donna #7)
+* ``PATCH  /api/v1/admin/provider-keys/{p}`` — rotate runtime key (Donna #7)
+* ``DELETE /api/v1/admin/provider-keys/{p}`` — revoke runtime key (Donna #7)
 * ``GET    /api/v1/admin/config``            — sanitized gateway config (D0.5)
 * ``GET    /api/v1/admin/audit-log``         — 501 (D3 wires real impl)
 * ``GET    /api/v1/admin/tier-policy``       — 501 (D1)
@@ -32,7 +36,7 @@ import uuid as _uuid_mod
 from datetime import datetime
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import ColumnElement, Select, Text, and_, func, select
@@ -557,6 +561,91 @@ async def get_admin_config(
     """Return the gateway's sanitized current config (D0.5)."""
 
     return await gateway.get_admin_config()
+
+
+# ---------------------------------------------------------------------------
+# Donna #7 — runtime provider-key (BYOK) proxy
+# ---------------------------------------------------------------------------
+# These endpoints proxy the gateway's ``/admin/v1/provider-keys`` surface,
+# mirroring the alias-CRUD proxy above. The backend is the only entity that
+# holds the gateway-key; the frontend never does. The gateway encrypts the
+# plaintext key, persists it to gateway.yaml, and hot-applies the rebuilt
+# adapter — the backend simply forwards the JSON. No secret is ever returned
+# (the gateway's status rows carry at most the last 4 characters of a key).
+#
+# Error propagation: the gateway returns 400 (``failed_precondition``) when
+# the master key is unset, 404 (``not_found``) for an unknown provider, and
+# 409 (``conflict``) when revoking a non-runtime (env-sourced) key. The
+# GatewayClient maps each via ``map_gateway_error_code`` to a backend typed
+# exception, so the same 4xx surfaces to the caller (the 400 master-key case
+# maps to ValidationError → 400, not a 500).
+
+
+class ProviderKeySetRequest(BaseModel):
+    """Request body for ``POST /api/v1/admin/provider-keys``."""
+
+    provider: str = Field(min_length=1)
+    api_key: str = Field(min_length=1)
+
+
+class ProviderKeyRotateRequest(BaseModel):
+    """Request body for ``PATCH /api/v1/admin/provider-keys/{provider}``."""
+
+    api_key: str = Field(min_length=1)
+
+
+@router.get("/provider-keys")
+async def list_provider_keys(
+    _admin: AdminUser,
+    gateway: Annotated[GatewayClient, Depends(get_gateway_client)],
+) -> dict[str, Any]:
+    """List provider-key status via the gateway. No secret is returned."""
+
+    return await gateway.list_provider_keys()
+
+
+@router.post("/provider-keys")
+async def set_provider_key(
+    body: ProviderKeySetRequest,
+    _admin: AdminUser,
+    gateway: Annotated[GatewayClient, Depends(get_gateway_client)],
+) -> dict[str, Any]:
+    """Set/replace a provider's runtime key. 400 / 404 propagate from the gateway."""
+
+    return await gateway.set_provider_key(body.model_dump(mode="json"))
+
+
+@router.patch("/provider-keys/{provider}")
+async def rotate_provider_key(
+    provider: str,
+    body: ProviderKeyRotateRequest,
+    _admin: AdminUser,
+    gateway: Annotated[GatewayClient, Depends(get_gateway_client)],
+) -> dict[str, Any]:
+    """Rotate a provider's runtime key. 400 / 404 propagate from the gateway."""
+
+    return await gateway.rotate_provider_key(provider, body.model_dump(mode="json"))
+
+
+@router.delete(
+    "/provider-keys/{provider}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def revoke_provider_key(
+    provider: str,
+    _admin: AdminUser,
+    gateway: Annotated[GatewayClient, Depends(get_gateway_client)],
+) -> Response:
+    """Revoke a provider's runtime key. 404 / 409 propagate from the gateway.
+
+    Uses the canonical DELETE-204 recipe (``response_class=Response`` plus an
+    explicit empty ``Response`` return) so the 204 carries a genuinely empty
+    body.
+    """
+
+    await gateway.delete_provider_key(provider)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/clients/gateway.py
+++ b/api/app/clients/gateway.py
@@ -764,6 +764,90 @@ class GatewayClient:
             allow_204=True,
         )
 
+    # --- Admin: provider-key CRUD (Donna #7) --------------------------------
+
+    async def list_provider_keys(
+        self,
+        *,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /admin/v1/provider-keys. Returns the secret-safe status list.
+
+        The response is ``{"provider_keys": [...]}`` where each row is
+        ``{provider, type, configured, last4, source}`` — never a full key.
+        """
+
+        return await self._admin_request(
+            method="GET",
+            path="/admin/v1/provider-keys",
+            op="list_provider_keys",
+            request_id=request_id,
+        )
+
+    async def set_provider_key(
+        self,
+        body: dict[str, Any],
+        *,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        """POST /admin/v1/provider-keys. Set/replace a runtime key and hot-apply.
+
+        400 (``failed_precondition``) surfaces when the gateway master key
+        is unset; 404 (``not_found``) when the provider isn't configured.
+        Returns the provider's secret-safe status dict.
+        """
+
+        return await self._admin_request(
+            method="POST",
+            path="/admin/v1/provider-keys",
+            op="set_provider_key",
+            request_id=request_id,
+            body=body,
+        )
+
+    async def rotate_provider_key(
+        self,
+        provider: str,
+        body: dict[str, Any],
+        *,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        """PATCH /admin/v1/provider-keys/{provider}. Rotate a configured key.
+
+        Same mechanics as :meth:`set_provider_key`; the provider comes from
+        the path. 400 master-key-missing / 404 unknown-provider surface as
+        on the set path.
+        """
+
+        return await self._admin_request(
+            method="PATCH",
+            path=f"/admin/v1/provider-keys/{provider}",
+            op="rotate_provider_key",
+            request_id=request_id,
+            body=body,
+        )
+
+    async def delete_provider_key(
+        self,
+        provider: str,
+        *,
+        request_id: str | None = None,
+    ) -> None:
+        """DELETE /admin/v1/provider-keys/{provider}. Revoke a runtime key.
+
+        404 (``not_found``) surfaces for an unknown provider; 409
+        (``conflict``) when the provider has no runtime key to revoke (e.g.
+        an env-sourced key). 204 on success.
+        """
+
+        await self._admin_request(
+            method="DELETE",
+            path=f"/admin/v1/provider-keys/{provider}",
+            op="delete_provider_key",
+            request_id=request_id,
+            allow_204=True,
+        )
+
     async def get_admin_config(
         self,
         *,

--- a/api/app/errors.py
+++ b/api/app/errors.py
@@ -500,6 +500,13 @@ _GATEWAY_CODE_MAP: dict[str, type[LQAIError]] = {
     # through with the matching backend-side typed exception.
     "not_found": NotFound,
     "conflict": Conflict,
+    # Donna #7: runtime provider-key management. The gateway returns 400
+    # with this code when the master key (LQ_AI_GATEWAY_MASTER_KEY) is
+    # unset and a runtime key write is attempted. Map to ValidationError
+    # (400) so the operator sees a sensible 4xx — without this entry the
+    # code falls through to InternalError (500), which would mask an
+    # operator-actionable misconfiguration as a server fault.
+    "failed_precondition": ValidationError,
 }
 
 

--- a/api/tests/test_admin_provider_keys.py
+++ b/api/tests/test_admin_provider_keys.py
@@ -1,0 +1,384 @@
+"""Integration tests for the backend admin provider-key proxy (Donna #7).
+
+The backend's ``/api/v1/admin/provider-keys*`` proxies the gateway's
+``/admin/v1/provider-keys`` surface (runtime BYOK). These tests mirror
+``test_admin_aliases.py``; they cover:
+
+* The is_admin gate (non-admin → 403; admin → proxied result)
+* Auth: bearer token required (401 without)
+* Proxy translation of success + the gateway's structured 4xx errors:
+  - 400 ``failed_precondition`` (master key unset) → backend 400
+  - 404 ``not_found`` (unknown provider)          → backend 404
+  - 409 ``conflict`` (env-only revoke)            → backend 409
+* DELETE returns 204 with a genuinely empty body
+* No secret appears in any response (the gateway returns only
+  ``{provider, type, configured, last4, source}``)
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.clients.gateway import GatewayClient, set_gateway_client
+from app.db.session import get_db
+from app.main import app
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+GATEWAY_BASE = "http://test-gateway"
+GATEWAY_KEY = "test-gw-key"
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def admin_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"admin-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Admin",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=True,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def regular_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"user-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Regular",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    gw = GatewayClient(base_url=GATEWAY_BASE, gateway_key=GATEWAY_KEY)
+    set_gateway_client(gw)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    set_gateway_client(None)
+    await gw.aclose()
+    app.dependency_overrides.pop(get_db, None)
+
+
+def _bearer_for(user: User) -> str:
+    return create_access_token(user.id, user.email, is_admin=user.is_admin)
+
+
+# A canned secret-safe status row — no full key, only last4 + source.
+_STATUS_ROW = {
+    "provider": "anthropic",
+    "type": "anthropic",
+    "configured": True,
+    "last4": "cdef",
+    "source": "runtime",
+}
+
+
+def _assert_no_secret(body: object) -> None:
+    """The status payload must never carry a full key / token field."""
+
+    text = repr(body)
+    for forbidden in ("api_key", "api_key_encrypted", "sk-", "plaintext"):
+        assert forbidden not in text, f"secret-like field {forbidden!r} leaked: {text}"
+
+
+# ---------------------------------------------------------------------------
+# Auth + admin gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_provider_keys_requires_auth(client: AsyncClient) -> None:
+    res = await client.get("/api/v1/admin/provider-keys")
+    assert res.status_code == 401
+
+
+@pytest.mark.unit
+async def test_list_provider_keys_rejects_non_admin(
+    client: AsyncClient, regular_user: User
+) -> None:
+    res = await client.get(
+        "/api/v1/admin/provider-keys",
+        headers={"Authorization": f"Bearer {_bearer_for(regular_user)}"},
+    )
+    assert res.status_code == 403
+    assert res.json()["detail"]["code"] == "forbidden"
+
+
+@pytest.mark.unit
+async def test_set_provider_key_rejects_non_admin(client: AsyncClient, regular_user: User) -> None:
+    res = await client.post(
+        "/api/v1/admin/provider-keys",
+        headers={"Authorization": f"Bearer {_bearer_for(regular_user)}"},
+        json={"provider": "anthropic", "api_key": "sk-abcdef"},
+    )
+    assert res.status_code == 403
+    assert res.json()["detail"]["code"] == "forbidden"
+
+
+@pytest.mark.unit
+async def test_rotate_provider_key_rejects_non_admin(
+    client: AsyncClient, regular_user: User
+) -> None:
+    res = await client.patch(
+        "/api/v1/admin/provider-keys/anthropic",
+        headers={"Authorization": f"Bearer {_bearer_for(regular_user)}"},
+        json={"api_key": "sk-abcdef"},
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.unit
+async def test_revoke_provider_key_rejects_non_admin(
+    client: AsyncClient, regular_user: User
+) -> None:
+    res = await client.delete(
+        "/api/v1/admin/provider-keys/anthropic",
+        headers={"Authorization": f"Bearer {_bearer_for(regular_user)}"},
+    )
+    assert res.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_list_provider_keys_proxies(client: AsyncClient, admin_user: User) -> None:
+    with respx.mock(base_url=GATEWAY_BASE, assert_all_called=False) as router:
+        router.get("/admin/v1/provider-keys").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "provider_keys": [
+                        _STATUS_ROW,
+                        {
+                            "provider": "openai",
+                            "type": "openai",
+                            "configured": False,
+                            "last4": None,
+                            "source": None,
+                        },
+                    ]
+                },
+            )
+        )
+        res = await client.get(
+            "/api/v1/admin/provider-keys",
+            headers={"Authorization": f"Bearer {_bearer_for(admin_user)}"},
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["provider_keys"][0]["provider"] == "anthropic"
+    assert body["provider_keys"][0]["last4"] == "cdef"
+    _assert_no_secret(body)
+
+
+@pytest.mark.unit
+async def test_set_provider_key_proxies(client: AsyncClient, admin_user: User) -> None:
+    with respx.mock(base_url=GATEWAY_BASE, assert_all_called=False) as router:
+        router.post("/admin/v1/provider-keys").mock(
+            return_value=httpx.Response(200, json=_STATUS_ROW)
+        )
+        res = await client.post(
+            "/api/v1/admin/provider-keys",
+            headers={"Authorization": f"Bearer {_bearer_for(admin_user)}"},
+            json={"provider": "anthropic", "api_key": "sk-test-abcdef"},
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["provider"] == "anthropic"
+    assert body["configured"] is True
+    _assert_no_secret(body)
+
+
+@pytest.mark.unit
+async def test_rotate_provider_key_proxies(client: AsyncClient, admin_user: User) -> None:
+    with respx.mock(base_url=GATEWAY_BASE, assert_all_called=False) as router:
+        router.patch("/admin/v1/provider-keys/anthropic").mock(
+            return_value=httpx.Response(200, json=_STATUS_ROW)
+        )
+        res = await client.patch(
+            "/api/v1/admin/provider-keys/anthropic",
+            headers={"Authorization": f"Bearer {_bearer_for(admin_user)}"},
+            json={"api_key": "sk-test-rotated"},
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["provider"] == "anthropic"
+    _assert_no_secret(body)
+
+
+@pytest.mark.unit
+async def test_revoke_provider_key_proxies_204_empty_body(
+    client: AsyncClient, admin_user: User
+) -> None:
+    with respx.mock(base_url=GATEWAY_BASE, assert_all_called=False) as router:
+        router.delete("/admin/v1/provider-keys/anthropic").mock(return_value=httpx.Response(204))
+        res = await client.delete(
+            "/api/v1/admin/provider-keys/anthropic",
+            headers={"Authorization": f"Bearer {_bearer_for(admin_user)}"},
+        )
+    assert res.status_code == 204
+    # Canonical DELETE-204 recipe → genuinely empty body.
+    assert res.content == b""
+
+
+# ---------------------------------------------------------------------------
+# Error propagation (gateway structured 4xx → backend 4xx)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_set_provider_key_master_key_missing_400(
+    client: AsyncClient, admin_user: User
+) -> None:
+    """Gateway 400 ``failed_precondition`` (master key unset) must surface
+    as a backend 4xx — NOT a 500."""
+
+    with respx.mock(base_url=GATEWAY_BASE, assert_all_called=False) as router:
+        router.post("/admin/v1/provider-keys").mock(
+            return_value=httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "code": "failed_precondition",
+                        "message": "runtime key storage requires LQ_AI_GATEWAY_MASTER_KEY to be set",
+                        "details": {"provider": "anthropic"},
+                    }
+                },
+            )
+        )
+        res = await client.post(
+            "/api/v1/admin/provider-keys",
+            headers={"Authorization": f"Bearer {_bearer_for(admin_user)}"},
+            json={"provider": "anthropic", "api_key": "sk-test"},
+        )
+    assert res.status_code == 400
+    assert res.json()["detail"]["code"] == "validation_error"
+
+
+@pytest.mark.unit
+async def test_set_provider_key_unknown_provider_404(client: AsyncClient, admin_user: User) -> None:
+    with respx.mock(base_url=GATEWAY_BASE, assert_all_called=False) as router:
+        router.post("/admin/v1/provider-keys").mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "error": {
+                        "code": "not_found",
+                        "message": "provider 'ghost' is not configured",
+                        "details": {"provider": "ghost"},
+                    }
+                },
+            )
+        )
+        res = await client.post(
+            "/api/v1/admin/provider-keys",
+            headers={"Authorization": f"Bearer {_bearer_for(admin_user)}"},
+            json={"provider": "ghost", "api_key": "sk-test"},
+        )
+    assert res.status_code == 404
+    assert res.json()["detail"]["code"] == "not_found"
+
+
+@pytest.mark.unit
+async def test_rotate_provider_key_master_key_missing_400(
+    client: AsyncClient, admin_user: User
+) -> None:
+    with respx.mock(base_url=GATEWAY_BASE, assert_all_called=False) as router:
+        router.patch("/admin/v1/provider-keys/anthropic").mock(
+            return_value=httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "code": "failed_precondition",
+                        "message": "runtime key storage requires LQ_AI_GATEWAY_MASTER_KEY to be set",
+                        "details": {"provider": "anthropic"},
+                    }
+                },
+            )
+        )
+        res = await client.patch(
+            "/api/v1/admin/provider-keys/anthropic",
+            headers={"Authorization": f"Bearer {_bearer_for(admin_user)}"},
+            json={"api_key": "sk-test"},
+        )
+    assert res.status_code == 400
+    assert res.json()["detail"]["code"] == "validation_error"
+
+
+@pytest.mark.unit
+async def test_revoke_provider_key_env_only_409(client: AsyncClient, admin_user: User) -> None:
+    with respx.mock(base_url=GATEWAY_BASE, assert_all_called=False) as router:
+        router.delete("/admin/v1/provider-keys/anthropic").mock(
+            return_value=httpx.Response(
+                409,
+                json={
+                    "error": {
+                        "code": "conflict",
+                        "message": "provider 'anthropic' has no runtime key to revoke",
+                        "details": {"provider": "anthropic"},
+                    }
+                },
+            )
+        )
+        res = await client.delete(
+            "/api/v1/admin/provider-keys/anthropic",
+            headers={"Authorization": f"Bearer {_bearer_for(admin_user)}"},
+        )
+    assert res.status_code == 409
+    assert res.json()["detail"]["code"] == "conflict"
+
+
+@pytest.mark.unit
+async def test_revoke_provider_key_unknown_provider_404(
+    client: AsyncClient, admin_user: User
+) -> None:
+    with respx.mock(base_url=GATEWAY_BASE, assert_all_called=False) as router:
+        router.delete("/admin/v1/provider-keys/ghost").mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "error": {
+                        "code": "not_found",
+                        "message": "provider 'ghost' is not configured",
+                        "details": {"provider": "ghost"},
+                    }
+                },
+            )
+        )
+        res = await client.delete(
+            "/api/v1/admin/provider-keys/ghost",
+            headers={"Authorization": f"Bearer {_bearer_for(admin_user)}"},
+        )
+    assert res.status_code == 404
+    assert res.json()["detail"]["code"] == "not_found"

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -180,6 +180,11 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("POST", "/api/v1/admin/aliases"),
     ("PATCH", "/api/v1/admin/aliases/{name}"),
     ("DELETE", "/api/v1/admin/aliases/{name}"),
+    # Donna #7 — runtime provider-key (BYOK) admin proxy
+    ("GET", "/api/v1/admin/provider-keys"),
+    ("POST", "/api/v1/admin/provider-keys"),
+    ("PATCH", "/api/v1/admin/provider-keys/{provider}"),
+    ("DELETE", "/api/v1/admin/provider-keys/{provider}"),
     ("GET", "/api/v1/admin/config"),
     # D3 — admin audit-log read endpoint
     ("GET", "/api/v1/admin/audit-log"),

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -132,6 +132,9 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/admin/config",
         "/api/v1/admin/aliases",
         "/api/v1/admin/aliases/{name}",
+        # Donna #7 — runtime provider-key (BYOK) admin proxy
+        "/api/v1/admin/provider-keys",
+        "/api/v1/admin/provider-keys/{provider}",
         # D0 — model availability proxy
         "/api/v1/models",
         # Wave D.1 T4 — admin tier-floor override re-run
@@ -273,7 +276,10 @@ async def test_openapi_paths_match_sketch() -> None:
     # /api/v1/autonomous/notifications/{notification_id}/read
     # Phase 1 §4.4 adds one new path:
     # /api/v1/autonomous/run-now
-    assert len(actual) == 114
+    # Donna #7 adds two new paths:
+    # /api/v1/admin/provider-keys
+    # /api/v1/admin/provider-keys/{provider}
+    assert len(actual) == 116
 
 
 @pytest.mark.unit

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -3081,6 +3081,133 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/Error'}
 
+  /api/v1/admin/provider-keys:
+    get:
+      tags: [admin]
+      summary: List provider-key status (admin only)
+      description: |
+        Donna #7 (runtime BYOK). Proxies the gateway's
+        ``/admin/v1/provider-keys`` surface. The backend holds the
+        gateway-key; the frontend never does. Returns a secret-safe status
+        row per configured provider — the response NEVER contains a full
+        key, only the last 4 characters of a resolved key. The caller's
+        bearer token must have ``is_admin = true`` or the endpoint returns
+        403 ``forbidden``.
+      responses:
+        '200':
+          description: Provider-key status list
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ProviderKeyList'}
+        '403':
+          description: Caller is not an admin
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+    post:
+      tags: [admin]
+      summary: Set/replace a provider's runtime key (admin only)
+      description: |
+        Proxies the gateway's set-key path. The gateway encrypts the
+        plaintext key, persists it to gateway.yaml, and hot-applies the
+        rebuilt adapter — no restart. The backend forwards the JSON and
+        never returns the secret. 400 when the gateway master key is unset
+        (surfaced as ``validation_error``); 404 when the provider isn't a
+        configured entry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/ProviderKeySetRequest'}
+      responses:
+        '200':
+          description: Key applied; provider status returned (no secret)
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ProviderKeyStatus'}
+        '400':
+          description: Gateway master key is not set
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+        '403':
+          description: Caller is not an admin
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+        '404':
+          description: Provider not configured
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+
+  /api/v1/admin/provider-keys/{provider}:
+    parameters:
+      - in: path
+        name: provider
+        required: true
+        schema: {type: string}
+    patch:
+      tags: [admin]
+      summary: Rotate a provider's runtime key (admin only)
+      description: |
+        Same mechanics as POST /api/v1/admin/provider-keys; the provider
+        comes from the path. Proxies the gateway, which retires the
+        displaced adapter and swaps the rebuilt one in. The backend never
+        returns the secret. 400 when the gateway master key is unset; 404
+        when the provider isn't configured.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/ProviderKeyRotateRequest'}
+      responses:
+        '200':
+          description: Key rotated; provider status returned (no secret)
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ProviderKeyStatus'}
+        '400':
+          description: Gateway master key is not set
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+        '403':
+          description: Caller is not an admin
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+        '404':
+          description: Provider not configured
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+    delete:
+      tags: [admin]
+      summary: Revoke a provider's runtime key (admin only)
+      description: |
+        Proxies the gateway's revoke path. Only runtime
+        (encrypted-at-rest) keys can be revoked; an env-sourced key is
+        owned by the operator's environment and returns 409.
+      responses:
+        '204':
+          description: Runtime key revoked
+        '403':
+          description: Caller is not an admin
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+        '404':
+          description: Provider not configured
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+        '409':
+          description: Provider has no runtime key to revoke (e.g., env-sourced)
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+
   /api/v1/admin/config:
     get:
       tags: [admin]
@@ -7060,6 +7187,81 @@ components:
         fallback:
           type: array
           items: {$ref: '#/components/schemas/AdminAliasFallback'}
+
+    # Donna #7 — runtime provider-key (BYOK) proxy. These mirror the
+    # gateway's ProviderKey* schemas; the backend forwards the JSON
+    # verbatim and never returns the secret (the status carries at most
+    # the last 4 characters of a resolved key).
+    ProviderKeySetRequest:
+      type: object
+      required: [provider, api_key]
+      properties:
+        provider:
+          type: string
+          minLength: 1
+          description: Name of an already-configured provider entry.
+        api_key:
+          type: string
+          minLength: 1
+          description: |
+            Plaintext provider key. The gateway encrypts it with the
+            gateway master key before it touches disk; it is never echoed
+            back in any response.
+
+    ProviderKeyRotateRequest:
+      type: object
+      required: [api_key]
+      properties:
+        api_key:
+          type: string
+          minLength: 1
+          description: |
+            Replacement plaintext provider key. Same handling as
+            ProviderKeySetRequest.api_key.
+
+    ProviderKeyStatus:
+      type: object
+      required: [provider, type, configured, last4, source]
+      description: |
+        Secret-safe status for one provider. Carries at most the last 4
+        characters of the resolved key — never the full key or token.
+      properties:
+        provider: {type: string}
+        type:
+          type: string
+          nullable: true
+          description: |
+            The provider's adapter type. Null only in the rare race where a
+            provider is removed between the write and the status read-back on
+            a single-provider (POST/PATCH) response; never null on the list.
+        configured:
+          type: boolean
+          description: |
+            True when the provider has a live, routable adapter (its key
+            resolved). A keyless or unresolvable provider is false.
+        last4:
+          type: string
+          nullable: true
+          minLength: 4
+          maxLength: 4
+          description: |
+            Last 4 characters of the resolved key, or null when the key is
+            absent, unresolvable, or shorter than 4 characters.
+        source:
+          type: string
+          nullable: true
+          enum: [env, runtime, null]
+          description: |
+            Key source: `runtime` (encrypted-at-rest in gateway.yaml),
+            `env` (api_key_env), or null (no key configured).
+
+    ProviderKeyList:
+      type: object
+      required: [provider_keys]
+      properties:
+        provider_keys:
+          type: array
+          items: {$ref: '#/components/schemas/ProviderKeyStatus'}
 
     Error:
       type: object

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -1142,7 +1142,12 @@ components:
         provider: {type: string}
         type:
           type: string
-          enum: [anthropic, openai, vertex, cohere, azure_openai, bedrock, ollama, vllm, openai_compatible]
+          nullable: true
+          enum: [anthropic, openai, vertex, cohere, azure_openai, bedrock, ollama, vllm, openai_compatible, null]
+          description: |
+            The provider's adapter type. Null only in the rare race where a
+            provider is removed between the write and the status read-back on
+            a single-provider (POST/PATCH) response; never null on the list.
         configured:
           type: boolean
           description: |

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -715,6 +715,130 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/GatewayError'}
 
+  /admin/v1/provider-keys:
+    get:
+      tags: [admin]
+      summary: List provider-key status (secret-safe)
+      description: |
+        Donna #7 (runtime BYOK). Returns a status row per configured
+        provider: whether it has a routable adapter, which key source it
+        uses (env vs encrypted-at-rest), and the last 4 characters of the
+        resolved key. NEVER returns a full key or the encrypted token.
+      security:
+        - apiKeyAuth: []
+      responses:
+        '200':
+          description: Provider-key status list
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ProviderKeyList'}
+    post:
+      tags: [admin]
+      summary: Set/replace a provider's runtime key and hot-apply it
+      description: |
+        Encrypts the plaintext key with the gateway master key
+        (LQ_AI_GATEWAY_MASTER_KEY), persists `api_key_encrypted` to
+        gateway.yaml (clearing any `api_key_env`), reloads, and swaps the
+        rebuilt adapter into the live registry with no restart. The
+        response carries only the secret-safe status (no key, no token).
+        400 when the master key is unset; 404 when the provider is not a
+        configured entry (adding a new provider is out of scope — that is
+        an operator edit of gateway.yaml).
+      security:
+        - apiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/ProviderKeySetRequest'}
+      responses:
+        '200':
+          description: Key applied; provider status returned
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ProviderKeyStatus'}
+        '400':
+          description: Master key (LQ_AI_GATEWAY_MASTER_KEY) is not set
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+        '404':
+          description: Provider not configured
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+        '422':
+          description: Reload validation failed (config rolled back)
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+
+  /admin/v1/provider-keys/{provider}:
+    parameters:
+      - in: path
+        name: provider
+        required: true
+        schema: {type: string}
+    patch:
+      tags: [admin]
+      summary: Rotate the runtime key on a configured provider
+      description: |
+        Same mechanics as POST /admin/v1/provider-keys; the provider name
+        comes from the path. The displaced adapter is retired (closed at
+        shutdown) and the rebuilt one swapped in. Response is secret-safe.
+      security:
+        - apiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/ProviderKeyRotateRequest'}
+      responses:
+        '200':
+          description: Key rotated; provider status returned
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ProviderKeyStatus'}
+        '400':
+          description: Master key (LQ_AI_GATEWAY_MASTER_KEY) is not set
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+        '404':
+          description: Provider not configured
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+        '422':
+          description: Reload validation failed (config rolled back)
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+    delete:
+      tags: [admin]
+      summary: Revoke a provider's runtime key
+      description: |
+        Deletes `api_key_encrypted` from gateway.yaml, reloads, and pops the
+        provider's live adapter (it routes 503 afterward). Only runtime
+        (encrypted-at-rest) keys can be revoked through this API; an
+        env-sourced key is owned by the operator's environment and returns
+        409.
+      security:
+        - apiKeyAuth: []
+      responses:
+        '204':
+          description: Runtime key revoked
+        '404':
+          description: Provider not configured
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+        '409':
+          description: Provider has no runtime key to revoke (e.g., env-sourced)
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+
 components:
   securitySchemes:
     apiKeyAuth:
@@ -982,6 +1106,73 @@ components:
           type: array
           items: {$ref: '#/components/schemas/AliasFallback'}
 
+    ProviderKeySetRequest:
+      type: object
+      required: [provider, api_key]
+      properties:
+        provider:
+          type: string
+          minLength: 1
+          description: Name of an already-configured provider entry.
+        api_key:
+          type: string
+          minLength: 1
+          description: |
+            Plaintext provider key. Encrypted with the gateway master key
+            before it touches disk; never echoed back in any response.
+
+    ProviderKeyRotateRequest:
+      type: object
+      required: [api_key]
+      properties:
+        api_key:
+          type: string
+          minLength: 1
+          description: |
+            Replacement plaintext provider key. Same handling as
+            ProviderKeySetRequest.api_key.
+
+    ProviderKeyStatus:
+      type: object
+      required: [provider, type, configured, last4, source]
+      description: |
+        Secret-safe status for one provider. Carries at most the last 4
+        characters of the resolved key — never the full key or token.
+      properties:
+        provider: {type: string}
+        type:
+          type: string
+          enum: [anthropic, openai, vertex, cohere, azure_openai, bedrock, ollama, vllm, openai_compatible]
+        configured:
+          type: boolean
+          description: |
+            True when the provider has a live, routable adapter (its key
+            resolved). This is the honest signal: a keyless or unresolvable
+            provider is false.
+        last4:
+          type: string
+          nullable: true
+          minLength: 4
+          maxLength: 4
+          description: |
+            Last 4 characters of the resolved key, or null when the key is
+            absent, unresolvable, or shorter than 4 characters.
+        source:
+          type: string
+          nullable: true
+          enum: [env, runtime, null]
+          description: |
+            Key source: `runtime` (encrypted-at-rest in gateway.yaml),
+            `env` (api_key_env), or null (no key configured).
+
+    ProviderKeyList:
+      type: object
+      required: [provider_keys]
+      properties:
+        provider_keys:
+          type: array
+          items: {$ref: '#/components/schemas/ProviderKeyStatus'}
+
     GatewayError:
       type: object
       required: [error]
@@ -1019,6 +1210,8 @@ components:
                 - not_found
                 - conflict
                 - internal_error
+                # Runtime provider-key management (Donna #7)
+                - failed_precondition
             message: {type: string}
             details: {type: object, additionalProperties: true}
 

--- a/gateway/app/api/admin.py
+++ b/gateway/app/api/admin.py
@@ -30,17 +30,26 @@ rolled back to the prior bytes on a best-effort basis.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.api.dependencies import make_require_gateway_key
 from app.config import GatewayConfig, ModelAliasConfig
 from app.config_holder import ConfigReloadError, MutableConfigHolder
-from app.config_writer import AliasMutationError, delete_alias, update_tier_policy, upsert_alias
+from app.config_writer import (
+    AliasMutationError,
+    ProviderKeyMutationError,
+    delete_alias,
+    update_tier_policy,
+    upsert_alias,
+)
+from app.provider_keys import apply_provider_key, list_provider_keys, revoke_provider_key
 from app.router import derive_routed_inference_tier
+from app.secrets import MASTER_KEY_ENV, ProviderKeyResolver
 
 require_gateway_key = make_require_gateway_key()
 
@@ -182,6 +191,33 @@ class AliasUpdateRequest(BaseModel):
     provider: str = Field(min_length=1)
     model: str = Field(min_length=1)
     fallback: list[_FallbackEntry] | None = None
+
+
+class ProviderKeySetRequest(BaseModel):
+    """``POST /admin/v1/provider-keys`` body (Donna #7).
+
+    ``api_key`` is the plaintext provider key. It is encrypted with the
+    gateway master key before it touches disk and is NEVER echoed back in
+    any response. ``min_length=1`` rejects an empty key at the edge.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str = Field(min_length=1)
+    api_key: str = Field(min_length=1)
+
+
+class ProviderKeyRotateRequest(BaseModel):
+    """``PATCH /admin/v1/provider-keys/{provider}`` body (Donna #7).
+
+    Rotate the runtime key on an already-configured provider. Same
+    secret-handling as :class:`ProviderKeySetRequest`; the provider comes
+    from the path.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    api_key: str = Field(min_length=1)
 
 
 # ---------------------------------------------------------------------------
@@ -477,3 +513,198 @@ def _alias_error_code(exc: AliasMutationError) -> str:
     if exc.http_status == status.HTTP_422_UNPROCESSABLE_ENTITY:
         return "invalid_request"
     return "internal_error"
+
+
+# ---------------------------------------------------------------------------
+# Donna #7: runtime provider-key management (BYOK hot-apply)
+# ---------------------------------------------------------------------------
+
+
+def _provider_key_error_code(exc: ProviderKeyMutationError) -> str:
+    """Map a :class:`ProviderKeyMutationError` HTTP status to a gateway code.
+
+    Parallel to :func:`_alias_error_code` — kept separate so the two
+    surfaces don't accidentally share status semantics (provider-key delete
+    uses 409 for "no runtime key to revoke", not the alias "conflict"
+    meaning, but they render the same stable code).
+    """
+
+    if exc.http_status == status.HTTP_404_NOT_FOUND:
+        return "not_found"
+    if exc.http_status == status.HTTP_409_CONFLICT:
+        return "conflict"
+    if exc.http_status == status.HTTP_422_UNPROCESSABLE_ENTITY:
+        return "invalid_request"
+    return "internal_error"
+
+
+def _resolved_master_key() -> str | None:
+    """Return the bound gateway master key, or ``None`` if unset.
+
+    Runtime (encrypted-at-rest) key storage is impossible without it; the
+    write endpoints fail fast with 400 when it's absent rather than writing
+    an unencryptable key.
+    """
+
+    return os.environ.get(MASTER_KEY_ENV) or None
+
+
+@router.get("/provider-keys")
+async def list_provider_keys_endpoint(request: Request) -> dict[str, Any]:
+    """List the secret-safe key status of every configured provider.
+
+    Each row is ``{provider, type, configured, last4, source}``. The
+    response NEVER contains a full key — only the last 4 characters of a
+    resolvable key, and only when the provider's adapter is built.
+    """
+
+    config = _config(request)
+    rows = list_provider_keys(
+        config,
+        request.app.state.adapters,
+        ProviderKeyResolver.from_environ(),
+    )
+    return {"provider_keys": rows}
+
+
+async def _apply_provider_key_request(
+    request: Request,
+    *,
+    provider_name: str,
+    plaintext: str,
+) -> dict[str, Any] | JSONResponse:
+    """Shared apply path for the POST (set) and PATCH (rotate) endpoints.
+
+    Both endpoints differ only in where ``provider_name`` comes from (POST
+    reads it from the body, PATCH from the path). The work is identical:
+    enforce the master-key precondition (400 when unset), hold the
+    serialization lock, delegate to :func:`apply_provider_key`, and map the
+    service-layer errors to the canonical ``GatewayError`` envelope.
+
+    Returns the provider's secret-safe status dict on success, or a
+    :class:`JSONResponse` error envelope on the precondition / mutation /
+    reload failure paths.
+    """
+
+    master_key = _resolved_master_key()
+    if not master_key:
+        return _gateway_error(
+            code="failed_precondition",
+            message=(f"runtime key storage requires {MASTER_KEY_ENV} to be set"),
+            http_status=status.HTTP_400_BAD_REQUEST,
+            details={"provider": provider_name},
+        )
+
+    holder = _holder(request)
+    async with request.app.state.provider_key_lock:
+        try:
+            return await apply_provider_key(
+                holder=holder,
+                app_state=request.app.state,
+                provider_name=provider_name,
+                plaintext=plaintext,
+                master_key=master_key,
+            )
+        except ProviderKeyMutationError as exc:
+            return _gateway_error(
+                code=_provider_key_error_code(exc),
+                message=str(exc),
+                http_status=exc.http_status,
+                details={"provider": provider_name},
+            )
+        except ConfigReloadError as exc:
+            return _gateway_error(
+                code="invalid_request",
+                message=str(exc),
+                http_status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                details={"provider": provider_name},
+            )
+
+
+@router.post("/provider-keys", response_model=None)
+async def set_provider_key(
+    request: Request,
+    body: ProviderKeySetRequest,
+) -> dict[str, Any] | JSONResponse:
+    """Set/replace a provider's runtime key and hot-apply it.
+
+    Encrypts the key with the master key, persists ``api_key_encrypted`` to
+    ``gateway.yaml``, reloads, and swaps the rebuilt adapter into the live
+    registry — no restart. 400 if the master key is unset; 404 if the
+    provider isn't configured. Returns the provider's status dict (no
+    secret).
+    """
+
+    return await _apply_provider_key_request(
+        request,
+        provider_name=body.provider,
+        plaintext=body.api_key,
+    )
+
+
+@router.patch("/provider-keys/{provider}", response_model=None)
+async def rotate_provider_key(
+    request: Request,
+    provider: str,
+    body: ProviderKeyRotateRequest,
+) -> dict[str, Any] | JSONResponse:
+    """Rotate the runtime key on an already-configured provider.
+
+    Same mechanics as POST; the provider comes from the path. 404 if the
+    provider isn't configured; 400 if the master key is unset.
+    """
+
+    return await _apply_provider_key_request(
+        request,
+        provider_name=provider,
+        plaintext=body.api_key,
+    )
+
+
+@router.delete(
+    "/provider-keys/{provider}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def revoke_provider_key_endpoint(
+    request: Request,
+    provider: str,
+) -> Response:
+    """Revoke a provider's runtime key and retire its live adapter.
+
+    Deletes ``api_key_encrypted`` from ``gateway.yaml``, reloads, and pops
+    the adapter from the live registry (it routes 503 afterward). 404 if
+    the provider isn't configured; 409 if the provider has no runtime key
+    to revoke (e.g., an env-sourced key, which the operator owns). 204 on
+    success.
+
+    Per the CLAUDE.md DELETE-204 recipe: ``response_class=Response`` plus an
+    explicit empty ``Response`` return so the 204 carries a genuinely empty
+    body. The error branch still returns a ``JSONResponse`` (a ``Response``
+    subclass) carrying the ``GatewayError`` envelope — FastAPI honors the
+    explicit return, so that is fine even with ``response_class=Response``.
+    """
+
+    holder = _holder(request)
+    async with request.app.state.provider_key_lock:
+        try:
+            await revoke_provider_key(
+                holder=holder,
+                app_state=request.app.state,
+                provider_name=provider,
+            )
+        except ProviderKeyMutationError as exc:
+            return _gateway_error(
+                code=_provider_key_error_code(exc),
+                message=str(exc),
+                http_status=exc.http_status,
+                details={"provider": provider},
+            )
+        except ConfigReloadError as exc:
+            return _gateway_error(
+                code="invalid_request",
+                message=str(exc),
+                http_status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                details={"provider": provider},
+            )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/gateway/app/config_writer.py
+++ b/gateway/app/config_writer.py
@@ -64,6 +64,22 @@ class AliasMutationError(ValueError):
         self.http_status = http_status
 
 
+class ProviderKeyMutationError(ValueError):
+    """Raised when a provider-key mutation cannot be applied (404, 409, 500).
+
+    Sibling of :class:`AliasMutationError` for the runtime BYOK
+    (Donna #7) provider-key endpoints. Carries an HTTP-status hint via
+    :attr:`http_status` so the route handler (Task B) can map cleanly
+    without parsing the message string. We keep this distinct from the
+    alias-named error so the two surfaces don't accidentally share
+    status semantics.
+    """
+
+    def __init__(self, message: str, *, http_status: int) -> None:
+        super().__init__(message)
+        self.http_status = http_status
+
+
 def _read_yaml_mapping(config_path: Path) -> dict[str, Any]:
     """Read the YAML file as a plain dict (no env-var expansion).
 
@@ -396,9 +412,137 @@ def update_tier_policy(
     return dict(holder.current().tier_policy.model_dump(mode="json"))
 
 
+# --- Provider-key mutation API (runtime BYOK, Donna #7) ----------------------
+
+
+def _find_provider_entry(
+    raw: dict[str, Any],
+    *,
+    provider_name: str,
+) -> dict[str, Any]:
+    """Locate the ``providers:`` list entry whose ``name`` matches.
+
+    ``providers`` is a YAML *list* of mappings (unlike ``model_aliases``,
+    which is a keyed mapping). We round-trip the raw list so unrelated
+    provider-specific keys (``base_url``, ``tier``, ``api_version``,
+    operator extras) survive the write.
+
+    Raises :class:`ProviderKeyMutationError` 500 when ``providers`` is
+    missing or not a list (malformed config), and 404 when no entry
+    matches ``provider_name``.
+    """
+
+    providers = raw.get("providers")
+    if not isinstance(providers, list):
+        raise ProviderKeyMutationError(
+            "gateway.yaml providers is missing or malformed (expected a list)",
+            http_status=500,
+        )
+    for entry in providers:
+        if isinstance(entry, dict) and entry.get("name") == provider_name:
+            return entry
+    raise ProviderKeyMutationError(
+        f"provider {provider_name!r} not found",
+        http_status=404,
+    )
+
+
+def upsert_provider_key(
+    holder: MutableConfigHolder,
+    *,
+    provider_name: str,
+    encrypted_token: str,
+) -> None:
+    """Set a provider's runtime ``api_key_encrypted`` and reload.
+
+    Scope: managing the key on an **existing** provider entry only.
+    Adding a brand-new provider (with type/base_url/tier) is out of
+    scope for this API — those land through the operator's edit of
+    ``gateway.yaml`` directly.
+
+    Setting a runtime key switches the entry's key source to the
+    encrypted-at-rest path: we set ``api_key_encrypted`` and clear any
+    ``api_key_env`` (the :class:`~app.config.ProviderConfig` validator
+    refuses both, so the env key must be dropped). The reload then
+    re-validates the whole file; on failure the file is rolled back to
+    the prior bytes and :class:`ConfigReloadError` re-raised (the exact
+    ``upsert_alias`` rollback pattern).
+
+    Raises :class:`ProviderKeyMutationError` 404 if no provider matches
+    ``provider_name`` (500 if the providers list is malformed, 422 if the
+    encrypted token is empty).
+    """
+
+    if not encrypted_token:
+        # ``encrypt_value`` already rejects empty plaintext, so a real
+        # ciphertext is never empty — this just keeps the contract honest
+        # if a route ever passes a malformed body and prevents an upsert
+        # from silently producing a keyless provider.
+        raise ProviderKeyMutationError(
+            "encrypted_token must be non-empty",
+            http_status=422,
+        )
+
+    raw = _read_yaml_mapping(holder.config_path)
+    entry = _find_provider_entry(raw, provider_name=provider_name)
+
+    entry["api_key_encrypted"] = encrypted_token
+    # Source becomes runtime; the validator forbids both key sources.
+    entry.pop("api_key_env", None)
+
+    prior_bytes = holder.config_path.read_bytes()
+    _atomic_write_yaml(holder.config_path, raw)
+    try:
+        holder.reload_from_disk()
+    except ConfigReloadError:
+        holder.config_path.write_bytes(prior_bytes)
+        raise
+
+
+def delete_provider_key(
+    holder: MutableConfigHolder,
+    *,
+    provider_name: str,
+) -> None:
+    """Revoke a provider's runtime ``api_key_encrypted`` and reload.
+
+    Only runtime (encrypted-at-rest) keys can be revoked through this
+    API. An env-sourced key (``api_key_env``) is owned by the operator's
+    environment, not the gateway file; attempting to revoke one raises
+    409 (documented behavior). A now-keyless provider entry is still
+    valid config — its adapter simply won't build, and Task B's
+    hot-apply pops it from the live registry.
+
+    Raises :class:`ProviderKeyMutationError` 404 if no provider matches,
+    409 if the matched provider has no runtime key to revoke.
+    """
+
+    raw = _read_yaml_mapping(holder.config_path)
+    entry = _find_provider_entry(raw, provider_name=provider_name)
+
+    if "api_key_encrypted" not in entry:
+        raise ProviderKeyMutationError(
+            f"provider {provider_name!r} has no runtime key to revoke",
+            http_status=409,
+        )
+
+    entry.pop("api_key_encrypted", None)
+
+    prior_bytes = holder.config_path.read_bytes()
+    _atomic_write_yaml(holder.config_path, raw)
+    try:
+        holder.reload_from_disk()
+    except ConfigReloadError:
+        holder.config_path.write_bytes(prior_bytes)
+        raise
+
+
 __all__ = [
     "AliasMutationError",
+    "ProviderKeyMutationError",
     "delete_alias",
+    "delete_provider_key",
     "update_tier_policy",
     "upsert_alias",
+    "upsert_provider_key",
 ]

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -41,6 +41,7 @@ The lifespan reads the path from ``GATEWAY_CONFIG_PATH``. Defaults:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from collections.abc import AsyncIterator
@@ -222,6 +223,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Otherwise shutdown's two close loops would double-close it.
     retired_adapters: list[ProviderAdapter] = []
     app.state.retired_adapters = retired_adapters
+    # Donna #7: serialize the runtime BYOK mutation (write → reload → swap)
+    # so two concurrent key mutations can't interleave their reload+swap and
+    # leave the live registry pointing at an adapter that doesn't match the
+    # on-disk config. The provider-key admin endpoints hold this lock across
+    # the whole mutation. Created here (inside the running event loop) so the
+    # lock binds to the right loop.
+    app.state.provider_key_lock = asyncio.Lock()
 
     # B4: build the request router around the loaded config + adapter
     # registry. Per-request handlers pull this off ``app.state.router``

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -58,7 +58,7 @@ from app.clients.backend import (
     close_backend_client,
     configure_backend_client,
 )
-from app.config import GatewayConfig
+from app.config import GatewayConfig, ProviderConfig
 from app.config_holder import MutableConfigHolder, install_sighup_reload
 from app.config_loader import ConfigLoadError, load_config
 from app.db import engine_or_none
@@ -90,6 +90,55 @@ def _resolve_config_path() -> Path:
     if override:
         return Path(override)
     return DEFAULT_CONFIG_PATH
+
+
+def build_adapter(provider: ProviderConfig) -> ProviderAdapter | None:
+    """Construct the adapter for one provider, or ``None`` if no live
+    adapter can be built.
+
+    ``None`` is returned for two distinct reasons:
+
+    (a) the provider is **disabled** (``enabled=False``); or
+    (b) the provider's ``type`` has **no adapter implementation** yet
+        (vertex/bedrock, or any unknown type).
+
+    Both mean "no live adapter was built" — they are not distinguished in
+    the return value. A caller that needs to tell "disabled" from
+    "unsupported type" apart (e.g. Task B's hot-apply) can re-check
+    ``provider.enabled`` / ``provider.type`` itself.
+
+    A supported, **enabled** provider whose key can't be resolved does
+    **not** return ``None`` — it raises :class:`ValueError`, the same
+    signal the ``from_config`` factories raise. Callers decide what to do
+    with that: startup (the lifespan loop) skips the provider with a
+    warning; runtime hot-apply (Task B) surfaces it.
+
+    This is the single source of truth for "which adapter does this
+    provider get"; it is reused by the lifespan at startup and by the
+    runtime BYOK hot-apply path (Donna #7, Task B). Behavior must match
+    the per-type dispatch the lifespan used previously, so the set of
+    adapters built for a given config is unchanged.
+    """
+
+    if not provider.enabled:
+        return None
+    if provider.type == "anthropic":
+        return AnthropicAdapter.from_config(provider)
+    if provider.type in ("openai", "openai_compatible"):
+        # C6 + B6: OpenAI adapter services both embeddings and chat
+        # completions and handles both ``openai`` and ``openai_compatible``.
+        return OpenAIAdapter.from_config(provider)
+    if provider.type == "azure_openai":
+        # M2-E1 (DE-267): Azure OpenAI mirrors the OpenAI wire shape with
+        # a deployment-scoped URL (+ api-version) and ``api-key`` auth.
+        return AzureOpenAIAdapter.from_config(provider)
+    if provider.type == "ollama":
+        # B6 partial: Ollama is the Mode-2 (air-gapped local inference)
+        # backbone per PRD §1.5.1 / §6.1.
+        return OllamaAdapter.from_config(provider)
+    # B6 lands the remaining adapters (Vertex, Bedrock); until then there
+    # is no adapter for those types (or any unknown type).
+    return None
 
 
 @asynccontextmanager
@@ -133,84 +182,46 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # routes to a provider with no adapter.
     adapters: dict[str, ProviderAdapter] = {}
     for provider in config.providers:
-        if not provider.enabled:
+        try:
+            adapter = build_adapter(provider)
+        except ValueError as exc:
+            # Missing/unresolvable key for a supported provider — non-fatal
+            # at startup; the provider is skipped and chat requests routing
+            # to it get a clean 503 at request time.
+            logger.warning(
+                "skipping provider %r (type=%s): %s",
+                provider.name,
+                provider.type,
+                exc,
+            )
             continue
-        if provider.type == "anthropic":
-            try:
-                adapters[provider.name] = AnthropicAdapter.from_config(provider)
-                logger.info("instantiated Anthropic adapter for provider %r", provider.name)
-            except ValueError as exc:
-                logger.warning(
-                    "skipping Anthropic provider %r: %s",
-                    provider.name,
-                    exc,
-                )
-            continue
-        if provider.type in ("openai", "openai_compatible"):
-            # C6 + B6: OpenAI adapter services both embeddings and chat
-            # completions. The lifespan-time check matches the pattern
-            # for Anthropic: a missing key for cloud OpenAI is non-fatal
-            # at startup but produces a clean 503 at request time.
-            try:
-                adapters[provider.name] = OpenAIAdapter.from_config(provider)
-                logger.info(
-                    "instantiated OpenAI adapter for provider %r (type=%s)",
+        if adapter is None:
+            # Disabled, or a type with no adapter yet (vertex/bedrock).
+            if provider.enabled:
+                # B6 lands the remaining adapters (Vertex, Bedrock).
+                logger.debug(
+                    "no adapter for provider %r (type=%s); awaiting B6",
                     provider.name,
                     provider.type,
                 )
-            except ValueError as exc:
-                logger.warning(
-                    "skipping OpenAI provider %r: %s",
-                    provider.name,
-                    exc,
-                )
             continue
-        if provider.type == "azure_openai":
-            # M2-E1 (DE-267): Azure OpenAI mirrors the OpenAI wire shape
-            # with a different URL (deployment-scoped + api-version)
-            # and ``api-key`` auth. Missing key or missing api_version
-            # surfaces as a startup warning (skip provider) and a clean
-            # 503 at request time, matching OpenAI's lifespan posture.
-            try:
-                adapters[provider.name] = AzureOpenAIAdapter.from_config(provider)
-                logger.info(
-                    "instantiated Azure OpenAI adapter for provider %r",
-                    provider.name,
-                )
-            except ValueError as exc:
-                logger.warning(
-                    "skipping Azure OpenAI provider %r: %s",
-                    provider.name,
-                    exc,
-                )
-            continue
-        if provider.type == "ollama":
-            # B6 partial: Ollama is the Mode-2 (air-gapped local
-            # inference) backbone per PRD §1.5.1 / §6.1. Chat
-            # completions are wired here; embeddings raise
-            # ProviderUnsupportedError (the embedding alias still routes
-            # through the OpenAI adapter per ADR 0008).
-            try:
-                adapters[provider.name] = OllamaAdapter.from_config(provider)
-                logger.info(
-                    "instantiated Ollama adapter for provider %r (base_url=%s)",
-                    provider.name,
-                    provider.base_url,
-                )
-            except ValueError as exc:
-                logger.warning(
-                    "skipping Ollama provider %r: %s",
-                    provider.name,
-                    exc,
-                )
-            continue
-        # B6 lands the remaining adapters (Vertex, Bedrock).
-        logger.debug(
-            "no adapter for provider %r (type=%s); awaiting B6",
+        adapters[provider.name] = adapter
+        logger.info(
+            "instantiated %s adapter for provider %r (type=%s)",
+            type(adapter).__name__,
             provider.name,
             provider.type,
         )
     app.state.adapters = adapters
+    # Donna #7: adapters displaced by a runtime BYOK hot-swap (Task B)
+    # are stashed here so they're closed at shutdown rather than
+    # mid-request. Empty at startup; Task B appends to it.
+    # Invariant the hot-swap MUST uphold: a displaced adapter is MOVED
+    # into this list — popped from the active ``adapters`` registry, not
+    # copied — so it lives in exactly one of the two collections.
+    # Otherwise shutdown's two close loops would double-close it.
+    retired_adapters: list[ProviderAdapter] = []
+    app.state.retired_adapters = retired_adapters
 
     # B4: build the request router around the loaded config + adapter
     # registry. Per-request handlers pull this off ``app.state.router``
@@ -278,6 +289,17 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 await adapter.aclose()
             except Exception:
                 logger.exception("error closing adapter %r", name)
+        # Donna #7: close any adapters retired by a runtime BYOK hot-swap.
+        # Defensive ``getattr`` — a test bypassing the lifespan may not
+        # have set the attribute.
+        retired = getattr(app.state, "retired_adapters", [])
+        if retired:
+            logger.info("closing %d retired adapters", len(retired))
+            for adapter in retired:
+                try:
+                    await adapter.aclose()
+                except Exception:
+                    logger.exception("error closing retired adapter")
         try:
             await close_backend_client()
         except Exception:

--- a/gateway/app/provider_keys.py
+++ b/gateway/app/provider_keys.py
@@ -1,0 +1,372 @@
+"""Runtime provider-key service layer (BYOK hot-apply, Donna #7).
+
+This module encapsulates the apply / revoke / list logic behind the
+``/admin/v1/provider-keys`` admin endpoints (Task B). The endpoints stay
+thin: they validate the request, resolve the master key, hold the
+serialization lock, and delegate the mutation here. Keeping the logic in
+a plain module (no FastAPI types in the signatures) makes it directly
+unit-testable.
+
+The three operations:
+
+* :func:`list_provider_keys` — a read-only, secret-safe status snapshot of
+  every configured provider. Never returns more than the last 4 characters
+  of any key.
+* :func:`apply_provider_key` — encrypt a plaintext key, persist it to
+  ``gateway.yaml`` as ``api_key_encrypted`` (via
+  :func:`app.config_writer.upsert_provider_key`, which writes + reloads),
+  then **hot-apply** by rebuilding the provider's adapter and swapping it
+  into the live registry with no restart.
+* :func:`revoke_provider_key` — delete the runtime key (writes + reloads),
+  then retire the live adapter. The provider subsequently routes 503.
+
+Secret-handling invariants (this is the security boundary):
+
+* No plaintext or ciphertext is ever logged or returned. ``last4`` is the
+  only fragment of a key that escapes this module, and it is capped at 4
+  characters and computed only for keys that are at least 4 long.
+* The displaced adapter on a hot-swap is **moved** (popped from
+  ``app.state.adapters``, appended to ``app.state.retired_adapters``) so it
+  lives in exactly one collection — never double-held, never double-closed.
+  In-flight requests keep their reference; shutdown closes the retired one.
+
+Concurrency
+-----------
+
+The write → reload → swap sequence must not interleave across concurrent
+key mutations: two callers reloading and swapping at once could leave the
+live registry pointing at an adapter that doesn't match the on-disk config.
+The endpoints serialize the whole mutation under
+``app.state.provider_key_lock`` (an :class:`asyncio.Lock` installed in the
+lifespan). The swap step here additionally pops-then-sets so a reader never
+sees a half-applied state.
+
+The SIGHUP-driven reload is intentionally **outside** this lock, and that is
+safe: SIGHUP's ``reload_from_disk`` only swaps the in-memory config snapshot
+(a GIL-atomic attribute set) and never touches ``app.state.adapters``. Because
+the encrypted key is written to disk *before* any reload can re-read it, a
+SIGHUP that lands mid-apply still reloads a config that already contains the
+new key — the on-disk file is the single source of truth, so the two paths
+cannot disagree.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+from app.config import GatewayConfig
+from app.config_holder import MutableConfigHolder
+from app.config_writer import delete_provider_key, upsert_provider_key
+from app.providers import ProviderAdapter
+from app.secrets import MasterKeyMissing, ProviderKeyResolver, encrypt_value
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AppState",
+    "apply_provider_key",
+    "list_provider_keys",
+    "provider_key_status",
+    "revoke_provider_key",
+]
+
+
+class AppState(Protocol):
+    """The subset of ``app.state`` this module reads and mutates.
+
+    Declared as a :class:`~typing.Protocol` so the service layer stays
+    decoupled from FastAPI's dynamically-typed ``State`` object while
+    remaining checkable under ``mypy --strict``. The lifespan installs all
+    three attributes; tests that exercise the service directly provide a
+    small stand-in with the same shape.
+    """
+
+    adapters: dict[str, ProviderAdapter]
+    retired_adapters: list[ProviderAdapter]
+
+
+def _key_source(*, api_key_env: str | None, api_key_encrypted: str | None) -> str | None:
+    """Classify a provider entry's key source: ``runtime`` / ``env`` / ``None``.
+
+    ``runtime`` (encrypted-at-rest) wins when both are somehow present —
+    matching the resolver's precedence — though the config validator
+    forbids that combination upfront.
+    """
+
+    if api_key_encrypted:
+        return "runtime"
+    if api_key_env:
+        return "env"
+    return None
+
+
+def _safe_last4(
+    resolver: ProviderKeyResolver,
+    *,
+    provider_name: str,
+    api_key_env: str | None,
+    api_key_encrypted: str | None,
+) -> str | None:
+    """Return the last 4 chars of the resolved key, or ``None``.
+
+    Wrapped in a broad ``try/except`` so a missing master key, a decrypt
+    failure, or any resolver error degrades to ``None`` rather than
+    breaking the list. NEVER returns more than 4 characters, and only
+    returns a value when the resolved plaintext is at least 4 long.
+    """
+
+    try:
+        plaintext = resolver.resolve(
+            provider_name=provider_name,
+            api_key_env=api_key_env,
+            api_key_encrypted=api_key_encrypted,
+        )
+    except Exception:
+        # Missing/malformed master key, decrypt error, etc. — the status
+        # list must never break on a single bad entry, and we must never
+        # surface the failure detail (it could leak ciphertext context).
+        return None
+    if len(plaintext) < 4:
+        return None
+    return plaintext[-4:]
+
+
+def provider_key_status(
+    *,
+    name: str,
+    provider_type: str,
+    api_key_env: str | None,
+    api_key_encrypted: str | None,
+    adapters: dict[str, ProviderAdapter],
+    resolver: ProviderKeyResolver,
+) -> dict[str, object]:
+    """Build the secret-safe status dict for one provider.
+
+    Shape (the only wire shape these endpoints emit)::
+
+        {provider, type, configured, last4, source}
+
+    * ``configured`` is ``name in adapters`` — the adapter built means the
+      key resolved and the provider is routable, which is the honest signal
+      an operator wants. A keyless / unresolvable provider is ``False``.
+    * ``last4`` is computed only when ``configured`` (so we never decrypt a
+      key we couldn't build an adapter from) and is capped at 4 chars.
+    * ``source`` reflects which key field is set on the config entry.
+    """
+
+    configured = name in adapters
+    last4 = (
+        _safe_last4(
+            resolver,
+            provider_name=name,
+            api_key_env=api_key_env,
+            api_key_encrypted=api_key_encrypted,
+        )
+        if configured
+        else None
+    )
+    return {
+        "provider": name,
+        "type": provider_type,
+        "configured": configured,
+        "last4": last4,
+        "source": _key_source(
+            api_key_env=api_key_env,
+            api_key_encrypted=api_key_encrypted,
+        ),
+    }
+
+
+def list_provider_keys(
+    config: GatewayConfig,
+    adapters: dict[str, ProviderAdapter],
+    resolver: ProviderKeyResolver,
+) -> list[dict[str, object]]:
+    """Return a secret-safe status row for every configured provider.
+
+    Pure read: never writes, never raises (per-entry resolve failures
+    degrade to ``last4=None``). Never includes a full key.
+    """
+
+    return [
+        provider_key_status(
+            name=provider.name,
+            provider_type=provider.type,
+            api_key_env=provider.api_key_env,
+            api_key_encrypted=provider.api_key_encrypted,
+            adapters=adapters,
+            resolver=resolver,
+        )
+        for provider in config.providers
+    ]
+
+
+def _status_for_provider(
+    *,
+    holder: MutableConfigHolder,
+    app_state: AppState,
+    provider_name: str,
+) -> dict[str, object]:
+    """Recompute the single-provider status dict from the live config.
+
+    Built with a fresh ``ProviderKeyResolver.from_environ()`` so the
+    master key currently bound to the process is used to derive ``last4``.
+    """
+
+    config = holder.current()
+    resolver = ProviderKeyResolver.from_environ()
+    provider = config.provider_by_name(provider_name)
+    if provider is None:
+        # The provider vanished between the write and this read — should not
+        # happen (upsert/delete operate on existing entries), but stay
+        # honest rather than fabricate a row.
+        return {
+            "provider": provider_name,
+            "type": None,
+            "configured": False,
+            "last4": None,
+            "source": None,
+        }
+    return provider_key_status(
+        name=provider.name,
+        provider_type=provider.type,
+        api_key_env=provider.api_key_env,
+        api_key_encrypted=provider.api_key_encrypted,
+        adapters=app_state.adapters,
+        resolver=resolver,
+    )
+
+
+def _swap_in_adapter(
+    *,
+    app_state: AppState,
+    provider_name: str,
+    new_adapter: ProviderAdapter | None,
+) -> None:
+    """Install (or remove) the live adapter for ``provider_name``.
+
+    MOVE semantics: pop the existing adapter first; if it differs from the
+    incoming one, retire it (so shutdown closes it once). Then set the new
+    adapter when there is one. When ``new_adapter`` is ``None`` (disabled /
+    unsupported type / unresolvable key) the provider is left with no live
+    adapter and routes 503.
+
+    Synchronous and lock-free here by design — the caller holds
+    ``app.state.provider_key_lock`` across the whole mutation, and we never
+    ``await`` between the pop and the set, so no reader observes a torn
+    state.
+    """
+
+    old = app_state.adapters.pop(provider_name, None)
+    if old is not None and old is not new_adapter:
+        # Never close in-place: in-flight requests may still hold ``old``.
+        # Retire it; the lifespan closes retired adapters at shutdown.
+        app_state.retired_adapters.append(old)
+    if new_adapter is not None:
+        app_state.adapters[provider_name] = new_adapter
+
+
+async def apply_provider_key(
+    *,
+    holder: MutableConfigHolder,
+    app_state: AppState,
+    provider_name: str,
+    plaintext: str,
+    master_key: str | None,
+) -> dict[str, object]:
+    """Encrypt + persist a runtime key, then hot-apply the adapter.
+
+    Steps:
+
+    1. Encrypt ``plaintext`` with ``master_key`` (Fernet token).
+    2. :func:`upsert_provider_key` — atomic ``gateway.yaml`` write that sets
+       ``api_key_encrypted`` (and clears ``api_key_env``), then reloads with
+       rollback. Raises :class:`~app.config_writer.ProviderKeyMutationError`
+       on an unknown provider (404) / malformed config (500) / reload-
+       validation failure.
+    3. Hot-apply: read the post-reload :class:`~app.config.ProviderConfig`,
+       rebuild its adapter via ``build_adapter`` (imported lazily to dodge
+       the ``app.main`` import cycle), and swap it into the live registry.
+       A ``None`` adapter (disabled / unsupported type) or a ``ValueError``
+       (unresolvable key — should not happen since we just set the key)
+       leaves the provider with no live adapter.
+
+    Returns the provider's secret-safe status dict. Raises
+    :class:`~app.secrets.MasterKeyMissing` if ``master_key`` is falsy — the
+    caller should map that to 400 and is expected to check first; this guard
+    is defense-in-depth so we never call ``encrypt_value`` with no key.
+    """
+
+    if not master_key:
+        raise MasterKeyMissing("runtime key storage requires a master key to be set")
+
+    encrypted_token = encrypt_value(plaintext, master_key=master_key)
+    # Writes + reloads (with rollback). May raise ProviderKeyMutationError
+    # (404 unknown provider, 500 malformed) which the caller maps to a
+    # GatewayError envelope.
+    upsert_provider_key(
+        holder,
+        provider_name=provider_name,
+        encrypted_token=encrypted_token,
+    )
+
+    # Lazy import to avoid an import cycle: app.main imports the admin
+    # router (which imports this module) at module load. Importing
+    # build_adapter at call time breaks the cycle.
+    from app.main import build_adapter
+
+    provider = holder.current().provider_by_name(provider_name)
+    new_adapter: ProviderAdapter | None
+    if provider is None:
+        # Should be unreachable — upsert_provider_key raises 404 first.
+        new_adapter = None
+    else:
+        try:
+            new_adapter = build_adapter(provider)
+        except ValueError:
+            # A supported, enabled provider whose key still won't resolve.
+            # We just wrote the encrypted key, so this is unexpected; treat
+            # it as "no live adapter" and surface configured=false rather
+            # than crash. The error is not logged with any key material.
+            logger.warning(
+                "provider %r key applied but adapter build failed; provider has no live adapter",
+                provider_name,
+            )
+            new_adapter = None
+
+    _swap_in_adapter(
+        app_state=app_state,
+        provider_name=provider_name,
+        new_adapter=new_adapter,
+    )
+
+    return _status_for_provider(
+        holder=holder,
+        app_state=app_state,
+        provider_name=provider_name,
+    )
+
+
+async def revoke_provider_key(
+    *,
+    holder: MutableConfigHolder,
+    app_state: AppState,
+    provider_name: str,
+) -> None:
+    """Delete a provider's runtime key, then retire its live adapter.
+
+    :func:`delete_provider_key` writes + reloads (raising
+    :class:`~app.config_writer.ProviderKeyMutationError` 404 for an unknown
+    provider, 409 when the provider has no runtime key to revoke). On
+    success the provider's live adapter is popped and retired; the provider
+    subsequently routes 503 (no adapter) — the documented revoke behavior.
+    """
+
+    delete_provider_key(holder, provider_name=provider_name)
+
+    old = app_state.adapters.pop(provider_name, None)
+    if old is not None:
+        # Move into the retire list — never close in-place (in-flight
+        # requests may hold it); shutdown closes it.
+        app_state.retired_adapters.append(old)

--- a/gateway/tests/test_build_adapter.py
+++ b/gateway/tests/test_build_adapter.py
@@ -1,0 +1,107 @@
+"""Tests for :func:`app.main.build_adapter` — the reusable adapter builder.
+
+``build_adapter`` is the single source of truth for "which adapter does
+this provider get", extracted from the lifespan so the runtime BYOK
+hot-apply path (Donna #7, Task B) can reuse it. These tests pin its
+contract directly; the heavier behavior-preservation guarantee (the
+exact set of adapters built for the example config) is covered by the
+full gateway suite running the real lifespan.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import ProviderConfig
+from app.main import build_adapter
+from app.providers import AnthropicAdapter, OllamaAdapter, OpenAIAdapter
+
+
+@pytest.mark.unit
+def test_build_adapter_returns_anthropic_for_keyed_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    provider = ProviderConfig(
+        name="anthropic-prod",
+        type="anthropic",
+        base_url="https://api.anthropic.com",
+        api_key_env="ANTHROPIC_API_KEY",
+        tier=4,
+    )
+    adapter = build_adapter(provider)
+    assert isinstance(adapter, AnthropicAdapter)
+
+
+@pytest.mark.unit
+def test_build_adapter_handles_openai_compatible_without_key() -> None:
+    # openai_compatible local servers legitimately have no key.
+    provider = ProviderConfig(
+        name="vllm-local",
+        type="openai_compatible",
+        base_url="http://vllm:8000/v1",
+        api_key_env="",
+        tier=1,
+    )
+    adapter = build_adapter(provider)
+    assert isinstance(adapter, OpenAIAdapter)
+
+
+@pytest.mark.unit
+def test_build_adapter_returns_ollama() -> None:
+    provider = ProviderConfig(
+        name="ollama-local",
+        type="ollama",
+        base_url="http://ollama:11434",
+        api_key_env="",
+        tier=1,
+    )
+    adapter = build_adapter(provider)
+    assert isinstance(adapter, OllamaAdapter)
+
+
+@pytest.mark.unit
+def test_build_adapter_returns_none_for_disabled_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    provider = ProviderConfig(
+        name="anthropic-prod",
+        type="anthropic",
+        base_url="https://api.anthropic.com",
+        api_key_env="ANTHROPIC_API_KEY",
+        tier=4,
+        enabled=False,
+    )
+    assert build_adapter(provider) is None
+
+
+@pytest.mark.unit
+def test_build_adapter_returns_none_for_typeless_adapter() -> None:
+    # vertex/bedrock have no adapter yet (awaiting B6) → None, not raise.
+    provider = ProviderConfig(
+        name="bedrock",
+        type="bedrock",
+        base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
+        tier=3,
+    )
+    assert build_adapter(provider) is None
+
+
+@pytest.mark.unit
+def test_build_adapter_raises_value_error_for_missing_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Supported provider whose key can't be resolved → ValueError
+    # (the signal the factories raise; the lifespan catches+skips).
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("LQ_AI_GATEWAY_MASTER_KEY", raising=False)
+    provider = ProviderConfig(
+        name="anthropic-prod",
+        type="anthropic",
+        base_url="https://api.anthropic.com",
+        api_key_env="ANTHROPIC_API_KEY",
+        tier=4,
+    )
+    with pytest.raises(ValueError):
+        build_adapter(provider)

--- a/gateway/tests/test_config_holder.py
+++ b/gateway/tests/test_config_holder.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 
 import pytest
+from cryptography.fernet import Fernet
 
 from app.config_holder import (
     ConfigReloadError,
@@ -19,6 +20,12 @@ from app.config_holder import (
     install_sighup_reload,
 )
 from app.config_loader import load_config
+from app.config_writer import (
+    ProviderKeyMutationError,
+    delete_provider_key,
+    upsert_provider_key,
+)
+from app.secrets import encrypt_value
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLE_CONFIG = REPO_ROOT / "gateway.yaml.example"
@@ -186,6 +193,154 @@ def test_sighup_handler_does_not_raise_on_bad_file(tmp_config: Path, example_env
     os.kill(os.getpid(), signal.SIGHUP)
     time.sleep(0.1)
     assert holder.current() is initial
+
+
+# --- Provider-key mutation (runtime BYOK, Donna #7) --------------------------
+
+
+def _read_provider_entry(config_path: Path, name: str) -> dict[str, object]:
+    """Read the raw YAML providers entry for ``name`` (no env expansion)."""
+
+    import yaml
+
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    for entry in raw["providers"]:
+        if entry.get("name") == name:
+            return entry
+    raise AssertionError(f"provider {name!r} not found in {config_path}")
+
+
+@pytest.mark.unit
+def test_upsert_provider_key_sets_encrypted_and_clears_env(
+    tmp_config: Path, example_env: None
+) -> None:
+    initial = load_config(tmp_config)
+    holder = MutableConfigHolder(initial, config_path=tmp_config)
+
+    token = encrypt_value("sk-test", master_key=Fernet.generate_key().decode())
+    upsert_provider_key(holder, provider_name="anthropic-prod", encrypted_token=token)
+
+    # On-disk YAML: gains api_key_encrypted, loses api_key_env.
+    entry = _read_provider_entry(tmp_config, "anthropic-prod")
+    assert entry["api_key_encrypted"] == token
+    assert "api_key_env" not in entry
+
+    # holder.current() reflects it (and round-trips the token).
+    provider = holder.current().provider_by_name("anthropic-prod")
+    assert provider is not None
+    assert provider.api_key_encrypted == token
+    assert provider.api_key_env is None
+
+
+@pytest.mark.unit
+def test_upsert_provider_key_unknown_provider_raises_404(
+    tmp_config: Path, example_env: None
+) -> None:
+    initial = load_config(tmp_config)
+    holder = MutableConfigHolder(initial, config_path=tmp_config)
+
+    token = encrypt_value("sk-test", master_key=Fernet.generate_key().decode())
+    with pytest.raises(ProviderKeyMutationError) as excinfo:
+        upsert_provider_key(holder, provider_name="does-not-exist", encrypted_token=token)
+    assert excinfo.value.http_status == 404
+
+
+@pytest.mark.unit
+def test_delete_provider_key_removes_runtime_key(tmp_config: Path, example_env: None) -> None:
+    initial = load_config(tmp_config)
+    holder = MutableConfigHolder(initial, config_path=tmp_config)
+
+    # First set a runtime key, then revoke it.
+    token = encrypt_value("sk-test", master_key=Fernet.generate_key().decode())
+    upsert_provider_key(holder, provider_name="anthropic-prod", encrypted_token=token)
+    delete_provider_key(holder, provider_name="anthropic-prod")
+
+    entry = _read_provider_entry(tmp_config, "anthropic-prod")
+    assert "api_key_encrypted" not in entry
+    provider = holder.current().provider_by_name("anthropic-prod")
+    assert provider is not None
+    assert provider.api_key_encrypted is None
+
+
+@pytest.mark.unit
+def test_delete_provider_key_env_only_raises_409(tmp_config: Path, example_env: None) -> None:
+    initial = load_config(tmp_config)
+    holder = MutableConfigHolder(initial, config_path=tmp_config)
+
+    # openai-prod ships with api_key_env only — no runtime key to revoke.
+    with pytest.raises(ProviderKeyMutationError) as excinfo:
+        delete_provider_key(holder, provider_name="openai-prod")
+    assert excinfo.value.http_status == 409
+
+
+@pytest.mark.unit
+def test_delete_provider_key_unknown_provider_raises_404(
+    tmp_config: Path, example_env: None
+) -> None:
+    initial = load_config(tmp_config)
+    holder = MutableConfigHolder(initial, config_path=tmp_config)
+
+    with pytest.raises(ProviderKeyMutationError) as excinfo:
+        delete_provider_key(holder, provider_name="does-not-exist")
+    assert excinfo.value.http_status == 404
+
+
+@pytest.mark.unit
+def test_upsert_provider_key_empty_token_raises_422(tmp_config: Path, example_env: None) -> None:
+    """An empty ciphertext can never produce a keyless provider."""
+
+    initial = load_config(tmp_config)
+    holder = MutableConfigHolder(initial, config_path=tmp_config)
+
+    with pytest.raises(ProviderKeyMutationError) as excinfo:
+        upsert_provider_key(holder, provider_name="anthropic-prod", encrypted_token="")
+    assert excinfo.value.http_status == 422
+
+
+@pytest.mark.unit
+def test_upsert_provider_key_no_providers_list_raises_500(
+    tmp_config: Path, example_env: None
+) -> None:
+    """A config whose ``providers:`` key is absent (or not a list) is
+    treated as a malformed config — 500, not 404."""
+
+    initial = load_config(tmp_config)
+    holder = MutableConfigHolder(initial, config_path=tmp_config)
+
+    # Overwrite the file with a mapping that has no ``providers`` list.
+    tmp_config.write_text("model_aliases: {}\n", encoding="utf-8")
+
+    token = encrypt_value("sk-test", master_key=Fernet.generate_key().decode())
+    with pytest.raises(ProviderKeyMutationError) as excinfo:
+        upsert_provider_key(holder, provider_name="anthropic-prod", encrypted_token=token)
+    assert excinfo.value.http_status == 500
+
+
+@pytest.mark.unit
+def test_upsert_provider_key_preserves_other_provider_fields(
+    tmp_config: Path, example_env: None
+) -> None:
+    """Mutating one provider leaves a DIFFERENT provider's fields intact.
+
+    Locks in the raw-YAML round-trip guarantee: ``base_url`` / ``tier``
+    on an unrelated entry must survive the write untouched.
+    """
+
+    initial = load_config(tmp_config)
+    holder = MutableConfigHolder(initial, config_path=tmp_config)
+
+    before = holder.current().provider_by_name("openai-prod")
+    assert before is not None
+    base_url_before = before.base_url
+    tier_before = before.tier
+
+    token = encrypt_value("sk-test", master_key=Fernet.generate_key().decode())
+    upsert_provider_key(holder, provider_name="anthropic-prod", encrypted_token=token)
+
+    after = holder.current().provider_by_name("openai-prod")
+    assert after is not None
+    assert after.base_url == base_url_before
+    assert after.tier == tier_before
 
 
 def test_install_sighup_reload_no_op_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/gateway/tests/test_provider_keys.py
+++ b/gateway/tests/test_provider_keys.py
@@ -1,0 +1,504 @@
+"""Acceptance + unit tests for runtime provider-key management (Donna #7).
+
+These exercise the ``/admin/v1/provider-keys`` endpoints end-to-end through
+the ASGI client AND the service layer directly. The hard requirements
+verified here:
+
+* A POST activates a previously-keyless provider's adapter *in the live
+  registry* with no restart (hot-apply).
+* No endpoint ever returns a full key or the encrypted token — only
+  ``last4`` (capped at 4 chars) escapes.
+* The encrypted token written to disk is not the plaintext.
+* Revoke pops the adapter (provider would route 503 afterward).
+* A rotation on an already-keyed provider MOVES the displaced adapter into
+  ``retired_adapters`` (never double-held).
+* Master-key precondition (400) and unknown-provider / env-only error
+  mapping (404 / 409).
+
+We never mutate the committed ``gateway.yaml.example`` — every fixture
+copies it to a writable temp path first.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.config import ProviderConfig
+from app.provider_keys import apply_provider_key, revoke_provider_key
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONFIG = REPO_ROOT / "gateway.yaml.example"
+
+# A provider that is env-sourced but whose env var is NOT set by the
+# ``example_env`` fixture, so it has no adapter at startup. POSTing a
+# runtime key must activate it — proving hot-apply without restart.
+KEYLESS_PROVIDER = "openai-prod"
+
+# A clearly-fake key whose last 4 chars are assertable.
+FAKE_KEY = "sk-test-ABCDwxyz"
+FAKE_KEY_LAST4 = "wxyz"
+
+
+@asynccontextmanager
+async def _run_lifespan(app: FastAPI) -> AsyncIterator[None]:
+    async with app.router.lifespan_context(app):
+        yield
+
+
+def _set_example_env(monkeypatch: pytest.MonkeyPatch, tmp_config: Path) -> None:
+    """Set the ``${VAR}`` placeholders the example config references."""
+
+    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
+    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_config))
+
+
+@pytest_asyncio.fixture
+async def writable_config(tmp_path: Path) -> Path:
+    """Copy the committed example config to a writable temp path."""
+
+    dest = tmp_path / "gateway.yaml"
+    shutil.copyfile(EXAMPLE_CONFIG, dest)
+    return dest
+
+
+@pytest_asyncio.fixture
+async def keyed_app(
+    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+) -> AsyncIterator[FastAPI]:
+    """Gateway app with a fresh master key + writable temp config."""
+
+    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", Fernet.generate_key().decode())
+
+    from app.main import app
+
+    async with _run_lifespan(app):
+        yield app
+
+
+@pytest_asyncio.fixture
+async def keyed_client(keyed_app: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=keyed_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as http_client:
+        yield http_client
+
+
+@pytest_asyncio.fixture
+async def no_master_key_app(
+    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+) -> AsyncIterator[FastAPI]:
+    """Gateway app WITHOUT a master key — POST/PATCH must 400."""
+
+    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.delenv("LQ_AI_GATEWAY_MASTER_KEY", raising=False)
+
+    from app.main import app
+
+    async with _run_lifespan(app):
+        yield app
+
+
+@pytest_asyncio.fixture
+async def no_master_key_client(no_master_key_app: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=no_master_key_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as http_client:
+        yield http_client
+
+
+def _assert_no_secret(body: object, *, plaintext: str) -> None:
+    """Assert the full plaintext key never appears anywhere in a response."""
+
+    import json
+
+    blob = json.dumps(body)
+    assert plaintext not in blob, "full key leaked into response body"
+    # Belt-and-suspenders: also reject the longer prefix so a partial leak
+    # beyond last4 is caught.
+    assert plaintext[:-4] not in blob
+
+
+# ---------------------------------------------------------------------------
+# Acceptance — end-to-end through the ASGI client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_post_activates_keyless_provider(
+    keyed_client: AsyncClient, keyed_app: FastAPI
+) -> None:
+    """POST a key → 200, configured, last4, source=runtime, adapter live."""
+
+    # Precondition: the env-sourced provider has no adapter at startup.
+    assert KEYLESS_PROVIDER not in keyed_app.state.adapters
+
+    resp = await keyed_client.post(
+        "/admin/v1/provider-keys",
+        json={"provider": KEYLESS_PROVIDER, "api_key": FAKE_KEY},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provider"] == KEYLESS_PROVIDER
+    assert body["configured"] is True
+    assert body["last4"] == FAKE_KEY_LAST4
+    assert body["source"] == "runtime"
+    _assert_no_secret(body, plaintext=FAKE_KEY)
+
+    # Hot-apply: the adapter is now live without a restart.
+    assert KEYLESS_PROVIDER in keyed_app.state.adapters
+
+
+@pytest.mark.unit
+async def test_list_provider_keys_is_secret_safe(
+    keyed_client: AsyncClient,
+) -> None:
+    """GET lists runtime + env sources; never leaks a full key."""
+
+    # Apply a runtime key first.
+    await keyed_client.post(
+        "/admin/v1/provider-keys",
+        json={"provider": KEYLESS_PROVIDER, "api_key": FAKE_KEY},
+    )
+
+    resp = await keyed_client.get("/admin/v1/provider-keys")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    rows = {row["provider"]: row for row in body["provider_keys"]}
+
+    runtime_row = rows[KEYLESS_PROVIDER]
+    assert runtime_row["configured"] is True
+    assert runtime_row["source"] == "runtime"
+    assert runtime_row["last4"] == FAKE_KEY_LAST4
+
+    # An env-sourced provider (ollama uses api_key_env='', so it's None;
+    # anthropic-prod uses api_key_env=ANTHROPIC_API_KEY → source 'env').
+    assert rows["anthropic-prod"]["source"] == "env"
+
+    _assert_no_secret(body, plaintext=FAKE_KEY)
+    # No field anywhere should carry the encrypted token either; last4 is
+    # the only key fragment, capped at 4 chars.
+    for row in body["provider_keys"]:
+        if row["last4"] is not None:
+            assert len(row["last4"]) == 4
+
+
+@pytest.mark.unit
+async def test_delete_revokes_and_pops_adapter(
+    keyed_client: AsyncClient, keyed_app: FastAPI
+) -> None:
+    """DELETE → 204; provider configured=false, adapter gone."""
+
+    await keyed_client.post(
+        "/admin/v1/provider-keys",
+        json={"provider": KEYLESS_PROVIDER, "api_key": FAKE_KEY},
+    )
+    assert KEYLESS_PROVIDER in keyed_app.state.adapters
+
+    resp = await keyed_client.delete(f"/admin/v1/provider-keys/{KEYLESS_PROVIDER}")
+    assert resp.status_code == 204, resp.text
+    # Per the CLAUDE.md DELETE-204 recipe the 204 carries a genuinely empty
+    # body (response_class=Response). Assert it's empty — and so trivially
+    # secret-free.
+    assert resp.content == b""
+
+    assert KEYLESS_PROVIDER not in keyed_app.state.adapters
+
+    listing = await keyed_client.get("/admin/v1/provider-keys")
+    rows = {row["provider"]: row for row in listing.json()["provider_keys"]}
+    assert rows[KEYLESS_PROVIDER]["configured"] is False
+
+
+@pytest.mark.unit
+async def test_post_without_master_key_returns_400(
+    no_master_key_client: AsyncClient,
+) -> None:
+    """POST with no master key → 400 failed_precondition."""
+
+    resp = await no_master_key_client.post(
+        "/admin/v1/provider-keys",
+        json={"provider": KEYLESS_PROVIDER, "api_key": FAKE_KEY},
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "failed_precondition"
+
+
+@pytest.mark.unit
+async def test_patch_without_master_key_returns_400(
+    no_master_key_client: AsyncClient,
+) -> None:
+    resp = await no_master_key_client.patch(
+        f"/admin/v1/provider-keys/{KEYLESS_PROVIDER}",
+        json={"api_key": FAKE_KEY},
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "failed_precondition"
+
+
+@pytest.mark.unit
+async def test_post_unknown_provider_returns_404(keyed_client: AsyncClient) -> None:
+    resp = await keyed_client.post(
+        "/admin/v1/provider-keys",
+        json={"provider": "does-not-exist", "api_key": FAKE_KEY},
+    )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["error"]["code"] == "not_found"
+
+
+@pytest.mark.unit
+async def test_patch_unknown_provider_returns_404(keyed_client: AsyncClient) -> None:
+    resp = await keyed_client.patch(
+        "/admin/v1/provider-keys/does-not-exist",
+        json={"api_key": FAKE_KEY},
+    )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["error"]["code"] == "not_found"
+
+
+@pytest.mark.unit
+async def test_delete_unknown_provider_returns_404(keyed_client: AsyncClient) -> None:
+    resp = await keyed_client.delete("/admin/v1/provider-keys/does-not-exist")
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["error"]["code"] == "not_found"
+
+
+@pytest.mark.unit
+async def test_delete_env_only_provider_returns_409(keyed_client: AsyncClient) -> None:
+    """Revoking an env-sourced provider (no runtime key) → 409 conflict."""
+
+    resp = await keyed_client.delete("/admin/v1/provider-keys/anthropic-prod")
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["error"]["code"] == "conflict"
+
+
+@pytest.mark.unit
+async def test_encrypted_token_written_not_plaintext(
+    keyed_client: AsyncClient, writable_config: Path
+) -> None:
+    """The on-disk YAML holds api_key_encrypted, never the plaintext."""
+
+    resp = await keyed_client.post(
+        "/admin/v1/provider-keys",
+        json={"provider": KEYLESS_PROVIDER, "api_key": FAKE_KEY},
+    )
+    assert resp.status_code == 200, resp.text
+
+    disk = writable_config.read_text(encoding="utf-8")
+    assert FAKE_KEY not in disk, "plaintext key written to disk"
+    assert "api_key_encrypted" in disk
+
+
+# A provider whose ``type`` has no adapter implementation (build_adapter
+# returns None): a runtime key is stored on disk but the provider is never
+# live-routable. ``vertex`` is such a type in the example config.
+UNSUPPORTED_PROVIDER = "vertex-anthropic"
+ROTATE_KEY = "sk-test-ROTATEmnop"
+ROTATE_KEY_LAST4 = "mnop"
+
+
+@pytest.mark.unit
+async def test_patch_rotates_keyed_provider_through_endpoint(
+    keyed_client: AsyncClient, keyed_app: FastAPI
+) -> None:
+    """PATCH rotates a key end-to-end → 200, new last4, source=runtime, live.
+
+    Covers the thin PATCH endpoint wiring: first POST a key (provider goes
+    live), then PATCH a *different* key on the same provider. The response
+    reflects the new key's last4, source stays ``runtime``, and the
+    provider's live adapter is a NEW object (the rotation rebuilt + swapped
+    it, retiring the displaced one).
+    """
+
+    # Bring the provider live via POST.
+    resp = await keyed_client.post(
+        "/admin/v1/provider-keys",
+        json={"provider": KEYLESS_PROVIDER, "api_key": FAKE_KEY},
+    )
+    assert resp.status_code == 200, resp.text
+    adapter_before = keyed_app.state.adapters[KEYLESS_PROVIDER]
+
+    # Rotate via PATCH (provider from the path).
+    resp = await keyed_client.patch(
+        f"/admin/v1/provider-keys/{KEYLESS_PROVIDER}",
+        json={"api_key": ROTATE_KEY},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provider"] == KEYLESS_PROVIDER
+    assert body["configured"] is True
+    assert body["last4"] == ROTATE_KEY_LAST4
+    assert body["source"] == "runtime"
+    _assert_no_secret(body, plaintext=ROTATE_KEY)
+
+    # Hot-apply on rotate: still routable, and a fresh adapter object.
+    assert KEYLESS_PROVIDER in keyed_app.state.adapters
+    assert keyed_app.state.adapters[KEYLESS_PROVIDER] is not adapter_before
+
+
+@pytest.mark.unit
+async def test_post_unsupported_provider_stored_but_not_live(
+    keyed_client: AsyncClient, keyed_app: FastAPI, writable_config: Path
+) -> None:
+    """POST to a no-adapter provider type → 200, stored on disk, NOT live.
+
+    A provider whose ``type`` has no adapter (``vertex``) still accepts a
+    runtime key: the write SUCCEEDS (200) and ``api_key_encrypted`` lands on
+    disk, but ``build_adapter`` returns None so the provider is reported
+    ``configured: false`` and is absent from the live adapter registry. This
+    is the documented "stored but not live-routable" branch.
+    """
+
+    assert UNSUPPORTED_PROVIDER not in keyed_app.state.adapters
+
+    resp = await keyed_client.post(
+        "/admin/v1/provider-keys",
+        json={"provider": UNSUPPORTED_PROVIDER, "api_key": FAKE_KEY},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provider"] == UNSUPPORTED_PROVIDER
+    # No adapter was built → not configured, no last4 surfaced.
+    assert body["configured"] is False
+    assert body["last4"] is None
+    _assert_no_secret(body, plaintext=FAKE_KEY)
+
+    # The key IS persisted (the write half succeeded)...
+    disk = writable_config.read_text(encoding="utf-8")
+    assert FAKE_KEY not in disk, "plaintext key written to disk"
+    assert "api_key_encrypted" in disk
+    # ...but the provider is NOT live-routable.
+    assert UNSUPPORTED_PROVIDER not in keyed_app.state.adapters
+
+
+# ---------------------------------------------------------------------------
+# Hot-swap unit test — service layer, no HTTP
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    """Minimal stand-in identified by a label."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    async def aclose(self) -> None:  # pragma: no cover - not exercised here
+        return None
+
+
+class _FakeState:
+    """Stand-in for ``app.state`` with the three attrs the service reads."""
+
+    def __init__(self) -> None:
+        self.adapters: dict[str, object] = {}
+        self.retired_adapters: list[object] = []
+
+
+@pytest.mark.unit
+async def test_rotation_retires_displaced_adapter(
+    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+) -> None:
+    """Rotating an already-keyed provider MOVES the old adapter to retired.
+
+    Drives the service layer directly against a real holder, with a stubbed
+    ``build_adapter`` so we control adapter identity and don't need live
+    provider credentials. Asserts the displaced adapter ends up in
+    ``retired_adapters`` exactly once and is not double-held.
+    """
+
+    monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
+    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
+    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
+
+    from app.config_holder import MutableConfigHolder
+    from app.config_loader import load_config
+
+    holder = MutableConfigHolder(load_config(writable_config), config_path=writable_config)
+    state = _FakeState()
+    master_key = Fernet.generate_key().decode()
+    monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", master_key)
+
+    # Stub build_adapter so each call yields a fresh, distinguishable
+    # adapter regardless of real provider credentials.
+    counter = {"n": 0}
+
+    def _fake_build(provider: ProviderConfig) -> _FakeAdapter:
+        counter["n"] += 1
+        return _FakeAdapter(f"{provider.name}-{counter['n']}")
+
+    monkeypatch.setattr("app.main.build_adapter", _fake_build)
+
+    # First apply → adapter v1 installed.
+    await apply_provider_key(
+        holder=holder,
+        app_state=state,  # type: ignore[arg-type]
+        provider_name=KEYLESS_PROVIDER,
+        plaintext="sk-test-first0",
+        master_key=master_key,
+    )
+    first = state.adapters[KEYLESS_PROVIDER]
+    assert isinstance(first, _FakeAdapter)
+    assert state.retired_adapters == []
+
+    # Rotate → adapter v2 installed, v1 retired (moved, not copied).
+    await apply_provider_key(
+        holder=holder,
+        app_state=state,  # type: ignore[arg-type]
+        provider_name=KEYLESS_PROVIDER,
+        plaintext="sk-test-second",
+        master_key=master_key,
+    )
+    second = state.adapters[KEYLESS_PROVIDER]
+    assert second is not first
+    assert state.retired_adapters == [first]
+    # Not double-held: the displaced adapter lives only in retired.
+    assert state.adapters[KEYLESS_PROVIDER] is not first
+
+
+@pytest.mark.unit
+async def test_revoke_retires_live_adapter(
+    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+) -> None:
+    """revoke_provider_key pops the live adapter into retired_adapters."""
+
+    master_key = Fernet.generate_key().decode()
+    monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", master_key)
+
+    from app.config_holder import MutableConfigHolder
+    from app.config_loader import load_config
+
+    holder = MutableConfigHolder(load_config(writable_config), config_path=writable_config)
+    state = _FakeState()
+
+    def _fake_build(provider: ProviderConfig) -> _FakeAdapter:
+        return _FakeAdapter(provider.name)
+
+    monkeypatch.setattr("app.main.build_adapter", _fake_build)
+
+    await apply_provider_key(
+        holder=holder,
+        app_state=state,  # type: ignore[arg-type]
+        provider_name=KEYLESS_PROVIDER,
+        plaintext="sk-test-ABCDwxyz",
+        master_key=master_key,
+    )
+    live = state.adapters[KEYLESS_PROVIDER]
+
+    await revoke_provider_key(
+        holder=holder,
+        app_state=state,  # type: ignore[arg-type]
+        provider_name=KEYLESS_PROVIDER,
+    )
+    assert KEYLESS_PROVIDER not in state.adapters
+    assert state.retired_adapters == [live]


### PR DESCRIPTION
Runtime provider API-key management (BYOK): admins add/rotate/revoke a provider's API key at runtime and have it **hot-applied to the live provider pool with no gateway restart**. Donna ask #7. Replaces env-only-at-startup key config.

> ⚠️ **Security-boundary change (`gateway/**`).** This is the component that holds privileged provider keys. Flagging for manual security review (per the PR #115 precedent — maintainer's call, not auto-merged).

## Architecture (two layers, mirrors the existing alias-CRUD precedent)
- **Backend** `/api/v1/admin/provider-keys` (GET/POST/PATCH/DELETE) — `is_admin`-gated proxy via `GatewayClient` (adds the gateway key). The frontend never holds the gateway key. This is the surface Donna pins.
- **Gateway** `/admin/v1/provider-keys` (the secret boundary) — Fernet-encrypts the key with `LQ_AI_GATEWAY_MASTER_KEY` (reusing the existing `encrypt_value` / ADR 0011 machinery), persists `api_key_encrypted` to `gateway.yaml` via the same atomic-write+reload-with-rollback pattern as alias mutations, then **hot-applies** by rebuilding the provider's adapter (`build_adapter`, extracted from the lifespan) and swapping it **in-place** into the live `app.state.adapters` registry the Router reads per-request. The displaced adapter is retired for shutdown-close (never closed mid-request).

## Security posture (the load-bearing properties)
- **Write-only secrets.** No endpoint or log on either service ever returns/emits the plaintext key or the Fernet token. The **only** key fragment that escapes is `last4` (≤4 chars, only when the key resolved). Verified end-to-end by a final holistic review tracing every sink (responses, logs, error `details`, spans, disk) — `_assert_no_secret` guards in both test suites would fail on a leak.
- **Encrypted at rest** in `gateway.yaml` (`api_key_encrypted`, Fernet). Setting a runtime key clears `api_key_env` (source → `runtime`); the `_exactly_one_key_source` validator stays satisfied.
- **Master key required.** POST/PATCH return **400** (`failed_precondition`) when `LQ_AI_GATEWAY_MASTER_KEY` is unset — can't store-at-rest without it.
- **Admin-only + gateway-key.** Backend `is_admin` gate; gateway `require_gateway_key`. TLS in transit (deployment).
- **Mutations serialized** under an `asyncio.Lock`; reload uses the holder's lock; SIGHUP reload is intentionally outside the endpoint lock (safe — disk is source of truth, documented).

## Decisions (maintainer-approved at kickoff)
- **Persistence:** `gateway.yaml` via `config_writer` (mirrors alias CRUD; ADR 0010 YAML-source-of-truth) — not a new gateway DB table.
- **Masking:** GET returns `{provider, type, configured, last4, source: env|runtime}` — `last4` (Stripe-style), never more.
- **Build both layers** this round.

## Acceptance (Donna's) — proven by tests
POST a key for a provider with no env key → the gateway routes to it immediately, no restart (adapter now live in the registry) → GET lists it `configured:true`, no secret → DELETE revokes (adapter popped → routes 503 as unconfigured). Env-provided keys still work and show `source:'env'`. Unknown provider → 404; revoking an env-only key → 409.

## Behavior notes for review
- `build_adapter` extracted from the lifespan; the adapter-set membership for a given config is **unchanged** (behavior-preserving refactor, verified by the full lifespan-driven suite). New `app.state.retired_adapters` closed at shutdown (MOVE-not-copy invariant documented).
- New DELETE endpoints use the canonical CLAUDE.md DELETE-204 recipe (`response_class=Response`); the pre-existing alias DELETE keeps its old pattern (left untouched).
- `errors.py` gains `failed_precondition → ValidationError (400)` so the gateway's master-key 400 surfaces as a 4xx (not 500) through the proxy.
- New deferral candidates (NOT filed yet — your call): adding a wholly-new provider (type/base_url/tier) at runtime is out of scope (key-management only); a mid-rotation `build_adapter` ValueError branch lacks a dedicated test (covered structurally).

## Tests / gates
Gateway: ruff + ruff format + **mypy --strict** clean; **564 passed**, 2 skipped. Backend: ruff + ruff format + mypy clean; admin/openapi/endpoints suites green, `test_openapi` path count 114→116, `IMPLEMENTED_ROUTES` updated, 18 new provider-key endpoint tests + `_assert_no_secret`. Built via subagent-driven loop (3 tasks × spec+quality review) + a final holistic security review.

After merge: report the backend SHA so Donna pins `vendor/lq-ai`, runs `npm run gen:api`, and builds the provider-keys management card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)