### PR TITLE
docs: coding-agent cold-start guide + CLAUDE.md build-loop refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 > **Purpose:** Ground orientation for any agentic coding assistant working on the LQ.AI codebase. Read this first; it points at the right reference for any decision and lays out the project's standards in one place.
 >
 > **Audience:** Claude Code, Cursor, Aider, or any human or agent making implementation decisions. Read in full before the first contribution; refer back as needed.
+>
+> **New here?** Start with the [cold-start guide for coding agents](docs/contribute/coding-agent-onboarding.md) — it gives you the read-order, the build loop, the dev-environment hard rules, and how to take a roadmap item to a merged PR. Then keep this file open as your decision reference.
 
 ---
 
@@ -172,6 +174,18 @@ Skills are the canonical artifact of value (per PRD §7.1). When implementing sk
 
 A few specific patterns that work well for agentic implementation on this project:
 
+### The build loop
+
+Run this for every non-trivial change — it is battle-tested across M1–M4 and the post-v0.4.0 integration run:
+
+1. **Verify the ask against the code first** — before writing anything. Most requests carry a wrong premise or a wider blast radius than reported; read the cited files and confirm the problem is real and where the asker thinks it is.
+2. **Surface the forks** — if the task hides an architectural / product / authz decision, a scope expansion, or a deferral, stop and put the options (with a recommendation) to the maintainer. Don't decide unilaterally.
+3. **Build in reviewed increments** — independent tasks, each: implement → spec-compliance review → code-quality review → fix → re-review. (The `superpowers:subagent-driven-development` skill encodes this.)
+4. **Run the gates yourself** — evidence before claims (see Testing + the collision guards below).
+5. **Ship** — `git commit -s` + the co-author trailer, push **both** remotes (`origin` + `tucuxi`, kept identical on `main`), open the PR, watch CI, merge per the gating rule, report the squash SHA.
+
+The full step-by-step, including merge-gating and dev-environment rules, is in the [cold-start guide](docs/contribute/coding-agent-onboarding.md).
+
 ### Read before writing
 
 Before implementing a task, read:
