### PR TITLE
fix(gateway): classify upstream provider 4xx as invalid_request, not provider_unavailable

### DIFF
--- a/gateway/app/api/inference.py
+++ b/gateway/app/api/inference.py
@@ -182,78 +182,97 @@ def _gateway_error(
     )
 
 
+def _classify_provider_error(exc: ProviderAdapterError) -> tuple[str, int]:
+    """Classify a provider adapter error into ``(gateway_code, http_status)``.
+
+    Single source of truth shared by the non-streaming response mapper
+    (:func:`_map_provider_error_to_response`), the streaming SSE error
+    frame, and the routing-log failure writers — so an upstream status is
+    classified identically on every path, not just the non-streaming one.
+
+    An upstream **4xx** (other than 429 and the invalid_model 404) is a
+    request-side, NON-retryable failure: the provider rejected the request
+    we assembled (bad param, oversized prompt, unsupported field, content
+    policy). It maps to ``invalid_request`` / 400 rather than the outage
+    code ``provider_unavailable`` / 502, so clients don't retry a request
+    that can never succeed and outage dashboards aren't polluted with
+    caller/config errors. Upstream 5xx and network failures stay
+    ``provider_unavailable``.
+    """
+
+    if isinstance(exc, ProviderUnsupportedError):
+        return exc.code, status.HTTP_501_NOT_IMPLEMENTED
+    if isinstance(exc, ProviderAuthError):
+        return exc.code, status.HTTP_502_BAD_GATEWAY
+    if isinstance(exc, ProviderHTTPError):
+        upstream = exc.upstream_status
+        if upstream == 429:
+            return "rate_limit_exceeded", status.HTTP_429_TOO_MANY_REQUESTS
+        if upstream == 404 and exc.code == "invalid_model":
+            # Adapter signaled "the request named a model the upstream
+            # can't serve" (e.g., Ollama's "model not found, pull first").
+            return "invalid_model", status.HTTP_400_BAD_REQUEST
+        if 400 <= upstream < 500:
+            return "invalid_request", status.HTTP_400_BAD_REQUEST
+        return exc.code, status.HTTP_502_BAD_GATEWAY
+    if isinstance(exc, ProviderNetworkError):
+        return exc.code, status.HTTP_503_SERVICE_UNAVAILABLE
+    return exc.code, status.HTTP_502_BAD_GATEWAY
+
+
 def _map_provider_error_to_response(exc: ProviderAdapterError) -> JSONResponse:
     """Map a :class:`ProviderAdapterError` to the right HTTP status + envelope.
 
-    Centralizes the mapping so the streaming and non-streaming paths use
-    the same rules. Per the gateway-openapi.yaml error enum:
+    Thin wrapper over :func:`_classify_provider_error` (the shared
+    classifier) plus operator-facing logging. Per the gateway-openapi.yaml
+    error enum:
 
     * Auth errors → ``unauthorized`` / 502 (the gateway is its own auth
       domain; an upstream credential failure is a misconfiguration, not
       the caller's fault).
     * Upstream 429 → ``rate_limit_exceeded`` / 429.
     * Upstream 404 with ``code = "invalid_model"`` (e.g., Ollama
-      "model not pulled") → ``invalid_model`` / 400. The caller named
-      a model the deployment can't serve — that's a request-side
-      mistake, not an upstream outage. Adapters set ``code`` on the
-      :class:`ProviderHTTPError` to opt into this mapping.
-    * Upstream other 4xx → ``provider_unavailable`` / 502.
+      "model not pulled") → ``invalid_model`` / 400.
+    * Upstream other 4xx → ``invalid_request`` / 400. The provider
+      rejected the request we assembled — request-side and non-retryable,
+      so it does NOT wear the outage code ``provider_unavailable``.
     * Upstream 5xx (after fallback exhausted) → ``provider_unavailable`` /
       502.
     * Network / DNS / TLS / timeout → ``provider_unavailable`` / 503.
     * ``ProviderUnsupportedError`` → ``not_implemented`` / 501.
     """
 
