### PR TITLE
chore(release): bump __version__ 0.4.1 → 0.4.2 (launcher-ready proxy images)

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI backend API service."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/gateway/app/__init__.py
+++ b/gateway/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI Inference Gateway."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"


### PR DESCRIPTION
## Summary

Version bump so a fresh **`v0.4.2`** image release publishes the launcher-compatible images.

The `v0.4.1` images aren't launcher-ready: the web image bakes same-origin `/api/v1`, but the launcher needs the **`/lq`-prefixed web build** + the new **`lq-ai-proxy`** image (both from #147). Tagging `v0.4.2` from `main` runs the upgraded `release.yml` to publish all four: `lq-ai-{api,gateway,web,proxy}` (web built with `PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1`).

Two-line bump (`api/app/__init__.py` + `gateway/app/__init__.py`), the established release-bump pattern (cf. #144). No API/gateway behavior change. `gateway/**` → routes to you to merge.

## After merge (yours)
1. Tag `v0.4.2` from `main` → publishes the 4 images (I'll do this on your go-ahead, or you can).
2. **Public-flip the new `lq-ai-proxy` package** (org UI — the other three are already public; no API for this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)