@@ -203,6 +217,22 @@ async def soft_delete_thing(...) -> Response:
 ```
 
 Both `response_class=Response` AND the explicit `return Response(...)` are required. Omitting either resurfaces the assertion.
+
+**Test-suite collision guards** — these crash the *whole* api suite at collection, not just the offending test:
+
+- A new fully-implemented route must be added to `IMPLEMENTED_ROUTES` (`api/tests/test_endpoints.py`) **and** bump the exact path count + `EXPECTED_PATHS` set in `api/tests/test_openapi.py`. The count is pinned; an off-by-one fails collection.
+- `docs/api/backend-openapi.yaml` does **not** parse with plain `yaml.safe_load` (pre-existing) — `test_openapi.py` is the authoritative conformance check; run it rather than eyeballing.
+- Decimal cost fields serialize as JSON **strings** — type them `string`, not `number`.
+
+### Dev-environment hard rules
+
+These corrupt the running dev stack or crash CI if violated:
+
+- **NEVER run host-side `alembic upgrade` against the live dev DB** (`127.0.0.1:15432/lq_ai`) — it desyncs the running stack and crash-loops the api trio. Verify migrations on a throwaway `pgvector/pgvector:pg16` container (conftest auto-migrates); apply to the dev stack by rebuilding the workers, not host alembic.
+- **When a migration lands, rebuild `api` + `arq-worker` + `ingest-worker` together** — stale siblings crash-loop on a revision mismatch.
+- **NEVER `docker compose down -v`** — it wipes volumes including expensive-to-recreate acceptance data. Rebuild a single service instead.
+- **The `web` container serves a pre-built static bundle (no HMR)** — rebuild `web` before debugging a UI change that "isn't appearing."
+- **Run BOTH `ruff format` and `ruff check`** locally — CI runs them as separate gates.
 
 ### Surface ideas as DE-XXX
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,8 @@ npm run typecheck
 
 ## What to work on
 
+> **Working with an AI coding agent (Claude Code, Cursor, …)?** Start it on the [cold-start guide for coding agents](docs/contribute/coding-agent-onboarding.md) — read-order, the build loop, dev-environment hard rules, and how to take a roadmap item to a merged PR.
+
 The project's [Deferred Enhancements list (PRD §9)](docs/PRD.md#9-deferred-enhancements-and-identified-future-work) catalogs ~50+ bounded enhancements where the architectural slot exists and the implementation is well-defined. Items tagged **P1** are particularly welcome for v1.5+. A few that are well-shaped for first-time contributors:
 
 - **DE-013 Saved Prompts Library** (S effort) — per-user saved prompts in a sidebar; CRUD plus promote-to-skill.

--- a/docs/contribute/coding-agent-onboarding.md
+++ b/docs/contribute/coding-agent-onboarding.md
@@ -1,0 +1,179 @@
+# Cold-start guide for a coding agent (Claude Code & friends)
+
+> **Purpose:** Get a fresh AI coding agent — or a new human contributor working alongside one — from zero to shipping a roadmap item correctly, the first time. This is the connective tissue between the docs that already exist; it does not duplicate them, it tells you the order to read them and the loop to run.
+>
+> **Read this once, in full, before your first contribution.** Then keep [CLAUDE.md](../../CLAUDE.md) open as your decision reference.
+
+---
+
+## 0. The 60-second orientation
+
+LQ.AI is an **open-source, self-hosted AI platform for in-house legal teams**. Three services talk over HTTP via OpenAPI contracts — no shared in-process code:
+
+- **`api/`** — FastAPI backend (sessions, chats, files, KBs, playbooks, tabular review, the autonomous layer). mypy *standard* mode.
+- **`gateway/`** — the Inference Gateway: the **security boundary**, the only component holding privileged provider API keys. mypy **`--strict`**. Changes here get security review.
+- **`web/`** — a SvelteKit fork of OpenWebUI. (Svelte only — no React in `web/`; the Word add-in is the only React surface.)
+
+The project's reason for existing is **transparency**: every artifact that shapes the user experience (especially skills) is visible, debuggable, forkable work product. That is an architectural commitment, not marketing — it shows up in how you're expected to build (honest docs, no overclaiming, explicit decisions).
+
+---
+
+## 1. Read-order for a cold start
+
+Read these in sequence before touching code. Each answers a different question:
+
+| Order | Doc | The question it answers |
+|---|---|---|
+| 1 | [CLAUDE.md](../../CLAUDE.md) | How do I make decisions here? (routing, code style, pitfalls, the build loop) |
+| 2 | [docs/HONEST-STATE.md](../HONEST-STATE.md) | What is **actually** built right now vs. planned? (the truth map — trust it over older prose) |
+| 3 | [README.md](../../README.md) | What does the product claim to do, publicly? |
+| 4 | [docs/architecture.md](../architecture.md) | How do the three services fit together? |
+| 5 | [docs/ROADMAP.md](../ROADMAP.md) + [docs/PRD.md §9](../PRD.md#9-deferred-enhancements-and-identified-future-work) | What's next, and what's deliberately deferred (the DE-XXX list)? |
+| 6 | [docs/contribute/EASIEST-CONTRIBUTIONS.md](EASIEST-CONTRIBUTIONS.md) + [mini-prds/](mini-prds/) | What's a good first item to pick up? |
+| 7 | [CONTRIBUTING.md](../../CONTRIBUTING.md) | Code style, DCO, PR mechanics. |
+
+For a specific task, then narrow: the PRD section for the capability, the OpenAPI sketch if it touches an endpoint, the DB schema if it touches a table, and **any existing code in the same area** (don't rebuild what exists). The full decision-routing priority order is in [CLAUDE.md § Decision routing](../../CLAUDE.md#decision-routing).
+
+---
+
+## 2. The build loop (the part that lived only in tribal memory)
+
+This is how work actually gets shipped here. It is battle-tested across the M1–M4 milestones and the post-v0.4.0 integration run. Run it for every non-trivial change.
+
+```
+1. VERIFY THE ASK AGAINST THE CODE — FIRST, before writing anything.
+   Nearly every incoming request has a wrong premise or a wider blast
+   radius than reported. Read the cited files. Confirm the problem is
+   real and is where the asker thinks it is. Report what you actually found.
+
+2. SURFACE THE FORKS — don't unilaterally decide.
+   If the task hides an architectural / product / authz decision, or a
+   scope expansion, or a deferral — STOP and put the options to the human
+   (a recommendation + the trade-offs). The maintainer makes those calls.
+   The cost of asking is minutes; an undocumented decision costs hours later.
+
+3. PLAN, then BUILD in reviewed increments.
+   Break the work into independent tasks. For each: implement (TDD where it
+   fits) → independent SPEC-compliance review → independent CODE-QUALITY
+   review → fix → re-review. Fresh context per task keeps reviews honest.
+   (The `superpowers:subagent-driven-development` skill encodes this; you
+   can also run it by hand.)
+
+4. RUN THE GATES YOURSELF — evidence before claims.
+   Never report "done" without the command output. See §4.
+
+5. SHIP.
+   Commit with DCO + trailer (§5) → push BOTH remotes → open PR → watch CI
+   → merge per the gating rule (§6) → report the squash SHA.
+```
+
+Two honesty rules that sit on top of the loop:
+
+- **Surface deferrals and scope expansions as choices.** Don't quietly absorb extra work or quietly drop something. Name it.
+- **Don't overclaim in code or docs.** "Handles PDF; DOCX is deferred" — not "handles all documents." If tests fail, say so with the output.
+
+---
+
+## 3. Hard rules about the dev environment (learn these before you run anything)
+
+These have each bitten this codebase. Violating them corrupts the running dev stack or crashes CI.
+
+- **NEVER run host-side `alembic upgrade` against the live dev DB** (`127.0.0.1:15432/lq_ai`). That IS the running stack's database; a host-side migration desyncs it and crash-loops the api trio. To **verify** a migration, use a throwaway container:
+  ```bash
+  docker run -d --name lqai-throwaway-pg \
+    -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=lqai_test \
+    -p 55432:5432 pgvector/pgvector:pg16
+  # then run pytest with DATABASE_URL=postgresql+asyncpg://test:test@127.0.0.1:55432/lqai_test
+  # (conftest auto-migrates to head). Remove the container when done.
+  docker rm -f lqai-throwaway-pg
+  ```
+  To **apply** a migration to the dev stack, rebuild the workers (next bullet) — don't reach for host alembic.
+- **When a migration lands, rebuild `api` + `arq-worker` + `ingest-worker` together.** Stale sibling containers crash-loop with "Can't locate revision identified by …" after a daemon bounce — they're all built from the api image and pin the revision.
+- **NEVER `docker compose down -v`.** It wipes volumes — including acceptance/review data that's expensive to recreate. Rebuild a single service (`docker compose build web && docker compose up -d web`), don't nuke volumes.
+- **The `web` container serves a pre-built static bundle (no HMR).** Source can be many commits ahead of what the browser shows. If a UI change "isn't appearing," rebuild `web` before debugging the code.
+- **Run BOTH `ruff format` and `ruff check`** locally — CI runs them as separate gates. `ruff check` passing doesn't mean `ruff format` will.
+
+---
+
+## 4. The gates (what "done" means)
+
+Before claiming a change is complete, run and read the output of:
+
+```bash
+cd api   # or gateway/
+.venv/bin/ruff format --check app tests
+.venv/bin/ruff check app tests
+.venv/bin/mypy app          # gateway is mypy --strict; api is standard
+# targeted tests for what you touched, then the relevant suites, on a throwaway DB:
+DATABASE_URL=postgresql+asyncpg://test:test@127.0.0.1:55432/lqai_test .venv/bin/pytest <paths> -q
+```
+
+CI runs three jobs: **API** (ruff + mypy + pytest — the long pole, ~11 min), **Gateway** (ruff + mypy --strict + pytest), **Web** (svelte-check + Vitest). Coverage target is 80% across `api/` and `gateway/`; CI enforces no-decrease. A new endpoint needs unit + integration + OpenAPI-conformance tests; a bug fix needs a regression test.
+
+### Test-suite collision guards (miss these and the **whole** api suite crashes at collection)
+
+These are non-obvious and have each taken down CI at least once:
+
+- **New fully-implemented route** → add it to `IMPLEMENTED_ROUTES` (`api/tests/test_endpoints.py`) **and** bump the exact path count + `EXPECTED_PATHS` set in `api/tests/test_openapi.py`. The count is pinned; an off-by-one fails collection for the entire suite.
+- **New `DELETE` endpoint returning `204`** → use the `response_class=Response` recipe (FastAPI's default `JSONResponse` asserts at import time on 204 and collapses the whole suite). The full recipe is in [CLAUDE.md § Common pitfalls](../../CLAUDE.md#common-pitfalls-catch-at-write-time-not-test-time).
+- **`docs/api/backend-openapi.yaml` does not parse with plain `yaml.safe_load`** (pre-existing). `api/tests/test_openapi.py` is the authoritative conformance check — run it; don't trust a hand-eyeball.
+- **Decimal cost fields serialize as JSON strings** — schemas type them as `string`, not `number`.
+
+---
+
+## 5. Commit & PR mechanics
+
+- **DCO sign-off on every commit:** `git commit -s`. Imperative mood ("Add X", not "Added X"). Reference issues in the body (`Closes #123`, `Refs DE-103`).
+- **Stage files explicitly** — never `git add -A`. There are intentionally-untracked files in the tree (e.g. `docs/lq-ai-skill-inputs-corpus.md`); a blanket add sweeps them in.
+- **Push BOTH remotes** after a merge: `origin` (LegalQuants/lq-ai) and `tucuxi` (Tucuxi-Inc mirror) are kept byte-identical on `main`.
+- **Branch preservation:** merged feature branches are kept on the remotes as a historical record for future contributors — don't delete them.
+- **Co-author trailer:** the project tags AI-assisted commits with a `Co-Authored-By:` trailer. Match the convention already in `git log` rather than inventing one.
+
+---
+
+## 6. Merge gating (who merges what)
+
+| Change touches… | Who merges |
+|---|---|
+| `gateway/**`, or **authentication / authorization / audit / crypto** | Maintainer reviews **and** merges (security boundary — see [.github/CODEOWNERS](../../.github/CODEOWNERS)). Offer review-vs-self-merge. |
+| `api/` (non-authz) or docs | Self-merge after CI is green. |
+| **External / community PR** (unknown contributor or fork) | **NEVER** auto- or self-merge. CI green ≠ vetted. Vet adversarially per [docs/security/external-contribution-vetting.md](../security/external-contribution-vetting.md), report, leave the merge to a maintainer. |
+
+When in doubt, treat it as the stricter row and ask.
+
+---
+
+## 7. Picking up a roadmap item, end to end
+
+A worked shape for taking an item from [ROADMAP.md](../ROADMAP.md) / a [mini-PRD](mini-prds/) to a merged PR:
+
+1. **Confirm it's still open and still shaped as described** — read HONEST-STATE and the relevant code; roadmap text can lag reality. If it's already partly built, scope to the gap.
+2. **Read the anchors** — PRD section, OpenAPI sketch, DB schema, neighbouring code.
+3. **Surface any fork** (§2 step 2) before building.
+4. **Branch** off `main` (`feat/...` or `fix/...`).
+5. **Build in reviewed increments** (§2 step 3).
+6. **Gates** (§4), including the collision guards and a throwaway-DB migration check if you added one.
+7. **Docs are part of the change** — update the PRD section, OpenAPI yaml, and DB schema doc that your change touches, in the same PR. Reconcile the narrative docs (README, HONEST-STATE, the feature guide) if behavior changed. File new deferrals as **DE-XXX in PRD §9** rather than expanding scope.
+8. **Ship** (§5–§6) and report the squash SHA.
+
+### Special case: skills with legal substance
+
+Skills that contain legal work product (playbook positions, drafting guidance) go through a claim → draft → **attorney attestation** → review → merge path ([skills/CONTRIBUTING.md](../../skills/CONTRIBUTING.md)). **Agents do not attest** — the human contributor is the attesting party, and the maintainer team does **not** review legal substance (the in-house attorney is the validator). Synthetic test fixtures are functional QA the maintainer team *does* own.
+
+---
+
+## 8. When to stop and ask (non-negotiable)
+
+Stop and put the decision to the human when:
+
+- The task surfaces an **architectural choice** that wasn't anticipated. (Don't decide unilaterally and continue.)
+- A decision isn't anchored in any decision-routing doc.
+- You'd be **expanding scope** to fold in a good idea (file it DE-XXX instead).
+- You'd be **adding a dependency** (it's part of the SBOM / supply-chain surface — needs justification).
+- A change touches the **gateway or an authz path** and you're unsure of the security implication.
+
+The friction is the point. An undocumented decision compounds across every task that follows it.
+
+---
+
+*Next stop: [CLAUDE.md](../../CLAUDE.md). Keep it open while you work.*


