### PR TITLE
docs: v0.4.2 Protocol 1 PASS + webui.db WAL bootstrap note (DE-335)

### DIFF
--- a/desktop/VERIFICATION.md
+++ b/desktop/VERIFICATION.md
@@ -98,9 +98,13 @@ curl -sS -o /dev/null -w "/api/v1/auth/login -> %{http_code}\n" -X POST \
 #    access_token and the URL leaves /login — then:
 #      cd web && npx cypress run --spec '<spec>' --config baseUrl=http://127.0.0.1:${WEB_HOST_PORT}
 #    NOTE: OpenWebUI keeps its OWN sqlite (web container /app/backend/data/webui.db) and honors
-#    WEBUI_AUTH=false only on a FRESH OpenWebUI install. If a prior browser run already created a
-#    non-default OpenWebUI user, auto-signin 400s and the root guard parks the SPA at /auth. On a fresh
-#    boot this is clean; if it happens, rm the web container's webui.db + restart web to re-bootstrap.
+#    WEBUI_AUTH=false only on a TRULY FRESH OpenWebUI db. If any non-default OpenWebUI user exists,
+#    auto-signin 400s ("can't turn off authentication … existing users") and the root guard parks the
+#    SPA at /auth. A throwaway project (or the launcher's Reset = `down -v`) removes the whole web
+#    volume, so it's clean. CAVEAT: OpenWebUI runs sqlite in WAL mode — removing only `webui.db`
+#    leaves `webui.db-wal`/`webui.db-shm`, which still carry the user. To re-bootstrap WITHOUT a full
+#    `down -v`, remove all three (`rm webui.db webui.db-wal webui.db-shm`) then restart web. Tracked
+#    for hardening as DE-335.
 
 # 7. Tear down the throwaway project (NEVER -v the dev stack):
 docker compose -f docker-compose.release.yml -p lq-ai-reltest --env-file /tmp/reltest.env down -v
@@ -134,8 +138,11 @@ REDIS 26700 / MINIO 29700-29701). The dev stack + the live `lq-ai-desktop` launc
       toast + "Welcome back, LQ.AI Administrator" home with the full LQ.AI nav. **Finding:** the first
       browser attempt parked at `/auth` — OpenWebUI keeps its OWN sqlite (`webui.db`) and refuses
       `WEBUI_AUTH=false` once a non-default OpenWebUI user exists (a prior Cypress run had created one).
-      Removing `webui.db` + restarting web re-bootstrapped the clean default user (matching the live dev
-      launcher, whose OpenWebUI user is `admin@localhost`), after which the browser flow passed. This is
+      Removing the webui.db sqlite set (`webui.db` **+ `webui.db-wal` + `webui.db-shm`** — OpenWebUI runs
+      WAL mode, so deleting only `webui.db` leaves the user in the WAL) + restarting web re-bootstrapped
+      the clean default user (matching the live dev launcher, whose OpenWebUI user is `admin@localhost`),
+      after which the browser flow passed. The launcher's Reset (`down -v`) removes the whole volume so
+      this can't bite a normal user; hardening tracked as DE-335. This is
       an OpenWebUI bootstrap-state artifact, NOT a proxy defect — the live dev launcher reaches
       `/lq-ai/login` with the form rendered, confirmed by the same Cypress harness against `:13012`.
 - [x] `down -v` on the throwaway project only; dev stack untouched — ✅ `lqai-lqtest` removed (volumes +

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4534,6 +4534,18 @@ Two bulk operations as originally written in the M3-C4 spec:
 
 ---
 
+#### DE-335 — Harden the OpenWebUI first-run bootstrap in the launcher (WEBUI_AUTH / WAL-mode webui.db)
+
+**Priority:** P2 · **Effort:** S
+
+**Context:** The `web` shell (OpenWebUI fork) keeps its OWN sqlite (`/app/backend/data/webui.db`) and honors `WEBUI_AUTH=false` auto-admin (`admin@localhost`) only on a *truly empty* db. If any non-default OpenWebUI user row exists, `POST /api/v1/auths/signin` returns 400 ("can't turn off authentication … existing users") and the SPA root guard parks at `/auth` with no self-recovery. OpenWebUI runs sqlite in **WAL mode**, so deleting only `webui.db` (leaving `webui.db-wal`/`webui.db-shm`) does NOT clear the user. Surfaced during the v0.4.2 Protocol-1 browser verification. The launcher's Reset does `docker compose down -v` (removes the whole volume incl. WAL/SHM), so a normal first install / Reset is clean — but an *interrupted* first-onboarding, or any path that probes `/auths/signin` before first paint, can wedge the shell with no in-app recovery.
+
+**Specific scope:** Make the first-run robust to a pre-existing OpenWebUI user — e.g. checkpoint/disable WAL for `webui.db`, or have the web entrypoint reset the OpenWebUI auth row to the default when `WEBUI_AUTH=false`, or give the launcher an in-app "repair" that wipes `webui.db*` (the full glob, not just `webui.db`) + restarts web. Until then, the manual remediation is `rm webui.db webui.db-wal webui.db-shm` + restart web (now documented in `desktop/VERIFICATION.md`).
+
+**When to ship:** Before a broad launcher install base; the `down -v` Reset covers the common case meanwhile.
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary


### PR DESCRIPTION
Records the v0.4.2 published-image Protocol 1 PASS (browser-verified via Cypress) in `desktop/VERIFICATION.md`, corrects the webui.db remediation note (OpenWebUI uses sqlite WAL mode — needs webui.db + -wal + -shm removed, or a full `down -v` which the launcher Reset does), and files **DE-335** to harden the OpenWebUI first-run bootstrap against a pre-existing user. Docs-only; self-merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)