### PR TITLE
Replay prior chat turns to the model (multi-turn memory)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,13 @@ JWT_REFRESH_TOKEN_TTL_SECONDS=604800
 API_BIND_ADDR=127.0.0.1
 API_HOST_PORT=8000
 
+# [OPTIONAL] Multi-turn chat memory. The chat send path replays prior
+# conversation turns to the model, trimmed most-recent-first to fit both a
+# token budget (~4 chars/token heuristic) and a hard message cap; oldest
+# turns drop first. Set the budget to 0 to disable history (single-turn).
+LQ_AI_CHAT_HISTORY_TOKEN_BUDGET=6000
+LQ_AI_CHAT_HISTORY_MAX_MESSAGES=20
+
 # ============================================================
 # Web client (OpenWebUI fork; lands in Task A1.d)
 # ============================================================

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -76,6 +76,7 @@ from app.audit import audit_action
 from app.citation import extract_citations, verify
 from app.citation.cost import estimate_judge_call_cost_usd
 from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
+from app.config import get_settings
 from app.db.session import get_db
 from app.errors import LQAIError, NotFound, ValidationError
 from app.knowledge.embed import DEFAULT_EMBEDDING_MODEL, request_embedding_vector
@@ -115,6 +116,90 @@ from app.skills.registry import MutableSkillRegistry, SkillRegistry
 
 router = APIRouter(prefix="/chats", tags=["chats"])
 log = logging.getLogger(__name__)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token count for history budgeting — ~4 chars per token.
