### PR TITLE
added caddy with tailscale deployment

### DIFF
--- a/deploy/caddy-tailscale/.env.example
+++ b/deploy/caddy-tailscale/.env.example
@@ -1,0 +1,374 @@
+# ============================================================
+# LQ.AI — environment configuration
+# ============================================================
+# Copy this file to `.env` and edit. The four REQUIRED variables
+# (POSTGRES_PASSWORD, MINIO_ROOT_PASSWORD, LQ_AI_GATEWAY_KEY,
+# JWT_SECRET) must be set before `docker compose up` will succeed.
+#
+# For Mode 1 (cloud LLM), set at least one provider key.
+# For Mode 2 (local inference), set OLLAMA-related variables and
+# bring up with `docker compose --profile local up`.
+#
+# Each variable below is annotated:
+#   [REQUIRED]  — must be set; deployment fails without it.
+#   [OPTIONAL]  — has a sensible default; override only if needed.
+#   [PROVIDER]  — set if using that provider; leave blank otherwise.
+#   [MODE 2]    — only used when --profile local is active.
+#
+# Var inventory expanded in Task A1.d for OpenWebUI-specific
+# variables (DATABASE_URL for OpenWebUI's own state, ENABLE_*, etc.)
+# once the fork is imported.
+
+# ============================================================
+# PostgreSQL (storage backend per PRD §2.1)
+# ============================================================
+
+# Database name and credentials. The app database holds users,
+# chats, files, projects, audit log, and pgvector embeddings.
+POSTGRES_DB=lq_ai
+POSTGRES_USER=lq_ai
+
+# [REQUIRED] Long random string. Generate with:
+#   python -c 'import secrets; print(secrets.token_urlsafe(32))'
+POSTGRES_PASSWORD=
+
+# Host bind address and port for each service. By default every
+# service binds to 127.0.0.1 (localhost-only) so a fresh `docker
+# compose up` does NOT expose your stack to the local network or
+# the public internet. Operators who deploy on a host that should
+# accept LAN/WAN traffic set the relevant *_BIND_ADDR to 0.0.0.0
+# (or a specific interface IP) — front the gateway/api/web with a
+# reverse proxy that terminates TLS and adds the rate-limiting
+# you want before doing so. Postgres / Redis / MinIO should remain
+# 127.0.0.1 in nearly all deployments; production reaches them
+# over Docker's internal network, not the host.
+POSTGRES_BIND_ADDR=127.0.0.1
+# Default 5432 matches the Postgres convention so `psql -h localhost` and
+# typical db-tooling defaults just work. If you already have a host
+# postgres holding :5432 (common on macOS with Homebrew), set this to
+# something free (e.g. 15432). The compose stack's internal traffic
+# uses 5432 unchanged either way — only the host-side mapping shifts.
+POSTGRES_HOST_PORT=5432
+
+# [OPTIONAL] Override the full DATABASE_URL only if you need a
+# non-Compose Postgres (e.g., RDS for production). The default
+# is derived from POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB.
+# DATABASE_URL=postgresql+asyncpg://lq_ai:CHANGEME@postgres:5432/lq_ai
+
+# ============================================================
+# Redis (sessions, queues, rate-limit token bucket)
+# ============================================================
+
+# [OPTIONAL] Default reaches the Compose service. Override to use
+# an external Redis (e.g., ElastiCache) in production.
+REDIS_URL=redis://redis:6379/0
+REDIS_BIND_ADDR=127.0.0.1
+REDIS_HOST_PORT=6379
+
+# ============================================================
+# MinIO / S3 (file storage per PRD §2.1)
+# ============================================================
+
+MINIO_ROOT_USER=lq_ai
+
+# [REQUIRED] Long random string. Generate with the same command
+# as POSTGRES_PASSWORD above.
+MINIO_ROOT_PASSWORD=
+
+# [OPTIONAL] S3 endpoint configuration. Override to use real S3
+# (or another S3-compatible store) in production. The default
+# values reach the Compose minio service.
+S3_ENDPOINT_URL=http://minio:9000
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+S3_BUCKET=lq-ai-files
+S3_REGION=us-east-1
+
+# [OPTIONAL] Per-request cap on uploaded-file size in MB (Task C4).
+# The backend streams uploads (no full-body buffering) and raises 413 the
+# instant the running byte count exceeds this limit. Operators raising
+# this must also raise their reverse-proxy / ingress body-size limit
+# (e.g., nginx `client_max_body_size`; Traefik `maxRequestBodyBytes`).
+LQ_AI_MAX_UPLOAD_SIZE_MB=100
+
+# Host ports for the MinIO API (S3-compatible) and console.
+MINIO_BIND_ADDR=127.0.0.1
+MINIO_API_HOST_PORT=9000
+MINIO_CONSOLE_HOST_PORT=9001
+
+# ============================================================
+# Inference Gateway (the security boundary, per PRD §4)
+# ============================================================
+
+# [REQUIRED] Shared secret between backend and gateway. The backend
+# includes this in the X-LQ-AI-Gateway-Key header on every
+# request to the gateway; the gateway rejects requests without it.
+# Generate with:
+#   python -c 'import secrets; print(secrets.token_urlsafe(32))'
+LQ_AI_GATEWAY_KEY=
+
+# [OPTIONAL] Override gateway URL (default reaches Compose service).
+LQ_AI_GATEWAY_URL=http://gateway:8001
+
+# Host port for direct gateway access (admin endpoints, debugging).
+GATEWAY_BIND_ADDR=127.0.0.1
+GATEWAY_HOST_PORT=8001
+
+# [OPTIONAL] Path to the gateway config file (mounted as /etc/gateway.yaml
+# inside the gateway container). Default points at gateway.yaml.example so
+# `docker compose up` works without operator setup. For real deployments:
+# cp gateway.yaml.example gateway.yaml, edit, then set
+# GATEWAY_CONFIG_FILE=./gateway.yaml here.
+GATEWAY_CONFIG_FILE=./gateway.yaml.example
+
+# ============================================================
+# Backend API (FastAPI service per PRD §2.1)
+# ============================================================
+
+# [REQUIRED] JWT signing secret for access and refresh tokens
+# (per ADR 0002, the backend owns auth). Generate with:
+#   python -c 'import secrets; print(secrets.token_urlsafe(64))'
+JWT_SECRET=
+
+# [OPTIONAL] Token TTLs in seconds. Defaults: 15min access,
+# 7 days refresh (per CONTRIBUTING.md / ADR 0002).
+JWT_ACCESS_TOKEN_TTL_SECONDS=900
+JWT_REFRESH_TOKEN_TTL_SECONDS=604800
+
+# Host port for the backend API.
+API_BIND_ADDR=127.0.0.1
+API_HOST_PORT=8000
+
+# ============================================================
+# Web client (OpenWebUI fork; lands in Task A1.d)
+# ============================================================
+
+# Branding and delegated-auth configuration per ADR 0002.
+WEBUI_NAME=LQ.AI
+WEBUI_AUTH=false
+WEBUI_URL=http://localhost:3000
+
+# [OPTIONAL] Backend URL for delegated auth + chat.
+LQ_AI_API_URL=http://api:8000
+
+# Host port the web client is exposed on.
+WEB_BIND_ADDR=127.0.0.1
+WEB_HOST_PORT=3000
+
+# Backend API URL the LQ.AI web shell calls. Vite bakes this into the
+# static build at image-build time (so it's a docker compose `args:`
+# value, not a runtime env). Production: leave unset (defaults to the
+# relative `/api/v1` path; deploy web + api at the same origin behind a
+# reverse proxy). Local Compose dev: must be the absolute URL of the
+# api container as the BROWSER sees it (i.e., http://localhost:8000),
+# not the in-network hostname (http://api:8000) — the browser is the
+# caller and resolves URLs from its own machine.
+PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1
+
+# CORS allowed origins for the api/. Empty disables CORS entirely.
+# Production behind a same-origin reverse proxy: leave UNSET. Local
+# Compose dev: http://localhost:3000 so the LQ.AI shell can call api/.
+LQ_AI_CORS_ORIGINS=http://localhost:3000
+
+# ============================================================
+# LLM provider keys (PRD §1.5.2 — Inference Choice Spectrum)
+# ============================================================
+# Set keys for whichever providers you want the gateway to route
+# to. The gateway.yaml (see gateway.yaml.example) declares which
+# providers are active and at which Inference Tier each routes.
+
+# [PROVIDER] Anthropic (Tier 4 by default; Tier 3 with ZDR addendum)
+ANTHROPIC_API_KEY=
+
+# [PROVIDER] OpenAI (Tier 4; Tier 3 with no-training contract)
+OPENAI_API_KEY=
+
+# [PROVIDER] Google Vertex AI (Tier 3 — operator's GCP project)
+# Path inside the gateway container to a service-account JSON file.
+# Mount the file via docker-compose.yml:gateway.volumes if used.
+GOOGLE_APPLICATION_CREDENTIALS=
+
+# [PROVIDER] AWS Bedrock (Tier 3 — operator's AWS account)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+
+# [PROVIDER] Azure OpenAI (Tier 3 — operator's Azure tenant)
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_RESOURCE=
+
+# ============================================================
+# Mode 2 — local inference (Tier 1; air-gap-capable)
+# ============================================================
+# Activated with: docker compose --profile local up
+
+# [MODE 2] Ollama base URL the gateway uses to reach Ollama.
+#
+# Two scenarios:
+#
+#   (A) HOST OLLAMA (typical macOS/Linux dev with `Ollama.app` or
+#       `brew install ollama`). The gateway runs in Docker; inside
+#       the container, `localhost:11434` is the container's loopback,
+#       NOT the host. Use Docker Desktop's DNS shim:
+#           OLLAMA_BASE_URL=http://host.docker.internal:11434
+#       This is the default below — host Ollama is the path most
+#       operators want, and this avoids the silent "discovery returns
+#       []" failure mode where the container points at a service that
+#       doesn't exist.
+#
+#   (B) IN-COMPOSE OLLAMA (air-gapped "Mode 2", started with
+#       `docker compose --profile local up`). The compose file brings
+#       up an `ollama` service; the gateway can reach it by name:
+#           OLLAMA_BASE_URL=http://ollama:11434
+#       Switch to this only when running --profile local; otherwise
+#       the container will try to resolve the `ollama` hostname and
+#       fail (silently — discovery returns [] per the never-raise
+#       posture, manifesting as "my Ollama models aren't showing up").
+#
+# Read by `gateway.yaml.example`'s `ollama-local` provider entry.
+OLLAMA_BASE_URL=http://host.docker.internal:11434
+OLLAMA_BIND_ADDR=127.0.0.1
+OLLAMA_HOST_PORT=11434
+
+# ============================================================
+# Observability (PRD §5.4 — off by default)
+# ============================================================
+
+# [OPTIONAL] OpenTelemetry endpoint. When set, both api and gateway
+# emit traces / metrics / logs to this endpoint over OTLP/HTTP.
+OTEL_EXPORTER_OTLP_ENDPOINT=
+
+# [OPTIONAL] Langfuse self-hosted observability for LLM-specific
+# tracing (per PRD §5.4). Leave blank to disable.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+LANGFUSE_HOST=
+
+# ============================================================
+# Operational
+# ============================================================
+
+# Logging level applied to api and gateway (debug | info | warn | error).
+LOG_LEVEL=info
+
+# Set to `true` to relax some safety checks during local development.
+# Per gateway.yaml.example, even dev mode keeps tier-5 disallowed
+# and rate limits active.
+LQ_AI_DEV_MODE=false
+
+# ============================================================
+# Document pipeline (Task C5; PRD §3 / ADR 0006)
+# ============================================================
+#
+# The document-pipeline worker (`ingest-worker` service) consumes
+# uploaded files from MinIO, parses them with PyMuPDF (canonical text
+# + byte-precise offsets) and Docling (structured representation, M2
+# consumption), produces character-precise chunks, and writes the
+# `documents` + `document_chunks` rows. ADR 0006 records the
+# architectural call-outs (parser cascade, embedding deferral to C6,
+# idempotency-on-replace).
+
+# How many ingest jobs the worker runs concurrently. Each is
+# CPU-bound; 2 is conservative and works on a single-core dev box.
+# Bump on multi-core dedicated hosts.
+LQ_AI_INGEST_WORKER_CONCURRENCY=2
+
+# Per-job timeout for the entire pipeline (parse + chunk + persist).
+# Docling can take >60s on multi-page contracts; 300s is a generous
+# default. Operators with structurally larger documents should raise.
+LQ_AI_DOCLING_TIMEOUT_SECONDS=300
+
+# When `false`, skip the Docling pass entirely and use PyMuPDF only.
+# Useful when Docling isnt available (constrained Python builds,
+# air-gapped environments without HuggingFace network access).
+LQ_AI_DOCLING_ENABLED=true
+
+# Chunker shape. Defaults are tuned for ~500-token chunks at the
+# typical English-prose char/token ratio. The chunker snaps the
+# actual end to a sentence terminator within a 200-char lookback
+# when possible; offsets stay character-precise either way.
+LQ_AI_CHUNK_TARGET_CHARS=2000
+LQ_AI_CHUNK_OVERLAP_CHARS=200
+
+# ============================================================
+# M3-D1 — slack-bridge integration
+# ============================================================
+#
+# The slack-bridge is an OPT-IN service gated by the `slack` Compose
+# profile. Operators who don't use Slack can leave all of the
+# variables below unset; the api refuses any inbound bridge traffic
+# with HTTP 500 in that state (rather than running open). Bring up
+# the bridge with: `docker compose --profile slack up -d slack-bridge`.
+
+# Slack-side credentials (from the operator's Slack App admin UI;
+# see slack-bridge/manifest.yml for the App manifest).
+SLACK_CLIENT_ID=
+SLACK_CLIENT_SECRET=
+SLACK_SIGNING_SECRET=
+
+# Shared bearer token the slack-bridge presents on its POSTs to
+# /api/v1/integrations/slack/workspaces. The api validates with the
+# same env var. Constant-time matched. Generate any sufficiently long
+# random string, e.g. `python -c 'import secrets; print(secrets.token_urlsafe(48))'`.
+LQ_AI_BRIDGE_TOKEN=
+
+# urlsafe-base64 Fernet master key used to encrypt Slack bot tokens
+# at rest in slack_workspaces.bot_token_encrypted. Distinct from
+# LQ_AI_GATEWAY_MASTER_KEY on purpose — different threat models. Mint
+# with `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'`.
+LQ_AI_BRIDGE_MASTER_KEY=
+
+# Externally reachable base URL of the slack-bridge — Slack uses this
+# to construct the OAuth callback URL. Operators typically front this
+# with their reverse proxy (e.g. https://lqai.example.com/slack).
+LQ_AI_BRIDGE_PUBLIC_URL=
+
+# Optional override of where the bridge dials the api inside the
+# compose network. Defaults to http://api:8000 (the in-network DNS).
+LQ_AI_BACKEND_URL=
+
+# Optional host-side bind for the slack-bridge port (defaults to
+# 127.0.0.1:8002). Most deployments leave this alone and reach the
+# bridge through their reverse proxy.
+SLACK_BRIDGE_BIND_ADDR=
+SLACK_BRIDGE_HOST_PORT=
+
+# ============================================================
+# M3-D3 — teams-bridge integration
+# ============================================================
+#
+# Mirrors the slack-bridge posture for Microsoft Teams. Gated by the
+# `teams` Compose profile. LQ_AI_BRIDGE_TOKEN above is REUSED for
+# teams-bridge → api auth per M3-D3 decision #2 (same bearer for both
+# bridges). Unlike Slack, Teams has NO per-tenant bot token to encrypt
+# — the bot uses operator-supplied APP-LEVEL credentials below.
+
+# Microsoft-side credentials (from operator's Azure AD multi-tenant
+# app registration; see teams-bridge/README.md for the registration
+# walk-through).
+MICROSOFT_APP_ID=
+MICROSOFT_APP_PASSWORD=
+
+# Externally reachable base URL of the teams-bridge — Microsoft uses
+# this to construct the OAuth callback URL. Operators typically front
+# this with their reverse proxy (e.g. https://lqai.example.com/teams).
+LQ_AI_TEAMS_BRIDGE_PUBLIC_URL=
+
+# Optional host-side bind for the teams-bridge port (defaults to
+# 127.0.0.1:8003).
+TEAMS_BRIDGE_BIND_ADDR=
+TEAMS_BRIDGE_HOST_PORT=
+LQ_AI_TEAMS_BRIDGE_LOG_LEVEL=
+# ============================================================
+# Caddy reverse proxy (designed for use with the host's Tailscale)
+# ============================================================
+
+# If you change CADDY_HOST_PORT below, point `tailscale serve` at
+# the new port (e.g., `http://127.0.0.1:8080`).
+CADDY_BIND_ADDR=127.0.0.1
+
+# [OPTIONAL] Host port Caddy listens on. 80 is the default so URLs
+# don't need an explicit port; pick a free non-privileged port (e.g.
+# 8080) if something else already owns 80 on the host, and remember
+# to update the `tailscale serve` upstream target accordingly.
+CADDY_HOST_PORT=80

