### PR TITLE
feat(gateway): per-provider use_max_completion_tokens for GPT-5/o-series

### DIFF
--- a/gateway/app/config.py
+++ b/gateway/app/config.py
@@ -118,6 +118,18 @@ class ProviderConfig(BaseModel):
     tier: InferenceTier
     models: list[str] = Field(default_factory=list)
     enabled: bool = True
+    use_max_completion_tokens: bool = False
+    """Send ``max_completion_tokens`` instead of ``max_tokens`` to the
+    provider. OpenAI/Azure GPT-5 and o-series reasoning deployments REJECT
+    ``max_tokens`` (hard HTTP 400) and require ``max_completion_tokens``; it
+    is also accepted by gpt-4o. Default off so OpenAI-compatible servers
+    that only recognize ``max_tokens`` (e.g. vLLM < 0.6.4 rejects unknown
+    fields; LM Studio / Ollama / TGI silently drop them) keep working.
+    Honored only by the OpenAI-family adapters (``openai`` /
+    ``openai_compatible`` / ``azure_openai``). NB: ``max_completion_tokens``
+    caps reasoning + visible output combined — pair this with a generous
+    budget on reasoning models or the response can come back empty with
+    ``finish_reason='length'``."""
 
     @model_validator(mode="after")
     def _exactly_one_key_source(self) -> ProviderConfig:

--- a/gateway/app/providers/azure_openai.py
+++ b/gateway/app/providers/azure_openai.py
@@ -102,6 +102,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
         api_version: str,
         timeout_s: float = DEFAULT_TIMEOUT_SECONDS,
         client: httpx.AsyncClient | None = None,
+        use_max_completion_tokens: bool = False,
     ) -> None:
         super().__init__(
             name=name,
@@ -109,6 +110,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
             api_key=api_key,
             timeout_s=timeout_s,
             client=client,
+            use_max_completion_tokens=use_max_completion_tokens,
         )
         self._api_version = api_version
 
@@ -183,6 +185,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
             api_version=api_version_raw,
             timeout_s=timeout_s,
             client=client,
+            use_max_completion_tokens=provider.use_max_completion_tokens,
         )
 
     # --- ProviderAdapter contract --------------------------------------------
@@ -202,7 +205,12 @@ class AzureOpenAIAdapter(OpenAIAdapter):
         reused verbatim from the OpenAI helpers.
         """
 
-        body = _to_openai_request(request, model=model, stream=stream)
+        body = _to_openai_request(
+            request,
+            model=model,
+            stream=stream,
+            use_max_completion_tokens=self._use_max_completion_tokens,
+        )
         path = self._chat_completions_path(deployment_id=model)
 
         if stream:

--- a/gateway/app/providers/openai.py
+++ b/gateway/app/providers/openai.py
@@ -137,11 +137,13 @@ class OpenAIAdapter(ProviderAdapter):
         api_key: str,
         timeout_s: float = DEFAULT_TIMEOUT_SECONDS,
         client: httpx.AsyncClient | None = None,
+        use_max_completion_tokens: bool = False,
     ) -> None:
         self.name = name
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._timeout = timeout_s
+        self._use_max_completion_tokens = use_max_completion_tokens
         self._owns_client = client is None
         self._client = client or httpx.AsyncClient(
             base_url=self._base_url,
@@ -214,6 +216,7 @@ class OpenAIAdapter(ProviderAdapter):
             api_key=api_key,
             timeout_s=timeout_s,
             client=client,
+            use_max_completion_tokens=provider.use_max_completion_tokens,
         )
 
     # --- ProviderAdapter contract --------------------------------------------
@@ -234,7 +237,12 @@ class OpenAIAdapter(ProviderAdapter):
         ``stream`` to match the route handler's decision.
         """
 
