### PR TITLE
fix(gateway): strip lq_ai_privileged and lq_ai_file_ids before provider dispatch

### DIFF
--- a/gateway/app/providers/openai.py
+++ b/gateway/app/providers/openai.py
@@ -99,6 +99,8 @@ _LQ_AI_EXTENSION_KEYS = frozenset(
         "lq_ai_message_id",
         "lq_ai_user_id",
         "lq_ai_purpose",
+        "lq_ai_privileged",
+        "lq_ai_file_ids",
     }
 )
 

--- a/gateway/tests/test_openai_adapter.py
+++ b/gateway/tests/test_openai_adapter.py
@@ -437,6 +437,8 @@ async def test_chat_completion_strips_lq_ai_extension_keys() -> None:
         lq_ai_purpose="judge_paraphrase",
         chat_id="audit-tag",
         anonymize=True,
+        lq_ai_privileged=True,
+        lq_ai_file_ids=["44444444-4444-4444-4444-444444444444"],
     )
     with respx.mock(base_url="https://api.openai.com/v1") as router:
         route = router.post("/chat/completions").mock(
@@ -467,6 +469,8 @@ async def test_chat_completion_strips_lq_ai_extension_keys() -> None:
         "lq_ai_message_id",
         "lq_ai_user_id",
         "lq_ai_purpose",
+        "lq_ai_privileged",
+        "lq_ai_file_ids",
     ):
         assert forbidden not in sent, f"LQ.AI extension {forbidden!r} leaked to OpenAI"
 


### PR DESCRIPTION
## Summary

The OpenAI adapter strips LQ.AI extension keys from the outbound provider body using an allowlist-pop over `_LQ_AI_EXTENSION_KEYS` (`gateway/app/providers/openai.py:483-485`). Two keys the backend sends were **missing** from that set, so they were forwarded verbatim to the provider — and OpenAI / Azure OpenAI reject unknown body fields with **HTTP 400**, failing any request that carried them.

This adds the two missing keys:

- **`lq_ai_privileged`** — a *typed* field (`bool = False`, `openai_schema.py:199`). Because the default is `False` (not `None`), it survives `exclude_none=True`, and being absent from the strip set it leaked through on the normal dispatch path. It's a gateway-internal flag read only by the anonymization middleware (`anonymization/middleware.py:94`), which reads but never pops it.
- **`lq_ai_file_ids`** — a backend wire key (`api/app/schemas/gateway.py`, forwarded at `api/app/api/chats.py`) captured via `ConfigDict(extra="allow")` (`openai_schema.py:154`) and likewise forwarded.

Because `AzureOpenAIAdapter(OpenAIAdapter)` delegates body construction to the same shared `_to_openai_request` (`azure_openai.py:205`), this fixes **both** the OpenAI and Azure adapters. This is the same class of bug previously fixed for `lq_ai_inline_skills` (see `test_chat_completion_inline_skill_body_does_not_leak_to_openai`).

## Test

Extends the existing strip regression test (`test_chat_completion_strips_lq_ai_extension_keys`) to set `lq_ai_privileged=True` and `lq_ai_file_ids=[...]` on the request and assert neither appears in the body sent to the provider.

## Credit & scope

This is the one fully-verified bug from an external Azure OpenAI + GPT-5 connectivity report. The report's other items (a new `azure_foundry` adapter, an Azure-only `max_tokens→max_completion_tokens` rename, a prefix-match refactor) were reviewed and intentionally **not** included here — happy to discuss separately, but a couple are redundant given `base_url` is already operator-configurable, and the reasoning-model `max_tokens` constraint, if wanted, belongs gated in the shared `_to_openai_request` rather than Azure-only.

## Follow-up (not in this PR)

Separately worth considering: an upstream provider **400** currently surfaces as `provider_unavailable` (HTTP 502, an *outage* code) via `inference.py:235-243`, so a client could wrongly retry a request-side error. That's the latent defect this missing-key bug actually tripped. Filing/▶ fixing that is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