--- a/deploy/caddy-tailscale/Caddyfile
+++ b/deploy/caddy-tailscale/Caddyfile
@@ -1,0 +1,16 @@
+{
+	auto_https off
+}
+
+:80 {
+	encode gzip zstd
+
+	handle /lq-ai-api/v1/* {
+		uri replace /lq-ai-api/v1 /api/v1
+		reverse_proxy api:8000
+	}
+
+	handle {
+		reverse_proxy web:8080
+	}
+}

--- a/deploy/caddy-tailscale/README.md
+++ b/deploy/caddy-tailscale/README.md
@@ -1,0 +1,191 @@
+# Caddy + Tailscale reverse proxy (tailnet-private)
+
+A reverse-proxy deployment recipe that puts **Caddy** in front of the LQ.AI web
+shell and backend and serves it **privately over your tailnet**, with HTTPS
+terminated by the host's **Tailscale** rather than by the proxy itself.
+
+> **Relation to the other recipes:** the `reverse-proxy/{caddy,traefik,nginx}`
+> recipes (DE-031) terminate TLS *at the proxy* for a **public** FQDN
+> (Let's Encrypt or operator-provided certs, public DNS A record, port 80 open
+> for the HTTP-01 challenge). This recipe is the **tailnet** alternative: no
+> public DNS, no inbound ports, no ACME — the UI is reachable only from devices
+> on your tailnet, and the certificate is handled by Tailscale. Reach for it
+> when you want a private, share-with-the-team URL rather than a public one.
+
+## When to use this
+
+- You want the UI on your **tailnet only**, not the public internet.
+- You don't want to manage a public DNS record, open inbound ports, or run
+  Let's Encrypt yourself.
+- You already run Tailscale on the deployment host.
+
+If you need a publicly reachable URL, use one of the `reverse-proxy` recipes
+instead.
+
+## How it works
+
+```
+Browser  →  https://<host>.<tailnet>.ts.net    valid, auto-renewing TLS cert
+         →  127.0.0.1:${CADDY_HOST_PORT}        host loopback (tailscale serve)
+         →  caddy container                      Docker port map
+         →  api:8000  /  web:8080                Compose bridge network
+```
+
+Tailscale does **not** run in Docker here. The host's existing `tailscale`
+publishes Caddy on the tailnet via `tailscale serve`, terminates TLS, and
+forwards decrypted traffic to Caddy on loopback. Caddy issues no certificates
+of its own (`auto_https off`) and only routes plain HTTP on `:80` inside the
+container. Caddy is given no tailnet identity — the host owns that.
+
+## Prerequisites
+
+- A **Linux host** with Docker and Docker Compose.
+- **Tailscale installed and authenticated** on that host, with `tailscale` in
+  `PATH`.
+- For the recommended (HTTPS) path, your tailnet must have **MagicDNS** and
+  **HTTPS Certificates** enabled (admin console → **DNS** → *HTTPS
+  Certificates* → **Enable HTTPS**). If they aren't enabled, the
+  `tailscale serve` command below prompts you with a consent URL to enable them.
+- The base `docker-compose.yml` stack (`web`, `api`, and their dependencies).
+
+## Quick start (recommended — gives you HTTPS)
+
+1. Bring up the stack with this overlay composed onto the base file:
+   ```bash
+   docker compose \
+     -f docker-compose.yml \
+     -f deploy/caddy-tailscale/docker-compose.proxy.yml \
+     up -d
+   ```
+   <!-- Adjust the overlay filename if yours differs from docker-compose.proxy.yml. -->
+2. Run this **once** on the host (not in a container):
+   ```bash
+   sudo tailscale serve --bg --https=443 http://127.0.0.1:80
+   ```
+   This lives in the host's Tailscale config and persists across host and stack
+   reboots. It terminates HTTPS with a valid, auto-renewing certificate for your
+   tailnet name (publicly trusted — no `-k` needed) and proxies to Caddy on
+   loopback.
+3. Open the UI from any device on your tailnet:
+   ```
+   https://<host>.<tailnet>.ts.net
+   ```
+
+If you change `CADDY_HOST_PORT`, point the `tailscale serve` upstream at the new
+port (e.g. `http://127.0.0.1:8080`). That command runs on the host, outside
+Compose, so it will not pick up the change on its own.
+
+## Verify it's live
+
+From any tailnet device:
+
+```bash
+# TLS terminates and the web shell answers (expect HTTP/2 200, valid cert):
+curl -fI https://<host>.<tailnet>.ts.net/
+
+# Inspect the active serve config on the host:
+tailscale serve status
+```
+
+A `200` over `https://` with no certificate warning confirms the full path:
+Tailscale TLS → loopback → Caddy → `web`.
+
+## Configuration
+
+| Variable          | Default     | Purpose                            |
+| ----------------- | ----------- | ---------------------------------- |
+| `CADDY_BIND_ADDR` | `127.0.0.1` | Host interface Caddy publishes on. |
+| `CADDY_HOST_PORT` | `80`        | Host port Caddy listens on.        |
+
+**`CADDY_BIND_ADDR`**
+- `127.0.0.1` — loopback only; pair with `tailscale serve` (recommended, HTTPS).
+- `100.x.y.z` — bind directly to the host's Tailscale IP (`tailscale ip -4`);
+  HTTP only over the tailnet (see the alternative below).
+- `0.0.0.0` — all host interfaces, **including LAN/WAN**. Only use this behind a
+  host firewall.
+
+**`CADDY_HOST_PORT`** — `80` keeps URLs port-free. If something already owns 80
+on the host, pick a free non-privileged port (e.g. `8080`) and update the
+`tailscale serve` target to match.
+
+## Routing
+
+| Path              | Destination | Notes                                            |
+| ----------------- | ----------- | ------------------------------------------------ |
+| `/lq-ai-api/v1/*` | `api:8000`  | LQ.AI backend; prefix rewritten to `/api/v1`.    |
+| `/*`              | `web:8080`  | Web container (OpenWebUI shell + its `/api/v1`). |
+
+The gateway is **not** routed through Caddy. Per PRD §4 it is the security
+boundary holding privileged provider keys; admin access stays on
+`127.0.0.1:${GATEWAY_HOST_PORT}`.
+
+### Why the `/lq-ai-api/v1` prefix?
+
+Per ADR 0009 the web container serves two shells side by side:
+
+- `/` — OpenWebUI's shell, which calls OpenWebUI's own `/api/v1` (OpenWebUI is
+  full-stack, so that API lives inside the web container).
+- `/lq-ai/*` — the LQ.AI shell, which calls the LQ.AI backend (the `api`
+  container).
+
+The LQ.AI backend also mounts at `/api/v1`, so same-origin behind Caddy the two
+`/api/v1` namespaces collide. Caddy resolves this by giving the LQ.AI backend
+its own public prefix, `/lq-ai-api/v1`, and rewriting it back to `/api/v1`
+before proxying. Everything else falls through to the web container, so
+OpenWebUI's own `/api/v1` is left untouched. WebSocket/SSE upgrades (used by the
+chat surface) are handled automatically by Caddy's `reverse_proxy`.
+
+## Using the LQ.AI shell over the tailnet
+
+This only matters if you use the LQ.AI shell at `/lq-ai`. If you only use
+OpenWebUI's shell at `/`, skip this — the default
+`PUBLIC_LQ_AI_API_BASE_URL=http://localhost:8000/api/v1` is fine, because the
+LQ.AI client never gets called. 
+
+To make `/lq-ai` work from any tailnet device (not just the Docker host), set:
+
+```
+PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1
+```
+
+then rebuild `web` so Vite bakes the new prefix into the static bundle:
+
+```bash
+docker compose -f docker-compose.yml -f deploy/caddy-tailscale/docker-compose.proxy.yml build web
+docker compose -f docker-compose.yml -f deploy/caddy-tailscale/docker-compose.proxy.yml up -d
+```
+
+Leaving it as `http://localhost:8000/...` breaks LQ.AI-shell calls from any
+device that is not the Docker host itself. The .env.example in this directory already has this changed. 
+
+## Alternative: bind Caddy straight to the tailnet (HTTP only)
+
+If you would rather skip `tailscale serve`, set `CADDY_BIND_ADDR` to the host's
+Tailscale IP (`tailscale ip -4`). Caddy then listens on that IP directly and the
+UI is reachable at `http://<host>:${CADDY_HOST_PORT}` over the tailnet.
+
+Traffic is still WireGuard-encrypted on the wire, but browsers treat the
+connection as plain **HTTP**, which affects cookies and Service Workers. The
+`tailscale serve` path is preferred for that reason.
+
+## Operational notes
+
+- **Certificates.** Tailscale provisions and auto-renews the TLS certificate for
+  your tailnet name; there is nothing to rotate on your side. This is the main
+  reason to choose this recipe over the ACME recipes.
+- **Startup ordering.** Caddy depends on `web` (`service_started`) and `api`
+  (`service_healthy`). `web` is not gated on health because its first boot pulls
+  embedding models from HuggingFace and can take minutes to become healthy. `service_started` is enough for DNS
+  resolution; until `web` is actually listening Caddy returns 502, which is a
+  recoverable state — preferable to holding the whole tailnet entry point down.
+- **Persistence.** Caddy's `/data` (state) and `/config` (autosave config) are
+  kept in the `caddy-data` and `caddy-config` named volumes.
+
+## Files
+
+```
+deploy/caddy-tailscale/
+├── README.md                    # this file
+├── docker-compose.proxy.yml     # Caddy service + overlays onto the base stack
+└── Caddyfile                    # auto_https off; :80; path routing to web/api
+```

--- a/deploy/caddy-tailscale/docker-compose.proxy.yml
+++ b/deploy/caddy-tailscale/docker-compose.proxy.yml
@@ -1,0 +1,66 @@
+name: lq-ai
+
+services:
+  # ============================================================
+  # Reverse proxy (optional; designed for use with the host's Tailscale)
+  # ============================================================
+  #
+  # This profile adds a Caddy reverse proxy in front of the web shell
+  # and backend. Caddy is NOT given its own tailnet identity — it
+  # publishes on the host's loopback by default, and the host's
+  # already-installed Tailscale fronts it via `tailscale serve`.
+  #
+  # Recommended end-to-end path (Linux host with `tailscale` in PATH):
+  #
+  #   Browser  →  https://<host>.<tailnet>.ts.net   (Tailscale CA cert)
+  #            →  127.0.0.1:80  on the host         (tailscale serve)
+  #            →  caddy container                    (Docker port map)
+  #            →  api:8000  /  web:8080              (Compose bridge net)
+  #
+  # One-time setup after `docker compose up -d`:
+  #
+  #   sudo tailscale serve --bg --https=443 / http://127.0.0.1:80
+  #
+  # That command lives in the HOST's tailscale config; it persists
+  # across host and stack reboots and gets the HTTPS cert from
+  # Tailscale's CA automatically. The Caddy container does not need
+  # to know anything about Tailscale.
+  #
+  # Caddy routes:
+  #   /api/v1/*  → api:8000   (FastAPI backend; ADR 0002 owns auth)
+  #   /*         → web:8080   (OpenWebUI fork — LQ.AI web shell)
+  #
+  # The gateway is intentionally NOT exposed via Caddy: per PRD §4 it
+  # is the security boundary holding privileged provider keys. Admin
+  # access to the gateway stays on 127.0.0.1:${GATEWAY_HOST_PORT}.
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      # web's first boot pulls embedding models from HuggingFace and
+      # may not become healthy for a few minutes. Don't block Caddy
+      # on it — `service_started` is enough for DNS resolution to
+      # work, and Caddy will return 502 until web is actually
+      # listening (a recoverable UX state, vs. the tailnet entry
+      # point staying down entirely).
+      web:
+        condition: service_started
+      api:
+        condition: service_healthy
+    configs:
+      - source: caddyfile
+        target: /etc/caddy/Caddyfile
+    volumes:
+      - caddy-data:/data
+      - caddy-config:/config
+    ports:
+      - "${CADDY_BIND_ADDR:-127.0.0.1}:${CADDY_HOST_PORT:-80}:80"
+volumes:
+  caddy-data:
+  caddy-config:
+
+configs:
+  caddyfile:
+    file: ./deploy/caddy-tailscale/Caddyfile
+# file path is if you keep these files in the current directory structure.


### PR DESCRIPTION
## What this PR does

<!-- One or two sentences describing the change. Keep this scoped to what
actually changed; the why goes in the next section. --> Added a deployment with caddy and tailscale for easy access in remote network. 

## Why

<!-- The motivation. If this PR closes an issue or implements a deferred
enhancement, link it: "Closes #123" or "Refs DE-013". --> This is related to PRD 6.3. 

## What this PR does *not* do

<!-- Optional but encouraged for non-trivial PRs. Naming the explicit
non-goals prevents reviewer scope creep and makes follow-up PRs cleaner. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ X] Documentation update
- [ ] Skill contribution (see attestation below)
- [ ] Refactor (no behavioral change)
- [ ] Test / CI / tooling

## Testing

<!-- How did you verify the change? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [X ] Manually tested against a real deployment (describe scenario below)
- [ ] Acceptance test plan updated (if changing skill behavior)

<details>
<summary>Manual testing notes (if applicable)

Ubuntu 24.04.4 LTS VM with docker and tailscale installed. 

Ran: 
```bash
docker compose -f docker-compose.yml -f deploy/caddy-tailscale/docker-compose.proxy.yml up -d
sudo tailscale serve --bg --https=443 http://127.0.0.1:80
```

After building, I was able to access lq-ai and login and browse around. 
</details></summary>



## Documentation

- [ ] PRD updated (if user-facing behavior changes)
- [ ] README updated (if quickstart or capability list changes)
- [ ] Skill-authoring guide updated (if skill conventions change)
- [X ] Deployment cookbook updated (if deployment changes)
- [ ] Compliance documentation updated (if compliance posture changes)
- [ ] OpenAPI schema regenerated (if API endpoints change)

I added the readme to the directory. I don't see a deployment-cookbook.md anywhere to add to. 

## DCO sign-off

- [ X] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

<!-- Verify with: git log --show-signature -->commit 04ebac670831b030b93c71cdae5b878b22819373 (HEAD -> feat/caddy-tailscale-recipe, origin/feat/caddy-tailscale-recipe)
Author: ThurgyThurg <tim@graham29.com>
Date:   Fri Jun 5 14:56:41 2026 -0400

    added caddy with tailscale deployment

    Signed-off-by: ThurgyThurg <tim@graham29.com>

## Related issues

<!-- Closes #123, Refs DE-013, etc. -->

---

<!-- ============================================================
SKILL CONTRIBUTION ATTESTATION (uncomment if this PR contributes
or substantively modifies a skill containing legal substance)

## Skill attestation

I have reviewed the substantive legal content of this skill and
certify that, to the best of my knowledge as a [practicing
attorney / legal professional / specific role], the patterns,
severity calibrations, recommended language, and reference
material reflect accurate and reasonable legal practice in
[jurisdiction(s)]. I understand that this skill will be used in
real practice and that errors could affect real legal work; I
have authored this skill with the same care I would apply to my
own client work.

Signed: [your name and any relevant qualifications]

If you are not a practicing attorney, follow the alternative
attestation paths in skills/CONTRIBUTING.md (pair with a
practicing-attorney co-author, or have a practicing attorney
review the skill before submission).
============================================================ -->

## Reviewer notes

<!-- Anything the reviewer should know — areas where you'd specifically
appreciate scrutiny, design decisions you considered alternatives for,
known limitations of this PR. -->
