### PR TITLE
fix(api): type autonomous session cost fields as string to match runtime

### DIFF
--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -5771,8 +5771,8 @@ components:
         halt_state:
           type: string
           enum: [running, halt_requested, halted, paused]
-        max_cost_usd: {type: number, format: decimal, nullable: true}
-        cost_total_usd: {type: number, format: decimal}
+        max_cost_usd: {type: string, nullable: true}
+        cost_total_usd: {type: string}
         cost_cap_reached: {type: boolean}
         idle_halt_minutes: {type: integer, minimum: 1}
         last_activity_at: {type: string, format: date-time}


### PR DESCRIPTION
Follow-up to #129 (requested by maintainer). `AutonomousSessionRead` typed `max_cost_usd` and `cost_total_usd` as `{type: number, format: decimal}`, but the runtime serializes these `Decimal` fields as JSON **strings** (Pydantic v2) — same as every other cost field in the contract (tabular costs; the schedule/watch `max_cost_usd` synced in #129). Verified by the autonomous endpoint tests, which read `Decimal(body["max_cost_usd"])`.

This aligns the last two `number/decimal` autonomous fields to `string`, so `gen:api` emits the correct type and the autonomous cost surface is uniform. `AutonomousSessionListResponse` / `SessionDetailResponse` `$ref` `SessionRead`, so they inherit the fix.

Docs-only; no code/path/behavior change. After merge I'll report the SHA for Donna's pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)