-        body = _to_openai_request(request, model=model, stream=stream)
+        body = _to_openai_request(
+            request,
+            model=model,
+            stream=stream,
+            use_max_completion_tokens=self._use_max_completion_tokens,
+        )
 
         if stream:
             return _openai_stream_iter(
@@ -459,6 +467,7 @@ def _to_openai_request(
     *,
     model: str,
     stream: bool,
+    use_max_completion_tokens: bool = False,
 ) -> dict[str, Any]:
     """Build the OpenAI ``POST /chat/completions`` request body.
 
@@ -492,6 +501,15 @@ def _to_openai_request(
             if isinstance(msg, dict):
                 for key in _LQ_AI_MESSAGE_EXTENSION_KEYS:
                     msg.pop(key, None)
+    # GPT-5 / o-series reasoning deployments reject ``max_tokens`` (hard
+    # 400) and require ``max_completion_tokens``. When the provider opts in
+    # (``use_max_completion_tokens``), rename the field and DROP
+    # ``max_tokens`` entirely — its mere presence re-triggers the 400 on
+    # reasoning models. Gated per-provider (not by model name) because
+    # Azure deployment-ids are opaque and OpenAI-compatible local servers
+    # may not accept ``max_completion_tokens``.
+    if use_max_completion_tokens and "max_tokens" in body:
+        body["max_completion_tokens"] = body.pop("max_tokens")
     body["model"] = model
     body["stream"] = stream
     # ``stream_options.include_usage`` is required for OpenAI to emit a

--- a/gateway/tests/test_max_completion_tokens.py
+++ b/gateway/tests/test_max_completion_tokens.py
@@ -1,0 +1,125 @@
+"""Tests for the per-provider ``use_max_completion_tokens`` flag.
+
+GPT-5 / o-series reasoning deployments reject ``max_tokens`` (hard 400) and
+require ``max_completion_tokens``. The gateway gates the rename per-provider
+(not by model name) so OpenAI-compatible local servers — which may reject the
+unknown field (vLLM < 0.6.4) or silently drop it (LM Studio / Ollama / TGI) —
+keep receiving ``max_tokens`` by default.
+
+What these tests pin:
+
+* When the flag is on, ``_to_openai_request`` renames ``max_tokens`` to
+  ``max_completion_tokens`` AND drops ``max_tokens`` entirely (its mere
+  presence re-triggers the 400 on reasoning models).
+* When off (the default), ``max_tokens`` is left untouched.
+* Both the OpenAI and Azure adapters read the flag from ``ProviderConfig``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import ProviderConfig
+from app.providers.azure_openai import AzureOpenAIAdapter
+from app.providers.openai import OpenAIAdapter, _to_openai_request
+from app.providers.openai_schema import ChatCompletionMessage, ChatCompletionRequest
+
+
+def _request(max_tokens: int | None = 256) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="gpt-5",
+        messages=[ChatCompletionMessage(role="user", content="hi")],
+        max_tokens=max_tokens,
+    )
+
+
+# --- _to_openai_request body translation ------------------------------------
+
+
+@pytest.mark.unit
+def test_flag_on_renames_max_tokens_and_drops_original() -> None:
+    body = _to_openai_request(
+        _request(256), model="gpt-5", stream=False, use_max_completion_tokens=True
+    )
+    assert body["max_completion_tokens"] == 256
+    assert "max_tokens" not in body  # presence alone re-triggers the 400
+
+
+@pytest.mark.unit
+def test_flag_off_keeps_max_tokens() -> None:
+    body = _to_openai_request(
+        _request(256), model="gpt-4o", stream=False, use_max_completion_tokens=False
+    )
+    assert body["max_tokens"] == 256
+    assert "max_completion_tokens" not in body
+
+
+@pytest.mark.unit
+def test_flag_defaults_off() -> None:
+    body = _to_openai_request(_request(256), model="gpt-4o", stream=False)
+    assert body["max_tokens"] == 256
+    assert "max_completion_tokens" not in body
+
+
+@pytest.mark.unit
+def test_flag_on_without_max_tokens_adds_nothing() -> None:
+    # max_tokens omitted by the caller (dropped via exclude_none); the flag
+    # must not invent a budget.
+    body = _to_openai_request(
+        _request(None), model="gpt-5", stream=False, use_max_completion_tokens=True
+    )
+    assert "max_tokens" not in body
+    assert "max_completion_tokens" not in body
+
+
+# --- ProviderConfig + adapter wiring ----------------------------------------
+
+
+@pytest.mark.unit
+def test_provider_config_flag_defaults_false() -> None:
+    cfg = ProviderConfig.model_validate(
+        {
+            "name": "openai-prod",
+            "type": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "api_key_env": "OPENAI_API_KEY_TEST",
+            "tier": 4,
+            "models": ["gpt-5"],
+        }
+    )
+    assert cfg.use_max_completion_tokens is False
+
+
+@pytest.mark.unit
+def test_openai_adapter_reads_flag_from_config() -> None:
+    cfg = ProviderConfig.model_validate(
+        {
+            "name": "openai-prod",
+            "type": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "api_key_env": "OPENAI_API_KEY_TEST",
+            "tier": 4,
+            "models": ["gpt-5"],
+            "use_max_completion_tokens": True,
+        }
+    )
+    adapter = OpenAIAdapter.from_config(cfg, env={"OPENAI_API_KEY_TEST": "sk-test"})
+    assert adapter._use_max_completion_tokens is True
+
+
+@pytest.mark.unit
+def test_azure_adapter_reads_flag_from_config() -> None:
+    cfg = ProviderConfig.model_validate(
+        {
+            "name": "azure-openai",
+            "type": "azure_openai",
+            "base_url": "https://res.openai.azure.com",
+            "api_key_env": "AZURE_OPENAI_API_KEY_TEST",
+            "api_version": "2024-10-21",
+            "tier": 3,
+            "models": ["gpt-5-prod"],
+            "use_max_completion_tokens": True,
+        }
+    )
+    adapter = AzureOpenAIAdapter.from_config(cfg, env={"AZURE_OPENAI_API_KEY_TEST": "az-test"})
+    assert adapter._use_max_completion_tokens is True