### PR DESCRIPTION
## Summary

A parting onboarding artifact for the team: gets a fresh AI coding agent (or a contributor working with one) from zero to shipping a roadmap item correctly, first time. Connective tissue over the docs that already exist — points rather than duplicates.

**New: `docs/contribute/coding-agent-onboarding.md`**
- 60-second orientation + the read-order (CLAUDE.md → HONEST-STATE → README → architecture → ROADMAP/PRD §9 → mini-PRDs → CONTRIBUTING)
- **The build loop** that previously lived only in tribal/session memory: verify-the-ask-against-code-first → surface-the-forks → build-in-reviewed-increments → run-the-gates → ship
- **Dev-environment hard rules**: never host-side alembic on the live DB (`127.0.0.1:15432`), throwaway-pgvector migration checks, rebuild api+arq-worker+ingest-worker together, never `down -v`, web bundle has no HMR, run both ruff gates
- **Test-suite collision guards**: `IMPLEMENTED_ROUTES` + `test_openapi` path-count pin, DELETE-204 recipe, yaml-doesn't-safe_load, Decimal=string
- Commit/PR mechanics, **merge gating** (gateway/authz → maintainer; api/docs → self; external → never auto-merge), and a worked roadmap-item-to-PR walkthrough incl. the skills-attestation special case

**CLAUDE.md** gains a "build loop" section + dev-environment rules + collision guards (previously only the DELETE-204 trap was written down), and links the cold-start guide from the top.

**CONTRIBUTING.md** points AI-agent users at the guide from "What to work on".

## Verification

Docs only. Every relative link verified to resolve; every factual claim drawn from this session's verified work (the post-v0.4.0 integration run) and consistent with the just-reconciled HONEST-STATE. Conservative voice throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)