### PR TITLE
feat(autonomous): document-grade artifacts from autonomous runs (Donna #8)

### DIFF
--- a/api/alembic/versions/0047_autonomous_artifacts.py
+++ b/api/alembic/versions/0047_autonomous_artifacts.py
@@ -1,0 +1,105 @@
+"""autonomous_artifacts — persist document-grade artifact references
+
+An opted-in autonomous run may persist document-grade artifacts
+(markdown memos) into its target knowledge base as real documents. This
+table records the *reference* per emitted artifact; the document itself
+lives in ``files`` / the KB like any other upload.
+
+``session_id`` FK is ``ON DELETE CASCADE`` — the artifact reference dies
+with its session. ``file_id`` FK is ``ON DELETE SET NULL`` — the KB
+document OUTLIVES the session (it is the user's deliverable); a hard
+file-delete nulls the ref while the name/size metadata survives. There
+is no ``user_id`` column: authz is via the owning session. An index on
+``session_id`` backs the read endpoint's by-session query. ``name`` and
+``mime`` are LLM-emitted free text — deliberately NO CHECK (the
+``autonomous_findings.severity`` precedent).
+
+Also adds the opt-in ``emit_artifacts`` flag to ``autonomous_schedules``
+and ``autonomous_watches`` (NOT NULL, default false — existing
+automations see zero behavior or cost change).
+
+Revision ID: 0047
+Revises: 0046
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0047"
+down_revision = "0046"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "autonomous_artifacts",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "session_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "autonomous_sessions.id",
+                ondelete="CASCADE",
+                name="fk_autonomous_artifacts_session_id",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "file_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "files.id",
+                ondelete="SET NULL",
+                name="fk_autonomous_artifacts_file_id",
+            ),
+            nullable=True,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("mime", sa.Text(), nullable=False),
+        sa.Column("size_bytes", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_autonomous_artifacts_session_id",
+        "autonomous_artifacts",
+        ["session_id"],
+    )
+    op.add_column(
+        "autonomous_schedules",
+        sa.Column(
+            "emit_artifacts",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "autonomous_watches",
+        sa.Column(
+            "emit_artifacts",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("autonomous_watches", "emit_artifacts")
+    op.drop_column("autonomous_schedules", "emit_artifacts")
+    op.drop_index("ix_autonomous_artifacts_session_id", table_name="autonomous_artifacts")
+    op.drop_table("autonomous_artifacts")

--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -1173,10 +1173,13 @@ async def _spawn_manual_session(
 
     Mirrors the session construction in
     :func:`app.workers.autonomous_worker._run_schedule_sweep`: builds
-    ``params`` carrying only the non-null target keys, sets a non-null
-    ``max_cost_usd`` (per-run cap or the config default so R4 always
-    arms), flushes to obtain the id, then best-effort enqueues. The
-    five-phase executor + R4/R5/R6 brakes + receipt are unchanged.
+    ``params`` carrying only the non-null target keys (plus
+    ``emit_artifacts`` — set to ``True`` only when the request body opted
+    in; Donna ask #8 — a manual run has no schedule/watch row, so the
+    body carries the flag), sets a non-null ``max_cost_usd`` (per-run cap
+    or the config default so R4 always arms), flushes to obtain the id,
+    then best-effort enqueues. The five-phase executor + R4/R5/R6 brakes
+    + receipt are unchanged.
     """
     enqueue_fn = enqueue if enqueue is not None else enqueue_autonomous_session_job
     settings = get_settings()
@@ -1193,6 +1196,10 @@ async def _spawn_manual_session(
         params["playbook_id"] = str(body.playbook_id)
     if body.skill_ref is not None:
         params["skill_ref"] = body.skill_ref
+    if body.emit_artifacts:
+        # Opt-in (Donna ask #8) — non-null-subset convention: the key is
+        # present iff the caller opted in.
+        params["emit_artifacts"] = True
 
     session = AutonomousSession(
         user_id=user_id,

--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -6,7 +6,10 @@ Sessions (M4-A4-i):
 * ``POST /sessions/{session_id}/halt`` — idempotent halt request.
 * ``GET  /sessions``                  — paginated list, newest first.
 * ``GET  /sessions/{session_id}``     — detail + live receipt.
-* ``GET  /sessions/{session_id}/findings`` — the run's findings, emission order.
+* ``GET  /sessions/{session_id}/findings`` — the run's findings, stable
+  ``created_at, id`` order.
+* ``GET  /sessions/{session_id}/artifacts`` — the run's document-grade
+  artifact references, same stable order (Donna ask #8).
 
 Memory curation (M4-B1):
 * ``GET  /memory``                           — list non-deleted entries.
@@ -53,6 +56,7 @@ from app.autonomous.receipt import build_receipt
 from app.config import get_settings
 from app.db.session import get_db
 from app.models.autonomous import (
+    AutonomousArtifact,
     AutonomousFinding,
     AutonomousMemory,
     AutonomousNotification,
@@ -62,9 +66,12 @@ from app.models.autonomous import (
     PrecedentEntry,
     ProjectContextProposal,
 )
+from app.models.document import Document
 from app.models.knowledge import KnowledgeBase
 from app.models.project import Project
 from app.schemas.autonomous import (
+    AutonomousArtifactListResponse,
+    AutonomousArtifactRead,
     AutonomousFindingListResponse,
     AutonomousFindingRead,
     AutonomousManualRunRequest,
@@ -498,7 +505,7 @@ async def get_session(
 @router.get(
     "/sessions/{session_id}/findings",
     response_model=AutonomousFindingListResponse,
-    summary="List a session's persisted findings (work-product, emission order)",
+    summary="List a session's persisted findings (work-product, stable order)",
     responses={
         404: {"description": "Session not found"},
         401: {"description": "Not authenticated"},
@@ -514,9 +521,13 @@ async def list_session_findings(
     """GET /api/v1/autonomous/sessions/{session_id}/findings
 
     Returns the run's persisted findings (the ``emit_finding`` chokepoint
-    work-product) ordered by ``created_at ASC`` — emission order, the run's
-    output sequence. This differs intentionally from the newest-first
-    autonomous lists: these are one run's sequential output, not a feed.
+    work-product) ordered by ``created_at ASC, id ASC``. Rows a run emits
+    in its single executor commit typically share one ``created_at``
+    (server-side ``now()`` is transaction-stable in Postgres), so ``id``
+    is the deterministic tiebreaker that keeps LIMIT/OFFSET pagination
+    stable — a repeatable order, NOT a guaranteed emission sequence (ids
+    are random UUIDs). This still differs intentionally from the
+    newest-first autonomous lists: these are one run's output, not a feed.
 
     Owner-gated by loading the owned session first (the findings table has
     no ``user_id`` — authz is via the parent session). Another user's
@@ -537,7 +548,7 @@ async def list_session_findings(
     rows_stmt = (
         select(AutonomousFinding)
         .where(*base_where)
-        .order_by(AutonomousFinding.created_at.asc())
+        .order_by(AutonomousFinding.created_at.asc(), AutonomousFinding.id.asc())
         .limit(limit)
         .offset(offset)
     )
@@ -545,6 +556,97 @@ async def list_session_findings(
 
     return AutonomousFindingListResponse(
         findings=[AutonomousFindingRead.model_validate(r) for r in rows],
+        total_count=total_count,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get(
+    "/sessions/{session_id}/artifacts",
+    response_model=AutonomousArtifactListResponse,
+    summary="List a session's persisted document-grade artifacts (work-product, stable order)",
+    responses={
+        404: {"description": "Session not found"},
+        401: {"description": "Not authenticated"},
+    },
+)
+async def list_session_artifacts(
+    session_id: uuid.UUID,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: int = _LIMIT_DEFAULT,
+    offset: int = 0,
+) -> AutonomousArtifactListResponse:
+    """GET /api/v1/autonomous/sessions/{session_id}/artifacts
+
+    Returns the run's persisted artifact references (the ``emit_artifact``
+    chokepoint work-product, Donna ask #8) ordered by ``created_at ASC,
+    id ASC``. Rows a run emits in its single executor commit typically
+    share one ``created_at`` (transaction-stable ``now()``), so ``id`` is
+    the deterministic tiebreaker that keeps LIMIT/OFFSET pagination
+    stable — a repeatable order, NOT a guaranteed emission sequence (ids
+    are random UUIDs). This differs intentionally from the newest-first
+    autonomous lists: these are one run's output, not a feed (mirrors the
+    findings read above).
+
+    Owner-gated by loading the owned session first (the artifacts table
+    has no ``user_id`` — authz is via the parent session). Another user's
+    ``session_id`` — or a missing one — returns 404 (not 403) to avoid
+    existence disclosure. ``limit`` is clamped to [1, 200]; ``offset`` to
+    [0, ∞).
+
+    ``document_id`` is NOT a column on ``autonomous_artifacts`` — it is
+    enriched here with one batched query over the page's non-null
+    ``file_id`` values against the unique ``documents.file_id`` (1:1), so
+    the UI can deep-link the KB document.
+
+    Deletion semantics: a hard file-delete SET-NULLs ``file_id`` (the
+    name/size metadata survives here; ``file_id`` and ``document_id``
+    return as null). Deleting the *session* CASCADE-deletes these
+    reference rows but never touches the KB document — the document
+    outlives the session (it is the user's deliverable).
+    """
+    await _load_owned_session(db, session_id=session_id, user_id=user.id)
+
+    limit = max(1, min(limit, _LIMIT_MAX))
+    offset = max(0, offset)
+
+    base_where = [AutonomousArtifact.session_id == session_id]
+
+    count_stmt = select(func.count()).select_from(AutonomousArtifact).where(*base_where)
+    total_count: int = (await db.execute(count_stmt)).scalar_one()
+
+    rows_stmt = (
+        select(AutonomousArtifact)
+        .where(*base_where)
+        .order_by(AutonomousArtifact.created_at.asc(), AutonomousArtifact.id.asc())
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = (await db.execute(rows_stmt)).scalars().all()
+
+    # document_id enrichment — one batched lookup over this page's non-null
+    # file_ids via the unique documents.file_id (1:1). A NULL file_id (the
+    # file was hard-deleted; FK is ON DELETE SET NULL) or a missing
+    # documents row maps to document_id=None.
+    file_ids = {r.file_id for r in rows if r.file_id is not None}
+    doc_id_by_file_id: dict[uuid.UUID, uuid.UUID] = {}
+    if file_ids:
+        doc_rows = await db.execute(
+            select(Document.id, Document.file_id).where(Document.file_id.in_(file_ids))
+        )
+        doc_id_by_file_id = {f_id: d_id for d_id, f_id in doc_rows.all()}
+
+    artifacts: list[AutonomousArtifactRead] = []
+    for row in rows:
+        item = AutonomousArtifactRead.model_validate(row)
+        if row.file_id is not None:
+            item.document_id = doc_id_by_file_id.get(row.file_id)
+        artifacts.append(item)
+
+    return AutonomousArtifactListResponse(
+        artifacts=artifacts,
         total_count=total_count,
         limit=limit,
         offset=offset,
@@ -1142,6 +1244,7 @@ async def create_schedule(
         skill_ref=body.skill_ref,
         target_kb_id=body.target_kb_id,
         enabled=body.enabled,
+        emit_artifacts=body.emit_artifacts,
         max_cost_usd=body.max_cost_usd,
         next_run_at=next_run_after(body.cron_expr, now),
     )
@@ -1358,6 +1461,10 @@ async def update_schedule(
         schedule.name = fields["name"]
     if "enabled" in fields:
         schedule.enabled = fields["enabled"]
+    if fields.get("emit_artifacts") is not None:
+        # bool | None on the Update schema; the column is NOT NULL, so an
+        # explicit null is a no-op rather than a constraint violation.
+        schedule.emit_artifacts = fields["emit_artifacts"]
     if "playbook_id" in fields:
         schedule.playbook_id = fields["playbook_id"]
     if "skill_ref" in fields:
@@ -1494,6 +1601,7 @@ async def create_watch(
         playbook_id=body.playbook_id,
         skill_ref=body.skill_ref,
         enabled=body.enabled,
+        emit_artifacts=body.emit_artifacts,
         max_cost_usd=body.max_cost_usd,
     )
     db.add(watch)
@@ -1601,6 +1709,10 @@ async def update_watch(
 
     if "enabled" in fields:
         watch.enabled = fields["enabled"]
+    if fields.get("emit_artifacts") is not None:
+        # bool | None on the Update schema; the column is NOT NULL, so an
+        # explicit null is a no-op rather than a constraint violation.
+        watch.emit_artifacts = fields["emit_artifacts"]
     if "playbook_id" in fields:
         watch.playbook_id = fields["playbook_id"]
     if "skill_ref" in fields:

--- a/api/app/autonomous/cost.py
+++ b/api/app/autonomous/cost.py
@@ -11,8 +11,10 @@ Cost model (per M4 implementation plan)
   :func:`~app.citation.cost.estimate_judge_call_cost_usd` which uses a
   per-model rolling average over the last 100 judge calls.
 * ``retrieve_chunks`` / ``propose_memory`` / ``propose_precedent`` /
-  ``emit_finding`` / ``notify`` — local operations with no provider
-  inference; marginal cost is zero for R4 pre-flight purposes.
+  ``emit_finding`` / ``emit_artifact`` / ``notify`` — local operations
+  with no provider inference; marginal cost is zero for R4 pre-flight
+  purposes (``emit_artifact`` writes storage + DB rows but burns no
+  provider tokens, exactly like ``emit_finding``).
 
 Usage::
 
@@ -52,9 +54,10 @@ async def estimate_tool_cost(
     ``"judge_model"`` (preferred) or ``"model"`` for these intents.
 
     All other intents (``retrieve_chunks``, ``propose_memory``,
-    ``propose_precedent``, ``emit_finding``, ``notify``) are local-only
-    operations with no provider inference; this function returns
-    :data:`decimal.Decimal` ``"0"`` for them without querying the DB.
+    ``propose_precedent``, ``emit_finding``, ``emit_artifact``,
+    ``notify``) are local-only operations with no provider inference;
+    this function returns :data:`decimal.Decimal` ``"0"`` for them
+    without querying the DB.
 
     Args:
         intent: The :class:`~app.autonomous.enums.ToolIntent` being considered.

--- a/api/app/autonomous/enums.py
+++ b/api/app/autonomous/enums.py
@@ -47,6 +47,7 @@ class ToolIntent(StrEnum):
     propose_memory = "propose_memory"
     propose_precedent = "propose_precedent"
     emit_finding = "emit_finding"
+    emit_artifact = "emit_artifact"
     notify = "notify"
 
 
@@ -70,6 +71,9 @@ PHASE_GRANTS: dict[Phase, frozenset[ToolIntent]] = {
             # propose_precedent at drafting: recurring patterns recognized
             # during synthesis (M4-B2, Decision B2-b).
             ToolIntent.propose_precedent,
+            # emit_artifact at drafting ONLY: the memo is synthesized work
+            # product, written exactly once where synthesis happens (Donna #8).
+            ToolIntent.emit_artifact,
         }
     ),
     Phase.ethics_review: frozenset({ToolIntent.emit_finding}),

--- a/api/app/autonomous/guard.py
+++ b/api/app/autonomous/guard.py
@@ -39,6 +39,10 @@ Local handlers implemented here (A3.3a)
 ----------------------------------------
 ``emit_finding``    — echoes the ``finding`` param as data; zero cost; no
                       DB row.
+``emit_artifact``   — persists a document-grade artifact into the run's
+                      target KB: upload-first to object storage, then
+                      File + Document + chunks + direct KB attach +
+                      an ``autonomous_artifacts`` reference; zero cost.
 ``propose_memory``  — writes a ``proposed`` :class:`~app.models.autonomous.AutonomousMemory`
                       row; zero cost.
 ``propose_precedent`` — upserts a :class:`~app.models.autonomous.PrecedentEntry`
@@ -85,6 +89,7 @@ from app.autonomous.enums import PHASE_GRANTS, HaltState, Phase, ToolIntent
 from app.autonomous.notify_email import send_notification_email
 from app.errors import CostCapReached, SessionHalted, ToolNotGranted
 from app.models.autonomous import (
+    AutonomousArtifact,
     AutonomousFinding,
     AutonomousMemory,
     AutonomousNotification,
@@ -100,6 +105,11 @@ _tracer = get_tracer(__name__)
 
 _DEFAULT_RETRIEVE_TOP_K: int = 4
 _DEFAULT_RETRIEVE_ALPHA: float = 0.5
+
+# emit_artifact: hard ceiling on artifact content length. LLM-emitted
+# content is clamped (truncated, flagged in the result data) rather than
+# rejected — a partial memo in the KB beats a lost run.
+_ARTIFACT_MAX_CHARS: int = 1_000_000
 
 
 @dataclass
@@ -308,6 +318,9 @@ async def _dispatch(
             cost_usd=Decimal("0"), data={**finding, "finding_id": str(finding_row.id)}
         )
 
+    if intent == ToolIntent.emit_artifact:
+        return await _handle_emit_artifact(params, db=db, session=session)
+
     if intent == ToolIntent.propose_memory:
         # Local, zero-cost: write a proposed autonomous_memory row.
         mem = AutonomousMemory(
@@ -417,6 +430,250 @@ async def _dispatch(
 
     # Should be unreachable: PHASE_GRANTS + R6 prevent unknown intents.
     raise ValueError(f"_dispatch: unhandled intent {intent!r}")
+
+
+def _sanitize_artifact_name(raw: Any) -> str:
+    """Normalize an LLM-emitted artifact name into a safe filename.
+
+    Strips NUL bytes and path separators/backslashes (basename), collapses
+    whitespace, clamps to ≤255 chars (the extensionless stem is clamped to
+    252 BEFORE the ``.md`` append so the guarantee actually holds), and
+    guarantees a file extension (``.md`` when none is present). Never
+    returns an empty string.
+    """
+    # Strip NUL bytes: valid JSON (LLM-emittable) but rejected by Postgres
+    # TEXT at flush.
+    name = str(raw or "artifact.md").replace("\x00", "")
+    # Basename: an LLM-emitted "../../etc/passwd" must never become a
+    # path-bearing filename.
+    name = name.replace("\\", "/").rsplit("/", 1)[-1]
+    # Collapse internal whitespace runs; trim edges.
+    name = " ".join(name.split())
+    if not name:
+        name = "artifact.md"
+    # Ensure a file extension so KB listings render sanely; clamp the stem
+    # to 252 BEFORE appending ".md" so the ≤255 guarantee actually holds.
+    name = f"{name[:252]}.md" if "." not in name else name[:255]
+    return name
+
+
+async def _handle_emit_artifact(
+    params: dict[str, Any],
+    *,
+    db: AsyncSession,
+    session: AutonomousSession,
+) -> ToolResult:
+    """Handle ``emit_artifact`` — persist a document-grade artifact into
+    the run's target KB as a REAL document.  Zero cost (local writes).
+
+    Order of operations is load-bearing:
+
+    1. Skip honestly when the session has no target KB or the artifact
+       content is empty — no rows, no upload.
+    2. Upload the bytes to object storage FIRST (client-generated
+       ``file_id`` as the key, per ADR 0005's bare-UUID scheme).  On any
+       storage failure, return an honest ``storage_error`` outcome with
+       NO DB rows (the gateway_error honesty pattern).
+    3. Only then write File + Document + chunks + KB attach +
+       ``autonomous_artifacts`` reference — all flushed, never committed
+       (the executor owns the commit boundary).
+    4. Best-effort embed enqueue; lazy embed-on-read covers the gap.
+
+    Args:
+        params: Must contain ``"artifact"`` — a dict with ``content``
+            and optional ``name`` / ``mime``.  Missing ``"artifact"`` is
+            a programming error at the call site; KeyError is acceptable
+            here (the emit_finding/propose_memory/notify convention).
+            The dict's inner keys are LLM-emitted, so they get tolerant
+            ``.get(...) or default`` guards.
+        db: An open :class:`~sqlalchemy.ext.asyncio.AsyncSession`.
+        session: The active :class:`~app.models.autonomous.AutonomousSession`;
+            the session supplies the target KB (``session.params["kb_id"]``),
+            the owner, and the project scope.
+    """
+    import hashlib
+
+    from app.models.document import Document, DocumentChunk
+    from app.models.file import File as FileModel
+    from app.models.knowledge import KnowledgeBaseFile
+    from app.pipeline.chunker import chunk_document
+    from app.pipeline.parsers import PageSpan, ParsedDocument
+    from app.storage import upload_bytes
+    from app.workers.queue import enqueue_embed_job
+
+    # Missing "artifact" key → KeyError, the established programming-error
+    # convention for local handlers (see emit_finding above).
+    artifact = params["artifact"]
+
+    # ── target KB ────────────────────────────────────────────────────────
+    # No target KB → honest skip, no rows, no upload. The drafting node
+    # surfaces this to the user via an explanatory finding (Task 3).
+    kb_id = (session.params or {}).get("kb_id")
+    if not kb_id:
+        return ToolResult(
+            cost_usd=Decimal("0"), outcome="skipped", data={"skipped": "no_target_kb"}
+        )
+    # Parse BEFORE the upload: a malformed kb_id must fail here, not at the
+    # KB-attach insert after the bytes have already landed in MinIO (orphan).
+    kb_uuid = uuid.UUID(str(kb_id))
+
+    # ── extract + sanitize (inner keys are LLM-emitted) ──────────────────
+    # Strip NUL bytes: "\u0000" is valid JSON (LLM-emittable) but Postgres
+    # TEXT rejects \x00 at flush — post-upload, that's an orphan + failed run.
+    content = str(artifact.get("content") or "").replace("\x00", "")
+    if not content:
+        return ToolResult(
+            cost_usd=Decimal("0"), outcome="skipped", data={"skipped": "empty_content"}
+        )
+
+    truncated = len(content) > _ARTIFACT_MAX_CHARS
+    if truncated:
+        content = content[:_ARTIFACT_MAX_CHARS]
+
+    name = _sanitize_artifact_name(artifact.get("name"))
+    mime = str(artifact.get("mime") or "text/markdown")
+
+    # size_bytes / hash are computed from THE ENCODED BYTES — what object
+    # storage actually holds — not the character count.
+    body = content.encode("utf-8")
+
+    # Client-generated id so the upload can happen BEFORE any DB state
+    # exists (per ADR 0005 the storage key IS the bare file UUID string).
+    file_id = uuid.uuid4()
+
+    # ── upload FIRST — no DB rows on storage failure ─────────────────────
+    # Mirrors the gateway_error honesty pattern: an artifact the user
+    # cannot download must never appear as a File row. A failed-late
+    # orphan MinIO object is acceptable — the same non-reaped class as
+    # ADR 0005's soft-deleted file bytes.
+    try:
+        await upload_bytes(storage_path=str(file_id), body=body, content_type=mime)
+    except Exception as exc:
+        log.warning(
+            "emit_artifact: storage upload failed; no DB rows written",
+            extra={
+                "event": "autonomous_artifact_storage_error",
+                "session_id": str(session.id),
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+        return ToolResult(
+            cost_usd=Decimal("0"),
+            outcome="storage_error",
+            data={"error": f"{type(exc).__name__}: {exc}"},
+        )
+
+    # ── File row ─────────────────────────────────────────────────────────
+    # ingestion_status='ready' immediately: the Document + chunks are
+    # written synchronously below, so the readiness the KB attach API's
+    # rule guards (chunks exist and are queryable) holds at flush time.
+    file_row = FileModel(
+        id=file_id,
+        owner_id=session.user_id,
+        project_id=session.project_id,
+        filename=name,
+        mime_type=mime,
+        size_bytes=len(body),
+        hash_sha256=hashlib.sha256(body).hexdigest(),
+        storage_path=str(file_id),
+        ingestion_status="ready",
+    )
+    db.add(file_row)
+    await db.flush()
+
+    # ── Document + chunks (direct-text sibling of the ingest pipeline) ──
+    # Synthetic single-page ParsedDocument over the artifact text — no PDF
+    # parser involved; parser/parser_version are honest about that.
+    parsed = ParsedDocument(
+        canonical_text=content,
+        pages=[PageSpan(page_number=1, char_start=0, char_end=len(content))],
+        page_count=1,
+        parser="autonomous-artifact",
+        parser_version="1",
+        structured_content=None,
+    )
+    chunks = chunk_document(parsed)
+
+    # Persisted EXACTLY in the ingest idiom (_persist_document_and_chunks):
+    # normalized_content is the same string the chunker sliced, so the
+    # M2-A1 re-read invariant holds for every chunk —
+    # chunk.content == normalized_content[char_offset_start:char_offset_end].
+    doc = Document(
+        file_id=file_row.id,
+        parser=parsed.parser,
+        parser_version=parsed.parser_version,
+        page_count=parsed.page_count,
+        character_count=len(parsed.canonical_text),
+        structured_content=parsed.structured_content,
+        normalized_content=parsed.canonical_text,
+        was_ocrd=False,
+    )
+    db.add(doc)
+    await db.flush()  # populate doc.id
+
+    for chunk in chunks:
+        db.add(
+            DocumentChunk(
+                document_id=doc.id,
+                chunk_index=chunk.chunk_index,
+                content=chunk.content,
+                page_start=chunk.page_start,
+                page_end=chunk.page_end,
+                char_offset_start=chunk.char_offset_start,
+                char_offset_end=chunk.char_offset_end,
+                tokens=None,
+                metadata_json=chunk.metadata,
+            )
+        )
+
+    # ── KB attach — DIRECT insert on purpose ─────────────────────────────
+    # fire_watches_for_kb only fires from the attach-file API handler, so
+    # a direct KnowledgeBaseFile insert cannot spawn a watch-triggered
+    # run — this is the loop-prevention design (a run's own memo must
+    # never trigger the watch that spawned it). No duplicate-attach
+    # concern: file_id is brand new.
+    db.add(KnowledgeBaseFile(kb_id=kb_uuid, file_id=file_row.id))
+
+    # ── artifact reference ───────────────────────────────────────────────
+    artifact_row = AutonomousArtifact(
+        session_id=session.id,
+        file_id=file_row.id,
+        name=name,
+        mime=mime,
+        size_bytes=len(body),
+    )
+    db.add(artifact_row)
+    await db.flush()
+
+    # ── best-effort embed enqueue ────────────────────────────────────────
+    # enqueue_embed_job already swallows transport errors, but wrap anyway
+    # (the notify-email belt-and-suspenders precedent). There is also a
+    # pre-commit race: the worker may dequeue the job before the executor
+    # commits, see no rows, and no-op — lazy embed-on-read at query time
+    # covers that gap (and any transport failure) either way.
+    try:
+        await enqueue_embed_job(file_row.id)
+    except Exception:
+        log.warning(
+            "emit_artifact: embed enqueue failed; embed-on-read covers the gap",
+            extra={
+                "event": "autonomous_artifact_embed_enqueue_error",
+                "file_id": str(file_row.id),
+            },
+            exc_info=True,
+        )
+
+    data: dict[str, Any] = {
+        "artifact_id": str(artifact_row.id),
+        "file_id": str(file_row.id),
+        "document_id": str(doc.id),
+        "name": name,
+        "size_bytes": len(body),
+    }
+    if truncated:
+        data["truncated"] = True
+    return ToolResult(cost_usd=Decimal("0"), data=data)
 
 
 async def _handle_retrieve_chunks(
@@ -618,6 +875,13 @@ async def _handle_retrieve_chunks_since(
     Soft-deleted files (``files.deleted_at IS NOT NULL``) are excluded
     so a deleted source never leaks back via the autonomous loop.
 
+    Files referenced by ``autonomous_artifacts`` are ALSO excluded —
+    a schedule's next tick retrieves "files attached since last run",
+    and a prior run's own memo lands in the KB as exactly such a file;
+    without the exclusion every tick re-analyzes the previous tick's
+    output (self-ingestion echo).  Query-mode (mode 1) and chat RAG
+    deliberately still see artifacts.
+
     Args:
         since_raw: cutoff as ISO-8601 ``str`` or aware
             :class:`datetime.datetime`.  Naive datetimes are NOT
@@ -671,6 +935,17 @@ async def _handle_retrieve_chunks_since(
                 .where(KnowledgeBaseFile.kb_id == kb_id)
                 .where(KnowledgeBaseFile.attached_at > since_dt)
                 .where(FileModel.deleted_at.is_(None))
+                # Self-ingestion-echo guard: a prior run's emit_artifact memo
+                # is attached to this KB as a real file; "new since last run"
+                # must not feed it back into the next run (mode 1 / chat RAG
+                # deliberately still see artifacts).
+                .where(
+                    ~FileModel.id.in_(
+                        select(AutonomousArtifact.file_id).where(
+                            AutonomousArtifact.file_id.is_not(None)
+                        )
+                    )
+                )
                 .order_by(
                     KnowledgeBaseFile.attached_at,
                     DocumentChunk.char_offset_start,

--- a/api/app/autonomous/nodes.py
+++ b/api/app/autonomous/nodes.py
@@ -283,11 +283,19 @@ def make_drafting_node(
        suggested precedent via
        :attr:`~app.autonomous.enums.ToolIntent.propose_precedent`. The
        parser's ``privilege_concerns`` / ``scope_concerns`` are forwarded
-       in the returned state for the ethics-review node.
+       in the returned state for the ethics-review node. When the session
+       opted in to artifacts (``params["emit_artifacts"]`` truthy — Donna
+       ask #8), each parsed artifact is additionally dispatched via
+       :attr:`~app.autonomous.enums.ToolIntent.emit_artifact`; skip /
+       storage-error outcomes surface as honest explanatory findings.
 
-    Every return path emits both ``findings`` (the list of dispatched
-    finding dicts) and ``findings_count`` (its length) — ``findings_count``
-    counts findings ONLY, never memories or precedents.
+    Every return path emits ``findings`` (the list of dispatched finding
+    dicts), ``findings_count`` (its length), and ``artifacts_count`` (the
+    number of artifacts PERSISTED through the chokepoint; 0 on cases 1-3
+    and when the opt-in flag is off) — ``findings_count`` counts findings
+    ONLY, never memories, precedents, or artifacts (though the
+    artifact-explanatory info/warn findings DO count: they go through
+    ``emit_finding`` like any other finding).
 
     Brakes propagate to the executor's terminal handler per the
     brake-commit contract.
@@ -330,6 +338,7 @@ def make_drafting_node(
                 "current_phase": str(Phase.drafting),
                 "findings": [finding],
                 "findings_count": 1,
+                "artifacts_count": 0,
             }
 
         # Case 2 — schedule first tick: emit ONE baseline finding.
@@ -353,6 +362,7 @@ def make_drafting_node(
                 "current_phase": str(Phase.drafting),
                 "findings": [finding],
                 "findings_count": 1,
+                "artifacts_count": 0,
             }
 
         parsed = parse_structured_output(state.get("analysis_content"))
@@ -375,6 +385,7 @@ def make_drafting_node(
                 "current_phase": str(Phase.drafting),
                 "findings": [finding],
                 "findings_count": 1,
+                "artifacts_count": 0,
             }
 
         # Case 4 — structured: dispatch each item as its own guarded call.
@@ -417,12 +428,99 @@ def make_drafting_node(
                 gateway,
             )
 
-        # ``findings_count`` counts findings ONLY — memories and precedents
-        # are deliberately excluded (they are proposals, not findings).
+        # Donna ask #8 — document-grade artifacts, OPT-IN ONLY. When the
+        # session flag is off, ``parsed.artifacts`` is ignored entirely
+        # (defense-in-depth: the model was never instructed to emit the
+        # ``artifacts`` key, so an unasked-for emission must never persist —
+        # and no finding is emitted about it either).
+        artifacts_count = 0
+        if (session.params or {}).get("emit_artifacts") and parsed.artifacts:
+            for artifact in parsed.artifacts:
+                result = await guarded_tool_call(
+                    session,
+                    ToolIntent.emit_artifact,
+                    {
+                        "artifact": {
+                            "name": artifact.get("name"),
+                            # Key mapping: ARTIFACT_OUTPUT_INSTRUCTION tells
+                            # the model to emit ``content_md``; the chokepoint
+                            # handler takes ``content``. Tolerate both so a
+                            # model that emits ``content`` anyway still lands.
+                            "content": artifact.get("content_md") or artifact.get("content") or "",
+                            "mime": "text/markdown",
+                        }
+                    },
+                    db,
+                    gateway,
+                )
+                data = result.data or {}
+                if data.get("artifact_id"):
+                    # Persisted — only real persists count toward the tally.
+                    artifacts_count += 1
+                    continue
+                if data.get("skipped") == "no_target_kb":
+                    # The session has no target KB, so EVERY remaining
+                    # artifact would skip for the same reason — emit ONE
+                    # ``info`` finding total (not one per artifact) and stop
+                    # attempting further artifacts.
+                    artifact_name = str(artifact.get("name") or "(unnamed)")[:255]
+                    finding = {
+                        "title": "Artifact not persisted — no target knowledge base",
+                        "summary": (
+                            f"The run produced the artifact "
+                            f"{artifact_name!r} but has no "
+                            "target knowledge base to save it into. Configure a "
+                            "target KB on the schedule or watch to persist "
+                            "artifacts."
+                        ),
+                        "severity": "info",
+                    }
+                    await guarded_tool_call(
+                        session,
+                        ToolIntent.emit_finding,
+                        {"finding": finding},
+                        db,
+                        gateway,
+                    )
+                    findings.append(finding)
+                    break
+                if data.get("skipped") == "empty_content":
+                    # Nothing to persist and nothing to explain — counted
+                    # nowhere; the remaining artifacts may still be fine.
+                    continue
+                if result.outcome == "storage_error":
+                    # Storage failures are per-artifact (and possibly
+                    # transient) — emit ONE ``warn`` finding for THIS
+                    # artifact and continue with the remaining ones.
+                    error_text = str(data.get("error") or "")[:500]
+                    artifact_name = str(artifact.get("name") or "(unnamed)")[:255]
+                    finding = {
+                        "title": "Artifact persistence failed at storage",
+                        "summary": (
+                            f"The artifact {artifact_name!r} "
+                            f"could not be uploaded to object storage: {error_text}"
+                        ),
+                        "severity": "warn",
+                    }
+                    await guarded_tool_call(
+                        session,
+                        ToolIntent.emit_finding,
+                        {"finding": finding},
+                        db,
+                        gateway,
+                    )
+                    findings.append(finding)
+                    continue
+
+        # ``findings_count`` counts findings ONLY — memories, precedents,
+        # and artifacts are deliberately excluded (the artifact-explanatory
+        # info/warn findings above DO count: they were dispatched through
+        # emit_finding and appended to ``findings`` like any other finding).
         return {
             "current_phase": str(Phase.drafting),
             "findings": findings,
             "findings_count": len(findings),
+            "artifacts_count": artifacts_count,
             "privilege_concerns": parsed.privilege_concerns,
             "scope_concerns": parsed.scope_concerns,
         }
@@ -507,10 +605,12 @@ def make_delivery_node(
     The delivery node transitions the session to :attr:`Phase.delivery`,
     calls :func:`~app.autonomous.guard.guarded_tool_call` with
     :attr:`~app.autonomous.enums.ToolIntent.notify` to write the
-    in-app notification row, writes the terminal
+    in-app notification row (payload always carries ``finding_count`` AND
+    ``artifact_count`` — Donna ask #8; the body mentions documents only
+    when ``artifact_count > 0``), writes the terminal
     ``autonomous_session.completed`` audit row (so the receipt's
-    ``terminal_reason`` populates), then marks the session as completed
-    and commits.
+    ``terminal_reason`` populates; it carries ``artifacts_count`` next to
+    ``findings_count``), then marks the session as completed and commits.
 
     Brakes propagate to the executor's terminal handler per the
     brake-commit contract.
@@ -534,13 +634,22 @@ def make_delivery_node(
         # Notify the user via the chokepoint — this is the canonical tool
         # call in the delivery phase; it must not bypass the gate.
         findings_count = state.get("findings_count", len(state.get("findings") or []))
+        artifact_count = state.get("artifacts_count", 0)
+        # Counts only, no content — one sentence; the document clause is
+        # appended only when artifacts persisted. The payload ALWAYS carries
+        # artifact_count (0 is honest, and lets a client distinguish
+        # "feature present, zero artifacts" from a pre-artifacts payload).
+        body = f"Session completed with {findings_count} finding(s)"
+        if artifact_count > 0:
+            body += f" and {artifact_count} document(s) saved to the knowledge base"
+        body += "."
         await guarded_tool_call(
             session,
             ToolIntent.notify,
             {
                 "title": "Autonomous session complete",
-                "body": f"Session completed with {findings_count} finding(s).",
-                "payload": {"finding_count": findings_count},
+                "body": body,
+                "payload": {"finding_count": findings_count, "artifact_count": artifact_count},
             },
             db,
             gateway,
@@ -555,6 +664,7 @@ def make_delivery_node(
             "completed",
             cost_total_usd=str(session.cost_total_usd or "0"),
             findings_count=findings_count,
+            artifacts_count=artifact_count,
         )
         session.status = "completed"
         session.completed_at = datetime.now(UTC)

--- a/api/app/autonomous/prompts.py
+++ b/api/app/autonomous/prompts.py
@@ -27,6 +27,13 @@ The structured-output instruction tail :data:`STRUCTURED_OUTPUT_INSTRUCTION`
 is always appended to the system prompt and tells the model exactly which
 JSON keys the drafting node parses (``findings``, ``suggested_memories``,
 ``suggested_precedents``, ``privilege_concerns``, ``scope_concerns``).
+
+When the session opted in to document-grade artifacts
+(``session.params["emit_artifacts"]`` is truthy — Donna ask #8), the
+additional :data:`ARTIFACT_OUTPUT_INSTRUCTION` tail is appended AFTER it,
+documenting the optional ``artifacts`` key. Sessions that did not opt in
+never see the artifact instruction, so existing automations see zero
+behavior/cost change.
 """
 
 from __future__ import annotations
@@ -88,6 +95,42 @@ response is logged as a finding only if the JSON cannot be parsed.
 
 
 # ---------------------------------------------------------------------------
+# Artifact instruction tail (opt-in — Donna ask #8)
+# ---------------------------------------------------------------------------
+#
+# Appended AFTER ``STRUCTURED_OUTPUT_INSTRUCTION`` ONLY when the session
+# opted in (``session.params["emit_artifacts"]`` is truthy).  It documents
+# one ADDITIONAL optional top-level key (``artifacts``) in the same JSON
+# object.  The contract spans three modules, all updated in this commit:
+#
+# - the parser (structured_output.py) fills ``StructuredResult.artifacts``
+#   via ``_as_dict_list`` regardless of the flag (flag-agnostic by design);
+# - the drafting node (nodes.py case 4) dispatches each parsed artifact
+#   through the ``emit_artifact`` chokepoint ONLY when the session flag is
+#   set (defense-in-depth: an un-asked-for ``artifacts`` key is ignored);
+# - the chokepoint handler (guard.py::_handle_emit_artifact) takes the
+#   inner ``content`` key — the drafting node maps ``content_md`` (the
+#   name instructed here) onto it.
+#
+# Changes here REQUIRE matching updates in those three places and a
+# regression test.
+
+ARTIFACT_OUTPUT_INSTRUCTION = """\
+The JSON object may also carry one ADDITIONAL optional top-level key:
+
+  "artifacts": [
+    {"name": "<filename, e.g. review-memo.md>",
+     "content_md": "<the full document in markdown>"}
+  ]
+
+When the work product warrants a standalone document (a review memo, a \
+summary, a report), emit it here as complete, self-contained markdown.  \
+The array may be empty.  Emit at most a few artifacts — the executor \
+persists each one into the run's knowledge base.
+"""
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -104,7 +147,10 @@ async def assemble_analysis_messages(
     Resolves the session's target (``skill_ref`` or ``playbook_id`` from
     ``session.params``) into a system prompt, formats the retrieved chunks
     as a user message, and appends :data:`STRUCTURED_OUTPUT_INSTRUCTION`
-    to the system prompt.
+    to the system prompt.  When the session opted in to artifacts
+    (``session.params["emit_artifacts"]`` is truthy),
+    :data:`ARTIFACT_OUTPUT_INSTRUCTION` is appended after it; otherwise
+    the model is never told about the ``artifacts`` key.
 
     Args:
         session: The autonomous session.  ``session.params`` must carry
@@ -152,6 +198,11 @@ async def assemble_analysis_messages(
 
     user_chunks = _format_chunks_as_user_content(chunks)
     full_system = system + "\n\n" + STRUCTURED_OUTPUT_INSTRUCTION
+    # Opt-in only (Donna ask #8): the artifact instruction is appended iff
+    # the spawn path copied ``emit_artifacts`` into the session params —
+    # non-opted-in sessions never pay the extra output tokens.
+    if (session.params or {}).get("emit_artifacts"):
+        full_system = full_system + "\n" + ARTIFACT_OUTPUT_INSTRUCTION
     return [
         {"role": "system", "content": full_system},
         {"role": "user", "content": user_chunks},
@@ -313,6 +364,7 @@ def _format_chunks_as_user_content(chunks: list[dict[str, Any]]) -> str:
 
 
 __all__ = [
+    "ARTIFACT_OUTPUT_INSTRUCTION",
     "STRUCTURED_OUTPUT_INSTRUCTION",
     "assemble_analysis_messages",
 ]

--- a/api/app/autonomous/state.py
+++ b/api/app/autonomous/state.py
@@ -87,3 +87,12 @@ class AutonomousSessionState(TypedDict, total=False):
     findings_count: int
     privilege_concerns: list[str]
     scope_concerns: list[str]
+
+    # Donna ask #8: number of document-grade artifacts the drafting node
+    # PERSISTED through the ``emit_artifact`` chokepoint (skips and storage
+    # errors are excluded). Always present on the drafting node's return —
+    # 0 when the session did not opt in (``params["emit_artifacts"]``
+    # absent) or on the non-structured drafting paths. The delivery node
+    # surfaces it as ``artifact_count`` in the notify payload and as
+    # ``artifacts_count`` on the terminal ``completed`` audit row.
+    artifacts_count: int

--- a/api/app/autonomous/structured_output.py
+++ b/api/app/autonomous/structured_output.py
@@ -11,6 +11,11 @@ This satisfies the inline contract in
 :mod:`api.app.autonomous.prompts` above ``STRUCTURED_OUTPUT_INSTRUCTION``:
 the parser MUST implement the malformed-response fallback (tolerant
 unstructured result with raw content preserved) — never raise.
+
+Tolerance is item-level too: in the dict-shaped arrays (``findings``,
+``suggested_memories``, ``suggested_precedents``, ``artifacts``), any
+non-dict item is silently dropped rather than passed through to the
+drafting node's ``.get()`` calls.
 """
 
 from __future__ import annotations
@@ -30,6 +35,13 @@ _FENCED_JSON_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
 class StructuredResult:
     """Result of parsing the analysis call's response content.
 
+    The four dict-shaped arrays (``findings``, ``suggested_memories``,
+    ``suggested_precedents``, ``artifacts``) contain dicts ONLY — any
+    non-dict items the model emitted are silently dropped at parse time
+    (tolerant parsing). The string arrays (``privilege_concerns``,
+    ``scope_concerns``) keep items as-is; they are only ever
+    string-formatted downstream.
+
     Attributes:
         is_structured: True iff a JSON object was successfully parsed.
         findings: Parsed ``findings`` array (empty when missing).
@@ -37,6 +49,11 @@ class StructuredResult:
         suggested_precedents: Parsed ``suggested_precedents`` array.
         privilege_concerns: Parsed ``privilege_concerns`` array.
         scope_concerns: Parsed ``scope_concerns`` array.
+        artifacts: Parsed ``artifacts`` array (Donna ask #8 — items shaped
+            ``{"name", "content_md"}`` per ``ARTIFACT_OUTPUT_INSTRUCTION``).
+            Parsed regardless of the session's ``emit_artifacts`` opt-in
+            flag — the parser is flag-agnostic; the drafting node enforces
+            opt-in and ignores this list when the flag is off.
         raw_content: Original response content, preserved verbatim.
             When ``is_structured`` is False this is the text the drafting
             node logs as a single fallback finding.
@@ -48,6 +65,7 @@ class StructuredResult:
     suggested_precedents: list[dict[str, Any]] = field(default_factory=list)
     privilege_concerns: list[str] = field(default_factory=list)
     scope_concerns: list[str] = field(default_factory=list)
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
     raw_content: str = ""
 
     @classmethod
@@ -59,6 +77,25 @@ class StructuredResult:
 def _as_list(value: Any) -> list[Any]:
     """Coerce a JSON value to a list — non-list values yield []."""
     return list(value) if isinstance(value, list) else []
+
+
+def _as_dict_list(value: Any) -> list[dict[str, Any]]:
+    """Coerce a JSON value to a list of dicts — tolerant, item-level.
+
+    Non-list values yield []; non-dict items inside a list are silently
+    dropped. The dict-shaped arrays (``findings``, ``suggested_memories``,
+    ``suggested_precedents``, ``artifacts``) are consumed downstream with
+    ``.get()`` calls, so a string or number smuggled into an otherwise
+    valid array would raise ``AttributeError`` in the drafting node and
+    fail the whole run — worse than this module's tolerant-degradation
+    contract allows. This helper intentionally hardens the three
+    pre-existing dict-shaped loops too, not just ``artifacts``: a uniform
+    posture beats per-loop drift (the failure mode is not "wrong decision"
+    but "different decisions in different files").
+    """
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
 
 
 def parse_structured_output(content: str | None) -> StructuredResult:
@@ -104,11 +141,12 @@ def parse_structured_output(content: str | None) -> StructuredResult:
 
     return StructuredResult(
         is_structured=True,
-        findings=_as_list(parsed.get("findings")),
-        suggested_memories=_as_list(parsed.get("suggested_memories")),
-        suggested_precedents=_as_list(parsed.get("suggested_precedents")),
+        findings=_as_dict_list(parsed.get("findings")),
+        suggested_memories=_as_dict_list(parsed.get("suggested_memories")),
+        suggested_precedents=_as_dict_list(parsed.get("suggested_precedents")),
         privilege_concerns=_as_list(parsed.get("privilege_concerns")),
         scope_concerns=_as_list(parsed.get("scope_concerns")),
+        artifacts=_as_dict_list(parsed.get("artifacts")),
         raw_content=content,
     )
 

--- a/api/app/autonomous/watch_trigger.py
+++ b/api/app/autonomous/watch_trigger.py
@@ -60,7 +60,9 @@ async def fire_watches_for_kb(
        by ``watch.user_id`` with ``trigger_kind='watch'``, ``trigger_ref``
        = the watch id, ``status='running'``, ``current_phase='intake'``,
        and ``params`` carrying the non-null subset of ``{"kb_id",
-       "playbook_id", "skill_ref", "file_id"}``.
+       "playbook_id", "skill_ref", "file_id", "emit_artifacts"}``
+       (``emit_artifacts`` is set — to ``True`` — only when the watch
+       opted in; Donna ask #8).
     2. Commits once after all session rows are created.
     3. ``await enqueue(session.id)`` for each created session — best-effort;
        the helper swallows transport errors and returns bool, and the loop
@@ -97,6 +99,10 @@ async def fire_watches_for_kb(
             params["playbook_id"] = str(watch.playbook_id)
         if watch.skill_ref is not None:
             params["skill_ref"] = watch.skill_ref
+        if watch.emit_artifacts:
+            # Opt-in (Donna ask #8) — non-null-subset convention: the key
+            # is present iff the watch opted in.
+            params["emit_artifacts"] = True
 
         session = AutonomousSession(
             user_id=watch.user_id,

--- a/api/app/models/autonomous.py
+++ b/api/app/models/autonomous.py
@@ -8,7 +8,8 @@ brakes. M4-A1 lands only the tables, models, and schemas — no executor,
 no API endpoints, no business logic. M4-A3.2 adds the in-app
 notification substrate (``autonomous_notifications``).
 
-Five tables (migration ``0039_autonomous_layer.py``) + one from 0040:
+Nine tables — five from migration ``0039_autonomous_layer.py``, plus
+one each from 0040, 0041, 0046, and 0047:
 
 * :class:`AutonomousSession` — the run record carrying the brakes
   (cost cap, halt state, idle-halt window, phase machine).
@@ -23,13 +24,20 @@ Five tables (migration ``0039_autonomous_layer.py``) + one from 0040:
   the authorized ``context_md`` write (ADR 0013 D5).
 * :class:`AutonomousNotification` — durable in-app notification written
   by the ``notify`` chokepoint handler (A3.3); migration 0040.
+* :class:`AutonomousFinding` — persisted analysis finding emitted by a
+  run via the ``emit_finding`` chokepoint; migration 0046.
+* :class:`AutonomousArtifact` — reference to a document-grade artifact
+  (a KB document) emitted by a run via the ``emit_artifact``
+  chokepoint; migration 0047.
 
 Every table carries a non-null ``user_id`` FK with ``ON DELETE
 CASCADE`` — the autonomous layer is **hard per-user isolated**. A
-user's deletion removes all of their autonomous state. This differs
-from the playbook tables (which ``SET NULL`` to preserve shared audit
-history) because autonomous sessions are private to the operator who
-ran them and carry no shared work product.
+user's deletion removes all of their autonomous state. (Exceptions:
+``autonomous_findings`` and ``autonomous_artifacts`` carry no
+``user_id`` — authz is via the owning session, which cascades from the
+user.) This differs from the playbook tables (which ``SET NULL`` to
+preserve shared audit history) because autonomous sessions are private
+to the operator who ran them and carry no shared work product.
 
 The CHECK constraints on the session enums + ``autonomous_memory.state``
 are enforced at the storage layer (see migration 0039); the canonical
@@ -44,7 +52,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric, Text, text
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Integer, Numeric, Text, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -136,8 +144,11 @@ class AutonomousSchedule(Base):
     ``cron_expr`` is a standard five-field cron string the scheduler
     parses. ``playbook_id`` / ``skill_ref`` / ``target_kb_id`` describe
     what the triggered session runs (a playbook, a skill, against a KB).
-    Soft-deleted via ``deleted_at`` so a disabled-then-removed schedule
-    keeps its audit trail.
+    ``emit_artifacts`` opts the schedule's sessions in to document-grade
+    artifact emission (migration 0047) — default off, so existing
+    automations see zero behavior or cost change. Soft-deleted via
+    ``deleted_at`` so a disabled-then-removed schedule keeps its audit
+    trail.
     """
 
     __tablename__ = "autonomous_schedules"
@@ -175,6 +186,9 @@ class AutonomousSchedule(Base):
         nullable=True,
     )
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+    emit_artifacts: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
     max_cost_usd: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
     last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     next_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -198,7 +212,10 @@ class AutonomousWatch(Base):
 
     When the watched ``knowledge_base_id`` changes (a new file ingested),
     the agent starts a session running ``playbook_id`` / ``skill_ref``
-    against the change. Soft-deleted via ``deleted_at``.
+    against the change. ``emit_artifacts`` opts the watch's sessions in
+    to document-grade artifact emission (migration 0047) — default off,
+    so existing automations see zero behavior or cost change.
+    Soft-deleted via ``deleted_at``.
     """
 
     __tablename__ = "autonomous_watches"
@@ -234,6 +251,9 @@ class AutonomousWatch(Base):
     )
     skill_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+    emit_artifacts: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
     max_cost_usd: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
@@ -474,6 +494,73 @@ class AutonomousFinding(Base):
         return (
             f"<AutonomousFinding id={self.id} session_id={self.session_id} "
             f"severity={self.severity!r} title={self.title!r}>"
+        )
+
+
+class AutonomousArtifact(Base):
+    """A reference to a document-grade artifact emitted by an autonomous run.
+
+    Artifacts are markdown memos (or other document-grade work product)
+    an opted-in run persists into its target knowledge base as real
+    documents. Rows are written by the ``emit_artifact`` chokepoint
+    handler (handler + read endpoint follow this substrate); this table
+    is the *reference*, not the document —
+    the document itself lives in ``files`` / the KB like any other
+    upload.
+
+    Deletion semantics: ``session_id`` FK is ``ON DELETE CASCADE`` — the
+    artifact *reference* dies with its session. ``file_id`` FK is ``ON
+    DELETE SET NULL`` — the KB document OUTLIVES the session (it is the
+    user's deliverable); deleting the session never deletes the KB
+    document, and a hard file-delete nulls the ref while the name/size
+    metadata survives here.
+
+    ``name`` and ``mime`` are LLM-emitted free text — deliberately NO
+    CHECK constraints (the ``autonomous_findings.severity`` precedent):
+    whatever the model produces must store, not reject the row.
+
+    There is no ``user_id`` column: authz is via the owning session,
+    exactly like :class:`AutonomousFinding` (the read endpoint
+    owner-gates by loading the owned session, then queries by
+    ``session_id``).
+    """
+
+    __tablename__ = "autonomous_artifacts"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "autonomous_sessions.id",
+            ondelete="CASCADE",
+            name="fk_autonomous_artifacts_session_id",
+        ),
+        nullable=False,
+    )
+    file_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "files.id",
+            ondelete="SET NULL",
+            name="fk_autonomous_artifacts_file_id",
+        ),
+        nullable=True,
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    mime: Mapped[str] = mapped_column(Text, nullable=False)
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<AutonomousArtifact id={self.id} session_id={self.session_id} "
+            f"name={self.name!r} file_id={self.file_id}>"
         )
 
 

--- a/api/app/schemas/autonomous.py
+++ b/api/app/schemas/autonomous.py
@@ -210,7 +210,10 @@ class AutonomousManualRunRequest(BaseModel):
     ``target_kb_id`` and ``project_id`` are optional scope. ``max_cost_usd``
     is the per-run cap (NULL = fall back to
     ``settings.autonomous_default_max_cost_usd`` at spawn time, so R4 always
-    trips).
+    trips). ``emit_artifacts`` opts the run in to document-grade artifacts
+    (Donna ask #8) — a manual run has no schedule/watch row to inherit the
+    flag from, so the request body IS the opt-in source; defaults off,
+    matching the schedule/watch column default.
     """
 
     playbook_id: uuid.UUID | None = None
@@ -218,6 +221,7 @@ class AutonomousManualRunRequest(BaseModel):
     target_kb_id: uuid.UUID | None = None
     project_id: uuid.UUID | None = None
     max_cost_usd: Decimal | None = None
+    emit_artifacts: bool = False
 
     @model_validator(mode="after")
     def _exactly_one_target(self) -> AutonomousManualRunRequest:

--- a/api/app/schemas/autonomous.py
+++ b/api/app/schemas/autonomous.py
@@ -140,6 +140,7 @@ class AutonomousScheduleRead(BaseModel):
     skill_ref: str | None = None
     target_kb_id: uuid.UUID | None = None
     enabled: bool
+    emit_artifacts: bool
     max_cost_usd: Decimal | None = None
     last_run_at: datetime | None = None
     next_run_at: datetime | None = None
@@ -155,8 +156,11 @@ class AutonomousScheduleCreate(BaseModel):
     :func:`app.autonomous.cron.validate_cron_expr` (invalid → 422). The
     target (``playbook_id`` / ``skill_ref`` / ``target_kb_id``) and
     ``project_id`` are optional; ``enabled`` defaults to True.
-    ``max_cost_usd`` is the per-schedule spend cap (NULL = fall back to
-    ``settings.autonomous_default_max_cost_usd`` at spawn time).
+    ``emit_artifacts`` opts the schedule's sessions in to document-grade
+    artifact emission (default off — zero behavior/cost change unless
+    requested). ``max_cost_usd`` is the per-schedule spend cap (NULL =
+    fall back to ``settings.autonomous_default_max_cost_usd`` at spawn
+    time).
     """
 
     cron_expr: str
@@ -166,6 +170,7 @@ class AutonomousScheduleCreate(BaseModel):
     target_kb_id: uuid.UUID | None = None
     project_id: uuid.UUID | None = None
     enabled: bool = True
+    emit_artifacts: bool = False
     max_cost_usd: Decimal | None = None
 
 
@@ -174,7 +179,9 @@ class AutonomousScheduleUpdate(BaseModel):
 
     All fields optional — a partial update. If ``cron_expr`` is provided
     it is re-validated (invalid → 422) and ``next_run_at`` is recomputed.
-    Toggling ``enabled`` is allowed. ``max_cost_usd`` may be edited
+    Toggling ``enabled`` is allowed. ``emit_artifacts`` may be toggled
+    to opt the schedule's future sessions in or out of document-grade
+    artifact emission. ``max_cost_usd`` may be edited
     (NULL clears the per-schedule cap → fall back to global default).
     The matter (``project_id``) may be reassigned; an explicit ``null``
     clears it (unassign). A non-null ``project_id`` the caller does not
@@ -184,6 +191,7 @@ class AutonomousScheduleUpdate(BaseModel):
     name: str | None = None
     cron_expr: str | None = None
     enabled: bool | None = None
+    emit_artifacts: bool | None = None
     playbook_id: uuid.UUID | None = None
     skill_ref: str | None = None
     target_kb_id: uuid.UUID | None = None
@@ -244,6 +252,7 @@ class AutonomousWatchRead(BaseModel):
     playbook_id: uuid.UUID | None = None
     skill_ref: str | None = None
     enabled: bool
+    emit_artifacts: bool
     max_cost_usd: Decimal | None = None
     deleted_at: datetime | None = None
     created_at: datetime
@@ -259,9 +268,11 @@ class AutonomousWatchCreate(BaseModel):
     ``skill_ref``) and ``project_id`` are optional; ``enabled`` defaults
     to True. The watch is bound to its KB — there is no
     ``knowledge_base_id`` on the update schema (create a new watch for a
-    different KB). ``max_cost_usd`` is the per-watch spend cap (NULL =
-    fall back to ``settings.autonomous_default_max_cost_usd`` at spawn
-    time).
+    different KB). ``emit_artifacts`` opts the watch's sessions in to
+    document-grade artifact emission (default off — zero behavior/cost
+    change unless requested). ``max_cost_usd`` is the per-watch spend
+    cap (NULL = fall back to
+    ``settings.autonomous_default_max_cost_usd`` at spawn time).
     """
 
     knowledge_base_id: uuid.UUID
@@ -269,6 +280,7 @@ class AutonomousWatchCreate(BaseModel):
     skill_ref: str | None = None
     project_id: uuid.UUID | None = None
     enabled: bool = True
+    emit_artifacts: bool = False
     max_cost_usd: Decimal | None = None
 
 
@@ -278,7 +290,9 @@ class AutonomousWatchUpdate(BaseModel):
     All fields optional — a partial update. Toggling ``enabled`` is
     allowed; ``playbook_id`` / ``skill_ref`` may be retargeted. The
     watch's ``knowledge_base_id`` is immutable (not present here) — a
-    watch is bound to its KB. ``max_cost_usd`` may be edited (NULL clears
+    watch is bound to its KB. ``emit_artifacts`` may be toggled to opt
+    the watch's future sessions in or out of document-grade artifact
+    emission. ``max_cost_usd`` may be edited (NULL clears
     the per-watch cap → fall back to global default). The matter
     (``project_id``) may be reassigned; an explicit ``null`` clears it
     (unassign). A non-null ``project_id`` the caller does not own is
@@ -286,6 +300,7 @@ class AutonomousWatchUpdate(BaseModel):
     """
 
     enabled: bool | None = None
+    emit_artifacts: bool | None = None
     playbook_id: uuid.UUID | None = None
     skill_ref: str | None = None
     project_id: uuid.UUID | None = None
@@ -467,6 +482,46 @@ class AutonomousFindingListResponse(BaseModel):
     """
 
     findings: list[AutonomousFindingRead]
+    total_count: int
+    limit: int
+    offset: int
+
+
+class AutonomousArtifactRead(BaseModel):
+    """ORM-read view of an ``autonomous_artifacts`` row (work-product ref).
+
+    An artifact is a document-grade deliverable (a markdown memo) an
+    opted-in run persisted into its target KB via the ``emit_artifact``
+    chokepoint. ``name`` and ``mime`` are LLM-emitted free text (no
+    CHECK constraints; the ``severity`` precedent). ``file_id`` is NULL
+    if the underlying file was later hard-deleted — the name/size
+    metadata survives here. ``document_id`` is NOT an ORM column: it is
+    enriched at the endpoint from ``documents.file_id`` (default None),
+    so the UI can deep-link the KB document. ``session_id`` is
+    deliberately omitted — the endpoint is session-scoped per the Donna
+    contract shape, so the caller already has it.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    mime: str
+    size_bytes: int
+    file_id: uuid.UUID | None = None
+    document_id: uuid.UUID | None = None
+    created_at: datetime
+
+
+class AutonomousArtifactListResponse(BaseModel):
+    """Paginated list of :class:`AutonomousArtifactRead` items.
+
+    Mirrors ``AutonomousFindingListResponse`` — total_count / limit /
+    offset envelope. Artifacts are read in emission order (``created_at
+    ASC``) — one run's sequential output, not a newest-first feed.
+    """
+
+    artifacts: list[AutonomousArtifactRead]
     total_count: int
     limit: int
     offset: int

--- a/api/app/schemas/autonomous.py
+++ b/api/app/schemas/autonomous.py
@@ -480,9 +480,12 @@ class AutonomousFindingListResponse(BaseModel):
     """Paginated list of :class:`AutonomousFindingRead` items.
 
     Mirrors ``AutonomousMemoryListResponse`` — total_count / limit /
-    offset envelope. Findings are read in emission order (``created_at
-    ASC``) — one run's sequential output, not a newest-first feed. Uses
-    the ``findings`` key (Donna's UI expects ``findings: [...]``).
+    offset envelope. Findings are read in a stable ``created_at ASC, id
+    ASC`` order — one run's rows typically share ``created_at``
+    (transaction-stable ``now()``), so ``id`` is the pagination
+    tiebreaker; repeatable, not a guaranteed emission sequence. Not a
+    newest-first feed. Uses the ``findings`` key (Donna's UI expects
+    ``findings: [...]``).
     """
 
     findings: list[AutonomousFindingRead]
@@ -521,8 +524,9 @@ class AutonomousArtifactListResponse(BaseModel):
     """Paginated list of :class:`AutonomousArtifactRead` items.
 
     Mirrors ``AutonomousFindingListResponse`` — total_count / limit /
-    offset envelope. Artifacts are read in emission order (``created_at
-    ASC``) — one run's sequential output, not a newest-first feed.
+    offset envelope. Artifacts are read in the same stable ``created_at
+    ASC, id ASC`` order (see that schema's note) — repeatable, not a
+    guaranteed emission sequence; not a newest-first feed.
     """
 
     artifacts: list[AutonomousArtifactRead]

--- a/api/app/workers/autonomous_worker.py
+++ b/api/app/workers/autonomous_worker.py
@@ -311,7 +311,9 @@ async def _run_schedule_sweep(
        ``trigger_kind='schedule'``, ``trigger_ref`` = the schedule id,
        ``status='running'``, ``current_phase='intake'``, and ``params``
        carrying the non-null subset of the schedule's target
-       (``kb_id`` ← ``target_kb_id``, ``playbook_id``, ``skill_ref``).
+       (``kb_id`` ← ``target_kb_id``, ``playbook_id``, ``skill_ref``,
+       plus ``emit_artifacts`` — set to ``True`` only when the schedule
+       opted in; Donna ask #8).
     2. Flushes to obtain the session id, then ``await enqueue(id)`` —
        best-effort; a failed enqueue leaves the row at ``running`` for
        manual re-enqueue (matching the queue-helper posture).
@@ -375,6 +377,10 @@ async def _run_schedule_sweep(
                 params["playbook_id"] = str(schedule.playbook_id)
             if schedule.skill_ref is not None:
                 params["skill_ref"] = schedule.skill_ref
+            if schedule.emit_artifacts:
+                # Opt-in (Donna ask #8) — non-null-subset convention: the
+                # key is present iff the schedule opted in.
+                params["emit_artifacts"] = True
 
             session = AutonomousSession(
                 user_id=schedule.user_id,

--- a/api/tests/autonomous/test_artifacts_endpoint.py
+++ b/api/tests/autonomous/test_artifacts_endpoint.py
@@ -1,18 +1,22 @@
-"""Integration tests for GET /autonomous/sessions/{id}/findings (Task 2).
+"""Integration tests for GET /autonomous/sessions/{id}/artifacts (Donna #8, Task 4).
 
-The read surface for a run's persisted findings (Task 1 work-product).
-Covers:
-- Happy path: a session's findings return with severity/title/content,
+The read surface for a run's persisted document-grade artifact references
+(Task 1 substrate + Task 2 chokepoint work-product). Mirrors
+test_findings_endpoint.py. Covers:
+- Happy path: a session's artifacts return with name/mime/size_bytes,
   correct total_count, ordered by created_at ASC with id ASC tiebreaker
   (stable, repeatable order — not a guaranteed emission sequence).
+- document_id enrichment: artifact with a File + Document → document_id
+  resolved via the unique documents.file_id; NULL file_id → document_id
+  None; file without a documents row → None.
 - Cross-user 404: user B requesting user A's session → 404 (id-probing-safe).
-- Empty: a session with no findings → 200, findings=[], total_count=0.
-- Pagination: ?limit=1&offset=1 returns the middle finding + full total_count.
+- Empty: a session with no artifacts → 200, artifacts=[], total_count=0.
+- Pagination: ?limit=1&offset=1 returns the middle artifact + full total_count.
 - Stable pagination under identical created_at: rows a run emits in one
   executor commit share a transaction-stable now(); the id tiebreaker
   keeps limit/offset paging free of skips/duplicates and repeatable.
 - Unauth → 401.
-- OpenAPI conformance for the findings path + schemas.
+- OpenAPI conformance for the artifacts path + schemas.
 """
 
 from __future__ import annotations
@@ -28,7 +32,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
 from app.main import app
-from app.models.autonomous import AutonomousFinding, AutonomousSession
+from app.models.autonomous import AutonomousArtifact, AutonomousSession
+from app.models.document import Document
+from app.models.file import File as FileModel
 from app.models.user import User
 from app.security import create_access_token, hash_password
 
@@ -55,8 +61,8 @@ async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
 
 async def _make_user(db: AsyncSession, *, suffix: str = "") -> User:
     user = User(
-        email=f"find-ep-{suffix or uuid.uuid4().hex[:8]}@example.com",
-        display_name=f"Finding Test User {suffix}".strip(),
+        email=f"artif-ep-{suffix or uuid.uuid4().hex[:8]}@example.com",
+        display_name=f"Artifact Test User {suffix}".strip(),
         hashed_password=hash_password("correct-horse-battery-staple"),
         is_admin=False,
         mfa_enabled=False,
@@ -97,86 +103,182 @@ async def _make_session(db: AsyncSession, *, user: User) -> AutonomousSession:
     return sess
 
 
-async def _make_finding(
+async def _make_file(db: AsyncSession, *, owner: User, name: str = "memo.md") -> FileModel:
+    file_id = uuid.uuid4()
+    file_row = FileModel(
+        id=file_id,
+        owner_id=owner.id,
+        filename=name,
+        mime_type="text/markdown",
+        size_bytes=10,
+        hash_sha256=uuid.uuid4().hex + uuid.uuid4().hex,
+        storage_path=str(file_id),
+        ingestion_status="ready",
+    )
+    db.add(file_row)
+    await db.flush()
+    return file_row
+
+
+async def _make_document(db: AsyncSession, *, file: FileModel) -> Document:
+    doc = Document(
+        file_id=file.id,
+        parser="autonomous-artifact",
+        page_count=1,
+        character_count=10,
+        normalized_content="# memo\nhi",
+    )
+    db.add(doc)
+    await db.flush()
+    return doc
+
+
+async def _make_artifact(
     db: AsyncSession,
     *,
     session: AutonomousSession,
-    severity: str = "info",
-    title: str = "Finding",
-    content: str = "body",
+    file_id: uuid.UUID | None = None,
+    name: str = "memo.md",
+    mime: str = "text/markdown",
+    size_bytes: int = 10,
     created_at: datetime | None = None,
-) -> AutonomousFinding:
-    finding = AutonomousFinding(
+) -> AutonomousArtifact:
+    artifact = AutonomousArtifact(
         session_id=session.id,
-        severity=severity,
-        title=title,
-        content=content,
+        file_id=file_id,
+        name=name,
+        mime=mime,
+        size_bytes=size_bytes,
     )
     if created_at is not None:
-        finding.created_at = created_at
-    db.add(finding)
+        artifact.created_at = created_at
+    db.add(artifact)
     await db.flush()
-    await db.refresh(finding)
-    return finding
+    await db.refresh(artifact)
+    return artifact
 
 
 # ---------------------------------------------------------------------------
-# Happy path
+# Happy path + document_id enrichment
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
-async def test_list_findings_returns_them_in_emission_order(
+async def test_list_artifacts_returns_them_in_emission_order(
     client: AsyncClient,
     db_session: AsyncSession,
     user_a: User,
 ) -> None:
-    """A session's findings return with severity/title/content, ASC by created_at."""
+    """A session's artifacts return with name/mime/size_bytes, ASC by created_at."""
     sess = await _make_session(db_session, user=user_a)
     base = datetime.now(UTC)
     # Insert out of order; explicit created_at proves the ASC sort.
-    await _make_finding(
+    await _make_artifact(
         db_session,
         session=sess,
-        severity="warn",
-        title="Second",
-        content="b2",
+        name="second.md",
+        size_bytes=22,
         created_at=base + timedelta(seconds=2),
     )
-    await _make_finding(
+    await _make_artifact(
         db_session,
         session=sess,
-        severity="info",
-        title="First",
-        content="b1",
+        name="first.md",
+        size_bytes=11,
         created_at=base + timedelta(seconds=1),
     )
-    await _make_finding(
+    await _make_artifact(
         db_session,
         session=sess,
-        severity="critical",
-        title="Third",
-        content="b3",
+        name="third.md",
+        size_bytes=33,
         created_at=base + timedelta(seconds=3),
     )
 
     resp = await client.get(
-        f"/api/v1/autonomous/sessions/{sess.id}/findings",
+        f"/api/v1/autonomous/sessions/{sess.id}/artifacts",
         headers=_bearer(user_a),
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
 
-    titles = [f["title"] for f in body["findings"]]
-    assert titles == ["First", "Second", "Third"]
+    names = [a["name"] for a in body["artifacts"]]
+    assert names == ["first.md", "second.md", "third.md"]
     assert body["total_count"] == 3
     assert body["limit"] == 50
     assert body["offset"] == 0
 
-    first = body["findings"][0]
-    assert first["severity"] == "info"
-    assert first["content"] == "b1"
-    assert first["session_id"] == str(sess.id)
+    first = body["artifacts"][0]
+    assert first["mime"] == "text/markdown"
+    assert first["size_bytes"] == 11
+    # No file rows were created — file_id and document_id are null.
+    assert first["file_id"] is None
+    assert first["document_id"] is None
+
+
+@pytest.mark.integration
+async def test_list_artifacts_enriches_document_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """An artifact whose file has a Document gets document_id via documents.file_id."""
+    sess = await _make_session(db_session, user=user_a)
+    file_row = await _make_file(db_session, owner=user_a)
+    doc = await _make_document(db_session, file=file_row)
+    await _make_artifact(db_session, session=sess, file_id=file_row.id)
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/artifacts",
+        headers=_bearer(user_a),
+    )
+    assert resp.status_code == 200, resp.text
+    item = resp.json()["artifacts"][0]
+    assert item["file_id"] == str(file_row.id)
+    assert item["document_id"] == str(doc.id)
+
+
+@pytest.mark.integration
+async def test_list_artifacts_null_file_id_yields_null_document_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """A SET-NULLed file_id (file hard-deleted) returns both refs as null."""
+    sess = await _make_session(db_session, user=user_a)
+    await _make_artifact(db_session, session=sess, file_id=None, name="orphan.md")
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/artifacts",
+        headers=_bearer(user_a),
+    )
+    assert resp.status_code == 200, resp.text
+    item = resp.json()["artifacts"][0]
+    # The metadata survives the hard delete; the refs are honest nulls.
+    assert item["name"] == "orphan.md"
+    assert item["file_id"] is None
+    assert item["document_id"] is None
+
+
+@pytest.mark.integration
+async def test_list_artifacts_file_without_document_yields_null_document_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """A live file_id with no documents row maps to document_id=None."""
+    sess = await _make_session(db_session, user=user_a)
+    file_row = await _make_file(db_session, owner=user_a)  # no Document created
+    await _make_artifact(db_session, session=sess, file_id=file_row.id)
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/artifacts",
+        headers=_bearer(user_a),
+    )
+    assert resp.status_code == 200, resp.text
+    item = resp.json()["artifacts"][0]
+    assert item["file_id"] == str(file_row.id)
+    assert item["document_id"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -185,31 +287,31 @@ async def test_list_findings_returns_them_in_emission_order(
 
 
 @pytest.mark.integration
-async def test_list_findings_cross_user_returns_404(
+async def test_list_artifacts_cross_user_returns_404(
     client: AsyncClient,
     db_session: AsyncSession,
     user_a: User,
     user_b: User,
 ) -> None:
-    """User B requesting user A's session findings returns 404 (no leakage)."""
+    """User B requesting user A's session artifacts returns 404 (no leakage)."""
     sess = await _make_session(db_session, user=user_a)
-    await _make_finding(db_session, session=sess, title="secret")
+    await _make_artifact(db_session, session=sess, name="secret.md")
 
     resp = await client.get(
-        f"/api/v1/autonomous/sessions/{sess.id}/findings",
+        f"/api/v1/autonomous/sessions/{sess.id}/artifacts",
         headers=_bearer(user_b),
     )
     assert resp.status_code == 404, resp.text
 
 
 @pytest.mark.integration
-async def test_list_findings_missing_session_returns_404(
+async def test_list_artifacts_missing_session_returns_404(
     client: AsyncClient,
     user_a: User,
 ) -> None:
     """A nonexistent session id returns 404 (same posture as cross-user)."""
     resp = await client.get(
-        f"/api/v1/autonomous/sessions/{uuid.uuid4()}/findings",
+        f"/api/v1/autonomous/sessions/{uuid.uuid4()}/artifacts",
         headers=_bearer(user_a),
     )
     assert resp.status_code == 404, resp.text
@@ -221,21 +323,21 @@ async def test_list_findings_missing_session_returns_404(
 
 
 @pytest.mark.integration
-async def test_list_findings_empty_session(
+async def test_list_artifacts_empty_session(
     client: AsyncClient,
     db_session: AsyncSession,
     user_a: User,
 ) -> None:
-    """A session with no findings returns 200, findings=[], total_count=0."""
+    """A session with no artifacts returns 200, artifacts=[], total_count=0."""
     sess = await _make_session(db_session, user=user_a)
 
     resp = await client.get(
-        f"/api/v1/autonomous/sessions/{sess.id}/findings",
+        f"/api/v1/autonomous/sessions/{sess.id}/artifacts",
         headers=_bearer(user_a),
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["findings"] == []
+    assert body["artifacts"] == []
     assert body["total_count"] == 0
 
 
@@ -245,43 +347,43 @@ async def test_list_findings_empty_session(
 
 
 @pytest.mark.integration
-async def test_list_findings_pagination_returns_middle(
+async def test_list_artifacts_pagination_returns_middle(
     client: AsyncClient,
     db_session: AsyncSession,
     user_a: User,
 ) -> None:
-    """?limit=1&offset=1 returns the middle finding + full total_count."""
+    """?limit=1&offset=1 returns the middle artifact + full total_count."""
     sess = await _make_session(db_session, user=user_a)
     base = datetime.now(UTC)
     for i in range(3):
-        await _make_finding(
+        await _make_artifact(
             db_session,
             session=sess,
-            title=f"F{i}",
+            name=f"a{i}.md",
             created_at=base + timedelta(seconds=i),
         )
 
     resp = await client.get(
-        f"/api/v1/autonomous/sessions/{sess.id}/findings",
+        f"/api/v1/autonomous/sessions/{sess.id}/artifacts",
         headers=_bearer(user_a),
         params={"limit": 1, "offset": 1},
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert len(body["findings"]) == 1
-    assert body["findings"][0]["title"] == "F1"
+    assert len(body["artifacts"]) == 1
+    assert body["artifacts"][0]["name"] == "a1.md"
     assert body["total_count"] == 3
     assert body["limit"] == 1
     assert body["offset"] == 1
 
 
 @pytest.mark.integration
-async def test_list_findings_identical_created_at_pagination_is_stable(
+async def test_list_artifacts_identical_created_at_pagination_is_stable(
     client: AsyncClient,
     db_session: AsyncSession,
     user_a: User,
 ) -> None:
-    """Findings sharing one created_at paginate with no skips/dupes, repeatably.
+    """Artifacts sharing one created_at paginate with no skips/dupes, repeatably.
 
     Rows a run emits in its single executor commit share one created_at
     (server-side now() is transaction-stable in Postgres); the id ASC
@@ -290,24 +392,24 @@ async def test_list_findings_identical_created_at_pagination_is_stable(
     sess = await _make_session(db_session, user=user_a)
     shared = datetime.now(UTC)
     created = [
-        await _make_finding(db_session, session=sess, title=f"F{i}", created_at=shared)
+        await _make_artifact(db_session, session=sess, name=f"memo-{i}.md", created_at=shared)
         for i in range(4)
     ]
-    expected_ids = {str(f.id) for f in created}
+    expected_ids = {str(a.id) for a in created}
 
     async def read_pages() -> list[str]:
         ids: list[str] = []
         for offset in range(4):
             resp = await client.get(
-                f"/api/v1/autonomous/sessions/{sess.id}/findings",
+                f"/api/v1/autonomous/sessions/{sess.id}/artifacts",
                 headers=_bearer(user_a),
                 params={"limit": 1, "offset": offset},
             )
             assert resp.status_code == 200, resp.text
             body = resp.json()
             assert body["total_count"] == 4
-            assert len(body["findings"]) == 1
-            ids.append(body["findings"][0]["id"])
+            assert len(body["artifacts"]) == 1
+            ids.append(body["artifacts"][0]["id"])
         return ids
 
     first_pass = await read_pages()
@@ -320,25 +422,25 @@ async def test_list_findings_identical_created_at_pagination_is_stable(
 
 
 @pytest.mark.integration
-async def test_list_findings_isolated_by_session(
+async def test_list_artifacts_isolated_by_session(
     client: AsyncClient,
     db_session: AsyncSession,
     user_a: User,
 ) -> None:
-    """Findings of one session are not returned for another session of the same user."""
+    """Artifacts of one session are not returned for another session of the same user."""
     sess1 = await _make_session(db_session, user=user_a)
     sess2 = await _make_session(db_session, user=user_a)
-    await _make_finding(db_session, session=sess1, title="for-1")
-    await _make_finding(db_session, session=sess2, title="for-2")
+    await _make_artifact(db_session, session=sess1, name="for-1.md")
+    await _make_artifact(db_session, session=sess2, name="for-2.md")
 
     resp = await client.get(
-        f"/api/v1/autonomous/sessions/{sess1.id}/findings",
+        f"/api/v1/autonomous/sessions/{sess1.id}/artifacts",
         headers=_bearer(user_a),
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    titles = {f["title"] for f in body["findings"]}
-    assert titles == {"for-1"}
+    names = {a["name"] for a in body["artifacts"]}
+    assert names == {"for-1.md"}
     assert body["total_count"] == 1
 
 
@@ -348,14 +450,14 @@ async def test_list_findings_isolated_by_session(
 
 
 @pytest.mark.integration
-async def test_list_findings_unauth_returns_401(
+async def test_list_artifacts_unauth_returns_401(
     client: AsyncClient,
     db_session: AsyncSession,
     user_a: User,
 ) -> None:
     """No Authorization header returns 401."""
     sess = await _make_session(db_session, user=user_a)
-    resp = await client.get(f"/api/v1/autonomous/sessions/{sess.id}/findings")
+    resp = await client.get(f"/api/v1/autonomous/sessions/{sess.id}/artifacts")
     assert resp.status_code == 401, resp.text
 
 
@@ -365,10 +467,10 @@ async def test_list_findings_unauth_returns_401(
 
 
 @pytest.mark.unit
-def test_openapi_findings_path_registered() -> None:
-    """The findings path is registered as a GET with 200/401/404."""
+def test_openapi_artifacts_path_registered() -> None:
+    """The artifacts path is registered as a GET with 200/401/404."""
     schema = app.openapi()
-    path = schema["paths"]["/api/v1/autonomous/sessions/{session_id}/findings"]
+    path = schema["paths"]["/api/v1/autonomous/sessions/{session_id}/artifacts"]
     assert "get" in path
     get_op = path["get"]
     assert "200" in get_op["responses"]
@@ -377,17 +479,17 @@ def test_openapi_findings_path_registered() -> None:
 
 
 @pytest.mark.unit
-def test_openapi_findings_schemas_in_components() -> None:
-    """AutonomousFindingRead + ListResponse are in components/schemas with the right shape."""
+def test_openapi_artifact_schemas_in_components() -> None:
+    """AutonomousArtifactRead + ListResponse are in components/schemas with the right shape."""
     schema = app.openapi()
     schemas = schema.get("components", {}).get("schemas", {})
-    assert "AutonomousFindingRead" in schemas
-    assert "AutonomousFindingListResponse" in schemas
+    assert "AutonomousArtifactRead" in schemas
+    assert "AutonomousArtifactListResponse" in schemas
 
-    read_props = schemas["AutonomousFindingRead"].get("properties", {})
-    for field in ("id", "session_id", "severity", "title", "content", "created_at"):
+    read_props = schemas["AutonomousArtifactRead"].get("properties", {})
+    for field in ("id", "name", "mime", "size_bytes", "file_id", "document_id", "created_at"):
         assert field in read_props
 
-    list_props = schemas["AutonomousFindingListResponse"].get("properties", {})
-    for field in ("findings", "total_count", "limit", "offset"):
+    list_props = schemas["AutonomousArtifactListResponse"].get("properties", {})
+    for field in ("artifacts", "total_count", "limit", "offset"):
         assert field in list_props

--- a/api/tests/autonomous/test_emit_artifact.py
+++ b/api/tests/autonomous/test_emit_artifact.py
@@ -1,0 +1,558 @@
+"""Chokepoint tests for the ``emit_artifact`` handler — Donna ask #8, Task 2.
+
+The ``emit_artifact`` chokepoint persists a run's document-grade artifact
+into the target KB as a REAL document: upload-first to object storage,
+then File + Document + chunks + direct KB attach + an
+``autonomous_artifacts`` reference. Covers:
+
+- Happy path: all five write surfaces (object storage, files, documents/
+  document_chunks, knowledge_base_files, autonomous_artifacts) plus the
+  returned data keys and zero cost.
+- Honest skips: no target KB / empty content → no rows, no upload.
+- Storage failure: ``storage_error`` outcome with NO DB rows (the
+  gateway_error honesty pattern).
+- Name sanitization (path-traversal name) and content truncation
+  (``_ARTIFACT_MAX_CHARS`` clamp).
+- R6: emit_artifact is drafting-only — any other phase raises
+  ToolNotGranted.
+- Mode-3 retrieval echo exclusion: a schedule's "files attached since
+  last run" fetch must NOT return a prior run's own memo.
+- Watch-loop guard: the direct KB attach bypasses fire_watches_for_kb
+  by design — no watch-triggered session can spawn from an artifact.
+
+``upload_bytes`` and ``enqueue_embed_job`` are monkeypatched at their
+source modules (the handler imports them locally) — no MinIO/Redis in
+unit tests, matching the FakeS3Client posture of test_storage_streaming.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.enums import PHASE_GRANTS, Phase, ToolIntent
+from app.autonomous.guard import _ARTIFACT_MAX_CHARS, _handle_retrieve_chunks, guarded_tool_call
+from app.models.autonomous import AutonomousArtifact, AutonomousSession
+from app.models.document import Document, DocumentChunk
+from app.models.file import File as FileModel
+from app.models.knowledge import KnowledgeBase, KnowledgeBaseFile
+from app.models.user import User
+from app.security import hash_password
+from tests.autonomous.conftest import _attach_file_with_chunk
+
+
+class _StubGateway:
+    """emit_artifact is local/zero-cost; the gateway is never touched."""
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        email=f"artifact-test-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+        autonomous_enabled=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_kb(db: AsyncSession, *, owner: User) -> KnowledgeBase:
+    kb = KnowledgeBase(
+        owner_id=owner.id,
+        name=f"artifact-kb-{uuid.uuid4().hex[:6]}",
+        hybrid_alpha=1.0,
+    )
+    db.add(kb)
+    await db.flush()
+    return kb
+
+
+async def _make_session(
+    db: AsyncSession,
+    *,
+    user: User,
+    phase: str = "drafting",
+    params: dict[str, Any] | None = None,
+) -> AutonomousSession:
+    sess = AutonomousSession(
+        user_id=user.id,
+        trigger_kind="manual",
+        status="running",
+        halt_state="running",
+        current_phase=phase,
+        params=params or {},
+    )
+    db.add(sess)
+    await db.flush()
+    await db.refresh(sess)
+    return sess
+
+
+def _stub_storage(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace ``app.storage.upload_bytes`` with a recording stub.
+
+    The handler imports ``upload_bytes`` locally at call time, so
+    patching the source module is picked up.
+    """
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_upload(*, storage_path: str, body: bytes, content_type: str) -> None:
+        calls.append({"storage_path": storage_path, "body": body, "content_type": content_type})
+
+    monkeypatch.setattr("app.storage.upload_bytes", _fake_upload)
+    return calls
+
+
+def _stub_embed(monkeypatch: pytest.MonkeyPatch) -> list[uuid.UUID]:
+    """Replace ``app.workers.queue.enqueue_embed_job`` with a recording stub."""
+    calls: list[uuid.UUID] = []
+
+    async def _fake_enqueue(file_id: uuid.UUID) -> bool:
+        calls.append(file_id)
+        return True
+
+    monkeypatch.setattr("app.workers.queue.enqueue_embed_job", _fake_enqueue)
+    return calls
+
+
+async def _count(db: AsyncSession, model: type) -> int:
+    return (await db.execute(select(func.count()).select_from(model))).scalar_one()
+
+
+async def _all_counts(db: AsyncSession) -> dict[str, int]:
+    """Row counts of the four tables the handler writes."""
+    return {
+        "files": await _count(db, FileModel),
+        "documents": await _count(db, Document),
+        "knowledge_base_files": await _count(db, KnowledgeBaseFile),
+        "autonomous_artifacts": await _count(db, AutonomousArtifact),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_emit_artifact_happy_path(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A drafting-phase session with a target KB persists all four row
+    kinds + the storage object, and returns the documented data keys."""
+    upload_calls = _stub_storage(monkeypatch)
+    embed_calls = _stub_embed(monkeypatch)
+
+    user = await _make_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+    sess = await _make_session(db_session, user=user, params={"kb_id": str(kb.id)})
+
+    content = "# Memo\n\nThe reviewed NDA's term clause is three (3) years."
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_artifact,
+        {"artifact": {"name": "Review memo", "content": content}},
+        db_session,
+        _StubGateway(),
+    )
+
+    assert result.cost_usd == Decimal("0")
+    assert result.outcome == "success"
+    data = result.data
+    assert set(data.keys()) == {"artifact_id", "file_id", "document_id", "name", "size_bytes"}
+
+    body = content.encode("utf-8")
+
+    # File row — owner/mime/status/storage-key/size/hash from encoded bytes.
+    file_row = await db_session.get(FileModel, uuid.UUID(data["file_id"]))
+    assert file_row is not None
+    assert file_row.owner_id == user.id
+    assert file_row.mime_type == "text/markdown"
+    assert file_row.ingestion_status == "ready"
+    assert file_row.storage_path == str(file_row.id)
+    assert file_row.size_bytes == len(body)
+    assert file_row.hash_sha256 == hashlib.sha256(body).hexdigest()
+    # Name had no extension → ".md" appended.
+    assert file_row.filename == "Review memo.md"
+
+    # Upload happened, keyed by the (client-generated) file id, BEFORE rows.
+    assert len(upload_calls) == 1
+    assert upload_calls[0]["storage_path"] == str(file_row.id)
+    assert upload_calls[0]["body"] == body
+    assert upload_calls[0]["content_type"] == "text/markdown"
+
+    # Document row — direct-text persistence, honest parser label.
+    doc = await db_session.get(Document, uuid.UUID(data["document_id"]))
+    assert doc is not None
+    assert doc.file_id == file_row.id
+    assert doc.parser == "autonomous-artifact"
+    assert doc.normalized_content == content
+    assert doc.character_count == len(content)
+    assert doc.page_count == 1
+
+    # Chunks exist and uphold the M2-A1 re-read invariant.
+    chunks = (
+        (await db_session.execute(select(DocumentChunk).where(DocumentChunk.document_id == doc.id)))
+        .scalars()
+        .all()
+    )
+    assert len(chunks) >= 1
+    for chunk in chunks:
+        assert (
+            chunk.content == doc.normalized_content[chunk.char_offset_start : chunk.char_offset_end]
+        )
+
+    # KB attach join row.
+    kbf = (
+        await db_session.execute(
+            select(KnowledgeBaseFile)
+            .where(KnowledgeBaseFile.kb_id == kb.id)
+            .where(KnowledgeBaseFile.file_id == file_row.id)
+        )
+    ).scalar_one()
+    assert kbf is not None
+
+    # Artifact reference row.
+    artifact_row = await db_session.get(AutonomousArtifact, uuid.UUID(data["artifact_id"]))
+    assert artifact_row is not None
+    assert artifact_row.session_id == sess.id
+    assert artifact_row.file_id == file_row.id
+    assert artifact_row.name == "Review memo.md"
+    assert artifact_row.mime == "text/markdown"
+    assert artifact_row.size_bytes == len(body)
+
+    # Best-effort embed enqueue fired for the new file.
+    assert embed_calls == [file_row.id]
+
+
+# ---------------------------------------------------------------------------
+# Honest skips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_emit_artifact_skips_without_target_kb(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No kb_id in session params → honest skip; zero rows, zero uploads."""
+    upload_calls = _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user, params={})
+
+    before = await _all_counts(db_session)
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_artifact,
+        {"artifact": {"name": "memo.md", "content": "# Memo"}},
+        db_session,
+        _StubGateway(),
+    )
+
+    assert result.data == {"skipped": "no_target_kb"}
+    assert result.outcome == "skipped"
+    assert result.cost_usd == Decimal("0")
+    assert await _all_counts(db_session) == before
+    assert upload_calls == []
+
+
+@pytest.mark.integration
+async def test_emit_artifact_skips_empty_content(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty (or missing) content → honest skip; zero rows, zero uploads."""
+    upload_calls = _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+
+    user = await _make_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+    sess = await _make_session(db_session, user=user, params={"kb_id": str(kb.id)})
+
+    before = await _all_counts(db_session)
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_artifact,
+        {"artifact": {"name": "memo.md", "content": ""}},
+        db_session,
+        _StubGateway(),
+    )
+
+    assert result.data == {"skipped": "empty_content"}
+    assert result.outcome == "skipped"
+    assert await _all_counts(db_session) == before
+    assert upload_calls == []
+
+    # Missing content key entirely → same honest skip.
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_artifact,
+        {"artifact": {"name": "x"}},
+        db_session,
+        _StubGateway(),
+    )
+
+    assert result.data == {"skipped": "empty_content"}
+    assert result.outcome == "skipped"
+    assert await _all_counts(db_session) == before
+    assert upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Storage failure — honest outcome, NO DB rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_emit_artifact_storage_failure_writes_no_rows(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Upload failure → outcome='storage_error', error in data, NO rows in
+    any of the four tables (the gateway_error honesty pattern)."""
+    _stub_embed(monkeypatch)
+
+    async def _failing_upload(*, storage_path: str, body: bytes, content_type: str) -> None:
+        raise RuntimeError("minio is down")
+
+    monkeypatch.setattr("app.storage.upload_bytes", _failing_upload)
+
+    user = await _make_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+    sess = await _make_session(db_session, user=user, params={"kb_id": str(kb.id)})
+
+    before = await _all_counts(db_session)
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_artifact,
+        {"artifact": {"name": "memo.md", "content": "# Memo"}},
+        db_session,
+        _StubGateway(),
+    )
+
+    assert result.outcome == "storage_error"
+    assert result.cost_usd == Decimal("0")
+    assert "RuntimeError" in result.data["error"]
+    assert await _all_counts(db_session) == before
+
+
+# ---------------------------------------------------------------------------
+# Sanitization + truncation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_emit_artifact_sanitizes_path_traversal_name(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A path-traversal name is basenamed and given an extension."""
+    _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+
+    user = await _make_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+    sess = await _make_session(db_session, user=user, params={"kb_id": str(kb.id)})
+
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_artifact,
+        {"artifact": {"name": "../../etc/passwd", "content": "# Memo"}},
+        db_session,
+        _StubGateway(),
+    )
+
+    file_row = await db_session.get(FileModel, uuid.UUID(result.data["file_id"]))
+    assert file_row is not None
+    assert "/" not in file_row.filename
+    assert "\\" not in file_row.filename
+    # Basename has no extension → ".md" appended.
+    assert file_row.filename == "passwd.md"
+    assert "." in file_row.filename
+
+
+@pytest.mark.integration
+async def test_emit_artifact_strips_nul_bytes(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """NUL bytes in content and name are stripped before persistence —
+    Postgres TEXT rejects \\x00 at flush (post-upload orphan otherwise)."""
+    _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+
+    user = await _make_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+    sess = await _make_session(db_session, user=user, params={"kb_id": str(kb.id)})
+
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_artifact,
+        {"artifact": {"name": "me\x00mo.md", "content": "a\x00b"}},
+        db_session,
+        _StubGateway(),
+    )
+
+    assert result.outcome == "success"
+    doc = await db_session.get(Document, uuid.UUID(result.data["document_id"]))
+    assert doc is not None
+    assert doc.normalized_content == "ab"
+    file_row = await db_session.get(FileModel, uuid.UUID(result.data["file_id"]))
+    assert file_row is not None
+    assert file_row.filename == "memo.md"
+
+
+@pytest.mark.integration
+async def test_emit_artifact_truncates_oversize_content(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Content beyond _ARTIFACT_MAX_CHARS is clamped and flagged."""
+    _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+
+    user = await _make_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+    sess = await _make_session(db_session, user=user, params={"kb_id": str(kb.id)})
+
+    oversize = "x" * (_ARTIFACT_MAX_CHARS + 17)
+    result = await guarded_tool_call(
+        sess,
+        ToolIntent.emit_artifact,
+        {"artifact": {"name": "big.md", "content": oversize}},
+        db_session,
+        _StubGateway(),
+    )
+
+    assert result.data["truncated"] is True
+    assert result.data["size_bytes"] == _ARTIFACT_MAX_CHARS  # ASCII: 1 byte/char
+
+    doc = await db_session.get(Document, uuid.UUID(result.data["document_id"]))
+    assert doc is not None
+    assert doc.character_count == _ARTIFACT_MAX_CHARS
+    assert len(doc.normalized_content) == _ARTIFACT_MAX_CHARS
+
+
+# ---------------------------------------------------------------------------
+# R6 — drafting-only grant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_emit_artifact_granted_at_drafting_only() -> None:
+    """emit_artifact appears in the drafting grant set and NOWHERE else."""
+    assert ToolIntent.emit_artifact in PHASE_GRANTS[Phase.drafting]
+    for phase in (Phase.intake, Phase.analysis, Phase.ethics_review, Phase.delivery):
+        assert ToolIntent.emit_artifact not in PHASE_GRANTS[phase], (
+            f"emit_artifact must not be granted at {phase}"
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("phase", ["intake", "analysis", "ethics_review", "delivery"])
+async def test_emit_artifact_rejected_at_ungranted_phase(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch, phase: str
+) -> None:
+    """The chokepoint raises ToolNotGranted outside drafting (R6)."""
+    from app.errors import ToolNotGranted
+
+    upload_calls = _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+
+    user = await _make_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+    sess = await _make_session(db_session, user=user, phase=phase, params={"kb_id": str(kb.id)})
+
+    with pytest.raises(ToolNotGranted):
+        await guarded_tool_call(
+            sess,
+            ToolIntent.emit_artifact,
+            {"artifact": {"name": "memo.md", "content": "# Memo"}},
+            db_session,
+            _StubGateway(),
+        )
+    # _dispatch was never reached — no upload attempted.
+    assert upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Mode-3 retrieval echo exclusion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_retrieve_chunks_since_excludes_artifact_files(
+    db_session: AsyncSession,
+) -> None:
+    """Mode 3 (since + kb_id) returns only ordinary files — a file referenced
+    by an autonomous_artifacts row (a prior run's own memo) is excluded so
+    the next tick does not re-analyze it (self-ingestion echo)."""
+    user = await _make_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+
+    # Both files attached AFTER the cutoff; one is an artifact.
+    ordinary_file, _, _ = await _attach_file_with_chunk(
+        db_session, owner=user, kb=kb, chunk_text="Ordinary contract uploaded today."
+    )
+    artifact_file, _, _ = await _attach_file_with_chunk(
+        db_session, owner=user, kb=kb, chunk_text="Prior run's memo content."
+    )
+    prior_sess = await _make_session(db_session, user=user)
+    db_session.add(
+        AutonomousArtifact(
+            session_id=prior_sess.id,
+            file_id=artifact_file.id,
+            name="memo.md",
+            mime="text/markdown",
+            size_bytes=25,
+        )
+    )
+    await db_session.flush()
+
+    since = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+    result = await _handle_retrieve_chunks({"since": since, "kb_id": str(kb.id)}, db=db_session)
+
+    returned_file_ids = {c["file_id"] for c in result.data["chunks"]}
+    assert str(ordinary_file.id) in returned_file_ids
+    assert str(artifact_file.id) not in returned_file_ids
+
+
+# ---------------------------------------------------------------------------
+# Watch-loop guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_emit_artifact_does_not_fire_watches(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The direct KB attach bypasses fire_watches_for_kb by design — no
+    watch dispatch, no new AutonomousSession spawned by the handler."""
+    from unittest.mock import AsyncMock
+
+    _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+    watch_spy = AsyncMock()
+    monkeypatch.setattr("app.autonomous.watch_trigger.fire_watches_for_kb", watch_spy)
+
+    user = await _make_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+    sess = await _make_session(db_session, user=user, params={"kb_id": str(kb.id)})
+
+    sessions_before = await _count(db_session, AutonomousSession)
+    await guarded_tool_call(
+        sess,
+        ToolIntent.emit_artifact,
+        {"artifact": {"name": "memo.md", "content": "# Memo"}},
+        db_session,
+        _StubGateway(),
+    )
+
+    watch_spy.assert_not_called()
+    assert await _count(db_session, AutonomousSession) == sessions_before

--- a/api/tests/autonomous/test_executor_real_work.py
+++ b/api/tests/autonomous/test_executor_real_work.py
@@ -30,6 +30,7 @@ Task 11 covers the analysis-node dispatch:
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -37,6 +38,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.autonomous.nodes import (
     make_analysis_node,
+    make_delivery_node,
     make_drafting_node,
     make_ethics_review_node,
     make_intake_node,
@@ -320,6 +322,332 @@ async def test_drafting_gateway_error_emits_single_explanatory_finding(
     rows = await _autonomous_audit_rows(db_session, str(running_session_at_drafting.id))
     assert _started_tool_calls(rows) == 1
     assert result["findings_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Donna ask #8 — drafting_node artifact dispatch (opt-in)
+# ---------------------------------------------------------------------------
+
+
+def _tool_started_calls(rows: list[Any], tool: str) -> int:
+    """Count the chokepoint's ``started`` audit rows for one tool intent."""
+    return sum(
+        1
+        for r in rows
+        if r.action == "autonomous_session.tool_call"
+        and (r.details or {}).get("tool") == tool
+        and (r.details or {}).get("outcome") == "started"
+    )
+
+
+def _stub_storage(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Recording stub for ``app.storage.upload_bytes`` (the emit_artifact
+    handler imports it locally at call time — the test_emit_artifact idiom)."""
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_upload(*, storage_path: str, body: bytes, content_type: str) -> None:
+        calls.append({"storage_path": storage_path, "body": body, "content_type": content_type})
+
+    monkeypatch.setattr("app.storage.upload_bytes", _fake_upload)
+    return calls
+
+
+def _stub_embed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No-op stub for ``app.workers.queue.enqueue_embed_job`` (no Redis)."""
+
+    async def _fake_enqueue(file_id: Any) -> bool:
+        return True
+
+    monkeypatch.setattr("app.workers.queue.enqueue_embed_job", _fake_enqueue)
+
+
+def _structured_content(artifacts: list[dict[str, Any]]) -> str:
+    """A well-formed analysis response carrying only an artifacts array."""
+    return (
+        "```json\n"
+        + json.dumps(
+            {
+                "findings": [],
+                "suggested_memories": [],
+                "suggested_precedents": [],
+                "privilege_concerns": [],
+                "scope_concerns": [],
+                "artifacts": artifacts,
+            }
+        )
+        + "\n```"
+    )
+
+
+_TWO_ARTIFACTS = [
+    {"name": "review-memo.md", "content_md": "# Memo\n\nFirst document body."},
+    {"name": "summary.md", "content_md": "# Summary\n\nSecond document body."},
+]
+
+
+async def _make_drafting_session_with_kb(
+    db_session: AsyncSession, *, emit_artifacts: bool
+) -> AutonomousSession:
+    """Running session at the drafting boundary with a real target KB.
+
+    Builds on the conftest helpers (the test_emit_artifact import
+    precedent) so the artifact persistence path has a real KB row to
+    attach into.
+    """
+    from tests.autonomous.conftest import _make_kb, _make_optedin_user, _make_running_session
+
+    user = await _make_optedin_user(db_session)
+    kb = await _make_kb(db_session, owner=user)
+    params: dict[str, Any] = {"kb_id": str(kb.id)}
+    if emit_artifacts:
+        params["emit_artifacts"] = True
+    return await _make_running_session(db_session, user=user, trigger_kind="watch", params=params)
+
+
+@pytest.mark.integration
+async def test_drafting_dispatches_artifacts_when_opted_in(
+    db_session: AsyncSession,
+    mock_gateway: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag on + 2 parsed artifacts → 2 emit_artifact chokepoint dispatches,
+    2 persisted rows, artifacts_count == 2, no extra findings."""
+    from sqlalchemy import select
+
+    from app.models.autonomous import AutonomousArtifact
+
+    _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+    session = await _make_drafting_session_with_kb(db_session, emit_artifacts=True)
+
+    state: AutonomousSessionState = {
+        "session_id": str(session.id),
+        "analysis_content": _structured_content(_TWO_ARTIFACTS),
+        "analysis_outcome": "success",
+    }
+    node = make_drafting_node(db_session, mock_gateway)
+    result = await node(state)
+
+    rows = await _autonomous_audit_rows(db_session, str(session.id))
+    assert _tool_started_calls(rows, "emit_artifact") == 2
+    assert result["artifacts_count"] == 2
+    assert result["findings_count"] == 0
+    artifact_rows = (
+        (
+            await db_session.execute(
+                select(AutonomousArtifact).where(AutonomousArtifact.session_id == session.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(artifact_rows) == 2
+
+
+@pytest.mark.integration
+async def test_drafting_ignores_artifacts_when_flag_off(
+    db_session: AsyncSession,
+    mock_gateway: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag off + artifacts present in the parsed output → zero dispatches,
+    artifacts_count == 0, no explanatory finding (defense-in-depth: the
+    model was never asked for artifacts, so an unasked-for emission is
+    ignored entirely)."""
+    from sqlalchemy import select
+
+    from app.models.autonomous import AutonomousArtifact
+
+    upload_calls = _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+    session = await _make_drafting_session_with_kb(db_session, emit_artifacts=False)
+
+    state: AutonomousSessionState = {
+        "session_id": str(session.id),
+        "analysis_content": _structured_content(_TWO_ARTIFACTS),
+        "analysis_outcome": "success",
+    }
+    node = make_drafting_node(db_session, mock_gateway)
+    result = await node(state)
+
+    rows = await _autonomous_audit_rows(db_session, str(session.id))
+    assert _tool_started_calls(rows, "emit_artifact") == 0
+    assert result["artifacts_count"] == 0
+    assert result["findings_count"] == 0
+    assert upload_calls == []
+    artifact_rows = (
+        (
+            await db_session.execute(
+                select(AutonomousArtifact).where(AutonomousArtifact.session_id == session.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert artifact_rows == []
+
+
+@pytest.mark.integration
+async def test_drafting_no_target_kb_emits_one_info_finding_and_stops(
+    db_session: AsyncSession,
+    running_session_at_drafting: AutonomousSession,
+    mock_gateway: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """no_target_kb skip → exactly ONE info finding (even with 2 artifacts)
+    and the loop stops after the first attempt — every remaining artifact
+    would skip for the same reason."""
+    upload_calls = _stub_storage(monkeypatch)
+    _stub_embed(monkeypatch)
+    # running_session_at_drafting has params={} → opt in without a kb_id.
+    running_session_at_drafting.params = {"emit_artifacts": True}
+    await db_session.flush()
+
+    state: AutonomousSessionState = {
+        "session_id": str(running_session_at_drafting.id),
+        "analysis_content": _structured_content(_TWO_ARTIFACTS),
+        "analysis_outcome": "success",
+    }
+    node = make_drafting_node(db_session, mock_gateway)
+    result = await node(state)
+
+    rows = await _autonomous_audit_rows(db_session, str(running_session_at_drafting.id))
+    # Loop stopped after the FIRST skip — the second artifact never dispatched.
+    assert _tool_started_calls(rows, "emit_artifact") == 1
+    assert result["artifacts_count"] == 0
+    # Exactly ONE explanatory info finding, counted like any other finding.
+    assert result["findings_count"] == 1
+    assert result["findings"][0]["title"] == ("Artifact not persisted — no target knowledge base")
+    assert result["findings"][0]["severity"] == "info"
+    assert upload_calls == []
+
+
+@pytest.mark.integration
+async def test_drafting_storage_error_emits_warn_and_continues(
+    db_session: AsyncSession,
+    mock_gateway: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A storage failure on one artifact → ONE warn finding for it, the
+    loop continues, and artifacts_count counts only the persisted one."""
+    _stub_embed(monkeypatch)
+    calls = {"n": 0}
+
+    async def _flaky_upload(*, storage_path: str, body: bytes, content_type: str) -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("minio is down")
+
+    monkeypatch.setattr("app.storage.upload_bytes", _flaky_upload)
+    session = await _make_drafting_session_with_kb(db_session, emit_artifacts=True)
+
+    state: AutonomousSessionState = {
+        "session_id": str(session.id),
+        "analysis_content": _structured_content(_TWO_ARTIFACTS),
+        "analysis_outcome": "success",
+    }
+    node = make_drafting_node(db_session, mock_gateway)
+    result = await node(state)
+
+    rows = await _autonomous_audit_rows(db_session, str(session.id))
+    # Both artifacts were attempted (the loop continued past the failure).
+    assert _tool_started_calls(rows, "emit_artifact") == 2
+    # Only the second persisted.
+    assert result["artifacts_count"] == 1
+    # ONE warn finding for the failed artifact, naming it + the error.
+    assert result["findings_count"] == 1
+    finding = result["findings"][0]
+    assert finding["title"] == "Artifact persistence failed at storage"
+    assert finding["severity"] == "warn"
+    assert "review-memo.md" in finding["summary"]
+    assert "RuntimeError" in finding["summary"]
+
+
+# ---------------------------------------------------------------------------
+# Donna ask #8 — delivery_node artifact_count in notify payload + audit
+# ---------------------------------------------------------------------------
+
+
+async def _delivery_notification_row(db_session: AsyncSession, session_id: Any) -> Any:
+    from sqlalchemy import select
+
+    from app.models.autonomous import AutonomousNotification
+
+    return (
+        await db_session.execute(
+            select(AutonomousNotification).where(AutonomousNotification.session_id == session_id)
+        )
+    ).scalar_one()
+
+
+async def _completed_audit_row(db_session: AsyncSession, session_id: str) -> Any:
+    from sqlalchemy import select
+
+    from app.models.audit import AuditLog
+
+    return (
+        await db_session.execute(
+            select(AuditLog)
+            .where(AuditLog.resource_type == "autonomous_session")
+            .where(AuditLog.resource_id == session_id)
+            .where(AuditLog.action == "autonomous_session.completed")
+        )
+    ).scalar_one()
+
+
+@pytest.mark.integration
+async def test_delivery_payload_and_body_carry_artifact_count(
+    db_session: AsyncSession,
+    running_session_at_delivery: AutonomousSession,
+    mock_gateway: object,
+) -> None:
+    """artifacts_count > 0 → payload carries artifact_count, the body
+    mentions the saved documents, and the completed audit row gains
+    artifacts_count."""
+    node = make_delivery_node(db_session, mock_gateway)
+    state: AutonomousSessionState = {
+        "session_id": str(running_session_at_delivery.id),
+        "findings": [],
+        "findings_count": 2,
+        "artifacts_count": 3,
+    }
+    await node(state)
+
+    note = await _delivery_notification_row(db_session, running_session_at_delivery.id)
+    assert note.payload == {"finding_count": 2, "artifact_count": 3}
+    assert "2 finding(s)" in note.body
+    assert "3 document(s) saved to the knowledge base" in note.body
+
+    audit = await _completed_audit_row(db_session, str(running_session_at_delivery.id))
+    assert (audit.details or {}).get("artifacts_count") == 3
+    assert (audit.details or {}).get("findings_count") == 2
+
+
+@pytest.mark.integration
+async def test_delivery_zero_artifacts_payload_honest_body_silent(
+    db_session: AsyncSession,
+    running_session_at_delivery: AutonomousSession,
+    mock_gateway: object,
+) -> None:
+    """artifacts_count absent (pre-artifacts state shape) → payload still
+    carries artifact_count == 0 (honest, distinguishes 'feature present,
+    zero artifacts' from an old payload) but the body stays counts-only
+    with no document mention."""
+    node = make_delivery_node(db_session, mock_gateway)
+    state: AutonomousSessionState = {
+        "session_id": str(running_session_at_delivery.id),
+        "findings": [],
+        "findings_count": 1,
+    }
+    await node(state)
+
+    note = await _delivery_notification_row(db_session, running_session_at_delivery.id)
+    assert note.payload == {"finding_count": 1, "artifact_count": 0}
+    assert "document" not in note.body
+    assert note.body == "Session completed with 1 finding(s)."
+
+    audit = await _completed_audit_row(db_session, str(running_session_at_delivery.id))
+    assert (audit.details or {}).get("artifacts_count") == 0
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/autonomous/test_executor_skeleton.py
+++ b/api/tests/autonomous/test_executor_skeleton.py
@@ -135,6 +135,9 @@ def test_phase_grants_exact_membership() -> None:
             # M4-B2: propose_precedent granted at drafting (patterns recognized
             # during synthesis).
             ToolIntent.propose_precedent,
+            # Donna #8: emit_artifact granted at drafting ONLY (the memo is
+            # synthesized work product).
+            ToolIntent.emit_artifact,
         }
     )
 
@@ -152,7 +155,8 @@ def test_phase_grants_covers_all_phases() -> None:
 
 @pytest.mark.unit
 def test_tool_intent_members() -> None:
-    """ToolIntent has exactly the seven members specified (M4-B2 adds propose_precedent)."""
+    """ToolIntent has exactly the eight members specified (M4-B2 adds
+    propose_precedent; Donna #8 adds emit_artifact)."""
     expected = {
         "retrieve_chunks",
         "run_skill",
@@ -160,6 +164,7 @@ def test_tool_intent_members() -> None:
         "propose_memory",
         "propose_precedent",
         "emit_finding",
+        "emit_artifact",
         "notify",
     }
     actual = {m.value for m in ToolIntent}

--- a/api/tests/autonomous/test_prompts.py
+++ b/api/tests/autonomous/test_prompts.py
@@ -28,6 +28,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.autonomous.prompts import (
+    ARTIFACT_OUTPUT_INSTRUCTION,
     STRUCTURED_OUTPUT_INSTRUCTION,
     assemble_analysis_messages,
 )
@@ -87,6 +88,53 @@ def test_structured_output_instruction_carries_schema_keys() -> None:
     assert "suggested_precedents" in inst
     assert "privilege_concerns" in inst
     assert "scope_concerns" in inst
+
+
+def test_artifact_instruction_carries_schema_keys() -> None:
+    """The artifact tail names the key + inner shape the drafting node maps."""
+    inst = ARTIFACT_OUTPUT_INSTRUCTION
+    assert "artifacts" in inst
+    assert "name" in inst
+    assert "content_md" in inst
+
+
+@pytest.mark.asyncio
+async def test_artifact_instruction_appended_when_opted_in(
+    db_session: AsyncSession,
+    session_with_skill_ref: AutonomousSession,
+    sample_chunks: list[dict[str, object]],
+) -> None:
+    """params["emit_artifacts"]=True → the artifact tail follows the
+    structured-output tail in the system prompt (Donna ask #8)."""
+    session_with_skill_ref.params = {
+        **(session_with_skill_ref.params or {}),
+        "emit_artifacts": True,
+    }
+    await db_session.flush()
+
+    msgs = await assemble_analysis_messages(
+        session_with_skill_ref, chunks=sample_chunks, db=db_session
+    )
+    system = msgs[0]["content"]
+    assert ARTIFACT_OUTPUT_INSTRUCTION in system
+    # Ordering: artifact tail comes AFTER the structured-output tail.
+    assert system.index(ARTIFACT_OUTPUT_INSTRUCTION) > system.index(STRUCTURED_OUTPUT_INSTRUCTION)
+
+
+@pytest.mark.asyncio
+async def test_artifact_instruction_absent_when_flag_off(
+    db_session: AsyncSession,
+    session_with_skill_ref: AutonomousSession,
+    sample_chunks: list[dict[str, object]],
+) -> None:
+    """No emit_artifacts key in params (the non-opted-in default) → the
+    model is never told about the ``artifacts`` key."""
+    msgs = await assemble_analysis_messages(
+        session_with_skill_ref, chunks=sample_chunks, db=db_session
+    )
+    full = "\n".join(m["content"] for m in msgs)
+    assert ARTIFACT_OUTPUT_INSTRUCTION not in full
+    assert "content_md" not in full
 
 
 @pytest.mark.asyncio

--- a/api/tests/autonomous/test_run_now.py
+++ b/api/tests/autonomous/test_run_now.py
@@ -115,6 +115,48 @@ async def test_run_now_spawns_manual_session(
     assert row.trigger_kind == "manual"
     assert row.max_cost_usd == Decimal("0.50")
     assert row.params.get("skill_ref") == "nda-review"
+    # emit_artifacts was not requested — excluded from params (non-null
+    # subset; the key is present iff the body opted in — Donna ask #8).
+    assert "emit_artifacts" not in row.params
+
+
+@pytest.mark.asyncio
+async def test_run_now_copies_emit_artifacts_flag_into_params(
+    client: AsyncClient,
+    opted_in_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """emit_artifacts=true in the body → session params carry the flag
+    (Donna ask #8 opt-in plumbing — run-now has no schedule/watch row to
+    inherit from, so the request body is the opt-in source)."""
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        json={"skill_ref": "nda-review", "emit_artifacts": True},
+        headers=_bearer(opted_in_user),
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = uuid.UUID(resp.json()["id"])
+    row = (
+        await db_session.execute(
+            select(AutonomousSession).where(AutonomousSession.id == session_id)
+        )
+    ).scalar_one()
+    assert row.params["emit_artifacts"] is True
+
+    # Explicit false behaves like the default: key absent.
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        json={"skill_ref": "nda-review", "emit_artifacts": False},
+        headers=_bearer(opted_in_user),
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = uuid.UUID(resp.json()["id"])
+    row = (
+        await db_session.execute(
+            select(AutonomousSession).where(AutonomousSession.id == session_id)
+        )
+    ).scalar_one()
+    assert "emit_artifacts" not in row.params
 
 
 @pytest.mark.asyncio

--- a/api/tests/autonomous/test_schedules.py
+++ b/api/tests/autonomous/test_schedules.py
@@ -595,6 +595,36 @@ async def test_create_schedule_computes_next_run_and_audits(
 
 
 @pytest.mark.integration
+async def test_create_schedule_emit_artifacts_round_trip(
+    client: AsyncClient,
+    user_a: User,
+) -> None:
+    """Create with emit_artifacts=true → the read echoes true (Donna #8)."""
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "emit_artifacts": True},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["emit_artifacts"] is True
+
+
+@pytest.mark.integration
+async def test_create_schedule_emit_artifacts_defaults_false(
+    client: AsyncClient,
+    user_a: User,
+) -> None:
+    """Omitting emit_artifacts at create → false (opt-in, default off)."""
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["emit_artifacts"] is False
+
+
+@pytest.mark.integration
 async def test_create_schedule_invalid_cron_returns_422(
     client: AsyncClient,
     user_a: User,
@@ -796,6 +826,32 @@ async def test_patch_schedule_toggles_enabled(
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["enabled"] is False
+
+
+@pytest.mark.integration
+async def test_patch_schedule_toggles_emit_artifacts_both_ways(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """PATCH flips emit_artifacts false→true and true→false (Donna #8)."""
+    sched = await _make_schedule(db_session, user=user_a, emit_artifacts=False)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"emit_artifacts": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["emit_artifacts"] is True
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"emit_artifacts": False},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["emit_artifacts"] is False
 
 
 @pytest.mark.integration

--- a/api/tests/autonomous/test_schedules.py
+++ b/api/tests/autonomous/test_schedules.py
@@ -96,6 +96,7 @@ async def _make_schedule(
     playbook_id: uuid.UUID | None = None,
     skill_ref: str | None = None,
     name: str | None = None,
+    emit_artifacts: bool = False,
 ) -> AutonomousSchedule:
     sched = AutonomousSchedule(
         user_id=user.id,
@@ -107,6 +108,7 @@ async def _make_schedule(
         playbook_id=playbook_id,
         skill_ref=skill_ref,
         name=name,
+        emit_artifacts=emit_artifacts,
     )
     db.add(sched)
     await db.flush()
@@ -311,6 +313,9 @@ async def test_dispatcher_due_schedule_spawns_one_session(
     # kb_id and playbook_id were None — excluded from params (non-null subset).
     assert "kb_id" not in sess.params
     assert "playbook_id" not in sess.params
+    # emit_artifacts defaults False — excluded too (non-null subset; the
+    # key is present iff the schedule opted in — Donna ask #8).
+    assert "emit_artifacts" not in sess.params
 
     enqueue.assert_awaited_once_with(sess.id)
 
@@ -318,6 +323,36 @@ async def test_dispatcher_due_schedule_spawns_one_session(
     assert sched.last_run_at == now
     assert sched.next_run_at is not None
     assert sched.next_run_at > now
+
+
+@pytest.mark.integration
+async def test_dispatcher_copies_emit_artifacts_flag_into_params(
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """A schedule with emit_artifacts=True spawns a session whose params
+    carry emit_artifacts=True (Donna ask #8 opt-in plumbing)."""
+    from app.workers.autonomous_worker import _run_schedule_sweep
+
+    now = datetime(2026, 5, 25, 10, 0, 0, tzinfo=UTC)
+    sched = await _make_schedule(
+        db_session,
+        user=user_a,
+        next_run_at=now - timedelta(minutes=1),
+        skill_ref="nda-review",
+        emit_artifacts=True,
+    )
+
+    enqueue = AsyncMock(return_value=True)
+    result = await _run_schedule_sweep(db_session, now=now, enqueue=enqueue)
+    assert result == {"spawned": 1}
+
+    sess = (
+        await db_session.execute(
+            select(AutonomousSession).where(AutonomousSession.trigger_ref == sched.id)
+        )
+    ).scalar_one()
+    assert sess.params["emit_artifacts"] is True
 
 
 @pytest.mark.integration

--- a/api/tests/autonomous/test_structured_output.py
+++ b/api/tests/autonomous/test_structured_output.py
@@ -8,6 +8,10 @@ fallback finding with the raw content.
 
 from __future__ import annotations
 
+import json
+
+import pytest
+
 from app.autonomous.structured_output import (
     StructuredResult,
     parse_structured_output,
@@ -135,6 +139,82 @@ def test_parse_non_array_value_for_array_key_defaults_to_empty() -> None:
         assert r.findings == [], f"Case {bad!r} should produce findings=[]"
 
 
+def test_parse_artifacts_array() -> None:
+    """The optional ``artifacts`` key (Donna ask #8) is parsed — and the
+    parser is flag-agnostic: it fills the list regardless of the session's
+    emit_artifacts opt-in (the drafting node enforces opt-in)."""
+    raw = (
+        '```json\n{"findings": [], '
+        '"artifacts": [{"name": "review-memo.md", "content_md": "# Memo\\n\\nBody."}, '
+        '{"name": "summary.md", "content_md": "# Summary"}]}\n```'
+    )
+    r = parse_structured_output(raw)
+    assert r.is_structured is True
+    assert len(r.artifacts) == 2
+    assert r.artifacts[0]["name"] == "review-memo.md"
+    assert r.artifacts[0]["content_md"] == "# Memo\n\nBody."
+
+
+def test_parse_missing_artifacts_defaults_to_empty() -> None:
+    """A response without the artifacts key (the common, non-opted-in
+    case) yields artifacts == []."""
+    raw = '{"findings": []}'
+    r = parse_structured_output(raw)
+    assert r.is_structured is True
+    assert r.artifacts == []
+
+
+def test_parse_non_list_artifacts_coerces_to_empty() -> None:
+    """Non-list values for artifacts coerce to [] — never raise."""
+    for bad in ('{"artifacts": 42}', '{"artifacts": "memo"}', '{"artifacts": {"a": 1}}'):
+        r = parse_structured_output(bad)
+        assert r.is_structured is True, f"Case {bad!r} should still be structured"
+        assert r.artifacts == [], f"Case {bad!r} should produce artifacts=[]"
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["findings", "suggested_memories", "suggested_precedents", "artifacts"],
+)
+def test_parse_non_dict_items_in_dict_shaped_arrays_are_dropped(key: str) -> None:
+    """Non-dict items inside dict-shaped arrays are silently dropped.
+
+    Valid JSON like ``{"artifacts": ["a string"]}`` previously survived
+    parsing and crashed the drafting node's ``.get()`` calls
+    (AttributeError → run marked failed) — worse than the documented
+    tolerant degradation. Only dict items may reach the drafting node.
+    """
+    survivor = {"title": "ok", "name": "a.md", "content_md": "x"}
+    raw = json.dumps({key: ["a string", 42, None, True, [1, 2], survivor]})
+    r = parse_structured_output(raw)
+    assert r.is_structured is True
+    assert getattr(r, key) == [survivor], f"key={key} should keep only dict items"
+
+
+def test_parse_mixed_contamination_across_all_dict_shaped_arrays() -> None:
+    """All four dict-shaped arrays drop non-dict items in one response;
+    the string arrays (privilege/scope concerns) are untouched — they are
+    only ever string-formatted downstream, never ``.get()``-accessed."""
+    raw = json.dumps(
+        {
+            "findings": ["str", {"title": "ok"}],
+            "suggested_memories": [1, {"category": "preference", "content": "C"}],
+            "suggested_precedents": [None, {"pattern_kind": "clause"}],
+            "artifacts": [42, {"name": "a.md", "content_md": "x"}],
+            "privilege_concerns": ["p1"],
+            "scope_concerns": ["s1"],
+        }
+    )
+    r = parse_structured_output(raw)
+    assert r.is_structured is True
+    assert r.findings == [{"title": "ok"}]
+    assert r.suggested_memories == [{"category": "preference", "content": "C"}]
+    assert r.suggested_precedents == [{"pattern_kind": "clause"}]
+    assert r.artifacts == [{"name": "a.md", "content_md": "x"}]
+    assert r.privilege_concerns == ["p1"]
+    assert r.scope_concerns == ["s1"]
+
+
 def test_parse_non_array_value_does_not_raise_on_any_array_key() -> None:
     """Every array key in the schema must coerce non-list to []."""
     for key in (
@@ -143,6 +223,7 @@ def test_parse_non_array_value_does_not_raise_on_any_array_key() -> None:
         "suggested_precedents",
         "privilege_concerns",
         "scope_concerns",
+        "artifacts",
     ):
         # Non-list value at the key under test:
         raw = '{"' + key + '": 99}'

--- a/api/tests/autonomous/test_watches.py
+++ b/api/tests/autonomous/test_watches.py
@@ -117,6 +117,7 @@ async def _make_watch(
     deleted: bool = False,
     playbook_id: uuid.UUID | None = None,
     skill_ref: str | None = None,
+    emit_artifacts: bool = False,
 ) -> AutonomousWatch:
     watch = AutonomousWatch(
         user_id=user.id,
@@ -125,6 +126,7 @@ async def _make_watch(
         deleted_at=datetime.now(UTC) if deleted else None,
         playbook_id=playbook_id,
         skill_ref=skill_ref,
+        emit_artifacts=emit_artifacts,
     )
     db.add(watch)
     await db.flush()
@@ -174,8 +176,39 @@ async def test_fire_watches_spawns_one_session(
     assert sess.params["skill_ref"] == "nda-review"
     # playbook_id was None — excluded from params (non-null subset).
     assert "playbook_id" not in sess.params
+    # emit_artifacts defaults False — excluded too (non-null subset; the
+    # key is present iff the watch opted in — Donna ask #8).
+    assert "emit_artifacts" not in sess.params
 
     enqueue.assert_awaited_once_with(sess.id)
+
+
+@pytest.mark.integration
+async def test_fire_watches_copies_emit_artifacts_flag_into_params(
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """A watch with emit_artifacts=True spawns a session whose params carry
+    emit_artifacts=True (Donna ask #8 opt-in plumbing)."""
+    from app.autonomous.watch_trigger import fire_watches_for_kb
+
+    kb = await _make_kb(db_session, owner=user_a)
+    watch = await _make_watch(
+        db_session, user=user_a, kb=kb, skill_ref="nda-review", emit_artifacts=True
+    )
+
+    enqueue = AsyncMock(return_value=True)
+    count = await fire_watches_for_kb(
+        db_session, kb_id=kb.id, file_id=uuid.uuid4(), enqueue=enqueue
+    )
+    assert count == 1
+
+    sess = (
+        await db_session.execute(
+            select(AutonomousSession).where(AutonomousSession.trigger_ref == watch.id)
+        )
+    ).scalar_one()
+    assert sess.params["emit_artifacts"] is True
 
 
 @pytest.mark.integration

--- a/api/tests/autonomous/test_watches.py
+++ b/api/tests/autonomous/test_watches.py
@@ -417,6 +417,42 @@ async def test_create_watch_returns_201_and_audits(
 
 
 @pytest.mark.integration
+async def test_create_watch_emit_artifacts_round_trip(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """Create with emit_artifacts=true → the read echoes true (Donna #8)."""
+    kb = await _make_kb(db_session, owner=user_a)
+
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(kb.id), "emit_artifacts": True},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["emit_artifacts"] is True
+
+
+@pytest.mark.integration
+async def test_create_watch_emit_artifacts_defaults_false(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """Omitting emit_artifacts at create → false (opt-in, default off)."""
+    kb = await _make_kb(db_session, owner=user_a)
+
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(kb.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["emit_artifacts"] is False
+
+
+@pytest.mark.integration
 async def test_create_watch_on_unowned_kb_returns_404(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -635,6 +671,33 @@ async def test_patch_watch_toggles_enabled(
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["enabled"] is False
+
+
+@pytest.mark.integration
+async def test_patch_watch_toggles_emit_artifacts_both_ways(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """PATCH flips emit_artifacts false→true and true→false (Donna #8)."""
+    kb = await _make_kb(db_session, owner=user_a)
+    watch = await _make_watch(db_session, user=user_a, kb=kb, emit_artifacts=False)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/watches/{watch.id}",
+        headers=_bearer(user_a),
+        json={"emit_artifacts": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["emit_artifacts"] is True
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/watches/{watch.id}",
+        headers=_bearer(user_a),
+        json={"emit_artifacts": False},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["emit_artifacts"] is False
 
 
 @pytest.mark.integration

--- a/api/tests/models/test_autonomous_models.py
+++ b/api/tests/models/test_autonomous_models.py
@@ -35,6 +35,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.autonomous import (
+    AutonomousArtifact,
     AutonomousMemory,
     AutonomousSchedule,
     AutonomousSession,
@@ -576,6 +577,7 @@ def test_autonomous_columns_match_migration() -> None:
         "target_kb_id",
         "max_cost_usd",
         "enabled",
+        "emit_artifacts",
         "last_run_at",
         "next_run_at",
         "deleted_at",
@@ -591,6 +593,7 @@ def test_autonomous_columns_match_migration() -> None:
         "skill_ref",
         "max_cost_usd",
         "enabled",
+        "emit_artifacts",
         "deleted_at",
         "created_at",
         "updated_at",
@@ -617,4 +620,13 @@ def test_autonomous_columns_match_migration() -> None:
         "dismissed_at",
         "created_at",
         "updated_at",
+    }
+    assert {c.name for c in inspect(AutonomousArtifact).columns} == {
+        "id",
+        "session_id",
+        "file_id",
+        "name",
+        "mime",
+        "size_bytes",
+        "created_at",
     }

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -294,6 +294,7 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("PATCH", "/api/v1/autonomous/schedules/{schedule_id}"),
     ("GET", "/api/v1/autonomous/sessions"),
     ("GET", "/api/v1/autonomous/sessions/{session_id}"),
+    ("GET", "/api/v1/autonomous/sessions/{session_id}/artifacts"),
     ("GET", "/api/v1/autonomous/sessions/{session_id}/findings"),
     ("POST", "/api/v1/autonomous/sessions/{session_id}/halt"),
     ("GET", "/api/v1/autonomous/watches"),

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -165,6 +165,8 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/autonomous/sessions/{session_id}/halt",
         # Findings read-model — a run's persisted findings (work-product)
         "/api/v1/autonomous/sessions/{session_id}/findings",
+        # Artifacts read-model — a run's document-grade artifact refs (Donna #8)
+        "/api/v1/autonomous/sessions/{session_id}/artifacts",
         # M4-B1 — per-user memory curation API (list, keep, dismiss, delete)
         "/api/v1/autonomous/memory",
         "/api/v1/autonomous/memory/{memory_id}/keep",
@@ -283,7 +285,9 @@ async def test_openapi_paths_match_sketch() -> None:
     # /api/v1/admin/provider-keys/{provider}
     # Findings read-model adds one new path:
     # /api/v1/autonomous/sessions/{session_id}/findings
-    assert len(actual) == 117
+    # Artifacts read-model (Donna #8) adds one new path:
+    # /api/v1/autonomous/sessions/{session_id}/artifacts
+    assert len(actual) == 118
 
 
 @pytest.mark.unit

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4483,6 +4483,30 @@ Two bulk operations as originally written in the M3-C4 spec:
 
 ---
 
+#### DE-332 — Text/markdown ingest-parser support (today the ingest pipeline is PDF-only)
+
+**Priority:** P3 · **Effort:** M · **Good first issue** (community-suitable)
+
+**Context:** The ingest pipeline rejects every non-PDF upload at parse time — `api/app/pipeline/ingest.py` gates on `is_pdf_mime` (`api/app/pipeline/parsers.py`) and marks anything else failed. This surfaced during the autonomous document-grade-artifacts work (Donna ask #8): a run's markdown memo could not ride the normal ingest path, so the `emit_artifact` chokepoint handler writes the `File` + `Document` + chunks **directly** (markdown is already text — no parser needed). That direct-write path is correct and stays, but the underlying gap is general: a user cannot upload `.md` / `.txt` files to a knowledge base at all, even though the chunker (`chunk_document`) operates on plain text and handles them trivially once a `ParsedDocument` exists.
+
+**Specific scope:** Add a plain-text parser branch to the ingest pipeline — accept `text/markdown` and `text/plain` mimes in (or alongside) `is_pdf_mime`'s gate, build a synthetic single-page `ParsedDocument` from the decoded bytes (the same shape `_handle_emit_artifact` constructs), and run the existing chunk/embed path unchanged. Set `parser` to an honest value (e.g. `"plain-text"`), `page_count=1`, `was_ocrd=False`. Update the upload endpoint's accepted-mime documentation in `docs/api/backend-openapi.yaml`, add ingest tests for both mimes (happy path + a non-UTF-8 byte-stream failure case), and update the file-upload docs that currently state PDF-only.
+
+**When to ship:** Post-v0.4.0; well-scoped for community pickup (the artifact handler already demonstrates the exact `ParsedDocument` construction needed).
+
+---
+
+#### DE-333 — Dedupe correlated artifact storage-failure warn findings
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** When an opted-in autonomous run emits N artifacts and object storage (MinIO) is down, the drafting node's dispatch loop produces one `storage_error` result — and therefore one `warn` finding — per artifact: N near-identical "artifact could not be stored" findings for a single underlying outage. A natural bound already exists (the artifact list comes from a single analysis response, so N is limited by the response token budget), and each finding is individually honest, so this is noise rather than harm — which is why it was deferred rather than absorbed into the Donna-#8 work.
+
+**Specific scope:** In the drafting node's artifact dispatch loop (`api/app/autonomous/nodes.py`), collapse consecutive/correlated `storage_error` outcomes into one `warn` finding that names the count and the artifact names (e.g. "3 artifacts could not be stored — object storage unavailable"), instead of one finding per failure. Keep the per-artifact audit `tool_call` rows untouched (the receipt should still show every attempted dispatch); only the user-facing finding is deduplicated. Add a test with ≥2 failing artifacts asserting exactly one warn finding.
+
+**When to ship:** If/when a real storage outage during an artifact-emitting run produces enough duplicate findings to bother a user; pure polish until then.
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -3907,12 +3907,16 @@ paths:
   /api/v1/autonomous/sessions/{session_id}/findings:
     get:
       tags: [autonomous]
-      summary: List a session's persisted findings (work-product, emission order)
+      summary: List a session's persisted findings (work-product, stable order)
       description: |
         Returns the run's persisted findings (the ``emit_finding`` chokepoint
-        work-product) ordered by ``created_at ASC`` — emission order, the
-        run's output sequence. This differs intentionally from the
-        newest-first autonomous lists: these are one run's sequential output.
+        work-product) ordered by ``created_at ASC, id ASC``. Rows a run
+        emits in its single executor commit typically share one
+        ``created_at`` (transaction-stable ``now()``), so ``id`` is the
+        deterministic tiebreaker that keeps pagination stable — a
+        repeatable order, not a guaranteed emission sequence. This differs
+        intentionally from the newest-first autonomous lists: these are one
+        run's output.
 
         Owner-gated by loading the owned session first (the findings table
         has no ``user_id`` — authz is via the parent session). Another
@@ -3938,11 +3942,65 @@ paths:
           description: Zero-based index of the first result to return.
       responses:
         '200':
-          description: Paginated list of the session's findings (emission order)
+          description: Paginated list of the session's findings (stable created_at, id order)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AutonomousFindingListResponse'
+        '401':
+          description: Not authenticated
+        '404':
+          description: Session not found
+
+  /api/v1/autonomous/sessions/{session_id}/artifacts:
+    get:
+      tags: [autonomous]
+      summary: List a session's persisted document-grade artifacts (work-product, stable order)
+      description: |
+        Returns the run's persisted artifact references (the
+        ``emit_artifact`` chokepoint work-product — markdown memos an
+        opted-in run saved into its target knowledge base as real
+        documents) ordered by ``created_at ASC, id ASC`` — one run's rows
+        typically share ``created_at`` (transaction-stable ``now()``), so
+        ``id`` is the deterministic tiebreaker that keeps pagination
+        stable; a repeatable order, not a guaranteed emission sequence.
+        Mirrors the findings read above.
+
+        Owner-gated by loading the owned session first (the artifacts
+        table has no ``user_id`` — authz is via the parent session).
+        Another user's ``session_id`` — or a missing one — returns 404
+        (not 403) to avoid existence disclosure. ``limit`` is clamped to
+        [1, 200]; ``offset`` to [0, ∞).
+
+        ``document_id`` is enriched at read time via the unique
+        ``documents.file_id``. Deletion semantics: a hard file-delete
+        SET-NULLs ``file_id`` (name/size metadata survives; both refs
+        return null); deleting the session removes these reference rows
+        but never the KB document — the document outlives the session.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: session_id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+        - name: limit
+          in: query
+          required: false
+          schema: {type: integer, default: 50, minimum: 1, maximum: 200}
+          description: Maximum number of artifacts to return (clamped to [1, 200]).
+        - name: offset
+          in: query
+          required: false
+          schema: {type: integer, default: 0, minimum: 0}
+          description: Zero-based index of the first result to return.
+      responses:
+        '200':
+          description: Paginated list of the session's artifact references (stable created_at, id order)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutonomousArtifactListResponse'
         '401':
           description: Not authenticated
         '404':
@@ -5477,13 +5535,72 @@ components:
     AutonomousFindingListResponse:
       type: object
       description: |
-        Paginated list of a session's findings, in emission order
-        (``created_at ASC``) — one run's sequential output.
+        Paginated list of a session's findings, in stable
+        ``created_at ASC, id ASC`` order — one run's rows typically
+        share ``created_at`` (transaction-stable ``now()``); ``id`` is
+        the pagination tiebreaker. Repeatable, not a guaranteed
+        emission sequence.
       required: [findings, total_count, limit, offset]
       properties:
         findings:
           type: array
           items: {$ref: '#/components/schemas/AutonomousFindingRead'}
+        total_count: {type: integer, minimum: 0}
+        limit: {type: integer, minimum: 1, maximum: 200}
+        offset: {type: integer, minimum: 0}
+
+    # Autonomous run artifacts (document-grade work-product, Donna #8) schemas
+
+    AutonomousArtifactRead:
+      type: object
+      description: |
+        Read-only view of an ``autonomous_artifacts`` row — a reference to
+        one document-grade artifact (a markdown memo) an opted-in run
+        persisted into its target knowledge base via the ``emit_artifact``
+        chokepoint. ``name`` and ``mime`` are LLM-emitted free text (no
+        CHECK; the ``severity`` precedent).
+      required:
+        - id
+        - name
+        - mime
+        - size_bytes
+        - created_at
+      properties:
+        id: {type: string, format: uuid}
+        name: {type: string}
+        mime: {type: string}
+        size_bytes: {type: integer, minimum: 0}
+        file_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: |
+            The backing ``files`` row. The FK is ``ON DELETE SET NULL`` —
+            null means the file was later hard-deleted; the name/size
+            metadata here survives. The KB document itself outlives the
+            session (deleting the session removes only this reference).
+        document_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: |
+            NOT a column on ``autonomous_artifacts`` — enriched at read
+            time via the unique ``documents.file_id`` (1:1) so a client
+            can deep-link the KB document. Null when ``file_id`` is null
+            or no ``documents`` row exists for the file.
+        created_at: {type: string, format: date-time}
+
+    AutonomousArtifactListResponse:
+      type: object
+      description: |
+        Paginated list of a session's artifact references, in the same
+        stable ``created_at ASC, id ASC`` order as the findings list —
+        repeatable, not a guaranteed emission sequence.
+      required: [artifacts, total_count, limit, offset]
+      properties:
+        artifacts:
+          type: array
+          items: {$ref: '#/components/schemas/AutonomousArtifactRead'}
         total_count: {type: integer, minimum: 0}
         limit: {type: integer, minimum: 1, maximum: 200}
         offset: {type: integer, minimum: 0}
@@ -5638,6 +5755,7 @@ components:
         - user_id
         - cron_expr
         - enabled
+        - emit_artifacts
         - created_at
         - updated_at
       properties:
@@ -5650,6 +5768,12 @@ components:
         skill_ref: {type: string, nullable: true}
         target_kb_id: {type: string, format: uuid, nullable: true}
         enabled: {type: boolean}
+        emit_artifacts:
+          type: boolean
+          description: |
+            Opt-in document-grade artifact emission (Donna #8) for the
+            schedule's sessions; default off so existing automations are
+            unchanged.
         max_cost_usd: {type: string, nullable: true}
         last_run_at: {type: string, format: date-time, nullable: true}
         next_run_at: {type: string, format: date-time, nullable: true}
@@ -5673,6 +5797,13 @@ components:
         target_kb_id: {type: string, format: uuid, nullable: true}
         project_id: {type: string, format: uuid, nullable: true}
         enabled: {type: boolean, default: true}
+        emit_artifacts:
+          type: boolean
+          default: false
+          description: |
+            Opt-in document-grade artifact emission (Donna #8) for the
+            schedule's sessions; default off so existing automations are
+            unchanged.
         max_cost_usd: {type: string, nullable: true}
 
     AutonomousScheduleUpdate:
@@ -5687,6 +5818,12 @@ components:
         name: {type: string, nullable: true}
         cron_expr: {type: string, nullable: true}
         enabled: {type: boolean, nullable: true}
+        emit_artifacts:
+          type: boolean
+          nullable: true
+          description: |
+            Toggle opt-in document-grade artifact emission (Donna #8)
+            for the schedule's future sessions; omitted/null = unchanged.
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
         target_kb_id: {type: string, format: uuid, nullable: true}
@@ -5700,13 +5837,21 @@ components:
         ``trigger_kind='manual'`` session.  Exactly one of ``playbook_id``
         / ``skill_ref`` must be set (zero or both → 422).  ``target_kb_id``
         / ``project_id`` are optional scope.  ``max_cost_usd`` is the
-        per-run cap (NULL → fall back to the config default).
+        per-run cap (NULL → fall back to the config default).  A manual
+        run has no schedule/watch row to inherit ``emit_artifacts`` from,
+        so this body IS the opt-in source.
       properties:
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
         target_kb_id: {type: string, format: uuid, nullable: true}
         project_id: {type: string, format: uuid, nullable: true}
         max_cost_usd: {type: string, nullable: true}
+        emit_artifacts:
+          type: boolean
+          default: false
+          description: |
+            Opt-in document-grade artifact emission (Donna #8) for this
+            one-off run; default off so existing callers are unchanged.
 
     AutonomousScheduleListResponse:
       type: object
@@ -5733,6 +5878,7 @@ components:
         - user_id
         - knowledge_base_id
         - enabled
+        - emit_artifacts
         - created_at
         - updated_at
       properties:
@@ -5743,6 +5889,12 @@ components:
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
         enabled: {type: boolean}
+        emit_artifacts:
+          type: boolean
+          description: |
+            Opt-in document-grade artifact emission (Donna #8) for the
+            watch's sessions; default off so existing automations are
+            unchanged.
         max_cost_usd: {type: string, nullable: true}
         deleted_at: {type: string, format: date-time, nullable: true}
         created_at: {type: string, format: date-time}
@@ -5762,6 +5914,13 @@ components:
         skill_ref: {type: string, nullable: true}
         project_id: {type: string, format: uuid, nullable: true}
         enabled: {type: boolean, default: true}
+        emit_artifacts:
+          type: boolean
+          default: false
+          description: |
+            Opt-in document-grade artifact emission (Donna #8) for the
+            watch's sessions; default off so existing automations are
+            unchanged.
         max_cost_usd: {type: string, nullable: true}
 
     AutonomousWatchUpdate:
@@ -5775,6 +5934,12 @@ components:
         404 (id-probing-safe).
       properties:
         enabled: {type: boolean, nullable: true}
+        emit_artifacts:
+          type: boolean
+          nullable: true
+          description: |
+            Toggle opt-in document-grade artifact emission (Donna #8)
+            for the watch's future sessions; omitted/null = unchanged.
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
         project_id: {type: string, format: uuid, nullable: true}
@@ -5802,7 +5967,9 @@ components:
         marking read is the dismiss action. ``channel`` is one of
         ``in_app`` / ``email`` / ``webhook`` (``webhook`` reserved).
         ``body``/``payload`` carry counts/IDs + a receipt link — never raw
-        entity values.
+        entity values. A run-completion notification's ``payload`` carries
+        ``finding_count`` and ``artifact_count`` (``artifact_count`` is 0
+        unless the run opted in via ``emit_artifacts``).
       required:
         - id
         - user_id

--- a/docs/autonomous-layer.md
+++ b/docs/autonomous-layer.md
@@ -34,6 +34,7 @@ catalog).
 | Four primitives (watches, schedules, per-user memory, precedent board) | **Shipped**, with API + web dashboard. |
 | Honest per-session receipt (`terminal_reason`) | **Shipped.** Built only from audit rows (counts/types/IDs/enums — never raw values). |
 | Per-user opt-in + per-session/per-trigger cost cap | **Shipped.** Off by default; mutate + spawn paths gated. |
+| Document-grade artifacts from runs (Donna #8) | **Shipped, opt-in (default off).** Markdown/plain-text memos written into the run's target KB as real documents; no PDF/DOCX rendering, no artifact editing/versioning, and interactive chat/playbook paths are NOT covered. |
 | Ethics-review phase | **Light v1.** Summarizes privilege/scope concerns surfaced upstream into one finding; a dedicated ethics LLM gate is a future enhancement. |
 | Gateway error mid-analysis | **Honest path.** Produces one explanatory finding and a *completed* (not fabricated) receipt — no invented analysis. |
 | Contract-Repository auto-relationship graph (PRD §3.16) | **Not built.** No `contract_relationships` table; roadmap (deferred-M4+). |
@@ -115,7 +116,7 @@ state deltas.
 |---|---|---|
 | **intake** | Scope the run. Fetches the arriving file's chunks (watch path: `file_id`) or chunks attached since the last run (schedule path: `kb_id` + `since`). | `retrieve_chunks` |
 | **analysis** | Read the scoped material and run inference (skill/playbook) over it; record whether the inference succeeded or hit a gateway error. | `retrieve_chunks`, `run_skill`, `run_playbook`, `propose_precedent` |
-| **drafting** | Synthesize findings. Parses the analysis output, emits one finding per item, optionally proposes memory/precedent, and forwards `privilege_concerns` / `scope_concerns` downstream. | `run_skill`, `emit_finding`, `propose_memory`, `propose_precedent` |
+| **drafting** | Synthesize findings. Parses the analysis output, emits one finding per item, optionally proposes memory/precedent, and forwards `privilege_concerns` / `scope_concerns` downstream. When the session opted in via `emit_artifacts`, also persists each parsed artifact (a markdown memo) into the target KB. | `run_skill`, `emit_finding`, `emit_artifact` (opt-in), `propose_memory`, `propose_precedent` |
 | **ethics_review** | Light v1: emit one finding summarizing the privilege/scope concerns the drafting node forwarded, or one "no concerns flagged" info finding when both are empty. | `emit_finding` |
 | **delivery** | Notify the user (durable in-app notification; best-effort email). On the expected-stop path the executor builds the receipt. | `notify` |
 
@@ -146,7 +147,7 @@ path to a tool. The closed set of operations is the `ToolIntent`
 enum (`api/app/autonomous/enums.py`):
 
 `retrieve_chunks`, `run_skill`, `run_playbook`, `propose_memory`,
-`propose_precedent`, `emit_finding`, `notify`.
+`propose_precedent`, `emit_finding`, `emit_artifact`, `notify`.
 
 `guarded_tool_call` enforces the three brakes **in this order — R5 →
 R6 → R4** — before dispatching, then records cost + outcome:
@@ -183,8 +184,11 @@ check computed is forwarded into `_dispatch`, so inference handlers
 charge exactly what R4 approved — no double-charge, no divergence
 between what was checked and what was billed.
 
-**Dispatch detail.** Local intents (`emit_finding`, `propose_memory`,
-`propose_precedent`, `notify`) and `retrieve_chunks` are zero-cost.
+**Dispatch detail.** Local intents (`emit_finding`, `emit_artifact`,
+`propose_memory`, `propose_precedent`, `notify`) and `retrieve_chunks`
+are zero-cost (`emit_artifact` writes to the DB and object storage but
+makes no inference call — the artifact content comes from the analysis
+phase's single inference response).
 `propose_precedent` upserts race-safely via `INSERT ... ON CONFLICT`
 against a partial unique index, incrementing `observed_count` on
 recurrence — it **never** touches the `projects` table (promotion into
@@ -239,6 +243,8 @@ sees only their own sessions/memory/precedents/etc.).
 |---|---|---|
 | `GET` | `/autonomous/sessions` | List the user's sessions. |
 | `GET` | `/autonomous/sessions/{session_id}` | Get one session (carries the receipt in `result`). |
+| `GET` | `/autonomous/sessions/{session_id}/findings` | The run's persisted findings (stable `created_at, id` order). |
+| `GET` | `/autonomous/sessions/{session_id}/artifacts` | The run's document-grade artifact references (same stable order; see the artifacts section below). |
 | `POST` | `/autonomous/sessions/{session_id}/halt` | Request an external halt (R5). |
 
 ### Watches (KB-arrival triggers)
@@ -311,6 +317,75 @@ index in `0043`).
 |---|---|---|
 | `GET` | `/autonomous/notifications` | List the user's notifications. |
 | `POST` | `/autonomous/notifications/{notification_id}/read` | Mark one read. |
+
+---
+
+## Document-grade artifacts (opt-in, Donna #8)
+
+An opted-in run can persist **document-grade artifacts** — markdown
+memos synthesized from its analysis — into its target knowledge base as
+*real documents*: visible in the KB file list, chat/RAG-queryable
+(embeddings are enqueued best-effort at emission; the lazy
+embed-on-read path covers any gap), and downloadable like any upload.
+
+**Opt-in, default off.** The `emit_artifacts` boolean on
+`autonomous_schedules` / `autonomous_watches` (migration `0047`; also
+on the `run-now` request body, since a manual run has no trigger row to
+inherit from) is copied into `session.params` at spawn. Existing
+automations see **zero** behavior or cost change: the artifact
+instruction is appended to the analysis prompt only when the flag is
+set, and the drafting node dispatches `emit_artifact` only when the
+session's flag is truthy — even if the model emits the key unasked
+(defense-in-depth; R6 additionally grants `emit_artifact` in `drafting`
+only).
+
+**Where artifacts come from.** The existing single analysis inference
+call — when opted in, the structured-output JSON gains an optional
+`artifacts: [{"name", "content_md"}]` list. There is no second
+inference call; `emit_artifact` is a zero-cost local intent.
+
+**The direct-write shape.** The chokepoint handler
+(`guard.py::_handle_emit_artifact`) uploads the bytes to object storage
+first, then writes a real `File` row + `Document` + chunks + KB attach
++ an `autonomous_artifacts` reference row — all through the normal
+commit boundary (the executor commits). The PDF-only ingest pipeline is
+not involved (markdown is already text); md/txt support for the general
+ingest path is deferred as DE-332.
+
+**Deletion semantics.** The `autonomous_artifacts` reference dies with
+its session (`session_id` FK CASCADE); the KB document **outlives** the
+session — it is the user's deliverable. A hard file-delete SET-NULLs
+the reference's `file_id` while the name/size metadata survives.
+
+**Loop/echo prevention.** The KB attach is a direct DB insert, not the
+attach API — so an artifact arriving in a watched KB does **not** fire
+the watch and spawn a new run. And mode-3 (`since`) retrieval excludes
+artifact-referenced files, so a schedule's next tick does not re-analyze
+the previous tick's memo. Query-mode retrieval and chat RAG deliberately
+*keep* artifacts retrievable — that is the point of the direct-write
+shape.
+
+**Honest fallbacks.** A run with no target KB skips persistence and
+emits one `info` finding saying why; a storage (MinIO) failure writes
+**no** DB rows and emits one `warn` finding per failed artifact
+(correlated-failure dedupe is deferred as DE-333). The delivery
+notification's payload carries `artifact_count` next to
+`finding_count`, and its body mentions documents only when the count is
+non-zero.
+
+**Read endpoint.** `GET /autonomous/sessions/{session_id}/artifacts`
+mirrors the findings read: owner-gated (404 id-probing-safe), stable
+order (`created_at ASC, id ASC` — one run's rows typically share
+`created_at` because server-side `now()` is transaction-stable, so `id`
+is the pagination tiebreaker; repeatable, not a guaranteed emission
+sequence), limit clamped [1, 200]; `document_id` is enriched at read
+time via the unique `documents.file_id` so a client can deep-link the
+KB document.
+
+**Honest scope.** Markdown/plain-text only — no PDF/DOCX rendering
+(deferred), no artifact editing/versioning, and the interactive chat /
+playbook-execution paths do **not** emit artifacts; this is an
+autonomous-run capability.
 
 ---
 
@@ -480,5 +555,6 @@ decision.
 - [docs/db-schema.md](db-schema.md) — `autonomous_sessions`,
   `autonomous_watches`, `autonomous_schedules`, `autonomous_memory`,
   `precedent_entries`, `project_context_proposals`,
-  `autonomous_notifications`
+  `autonomous_notifications`, `autonomous_findings`,
+  `autonomous_artifacts`
 - [docs/observability.md](observability.md) — autonomous spans

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -556,7 +556,7 @@ reference is stored unbound.
 > early sketch from before [ADR 0004](adr/0004-skill-loader-locus.md)
 > made skills **filesystem-canonical**. There is no `skills` SQL table,
 > no `skill_reference_files` table, and no `skill_example_files` table in
-> the shipped schema (verified against migrations 0001–0045 and
+> the shipped schema (verified against migrations 0001–0047 and
 > `api/app/models/` — no `Skill` ORM model exists). Built-in skills load
 > from disk at startup; user/team-scoped skills are stored in the
 > **`user_skills`** table (migration 0013, documented below), and the
@@ -1524,6 +1524,10 @@ CREATE TABLE autonomous_schedules (
     skill_ref     TEXT,
     target_kb_id  UUID REFERENCES knowledge_bases(id) ON DELETE SET NULL,         -- fk_autonomous_schedules_target_kb_id
     enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+    -- Donna #8 (migration 0047): opt-in document-grade artifact emission
+    -- for the schedule's sessions; default off — existing automations
+    -- see zero behavior/cost change.
+    emit_artifacts BOOLEAN NOT NULL DEFAULT FALSE,
     last_run_at   TIMESTAMPTZ,
     next_run_at   TIMESTAMPTZ,
     -- M4 real-executor work (migration 0045): per-schedule cost cap.
@@ -1559,6 +1563,10 @@ CREATE TABLE autonomous_watches (
     playbook_id        UUID REFERENCES playbooks(id) ON DELETE SET NULL,          -- fk_autonomous_watches_playbook_id
     skill_ref          TEXT,
     enabled            BOOLEAN NOT NULL DEFAULT TRUE,
+    -- Donna #8 (migration 0047): opt-in document-grade artifact emission
+    -- for the watch's sessions; default off — existing automations see
+    -- zero behavior/cost change.
+    emit_artifacts     BOOLEAN NOT NULL DEFAULT FALSE,
     -- M4 real-executor work (migration 0045): per-watch cost cap.
     -- NULL = fall back to settings.autonomous_default_max_cost_usd at spawn.
     max_cost_usd       NUMERIC(10,4),
@@ -1725,6 +1733,85 @@ CREATE INDEX idx_project_context_proposals_user_state
     ON project_context_proposals (user_id, state);
 ```
 
+### `autonomous_findings` (migration 0046)
+
+Persists one row per finding a run emits via the `emit_finding`
+chokepoint, so the run's work-product can be read back after the run
+(`GET /autonomous/sessions/{id}/findings`, stable `created_at, id`
+order — rows from one run share a transaction-stable `now()`). Before
+0046, findings were echoed into transient LangGraph state and only a
+count survived.
+
+**No `user_id` column.** Authz is via the owning session: the read
+endpoint loads the owned session first (404 id-probing-safe), then
+queries by `session_id`. The `session_id` FK is `ON DELETE CASCADE` — a
+finding belongs to one session and is meaningless without it.
+
+**No CHECK on `severity`.** Unlike the other autonomous enum columns,
+`severity` is LLM-emitted free text (`info` | `warn` | `critical` are
+the intended values, but a stray `high` etc. must store, not reject the
+finding row).
+
+```sql
+CREATE TABLE autonomous_findings (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id  UUID NOT NULL REFERENCES autonomous_sessions(id) ON DELETE CASCADE,  -- fk_autonomous_findings_session_id
+    severity    TEXT NOT NULL,  -- LLM-emitted free text; deliberately NO CHECK
+    title       TEXT NOT NULL,
+    content     TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The read endpoint's by-session query.
+CREATE INDEX ix_autonomous_findings_session_id ON autonomous_findings(session_id);
+```
+
+### `autonomous_artifacts` (migration 0047, Donna #8)
+
+References to document-grade artifacts (markdown memos) an **opted-in**
+run persisted into its target knowledge base via the `emit_artifact`
+chokepoint. This table is the *reference*, not the document — the
+document itself lives in `files` / the KB like any other upload (the
+handler writes File + Document + chunks + KB attach directly). Read
+back via `GET /autonomous/sessions/{id}/artifacts` (stable
+`created_at, id` order — rows from one run share a transaction-stable
+`now()`);
+`document_id` is enriched at read time via the unique
+`documents.file_id` — it is not a column here.
+
+**Deletion semantics.** `session_id` FK is `ON DELETE CASCADE` — the
+artifact *reference* dies with its session. `file_id` FK is `ON DELETE
+SET NULL` — the KB document **outlives** the session (it is the user's
+deliverable); a hard file-delete nulls the ref while the name/size
+metadata survives here.
+
+**No `user_id` column.** Authz is via the owning session, exactly like
+`autonomous_findings` (the read endpoint owner-gates by loading the
+owned session, then queries by `session_id`).
+
+**No CHECK on `name`/`mime`.** Both are LLM-emitted free text (the
+`autonomous_findings.severity` precedent) — whatever the model produces
+must store.
+
+Migration 0047 also adds the opt-in `emit_artifacts` flag (BOOLEAN NOT
+NULL DEFAULT FALSE) to `autonomous_schedules` and `autonomous_watches`
+(documented in their blocks above).
+
+```sql
+CREATE TABLE autonomous_artifacts (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id  UUID NOT NULL REFERENCES autonomous_sessions(id) ON DELETE CASCADE,  -- fk_autonomous_artifacts_session_id
+    file_id     UUID REFERENCES files(id) ON DELETE SET NULL,                        -- fk_autonomous_artifacts_file_id
+    name        TEXT NOT NULL,    -- LLM-emitted free text; deliberately NO CHECK
+    mime        TEXT NOT NULL,    -- LLM-emitted free text; deliberately NO CHECK
+    size_bytes  BIGINT NOT NULL,  -- of the encoded bytes object storage holds
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The read endpoint's by-session query.
+CREATE INDEX ix_autonomous_artifacts_session_id ON autonomous_artifacts(session_id);
+```
+
 ## M4+ tables (sketched, land at the indicated milestone)
 
 ### `autonomous_tasks` (M4 — **superseded**)
@@ -1808,8 +1895,8 @@ CREATE INDEX idx_relationships_target ON contract_relationships(target_file_id);
 
 ## Migration approach
 
-- **Alembic** for schema migrations. **Migration head is `0045`.** The
-  `0001`–`0045` sequence in `api/alembic/versions/` is the schema truth;
+- **Alembic** for schema migrations. **Migration head is `0047`.** The
+  `0001`–`0047` sequence in `api/alembic/versions/` is the schema truth;
   this document is reconciled to it.
 - `0001_initial.py` creates the core M1 tables (`users`, `user_sessions`,
   `audit_log`, `inference_routing_log`, and the M1 foundation). Note:
@@ -1833,8 +1920,11 @@ CREATE INDEX idx_relationships_target ON contract_relationships(target_file_id);
   precedent upsert index), `0042` (autonomous_sessions.params +
   schedule due-index), `0043` (notifications read-index), `0044`
   (users.autonomous_enabled), `0045` (per-trigger max_cost_usd on
-  watches + schedules). `contract_relationships` remains a sketch — it is
-  **not** created by any migration (see the M4+ sketched section).
+  watches + schedules), `0046` (autonomous_findings — persisted run
+  work-product), `0047` (autonomous_artifacts + the `emit_artifacts`
+  opt-in flag on schedules/watches, Donna #8). `contract_relationships`
+  remains a sketch — it is **not** created by any migration (see the M4+
+  sketched section).
 
 Migration conventions:
 - Every migration is reversible (`downgrade()` always implemented).

--- a/docs/superpowers/plans/2026-06-06-donna-8-autonomous-artifacts.md
+++ b/docs/superpowers/plans/2026-06-06-donna-8-autonomous-artifacts.md
@@ -1,0 +1,173 @@
+# Donna ask #8 — document-grade artifacts from autonomous runs
+
+**Date:** 2026-06-06 · **Branch:** `feat/donna-8-autonomous-artifacts` · **Base:** `d95cddf`
+**Source ask:** Donna "document-grade artifacts from autonomous runs" (filed 2026-06-06, follow-up to findings ask shipped as #135 / `0097b01`).
+
+## Decisions (locked by Kevin at kickoff, 2026-06-06)
+
+- **D8-1 Storage shape = (a) direct-write.** The artifact lands in the run's
+  target KB as a real document: the chokepoint handler synchronously creates a
+  `File` row (mime `text/markdown`, `ingestion_status='ready'`), uploads bytes
+  via `upload_bytes`, creates the `Document` + chunks directly (markdown is
+  already text — the PDF-only ingest pipeline is NOT touched), attaches to the
+  KB via direct `KnowledgeBaseFile` insert, and enqueues the existing embed
+  job best-effort. A new `autonomous_artifacts` reference table carries
+  provenance.
+- **D8-2 Opt-in, default off.** New `emit_artifacts` boolean on
+  `autonomous_schedules` + `autonomous_watches` (server_default false). The
+  artifact instruction is appended to the analysis prompt ONLY when set;
+  existing automations see zero behavior/cost change.
+
+## Derived design (conventions, not forks)
+
+- **Deletion semantics:** `autonomous_artifacts.session_id` FK CASCADE (ref
+  dies with session); `file_id` FK SET NULL (the KB document OUTLIVES the
+  session — it is the user's deliverable). No `user_id` column: authz via the
+  owning session, exactly like `autonomous_findings`.
+- **Self-ingestion echo prevention:** mode-3 (`since`) retrieval in
+  `_handle_retrieve_chunks_since` excludes files referenced by
+  `autonomous_artifacts` — otherwise every schedule tick re-analyzes the
+  previous tick's memo. Query-mode retrieval and chat RAG deliberately KEEP
+  artifacts retrievable (that is the point of shape (a)).
+- **No watch loop:** the artifact KB attach is a direct DB insert;
+  `fire_watches_for_kb` only fires from the `attach_file` API handler, so an
+  artifact arriving in a watched KB does not spawn a new run.
+- **No-target-KB runs:** skip persistence, handler returns
+  `data={"skipped": "no_target_kb"}`, drafting node emits ONE `info` finding
+  saying why (Donna's stated fallback).
+- **Artifact content source:** the existing single analysis inference call —
+  the structured-output JSON gains an optional `artifacts:
+  [{"name", "content_md"}]` key (only instructed when opted in). No second
+  inference call; `emit_artifact` is a local zero-cost intent.
+- **Defense-in-depth:** drafting node dispatches `emit_artifact` only when
+  `session.params["emit_artifacts"]` is truthy, even if the model emits the
+  key unasked. R6 additionally grants `emit_artifact` in `drafting` only.
+- **Free-text tolerance:** `name`/`mime` are LLM-emitted → no CHECKs (the
+  `autonomous_findings.severity` precedent). Content clamped to 1,000,000
+  chars (truncated, not rejected) so an over-long emission still persists.
+- **Read model:** `GET /api/v1/autonomous/sessions/{id}/artifacts` mirrors the
+  findings endpoint exactly — owner-gated via `_load_owned_session`, 404
+  id-probing-safe, `created_at` ASC, limit clamped [1,200]. `document_id` is
+  resolved at read time via the unique `documents.file_id` (NULL after a file
+  hard-delete).
+- **Notification:** delivery `notify` payload gains `artifact_count` next to
+  `finding_count`; body says "… N finding(s), M document(s)" when M>0.
+- **Out of scope** (per the ask): PDF/DOCX rendering, artifact
+  editing/versioning, artifacts for interactive chat/playbook paths. The
+  md/txt ingest-parser gap surfaced during verification is filed as a DE, not
+  absorbed.
+
+## Tasks
+
+### Task 1 — Substrate: model + migration 0047 + schemas
+
+- `AutonomousArtifact` in `api/app/models/autonomous.py`: `id`, `session_id`
+  (FK `autonomous_sessions` CASCADE, not null), `file_id` (FK `files`
+  SET NULL, nullable), `name` TEXT NOT NULL, `mime` TEXT NOT NULL,
+  `size_bytes` BIGINT NOT NULL, `created_at`. Index on `session_id`.
+- `emit_artifacts` BOOLEAN NOT NULL server_default `false` on
+  `autonomous_schedules` and `autonomous_watches`.
+- Migration `0047` (down_revision `0046`), both directions.
+- Schemas in `api/app/schemas/autonomous.py`: `AutonomousArtifactRead`
+  (id, name, mime, size_bytes, file_id, document_id, created_at),
+  `AutonomousArtifactListResponse` (artifacts, total_count, limit, offset) —
+  mirror the finding schemas; add `emit_artifacts: bool = False` to schedule
+  and watch Create/Update/Read schemas.
+- Verify migration via throwaway pgvector container ONLY (never the live dev
+  DB at 127.0.0.1:15432).
+
+### Task 2 — `emit_artifact` intent + chokepoint handler + echo exclusion
+
+- `ToolIntent.emit_artifact`; `PHASE_GRANTS[Phase.drafting]` gains it
+  (drafting ONLY).
+- Handler in `guard.py::_dispatch` — params `{"artifact": {"name", "content",
+  "mime"?}}`, zero cost, flush-not-commit like siblings:
+  1. `kb_id = session.params.get("kb_id")`; missing → return
+     `ToolResult(data={"skipped": "no_target_kb"})`.
+  2. Sanitize `name` (strip path separators, default `artifact.md`, ensure an
+     extension); clamp content at 1,000,000 chars; `mime` default
+     `text/markdown`.
+  3. Upload FIRST (no DB state on storage failure): `File` row
+     (owner=`session.user_id`, project_id=`session.project_id`,
+     storage_path=str(file.id) per ADR 0005, `ingestion_status='ready'`,
+     sha256, size); `app.storage.upload_bytes`. Storage failure → return
+     `ToolResult(outcome="storage_error", data={"error": …})` with no rows
+     (mirrors the gateway_error honesty pattern).
+  4. `Document` (parser `"autonomous-artifact"`, `page_count=1`,
+     `normalized_content=content`, `character_count`, `was_ocrd=False`) +
+     chunks via `chunk_document` over a synthetic single-page
+     `ParsedDocument` — preserves the M2-A1 re-read invariant.
+  5. Direct `KnowledgeBaseFile(kb_id, file_id)` insert (NOT the attach API —
+     no watch fire). Tolerate the duplicate-attach IntegrityError path
+     defensively.
+  6. `AutonomousArtifact` row; best-effort
+     `app.workers.queue.enqueue_embed_job(file_id)` wrapped try/except (the
+     notify-email pattern; lazy embed-on-read covers the gap).
+  7. `data={"artifact_id", "file_id", "document_id", "name", "size_bytes"}`.
+- Mode-3 echo exclusion in `_handle_retrieve_chunks_since`:
+  `FileModel.id NOT IN (SELECT file_id FROM autonomous_artifacts WHERE
+  file_id IS NOT NULL)`.
+- Tests (`api/tests/autonomous/`): happy-path persistence (file + doc +
+  chunks + attach + ref row + data shape), no-kb skip, storage failure (no
+  orphan rows), oversize truncation, R6 rejects `emit_artifact` outside
+  drafting, mode-3 exclusion regression (artifact file not re-retrieved).
+
+### Task 3 — Flag plumbing: spawn paths, prompt, parser, nodes
+
+- Spawn paths copy the flag into `session.params` (non-null-subset
+  convention — only set when true): `watch_trigger.fire_watches_for_kb`
+  (from `watch.emit_artifacts`), the schedule sweep in
+  `api/app/workers/autonomous_worker.py` (from `schedule.emit_artifacts`),
+  `_spawn_manual_session` in `api/app/api/autonomous.py` (run-now inherits
+  the schedule's flag).
+- `prompts.py`: new `ARTIFACT_OUTPUT_INSTRUCTION` documenting the optional
+  `"artifacts": [{"name": "...", "content_md": "..."}]` key; appended in
+  `assemble_analysis_messages` ONLY when `session.params.get("emit_artifacts")`.
+- `structured_output.py`: `StructuredResult.artifacts` parsed via `_as_list`.
+- `nodes.py` drafting case 4: when the session flag is set, dispatch each
+  parsed artifact via `guarded_tool_call(emit_artifact)`; count successful
+  persists as `artifacts_count`; a `skipped: no_target_kb` result emits ONE
+  `info` finding ("Artifact not persisted — run has no target knowledge
+  base"); `storage_error` emits ONE `warn` finding. Flag off → parsed
+  artifacts ignored.
+- Delivery node: `notify` body appends ", M document(s)" when M>0; payload
+  `{"finding_count": n, "artifact_count": m}`; `completed` audit row gains
+  `artifacts_count`.
+- Tests: prompt conditional on/off, parser artifacts (+ tolerance), drafting
+  dispatch on/off + skip/storage findings, delivery payload + body.
+
+### Task 4 — Read endpoint + contract + docs
+
+- `GET /api/v1/autonomous/sessions/{session_id}/artifacts` — clone of
+  `list_session_findings` (owner-gated, 404-safe, clamp [1,200],
+  `created_at` ASC); enrich `document_id` via one `IN`-query join on
+  `documents.file_id`.
+- `create_schedule`/`update_schedule`/`create_watch`/`update_watch` accept +
+  persist `emit_artifacts`; reads echo it.
+- `docs/api/backend-openapi.yaml`: new path + `AutonomousArtifactRead`/
+  `…ListResponse` components + `emit_artifacts` on the 6 schedule/watch
+  schemas + notification-payload description note. `api/tests/test_openapi.py`
+  path count 117 → 118 + `EXPECTED_PATHS`; new route into
+  `IMPLEMENTED_ROUTES` (`tests/test_endpoints.py`).
+- Docs: `docs/db-schema.md` (table + 2 columns), `docs/autonomous-layer.md`
+  (artifacts section: opt-in flag, direct-write shape, deletion semantics,
+  echo/loop prevention), PRD §9 DE-332 (text/markdown ingest-parser support —
+  the gap that forced direct-write).
+- Tests: endpoint authz (another user's session → 404), pagination + ASC,
+  `document_id` enrichment incl. NULL-file case, schedule/watch flag
+  round-trip (create → read → patch → read), OpenAPI conformance green.
+
+## Gates (after every task, run by the controller)
+
+`ruff format --check` + `ruff check` + `mypy app` over `api/`; targeted
+pytest for the touched suites; full
+`pytest tests/autonomous tests/test_openapi.py tests/test_endpoints.py`
+before PR. Migration verified on the throwaway pgvector container.
+
+## Loop conventions
+
+DCO `-s` + `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`;
+explicit staging (never `git add -A` — `docs/lq-ai-skill-inputs-corpus.md`
+stays untracked); push both remotes; PR; CI watch; merge gating decision
+(this touches an authz-adjacent KB write path → offer Kevin review) before
+merge; report squash SHA for Donna's pin.


### PR DESCRIPTION
## Summary

Donna ask #8: opted-in autonomous runs now persist **document-grade artifacts** (markdown memos/reports) into the run's target knowledge base as real documents — in addition to the findings-as-text shipped in #135. Findings rendering is unchanged.

**Decisions locked at kickoff (Kevin, 2026-06-06):**
- **Storage shape (a), direct-write**: the `emit_artifact` chokepoint handler synchronously creates a real KB document — MinIO upload-first (no DB rows on storage failure) → `File` (`text/markdown`, `ready`) → `Document` + chunks (M2-A1 re-read invariant preserved) → direct `KnowledgeBaseFile` attach → `autonomous_artifacts` reference row → best-effort embed enqueue (lazy embed-on-read covers the gap). The PDF-only ingest pipeline is untouched (gap filed as **DE-332**).
- **Opt-in, default off**: new `emit_artifacts` boolean on schedules, watches, and the run-now request. Existing automations see zero behavior/cost change. The artifacts instruction is only added to the analysis prompt when opted in; drafting refuses to dispatch artifacts when off (defense-in-depth).

**Hazards closed (neither was in the ask):**
- **Self-ingestion echo**: schedule mode-3 ("since last run") retrieval excludes artifact files — otherwise every tick re-analyzes the previous tick's memo. Query-mode retrieval and chat RAG deliberately keep artifacts visible.
- **Watch loop**: the KB attach is a direct DB insert; `fire_watches_for_kb` only fires from the attach API handler — an artifact arriving in a watched KB cannot spawn a run.

## Surface

- `GET /api/v1/autonomous/sessions/{session_id}/artifacts` — owner-gated (404 id-probing-safe), paginated ([1,200] clamp), stable `created_at, id` order; `document_id` enriched via the unique `documents.file_id`. (Same stable-order tiebreaker retrofitted to the findings read.)
- `emit_artifacts` on schedule/watch create/update/read + run-now request (OpenAPI: 7 schemas, path count 117→118).
- Notification payload gains `artifact_count` next to `finding_count` (always present; 0 honest).
- Deletion semantics per the ask: the reference CASCADEs with the session; the KB document **outlives** it (`file_id` FK SET NULL).
- Honest fallbacks: no target KB → one `info` finding; storage failure → `warn` finding per failed artifact, run continues.

## Migration

`0047` — `autonomous_artifacts` table + `emit_artifacts` columns. **Deploy: rebuild api + arq-worker + ingest-worker together** (stale siblings crash-loop on revision mismatch).

## Out of scope (per the ask)

PDF/DOCX rendering, artifact editing/versioning, interactive chat/playbook paths. New deferrals: DE-332 (md/txt ingest parser), DE-333 (storage-failure finding dedupe).

## Verification

Built via subagent-driven loop (fresh implementer per task + independent spec-compliance and code-quality reviews per task + final holistic review ✅ READY). Full api suite vs throwaway pgvector: **1922 passed, 1 skipped (pre-existing), 0 failed**; `ruff format` + `ruff check` + `mypy` clean; migration up/down round-trip verified. Security: artifact mime pinned server-side; `/files/{id}/content` serves `attachment` + `nosniff` (narrower than the existing upload posture); prompt-injection-persistence posture documented in `docs/autonomous-layer.md`.

Plan: `docs/superpowers/plans/2026-06-06-donna-8-autonomous-artifacts.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)