+
+    Deliberately dependency-free (no tiktoken / model tokenizer) per the
+    SBOM posture in CLAUDE.md. Slightly over-estimates for code/markup,
+    which is the safe direction for a budget cap. Never returns 0.
+    """
+    return max(1, (len(text) + 3) // 4)
+
+
+def _select_history_within_budget(
+    history: list[tuple[str, str]],
+    *,
+    token_budget: int,
+    max_messages: int,
+) -> list[tuple[str, str]]:
+    """Trim ``history`` to the most recent turns that fit the budget.
+
+    ``history`` is ``(role, content)`` in chronological order (oldest
+    first). Returns the most-recent turns that fit within BOTH
+    ``token_budget`` and ``max_messages``, back in chronological order.
+    Oldest turns drop first. The single most-recent turn is always kept
+    even if it alone exceeds the token budget — dropping it would discard
+    the context immediately preceding the live turn, which is the most
+    valuable. ``token_budget`` or ``max_messages`` of 0 disables history.
+    """
+    if token_budget <= 0 or max_messages <= 0:
+        return []
+    selected_rev: list[tuple[str, str]] = []
+    used = 0
+    for role, content in reversed(history):
+        if len(selected_rev) >= max_messages:
+            break
+        cost = _estimate_tokens(content)
+        if selected_rev and used + cost > token_budget:
+            break
+        used += cost
+        selected_rev.append((role, content))
+    selected_rev.reverse()
+    return selected_rev
+
+
+async def _load_history_messages(
+    db: AsyncSession,
+    *,
+    chat_id: uuid.UUID,
+    exclude_message_id: uuid.UUID,
+    token_budget: int,
+    max_messages: int,
+) -> list[ChatCompletionMessage]:
+    """Load prior conversation turns for ``chat_id`` as gateway messages.
+
+    Returns the most-recent ``user``/``assistant`` turns (chronological)
+    that fit the budget, EXCLUDING ``exclude_message_id`` — the just-
+    persisted current user turn, which the caller appends separately as
+    the live turn. Errored assistant rows (``error_code`` set) and rows
+    with empty content are skipped. History messages carry no
+    ``lq_ai_skip_anonymization`` flag, so the gateway pseudonymizes them
+    with the same per-request map as the current turn (consistent entity
+    mapping across the conversation).
+    """
+    if token_budget <= 0 or max_messages <= 0:
+        return []
+    stmt = (
+        select(Message.role, Message.content)
+        .where(
+            Message.chat_id == chat_id,
+            Message.id != exclude_message_id,
+            Message.role.in_(("user", "assistant")),
+            Message.error_code.is_(None),
+        )
+        .order_by(Message.created_at.asc(), Message.id.asc())
+    )
+    rows = (await db.execute(stmt)).all()
+    history: list[tuple[str, str]] = [(row[0], row[1]) for row in rows if row[1]]
+    selected = _select_history_within_budget(
+        history, token_budget=token_budget, max_messages=max_messages
+    )
+    return [
+        ChatCompletionMessage.model_validate({"role": role, "content": content})
+        for role, content in selected
+    ]
 
 
 # Wave D.2 Task 2.7 — send-time slash fallback. If the user's content
@@ -1365,13 +1450,33 @@ async def send_message(
         )
         await db.commit()
 
+    # Multi-turn memory — replay prior conversation turns so chat is
+    # genuinely conversational. Previously this path sent only the current
+    # turn (single-turn requests). History is trimmed most-recent-first to
+    # the configured token budget + message cap (oldest dropped); set
+    # ``LQ_AI_CHAT_HISTORY_TOKEN_BUDGET=0`` to revert to single-turn.
+    # Inserted AFTER the current-turn system context blocks (RAG / attached
+    # files) and BEFORE the live user turn, so the provider sees
+    # ``[system context] + [prior turns] + [current user turn]``. History
+    # turns carry no ``lq_ai_skip_anonymization`` flag, so the gateway
+    # pseudonymizes them with the same per-request map as the current turn
+    # (entities stay consistent across the conversation).
+    settings = get_settings()
+    history_messages = await _load_history_messages(
+        db,
+        chat_id=cid,
+        exclude_message_id=user_message.id,
+        token_budget=settings.lq_ai_chat_history_token_budget,
+        max_messages=settings.lq_ai_chat_history_max_messages,
+    )
+    gw_messages.extend(history_messages)
+
     gw_messages.append(ChatCompletionMessage(role="user", content=effective_content))
 
-    # Build the gateway request. C3 still sends a single-turn request
-    # (the user's content as one ``user`` message); a future task may
-    # widen this to include prior history. The gateway does the skill
-    # prompt assembly per ADR 0007. T7b prepends a system context
-    # block when KB retrieval returned chunks (see above).
+    # Build the gateway request. The gateway does the skill prompt
+    # assembly per ADR 0007. T7b prepends a system context block when KB
+    # retrieval returned chunks (see above); the replayed history sits
+    # between that context and the live user turn.
     #
     # Wave D.2 Task 3.0 — ``lq_ai_inline_skills`` carries inline-body
     # attachments. The gateway assembles them alongside ``lq_ai_skills``

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -145,6 +145,32 @@ class Settings(BaseSettings):
         description="Shared secret for backend ↔ gateway. Required in prod.",
     )
 
+    # ----- Chat history (multi-turn memory) -----
+    # The chat send path (api/app/api/chats.py) replays prior turns of the
+    # conversation to the model so chat is genuinely multi-turn — previously
+    # only the current turn was sent. History is trimmed most-recent-first to
+    # fit BOTH a token budget and a hard message-count cap; oldest turns drop
+    # first when either is exceeded. Token counts use a cheap ~4-chars/token
+    # heuristic (no tokenizer dependency — CLAUDE.md SBOM posture). Operators
+    # on long-context models can raise the budget; set it to 0 to disable
+    # history replay entirely (revert to single-turn requests).
+    lq_ai_chat_history_token_budget: int = Field(
+        default=6_000,
+        ge=0,
+        description=(
+            "Approximate token budget (~4 chars/token) for prior chat turns "
+            "replayed to the model. 0 disables multi-turn history."
+        ),
+    )
+    lq_ai_chat_history_max_messages: int = Field(
+        default=20,
+        ge=0,
+        description=(
+            "Hard cap on the number of prior chat messages replayed to the "
+            "model, independent of the token budget. 0 disables history."
+        ),
+    )
+
     # ----- JWT (per ADR 0002 — backend owns auth) -----
     jwt_secret: str = Field(
         default="dev-jwt-secret-change-me",

--- a/api/tests/test_chat_history.py
+++ b/api/tests/test_chat_history.py
@@ -1,0 +1,56 @@
+"""Unit tests for multi-turn chat-history assembly in the send_message path.
+
+Covers the pure budgeting/truncation helpers added to give chat real
+multi-turn memory (replaying prior turns to the model). The DB-backed
+loader (`_load_history_messages`) is exercised by the chats integration
+suite against Postgres; these tests pin the trimming logic, which is the
+part with the interesting edge cases.
+"""
+
+from __future__ import annotations
+
+from app.api.chats import _estimate_tokens, _select_history_within_budget
+
+
+def test_estimate_tokens_rough_four_chars_per_token() -> None:
+    assert _estimate_tokens("") == 1  # never zero — avoids div-by-zero-ish edges
+    assert _estimate_tokens("a") == 1
+    assert _estimate_tokens("a" * 4) == 1
+    assert _estimate_tokens("a" * 8) == 2
+
+
+def test_select_history_empty() -> None:
+    assert _select_history_within_budget([], token_budget=100, max_messages=10) == []
+
+
+def test_select_history_returns_chronological_within_message_cap() -> None:
+    hist = [
+        ("user", "u1"),
+        ("assistant", "a1"),
+        ("user", "u2"),
+        ("assistant", "a2"),
+    ]
+    out = _select_history_within_budget(hist, token_budget=10_000, max_messages=2)
+    # most-recent two turns, restored to chronological order
+    assert out == [("user", "u2"), ("assistant", "a2")]
+
+
+def test_select_history_drops_oldest_over_token_budget() -> None:
+    # each 4-char content ~= 1 token; budget of 2 keeps the most recent two
+    hist = [("user", "aaaa"), ("assistant", "bbbb"), ("user", "cccc")]
+    out = _select_history_within_budget(hist, token_budget=2, max_messages=100)
+    assert out == [("assistant", "bbbb"), ("user", "cccc")]
+
+
+def test_select_history_keeps_most_recent_even_if_over_budget() -> None:
+    # the single most-recent turn is always kept, even if it alone busts the
+    # budget — dropping it would discard the immediately-preceding context.
+    hist = [("user", "short"), ("assistant", "x" * 400)]
+    out = _select_history_within_budget(hist, token_budget=1, max_messages=100)
+    assert out == [("assistant", "x" * 400)]
+
+
+def test_select_history_disabled_by_zero_budget_or_zero_cap() -> None:
+    hist = [("user", "u1"), ("assistant", "a1")]
+    assert _select_history_within_budget(hist, token_budget=0, max_messages=10) == []
+    assert _select_history_within_budget(hist, token_budget=10, max_messages=0) == []


### PR DESCRIPTION
## What & why

The chat send path (`api/app/api/chats.py` → `send_message`) built the gateway request from only the **current** user turn plus current-turn system context (RAG / attached files). Prior messages were persisted and full-text searchable, but **never replayed to the model** — so chat was effectively single-turn at the model layer. This was the widest gap between the product's "conversational legal AI" framing and its actual behavior, and `send_message`'s own comment admitted it:

> "C3 still sends a single-turn request … a future task may widen this to include prior history."

`docs/HONEST-STATE.md` already lists *"Multi-turn chat with persistent history"* as shipped. This PR makes that claim true **at the model layer**, not just persistence + FTS. (No HONEST-STATE row to flip — it already claimed multi-turn; this closes the claim↔code gap.)

## Change

`send_message` now loads prior `user`/`assistant` turns and injects them into the request, ordered `[system context] + [prior turns] + [current user turn]`:

- **Trimming:** most-recent-first to fit **both** a token budget and a hard message cap; oldest turns drop first. The single most-recent turn is always kept even if it alone exceeds the budget (dropping it would discard the immediately-preceding context).
- **Token counting:** `~4 chars/token` heuristic — no tokenizer dependency (SBOM posture).
- **Anonymization (the subtle bit):** history turns carry no `lq_ai_skip_anonymization` flag, so the gateway pseudonymizes them with the **same per-request map** as the live turn → entities stay consistent across the conversation. Privileged projects already bypass anonymization wholesale.
- **Ordering:** history sits *after* the current-turn system blocks (so all `system` messages lead — matters for the Anthropic adapter, which lifts `system` out of the message array) and *before* the live user turn.
- Errored assistant rows (`error_code` set) and empty content are skipped.

## Config

- `LQ_AI_CHAT_HISTORY_TOKEN_BUDGET` — default `6000`; set to `0` to disable history (revert to single-turn)
- `LQ_AI_CHAT_HISTORY_MAX_MESSAGES` — default `20`

Added to `api/app/config.py` and documented in `.env.example`.

## Tests / verification

- New `api/tests/test_chat_history.py` covers the trimming/budget edge cases: chronological order, message cap, token-budget drop-oldest, keep-most-recent-over-budget, and the `0`-disables path.
- The DB loader `_load_history_messages` is exercised by the existing `send_message` integration suite.
- **Local limitation:** I verified syntax (`py_compile`) and ran the trimming algorithm against the unit-test assertions, but could **not** run the full `pytest` / `ruff` / `mypy` gates locally (api deps + a Postgres test DB weren't available in my environment). Relying on CI to run the gates.

## Files

- `api/app/api/chats.py` — `_estimate_tokens`, `_select_history_within_budget`, `_load_history_messages` + wiring
- `api/app/config.py` — two settings
- `.env.example` — documented vars
- `api/tests/test_chat_history.py` — unit tests

## Deferred (follow-up DE)

- Summarization of dropped turns (vs. drop-oldest).
- Per-tier/model token budgets (long-context models could carry far more history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
