### PR TITLE
fix(api): sync max_cost_usd onto autonomous schedule/watch OpenAPI schemas (contract drift)

### DIFF
--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -5558,6 +5558,7 @@ components:
         skill_ref: {type: string, nullable: true}
         target_kb_id: {type: string, format: uuid, nullable: true}
         enabled: {type: boolean}
+        max_cost_usd: {type: string, nullable: true}
         last_run_at: {type: string, format: date-time, nullable: true}
         next_run_at: {type: string, format: date-time, nullable: true}
         deleted_at: {type: string, format: date-time, nullable: true}
@@ -5580,6 +5581,7 @@ components:
         target_kb_id: {type: string, format: uuid, nullable: true}
         project_id: {type: string, format: uuid, nullable: true}
         enabled: {type: boolean, default: true}
+        max_cost_usd: {type: string, nullable: true}
 
     AutonomousScheduleUpdate:
       type: object
@@ -5594,6 +5596,7 @@ components:
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
         target_kb_id: {type: string, format: uuid, nullable: true}
+        max_cost_usd: {type: string, nullable: true}
 
     AutonomousManualRunRequest:
       type: object
@@ -5645,6 +5648,7 @@ components:
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
         enabled: {type: boolean}
+        max_cost_usd: {type: string, nullable: true}
         deleted_at: {type: string, format: date-time, nullable: true}
         created_at: {type: string, format: date-time}
         updated_at: {type: string, format: date-time}
@@ -5663,6 +5667,7 @@ components:
         skill_ref: {type: string, nullable: true}
         project_id: {type: string, format: uuid, nullable: true}
         enabled: {type: boolean, default: true}
+        max_cost_usd: {type: string, nullable: true}
 
     AutonomousWatchUpdate:
       type: object
@@ -5674,6 +5679,7 @@ components:
         enabled: {type: boolean, nullable: true}
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
+        max_cost_usd: {type: string, nullable: true}
 
     AutonomousWatchListResponse:
       type: object


### PR DESCRIPTION
**Reported by Donna CC** (Automations slice F). The hand-maintained `docs/api/backend-openapi.yaml` drifted from the shipped Pydantic models: `max_cost_usd` (added by migration `0045_autonomous_per_trigger_max_cost.py`, on the models in `api/app/schemas/autonomous.py`) was missing from the autonomous schedule/watch schemas, so Donna's `npm run gen:api` emitted no typed `max_cost_usd` for them.

## Blast radius (verified against the models — broader than the original report)
Six schemas were missing the field; added to all:
- `AutonomousScheduleCreate`, `AutonomousScheduleUpdate` (reported)
- `AutonomousWatchCreate`, `AutonomousWatchUpdate` (Donna flagged as likely — confirmed)
- `AutonomousScheduleRead`, `AutonomousWatchRead` (**also drifted** — found by verifying; the read/list endpoints return `max_cost_usd`, so the grid/detail views were missing the typed field too)

`AutonomousManualRunRequest` (run-now) and `AutonomousSessionRead` already had it — untouched.

## Type: `string`
Typed as `{type: string, nullable: true}`, matching `AutonomousManualRunRequest` and the **verified runtime wire type** — `tests/autonomous/test_watch_schedule_max_cost_endpoints.py` sends `"max_cost_usd": "0.50"` and reads `Decimal(body["max_cost_usd"])`, i.e. Decimal serializes as a JSON **string** on both requests and responses.

## Known adjacent inconsistency (NOT changed here — your call)
`AutonomousSessionRead` types `max_cost_usd` (and `cost_total_usd`) as `{type: number, format: decimal}`, which the same tests show is **wrong** (runtime emits strings). I left those shipped fields as-is rather than silently re-typing them — happy to standardize the autonomous Decimal fields to `string` in a follow-up if you want. Flagging so the new `string` reads don't look inconsistent by accident.

Docs-only; no code, no path, no behavior change (`test_openapi` path count unchanged at 116). After merge I'll report the SHA for Donna's pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)