### PR TITLE
feat(autonomous): persist + expose run findings (work-product surfacing)

### DIFF
--- a/api/alembic/versions/0046_autonomous_findings.py
+++ b/api/alembic/versions/0046_autonomous_findings.py
@@ -1,0 +1,72 @@
+"""autonomous_findings — persist run findings
+
+Findings emitted via the ``emit_finding`` chokepoint were echoed into
+transient LangGraph state and discarded after the run; only a count
+survived. This table persists one row per finding so a run's
+work-product can be read back later (read endpoint + contract follow).
+
+``session_id`` FK is ``ON DELETE CASCADE`` — a finding belongs to one
+session and is meaningless without it. There is no ``user_id`` column:
+authz is via the owning session. An index on ``session_id`` backs the
+read endpoint's by-session query. Unlike the other autonomous enum
+columns (which carry CHECK constraints — see migrations 0039/0040),
+``severity`` deliberately has NO CHECK: it is LLM-emitted free text, so
+we persist whatever the model produces (``info`` | ``warn`` |
+``critical`` are the intended values, but a stray ``high`` etc. must
+store, not reject the finding row).
+
+Revision ID: 0046
+Revises: 0045
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0046"
+down_revision = "0045"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "autonomous_findings",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "session_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "autonomous_sessions.id",
+                ondelete="CASCADE",
+                name="fk_autonomous_findings_session_id",
+            ),
+            nullable=False,
+        ),
+        sa.Column("severity", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_autonomous_findings_session_id",
+        "autonomous_findings",
+        ["session_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_autonomous_findings_session_id", table_name="autonomous_findings")
+    op.drop_table("autonomous_findings")

--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -6,6 +6,7 @@ Sessions (M4-A4-i):
 * ``POST /sessions/{session_id}/halt`` — idempotent halt request.
 * ``GET  /sessions``                  — paginated list, newest first.
 * ``GET  /sessions/{session_id}``     — detail + live receipt.
+* ``GET  /sessions/{session_id}/findings`` — the run's findings, emission order.
 
 Memory curation (M4-B1):
 * ``GET  /memory``                           — list non-deleted entries.
@@ -52,6 +53,7 @@ from app.autonomous.receipt import build_receipt
 from app.config import get_settings
 from app.db.session import get_db
 from app.models.autonomous import (
+    AutonomousFinding,
     AutonomousMemory,
     AutonomousNotification,
     AutonomousSchedule,
@@ -63,6 +65,8 @@ from app.models.autonomous import (
 from app.models.knowledge import KnowledgeBase
 from app.models.project import Project
 from app.schemas.autonomous import (
+    AutonomousFindingListResponse,
+    AutonomousFindingRead,
     AutonomousManualRunRequest,
     AutonomousMemoryListResponse,
     AutonomousMemoryRead,
@@ -491,6 +495,62 @@ async def get_session(
     )
 
 
+@router.get(
+    "/sessions/{session_id}/findings",
+    response_model=AutonomousFindingListResponse,
+    summary="List a session's persisted findings (work-product, emission order)",
+    responses={
+        404: {"description": "Session not found"},
+        401: {"description": "Not authenticated"},
+    },
+)
+async def list_session_findings(
+    session_id: uuid.UUID,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: int = _LIMIT_DEFAULT,
+    offset: int = 0,
+) -> AutonomousFindingListResponse:
+    """GET /api/v1/autonomous/sessions/{session_id}/findings
+
+    Returns the run's persisted findings (the ``emit_finding`` chokepoint
+    work-product) ordered by ``created_at ASC`` — emission order, the run's
+    output sequence. This differs intentionally from the newest-first
+    autonomous lists: these are one run's sequential output, not a feed.
+
+    Owner-gated by loading the owned session first (the findings table has
+    no ``user_id`` — authz is via the parent session). Another user's
+    ``session_id`` — or a missing one — returns 404 (not 403) to avoid
+    existence disclosure. ``limit`` is clamped to [1, 200]; ``offset`` to
+    [0, ∞).
+    """
+    await _load_owned_session(db, session_id=session_id, user_id=user.id)
+
+    limit = max(1, min(limit, _LIMIT_MAX))
+    offset = max(0, offset)
+
+    base_where = [AutonomousFinding.session_id == session_id]
+
+    count_stmt = select(func.count()).select_from(AutonomousFinding).where(*base_where)
+    total_count: int = (await db.execute(count_stmt)).scalar_one()
+
+    rows_stmt = (
+        select(AutonomousFinding)
+        .where(*base_where)
+        .order_by(AutonomousFinding.created_at.asc())
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = (await db.execute(rows_stmt)).scalars().all()
+
+    return AutonomousFindingListResponse(
+        findings=[AutonomousFindingRead.model_validate(r) for r in rows],
+        total_count=total_count,
+        limit=limit,
+        offset=offset,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Memory curation endpoints (M4-B1)
 # ---------------------------------------------------------------------------
@@ -508,6 +568,7 @@ async def list_memory(
     user: ActiveUser,
     db: Annotated[AsyncSession, Depends(get_db)],
     state: Annotated[MemoryState | None, Query()] = None,
+    source_session_id: Annotated[uuid.UUID | None, Query()] = None,
     limit: int = _LIMIT_DEFAULT,
     offset: int = 0,
 ) -> AutonomousMemoryListResponse:
@@ -515,7 +576,9 @@ async def list_memory(
 
     Returns the caller's non-deleted memory entries ordered by
     ``created_at DESC``.  Pass ``?state=proposed|kept|dismissed`` to
-    filter; omitting ``state`` returns all non-deleted entries.
+    filter by review state; omitting ``state`` returns all non-deleted
+    entries.  Pass ``?source_session_id=`` to narrow to the memories a
+    specific run proposed (the run's "memories this run proposed" view).
     ``limit`` is clamped to [1, 200]; ``offset`` to [0, ∞).
     """
     limit = max(1, min(limit, _LIMIT_MAX))