-    if isinstance(exc, ProviderUnsupportedError):
-        return _gateway_error(
-            code=exc.code,
-            message=exc.message,
-            http_status=status.HTTP_501_NOT_IMPLEMENTED,
-            details=exc.details,
-        )
+    code, http_status = _classify_provider_error(exc)
     if isinstance(exc, ProviderAuthError):
         logger.warning("provider auth rejected: %s", exc.message)
-        return _gateway_error(
-            code=exc.code,
-            message=exc.message,
-            http_status=status.HTTP_502_BAD_GATEWAY,
-            details=exc.details,
-        )
-    if isinstance(exc, ProviderHTTPError):
-        upstream = exc.upstream_status
-        if upstream == 429:
-            gw_status = status.HTTP_429_TOO_MANY_REQUESTS
-            gw_code = "rate_limit_exceeded"
-        elif upstream == 404 and exc.code == "invalid_model":
-            # Adapter signaled "the request named a model the upstream
-            # can't serve" (e.g., Ollama's "model not found, try
-            # pulling it first"). Surface as 400 invalid_model so
-            # callers see the request-side mistake clearly rather
-            # than a generic upstream-flake 502.
-            gw_status = status.HTTP_400_BAD_REQUEST
-            gw_code = "invalid_model"
-        else:
-            gw_status = status.HTTP_502_BAD_GATEWAY
-            gw_code = exc.code
-        return _gateway_error(
-            code=gw_code,
-            message=exc.message,
-            http_status=gw_status,
-            details=exc.details,
-        )
-    if isinstance(exc, ProviderNetworkError):
-        return _gateway_error(
-            code=exc.code,
-            message=exc.message,
-            http_status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            details=exc.details,
+    elif code == "invalid_request":
+        logger.warning(
+            "provider rejected request: upstream_status=%s provider=%s",
+            getattr(exc, "upstream_status", None),
+            exc.details.get("provider"),
         )
     return _gateway_error(
-        code=exc.code,
+        code=code,
         message=exc.message,
-        http_status=status.HTTP_502_BAD_GATEWAY,
+        http_status=http_status,
         details=exc.details,
     )
+
+
+def _failure_reason(error: ProviderAdapterError) -> str:
+    """Build the routing-log ``refusal_reason`` for an upstream failure.
+
+    Carries the *classified* gateway code (so a 4xx rejection reads
+    ``invalid_request``, not the class-default ``provider_unavailable``)
+    plus the upstream HTTP status when known — the distinguishing signal
+    an operator needs to tell a request rejection from a genuine outage
+    when reading inference_routing_log rows.
+    """
+
+    code, _ = _classify_provider_error(error)
+    if isinstance(error, ProviderHTTPError):
+        return f"upstream_error:{code}:status={error.upstream_status}"
+    return f"upstream_error:{code}"
 
 
 def _config(request: Request) -> GatewayConfig:
@@ -1176,7 +1195,11 @@ async def _stream_openai_sse(
             payload = chunk.model_dump(mode="json", exclude_none=True)
             yield f"data: {json.dumps(payload, separators=(',', ':'))}\n\n".encode()
     except ProviderAdapterError as exc:
-        envelope = {"error": {"code": exc.code, "message": exc.message, "details": exc.details}}
+        # Classify so a streaming upstream 4xx surfaces as invalid_request
+        # (not the raw class-default provider_unavailable) — same rule the
+        # non-streaming path applies via _map_provider_error_to_response.
+        code, _ = _classify_provider_error(exc)
+        envelope = {"error": {"code": code, "message": exc.message, "details": exc.details}}
         yield f"data: {json.dumps(envelope, separators=(',', ':'))}\n\n".encode()
         await _write_failure(
             log_writer,
@@ -1411,7 +1434,7 @@ async def _write_failure(
             latency_ms=latency_ms,
             anonymization_applied=anonymization_applied,
             refused=False,
-            refusal_reason=f"upstream_error:{error.code}",
+            refusal_reason=_failure_reason(error),
             request_id=request_id,
             chat_id=chat_id,
             message_id=message_id,
@@ -1637,7 +1660,7 @@ async def _write_embeddings_failure(
             routed_inference_tier=target.routed_inference_tier,
             latency_ms=latency_ms,
             refused=False,
-            refusal_reason=f"upstream_error:{error.code}",
+            refusal_reason=_failure_reason(error),
             request_id=request_id,
             purpose="embedding",
         )

--- a/gateway/app/providers/base.py
+++ b/gateway/app/providers/base.py
@@ -93,7 +93,8 @@ class ProviderHTTPError(ProviderAdapterError):
 
     The adapter populates ``details["upstream_status"]`` with the integer
     status code so the route handler can map sensibly (e.g., upstream
-    400 -> gateway 502, upstream 429 -> gateway 429).
+    4xx -> gateway 400 ``invalid_request``, upstream 429 -> gateway 429,
+    upstream 5xx -> gateway 502 ``provider_unavailable``).
     """
 
     code = "provider_unavailable"

--- a/gateway/tests/test_provider_error_mapping.py
+++ b/gateway/tests/test_provider_error_mapping.py
@@ -1,0 +1,128 @@
+"""Unit tests for provider-error classification (P1 error-code accuracy).
+
+The load-bearing contract these tests pin:
+
+* An upstream **4xx** (the provider rejected the request we assembled) is
+  a request-side, non-retryable failure → ``invalid_request`` / HTTP 400,
+  NOT the outage code ``provider_unavailable`` / 502. This stops clients
+  retrying a request that can never succeed and keeps outage dashboards
+  free of caller/config errors.
+* Upstream **5xx** and network failures remain ``provider_unavailable``.
+* 429, the invalid_model 404, auth, and unsupported keep their dedicated
+  mappings.
+* The classification is applied on BOTH the non-streaming mapper and the
+  routing-log failure-reason builder (so a streaming 4xx is logged as a
+  rejection, not an outage).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.api.inference import (
+    _classify_provider_error,
+    _failure_reason,
+    _map_provider_error_to_response,
+)
+from app.providers.base import (
+    ProviderAdapterError,
+    ProviderAuthError,
+    ProviderHTTPError,
+    ProviderNetworkError,
+    ProviderUnsupportedError,
+)
+
+
+def _decode(exc: ProviderAdapterError) -> tuple[int, str]:
+    response = _map_provider_error_to_response(exc)
+    body = json.loads(bytes(response.body))
+    return response.status_code, body["error"]["code"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("upstream", [400, 403, 404, 413, 422, 499])
+def test_upstream_4xx_maps_to_invalid_request(upstream: int) -> None:
+    """Any non-429 upstream 4xx is a request-side 400, not an outage."""
+
+    status_code, code = _decode(ProviderHTTPError("bad request", upstream_status=upstream))
+    assert status_code == 400
+    assert code == "invalid_request"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("upstream", [500, 502, 503, 504])
+def test_upstream_5xx_stays_provider_unavailable(upstream: int) -> None:
+    """Upstream 5xx is a genuine outage → provider_unavailable / 502."""
+
+    status_code, code = _decode(ProviderHTTPError("svc down", upstream_status=upstream))
+    assert status_code == 502
+    assert code == "provider_unavailable"
+
+
+@pytest.mark.unit
+def test_upstream_429_stays_rate_limit_exceeded() -> None:
+    status_code, code = _decode(ProviderHTTPError("slow down", upstream_status=429))
+    assert status_code == 429
+    assert code == "rate_limit_exceeded"
+
+
+@pytest.mark.unit
+def test_invalid_model_404_keeps_dedicated_mapping() -> None:
+    """A 404 the adapter tagged invalid_model still surfaces as invalid_model/400."""
+
+    exc = ProviderHTTPError("model not pulled", upstream_status=404)
+    exc.code = "invalid_model"
+    status_code, code = _decode(exc)
+    assert status_code == 400
+    assert code == "invalid_model"
+
+
+@pytest.mark.unit
+def test_network_error_stays_provider_unavailable_503() -> None:
+    status_code, code = _decode(ProviderNetworkError("dns failure"))
+    assert status_code == 503
+    assert code == "provider_unavailable"
+
+
+@pytest.mark.unit
+def test_auth_error_stays_unauthorized_502() -> None:
+    status_code, code = _decode(ProviderAuthError("bad key"))
+    assert status_code == 502
+    assert code == "unauthorized"
+
+
+@pytest.mark.unit
+def test_unsupported_stays_not_implemented_501() -> None:
+    status_code, code = _decode(ProviderUnsupportedError("no embeddings"))
+    assert status_code == 501
+    assert code == "not_implemented"
+
+
+@pytest.mark.unit
+def test_classifier_is_pure_tuple() -> None:
+    """The shared classifier returns (code, status) without building a response."""
+
+    assert _classify_provider_error(ProviderHTTPError("x", upstream_status=400)) == (
+        "invalid_request",
+        400,
+    )
+    assert _classify_provider_error(ProviderHTTPError("x", upstream_status=503)) == (
+        "provider_unavailable",
+        502,
+    )
+
+
+@pytest.mark.unit
+def test_failure_reason_records_classified_code_and_upstream_status() -> None:
+    """Routing-log reason distinguishes a 4xx rejection from a 5xx outage."""
+
+    rejected = _failure_reason(ProviderHTTPError("bad", upstream_status=400))
+    assert rejected == "upstream_error:invalid_request:status=400"
+
+    outage = _failure_reason(ProviderHTTPError("down", upstream_status=503))
+    assert outage == "upstream_error:provider_unavailable:status=503"
+
+    network = _failure_reason(ProviderNetworkError("dns"))
+    assert network == "upstream_error:provider_unavailable"


### PR DESCRIPTION
## Summary

An upstream provider **4xx** (bad param, oversized prompt, unsupported field, content policy, etc.) was surfaced under **`provider_unavailable` / HTTP 502** — the *outage* code. That mislabels a request-side, **non-retryable** failure as a transient outage: a client keyed to the code can retry a request that can never succeed, and outage dashboards get polluted with caller/config errors.

This reclassifies upstream 4xx (other than 429 and the `invalid_model` 404) as **`invalid_request` / 400**.

### Why reuse `invalid_request` (and not a new code)

`invalid_request` already exists, already crosses to the backend (it's in `EXPECTED_CROSSING_CODES`), already maps to the backend's `ValidationError`/400 via `map_gateway_error_code`, and is already in the `gateway-openapi.yaml` enum. So this needs **no new error code, no contract-test change, no backend change, no enum change** — just the classification logic.

### What changed (`gateway/app/api/inference.py`)

- Extracted **`_classify_provider_error(exc) -> (code, http_status)`** as the single source of truth: upstream 4xx → `invalid_request`/400; 5xx + network → `provider_unavailable`; 429, auth, `invalid_model`, unsupported keep their dedicated mappings.
- `_map_provider_error_to_response` now delegates to it (covers non-streaming chat, embeddings, and fallback-exhausted paths).
- **Streaming fix:** the SSE error frame previously emitted the raw class-default `exc.code` (always `provider_unavailable`) and bypassed the mapper — it now classifies too, so a *streaming* 4xx is correctly reported as `invalid_request`. (Caught by an adversarial review of an earlier draft.)
- **Observability:** routing-log `refusal_reason` now records the *classified* code **plus the upstream status** — `upstream_error:invalid_request:status=400` vs `upstream_error:provider_unavailable:status=503` — so operators can distinguish a request rejection from a genuine outage in `inference_routing_log`.

### Tests

New `gateway/tests/test_provider_error_mapping.py` pins the classifier, the response mapping, and the failure-reason builder across 4xx / 5xx / 429 / invalid-model / network / auth / unsupported. No existing test asserted the old 4xx→`provider_unavailable` behavior (verified), so nothing regresses.

## Context

Follow-up to #154. This is the P1 item from a review of an Azure-OpenAI connectivity report — the latent defect the report's "provider_unavailable on every request" symptom was actually hinting at. Scope was deliberately kept minimal (reuse `invalid_request`) rather than minting a dedicated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