### PR DESCRIPTION
## Summary

GPT-5 and o-series reasoning deployments **reject `max_tokens` with a hard HTTP 400** ("Unsupported parameter: `max_tokens` is not supported with this model. Use `max_completion_tokens` instead.") on both OpenAI and Azure Chat Completions. The gateway sent `max_tokens` verbatim, so chat against those models failed at the provider.

Adds an opt-in per-provider flag **`use_max_completion_tokens`** (default `false`). When set, the shared `_to_openai_request` renames `max_tokens` → `max_completion_tokens` **and drops `max_tokens` entirely** (its mere presence re-triggers the 400 on reasoning models). Covers both the `openai` and `azure_openai` adapters via the shared body builder.

## Why a per-provider flag, not a model-name heuristic or blanket rename

Verified against current OpenAI + Azure + local-server behavior:

- **Backward-compatible on cloud** — `max_completion_tokens` is accepted by gpt-4o / gpt-4-turbo / gpt-3.5 too, and *required* by GPT-5 / o-series. So on cloud the rename is always safe.
- **Azure deployment-ids are opaque** — they're operator-named, so a `is-this-gpt-5?` regex can't reliably detect a GPT-5 deployment (and Azure auto-upgrade can even run GPT-5.x under a `gpt-4o` name). A name heuristic is unreliable exactly where it matters.
- **Local OpenAI-compatible servers vary** — vLLM `< 0.6.4` **hard-rejects** the unknown field (400); LM Studio / Ollama / TGI **silently drop** it (truncating output, no error). A blanket rename in the shared builder would break or silently degrade Tier-1 local inference. Defaulting off keeps them working; operators opt in only for their cloud GPT-5/o-series providers.

Set `use_max_completion_tokens: true` on a provider entry to enable it.

## Caveat (documented on the config field)

`max_completion_tokens` caps **reasoning + visible output combined**, and reasoning is spent first — so flipping the flag must be paired with a generous budget on reasoning models, or the response can come back empty with `finish_reason: "length"`. Not a 1:1 copy of the old `max_tokens` value.

## Tests

`gateway/tests/test_max_completion_tokens.py` — the rename/drop behavior, the default-off path, the no-`max_tokens` case, and that both adapters read the flag from `ProviderConfig`.

## Composes with the example config

The GPT-5 example providers in #156 set this flag, so the modernized example config works out of the box once both land. This PR is code-only; #156 is the example config — different files, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