@@ -527,6 +590,8 @@ async def list_memory(
     ]
     if state is not None:
         base_where.append(AutonomousMemory.state == str(state))
+    if source_session_id is not None:
+        base_where.append(AutonomousMemory.source_session_id == source_session_id)
 
     count_stmt = select(func.count()).select_from(AutonomousMemory).where(*base_where)
     total_count: int = (await db.execute(count_stmt)).scalar_one()

--- a/api/app/autonomous/guard.py
+++ b/api/app/autonomous/guard.py
@@ -85,6 +85,7 @@ from app.autonomous.enums import PHASE_GRANTS, HaltState, Phase, ToolIntent
 from app.autonomous.notify_email import send_notification_email
 from app.errors import CostCapReached, SessionHalted, ToolNotGranted
 from app.models.autonomous import (
+    AutonomousFinding,
     AutonomousMemory,
     AutonomousNotification,
     AutonomousSession,
@@ -283,13 +284,29 @@ async def _dispatch(
         A :class:`ToolResult` with ``cost_usd`` and tool-specific ``data``.
     """
     if intent == ToolIntent.emit_finding:
-        # Local, zero-cost: echo the finding payload back as data.
-        # The calling node appends it to state["findings"].
+        # Local, zero-cost: persist the finding row, then echo the payload
+        # (plus the new row id) back as data. The calling node still appends
+        # the finding to state["findings"] and computes findings_count — that
+        # transient-state behavior is unchanged; this only ADDS durable
+        # persistence so a run's findings can be read back later.
         # Missing "finding" key is a programming error at the call site;
         # KeyError is acceptable here (unreachable via the executor) and is
         # consistent with the propose_memory/notify required-param access —
         # a silent None finding must never propagate into state["findings"].
-        return ToolResult(cost_usd=Decimal("0"), data=params["finding"])
+        # The finding dict may omit keys (LLM structured output) — the
+        # `.get(...) or default` guards keep non-null DB columns satisfied.
+        finding = params["finding"]
+        finding_row = AutonomousFinding(
+            session_id=session.id,
+            severity=str(finding.get("severity") or "info"),
+            title=str(finding.get("title") or "(untitled)"),
+            content=str(finding.get("summary") or ""),
+        )
+        db.add(finding_row)
+        await db.flush()
+        return ToolResult(
+            cost_usd=Decimal("0"), data={**finding, "finding_id": str(finding_row.id)}
+        )
 
     if intent == ToolIntent.propose_memory:
         # Local, zero-cost: write a proposed autonomous_memory row.

--- a/api/app/models/autonomous.py
+++ b/api/app/models/autonomous.py
@@ -423,6 +423,60 @@ class ProjectContextProposal(Base):
         )
 
 
+class AutonomousFinding(Base):
+    """A persisted analysis finding emitted by an autonomous run.
+
+    Findings are the core work-product of a run — written by the
+    ``emit_finding`` chokepoint handler each time a node emits one. Until
+    now findings were echoed into transient LangGraph state and discarded
+    after the run; only a count survived. This table makes a run's
+    findings readable back later (read endpoint + contract follow).
+
+    Unlike the other autonomous enum columns (which carry CHECK
+    constraints — see migrations 0039/0040), ``severity`` deliberately has
+    NO CHECK: it is LLM-emitted free text, so we persist whatever the model
+    produces (``info`` | ``warn`` | ``critical`` are the intended values,
+    but a stray ``high`` etc. must store, not reject the finding row).
+    ``title`` is the short headline; ``content`` is the finding's summary
+    body.
+
+    ``session_id`` FK is ``ON DELETE CASCADE`` — a finding belongs to one
+    session and is meaningless without it; deleting the session deletes its
+    findings. There is no ``user_id`` column: authz is via the owning
+    session (the read endpoint owner-gates by loading the owned session,
+    then queries by ``session_id``).
+    """
+
+    __tablename__ = "autonomous_findings"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "autonomous_sessions.id",
+            ondelete="CASCADE",
+            name="fk_autonomous_findings_session_id",
+        ),
+        nullable=False,
+    )
+    severity: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<AutonomousFinding id={self.id} session_id={self.session_id} "
+            f"severity={self.severity!r} title={self.title!r}>"
+        )
+
+
 class AutonomousNotification(Base):
     """A durable in-app notification written by the autonomous agent.
 

--- a/api/app/schemas/autonomous.py
+++ b/api/app/schemas/autonomous.py
@@ -437,6 +437,41 @@ class AutonomousMemoryListResponse(BaseModel):
     offset: int
 
 
+class AutonomousFindingRead(BaseModel):
+    """ORM-read view of an ``autonomous_findings`` row (work-product).
+
+    A finding is one analysis result emitted by an autonomous run via the
+    ``emit_finding`` chokepoint. ``content`` is the finding body — the
+    LLM's ``summary`` for the finding. ``severity`` is LLM-emitted free
+    text (no CHECK constraint; ``info`` | ``warn`` | ``critical`` are the
+    intended values but anything stores).
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    session_id: uuid.UUID
+    severity: str
+    title: str
+    content: str
+    created_at: datetime
+
+
+class AutonomousFindingListResponse(BaseModel):
+    """Paginated list of :class:`AutonomousFindingRead` items.
+
+    Mirrors ``AutonomousMemoryListResponse`` — total_count / limit /
+    offset envelope. Findings are read in emission order (``created_at
+    ASC``) — one run's sequential output, not a newest-first feed. Uses
+    the ``findings`` key (Donna's UI expects ``findings: [...]``).
+    """
+
+    findings: list[AutonomousFindingRead]
+    total_count: int
+    limit: int
+    offset: int
+
+
 class AutonomousSessionListResponse(BaseModel):
     """Paginated list of :class:`AutonomousSessionRead` items.
 

--- a/api/tests/autonomous/test_brakes.py
+++ b/api/tests/autonomous/test_brakes.py
@@ -40,6 +40,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.autonomous.enums import PHASE_GRANTS, Phase, ToolIntent
 from app.models.audit import AuditLog
 from app.models.autonomous import (
+    AutonomousFinding,
     AutonomousMemory,
     AutonomousNotification,
     AutonomousSession,
@@ -383,7 +384,9 @@ async def test_r6_granted_intent_passes_through(db_session: AsyncSession) -> Non
         gateway,
     )
     assert isinstance(result, ToolResult)
-    assert result.data == {"flag": "privilege_sensitive"}
+    # emit_finding echoes the finding plus the persisted row's id (Task 1).
+    assert result.data["flag"] == "privilege_sensitive"
+    assert "finding_id" in result.data
 
 
 # ---------------------------------------------------------------------------
@@ -532,10 +535,16 @@ async def test_success_notify_writes_notification_row(db_session: AsyncSession) 
 
 
 @pytest.mark.integration
-async def test_success_emit_finding_returns_data_no_db_row(
+async def test_success_emit_finding_persists_row_and_echoes(
     db_session: AsyncSession,
 ) -> None:
-    """emit_finding: the finding dict is echoed as data; no DB row written."""
+    """emit_finding: the finding is echoed (plus finding_id) AND persisted.
+
+    Task 1 added durable persistence: emit_finding now writes one
+    autonomous_findings row per finding (the run's work-product) in
+    addition to the transient echo, at zero cost. It does NOT write an
+    autonomous_memory row.
+    """
     from app.autonomous.guard import ToolResult, guarded_tool_call
 
     user = await _make_user(db_session)
@@ -558,7 +567,26 @@ async def test_success_emit_finding_returns_data_no_db_row(
 
     assert isinstance(result, ToolResult)
     assert result.cost_usd == Decimal("0")
-    assert result.data == finding
+    # Echo carries the original keys plus the persisted row's id.
+    assert result.data["clause"] == "limitation_of_liability"
+    assert result.data["severity"] == "high"
+    assert "finding_id" in result.data
+
+    # One autonomous_findings row was written for this session.
+    finding_rows = (
+        (
+            await db_session.execute(
+                select(AutonomousFinding).where(AutonomousFinding.session_id == sess.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(finding_rows) == 1
+    assert finding_rows[0].severity == "high"
+    # "clause" maps nowhere on the model; missing title/summary → defaults.
+    assert finding_rows[0].title == "(untitled)"
+    assert finding_rows[0].content == ""
 
     # No autonomous_memory rows should have been written
     mem_rows = (

--- a/api/tests/autonomous/test_findings.py
+++ b/api/tests/autonomous/test_findings.py
@@ -1,0 +1,206 @@
+"""Chokepoint persistence tests for the emit_finding handler — Task 1.
+
+The ``emit_finding`` chokepoint persists one ``autonomous_findings`` row
+per finding (the run's core work-product), in addition to the existing
+transient state echo. Covers:
+
+- Happy path: a complete finding dict persists severity/title/content
+  verbatim against the emitting session, and the result echoes the
+  finding plus the new ``finding_id``.
+- Defensive path: a finding dict missing ``summary``/``title``/
+  ``severity`` persists with the defaults ("(untitled)" / "" / "info")
+  rather than crashing on the non-null DB columns.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.enums import PHASE_GRANTS, ToolIntent
+from app.autonomous.guard import guarded_tool_call
+from app.models.autonomous import AutonomousFinding, AutonomousSession
+from app.models.user import User
+from app.security import hash_password
+
+
+class _StubGateway:
+    """emit_finding is local/zero-cost; the gateway is never touched."""
+
+
+def _granting_phase() -> str:
+    """A phase whose grant set includes emit_finding (e.g. ethics_review)."""
+    phase = next(
+        (p for p, grants in PHASE_GRANTS.items() if ToolIntent.emit_finding in grants),
+        None,
+    )
+    assert phase is not None, "emit_finding must be granted in at least one phase"
+    return str(phase)
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        email=f"find-test-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+        autonomous_enabled=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_session(db: AsyncSession, *, user: User) -> AutonomousSession:
+    sess = AutonomousSession(
+        user_id=user.id,
+        trigger_kind="manual",
+        status="running",
+        halt_state="running",
+        current_phase=_granting_phase(),
+    )
+    db.add(sess)
+    await db.flush()
+    await db.refresh(sess)
+    return sess
+
+
+@pytest.mark.integration
+async def test_emit_finding_persists_row(db_session: AsyncSession) -> None:
+    """A complete finding persists severity/title/content for the session."""
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user)
+
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_finding,
+        {"finding": {"title": "T", "summary": "S", "severity": "warn"}},
+        db_session,
+        _StubGateway(),
+    )
+
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousFinding).where(AutonomousFinding.session_id == sess.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.session_id == sess.id
+    assert row.severity == "warn"
+    assert row.title == "T"
+    assert row.content == "S"
+
+    # The chokepoint echoes the finding plus the new row id.
+    assert result.data["title"] == "T"
+    assert result.data["finding_id"] == str(row.id)
+
+
+@pytest.mark.integration
+async def test_emit_finding_defensive_defaults(db_session: AsyncSession) -> None:
+    """A finding missing every key persists with defaults, no crash."""
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user)
+
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_finding,
+        {"finding": {}},
+        db_session,
+        _StubGateway(),
+    )
+
+    row = (
+        await db_session.execute(
+            select(AutonomousFinding).where(AutonomousFinding.session_id == sess.id)
+        )
+    ).scalar_one()
+    assert row.severity == "info"
+    assert row.title == "(untitled)"
+    assert row.content == ""
+    assert result.data["finding_id"] == str(row.id)
+
+
+@pytest.mark.integration
+async def test_finding_cascade_deletes_with_session(db_session: AsyncSession) -> None:
+    """Deleting the owning session cascades and removes its findings."""
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user)
+    session_id = sess.id
+
+    await guarded_tool_call(
+        sess,
+        ToolIntent.emit_finding,
+        {"finding": {"title": "T", "summary": "S", "severity": "warn"}},
+        db_session,
+        _StubGateway(),
+    )
+
+    # Sanity: the finding is present before the cascade.
+    before = (
+        (
+            await db_session.execute(
+                select(AutonomousFinding).where(AutonomousFinding.session_id == session_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(before) == 1
+
+    # Delete the owning session in the same session so the DB cascade fires.
+    await db_session.delete(sess)
+    await db_session.commit()
+
+    after = (
+        (
+            await db_session.execute(
+                select(AutonomousFinding).where(AutonomousFinding.session_id == session_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(after) == 0
+
+
+@pytest.mark.integration
+async def test_findings_do_not_dedup(db_session: AsyncSession) -> None:
+    """Two emitted findings persist as two rows — findings never upsert."""
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user)
+
+    await guarded_tool_call(
+        sess,
+        ToolIntent.emit_finding,
+        {"finding": {"title": "First", "summary": "S1", "severity": "warn"}},
+        db_session,
+        _StubGateway(),
+    )
+    await guarded_tool_call(
+        sess,
+        ToolIntent.emit_finding,
+        {"finding": {"title": "Second", "summary": "S2", "severity": "critical"}},
+        db_session,
+        _StubGateway(),
+    )
+
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousFinding).where(AutonomousFinding.session_id == sess.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert {r.title for r in rows} == {"First", "Second"}

--- a/api/tests/autonomous/test_findings_endpoint.py
+++ b/api/tests/autonomous/test_findings_endpoint.py
@@ -1,0 +1,345 @@
+"""Integration tests for GET /autonomous/sessions/{id}/findings (Task 2).
+
+The read surface for a run's persisted findings (Task 1 work-product).
+Covers:
+- Happy path: a session's findings return with severity/title/content,
+  correct total_count, ordered by created_at ASC (emission order).
+- Cross-user 404: user B requesting user A's session → 404 (id-probing-safe).
+- Empty: a session with no findings → 200, findings=[], total_count=0.
+- Pagination: ?limit=1&offset=1 returns the middle finding + full total_count.
+- Unauth → 401.
+- OpenAPI conformance for the findings path + schemas.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.main import app
+from app.models.autonomous import AutonomousFinding, AutonomousSession
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+async def _make_user(db: AsyncSession, *, suffix: str = "") -> User:
+    user = User(
+        email=f"find-ep-{suffix or uuid.uuid4().hex[:8]}@example.com",
+        display_name=f"Finding Test User {suffix}".strip(),
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+        autonomous_enabled=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def user_a(db_session: AsyncSession) -> User:
+    return await _make_user(db_session, suffix="a")
+
+
+@pytest_asyncio.fixture
+async def user_b(db_session: AsyncSession) -> User:
+    return await _make_user(db_session, suffix="b")
+
+
+def _bearer(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_session(db: AsyncSession, *, user: User) -> AutonomousSession:
+    sess = AutonomousSession(
+        user_id=user.id,
+        trigger_kind="manual",
+        halt_state="running",
+        status="running",
+        current_phase="intake",
+    )
+    db.add(sess)
+    await db.flush()
+    await db.refresh(sess)
+    return sess
+
+
+async def _make_finding(
+    db: AsyncSession,
+    *,
+    session: AutonomousSession,
+    severity: str = "info",
+    title: str = "Finding",
+    content: str = "body",
+    created_at: datetime | None = None,
+) -> AutonomousFinding:
+    finding = AutonomousFinding(
+        session_id=session.id,
+        severity=severity,
+        title=title,
+        content=content,
+    )
+    if created_at is not None:
+        finding.created_at = created_at
+    db.add(finding)
+    await db.flush()
+    await db.refresh(finding)
+    return finding
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_list_findings_returns_them_in_emission_order(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """A session's findings return with severity/title/content, ASC by created_at."""
+    sess = await _make_session(db_session, user=user_a)
+    base = datetime.now(UTC)
+    # Insert out of order; explicit created_at proves the ASC sort.
+    await _make_finding(
+        db_session,
+        session=sess,
+        severity="warn",
+        title="Second",
+        content="b2",
+        created_at=base + timedelta(seconds=2),
+    )
+    await _make_finding(
+        db_session,
+        session=sess,
+        severity="info",
+        title="First",
+        content="b1",
+        created_at=base + timedelta(seconds=1),
+    )
+    await _make_finding(
+        db_session,
+        session=sess,
+        severity="critical",
+        title="Third",
+        content="b3",
+        created_at=base + timedelta(seconds=3),
+    )
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/findings",
+        headers=_bearer(user_a),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    titles = [f["title"] for f in body["findings"]]
+    assert titles == ["First", "Second", "Third"]
+    assert body["total_count"] == 3
+    assert body["limit"] == 50
+    assert body["offset"] == 0
+
+    first = body["findings"][0]
+    assert first["severity"] == "info"
+    assert first["content"] == "b1"
+    assert first["session_id"] == str(sess.id)
+
+
+# ---------------------------------------------------------------------------
+# Cross-user 404 (id-probing-safe)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_list_findings_cross_user_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    """User B requesting user A's session findings returns 404 (no leakage)."""
+    sess = await _make_session(db_session, user=user_a)
+    await _make_finding(db_session, session=sess, title="secret")
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/findings",
+        headers=_bearer(user_b),
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.integration
+async def test_list_findings_missing_session_returns_404(
+    client: AsyncClient,
+    user_a: User,
+) -> None:
+    """A nonexistent session id returns 404 (same posture as cross-user)."""
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{uuid.uuid4()}/findings",
+        headers=_bearer(user_a),
+    )
+    assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Empty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_list_findings_empty_session(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """A session with no findings returns 200, findings=[], total_count=0."""
+    sess = await _make_session(db_session, user=user_a)
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/findings",
+        headers=_bearer(user_a),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["findings"] == []
+    assert body["total_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_list_findings_pagination_returns_middle(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """?limit=1&offset=1 returns the middle finding + full total_count."""
+    sess = await _make_session(db_session, user=user_a)
+    base = datetime.now(UTC)
+    for i in range(3):
+        await _make_finding(
+            db_session,
+            session=sess,
+            title=f"F{i}",
+            created_at=base + timedelta(seconds=i),
+        )
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/findings",
+        headers=_bearer(user_a),
+        params={"limit": 1, "offset": 1},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body["findings"]) == 1
+    assert body["findings"][0]["title"] == "F1"
+    assert body["total_count"] == 3
+    assert body["limit"] == 1
+    assert body["offset"] == 1
+
+
+@pytest.mark.integration
+async def test_list_findings_isolated_by_session(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """Findings of one session are not returned for another session of the same user."""
+    sess1 = await _make_session(db_session, user=user_a)
+    sess2 = await _make_session(db_session, user=user_a)
+    await _make_finding(db_session, session=sess1, title="for-1")
+    await _make_finding(db_session, session=sess2, title="for-2")
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess1.id}/findings",
+        headers=_bearer(user_a),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    titles = {f["title"] for f in body["findings"]}
+    assert titles == {"for-1"}
+    assert body["total_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_list_findings_unauth_returns_401(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """No Authorization header returns 401."""
+    sess = await _make_session(db_session, user=user_a)
+    resp = await client.get(f"/api/v1/autonomous/sessions/{sess.id}/findings")
+    assert resp.status_code == 401, resp.text
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI conformance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_openapi_findings_path_registered() -> None:
+    """The findings path is registered as a GET with 200/401/404."""
+    schema = app.openapi()
+    path = schema["paths"]["/api/v1/autonomous/sessions/{session_id}/findings"]
+    assert "get" in path
+    get_op = path["get"]
+    assert "200" in get_op["responses"]
+    assert "401" in get_op["responses"]
+    assert "404" in get_op["responses"]
+
+
+@pytest.mark.unit
+def test_openapi_findings_schemas_in_components() -> None:
+    """AutonomousFindingRead + ListResponse are in components/schemas with the right shape."""
+    schema = app.openapi()
+    schemas = schema.get("components", {}).get("schemas", {})
+    assert "AutonomousFindingRead" in schemas
+    assert "AutonomousFindingListResponse" in schemas
+
+    read_props = schemas["AutonomousFindingRead"].get("properties", {})
+    for field in ("id", "session_id", "severity", "title", "content", "created_at"):
+        assert field in read_props
+
+    list_props = schemas["AutonomousFindingListResponse"].get("properties", {})
+    for field in ("findings", "total_count", "limit", "offset"):
+        assert field in list_props

--- a/api/tests/autonomous/test_memory.py
+++ b/api/tests/autonomous/test_memory.py
@@ -387,6 +387,47 @@ async def test_list_memory_isolation(
 
 
 @pytest.mark.integration
+async def test_list_memory_filter_by_source_session_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """?source_session_id= narrows to the memories a specific run proposed.
+
+    Omitting the filter returns all of the user's non-deleted memories
+    (back-compat); supplying it returns only the matching run's memories.
+    """
+    sess_a = await _make_session(db_session, user=user_a)
+    sess_b = await _make_session(db_session, user=user_a)
+
+    mem_a1 = await _make_memory(db_session, user=user_a)
+    mem_a1.source_session_id = sess_a.id
+    mem_a2 = await _make_memory(db_session, user=user_a)
+    mem_a2.source_session_id = sess_a.id
+    mem_b = await _make_memory(db_session, user=user_a)
+    mem_b.source_session_id = sess_b.id
+    await db_session.flush()
+
+    # Filtered to run A
+    resp = await client.get(
+        "/api/v1/autonomous/memory",
+        headers=_bearer(user_a),
+        params={"source_session_id": str(sess_a.id)},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    ids = {e["id"] for e in body["entries"]}
+    assert ids == {str(mem_a1.id), str(mem_a2.id)}
+    assert str(mem_b.id) not in ids
+    assert body["total_count"] == 2
+
+    # Omitted → all three (back-compat).
+    resp = await client.get("/api/v1/autonomous/memory", headers=_bearer(user_a))
+    body = resp.json()
+    assert body["total_count"] == 3
+
+
+@pytest.mark.integration
 async def test_list_memory_unauth_returns_401(client: AsyncClient) -> None:
     """No Authorization header returns 401."""
     resp = await client.get("/api/v1/autonomous/memory")

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -294,6 +294,7 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("PATCH", "/api/v1/autonomous/schedules/{schedule_id}"),
     ("GET", "/api/v1/autonomous/sessions"),
     ("GET", "/api/v1/autonomous/sessions/{session_id}"),
+    ("GET", "/api/v1/autonomous/sessions/{session_id}/findings"),
     ("POST", "/api/v1/autonomous/sessions/{session_id}/halt"),
     ("GET", "/api/v1/autonomous/watches"),
     ("POST", "/api/v1/autonomous/watches"),

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -163,6 +163,8 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/autonomous/sessions",
         "/api/v1/autonomous/sessions/{session_id}",
         "/api/v1/autonomous/sessions/{session_id}/halt",
+        # Findings read-model — a run's persisted findings (work-product)
+        "/api/v1/autonomous/sessions/{session_id}/findings",
         # M4-B1 — per-user memory curation API (list, keep, dismiss, delete)
         "/api/v1/autonomous/memory",
         "/api/v1/autonomous/memory/{memory_id}/keep",
@@ -279,7 +281,9 @@ async def test_openapi_paths_match_sketch() -> None:
     # Donna #7 adds two new paths:
     # /api/v1/admin/provider-keys
     # /api/v1/admin/provider-keys/{provider}
-    assert len(actual) == 116
+    # Findings read-model adds one new path:
+    # /api/v1/autonomous/sessions/{session_id}/findings
+    assert len(actual) == 117
 
 
 @pytest.mark.unit

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -3904,6 +3904,50 @@ paths:
         '404':
           description: Session not found
 
+  /api/v1/autonomous/sessions/{session_id}/findings:
+    get:
+      tags: [autonomous]
+      summary: List a session's persisted findings (work-product, emission order)
+      description: |
+        Returns the run's persisted findings (the ``emit_finding`` chokepoint
+        work-product) ordered by ``created_at ASC`` — emission order, the
+        run's output sequence. This differs intentionally from the
+        newest-first autonomous lists: these are one run's sequential output.
+
+        Owner-gated by loading the owned session first (the findings table
+        has no ``user_id`` — authz is via the parent session). Another
+        user's ``session_id`` — or a missing one — returns 404 (not 403) to
+        avoid existence disclosure. ``limit`` is clamped to [1, 200];
+        ``offset`` to [0, ∞).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: session_id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+        - name: limit
+          in: query
+          required: false
+          schema: {type: integer, default: 50, minimum: 1, maximum: 200}
+          description: Maximum number of findings to return (clamped to [1, 200]).
+        - name: offset
+          in: query
+          required: false
+          schema: {type: integer, default: 0, minimum: 0}
+          description: Zero-based index of the first result to return.
+      responses:
+        '200':
+          description: Paginated list of the session's findings (emission order)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutonomousFindingListResponse'
+        '401':
+          description: Not authenticated
+        '404':
+          description: Session not found
+
   /api/v1/autonomous/sessions/{session_id}/halt:
     post:
       tags: [autonomous]
@@ -3960,6 +4004,11 @@ paths:
             type: string
             enum: [proposed, kept, dismissed]
           description: Filter by review state; omit to return all non-deleted entries.
+        - name: source_session_id
+          in: query
+          required: false
+          schema: {type: string, format: uuid}
+          description: Narrow to the memories a specific run proposed; omit for all.
         - name: limit
           in: query
           required: false
@@ -5399,6 +5448,45 @@ components:
         created_at: {type: string, format: date-time}
         last_login_at: {type: string, format: date-time, nullable: true}
         deletion_scheduled_at: {type: string, format: date-time, nullable: true}
+
+    # Autonomous run findings (work-product) schemas
+
+    AutonomousFindingRead:
+      type: object
+      description: |
+        Read-only view of an ``autonomous_findings`` row — one analysis
+        finding emitted by a run via the ``emit_finding`` chokepoint.
+        ``content`` is the finding body (the LLM's ``summary``).
+        ``severity`` is LLM-emitted free text (no CHECK; ``info`` |
+        ``warn`` | ``critical`` are the intended values).
+      required:
+        - id
+        - session_id
+        - severity
+        - title
+        - content
+        - created_at
+      properties:
+        id: {type: string, format: uuid}
+        session_id: {type: string, format: uuid}
+        severity: {type: string}
+        title: {type: string}
+        content: {type: string}
+        created_at: {type: string, format: date-time}
+
+    AutonomousFindingListResponse:
+      type: object
+      description: |
+        Paginated list of a session's findings, in emission order
+        (``created_at ASC``) — one run's sequential output.
+      required: [findings, total_count, limit, offset]
+      properties:
+        findings:
+          type: array
+          items: {$ref: '#/components/schemas/AutonomousFindingRead'}
+        total_count: {type: integer, minimum: 0}
+        limit: {type: integer, minimum: 1, maximum: 200}
+        offset: {type: integer, minimum: 0}
 
     # M4-B1 — Autonomous memory curation schemas
 


### PR DESCRIPTION
Requested by Donna CC (Automations "run output surfacing"). A user could see *that* an autonomous run happened (the transparency receipt + a finding **count**) but never **what it produced**. Findings — the core analysis work-product — were emitted via the `emit_finding` chokepoint into transient in-memory state and discarded after the run. This persists them and exposes a read surface.

## What I found (informing the design)
The autonomous **audit log deliberately stores metadata only** (counts/types/IDs/enums — `api/app/autonomous/audit.py`), never finding bodies, and `emit_finding` just echoed the finding into `state["findings"]` (discarded post-run). So Donna's "surface the audit log instead" fallback couldn't show content — **persistence was required**. (Memories/precedents are already persisted; findings were the gap.)

## Design decisions (maintainer-approved at kickoff)
- **Persist via a new `autonomous_findings` table** (not a JSONB column, not metadata-only) — consistent with how `autonomous_memory` / `precedent_entries` already persist LLM-produced content in the same api DB. New persistence surface for analysis content, blessed deliberately.
- **Separate paginated `GET /sessions/{id}/findings`** (not folded into session-detail).
- **Scope = #1 findings + #2 `?source_session_id=` filter on `GET /memory`.** Precedents excluded from #2 — they're recurrence-aggregated across sessions, so a per-session precedent filter is semantically fuzzy (flagged for separate consideration).

## Changes
- **Table + migration `0046`** — `autonomous_findings` {id, session_id FK **ON DELETE CASCADE**, severity, title, content, created_at}, indexed on session_id. CASCADE is the retention story (delete a session → its findings go; tested). No `user_id` — authz is via the owning session. `severity` is free-text by design (LLM-emitted; we store `high` etc. rather than reject — no CHECK, documented).
- **Chokepoint persist** — `emit_finding` writes a row (mapping the finding's `summary` → `content`) inside the executor transaction; the count/state path is unchanged, and the notification's `finding_count` still agrees with the row count.
- **Read endpoint** — `GET /api/v1/autonomous/sessions/{id}/findings`: owner-gated via `_load_owned_session` (404 id-probing-safe on cross-user/missing), paginated, ordered `created_at ASC` (emission order — the run's output sequence, intentionally not newest-first).
- **Memory filter** — `?source_session_id=<uuid>` on `GET /memory` (additive, user-scoped; omitted = all).
- **Contract** — backend-openapi.yaml (new path + `AutonomousFindingRead`/`ListResponse` + the memory param); `test_openapi` 116→117 + `EXPECTED_PATHS` + `IMPLEMENTED_ROUTES` updated.

## Posture / acceptance
A run that emits findings now has them readable under its receipt; cross-user reads → 404 (no leak); finding content does NOT leak into audit rows/logs/spans (verified end-to-end). Built via the subagent loop (2 tasks × spec+quality review) + a final holistic review (verdict: ready; no issues at any severity). Gates: ruff + mypy clean; 409 passed.

## ⚠️ Ops note (deploy)
This adds **migration `0046`**. On the dev/prod stack: apply it and **rebuild the api + arq-worker + ingest-worker together** (stale sibling workers crash-loop on a revision mismatch).

After merge I'll report the SHA for Donna's pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)