### PR TITLE
chore(release): bump __version__ 0.4.0 → 0.4.1 (launcher-ready images)

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI backend API service."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/gateway/app/__init__.py
+++ b/gateway/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI Inference Gateway."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
## Summary

Patch bump to enable a **fresh image release** that publishes launcher-ready container images.

The only `ghcr.io/legalquants/lq-ai-*` images currently published are from the **v0.4.0 tag (2026-06-01)** — built *before* the macOS launcher work, so they are:
- **single-arch (amd64 only)** — won't run on Apple Silicon, and
- **built from subdir contexts** — neither the **skills corpus** nor the **gateway config** is baked in.

Today's `release.yml` upgrade (multi-arch `linux/amd64,linux/arm64` + `api/Dockerfile.release`/`gateway/Dockerfile.release` baking, merged in #143) is on `main` but only runs on a new `v*` tag. This bump lets you cut **`v0.4.1`** to publish images the launcher can actually pull and boot.

No API or gateway behavior change — only `__version__` in `api/app/__init__.py` + `gateway/app/__init__.py` (the established release-bump pattern; pyproject versions are unmanaged at 0.1.0 as before).

## After merge (yours — outward-facing)

1. **Tag `v0.4.1` from `main`** → `release.yml` publishes multi-arch, skills-baked `lq-ai-{api,gateway,web}:v0.4.1` + `:latest`.
2. **Flip the 3 packages to Public** (org UI — `docs/BUILD-AND-RELEASE.md`).

Then the signed `.dmg` (from the in-flight desktop-release run) boots end-to-end for a recipient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)