### PR TITLE
fix(launcher): reverse proxy with /lq prefix so the web shell reaches the api

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,20 @@ jobs:
           - service: gateway
             context: .
             file: gateway/Dockerfile.release
+          # web bakes PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1 so the LQ.AI client
+          # addresses its own /lq-prefixed origin behind the proxy (never
+          # colliding with OpenWebUI's same-origin /api). Other services pass no
+          # build-arg (build_args defaults empty below).
           - service: web
             context: ./web
             file: web/Dockerfile
+            build_args: |
+              PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1
+          # proxy bakes the Caddyfile (no repo on the user's Mac) → own subdir
+          # context + default Dockerfile. caddy:2-alpine is multi-arch upstream.
+          - service: proxy
+            context: ./proxy
+            file: proxy/Dockerfile
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,6 +87,10 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
+          # Only the web matrix entry sets build_args; for api/gateway/proxy this
+          # resolves to empty (no stray build-arg). docker/build-push-action
+          # accepts a multi-line build-args input (KEY=VALUE per line).
+          build-args: ${{ matrix.build_args }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' || !inputs.dry_run }}
           tags: |
@@ -100,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: [api, gateway, web]
+        service: [api, gateway, web, proxy]
     permissions:
       contents: read
       packages: read
@@ -159,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: [api, gateway, web]
+        service: [api, gateway, web, proxy]
     permissions:
       contents: read
       packages: write

--- a/desktop/VERIFICATION.md
+++ b/desktop/VERIFICATION.md
@@ -1,18 +1,29 @@
 # LQ.AI for Mac — release verification protocol
 
-> **STATUS: PARTIALLY EXECUTED (2026-06-14).** **Protocol 1 (isolated boot of the published images) —
-> PASSED** against the public `v0.4.1` images (results below). **Protocol 2 → "Verify the downloaded
-> dmg" (signing/notarization) — PASSED** against the published `desktop-v0.4.0` release (results below).
-> The only remaining piece is the **Protocol 2 launcher-lifecycle** (real Finder double-click → wizard
-> → BYOK → chat), which needs a human clean-Mac run. Unchecked boxes there are genuinely not-yet-run —
-> **do not pre-fill them.**
+> **STATUS: PARTIALLY EXECUTED (2026-06-14).** The signed-`.dmg` Gatekeeper/notarization checks in
+> **Protocol 2 → "Verify the downloaded dmg"** have been run against the real published
+> `desktop-v0.4.0` release and passed (results filled in below). **Protocol 1** has now been run on
+> `fix/launcher-reverse-proxy` as a full 9-service boot with the **/lq prefix** routing (locally-built
+> `web` baked with `PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1` + locally-built `lq-ai-proxy`, on top of the
+> published `v0.4.1` api/gateway). It was verified **in a real headless browser (Cypress)**: the web
+> shell loads at `/` WITHOUT redirecting to `/error`, the LQ.AI login form renders, and login through
+> the proxy reaches the authed app (results + screenshot finding below). This supersedes both the
+> earlier api-direct Protocol 1 record (#146) AND the first attempt at this fix (commit `7841121`),
+> which used a blanket `/api/*` proxy that stole OpenWebUI's `/api/config` and broke first paint.
+> Still pending: re-running Protocol 1 against the *published* proxy image + the `/lq`-baked web image
+> once they ship to GHCR, and the **Protocol 2 launcher-lifecycle** boxes (needs a clean Mac).
+> Unchecked boxes are genuinely not-yet-run — **do not pre-fill them.**
 
 **What this proves:** the **published images** stand up to a real login for a stranger, and the
 **signed/notarized `.dmg`** installs and runs on a Mac with Docker but **no LQ.AI repo cloned**.
 
 **Artifacts under test (fill in at release time):**
 
-- Images: `ghcr.io/legalquants/lq-ai-{api,gateway,web}:vX.Y.Z` (public).
+- Images: `ghcr.io/legalquants/lq-ai-{api,gateway,web,proxy}:vX.Y.Z` (public). The `proxy` image
+  (reverse proxy, fix/launcher-reverse-proxy) is the 4th release image and the 9th stack service. The
+  `web` image is built with `--build-arg PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1` (release.yml passes this
+  build-arg for the `web` matrix entry only), so the LQ.AI client addresses its own `/lq`-prefixed
+  origin and never collides with OpenWebUI's same-origin `/api`.
 - App: `LQ.AI-<version>-arm64.dmg` from the `desktop-vX.Y.Z` GitHub Release (Developer ID:
   Tucuxi, Inc., team `MC8BT9Z8GD` — signed, notarized, stapled).
 
@@ -20,13 +31,35 @@
 
 ## Protocol 1 — Automated isolated boot of the published images (no GUI)
 
+> **Why this protocol changed (fix/launcher-reverse-proxy).** The earlier Protocol 1 (and PR #146)
+> recorded a login PASS, but that test authenticated against the **api port directly** — NOT the
+> browser's web→api path. It therefore never exercised the same-origin call the web shell actually
+> makes, and so missed a whole class of bug: the published web image bakes a relative, same-origin
+> `PUBLIC_LQ_AI_API_BASE_URL`, which by design needs a reverse proxy fronting web + api on ONE origin.
+> The core-8 stack had none, so the real browser login failed with "Failed to fetch" even though the
+> api-direct test was green.
+>
+> A first fix (commit `7841121`) added a proxy with a **blanket `/api/*` → api** route. That was wrong:
+> the web image runs the OpenWebUI Python backend, which serves `/api/config` (the SPA fetches it at
+> first paint via `getBackendConfig()`) AND its own `/api/v1/*` groups — so the blanket rule stole
+> `/api/config` (404 on our api) and the shell redirected to `/error` before it could render.
+>
+> The resolution gives the LQ.AI client its OWN path prefix: the `web` image is built with
+> `PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1`, so its calls are `/lq/api/v1/*`. The proxy
+> (`lq-ai-proxy` image) `handle_path /lq/*` STRIPS the `/lq` prefix and forwards to `api:8000` (which
+> mounts `/api/v1`), and routes EVERYTHING else — `/api/config`, OpenWebUI's own `/api/v1/*`,
+> websockets, static — to `web:8080`. The proxy owns the user-facing `WEB_HOST_PORT`; web is internal.
+> **Protocol 1 below now verifies the actual browser path IN A REAL HEADLESS BROWSER (Cypress) — the
+> shell loads without `/error` and login through the proxy reaches the authed app — and the stack is 9
+> services, not 8.**
+
 Proves the published images work for a fresh install, independent of the launcher chrome. Run under a
 **distinct compose project + the shifted ports** so it cannot touch the dev stack or a launcher stack.
 Tear down with `down -v` (the throwaway project only — never the dev stack).
 
 ```bash
-# 1. Confirm the images are anonymously pullable (200 = public):
-for img in lq-ai-api lq-ai-gateway lq-ai-web; do
+# 1. Confirm the images are anonymously pullable (200 = public). NOTE the proxy image:
+for img in lq-ai-api lq-ai-gateway lq-ai-web lq-ai-proxy; do
   TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:legalquants/$img:pull" \
     | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
   curl -s -o /dev/null -w "$img -> %{http_code}\n" -H "Authorization: Bearer $TOKEN" \
@@ -38,7 +71,7 @@ done
 LQ_AI_IMAGE_TAG=vX.Y.Z docker compose -f docker-compose.release.yml -p lq-ai-reltest \
   --env-file /tmp/reltest.env up -d
 
-# 3. Wait for all 8 services healthy:
+# 3. Wait for all 9 services healthy (the 9th is the reverse proxy):
 docker compose -f docker-compose.release.yml -p lq-ai-reltest --env-file /tmp/reltest.env ps
 
 # 4. Create the admin login fixture:
@@ -46,26 +79,73 @@ docker compose -f docker-compose.release.yml -p lq-ai-reltest --env-file /tmp/re
   exec -T api python -m app.cli reset-admin-password \
   --email admin@lq.ai --password 'Reltest123456!' --no-force-change
 
-# 5. Authenticate end-to-end through the web BFF (Origin header required) and confirm session cookies:
-#    expect HTTP 200 + Set-Cookie session tokens.
-#    (web is published on the shifted WEB_HOST_PORT — default 13012 for the hand-run defaults.)
+# 5. curl PRE-CHECKS through the proxy origin (necessary, NOT sufficient — see step 6).
+#    (a) /api/config must reach WEB (proves the blanket-/api regression is gone): expect 200.
+curl -sS -o /dev/null -w "/api/config -> %{http_code}\n" http://127.0.0.1:${WEB_HOST_PORT}/api/config
+#    (b) /lq/api/v1/auth/login must STRIP /lq and reach the api: expect 200 + access_token.
+curl -sS -X POST http://127.0.0.1:${WEB_HOST_PORT}/lq/api/v1/auth/login \
+  -H "Origin: http://localhost:${WEB_HOST_PORT}" -H 'Content-Type: application/json' \
+  -d '{"email":"admin@lq.ai","password":"Reltest123456!"}'
+#    (c) /api/v1/auth/login is OpenWebUI's namespace now (must NOT reach our api): expect 404/405 from web.
+curl -sS -o /dev/null -w "/api/v1/auth/login -> %{http_code}\n" -X POST \
+  http://127.0.0.1:${WEB_HOST_PORT}/api/v1/auth/login -H 'Content-Type: application/json' -d '{}'
 
-# 6. Tear down the throwaway project (NEVER -v the dev stack):
+# 6. REQUIRED real-browser check (curl alone has missed JS-bootstrap bugs three times). Drive a
+#    headless browser to load http://127.0.0.1:${WEB_HOST_PORT}/ and assert it does NOT redirect to
+#    /error and the LQ.AI login form renders, then log in and assert the authed app appears. Cypress
+#    ships in web/ — write a one-off spec asserting (i) location does not include /error, (ii) the
+#    [data-testid="lq-ai-login-*"] form renders, (iii) after submit, localStorage 'lq_ai_auth' holds an
+#    access_token and the URL leaves /login — then:
+#      cd web && npx cypress run --spec '<spec>' --config baseUrl=http://127.0.0.1:${WEB_HOST_PORT}
+#    NOTE: OpenWebUI keeps its OWN sqlite (web container /app/backend/data/webui.db) and honors
+#    WEBUI_AUTH=false only on a FRESH OpenWebUI install. If a prior browser run already created a
+#    non-default OpenWebUI user, auto-signin 400s and the root guard parks the SPA at /auth. On a fresh
+#    boot this is clean; if it happens, rm the web container's webui.db + restart web to re-bootstrap.
+
+# 7. Tear down the throwaway project (NEVER -v the dev stack):
 docker compose -f docker-compose.release.yml -p lq-ai-reltest --env-file /tmp/reltest.env down -v
 ```
 
-Results — **EXECUTED 2026-06-14, PASSED** against the public `v0.4.1` images
-(`ghcr.io/legalquants/lq-ai-{api,gateway,web}:v0.4.1`, published by [release run
-27512135750](https://github.com/LegalQuants/lq-ai/actions/runs/27512135750); booted under throwaway
-project `lq-ai-fulltest` + shifted ports, **no provider keys set** to prove the BYOK boot):
+Results — **EXECUTED 2026-06-14** on `fix/launcher-reverse-proxy`, against the published `api` +
+`gateway` images at **`v0.4.1`** + a **locally-built `web`** (built with
+`--build-arg PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1`, simulating the release build) + a **locally-built
+`lq-ai-proxy`** (proxy + /lq-baked web are not published yet — built from this branch). All four ran
+under a dedicated `:lqtest` tag so the live `:latest` the `lq-ai-desktop` launcher uses was untouched.
+Throwaway project `lqai-lqtest`, shifted ports (WEB 13700 / API 18700 / GATEWAY 18701 / PG 25700 /
+REDIS 26700 / MINIO 29700-29701). The dev stack + the live `lq-ai-desktop` launcher were untouched.
 
-- [x] All 3 `ghcr.io/legalquants/lq-ai-*:v0.4.1` images anonymously pullable (HTTP 200) — ✅ also `:latest`; both `linux/amd64` + `linux/arm64` (native on Apple Silicon)
-- [x] All 8 services reach **Healthy** — ✅ 8/8 (postgres, redis, minio, gateway, api, ingest-worker, arq-worker, web); api migrated the fresh DB from the published image
-- [x] Admin fixture created the login (exit 0) — ✅ `reset-admin-password --email admin@lq.ai … --no-force-change`
-- [x] `POST /api/v1/auth/login` (with `Origin` header) returns a session — ✅ HTTP 200, `Bearer` `access_token` + `refresh_token`, `user.email=admin@lq.ai`
-- [x] `down -v` on the throwaway project only; dev stack untouched — ✅
-- [x] **Baked assets present in the published images** (the no-bind-mount crux) — ✅ api `/skills` = 17 skills (`nda-review/SKILL.md` present, `LQ_AI_SKILLS_DIR=/skills`); gateway seeded `/etc/lq-ai/gateway.yaml` from the baked `/usr/share/lq-ai/gateway.yaml.example`
-- [x] Web reachable on the host port — ✅ `http://127.0.0.1:13099` → HTTP 200
+- [x] Images anonymously pullable (HTTP 200) — **N/A for this run** (proxy + /lq-web unpublished; tested
+      with locally-built proxy + /lq-baked web + the published `v0.4.1` api/gateway). The 4-image
+      public-pull check above reruns at the real release once these ship to GHCR. Confirmed the web bundle
+      baked the right value: `/app/build/_app/env.js` → `{"PUBLIC_LQ_AI_API_BASE_URL":"/lq/api/v1"}`.
+- [x] All **9** services reach **Healthy** — ✅ `9/9 healthy`: api, arq-worker, gateway, ingest-worker,
+      minio, postgres, **proxy**, redis, web (all `running`/`healthy`).
+- [x] Admin fixture created the login (exit 0) — ✅ `RESET_EXIT=0` ("Reset password for admin@lq.ai…").
+- [x] **curl (a)** `GET /api/config` (→ web) — ✅ **HTTP 200** (JSON name/features). The blanket-`/api`
+      regression that broke first paint is gone.
+- [x] **curl (b)** `POST /lq/api/v1/auth/login` (Origin `http://localhost:13700`) — ✅ **HTTP 200 +
+      access_token** (259 chars). The `/lq` prefix is stripped and reaches the api.
+- [x] **curl (c)** `POST /api/v1/auth/login` (OpenWebUI's namespace) — ✅ **HTTP 405** from web (does
+      NOT reach our api), confirming the same-origin separation.
+- [x] **REAL BROWSER (Cypress 13.17.0, Electron headless)** — ✅ **2/2 passing.** (i) `GET /` does NOT
+      redirect to `/error` and the shell renders; (ii) the LQ.AI login form (`lq-ai-login-*` testids)
+      renders at `/lq-ai/login`; (iii) after submit, `localStorage['lq_ai_auth']` holds an `access_token`
+      (>20 chars) and the URL leaves `/login`. Authed-app screenshot showed the "You're now logged in."
+      toast + "Welcome back, LQ.AI Administrator" home with the full LQ.AI nav. **Finding:** the first
+      browser attempt parked at `/auth` — OpenWebUI keeps its OWN sqlite (`webui.db`) and refuses
+      `WEBUI_AUTH=false` once a non-default OpenWebUI user exists (a prior Cypress run had created one).
+      Removing `webui.db` + restarting web re-bootstrapped the clean default user (matching the live dev
+      launcher, whose OpenWebUI user is `admin@localhost`), after which the browser flow passed. This is
+      an OpenWebUI bootstrap-state artifact, NOT a proxy defect — the live dev launcher reaches
+      `/lq-ai/login` with the form rendered, confirmed by the same Cypress harness against `:13012`.
+- [x] `down -v` on the throwaway project only; dev stack untouched — ✅ `lqai-lqtest` removed (volumes +
+      network), `lq-ai-desktop` stack still running, temp env removed.
+
+Also confirmed (still true of the published images): the `ghcr.io/legalquants/lq-ai-{api,gateway}:v0.4.1`
+images are **multi-arch** (`linux/amd64` + `linux/arm64`, native on Apple Silicon); the **baked assets**
+are present (api `/skills` corpus, `LQ_AI_SKILLS_DIR=/skills`; gateway seeds `/etc/lq-ai/gateway.yaml`
+from the baked `/usr/share/lq-ai/gateway.yaml.example`); the stack boots fully healthy with **no
+provider keys** (BYOK).
 
 ---
 
@@ -99,7 +179,7 @@ first attempt):
 - [ ] **Install** — `.dmg` opens, `LQ.AI.app` → Applications, launches with **no Gatekeeper warning** — _____
 - [ ] **Wizard** — sets a password (login shown as `admin@lq.ai`), **Start LQ.AI** — no terminal, no hand-edited `.env` — _____
 - [ ] **No provider key asked for** in the wizard (BYOK is in-app) — _____
-- [ ] **Live progress** — shows live "N/8 services ready" (honest state, not a fake "ready") — _____
+- [ ] **Live progress** — shows live "N/9 services ready" (honest state, not a fake "ready") — _____
 - [ ] **Healthy** — reaches **Running**; **Open LQ.AI** enabled — _____
 - [ ] **Open LQ.AI** — window loads the web login page (`http://localhost:13012`) — _____
 - [ ] **Login** — `admin@lq.ai` + the wizard password → reaches the authed app — _____

--- a/desktop/src/core/state.test.ts
+++ b/desktop/src/core/state.test.ts
@@ -22,8 +22,14 @@ describe('deriveLauncherState', () => {
 		expect(deriveLauncherState(present, [])).toBe('STOPPED')
 	})
 
-	it('HEALTHY only when all 8 services are healthy', () => {
+	it('HEALTHY only when all 9 services are healthy', () => {
 		expect(deriveLauncherState(present, allHealthy())).toBe('HEALTHY')
+	})
+
+	it('STACK_STARTING when the proxy is still coming up (others healthy)', () => {
+		const services = allHealthy()
+		services[8] = { name: 'proxy', state: 'running', health: 'starting' }
+		expect(deriveLauncherState(present, services)).toBe('STACK_STARTING')
 	})
 
 	it('STACK_STARTING when some services are present but not all healthy', () => {
@@ -32,7 +38,7 @@ describe('deriveLauncherState', () => {
 		expect(deriveLauncherState(present, services)).toBe('STACK_STARTING')
 	})
 
-	it('STACK_STARTING when only some of the 8 services have come up yet', () => {
+	it('STACK_STARTING when only some of the 9 services have come up yet', () => {
 		const partial = allHealthy().slice(0, 3)
 		expect(deriveLauncherState(present, partial)).toBe('STACK_STARTING')
 	})

--- a/desktop/src/core/state.ts
+++ b/desktop/src/core/state.ts
@@ -7,7 +7,7 @@ import type { EngineProbe, LauncherState, ServiceStatus } from './types'
  *   1. engine not usable        -> NO_ENGINE
  *   2. any service failed       -> FAILED   (exited / unhealthy)
  *   3. no services at all       -> STOPPED
- *   4. all 8 services healthy   -> HEALTHY
+ *   4. all 9 services healthy   -> HEALTHY
  *   5. otherwise (coming up)    -> STACK_STARTING
  * The "pulling images" and "models downloading" windows are surfaced separately by the
  * orchestrator from command/log signals; they are not decidable from `ps` alone.

--- a/desktop/src/core/types.test.ts
+++ b/desktop/src/core/types.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { EXPECTED_SERVICES, DEFAULT_PORTS } from './types'
 
 describe('core constants', () => {
-	it('lists all 8 release-stack services (frontend service is "web")', () => {
+	it('lists all 9 release-stack services (web is internal; "proxy" owns the web port)', () => {
 		expect(EXPECTED_SERVICES).toEqual([
 			'postgres',
 			'redis',
@@ -11,7 +11,8 @@ describe('core constants', () => {
 			'api',
 			'ingest-worker',
 			'arq-worker',
-			'web'
+			'web',
+			'proxy'
 		])
 	})
 

--- a/desktop/src/core/types.ts
+++ b/desktop/src/core/types.ts
@@ -7,7 +7,13 @@ export const EXPECTED_SERVICES = [
 	'api',
 	'ingest-worker',
 	'arq-worker',
-	'web'
+	'web',
+	// The reverse proxy owns the user-facing WEB_HOST_PORT and unifies the
+	// origin: it strips /lq and forwards the lq-ai client's /lq/api/v1/* calls
+	// to the api, while everything else (the OpenWebUI shell, /api/config, its
+	// own /api/v1/*, websockets, static) stays on web. Last in the dependency
+	// order: it depends on both api + web being healthy.
+	'proxy'
 ] as const
 
 export type ServiceName = (typeof EXPECTED_SERVICES)[number]

--- a/desktop/src/main/orchestrator.test.ts
+++ b/desktop/src/main/orchestrator.test.ts
@@ -20,14 +20,15 @@ describe('snapshot', () => {
 			'{"Service":"api","State":"running","Health":"healthy"}\n' +
 			'{"Service":"ingest-worker","State":"running","Health":"healthy"}\n' +
 			'{"Service":"arq-worker","State":"running","Health":"healthy"}\n' +
-			'{"Service":"web","State":"running","Health":"healthy"}'
+			'{"Service":"web","State":"running","Health":"healthy"}\n' +
+				'{"Service":"proxy","State":"running","Health":"healthy"}'
 		const runner = fakeRunner({
 			info: { code: 0, stdout: 'Server Version: 27.0.3', stderr: '' },
 			ps: { code: 0, stdout: ps, stderr: '' }
 		})
 		const snap = await snapshot(['compose', '-f', 'x', '-p', 'lq-ai-desktop'], runner)
 		expect(snap.state).toBe('HEALTHY')
-		expect(snap.services).toHaveLength(8)
+		expect(snap.services).toHaveLength(9)
 	})
 
 	it('reports NO_ENGINE when docker info fails', async () => {

--- a/desktop/src/renderer/panel.ts
+++ b/desktop/src/renderer/panel.ts
@@ -42,7 +42,7 @@ export function renderPanel(root: HTMLElement): void {
 		let label = LABELS[snap.state] ?? snap.state
 		if (snap.state === 'STACK_STARTING') {
 			const healthy = (snap.services ?? []).filter((s) => s.health === 'healthy').length
-			label = `Starting… ${healthy}/8 services ready`
+			label = `Starting… ${healthy}/9 services ready`
 		}
 		stateEl.textContent = label
 		open.disabled = snap.state !== 'HEALTHY'

--- a/desktop/src/renderer/wizard.ts
+++ b/desktop/src/renderer/wizard.ts
@@ -48,7 +48,7 @@ export function renderWizard(root: HTMLElement, onDone: () => void): void {
 		if (s.state === 'STACK_STARTING') {
 			const healthy = (s.services ?? []).filter((x) => x.health === 'healthy').length
 			status.style.color = '#555'
-			status.textContent = `Starting LQ.AI… ${healthy}/8 services ready (first run pulls images + document-processing models; this can take a few minutes).`
+			status.textContent = `Starting LQ.AI… ${healthy}/9 services ready (first run pulls images + document-processing models; this can take a few minutes).`
 		} else if (s.state === 'NO_ENGINE') {
 			status.style.color = '#c00'
 			status.textContent = "Docker isn't running — start Docker Desktop and try again."

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -25,10 +25,20 @@
 # every command AND shift the host ports in .env (see .env.release.example) so the
 # two stacks coexist without project-name or port collisions.
 #
-# Core 8 only: postgres, redis, minio, gateway, api, ingest-worker,
-# arq-worker, web. No ollama, no slack/teams bridges (launcher decision L-2;
-# bridges need OAuth and defeat zero-config). The image namespace is
-# overridable via LQ_AI_IMAGE_NAMESPACE so forks/mirrors are portable.
+# Core services: postgres, redis, minio, gateway, api, ingest-worker,
+# arq-worker, web, plus a reverse proxy. No ollama, no slack/teams bridges
+# (launcher decision L-2; bridges need OAuth and defeat zero-config). The
+# image namespace is overridable via LQ_AI_IMAGE_NAMESPACE so forks/mirrors
+# are portable.
+#
+# Reverse proxy: the user-facing WEB_HOST_PORT is served by the `proxy`
+# service (not `web` directly). The web image is built with
+# PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1, so the LQ.AI client calls /lq/api/v1/*;
+# the proxy STRIPS the /lq prefix and forwards to api:8000, and routes
+# everything else (the OpenWebUI shell, /api/config, its own /api/v1/*,
+# websockets, static) to web:8080 — putting the web shell and the api on ONE
+# origin without colliding on /api. Browse to http://127.0.0.1:${WEB_HOST_PORT}
+# as before.
 
 name: lq-ai
 
@@ -262,9 +272,10 @@ services:
   web:
     # OpenWebUI fork (ADR 0001). The release image bakes the static build;
     # PUBLIC_LQ_AI_API_BASE_URL is a BUILD-time arg baked at image-build time
-    # (defaults to the relative /api/v1, which works behind the same-origin
-    # launcher), so it is NOT settable here at runtime. The container serves
-    # on 8080 (PORT=8080) and ships its own /health healthcheck.
+    # (the release web image is built with /lq/api/v1 so the LQ.AI client uses
+    # its own /lq-prefixed origin behind the proxy, never colliding with
+    # OpenWebUI's same-origin /api), so it is NOT settable here at runtime. The
+    # container serves on 8080 (PORT=8080) and ships its own /health healthcheck.
     image: ghcr.io/${LQ_AI_IMAGE_NAMESPACE:-legalquants}/lq-ai-web:${LQ_AI_IMAGE_TAG:-latest}
     restart: unless-stopped
     depends_on:
@@ -275,10 +286,38 @@ services:
       WEBUI_AUTH: ${WEBUI_AUTH:-false}
       WEBUI_NAME: ${WEBUI_NAME:-LQ.AI}
       WEBUI_URL: ${WEBUI_URL:-http://localhost:3000}
+    # No host ports: web is INTERNAL-ONLY now. The proxy below owns the
+    # user-facing WEB_HOST_PORT and routes everything-but-/lq to web:8080 on
+    # the compose network (including /api/config and OpenWebUI's own /api/v1/*).
+    # The LQ.AI client's /lq/api/v1/* calls are stripped to /api/v1/* and sent
+    # to the api — that is the proxy's whole job (fix/launcher-reverse-proxy).
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  proxy:
+    # Reverse proxy (lq-ai-proxy image) that puts the web shell and the api on
+    # ONE origin. The web image bakes PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1, so
+    # the LQ.AI client calls /lq/api/v1/*; this proxy STRIPS /lq and forwards to
+    # api:8000, and routes everything else (the OpenWebUI shell, /api/config,
+    # its own /api/v1/*, ws, static) to web:8080. A blanket /api proxy would
+    # have stolen OpenWebUI's /api/config (first-paint getBackendConfig ->
+    # /error); the /lq prefix avoids that collision. The proxy OWNS the
+    # user-facing WEB_HOST_PORT (the launcher window loads this origin).
+    image: ghcr.io/${LQ_AI_IMAGE_NAMESPACE:-legalquants}/lq-ai-proxy:${LQ_AI_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+      web:
+        condition: service_healthy
     ports:
       - "${WEB_BIND_ADDR:-127.0.0.1}:${WEB_HOST_PORT:-3000}:8080"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/ >/dev/null 2>&1 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/proxy/Caddyfile
+++ b/proxy/Caddyfile
@@ -1,0 +1,33 @@
+# LQ.AI release-stack reverse proxy.
+#
+# The published web image runs the OpenWebUI Python backend AND serves the
+# LQ.AI SPA. BOTH our api and the OpenWebUI backend mount /api/v1/* (with
+# overlapping group names — users, chats, models), and the OpenWebUI backend
+# also serves /api/config, which the SPA root layout fetches at first paint
+# via getBackendConfig() (web/src/routes/+layout.svelte). A blanket /api proxy
+# to our api therefore steals /api/config (404 on our api) → the shell
+# redirects to /error before it can render.
+#
+# Resolution: give the LQ.AI client its OWN path prefix. The web image is
+# built with PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1
+# (web/src/lib/lq-ai/api/client.ts), so every LQ.AI client call is /lq/api/v1/*
+# and never collides with OpenWebUI's same-origin /api.
+#
+#   /lq/*  -> api:8000   (LQ.AI client; the /lq prefix is STRIPPED before
+#                         forwarding, so the api — which mounts /api/v1 — sees
+#                         /api/v1/*)
+#   *      -> web:8080   (OpenWebUI shell, /api/config, its own /api/v1/*,
+#                         websockets, static bundle)
+:8080 {
+	# lq-ai backend: the web image bakes PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1,
+	# so the lq-ai client calls /lq/api/v1/*. handle_path strips the /lq prefix
+	# before proxying, so the api (which mounts /api/v1) sees /api/v1/*.
+	handle_path /lq/* {
+		reverse_proxy api:8000
+	}
+	# Everything else — the OpenWebUI shell, /api/config, its own /api/v1/*,
+	# websockets, static assets — stays on the web container.
+	handle {
+		reverse_proxy web:8080
+	}
+}

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,14 @@
+# LQ.AI release-stack reverse proxy (lq-ai-proxy image).
+#
+# Bakes the proven Caddyfile into the published image so the macOS launcher —
+# which has no repo on the user's Mac — gets the proxy config without a bind
+# mount (mirrors how the api/gateway images bake the skills corpus +
+# gateway.yaml.example). caddy:2-alpine is multi-arch upstream, so the
+# release workflow builds linux/amd64 + linux/arm64 without trouble.
+FROM caddy:2-alpine
+
+COPY Caddyfile /etc/caddy/Caddyfile
+
+# Caddy serves the unified origin on :8080. wget ships in the BusyBox base.
+HEALTHCHECK --interval=10s --timeout=5s --retries=10 --start-period=10s \
+  CMD wget -qO- http://localhost:8080/ >/dev/null 2>&1 || exit 1


### PR DESCRIPTION
## Summary

Fixes the launcher's **"Failed to fetch"** login. Root cause was a web→api topology gap, not the password.

**The chain of findings:**
1. The launcher was running a **stale dev-built web image** (baked the absolute dev URL `localhost:8000`) → browser called a port nothing listens on.
2. Even the correctly-published `v0.4.1` web bakes same-origin `/api/v1` — which by design needs a **reverse proxy** fronting web + api on one origin. The core-8 stack had none.
3. A first attempt (blanket `/api/* → api`) was wrong: the web shell's OpenWebUI backend serves `/api/config` (the SPA fetches it at first paint), so the blanket rule stole it → `/error` redirect.
4. **Both** our api and the OpenWebUI shell mount `/api/v1/*` (overlapping names) — in dev they're separated by origin; on one proxied origin they collide.

**The fix (Kevin's call — `/lq` prefix):** give the lq-ai client its own path prefix. The web image is built with `PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1`; a baked **Caddy proxy** (`lq-ai-proxy`, the 4th release image / 9th service) does `handle_path /lq/*` → strips `/lq` → `api:8000`, and routes **everything else** (`/api/config`, OpenWebUI's own `/api/v1/*`, websockets, static) → `web:8080`. Total namespace separation, no enumeration, future-proof. The proxy owns the user-facing port; web is internal.

## Verified — in a REAL headless browser this time

Earlier verification used curl and missed JS-bootstrap bugs twice. This was confirmed with **Cypress (headless)** against the full 9-service proxied stack:
- Shell loads at `/` **without redirecting to `/error`**; the LQ.AI login form renders.
- Login through the proxy reaches the **authed app** (`localStorage` token set, URL leaves `/login`, home renders).
- curl separation proof: `/api/config` → 200 (web), `/lq/api/v1/auth/login` → 200 + token (api via strip), `/api/v1/auth/login` → 405 (web — confirms separation).
- 9/9 healthy; `vitest` 47/47; `tsc` clean; dev stack + running launcher untouched.

Honest caveat recorded in `VERIFICATION.md`: OpenWebUI honors `WEBUI_AUTH=false` only on a fresh `webui.db`; the launcher's first install (and Reset = `down -v`) is always fresh, so this is a test-only artifact, not a user risk.

## After merge (yours)

This changes the web image (now `/lq`-baked) and adds the proxy image, so the current `v0.4.1` images are **not** launcher-compatible. Cut **`v0.4.2`** → publishes `lq-ai-{api,gateway,web,proxy}` (web with `/lq`, + the proxy) → the launcher pulls them and the browser login works end-to-end. (No GHCR re-flip needed; new package `lq-ai-proxy` will need the same public visibility as the others.)

## Merge gating

Touches `.github/workflows/**` (release.yml) → **Kevin reviews + merges.** Build-arg isolation (web-only) + `handle_path` strip verified in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)