### PR TITLE
feat(autonomous): reassign matter via PATCH + validate project_id ownership

### DIFF
--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -1034,6 +1034,7 @@ async def reject_project_context_proposal(
     responses={
         201: {"description": "Schedule created"},
         422: {"description": "Invalid cron expression"},
+        404: {"description": "Referenced project not found"},
         401: {"description": "Not authenticated"},
     },
 )
@@ -1060,6 +1061,11 @@ async def create_schedule(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"invalid cron expression: {exc}",
         ) from exc
+
+    # Validate matter ownership — a non-null project_id the caller doesn't own
+    # is rejected 404 (id-probing-safe). NULL = no matter; no check needed.
+    if body.project_id is not None:
+        await _load_owned_project(db, project_id=body.project_id, user_id=user.id)
 
     now = datetime.now(UTC)
     schedule = AutonomousSchedule(
@@ -1110,6 +1116,11 @@ async def _spawn_manual_session(
     enqueue_fn = enqueue if enqueue is not None else enqueue_autonomous_session_job
     settings = get_settings()
 
+    # Validate matter ownership — a non-null project_id the caller doesn't own
+    # is rejected 404 (id-probing-safe). NULL = no matter; no check needed.
+    if body.project_id is not None:
+        await _load_owned_project(db, project_id=body.project_id, user_id=user_id)
+
     params: dict[str, object] = {"since": None}
     if body.target_kb_id is not None:
         params["kb_id"] = str(body.target_kb_id)
@@ -1145,6 +1156,7 @@ async def _spawn_manual_session(
         201: {"description": "Session spawned"},
         403: {"description": "Autonomous layer not enabled for this user"},
         422: {"description": "Invalid target (need exactly one of playbook_id/skill_ref)"},
+        404: {"description": "Referenced project not found"},
         401: {"description": "Not authenticated"},
     },
 )
@@ -1233,7 +1245,7 @@ async def list_schedules(
     response_model=AutonomousScheduleRead,
     summary="Partially update an autonomous schedule (edit / enable / disable)",
     responses={
-        404: {"description": "Schedule not found"},
+        404: {"description": "Schedule or referenced project not found"},
         422: {"description": "Invalid cron expression"},
         401: {"description": "Not authenticated"},
     },
@@ -1280,6 +1292,11 @@ async def update_schedule(
         schedule.skill_ref = fields["skill_ref"]
     if "target_kb_id" in fields:
         schedule.target_kb_id = fields["target_kb_id"]
+    if "project_id" in fields:
+        new_project_id = fields["project_id"]
+        if new_project_id is not None:
+            await _load_owned_project(db, project_id=new_project_id, user_id=user.id)
+        schedule.project_id = new_project_id  # explicit null clears the matter
     if "max_cost_usd" in fields:
         # Per design: NULL clears the per-schedule cap → fall back to global default.
         # `exclude_unset=True` makes "explicitly sent null" distinguishable from "omitted".
@@ -1360,7 +1377,7 @@ async def delete_schedule(
     summary="Create an autonomous watch (KB-arrival-triggered run definition)",
     responses={
         201: {"description": "Watch created"},
-        404: {"description": "Target knowledge base not found"},
+        404: {"description": "Target knowledge base or referenced project not found"},
         401: {"description": "Not authenticated"},
     },
 )
@@ -1392,6 +1409,11 @@ async def create_watch(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="knowledge base not found",
         )
+
+    # Validate matter ownership — a non-null project_id the caller doesn't own
+    # is rejected 404 (id-probing-safe). NULL = no matter; no check needed.
+    if body.project_id is not None:
+        await _load_owned_project(db, project_id=body.project_id, user_id=user.id)
 
     watch = AutonomousWatch(
         user_id=user.id,
@@ -1480,7 +1502,7 @@ async def list_watches(
     response_model=AutonomousWatchRead,
     summary="Partially update an autonomous watch (enable / disable / retarget)",
     responses={
-        404: {"description": "Watch not found"},
+        404: {"description": "Watch or referenced project not found"},
         401: {"description": "Not authenticated"},
     },
 )
@@ -1511,6 +1533,11 @@ async def update_watch(
         watch.playbook_id = fields["playbook_id"]
     if "skill_ref" in fields:
         watch.skill_ref = fields["skill_ref"]
+    if "project_id" in fields:
+        new_project_id = fields["project_id"]
+        if new_project_id is not None:
+            await _load_owned_project(db, project_id=new_project_id, user_id=user.id)
+        watch.project_id = new_project_id  # explicit null clears the matter
     if "max_cost_usd" in fields:
         # Per design: NULL clears the per-watch cap → fall back to global default.
         # `exclude_unset=True` makes "explicitly sent null" distinguishable from "omitted".

--- a/api/app/schemas/autonomous.py
+++ b/api/app/schemas/autonomous.py
@@ -176,6 +176,9 @@ class AutonomousScheduleUpdate(BaseModel):
     it is re-validated (invalid → 422) and ``next_run_at`` is recomputed.
     Toggling ``enabled`` is allowed. ``max_cost_usd`` may be edited
     (NULL clears the per-schedule cap → fall back to global default).
+    The matter (``project_id``) may be reassigned; an explicit ``null``
+    clears it (unassign). A non-null ``project_id`` the caller does not
+    own is rejected (404, id-probing-safe).
     """
 
     name: str | None = None
@@ -184,6 +187,7 @@ class AutonomousScheduleUpdate(BaseModel):
     playbook_id: uuid.UUID | None = None
     skill_ref: str | None = None
     target_kb_id: uuid.UUID | None = None
+    project_id: uuid.UUID | None = None
     max_cost_usd: Decimal | None = None
 
 
@@ -275,12 +279,16 @@ class AutonomousWatchUpdate(BaseModel):
     allowed; ``playbook_id`` / ``skill_ref`` may be retargeted. The
     watch's ``knowledge_base_id`` is immutable (not present here) — a
     watch is bound to its KB. ``max_cost_usd`` may be edited (NULL clears
-    the per-watch cap → fall back to global default).
+    the per-watch cap → fall back to global default). The matter
+    (``project_id``) may be reassigned; an explicit ``null`` clears it
+    (unassign). A non-null ``project_id`` the caller does not own is
+    rejected (404, id-probing-safe).
     """
 
     enabled: bool | None = None
     playbook_id: uuid.UUID | None = None
     skill_ref: str | None = None
+    project_id: uuid.UUID | None = None
     max_cost_usd: Decimal | None = None
 
 

--- a/api/tests/autonomous/test_project_reassign_ownership.py
+++ b/api/tests/autonomous/test_project_reassign_ownership.py
@@ -1,0 +1,646 @@
+"""Matter (project_id) reassignment + ownership validation across the
+autonomous schedule / watch / run-now surfaces.
+
+Two concerns are exercised here:
+
+1. **Reassignment** — ``project_id`` is now patchable on schedules and
+   watches. An owned project_id is accepted (200, row reflects it); an
+   explicit ``null`` clears the matter (unassign); an omitted project_id
+   leaves the existing matter unchanged (``exclude_unset`` back-compat).
+
+2. **Ownership** — assigning a non-null project_id the caller does not own
+   (another user's project, or a random UUID) is rejected **404**
+   (id-probing-safe via ``_load_owned_project``) on EVERY assignment site:
+   create_schedule, update_schedule, create_watch, update_watch, and the
+   run-now ``_spawn_manual_session``. On the update sites, the row MUST NOT
+   be mutated when the foreign project is rejected.
+
+Fixtures mirror ``test_schedules.py`` / ``test_watches.py`` / ``test_run_now.py``:
+a per-file ``client`` fixture overriding ``get_db`` onto the SAVEPOINT
+session, locally-built ``autonomous_enabled`` users, ``_bearer()`` headers,
+and a stubbed enqueue so run-now never touches Redis.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.api.autonomous as autonomous_api
+from app.db.session import get_db
+from app.main import app
+from app.models.autonomous import AutonomousSchedule, AutonomousSession, AutonomousWatch
+from app.models.knowledge import KnowledgeBase
+from app.models.project import Project
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture(autouse=True)
+def _stub_enqueue(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run-now enqueues onto arq; stub to an async no-op so missing Redis never errors."""
+    monkeypatch.setattr(
+        autonomous_api, "enqueue_autonomous_session_job", AsyncMock(return_value=True)
+    )
+
+
+async def _make_user(db: AsyncSession, *, suffix: str = "") -> User:
+    user = User(
+        email=f"reassign-{suffix or uuid.uuid4().hex[:8]}@example.com",
+        display_name=f"Reassign User {suffix}".strip(),
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+        autonomous_enabled=True,  # mutate endpoints require opt-in
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def user_a(db_session: AsyncSession) -> User:
+    return await _make_user(db_session, suffix="a")
+
+
+@pytest_asyncio.fixture
+async def user_b(db_session: AsyncSession) -> User:
+    return await _make_user(db_session, suffix="b")
+
+
+def _bearer(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_project(db: AsyncSession, *, owner: User, name: str = "Acme Deal") -> Project:
+    project = Project(
+        owner_id=owner.id,
+        name=name,
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(project)
+    await db.flush()
+    await db.refresh(project)
+    return project
+
+
+async def _make_schedule(
+    db: AsyncSession,
+    *,
+    user: User,
+    project_id: uuid.UUID | None = None,
+    cron_expr: str = "*/5 * * * *",
+) -> AutonomousSchedule:
+    sched = AutonomousSchedule(
+        user_id=user.id,
+        cron_expr=cron_expr,
+        enabled=True,
+        project_id=project_id,
+    )
+    db.add(sched)
+    await db.flush()
+    await db.refresh(sched)
+    return sched
+
+
+async def _make_kb(db: AsyncSession, *, owner: User) -> KnowledgeBase:
+    kb = KnowledgeBase(owner_id=owner.id, name="watched")
+    db.add(kb)
+    await db.flush()
+    await db.refresh(kb)
+    return kb
+
+
+async def _make_watch(
+    db: AsyncSession,
+    *,
+    user: User,
+    kb: KnowledgeBase,
+    project_id: uuid.UUID | None = None,
+) -> AutonomousWatch:
+    watch = AutonomousWatch(
+        user_id=user.id,
+        knowledge_base_id=kb.id,
+        enabled=True,
+        project_id=project_id,
+        deleted_at=None,
+    )
+    db.add(watch)
+    await db.flush()
+    await db.refresh(watch)
+    return watch
+
+
+# ===========================================================================
+# Schedule — create ownership
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_create_schedule_owned_project_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    project = await _make_project(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "project_id": str(project.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["project_id"] == str(project.id)
+
+
+@pytest.mark.integration
+async def test_create_schedule_no_project_succeeds(
+    client: AsyncClient,
+    user_a: User,
+) -> None:
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["project_id"] is None
+
+
+@pytest.mark.integration
+async def test_create_schedule_foreign_project_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    """The closed gap: project_id is from user input; another user's → 404 (no row)."""
+    foreign = await _make_project(db_session, owner=user_b)
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "project_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    # No schedule was created for user_a.
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousSchedule).where(AutonomousSchedule.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.integration
+async def test_create_schedule_nonexistent_project_returns_404(
+    client: AsyncClient,
+    user_a: User,
+) -> None:
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "project_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+# ===========================================================================
+# Schedule — update (reassign / unassign / omit / foreign-404)
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_patch_schedule_reassigns_matter(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    old_project = await _make_project(db_session, owner=user_a, name="Old Matter")
+    new_project = await _make_project(db_session, owner=user_a, name="New Matter")
+    sched = await _make_schedule(db_session, user=user_a, project_id=old_project.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"project_id": str(new_project.id)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] == str(new_project.id)
+
+    await db_session.refresh(sched)
+    assert sched.project_id == new_project.id
+
+
+@pytest.mark.integration
+async def test_patch_schedule_explicit_null_unassigns_matter(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    project = await _make_project(db_session, owner=user_a)
+    sched = await _make_schedule(db_session, user=user_a, project_id=project.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"project_id": None},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] is None
+
+    await db_session.refresh(sched)
+    assert sched.project_id is None
+
+
+@pytest.mark.integration
+async def test_patch_schedule_omitted_project_leaves_matter_unchanged(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """exclude_unset: a PATCH that does not send project_id must not clear it."""
+    project = await _make_project(db_session, owner=user_a)
+    sched = await _make_schedule(db_session, user=user_a, project_id=project.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"name": "renamed only"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] == str(project.id)
+
+    await db_session.refresh(sched)
+    assert sched.project_id == project.id
+
+
+@pytest.mark.integration
+async def test_patch_schedule_foreign_project_returns_404_no_mutation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    original = await _make_project(db_session, owner=user_a)
+    foreign = await _make_project(db_session, owner=user_b)
+    sched = await _make_schedule(db_session, user=user_a, project_id=original.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"project_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+
+    # The row's matter is unchanged — the foreign assignment was rejected.
+    await db_session.refresh(sched)
+    assert sched.project_id == original.id
+
+
+@pytest.mark.integration
+async def test_patch_schedule_nonexistent_project_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    sched = await _make_schedule(db_session, user=user_a)
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"project_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404, resp.text
+    await db_session.refresh(sched)
+    assert sched.project_id is None
+
+
+# ===========================================================================
+# Watch — create ownership
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_create_watch_owned_project_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    project = await _make_project(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(kb.id), "project_id": str(project.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["project_id"] == str(project.id)
+
+
+@pytest.mark.integration
+async def test_create_watch_no_project_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(kb.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["project_id"] is None
+
+
+@pytest.mark.integration
+async def test_create_watch_foreign_project_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    foreign = await _make_project(db_session, owner=user_b)
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(kb.id), "project_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousWatch).where(AutonomousWatch.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.integration
+async def test_create_watch_nonexistent_project_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(kb.id), "project_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+# ===========================================================================
+# Watch — update (reassign / unassign / omit / foreign-404)
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_patch_watch_reassigns_matter(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    old_project = await _make_project(db_session, owner=user_a, name="Old")
+    new_project = await _make_project(db_session, owner=user_a, name="New")
+    watch = await _make_watch(db_session, user=user_a, kb=kb, project_id=old_project.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/watches/{watch.id}",
+        headers=_bearer(user_a),
+        json={"project_id": str(new_project.id)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] == str(new_project.id)
+
+    await db_session.refresh(watch)
+    assert watch.project_id == new_project.id
+
+
+@pytest.mark.integration
+async def test_patch_watch_explicit_null_unassigns_matter(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    project = await _make_project(db_session, owner=user_a)
+    watch = await _make_watch(db_session, user=user_a, kb=kb, project_id=project.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/watches/{watch.id}",
+        headers=_bearer(user_a),
+        json={"project_id": None},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] is None
+
+    await db_session.refresh(watch)
+    assert watch.project_id is None
+
+
+@pytest.mark.integration
+async def test_patch_watch_omitted_project_leaves_matter_unchanged(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    project = await _make_project(db_session, owner=user_a)
+    watch = await _make_watch(db_session, user=user_a, kb=kb, project_id=project.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/watches/{watch.id}",
+        headers=_bearer(user_a),
+        json={"enabled": False},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] == str(project.id)
+
+    await db_session.refresh(watch)
+    assert watch.project_id == project.id
+
+
+@pytest.mark.integration
+async def test_patch_watch_foreign_project_returns_404_no_mutation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    original = await _make_project(db_session, owner=user_a)
+    foreign = await _make_project(db_session, owner=user_b)
+    watch = await _make_watch(db_session, user=user_a, kb=kb, project_id=original.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/watches/{watch.id}",
+        headers=_bearer(user_a),
+        json={"project_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+
+    await db_session.refresh(watch)
+    assert watch.project_id == original.id
+
+
+@pytest.mark.integration
+async def test_patch_watch_nonexistent_project_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    watch = await _make_watch(db_session, user=user_a, kb=kb)
+    resp = await client.patch(
+        f"/api/v1/autonomous/watches/{watch.id}",
+        headers=_bearer(user_a),
+        json={"project_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404, resp.text
+    await db_session.refresh(watch)
+    assert watch.project_id is None
+
+
+# ===========================================================================
+# Run-now — ownership
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_run_now_owned_project_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    project = await _make_project(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        headers=_bearer(user_a),
+        json={"skill_ref": "nda-review", "project_id": str(project.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = uuid.UUID(resp.json()["id"])
+    row = (
+        await db_session.execute(
+            select(AutonomousSession).where(AutonomousSession.id == session_id)
+        )
+    ).scalar_one()
+    assert row.project_id == project.id
+
+
+@pytest.mark.integration
+async def test_run_now_no_project_succeeds(
+    client: AsyncClient,
+    user_a: User,
+) -> None:
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        headers=_bearer(user_a),
+        json={"skill_ref": "nda-review"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["project_id"] is None
+
+
+@pytest.mark.integration
+async def test_run_now_foreign_project_returns_404_no_session(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    foreign = await _make_project(db_session, owner=user_b)
+
+    # Count sessions before to assert none were spawned for user_a.
+    before = (
+        (
+            await db_session.execute(
+                select(AutonomousSession).where(AutonomousSession.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        headers=_bearer(user_a),
+        json={"skill_ref": "nda-review", "project_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+
+    after = (
+        (
+            await db_session.execute(
+                select(AutonomousSession).where(AutonomousSession.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(after) == len(before)
+
+
+@pytest.mark.integration
+async def test_run_now_nonexistent_project_returns_404(
+    client: AsyncClient,
+    user_a: User,
+) -> None:
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        headers=_bearer(user_a),
+        json={"skill_ref": "nda-review", "project_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+# ===========================================================================
+# OpenAPI conformance — project_id on Update schemas
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_openapi_update_schemas_carry_project_id() -> None:
+    schemas = app.openapi().get("components", {}).get("schemas", {})
+    sched_props = schemas["AutonomousScheduleUpdate"].get("properties", {})
+    watch_props = schemas["AutonomousWatchUpdate"].get("properties", {})
+    assert "project_id" in sched_props
+    assert "project_id" in watch_props

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -4320,6 +4320,8 @@ paths:
                 $ref: '#/components/schemas/AutonomousScheduleRead'
         '401':
           description: Not authenticated
+        '404':
+          description: Referenced project not found
         '422':
           description: Invalid cron expression
     get:
@@ -4384,7 +4386,7 @@ paths:
         '401':
           description: Not authenticated
         '404':
-          description: Schedule not found
+          description: Schedule or referenced project not found
         '422':
           description: Invalid cron expression
     delete:
@@ -4442,7 +4444,7 @@ paths:
         '401':
           description: Not authenticated
         '404':
-          description: Target knowledge base not found
+          description: Target knowledge base or referenced project not found
     get:
       tags: [autonomous]
       summary: List the calling user's autonomous watches (non-deleted, newest first)
@@ -4510,7 +4512,7 @@ paths:
         '401':
           description: Not authenticated
         '404':
-          description: Watch not found
+          description: Watch or referenced project not found
     delete:
       tags: [autonomous]
       summary: Soft-delete an autonomous watch (returns 200 with updated entity)
@@ -4633,6 +4635,8 @@ paths:
           description: Not authenticated
         '403':
           description: Autonomous layer not enabled for this user
+        '404':
+          description: Referenced project not found
         '422':
           description: Invalid target (need exactly one of playbook_id/skill_ref)
 
@@ -5588,7 +5592,9 @@ components:
       description: |
         Request body for ``PATCH /autonomous/schedules/{id}``.  All fields
         optional.  Changing ``cron_expr`` re-validates (422) and recomputes
-        ``next_run_at``.
+        ``next_run_at``.  The matter (``project_id``) may be reassigned; an
+        explicit ``null`` unassigns it, and a non-null ``project_id`` the
+        caller does not own returns 404 (id-probing-safe).
       properties:
         name: {type: string, nullable: true}
         cron_expr: {type: string, nullable: true}
@@ -5596,6 +5602,7 @@ components:
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
         target_kb_id: {type: string, format: uuid, nullable: true}
+        project_id: {type: string, format: uuid, nullable: true}
         max_cost_usd: {type: string, nullable: true}
 
     AutonomousManualRunRequest:
@@ -5674,11 +5681,15 @@ components:
       description: |
         Request body for ``PATCH /autonomous/watches/{id}``.  All fields
         optional.  The watch's ``knowledge_base_id`` is immutable (not
-        present here) — a watch is bound to its KB.
+        present here) — a watch is bound to its KB.  The matter
+        (``project_id``) may be reassigned; an explicit ``null`` unassigns
+        it, and a non-null ``project_id`` the caller does not own returns
+        404 (id-probing-safe).
       properties:
         enabled: {type: boolean, nullable: true}
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
+        project_id: {type: string, format: uuid, nullable: true}
         max_cost_usd: {type: string, nullable: true}
 
     AutonomousWatchListResponse:


### PR DESCRIPTION
Two things, both surfaced by Donna CC's Automations review.

## 1. Feature — make a schedule's/watch's matter reassignable
`AutonomousScheduleUpdate` / `AutonomousWatchUpdate` had no `project_id`, so a schedule/watch's matter was fixed at creation (a PATCH carrying `project_id` was silently dropped, and Donna had to render the matter read-only). Added `project_id` to both Update models — now PATCH can reassign the matter; an explicit `null` unassigns it; an omitted `project_id` leaves it unchanged (`exclude_unset` back-compat). Donna can swap the read-only matter control for an editable one.

## 2. Security — close a pre-existing project ownership gap (⚠️ authorization change)
While scoping I found `project_id` was assigned from user input with **no ownership check** at three sites — `create_schedule`, `create_watch`, and the run-now `_spawn_manual_session` — so a caller could point a schedule/watch/run at **another user's matter** (IDOR-shaped). This PR validates ownership via the existing `_load_owned_project` (404, id-probing-safe — conflates missing vs. another user's, no existence disclosure) at **all five** `project_id` assignment sites (the two creates, run-now, and the two new Update paths). Validation runs **before any write**, so a foreign/unknown `project_id` → 404 with no row created or mutated.

**Behavior change:** create/run-now now return **404** for an unowned `project_id` (previously accepted silently). Legitimate callers pass their own projects → unaffected; only adversarial/buggy callers passing an unowned id are now rejected. Validation is gated on `project_id is not None`, so the keyless/no-matter path is unchanged.

## Tests / contract
`api/tests/autonomous/test_project_reassign_ownership.py` (23 tests): for schedule, watch, and run-now — owned→success, none→success, foreign(second user's project)→404, nonexistent→404; plus update reassign / explicit-null unassign / omit-unchanged and **no-mutation-on-rejection** assertions. `backend-openapi.yaml` updated (`project_id` on both Update schemas + 404 documented on the five endpoints). No new path — `test_openapi` count stays 116. ruff + mypy clean.

> Flagging the **authorization** nature explicitly — happy to have you review before merge (like the gateway PR) rather than self-merge, your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)