### PR TITLE
WS1/PR1: gateway tool-provider egress boundary + ADRs 0014/0015 (legal-research + MCP milestone)

### DIFF
--- a/api/alembic/versions/0048_tool_egress_log.py
+++ b/api/alembic/versions/0048_tool_egress_log.py
@@ -1,0 +1,67 @@
+"""tool_egress_log — per-call audit of third-party tool/data-source egress
+
+One row per outbound tool-provider call through the gateway (ADR 0014 D3).
+Mirrors ``inference_routing_log``: gateway-written, raw SQL, counts/types
+only — NEVER raw payloads. Distinct table because egress has a different
+access pattern and retention from inference routing.
+
+Revision ID: 0048
+Revises: 0047
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0048"
+down_revision = "0047"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tool_egress_log",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("request_id", sa.String(), nullable=True),
+        sa.Column("provider", sa.String(), nullable=False),
+        sa.Column("tool", sa.String(), nullable=False),
+        sa.Column("tier", sa.Integer(), nullable=False),
+        sa.Column("bytes_out", sa.Integer(), nullable=True),
+        sa.Column("bytes_in", sa.Integer(), nullable=True),
+        sa.Column(
+            "anonymization_applied",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "refused",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("refusal_reason", sa.String(), nullable=True),
+        sa.CheckConstraint("tier BETWEEN 1 AND 5", name="chk_tool_egress_log_tier_range"),
+    )
+    op.create_index("ix_tool_egress_log_provider", "tool_egress_log", ["provider"])
+    op.create_index("ix_tool_egress_log_timestamp", "tool_egress_log", ["timestamp"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tool_egress_log_timestamp", table_name="tool_egress_log")
+    op.drop_index("ix_tool_egress_log_provider", table_name="tool_egress_log")
+    op.drop_table("tool_egress_log")

--- a/api/alembic/versions/0048_tool_egress_log.py
+++ b/api/alembic/versions/0048_tool_egress_log.py
@@ -55,7 +55,7 @@ def upgrade() -> None:
             server_default=sa.text("false"),
         ),
         sa.Column("refusal_reason", sa.String(), nullable=True),
-        sa.CheckConstraint("tier BETWEEN 1 AND 5", name="chk_tool_egress_log_tier_range"),
+        sa.CheckConstraint("tier BETWEEN 0 AND 5", name="chk_tool_egress_log_tier_range"),
     )
     op.create_index("ix_tool_egress_log_provider", "tool_egress_log", ["provider"])
     op.create_index("ix_tool_egress_log_timestamp", "tool_egress_log", ["timestamp"])

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -32,6 +32,7 @@ from app.models.project_knowledge_base import ProjectKnowledgeBase
 from app.models.saved_prompt import SavedPrompt
 from app.models.slack_workspace import SlackWorkspace
 from app.models.tabular import TabularExecution
+from app.models.tool_egress import ToolEgressLog
 from app.models.team import Team, TeamMember
 from app.models.teams_tenant import TeamsTenant
 from app.models.user import User, UserSession
@@ -67,6 +68,7 @@ __all__ = [
     "SavedPrompt",
     "SlackWorkspace",
     "TabularExecution",
+    "ToolEgressLog",
     "Team",
     "TeamMember",
     "TeamsTenant",

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -32,9 +32,9 @@ from app.models.project_knowledge_base import ProjectKnowledgeBase
 from app.models.saved_prompt import SavedPrompt
 from app.models.slack_workspace import SlackWorkspace
 from app.models.tabular import TabularExecution
-from app.models.tool_egress import ToolEgressLog
 from app.models.team import Team, TeamMember
 from app.models.teams_tenant import TeamsTenant
+from app.models.tool_egress import ToolEgressLog
 from app.models.user import User, UserSession
 from app.models.user_export import UserExportJob
 from app.models.user_skill import UserSkill
@@ -68,10 +68,10 @@ __all__ = [
     "SavedPrompt",
     "SlackWorkspace",
     "TabularExecution",
-    "ToolEgressLog",
     "Team",
     "TeamMember",
     "TeamsTenant",
+    "ToolEgressLog",
     "User",
     "UserExportJob",
     "UserSession",

--- a/api/app/models/tool_egress.py
+++ b/api/app/models/tool_egress.py
@@ -1,0 +1,50 @@
+"""Tool egress log — per docs/db-schema.md §`tool_egress_log`.
+
+One row per outbound tool/data-source call through the gateway (ADR 0014
+D3). Distinct from `inference_routing_log` (different egress, retention)
+and from `audit_log` (hot path, counts-only). Gateway-written via raw SQL
+(`gateway/app/tool_egress_log.py`, a later task); this ORM model backs
+api-side reads.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, CheckConstraint, DateTime, Integer, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ToolEgressLog(Base):
+    __tablename__ = "tool_egress_log"
+    __table_args__ = (
+        CheckConstraint("tier BETWEEN 1 AND 5", name="chk_tool_egress_log_tier_range"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    request_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    tool: Mapped[str] = mapped_column(String, nullable=False)
+    tier: Mapped[int] = mapped_column(Integer, nullable=False)
+    bytes_out: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    bytes_in: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    anonymization_applied: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    refused: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    refusal_reason: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<ToolEgressLog id={self.id} provider={self.provider} "
+            f"tool={self.tool} tier={self.tier} refused={self.refused}>"
+        )

--- a/api/app/models/tool_egress.py
+++ b/api/app/models/tool_egress.py
@@ -22,7 +22,7 @@ from app.db.base import Base
 class ToolEgressLog(Base):
     __tablename__ = "tool_egress_log"
     __table_args__ = (
-        CheckConstraint("tier BETWEEN 1 AND 5", name="chk_tool_egress_log_tier_range"),
+        CheckConstraint("tier BETWEEN 0 AND 5", name="chk_tool_egress_log_tier_range"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/api/tests/test_tool_egress_log_model.py
+++ b/api/tests/test_tool_egress_log_model.py
@@ -18,8 +18,11 @@ async def test_tool_egress_log_allows_tier_zero_for_unresolved_provider(db_sessi
     """tier=0 (unknown-provider refusal) must persist — the prod writer
     relies on this so unresolved-provider refusals are actually audited."""
     row = ToolEgressLog(
-        provider="missing", tool="echo", tier=0,
-        refused=True, refusal_reason="unknown tool provider",
+        provider="missing",
+        tool="echo",
+        tier=0,
+        refused=True,
+        refusal_reason="unknown tool provider",
     )
     db_session.add(row)
     await db_session.flush()

--- a/api/tests/test_tool_egress_log_model.py
+++ b/api/tests/test_tool_egress_log_model.py
@@ -14,6 +14,19 @@ import uuid
 from app.models.tool_egress import ToolEgressLog
 
 
+async def test_tool_egress_log_allows_tier_zero_for_unresolved_provider(db_session) -> None:
+    """tier=0 (unknown-provider refusal) must persist — the prod writer
+    relies on this so unresolved-provider refusals are actually audited."""
+    row = ToolEgressLog(
+        provider="missing", tool="echo", tier=0,
+        refused=True, refusal_reason="unknown tool provider",
+    )
+    db_session.add(row)
+    await db_session.flush()
+    assert row.tier == 0
+    assert row.refused is True
+
+
 async def test_tool_egress_log_row_roundtrips(db_session) -> None:
     """A tool_egress_log row persists and reads back with its core fields."""
     row = ToolEgressLog(

--- a/api/tests/test_tool_egress_log_model.py
+++ b/api/tests/test_tool_egress_log_model.py
@@ -1,0 +1,33 @@
+"""Model + migration test for tool_egress_log — ADR 0014 D3.
+
+Verifies that a ``tool_egress_log`` row persists and reads back with
+its core fields intact after the 0048 migration runs.
+
+Tests run against the same SAVEPOINT-rolled-back per-test session as
+the rest of the API tests (per ``tests/conftest.py``).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.models.tool_egress import ToolEgressLog
+
+
+async def test_tool_egress_log_row_roundtrips(db_session) -> None:
+    """A tool_egress_log row persists and reads back with its core fields."""
+    row = ToolEgressLog(
+        request_id="req_abc",
+        provider="echo-test",
+        tool="echo",
+        tier=4,
+        bytes_out=12,
+        bytes_in=12,
+        refused=False,
+        anonymization_applied=False,
+    )
+    db_session.add(row)
+    await db_session.flush()
+    assert isinstance(row.id, uuid.UUID)
+    assert row.refused is False
+    assert row.tier == 4

--- a/docs/adr/0014-gateway-egress-boundary-for-tool-providers.md
+++ b/docs/adr/0014-gateway-egress-boundary-for-tool-providers.md
@@ -1,0 +1,80 @@
+# ADR 0014 — Gateway egress boundary for tool / data-source providers
+
+**Status:** Proposed
+**Date:** 2026-06-16
+**Owner:** Legal-research + MCP milestone kickoff (feature branch `feat/legal-research-mcp-plan`)
+
+## Context
+
+[PRD §3.6 Research](../PRD.md#36-research) commits real-time legal-information retrieval (CourtListener first) with full Citation-Engine fidelity, and [§8.5 / DE-200](../PRD.md#de-200) commits an MCP-client subsystem. Both want LQ.AI to make **outbound calls to third-party tool/data endpoints** — something the platform does not do today. The only egress the platform performs now is **inference**, and that egress is funnelled through a single audited boundary: the Inference Gateway ([§1.8 security posture](../PRD.md#18-security-posture), [`docs/security/boundary-registers.md`](../security/boundary-registers.md)). The gateway is the only component holding privileged provider credentials and the only place tier-routing, anonymization, and the egress audit log (`inference_routing_log`, `api/app/models/inference.py`) attach.
+
+The closest public prior art — [MikeOSS](https://github.com/willchen96/mike) — implements CourtListener and MCP by **egressing directly from the backend**, with per-user connectors and SSRF guards (`guardedFetch`, `validateRemoteMcpUrl`) bolted onto the backend process. That style contradicts three LQ.AI postures: gateway-as-sole-egress, operator-controlled credentials, and one audited boundary. We want parity on *capability*, not on *implementation style*.
+
+This ADR pins **where third-party tool/data egress lives**. It is load-bearing for the legal-research mini-PRD ([`docs/proposals/legal-research-and-mcp.md`](../proposals/legal-research-and-mcp.md)) WS1, WS2, and WS3, and is the decision record gateway security review (`.github/CODEOWNERS` → `gateway/**`) will check the implementation against.
+
+## Decision drivers
+
+1. **One audited egress boundary, not two.** Adding a second place that holds third-party credentials and makes outbound calls doubles the security-review surface and the audit-gap risk. Whatever we build should extend the existing boundary, not stand up a rival.
+2. **Reuse the gateway primitives that already exist.** The gateway has a provider adapter abstraction (`ProviderAdapter`, `gateway/app/providers/base.py`), a router with tier derivation and fallback (`gateway/app/router.py`), config-driven provider declaration (`gateway.yaml` / `gateway.yaml.example`), and Fernet key management (ADR 0011, runtime provider-keys API #128). A tool-provider class should slot into these, not reinvent them.
+3. **SSRF / allowlist control is a boundary primitive, not per-call glue.** MikeOSS proves you need HTTPS-required, DNS private-address blocking, host allowlist, no `Host` override, and header validation. Those controls belong in one place that every outbound tool call passes through.
+4. **Egress must be auditable in the same shape as inference.** An operator deploying this in a privileged environment needs one log answering "what data left, to whom, at what tier, and what was refused" — mirroring `inference_routing_log`, never logging raw payloads.
+5. **Anonymization policy must be decidable for tool-call payloads.** Tool arguments (`find_in_case` keywords, `verify_citations` strings) can carry matter context; returned opinion text is public and must stay verbatim for citation grounding. The boundary is where that policy is enforced (see O1).
+
+## Considered alternatives
+
+### A. A new "tool provider" class inside the gateway — **chosen**
+
+Introduce a **tool provider** (a.k.a. data-source provider) as a first-class gateway concept *distinct from* inference providers but reusing the same machinery. Declared in `gateway.yaml` under a new `tool_providers:` block; routed, tier-tagged, SSRF/allowlist-guarded, and audited by the gateway. The backend never calls a third-party tool endpoint directly — it asks the gateway, exactly as it asks for inference.
+
+- **Cost:** a new provider subpackage (`gateway/app/providers/tool/`), a router path for non-inference egress, a new `tool_egress_log` table, and `gateway.yaml` schema additions. Real engineering, security-reviewed.
+- **Why it wins:** every primitive the boundary needs already exists in the gateway and nowhere else. CourtListener becomes the first concrete `type`; each MCP server becomes another. SSRF/allowlist/tier/audit are written once and inherited by every future source (GovInfo, EUR-Lex, SEC EDGAR — DE-280/281). The backend's posture is unchanged: it holds no third-party credentials and makes no third-party calls.
+
+### B. A separate egress-broker service
+
+A dedicated third service (besides `api/` and `gateway/`) that brokers all third-party tool egress.
+
+- **Rejected:** a whole new subsystem — its own deploy unit, auth surface, config, SBOM, and operational story — to do what the gateway is already architected to do. It would *also* need the gateway's tier/anonymization context to make egress decisions, so it would either duplicate that context or call back into the gateway. No capability we lack justifies the second service.
+
+### C. Backend-direct egress with per-call guards (the MikeOSS shape)
+
+The backend calls CourtListener / MCP servers directly, with `guardedFetch`-style SSRF guards inline.
+
+- **Rejected:** breaks the single-boundary posture outright. It puts third-party credentials in the backend (operator-credential-control violation), creates a second un-audited egress path, and scatters SSRF logic across call sites instead of centralizing it. This is exactly the implementation style §1.8 exists to prevent. Named to reject it explicitly, because it is the obvious path and the wrong one.
+
+## Decision
+
+### D1. Tool providers are a new gateway provider class — chosen alternative A
+
+A `tool_providers:` block in `gateway.yaml` declares each source: `name`, `type` (e.g. `courtlistener`, `mcp`), `base_url`, credential reference (`api_key_env` / `api_key_encrypted` / runtime — same three paths as inference providers per ADR 0011 + #128), `tier`, and an allowlist/SSRF policy. A `ToolProviderAdapter` base (sibling to `ProviderAdapter`, NOT a subclass — it exposes `invoke_tool(...)`, not `chat_completion(...)`) lives in `gateway/app/providers/tool/`. The router gains a tool-egress path alongside the inference path; alias/tier-derivation logic is reused where it applies.
+
+> **Note on rate limiting.** The gateway's `RateLimitsConfig` (`gateway/app/config.py`) loads but its **enforcement middleware is not yet wired** (deferred to the gateway's "Phase E"). This ADR does NOT depend on that middleware. Tool-provider rate limiting in v1 is **per-provider, enforced at the tool-provider adapter** (a token-bucket/leaky-bucket the adapter owns), so it ships independently of the global enforcement work. If/when global enforcement lands, the tool-provider limits fold into it. The mini-PRD WS1 must not claim it "reuses" rate-limit enforcement that does not exist.
+
+### D2. SSRF + allowlist controls are a gateway egress primitive
+
+A single guarded-egress helper in the gateway enforces, for every outbound tool call: HTTPS required; DNS resolution checked against private/link-local/loopback ranges (block); host allowlist (per-provider, from config); no caller-supplied `Host` override; outbound header validation. This is the gateway-native equivalent of MikeOSS's `validateRemoteMcpUrl` / `guardedFetch`, written once. No tool-provider adapter may make a raw outbound request that bypasses it.
+
+### D3. Egress audit log: `tool_egress_log`, mirroring `inference_routing_log`
+
+A new table records, per outbound tool call: `timestamp`, `provider`, `tool`, `request_id`, `tier`, `bytes_out` / `bytes_in` (or row counts), `refused` + `refusal_reason`, `anonymization_applied`. **Never raw payloads** — counts and types only, the same guarantee `inference_routing_log` and the OTel anonymization-span contract (ADR 0013 D6) give. This is the operator's single "what data left" view for third-party egress.
+
+### D4. Egress tiering: a tool provider declares a data-egress tier
+
+Each tool provider declares a **data-egress tier** so the gateway can refuse a call whose payload sensitivity exceeds the matter/skill minimum (the inverse of the inference tier-floor: inference floors on *where the model runs*; egress ceilings on *where matter data may travel*). The tier also makes the anonymization decision (D5 / O1) decidable per provider. Concrete tier semantics for egress are pinned in the implementation plan; the *mechanism* (declared tier + gateway refusal + audit row) is fixed here.
+
+### D5. Anonymization applies to outbound tool-call payloads by default (resolves O1)
+
+Outbound tool-call arguments are anonymized by default through the existing M2 anonymization layer, exactly as inference request payloads are. **Inbound** fetched opinion / case text is marked `skip_anonymization` (it is public data, and citation grounding requires verbatim text) — mirroring the existing retrieval-context handling where retrieved chunks carry `lq_ai_skip_anonymization`. Rehydration of returned text into citations follows the same path as document citations. This default can be overridden per provider only with an explicit, audited config flag.
+
+## Open questions (for the implementation plan / contributor)
+
+1. **O2 — object-storage layout for cached opinions.** Reuse the `api/app/storage.py` MinIO/S3 abstraction (ADR 0005 sibling); confirm a key scheme (`courtlistener/opinions/by-cluster/{cluster_id}/...`) and retention policy in the WS3 plan.
+2. **Streaming vs. request/response for tool egress.** Inference egress streams (SSE); tool egress is mostly request/response with occasional large bodies (opinion text). Confirm the adapter interface is request/response with a streamed-download escape hatch for large inbound bodies, pinned in WS1.
+3. **Where the tool-result-to-citation handoff crosses the boundary.** Returned opinion text must reach the citation engine (`api/app/citation/`) with provenance intact; confirm whether the gateway returns structured provenance the backend persists, or the backend re-derives it. Pin in WS3/WS5.
+
+## Cross-references
+
+- PRD [§1.8](../PRD.md#18-security-posture), [§3.6](../PRD.md#36-research), [§4](../PRD.md#4-the-lq-ai-inference-gateway), [§4.7 anonymization](../PRD.md#47-anonymization-layer), [§8.5 / DE-200](../PRD.md#de-200), [DE-279/280/281](../PRD.md#de-279).
+- [ADR 0011](0011-transparency-first-model-selection.md) (provider credential paths this reuses), [ADR 0005](0005-document-pipeline-architecture.md) sibling (storage), [ADR 0013](0013-autonomous-layer-design-influences.md) (the audit/OTel-counts-only guarantee this extends), [ADR 0015](0015-governed-tool-calling-model.md) (the consumer of this boundary — how tool calls are *invoked* and *governed*).
+- [`docs/security/boundary-registers.md`](../security/boundary-registers.md) (the egress boundary is a new register entry).
+- Mini-PRD: [`docs/proposals/legal-research-and-mcp.md`](../proposals/legal-research-and-mcp.md) (WS1 discharges this ADR).
+- Reference (shapes, not implementation): [MikeOSS](https://github.com/willchen96/mike) `validateRemoteMcpUrl` / `guardedFetch`.

--- a/docs/adr/0015-governed-tool-calling-model.md
+++ b/docs/adr/0015-governed-tool-calling-model.md
@@ -1,0 +1,86 @@
+# ADR 0015 — Governed tool-calling model (closed-intent posture extended, not abandoned)
+
+**Status:** Proposed
+**Date:** 2026-06-16
+**Owner:** Legal-research + MCP milestone kickoff (feature branch `feat/legal-research-mcp-plan`)
+
+## Context
+
+Bringing CourtListener and MCP to LQ.AI means, for the first time, **letting the model call tools** — both in interactive chat and in the autonomous layer. The closest prior art, [MikeOSS](https://github.com/willchen96/mike), gives the model an **open, per-user function-calling surface** that egresses directly from the backend. That is the single most consequential divergence from LQ.AI's posture, which is built on **bounded, closed-set tool intents**: the autonomous layer already enforces a closed `ToolIntent` enum gated by `PHASE_GRANTS` and the R5→R6→R4 brakes (`api/app/autonomous/enums.py`, `api/app/autonomous/guard.py`, [ADR 0013](0013-autonomous-layer-design-influences.md)).
+
+The question this ADR pins: **how does the model invoke research / MCP tools, and how is each invocation governed**, in a way that delivers interactive-research parity *without* abandoning the closed-set posture. It is the companion to [ADR 0014](0014-gateway-egress-boundary-for-tool-providers.md) (which pins *where egress lives*); this ADR pins *how a tool call is decided, authorized, audited, and surfaced*. It is load-bearing for mini-PRD WS4 and WS5.
+
+A correctness note carried from the verification pass: the autonomous brakes execute **R5 (temporal/halt) → R6 (contextual/phase-grant) → R4 (economic/cost)**, in that order. Earlier proposal text said "R4/R5/R6"; the governed loop here adopts the brakes in their real execution order.
+
+## Decision drivers
+
+1. **Interactive research needs a real tool-calling loop.** Citation verification, case lookup, and "find in this opinion" are inherently multi-step and model-driven within a turn. A pure closed-intent batch call is too weak for the interactive parity target.
+2. **The closed-set posture is the product, not overhead.** Transparency and governability come from the operator knowing *exactly* which tools the model may call. An open function-calling surface forfeits that.
+3. **Chat and the autonomous layer should share one governed substrate.** The autonomous layer already has brakes + audit + closed intents. Re-deriving a parallel governance path for chat would fork the posture and double the security surface.
+4. **Destructive tools need a human gate.** MCP tools carry `read_only` / `destructive` / `requires_confirmation` metadata. A destructive tool must never fire un-approved in chat, and must never be auto-granted to the autonomous layer in v1.
+5. **Every tool call must be auditable and inspectable.** The transparency differentiator (§1.3) applied to tool use: which tool, which provider, which tier, the result provenance, an audit row, and a UI provenance pill.
+
+## Considered alternatives
+
+### A. Governed hybrid loop on an operator-enabled allowlist — **chosen**
+
+A gateway-mediated function-calling loop for chat, **restricted to an operator-enabled allowlist** of research + enabled MCP tools (not open function-calling). Each proposed call is, per invocation: tier-checked, audited (`tool_call_log`), cost-accounted, and **confirmation-gated** when the tool is `destructive`. The *same* tools are exposed to the autonomous layer as **new bounded `ToolIntent`s** (`retrieve_caselaw`, `call_mcp_tool`) under the existing `PHASE_GRANTS` + R5→R6→R4 brakes.
+
+- **Cost:** a chat tool-loop module, a `tool_call_log` table, two new `ToolIntent` members + phase-grant wiring, and confirmation-gate plumbing through to the UI.
+- **Why it wins:** it gives interactive research the loop it needs while keeping the surface closed — the allowlist *is* the closed set, just operator-configured rather than hard-coded. Chat and autonomous share one governance substrate (the brakes/audit/closed-intent machinery already exists and is proven). The model picks *among* allowed tools; it cannot reach beyond them.
+
+### B. Closed-intents-only (no interactive loop)
+
+Expose research only as fixed, single-shot intents (the existing autonomous pattern), no in-turn model-driven loop.
+
+- **Rejected:** too weak for the interactive parity target. "Verify these citations, then read the cluster the model found, then search within it" is a loop; flattening it to one batched intent either over-fetches or fails the use case. Keeps the posture but misses the capability.
+
+### C. Open model-driven function-calling (the MikeOSS shape)
+
+Let the model call any discovered tool, backend-direct.
+
+- **Rejected:** abandons the closed-set posture that is the product's governance story. No operator allowlist, no per-call tier ceiling, an un-bounded egress surface. This is the divergence §1.8 and ADR 0013's closed `ToolIntent` enum exist to prevent. Named to reject it explicitly.
+
+## Decision
+
+### D1. Chat tool-calling is a gateway-mediated loop over an operator allowlist — chosen alternative A
+
+The chat send path (`api/app/api/chats.py`) gains a tool-calling loop: the gateway exposes the **operator-enabled allowlist** of tools to the model; the model proposes a call; the backend governs and executes it via the ADR 0014 egress boundary; the result is fed back; the loop continues until the model emits a final answer or a per-turn tool-call cap is hit. The allowlist is operator-configured (research tools when CourtListener is enabled; MCP tools per `mcp.yaml` + per-tool enable/disable). The model may only call tools on the allowlist — there is no open function-calling.
+
+### D2. Per-call governance: tier check, audit, cost, confirmation
+
+Every proposed tool call passes, before execution:
+- **Tier check** — the tool provider's data-egress tier (ADR 0014 D4) vs. the matter/skill minimum; refuse + audit if exceeded.
+- **`tool_call_log` audit row** — tool, provider, tier, request_id, outcome, cost; counts/types only, never raw payloads.
+- **Cost accounting** — folded into the same estimator the inference path and autonomous R4 brake use.
+- **Confirmation gate** — if the tool is `destructive` (or `requires_confirmation`), the model *proposes* the call, the loop pauses, the user approves, then it executes. `read_only` tools execute without a gate.
+
+### D3. Two new bounded `ToolIntent`s for the autonomous layer
+
+`retrieve_caselaw` and `call_mcp_tool` are added to `ToolIntent` (`api/app/autonomous/enums.py`) and to `PHASE_GRANTS`:
+- `retrieve_caselaw` → granted in the `analysis` phase (alongside `retrieve_chunks`), conservative elsewhere.
+- `call_mcp_tool` → granted **per-phase, conservative default** (most phases: not granted), and only for tools the operator has enabled.
+
+Both are enforced by the existing `guarded_tool_call` R5→R6→R4 brakes — no new brake machinery. The autonomous layer reuses the *same* allowlist and the *same* egress boundary as chat; the only difference is the additional R-class restraint envelope.
+
+### D4. Destructive / confirmation-required tools are never auto-granted to the autonomous layer in v1
+
+A tool whose metadata is `destructive` or `requires_confirmation` is **excluded from `PHASE_GRANTS` in all phases** for the autonomous layer in v1. The autonomous layer cannot fire a human-gated tool without a human, and v1 does not build an async approval channel for autonomous sessions (defer to a DE if demanded). Interactive chat (D2) is the only place a destructive tool can fire, and only behind the confirmation gate.
+
+### D5. Tool use is transparent by construction
+
+Mirroring ADR 0013 D6: every tool call emits an OTel span (`chat.tool_call` / `autonomous.tool_call`, attributes = tool/provider/tier/outcome/cost, counts and types only), writes a `tool_call_log` row, and surfaces in the UI as a **provenance pill** (which tool, which provider, which tier). Case-law answers additionally carry external-source citation provenance (ADR 0014 D5 + the citation engine), so a research answer is reproducible, not a bare chat bubble. A skill that uses tools **declares** that usage and its `minimum_inference_tier` in SKILL.md frontmatter — note that frontmatter is authored today but **not yet parsed/validated in code**, so WS5 must build the parser before the declaration is load-bearing.
+
+## Open questions (for the implementation plan / contributor)
+
+1. **Per-turn tool-call cap.** What is the default cap on tool calls per chat turn (cost + latency bound)? Pin in WS4 (a small integer, operator-overridable).
+2. **Confirmation-gate transport.** How does the pause/approve round-trip render over the existing SSE chat stream — a special event the UI renders as an approve/deny prompt, resuming the loop on POST? Pin the event shape in WS4 alongside the chat-stream contract.
+3. **Allowlist source of truth.** Research tools key off CourtListener-enabled; MCP tools off `mcp.yaml` + per-tool enable/disable. Confirm whether the allowlist is assembled in the backend or surfaced by the gateway; likely backend-assembled, gateway-enforced. Pin in WS2/WS4.
+
+## Cross-references
+
+- [ADR 0014](0014-gateway-egress-boundary-for-tool-providers.md) (the egress boundary this loop invokes), [ADR 0013](0013-autonomous-layer-design-influences.md) (the closed `ToolIntent` enum, `PHASE_GRANTS`, and R5→R6→R4 brakes this extends).
+- PRD [§1.8 security posture](../PRD.md#18-security-posture), [§3.6 research](../PRD.md#36-research), [§3.10 autonomous layer](../PRD.md#310-autonomous-layer-m4), [§8.5 / DE-200](../PRD.md#de-200).
+- [`docs/security/boundary-registers.md`](../security/boundary-registers.md) (R4/R5/R6).
+- Mini-PRD: [`docs/proposals/legal-research-and-mcp.md`](../proposals/legal-research-and-mcp.md) (WS4 + WS5 discharge this ADR).
+- Reference (the divergence we reject): [MikeOSS](https://github.com/willchen96/mike) open per-user function-calling.

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1124,6 +1124,31 @@ CREATE INDEX idx_inference_log_refused ON inference_routing_log(timestamp DESC) 
 
 ---
 
+### `tool_egress_log`
+
+Gateway-written (ADR 0014 D3); counts/types only, never raw payloads. One row per outbound tool/data-source call through the gateway. Distinct from `inference_routing_log` (different access pattern and retention) and from `audit_log` (hot path, per-call counts only).
+
+| Column                  | Type        | Nullable | Default              | Notes                                             |
+|-------------------------|-------------|----------|----------------------|---------------------------------------------------|
+| `id`                    | UUID        | NO       | `gen_random_uuid()`  | Primary key                                       |
+| `timestamp`             | TIMESTAMPTZ | NO       | `now()`              | When the call was made                            |
+| `request_id`            | TEXT        | YES      |                      | Correlates with gateway request span              |
+| `provider`              | TEXT        | NO       |                      | Tool provider name (e.g. `courtlistener`)         |
+| `tool`                  | TEXT        | NO       |                      | Tool/endpoint called (e.g. `search_opinions`)     |
+| `tier`                  | INTEGER     | NO       |                      | Inference tier (1–5); CHECK enforced              |
+| `bytes_out`             | INTEGER     | YES      |                      | Bytes sent to provider                            |
+| `bytes_in`              | INTEGER     | YES      |                      | Bytes received from provider                      |
+| `anonymization_applied` | BOOLEAN     | NO       | `false`              | Whether PII anonymization ran before egress       |
+| `refused`               | BOOLEAN     | NO       | `false`              | Whether the call was refused by the gateway       |
+| `refusal_reason`        | TEXT        | YES      |                      | E.g. `tier_below_minimum`, `provider_unavailable` |
+
+```sql
+CREATE INDEX ix_tool_egress_log_provider  ON tool_egress_log(provider);
+CREATE INDEX ix_tool_egress_log_timestamp ON tool_egress_log(timestamp);
+```
+
+---
+
 ## Playbooks (per [PRD §3.7](PRD.md#37-playbooks), M3-A1)
 
 Substrate for the Playbook engine landing in M3. A playbook codifies an

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1135,7 +1135,7 @@ Gateway-written (ADR 0014 D3); counts/types only, never raw payloads. One row pe
 | `request_id`            | TEXT        | YES      |                      | Correlates with gateway request span              |
 | `provider`              | TEXT        | NO       |                      | Tool provider name (e.g. `courtlistener`)         |
 | `tool`                  | TEXT        | NO       |                      | Tool/endpoint called (e.g. `search_opinions`)     |
-| `tier`                  | INTEGER     | NO       |                      | Inference tier (1–5); CHECK enforced              |
+| `tier`                  | INTEGER     | NO       |                      | Egress tier: `0` = no provider resolved (pre-resolution refusal); `1`–`5` = egress tier; CHECK enforced |
 | `bytes_out`             | INTEGER     | YES      |                      | Bytes sent to provider                            |
 | `bytes_in`              | INTEGER     | YES      |                      | Bytes received from provider                      |
 | `anonymization_applied` | BOOLEAN     | NO       | `false`              | Whether PII anonymization ran before egress       |

--- a/docs/proposals/legal-research-and-mcp.md
+++ b/docs/proposals/legal-research-and-mcp.md
@@ -1,0 +1,222 @@
+# Mini-PRD: Legal Research Sources + MCP Client — gateway-brokered, governed, operator-controlled
+
+> **Status:** Architecture pinned — decisions promoted to [ADR 0014](../adr/0014-gateway-egress-boundary-for-tool-providers.md) (egress boundary) and [ADR 0015](../adr/0015-governed-tool-calling-model.md) (governed tool-calling). Open for contribution.
+> **Effort:** L (a milestone, split into ~6 PRs across two architectural cores and two features).
+> **Contributor profile:** Backend engineer comfortable in the `gateway/` security boundary and `api/` (FastAPI + httpx + LangGraph). MCP familiarity helpful. The two ADR-level pieces want a contributor who has read [PRD §1.8](../PRD.md#18-security-posture) and the autonomous-layer ADR ([0013](../adr/0013-autonomous-layer-design-influences.md)).
+> **Mentor:** Maintainer (via PR review); security review required (`gateway/**`).
+
+## What this is
+
+Bring **case-law research** (CourtListener) and an **MCP client** to LQ.AI with feature parity to the work product a lawyer gets in [MikeOSS](https://github.com/willchen96/mike) — but re-seated on LQ.AI's boundaries rather than copied in MikeOSS's implementation style.
+
+Both capabilities already have committed-but-deferred slots:
+
+- **MCP client** — [DE-200](../PRD.md#de-200) / [PRD §8.5](../PRD.md#85-mcp-client-subsystem). Today only a stub exists (`web/backend/open_webui/utils/mcp/client.py`), not wired into the FastAPI backend.
+- **Legal research sources** — [PRD §3.6 Research](../PRD.md#36-research) and [DE-279–281](../PRD.md#de-279). No routes, migrations, or handlers exist yet.
+
+This mini-PRD frames them as one coherent work package because they share the same three new substrates: a gateway egress class, a governed tool-calling loop, and external-source citation provenance.
+
+## The parity target (what MikeOSS ships)
+
+Both features landed in MikeOSS in early–mid June 2026.
+
+**CourtListener** (`backend/src/lib/courtlistener.ts`, `lib/legalSourcesTools/courtlistenerTools.ts`) — five model-callable tools:
+
+| Tool | Purpose |
+|---|---|
+| `courtlistener_verify_citations` | Reporter citations (`467 U.S. 837`) → cluster IDs + metadata |
+| `courtlistener_search_case_law` | Full-text discovery (counts only) |
+| `courtlistener_get_cases` | Fetch/cache cluster metadata + opinions by cluster ID |
+| `courtlistener_find_in_case` | Keyword search within a fetched opinion (≤3/turn) |
+| `courtlistener_read_case` | Read selected opinion text from a fetched cluster |
+
+Optional **bulk-data caching** (opinions in object storage under `courtlistener/opinions/by-cluster/`, metadata in the DB) with live-API fallback; per-turn cluster cache; feature-flagged system-prompt splice; SSE events driving a UI case-law panel; configured via `COURTLISTENER_API_TOKEN`.
+
+**MCP client** (`backend/src/lib/mcp/*`, `lib/mcpConnectors.ts`):
+
+- Transport: **`streamable_http` only** (no stdio)
+- **Per-user** connectors in the DB, auth config encrypted (`aes-256-gcm`)
+- Auth: `none | bearer | oauth` (full OAuth callback flow, encrypted token rows)
+- Tool discovery + cache, per-tool enable/disable, metadata flags `readOnly`/`destructive`/`requiresConfirmation`
+- SSRF hardening: HTTPS-required, DNS private-address blocking, `guardedFetch`, header validation, no `Host` override
+- Tools surfaced to the model `mcp_`-prefixed; `executeMcpToolCall()` routes invocations
+
+The defining architectural fact: **MikeOSS gives the model an open, per-user function-calling surface that egresses directly from the backend.** That implementation style contradicts three LQ.AI postures — gateway-as-sole-egress, closed bounded tool intents, and operator-controlled credentials. Parity on *capability* is the goal; parity on *implementation* is explicitly not.
+
+## Decisions (pinned with the maintainer → ADRs)
+
+These three forks were put to the maintainer with recommendations and confirmed; they are now promoted to ADRs.
+
+1. **Egress boundary → extend the gateway.** ([ADR 0014](../adr/0014-gateway-egress-boundary-for-tool-providers.md)) CourtListener and every MCP server become a new gateway **"tool provider" / data-source** class alongside inference providers — configured in `gateway.yaml`, tier-tagged, rate-limited (per-provider, at the adapter — see correction C3), SSRF/allowlist-guarded, and written to a `tool_egress_log`. The gateway remains the single audited boundary; the backend never calls a third-party tool endpoint directly. *(Rejected: a separate broker service; backend-direct + guards.)*
+
+2. **Chat tool-calling → governed hybrid loop.** ([ADR 0015](../adr/0015-governed-tool-calling-model.md)) A gateway-mediated function-calling loop restricted to an **operator-enabled allowlist** of research/MCP tools. Every call is tier-checked, audited (new `tool_call_log`), confirmation-gated when a tool is `destructive`, and rendered with provenance pills. The *same* tools are exposed to the [autonomous layer](../adr/0013-autonomous-layer-design-influences.md) as new bounded `ToolIntent`s (`retrieve_caselaw`, `call_mcp_tool`) under the existing `PHASE_GRANTS` + R5→R6→R4 brakes. *(Rejected: closed-intents-only; open function-calling.)*
+
+3. **Connector ownership → operator-allowlisted.** MCP servers are declared in an operator-controlled `mcp.yaml` (mirroring `gateway.yaml.example`), with per-user OAuth **only** where a server needs user identity. Egress destinations stay under operator control and auditable. *(Rejected: per-user connectors; both.)*
+
+## Code-grounded corrections (verified 2026-06-16 against `main`)
+
+The original proposal was checked against the codebase before this plan. Five findings change the work:
+
+- **C1 — Research is PRD §3.6, not §3.8.** §3.8 is "Multi-Model Ensemble Verification" (the citation engine's final stage). All research references point to §3.6. (Corrected throughout this doc.)
+- **C2 — Brake order is R5→R6→R4** (temporal/halt → contextual/phase-grant → economic/cost), not "R4/R5/R6." `guarded_tool_call` (`api/app/autonomous/guard.py`) checks halt first. WS4 wording follows the real order.
+- **C3 — Gateway rate-limit *enforcement* is not wired.** `RateLimitsConfig` (`gateway/app/config.py`) loads, but enforcement middleware is deferred to the gateway's "Phase E." WS1 does **not** reuse rate-limit enforcement — it ships **per-provider rate limiting at the tool-provider adapter**, independent of the unbuilt global middleware.
+- **C4 — No "source-kind" abstraction exists.** The citation engine (`api/app/citation/verification.py`) assumes documents with char-precise offsets (`source_document_id`, `source_offset_start/end`). External-source citations (court / cluster ID / opinion ID / `retrieved_at`) are **net-new modeling** in WS5, not a field extension — larger than the original proposal implied.
+- **C5 — Skills frontmatter is declared but not parsed.** `minimum_inference_tier` appears in some SKILL.md frontmatter (e.g. `skills/nda-snapshot/`) but **no parser/validator loads it in code**. WS5's "skill declares its tool usage" needs the parser built first (or scoped to documentation-only in v1 — see WS5).
+
+Also confirmed solid (build directly on these): gateway `ProviderAdapter` + router + `inference_routing_log`; autonomous `ToolIntent`/`PHASE_GRANTS`/`guarded_tool_call`; citation cascade (exact→tolerant→paraphrase→ensemble); `api/app/storage.py` (MinIO/S3); `api/app/models/audit.py` (free-form string actions, **not** an enum — easy to add new actions); `api/app/api/admin.py` (prefix `/admin`, ActiveUser+AdminUser auth). The `web/` MCP stub is production-grade (streamable_http, 5 functions) — a real reference for the WS2 client. Migration head **0047**; `EXPECTED_PATHS` collision-guard count is **118** (`api/tests/test_openapi.py`).
+
+## Why it matters
+
+- **A real capability gap.** In-house legal teams need case-law verification and lookup inside the tool they already use; MCP opens the door to the operator's own systems. PRD §3.6 already commits the research capability.
+- **The transparency posture is the differentiator.** MikeOSS's answer is a chat bubble. LQ.AI's answer must be *inspectable*: which opinion, which cluster, a quote verified against the fetched text, the routed tier, and an audit row. That is the whole reason to do this in LQ.AI's frame rather than fork MikeOSS.
+- **The egress boundary is a security asset, not overhead.** Routing every external tool call through the gateway means one place to tier, rate-limit, anonymize, allowlist, and audit third-party data egress — exactly what an operator deploying this in a privileged environment needs.
+
+## What we'd ship — six workstreams
+
+WS1 and WS4 are the architectural cores (each ~an ADR + a milestone-sized change). WS2 and WS3 are sizable features that parallelize once WS1 lands. WS5/WS6 ride alongside.
+
+### WS1 — Gateway egress boundary for data-source / tool providers (`gateway/`)
+
+Discharges [ADR 0014](../adr/0014-gateway-egress-boundary-for-tool-providers.md). **Detailed design below.**
+
+- New provider class in the gateway: a **"tool provider"** (a.k.a. data-source) distinct from inference providers, but reusing the existing router/audit machinery.
+- `gateway.yaml`: a `tool_providers:` block (name, type, base_url, `api_key_env`/encrypted/admin-API key, tier, allowlist policy). CourtListener is the first concrete `type`.
+- SSRF + allowlist controls live here as a gateway primitive: HTTPS-required, DNS private-address blocking, host allowlist, no `Host` override, header validation.
+- New **egress audit log** (`tool_egress_log`): timestamp, provider, tool, request_id, tier, bytes/row counts (never raw payloads), refused + reason. Mirrors `inference_routing_log`.
+- Per-provider rate limiting **at the adapter** (C3), not via the unbuilt global middleware.
+- Egress tier semantics (ADR 0014 D4): a tool provider declares a **data-egress tier** so the gateway can refuse a call whose payload sensitivity exceeds the matter/skill minimum.
+- Anonymization of outbound payloads by default; inbound public text marked `skip_anonymization` (ADR 0014 D5).
+
+**Files:** `gateway/app/providers/tool/` (new subpackage), `gateway/app/router.py` (tool-egress path), `gateway.yaml.example`, `gateway/tests/`. **Security review required.**
+
+### WS2 — MCP client subsystem (DE-200)
+
+- `streamable_http` transport client (parity with MikeOSS — no stdio). Lives behind WS1's egress boundary: the gateway brokers the outbound MCP HTTP. Port the proven `web/` stub logic into `api/`.
+- Operator config `mcp.yaml` (allowlisted servers: name, server_url, auth type, tier, tool policy). Loaded like `gateway.yaml`.
+- Tool discovery + cache (DB-backed), per-tool enable/disable, metadata flags `read_only`/`destructive`/`requires_confirmation` carried through to WS4's confirmation gates.
+- Optional **per-user OAuth** only where a server needs user identity (encrypted token storage following the existing Fernet key-encryption pattern). Bearer/none otherwise.
+- Admin surface `/api/v1/admin/mcp` to list/refresh connectors and tools. No per-user connector creation in v1 (decision 3).
+
+**Files:** new `api/app/mcp/` (client, discovery, registry), `mcp.yaml.example`, `api/app/api/admin.py` additions, migration, `api/tests/`. Retire/replace the `web/` stub.
+
+### WS3 — CourtListener data source (DE-279)
+
+- The five tools as gateway tool-provider operations + thin `api/` handlers: `verify_citations`, `search_case_law`, `get_cases`, `find_in_case`, `read_case`.
+- Opinion caching: object storage for opinion bodies + DB rows for cluster/opinion metadata, with live-API fallback. Per-turn cluster cache to avoid redundant fetches.
+- Citation-verification integration (see WS5) so quoted passages are verified, not just pasted.
+- `/api/v1/research/` surface for the interactive case-law panel; SSE events for UI parity.
+
+**Files:** `gateway/app/providers/tool/courtlistener.py`, `api/app/research/`, `api/app/api/research.py` (NEW route — remember `IMPLEMENTED_ROUTES` in `api/tests/test_endpoints.py` + bump the pinned **118** path count + `EXPECTED_PATHS` in `api/tests/test_openapi.py`), migration, `docs/api/backend-openapi.yaml`.
+
+### WS4 — Governed tool-calling loop + `ToolIntent` extension
+
+Discharges [ADR 0015](../adr/0015-governed-tool-calling-model.md).
+
+- A gateway-mediated function-calling loop for chat, **restricted to the operator allowlist** (research + enabled MCP tools). Not open function-calling.
+- Per-call governance: tier check, `tool_call_log` audit row, cost accounting, **confirmation gate** for `destructive` tools (model proposes → user approves → execute). Per-turn tool-call cap.
+- New bounded intents for the autonomous layer: `retrieve_caselaw`, `call_mcp_tool` added to `ToolIntent` (`api/app/autonomous/enums.py`) and to `PHASE_GRANTS` (research in `analysis`; MCP grants per-phase, conservative default), enforced by the existing `guarded_tool_call` **R5→R6→R4** brakes.
+- `destructive`/`requires_confirmation` MCP tools are **never** auto-granted to the autonomous layer in v1.
+
+**Files:** `api/app/autonomous/enums.py`, `api/app/autonomous/guard.py`, a chat tool-loop module in `api/app/`, `api/app/api/chats.py` (loop integration), migration (`tool_call_log`), tests.
+
+### WS5 — Transparency surfaces
+
+- **External-source citations (C4 — net-new modeling).** Add an external-source kind (court / cluster ID / opinion ID / `retrieved_at`) so case-law quotes run through the existing exact/tolerant verification cascade and persist provenance. A case-law answer becomes reproducible and trust-pilled, not a bare bubble.
+- New `audit_log` actions (`research.search`, `research.read_opinion`, `mcp.tool_call`) — free-form strings, no enum change needed (C-confirmed).
+- A **"Case-law research" skill** that *declares* its tool usage and `minimum_inference_tier` in SKILL.md frontmatter. **(C5)** v1 either builds the frontmatter parser/validator or scopes the declaration to documentation-only — pin in the WS5 plan.
+- UI: case-law panel parity, MCP tool provenance pills, confirmation prompt for destructive tools.
+
+**Files:** `api/app/citation/` (source-kind extension), `api/app/models/audit.py` (or just new action strings), `skills/case-law-research/`, `web/` panel + pills, `docs/db-schema.md`.
+
+### WS6 — Docs
+
+- PRD: flesh out §3.6 (research) and promote MCP from a §8.5 slot to a specified capability; update DE-200 / DE-279–281 to "in progress".
+- **The two ADRs are already written** ([0014](../adr/0014-gateway-egress-boundary-for-tool-providers.md), [0015](../adr/0015-governed-tool-calling-model.md)) — flip Status to "Accepted" when the implementation lands.
+- `gateway.yaml.example` (+ `tool_providers`), `mcp.yaml.example`, `docs/db-schema.md` migrations, `docs/api/backend-openapi.yaml` for `/research` + `/admin/mcp`.
+- `docs/security/boundary-registers.md`: add the egress-boundary register entry.
+
+## PR decomposition & sequencing (the roadmap)
+
+Dependency spine: **WS1 must land first** (it is the boundary every tool call traverses). WS2 and WS3 parallelize once WS1 is in. WS4 needs WS1 (+ at least one tool provider to call). WS5/WS6 ride alongside their feature.
+
+| PR | Workstream | Depends on | Security review | Acceptance criteria (the merge bar) |
+|---|---|---|---|---|
+| **PR1** | WS1 — gateway tool-provider boundary | — | **Yes** (`gateway/**`) | `tool_providers:` block parses from `gateway.yaml`; a `ToolProviderAdapter` base + a test/echo provider type; guarded-egress helper enforces HTTPS/DNS-private-block/host-allowlist/no-Host-override (unit-tested with attempted SSRF); `tool_egress_log` migration + rows written (counts only, never payloads); per-adapter rate limit; egress-tier refusal path tested. Gateway mypy `--strict` clean. |
+| **PR2** | WS3a — CourtListener provider + read tools | PR1 | Yes (`gateway/**`) | `courtlistener` tool-provider type; `verify_citations` + `search_case_law` + `get_cases` against live API (gated `-m provider`) with VCR/cassette unit tests; opinion-body caching to `api/app/storage.py` under `courtlistener/opinions/by-cluster/` + DB metadata rows + live-API fallback; per-turn cluster cache. |
+| **PR3** | WS3b — `/api/v1/research/` surface | PR2 | No (api/) | `POST /api/v1/research` + `GET /api/v1/research/sources` handlers (thin, call the gateway); `IMPLEMENTED_ROUTES` + `EXPECTED_PATHS` (118→) bumped; `find_in_case` + `read_case`; `backend-openapi.yaml` updated + conformance test green; SSE research events. |
+| **PR4** | WS2 — MCP client subsystem | PR1 (parallel to PR2/3) | Partial (egress in gateway) | `mcp.yaml` parses; `streamable_http` client in `api/app/mcp/` brokered through the gateway egress boundary; tool discovery + DB cache + per-tool enable/disable + metadata flags; `none`/`bearer` auth; `/api/v1/admin/mcp` list/refresh; per-user OAuth **stub-or-ship** decision pinned; `web/` stub retired. |
+| **PR5** | WS4 — governed tool-calling loop + ToolIntent | PR2 (a callable tool) + PR4 | **Yes** (touches autonomous guard) | Chat tool-loop over the operator allowlist with per-turn cap; `tool_call_log` migration + rows; tier check + cost accounting per call; `destructive` confirmation gate (SSE pause→approve→resume) tested; `retrieve_caselaw` + `call_mcp_tool` added to `ToolIntent` + `PHASE_GRANTS`, enforced by R5→R6→R4; destructive tools excluded from all autonomous phase grants (test). |
+| **PR6** | WS5 — transparency surfaces + WS6 docs | PR3 + PR5 | No (api/ + web/ + docs) | External-source citation kind through the verification cascade with persisted provenance (C4); new audit actions; case-law-research skill (+ frontmatter parser **or** docs-only per C5 decision); UI case-law panel + provenance pills + destructive-confirm prompt; PRD §3.6/§8.5 + DE updates; ADR statuses → Accepted; `db-schema.md` + boundary-registers updated. |
+
+Six PRs, security review on PR1/PR2/PR5. Each PR is independently shippable behind its feature flag (CourtListener off until `COURTLISTENER_API_TOKEN` set; MCP off until `mcp.yaml` declares a server; the chat loop off until a tool is enabled).
+
+## WS1 detailed design (the first buildable slice)
+
+WS1 is the load-bearing core; everything else calls it. Detailed below so PR1 can start without re-deriving shape. (PRs 2–6 get their own plans at their turn, per the maintainer's chosen planning depth.)
+
+### Config shape — `gateway.yaml` `tool_providers:` block
+
+A new top-level block parallel to `providers:`. Each entry:
+
+```yaml
+tool_providers:
+  - name: courtlistener-prod        # operator-chosen id, referenced by tool routing
+    type: courtlistener             # adapter family (first concrete type)
+    base_url: https://www.courtlistener.com/api/rest/v4
+    api_key_env: COURTLISTENER_API_TOKEN   # OR api_key_encrypted (Fernet, ADR 0011) OR runtime
+    egress_tier: 4                  # data-egress tier (ADR 0014 D4): max matter-sensitivity allowed out
+    allowlist:
+      hosts: [www.courtlistener.com]   # outbound host allowlist (SSRF guard)
+    rate_limit:
+      requests_per_minute: 60       # per-provider, enforced at the adapter (C3)
+    anonymize_outbound: true        # default true (ADR 0014 D5)
+```
+
+Reuses the three credential paths inference providers already have (`api_key_env` / `api_key_encrypted` / runtime admin API per ADR 0011 + #128). A new Pydantic config model `ToolProviderConfig` sits beside the inference provider config in `gateway/app/config.py`.
+
+### `ToolProviderAdapter` base — sibling to `ProviderAdapter`, NOT a subclass
+
+`ProviderAdapter` exposes `chat_completion` / `embeddings` — wrong surface for tools. The new base (`gateway/app/providers/tool/base.py`) exposes:
+
+```python
+class ToolProviderAdapter(ABC):
+    async def list_tools(self) -> list[ToolSpec]: ...          # name, description, json-schema params, metadata flags
+    async def invoke_tool(self, tool: str, args: dict, *, request_id: str) -> ToolResult: ...
+    async def health_check(self) -> ProviderHealth: ...        # reuse the existing dataclass
+    async def aclose(self) -> None: ...
+```
+
+`ToolResult` carries structured provenance (provider, tool, bytes/row counts, and — for read tools — the inbound text marked `skip_anonymization` so it reaches the citation engine verbatim). Typed errors reuse/mirror the existing `ProviderAdapterError` hierarchy (`ToolProviderAuthError`, `ToolProviderHTTPError`, `ToolProviderNetworkError`, `ToolEgressRefused`).
+
+### Guarded egress helper — the SSRF primitive (ADR 0014 D2)
+
+A single `guarded_egress(...)` in the gateway that every tool-provider adapter MUST route outbound HTTP through. Enforces, in order: scheme is HTTPS; resolve DNS and reject private/loopback/link-local/CGNAT ranges; host ∈ provider allowlist; reject caller-supplied `Host`; validate outbound headers (no smuggled auth). Returns a guarded `httpx.AsyncClient` request or raises `ToolEgressRefused(reason)`. This is the gateway-native equivalent of MikeOSS `validateRemoteMcpUrl`/`guardedFetch`. Unit tests attempt each bypass (private IP, IP-literal host, redirect-to-private, Host override) and assert refusal + an audit row.
+
+### Router tool-egress path
+
+`gateway/app/router.py` gains a `route_tool_call(provider_name, tool, args)` alongside the inference dispatch. It: resolves the `tool_providers` entry → builds/holds the adapter (same lazy-build pattern as inference adapters) → applies the per-provider rate limit → checks egress tier vs. the call's declared matter-sensitivity (refuse if exceeded) → applies outbound anonymization → calls `adapter.invoke_tool` → writes a `tool_egress_log` row → returns `ToolResult`. The inference router path is untouched.
+
+### `tool_egress_log` — new table (migration 0048)
+
+Mirrors `inference_routing_log` (`api/app/models/inference.py`). Columns: `id`, `timestamp`, `request_id`, `provider`, `tool`, `tier`, `bytes_out`, `bytes_in` (or `rows`), `refused` (bool), `refusal_reason` (nullable), `anonymization_applied` (bool). **No raw payloads** — counts and types only, the `inference_routing_log` guarantee. Migration sits at head 0048 (current head 0047); verify on a throwaway pgvector container, never host-side `alembic upgrade` on the dev DB. *(Note: this log is read/written from the gateway's egress decision; confirm in PR1 whether the row is written by the gateway directly or returned to the backend to persist — see ADR 0014 O3. Default: gateway writes it, same as `inference_routing_log` is written on the inference path.)*
+
+### What WS1 explicitly does NOT do
+
+No CourtListener semantics (PR2), no MCP (PR4), no chat loop or `ToolIntent` change (PR5), no citation modeling (PR6). PR1 ships the boundary + a trivial echo/test tool-provider type to prove the path end-to-end under test. This keeps the security-review surface tight: PR1 is "is the egress boundary sound?", nothing else.
+
+## Open questions (resolve during WS1/WS5)
+
+- **O1 — Anonymization of tool-call payloads.** *Resolved in [ADR 0014 D5](../adr/0014-gateway-egress-boundary-for-tool-providers.md):* anonymize outbound by default; mark inbound public opinion text `skip_anonymization` (mirrors retrieval-context handling). Rehydration into citations follows the document-citation path. Confirm the exact flag plumbing in PR1.
+- **O2 — Object-storage layout for cached opinions.** Reuse `api/app/storage.py`; confirm key scheme `courtlistener/opinions/by-cluster/{cluster_id}/{opinion_id}` and retention policy in the PR2 plan (ADR 0005 sibling).
+- **O3 — Bulk data import.** v1 ships live-API + per-turn/object-cache and defers CourtListener bulk import to a DE if operators want it.
+- **O4 — `tool_egress_log` write site.** Gateway-writes (default, mirrors inference) vs. backend-persists from a returned provenance struct. Pin in PR1.
+- **O5 — Frontmatter parser scope (C5).** WS5: build the `minimum_inference_tier` parser/validator, or ship the case-law-research skill's declaration as documentation-only in v1. Pin in PR6 plan.
+
+## Out of scope (file as DE-XXX if they surface)
+
+- stdio MCP transport (parity is `streamable_http` only).
+- Per-user MCP connector registration (decision 3 — operator-allowlisted in v1).
+- Async approval channel for autonomous-layer destructive tools (ADR 0015 D4 — excluded in v1).
+- Non-US legal sources (GovInfo, EUR-Lex, SEC EDGAR — DE-280/281); the tool-provider class is built to host them next.
+- Open model-driven function-calling beyond the operator allowlist.
+- Global gateway rate-limit enforcement middleware (the gateway's "Phase E" — C3); WS1 ships per-adapter limiting instead.

--- a/docs/security/boundary-registers.md
+++ b/docs/security/boundary-registers.md
@@ -234,7 +234,7 @@ This boundary is **orthogonal to R1–R6** (which restrain the model) and to the
 - **DNS private/loopback/link-local block.** SSRF guard: the adapter resolves the configured `base_url` and rejects results that resolve to RFC-1918, loopback, or link-local addresses before any connection is attempted.
 - **Per-provider host allowlist.** Each `tool_providers:` entry declares `allowlist.hosts`; the adapter checks the resolved host against the exact allowlist before dispatch. A call whose resolved host is not in the allowlist is refused with a structured error.
 - **No caller `Host` override.** The gateway sets the `Host` header from the configured `base_url`; callers cannot substitute a different host through request parameters.
-- **Outbound header validation.** Only headers in a narrow allowlist (Authorization, Content-Type, Accept, User-Agent) are forwarded. Caller-supplied headers are dropped, not proxied.
+- **Outbound header validation (denylist: rejects caller-supplied `Host` override and smuggled gateway-auth headers; full enforcement wired in WS3 when real adapters egress).**
 - **Egress-tier ceiling.** Each provider carries `egress_tier`. If the provider's egress_tier exceeds the matter's or skill's allowed ceiling, the request is refused with a tier-mismatch error — the same enforcement pattern as the inference-tier floor (R2, above).
 - **Per-provider rate limit.** Each entry declares `rate_limit.requests_per_minute`; the adapter enforces it. Requests over the limit return a structured rate-limit error rather than being forwarded.
 

--- a/docs/security/boundary-registers.md
+++ b/docs/security/boundary-registers.md
@@ -222,6 +222,41 @@ It is named here so a reader doesn't conflate the two boundaries: a deployment c
 
 ---
 
+## Gateway boundary — tool / data-source egress (ADR 0014)
+
+This boundary is **orthogonal to R1–R6** (which restrain the model) and to the Inference Choice Spectrum (which restrains where inference data flows). It restrains *outbound calls the gateway makes on behalf of a skill or user to third-party data sources* — case-law APIs, MCP servers, and similar.
+
+**What it guards.** Any HTTP egress the gateway brokers to a tool provider: case-law retrieval (CourtListener, etc.), MCP server calls, future data-source adapters. These calls carry query terms derived from the user's matter; each is an egress vector that must be allowlisted, tier-tagged, rate-limited, and audited independently of the inference path.
+
+**Controls.**
+
+- **HTTPS-only.** Non-TLS outbound requests are refused at the adapter layer; no plaintext egress.
+- **DNS private/loopback/link-local block.** SSRF guard: the adapter resolves the configured `base_url` and rejects results that resolve to RFC-1918, loopback, or link-local addresses before any connection is attempted.
+- **Per-provider host allowlist.** Each `tool_providers:` entry declares `allowlist.hosts`; the adapter checks the resolved host against the exact allowlist before dispatch. A call whose resolved host is not in the allowlist is refused with a structured error.
+- **No caller `Host` override.** The gateway sets the `Host` header from the configured `base_url`; callers cannot substitute a different host through request parameters.
+- **Outbound header validation.** Only headers in a narrow allowlist (Authorization, Content-Type, Accept, User-Agent) are forwarded. Caller-supplied headers are dropped, not proxied.
+- **Egress-tier ceiling.** Each provider carries `egress_tier`. If the provider's egress_tier exceeds the matter's or skill's allowed ceiling, the request is refused with a tier-mismatch error — the same enforcement pattern as the inference-tier floor (R2, above).
+- **Per-provider rate limit.** Each entry declares `rate_limit.requests_per_minute`; the adapter enforces it. Requests over the limit return a structured rate-limit error rather than being forwarded.
+
+**Audit surface.** Every dispatched (and refused) tool-provider call is written to `tool_egress_log`: provider name, egress tier, timestamp, and status. Counts and types are logged; raw request/response payloads are never written to the log (anonymize_outbound default: true).
+
+**Current implementation state.** PARTIAL — `tool_providers:` schema and config loading shipped (ADR 0014 D1/D2); `echo` adapter ships as the test type. CourtListener adapter (D3), MCP server adapter (WS3/WS4), and the `tool_egress_log` table (D4) are tracked by the ADR 0014 work plan.
+
+**Reference.** ADR 0014 (`docs/adr/0014-tool-provider-egress-boundary.md`).
+
+**Verification path.**
+
+```bash
+# Schema definition:
+grep -n "ToolProviderConfig\|tool_providers" gateway/app/config.py
+# Example config block (commented, default empty list):
+grep -A 20 "TOOL / DATA-SOURCE PROVIDERS" gateway.yaml.example
+# Regression test (guards commented block → empty list):
+cd gateway && pytest tests/test_example_config_tool_providers.py -v
+```
+
+---
+
 ## Cross-references
 
 - [PRD §1.8 Security Posture](../PRD.md#18-security-posture) — names this catalog as the framework for restraint work.

--- a/docs/superpowers/plans/2026-06-16-ws1-gateway-egress-boundary.md
+++ b/docs/superpowers/plans/2026-06-16-ws1-gateway-egress-boundary.md
@@ -21,7 +21,13 @@
 - **No outbound anonymization transform.** ADR 0014 D5 makes anonymization the default, but the transform needs the M2 anonymization mapper + real matter context (which PR1 has neither of). PR1 *parses* the `anonymize_outbound` flag (schema completeness) and writes an honest `anonymization_applied = False`; the transform lands in WS3/WS4 with the first real provider. Leave the typed seam, do not fake it. This mirrors how the gateway already ships `rate_limits` config ahead of global enforcement.
 - **No HTTP route exposing tool calls to the backend.** PR1 wires the *internal* `route_tool_call` path and tests it directly; the `/api/v1/research` surface is PR3.
 
-**Hard rules (from CLAUDE.md / handoff):** gateway is mypy `--strict`; run BOTH `ruff format` and `ruff check`; NEVER run host-side `alembic upgrade` on the dev DB — the api test conftest auto-migrates a throwaway `pgvector/pgvector:pg16` container; commit `-s` with the trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+**Hard rules (from CLAUDE.md / handoff):** gateway is mypy `--strict`; run BOTH `ruff format` and `ruff check`; NEVER run host-side `alembic upgrade` on the live dev DB (`127.0.0.1:15432/lq_ai`); commit `-s` with the trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+> **⚠️ TEST/LINT RUNNER CORRECTION (discovered during execution).** The canonical runner is the **host venv**, NOT `docker compose` — the compose `api`/`gateway` services bake code into the image (no source bind-mount), so `docker compose run --rm <svc> pytest` would test stale baked code. Translate every command in the tasks below:
+> - `docker compose run --rm gateway pytest tests/X` → `cd ~/Code/lq-ai/gateway && .venv/bin/pytest tests/X -v` (gateway tests are pure unit/respx — no DB needed).
+> - `docker compose run --rm api pytest api/tests/X` → `cd ~/Code/lq-ai/api && DATABASE_URL='postgresql+asyncpg://lq_ai:test@127.0.0.1:15433/lq_ai' .venv/bin/pytest tests/X -v`. The api conftest does NOT spin up its own DB — it needs `DATABASE_URL` pointing at a Postgres and creates isolated `lq_ai_test_*` databases on it. Use a **throwaway `pgvector/pgvector:pg16` container on port 15433** (`docker run -d --name lq-test-pg -p 15433:5432 -e POSTGRES_USER=lq_ai -e POSTGRES_PASSWORD=test -e POSTGRES_DB=lq_ai pgvector/pgvector:pg16`), fully isolated from the running dev stack.
+> - Lint: `cd gateway && .venv/bin/ruff format . && .venv/bin/ruff check . && .venv/bin/mypy app` (mypy is `--strict` via config); api: `cd api && .venv/bin/ruff format . && .venv/bin/ruff check . && .venv/bin/mypy app`.
+> The docker compose stack is the *running* LQ.AI app, not the test harness — leave it alone (never `docker compose down -v`).
 
 ---
 

--- a/docs/superpowers/plans/2026-06-16-ws1-gateway-egress-boundary.md
+++ b/docs/superpowers/plans/2026-06-16-ws1-gateway-egress-boundary.md
@@ -1,0 +1,1979 @@
+# WS1 — Gateway Egress Boundary for Tool/Data-Source Providers (PR1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a first-class **tool-provider** egress class to the Inference Gateway — config schema, an adapter base, an SSRF-guarded outbound primitive, per-provider rate limiting, an egress-tier refusal check, a gateway-written `tool_egress_log`, and a trivial `echo` provider that proves the path end-to-end under test — without any CourtListener/MCP semantics.
+
+**Architecture:** A tool provider is a sibling of inference providers, not a subclass. It is declared in `gateway.yaml` under a new `tool_providers:` block, built into an adapter at startup (held in `app.state.tool_adapters`), and invoked via a new `Router.route_tool_call(...)` path that rate-limits, checks the egress tier, calls the adapter through the `guarded_egress` SSRF primitive, and writes a `tool_egress_log` row (raw SQL, gateway-side, mirroring `inference_routing_log`). This discharges [ADR 0014](../../adr/0014-gateway-egress-boundary-for-tool-providers.md).
+
+**Tech Stack:** Python 3.12, FastAPI, Pydantic v2, httpx, SQLAlchemy (raw `text()` for the gateway writer), Alembic (api-side schema), pytest + pytest-asyncio + respx. Gateway is mypy `--strict`.
+
+**Branch:** `feat/legal-research-mcp-plan` (off `main`). This PR is **security-reviewed** (`gateway/**`) — see CLAUDE.md merge-gating: maintainer reviews + merges.
+
+---
+
+## Scope: what PR1 does and does NOT do
+
+**Does:** config schema for `tool_providers`; `ToolProviderAdapter` base + `ToolSpec`/`ToolResult`/error hierarchy; `guarded_egress` SSRF primitive; per-provider rate limiter; egress-tier refusal; `tool_egress_log` migration + ORM model + gateway writer; an `echo` provider type; lifespan wiring; `Router.route_tool_call`; an end-to-end test through the router.
+
+**Does NOT (honest deferrals — do not claim these):**
+- **No CourtListener / MCP semantics** — those are PR2/PR4. The only concrete type here is `echo`.
+- **No outbound anonymization transform.** ADR 0014 D5 makes anonymization the default, but the transform needs the M2 anonymization mapper + real matter context (which PR1 has neither of). PR1 *parses* the `anonymize_outbound` flag (schema completeness) and writes an honest `anonymization_applied = False`; the transform lands in WS3/WS4 with the first real provider. Leave the typed seam, do not fake it. This mirrors how the gateway already ships `rate_limits` config ahead of global enforcement.
+- **No HTTP route exposing tool calls to the backend.** PR1 wires the *internal* `route_tool_call` path and tests it directly; the `/api/v1/research` surface is PR3.
+
+**Hard rules (from CLAUDE.md / handoff):** gateway is mypy `--strict`; run BOTH `ruff format` and `ruff check`; NEVER run host-side `alembic upgrade` on the dev DB — the api test conftest auto-migrates a throwaway `pgvector/pgvector:pg16` container; commit `-s` with the trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+**Gateway (new):**
+- `gateway/app/providers/tool/__init__.py` — package marker + re-exports.
+- `gateway/app/providers/tool/base.py` — `ToolProviderAdapter` ABC, `ToolSpec`, `ToolResult`, error hierarchy.
+- `gateway/app/providers/tool/egress.py` — `guarded_egress` SSRF primitive + `EgressRefused`.
+- `gateway/app/providers/tool/ratelimit.py` — `FixedWindowRateLimiter` + `RateLimited`.
+- `gateway/app/providers/tool/echo.py` — `EchoToolAdapter` (the test/proof provider type).
+- `gateway/app/tool_egress_log.py` — `ToolEgressLogRow` + `ToolEgressLogWriter` protocol + SQL/Null/Recording impls.
+
+**Gateway (modified):**
+- `gateway/app/config.py` — `ToolProviderConfig`, `ToolProviderType`, `GatewayConfig.tool_providers`, `provider`-style accessor.
+- `gateway/app/main.py` — `build_tool_adapter` factory + lifespan wiring (`app.state.tool_adapters`, `app.state.tool_egress_log`).
+- `gateway/app/router.py` — `Router.route_tool_call(...)` + `ToolCallRoutedResult`.
+
+**API (new/modified — schema only, gateway owns the writes):**
+- `api/alembic/versions/0048_tool_egress_log.py` — create `tool_egress_log`.
+- `api/app/models/tool_egress.py` — `ToolEgressLog` ORM model (for api-side reads/tests; mirrors `inference.py`).
+- `docs/db-schema.md` — add the `tool_egress_log` section.
+
+**Config example / docs (modified):**
+- `gateway.yaml.example` — `tool_providers:` block with the `echo` example commented + a CourtListener-shaped example commented.
+- `docs/security/boundary-registers.md` — egress-boundary register entry.
+
+---
+
+## Task 1: `tool_egress_log` migration + ORM model (api-side schema)
+
+The table is api-owned (schema authority) but gateway-written. Build the schema first so the gateway writer has something to insert into and the api test conftest auto-migrates it.
+
+**Files:**
+- Create: `api/alembic/versions/0048_tool_egress_log.py`
+- Create: `api/app/models/tool_egress.py`
+- Modify: `docs/db-schema.md`
+- Test: `api/tests/test_tool_egress_log_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/test_tool_egress_log_model.py
+import uuid
+
+import pytest
+
+from app.models.tool_egress import ToolEgressLog
+
+
+@pytest.mark.asyncio
+async def test_tool_egress_log_row_roundtrips(db_session) -> None:
+    """A tool_egress_log row persists and reads back with its core fields."""
+    row = ToolEgressLog(
+        request_id="req_abc",
+        provider="echo-test",
+        tool="echo",
+        tier=4,
+        bytes_out=12,
+        bytes_in=12,
+        refused=False,
+        anonymization_applied=False,
+    )
+    db_session.add(row)
+    await db_session.flush()
+    assert isinstance(row.id, uuid.UUID)
+    assert row.refused is False
+    assert row.tier == 4
+```
+
+*(Use the existing api test DB-session fixture — confirm its name in `api/tests/conftest.py`; it is the same fixture other `app.models` tests use, e.g. `db_session`.)*
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm api pytest api/tests/test_tool_egress_log_model.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.models.tool_egress'`.
+
+- [ ] **Step 3: Write the migration**
+
+```python
+# api/alembic/versions/0048_tool_egress_log.py
+"""tool_egress_log — per-call audit of third-party tool/data-source egress
+
+One row per outbound tool-provider call through the gateway (ADR 0014 D3).
+Mirrors ``inference_routing_log``: gateway-written, raw SQL, counts/types
+only — NEVER raw payloads. Distinct table because egress has a different
+access pattern and retention from inference routing.
+
+Revision ID: 0048
+Revises: 0047
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0048"
+down_revision = "0047"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tool_egress_log",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("request_id", sa.String(), nullable=True),
+        sa.Column("provider", sa.String(), nullable=False),
+        sa.Column("tool", sa.String(), nullable=False),
+        sa.Column("tier", sa.Integer(), nullable=False),
+        sa.Column("bytes_out", sa.Integer(), nullable=True),
+        sa.Column("bytes_in", sa.Integer(), nullable=True),
+        sa.Column(
+            "anonymization_applied",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "refused",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("refusal_reason", sa.String(), nullable=True),
+        sa.CheckConstraint("tier BETWEEN 1 AND 5", name="chk_tool_egress_log_tier_range"),
+    )
+    op.create_index("ix_tool_egress_log_provider", "tool_egress_log", ["provider"])
+    op.create_index("ix_tool_egress_log_timestamp", "tool_egress_log", ["timestamp"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tool_egress_log_timestamp", table_name="tool_egress_log")
+    op.drop_index("ix_tool_egress_log_provider", table_name="tool_egress_log")
+    op.drop_table("tool_egress_log")
+```
+
+- [ ] **Step 4: Write the ORM model**
+
+```python
+# api/app/models/tool_egress.py
+"""Tool egress log — per docs/db-schema.md §`tool_egress_log`.
+
+One row per outbound tool/data-source call through the gateway (ADR 0014
+D3). Distinct from `inference_routing_log` (different egress, retention)
+and from `audit_log` (hot path, counts-only). Gateway-written via raw SQL
+(`gateway/app/tool_egress_log.py`); this ORM model backs api-side reads.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, CheckConstraint, DateTime, Integer, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ToolEgressLog(Base):
+    __tablename__ = "tool_egress_log"
+    __table_args__ = (
+        CheckConstraint("tier BETWEEN 1 AND 5", name="chk_tool_egress_log_tier_range"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    request_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    tool: Mapped[str] = mapped_column(String, nullable=False)
+    tier: Mapped[int] = mapped_column(Integer, nullable=False)
+    bytes_out: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    bytes_in: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    anonymization_applied: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    refused: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    refusal_reason: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<ToolEgressLog id={self.id} provider={self.provider} "
+            f"tool={self.tool} tier={self.tier} refused={self.refused}>"
+        )
+```
+
+Then register the model so the metadata sees it — add to `api/app/models/__init__.py` following the existing import pattern there (open the file, add `from app.models.tool_egress import ToolEgressLog` and append `"ToolEgressLog"` to `__all__` if present). Add a `tool_egress_log` section to `docs/db-schema.md` mirroring the `inference_routing_log` section (columns table + the "counts only, never payloads" note).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm api pytest api/tests/test_tool_egress_log_model.py -v`
+Expected: PASS (conftest auto-migrates the throwaway pgvector container through 0048).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add api/alembic/versions/0048_tool_egress_log.py api/app/models/tool_egress.py api/app/models/__init__.py docs/db-schema.md api/tests/test_tool_egress_log_model.py
+git commit -s -m "feat(api): add tool_egress_log table + ORM model (ADR 0014 D3)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `ToolProviderConfig` + `tool_providers` in `GatewayConfig`
+
+**Files:**
+- Modify: `gateway/app/config.py`
+- Test: `gateway/tests/test_tool_provider_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# gateway/tests/test_tool_provider_config.py
+import pytest
+
+from app.config import GatewayConfig, ToolProviderConfig
+
+
+@pytest.mark.unit
+def test_tool_provider_config_parses_minimal() -> None:
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test",
+                    "type": "echo",
+                    "base_url": "https://example.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    assert len(cfg.tool_providers) == 1
+    tp = cfg.tool_providers[0]
+    assert isinstance(tp, ToolProviderConfig)
+    assert tp.name == "echo-test"
+    assert tp.egress_tier == 4
+    assert tp.allowlist.hosts == ["example.test"]
+    assert tp.anonymize_outbound is True  # default per ADR 0014 D5
+
+
+@pytest.mark.unit
+def test_tool_provider_rejects_both_key_sources() -> None:
+    with pytest.raises(ValueError, match="api_key_env OR"):
+        ToolProviderConfig.model_validate(
+            {
+                "name": "x",
+                "type": "echo",
+                "base_url": "https://example.test",
+                "egress_tier": 4,
+                "allowlist": {"hosts": ["example.test"]},
+                "api_key_env": "FOO",
+                "api_key_encrypted": "gAAAA",
+            }
+        )
+
+
+@pytest.mark.unit
+def test_tool_provider_requires_nonempty_allowlist() -> None:
+    with pytest.raises(ValueError):
+        ToolProviderConfig.model_validate(
+            {
+                "name": "x",
+                "type": "echo",
+                "base_url": "https://example.test",
+                "egress_tier": 4,
+                "allowlist": {"hosts": []},
+            }
+        )
+
+
+@pytest.mark.unit
+def test_tool_provider_by_name_accessor() -> None:
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test",
+                    "type": "echo",
+                    "base_url": "https://example.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    assert cfg.tool_provider_by_name("echo-test") is not None
+    assert cfg.tool_provider_by_name("missing") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_provider_config.py -v`
+Expected: FAIL — `ImportError: cannot import name 'ToolProviderConfig'`.
+
+- [ ] **Step 3: Add the config models**
+
+In `gateway/app/config.py`, after the `ProviderConfig` block (around line 133), add:
+
+```python
+# --- Tool / data-source providers (ADR 0014) ---------------------------------
+
+
+ToolProviderType = Literal["echo", "courtlistener", "mcp"]
+"""Tool-provider family. ``echo`` is the test/proof type (PR1); ``courtlistener``
+and ``mcp`` land in later PRs."""
+
+
+class EgressAllowlistConfig(BaseModel):
+    """Per-provider outbound host allowlist (the SSRF guard's allow set)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    hosts: list[str] = Field(min_length=1)
+    """Non-empty list of exact hostnames the provider may egress to. An empty
+    allowlist is a misconfiguration, not 'allow all' — reject at config load."""
+
+
+class ToolProviderRateLimitConfig(BaseModel):
+    """Per-provider rate limit, enforced at the adapter (ADR 0014 D1 note).
+
+    NOT the gateway's global ``rate_limits`` (whose enforcement middleware is
+    unwired). This is a self-contained per-provider limit applied by
+    :class:`Router.route_tool_call` before each outbound call."""
+
+    model_config = ConfigDict(extra="allow")
+
+    requests_per_minute: int = Field(default=60, ge=1)
+
+
+class ToolProviderConfig(BaseModel):
+    """One entry under ``tool_providers:`` (ADR 0014 D1).
+
+    Sibling of :class:`ProviderConfig`, not a subclass — a tool provider is
+    invoked via ``invoke_tool``, not ``chat_completion``. Reuses the same
+    two API-key sourcing paths as inference providers (ADR 0011)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(min_length=1)
+    type: ToolProviderType
+    base_url: str = Field(min_length=1)
+    api_key_env: str | None = None
+    api_key_encrypted: str | None = None
+    egress_tier: InferenceTier
+    """Data-egress tier (ADR 0014 D4). The gateway refuses a call whose
+    matter/skill ceiling is more restrictive (a lower tier number) than this
+    provider's egress_tier."""
+    allowlist: EgressAllowlistConfig
+    rate_limit: ToolProviderRateLimitConfig = Field(
+        default_factory=ToolProviderRateLimitConfig
+    )
+    anonymize_outbound: bool = True
+    """Default True per ADR 0014 D5. NOTE: PR1 parses but does not yet apply
+    the transform (no matter context exists); enforcement lands in WS3/WS4."""
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def _exactly_one_key_source(self) -> ToolProviderConfig:
+        if self.api_key_env and self.api_key_encrypted:
+            raise ValueError(
+                f"Tool provider {self.name!r}: set either api_key_env OR "
+                f"api_key_encrypted, not both."
+            )
+        return self
+```
+
+In `GatewayConfig` (around line 425, beside `providers:`), add the field and accessor:
+
+```python
+    tool_providers: list[ToolProviderConfig] = Field(default_factory=list)
+```
+
+```python
+    def tool_provider_by_name(self, name: str) -> ToolProviderConfig | None:
+        """Look up a configured tool provider by name; ``None`` if not found."""
+        for provider in self.tool_providers:
+            if provider.name == name:
+                return provider
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_provider_config.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add gateway/app/config.py gateway/tests/test_tool_provider_config.py
+git commit -s -m "feat(gateway): tool_providers config schema (ADR 0014 D1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `ToolProviderAdapter` base + `ToolSpec` / `ToolResult` / errors
+
+**Files:**
+- Create: `gateway/app/providers/tool/__init__.py`
+- Create: `gateway/app/providers/tool/base.py`
+- Test: `gateway/tests/test_tool_provider_base.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# gateway/tests/test_tool_provider_base.py
+import pytest
+
+from app.providers.tool.base import (
+    ToolProviderAdapter,
+    ToolProviderError,
+    ToolResult,
+    ToolSpec,
+)
+
+
+@pytest.mark.unit
+def test_tool_provider_adapter_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        ToolProviderAdapter()  # type: ignore[abstract]
+
+
+@pytest.mark.unit
+def test_tool_result_holds_provenance_and_counts() -> None:
+    result = ToolResult(
+        provider="echo-test",
+        tool="echo",
+        payload={"echoed": "hi"},
+        bytes_in=2,
+        bytes_out=2,
+    )
+    assert result.provider == "echo-test"
+    assert result.payload == {"echoed": "hi"}
+    assert result.bytes_in == 2
+
+
+@pytest.mark.unit
+def test_tool_spec_carries_metadata_flags() -> None:
+    spec = ToolSpec(
+        name="echo",
+        description="echoes its input",
+        parameters={"type": "object"},
+        read_only=True,
+        destructive=False,
+        requires_confirmation=False,
+    )
+    assert spec.read_only is True
+    assert spec.destructive is False
+
+
+@pytest.mark.unit
+def test_tool_provider_error_envelope() -> None:
+    err = ToolProviderError("boom", details={"k": "v"})
+    assert err.to_envelope()["error"]["code"] == "tool_provider_error"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_provider_base.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.providers.tool'`.
+
+- [ ] **Step 3: Write the package + base**
+
+```python
+# gateway/app/providers/tool/__init__.py
+"""Tool / data-source provider egress class (ADR 0014).
+
+A tool provider is a sibling of the inference :class:`ProviderAdapter`,
+invoked via ``invoke_tool`` rather than ``chat_completion``. All outbound
+HTTP from a tool adapter MUST route through ``guarded_egress`` (ADR 0014 D2).
+"""
+
+from app.providers.tool.base import (
+    ToolProviderAdapter,
+    ToolProviderAuthError,
+    ToolProviderError,
+    ToolProviderHTTPError,
+    ToolProviderNetworkError,
+    ToolResult,
+    ToolSpec,
+)
+
+__all__ = [
+    "ToolProviderAdapter",
+    "ToolProviderAuthError",
+    "ToolProviderError",
+    "ToolProviderHTTPError",
+    "ToolProviderNetworkError",
+    "ToolResult",
+    "ToolSpec",
+]
+```
+
+```python
+# gateway/app/providers/tool/base.py
+"""Abstract :class:`ToolProviderAdapter` contract + shared types.
+
+Mirrors the design of :mod:`app.providers.base` (the inference adapter
+contract) but for non-inference egress: list the tools a provider offers,
+invoke one, return structured provenance. Errors follow the same
+public-safe, key-scrubbing discipline (CONTRIBUTING.md security rules).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.providers.base import ProviderHealth
+
+
+# --- Errors -------------------------------------------------------------------
+
+
+class ToolProviderError(Exception):
+    """Base class for tool-provider errors. Public-safe; never leak keys."""
+
+    code: str = "tool_provider_error"
+
+    def __init__(self, message: str, *, details: dict[str, object] | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.details = details or {}
+
+    def to_envelope(self) -> dict[str, object]:
+        return {"error": {"code": self.code, "message": self.message, "details": dict(self.details)}}
+
+
+class ToolProviderAuthError(ToolProviderError):
+    code = "unauthorized"
+
+
+class ToolProviderHTTPError(ToolProviderError):
+    code = "tool_provider_unavailable"
+
+    def __init__(
+        self, message: str, *, upstream_status: int, details: dict[str, object] | None = None
+    ) -> None:
+        merged: dict[str, object] = dict(details or {})
+        merged["upstream_status"] = upstream_status
+        super().__init__(message, details=merged)
+        self.upstream_status = upstream_status
+
+
+class ToolProviderNetworkError(ToolProviderError):
+    code = "tool_provider_unavailable"
+
+
+# --- Tool spec + result -------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """One model-callable tool a provider offers.
+
+    ``parameters`` is a JSON-schema object. The metadata flags map to
+    MikeOSS's ``readOnly``/``destructive``/``requiresConfirmation`` and are
+    carried through to WS4's confirmation gates (ADR 0015 D2/D4)."""
+
+    name: str
+    description: str
+    parameters: dict[str, Any]
+    read_only: bool = True
+    destructive: bool = False
+    requires_confirmation: bool = False
+
+
+@dataclass
+class ToolResult:
+    """Result of one tool invocation, with provenance + byte counts.
+
+    ``payload`` is the structured tool output. ``skip_anonymization`` marks
+    inbound public text (e.g. opinion bodies) that must reach the citation
+    engine verbatim (ADR 0014 D5); the echo provider leaves it False."""
+
+    provider: str
+    tool: str
+    payload: Any
+    bytes_in: int = 0
+    bytes_out: int = 0
+    skip_anonymization: bool = False
+    details: dict[str, object] = field(default_factory=dict)
+
+
+# --- Adapter contract ---------------------------------------------------------
+
+
+class ToolProviderAdapter(ABC):
+    """Abstract contract for a tool/data-source provider adapter.
+
+    Constructed once at startup, held in ``app.state.tool_adapters``, reused
+    across requests. All outbound HTTP MUST go through ``guarded_egress``."""
+
+    name: str
+
+    @abstractmethod
+    async def list_tools(self) -> list[ToolSpec]:
+        """Return the model-callable tools this provider offers."""
+
+    @abstractmethod
+    async def invoke_tool(self, tool: str, args: dict[str, Any], *, request_id: str) -> ToolResult:
+        """Invoke ``tool`` with ``args``; return structured provenance."""
+
+    @abstractmethod
+    async def health_check(self) -> ProviderHealth:
+        """Cheap reachability/credential probe."""
+
+    @abstractmethod
+    async def aclose(self) -> None:
+        """Release owned resources (HTTP clients, etc.)."""
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_provider_base.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add gateway/app/providers/tool/__init__.py gateway/app/providers/tool/base.py gateway/tests/test_tool_provider_base.py
+git commit -s -m "feat(gateway): ToolProviderAdapter base + ToolSpec/ToolResult (ADR 0014)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `guarded_egress` SSRF primitive
+
+This is the security heart of the PR. Every outbound tool call passes through it.
+
+**Files:**
+- Create: `gateway/app/providers/tool/egress.py`
+- Test: `gateway/tests/test_guarded_egress.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# gateway/tests/test_guarded_egress.py
+import pytest
+
+from app.providers.tool.egress import EgressRefused, validate_egress_target
+
+
+@pytest.mark.unit
+def test_rejects_non_https() -> None:
+    with pytest.raises(EgressRefused, match="https"):
+        validate_egress_target("http://example.test/x", allowlist=["example.test"])
+
+
+@pytest.mark.unit
+def test_rejects_host_not_in_allowlist() -> None:
+    with pytest.raises(EgressRefused, match="allowlist"):
+        validate_egress_target("https://evil.test/x", allowlist=["example.test"])
+
+
+@pytest.mark.unit
+def test_rejects_private_ip_literal_host() -> None:
+    with pytest.raises(EgressRefused, match="private"):
+        validate_egress_target("https://127.0.0.1/x", allowlist=["127.0.0.1"])
+
+
+@pytest.mark.unit
+def test_rejects_link_local_and_metadata_ip() -> None:
+    with pytest.raises(EgressRefused, match="private"):
+        validate_egress_target("https://169.254.169.254/latest", allowlist=["169.254.169.254"])
+
+
+@pytest.mark.unit
+def test_allows_public_host_in_allowlist(monkeypatch) -> None:
+    # Stub DNS so the test never makes a real resolution.
+    monkeypatch.setattr(
+        "app.providers.tool.egress._resolve_ips",
+        lambda host: ["93.184.216.34"],  # example.com public IP
+    )
+    # Should not raise.
+    validate_egress_target("https://example.test/x", allowlist=["example.test"])
+
+
+@pytest.mark.unit
+def test_rejects_dns_rebind_to_private(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.providers.tool.egress._resolve_ips",
+        lambda host: ["10.0.0.5"],  # allowlisted host that resolves private
+    )
+    with pytest.raises(EgressRefused, match="private"):
+        validate_egress_target("https://example.test/x", allowlist=["example.test"])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_guarded_egress.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.providers.tool.egress'`.
+
+- [ ] **Step 3: Write the primitive**
+
+```python
+# gateway/app/providers/tool/egress.py
+"""SSRF-guarded outbound egress primitive (ADR 0014 D2).
+
+The gateway-native equivalent of MikeOSS's ``validateRemoteMcpUrl`` /
+``guardedFetch``. Every tool-provider adapter MUST validate its outbound URL
+through :func:`validate_egress_target` before issuing a request. Enforces:
+HTTPS-only; host in the per-provider allowlist; resolved IPs are public
+(blocks private/loopback/link-local/CGNAT, defeating DNS-rebind)."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+class EgressRefused(Exception):
+    """Raised when an outbound target violates egress policy."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _resolve_ips(host: str) -> list[str]:
+    """Resolve ``host`` to its IP addresses. Wrapped so tests can stub it."""
+    infos = socket.getaddrinfo(host, None)
+    return [info[4][0] for info in infos]
+
+
+def _is_public_ip(ip: str) -> bool:
+    addr = ipaddress.ip_address(ip)
+    return not (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+def validate_egress_target(url: str, *, allowlist: list[str]) -> None:
+    """Validate ``url`` against egress policy. Raise :class:`EgressRefused`.
+
+    Checks, in order: scheme is https; host present; host is in ``allowlist``;
+    every resolved IP for the host is public (blocks IP-literal private hosts
+    and DNS-rebind of an allowlisted name to a private address)."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise EgressRefused(f"egress must use https, got scheme {parsed.scheme!r}")
+    host = parsed.hostname
+    if not host:
+        raise EgressRefused("egress target has no host")
+    if host not in allowlist:
+        raise EgressRefused(f"host {host!r} not in provider allowlist")
+    for ip in _resolve_ips(host):
+        if not _is_public_ip(ip):
+            raise EgressRefused(f"host {host!r} resolves to private/blocked address {ip}")
+
+
+# Headers a caller may never override on an outbound tool request.
+_FORBIDDEN_OUTBOUND_HEADERS = frozenset({"host", "x-lq-ai-gateway-key"})
+
+
+def validate_outbound_headers(headers: dict[str, str]) -> None:
+    """Reject caller-supplied Host overrides and smuggled gateway auth."""
+    for name in headers:
+        if name.lower() in _FORBIDDEN_OUTBOUND_HEADERS:
+            raise EgressRefused(f"outbound header {name!r} is not allowed")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_guarded_egress.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Add the header-validation test + commit**
+
+Append to `gateway/tests/test_guarded_egress.py`:
+
+```python
+@pytest.mark.unit
+def test_rejects_host_header_override() -> None:
+    from app.providers.tool.egress import validate_outbound_headers
+
+    with pytest.raises(EgressRefused, match="Host"):
+        validate_outbound_headers({"Host": "evil.test"})
+```
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_guarded_egress.py -v` → PASS (7 tests).
+
+```bash
+cd ~/Code/lq-ai && git add gateway/app/providers/tool/egress.py gateway/tests/test_guarded_egress.py
+git commit -s -m "feat(gateway): SSRF-guarded egress primitive (ADR 0014 D2)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Per-provider rate limiter
+
+**Files:**
+- Create: `gateway/app/providers/tool/ratelimit.py`
+- Test: `gateway/tests/test_tool_ratelimit.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# gateway/tests/test_tool_ratelimit.py
+import pytest
+
+from app.providers.tool.ratelimit import FixedWindowRateLimiter, RateLimited
+
+
+@pytest.mark.unit
+def test_allows_up_to_limit_then_refuses() -> None:
+    clock = {"t": 1000.0}
+    limiter = FixedWindowRateLimiter(requests_per_minute=3, now=lambda: clock["t"])
+    for _ in range(3):
+        limiter.check("echo-test")  # no raise
+    with pytest.raises(RateLimited):
+        limiter.check("echo-test")
+
+
+@pytest.mark.unit
+def test_window_resets_after_60s() -> None:
+    clock = {"t": 1000.0}
+    limiter = FixedWindowRateLimiter(requests_per_minute=1, now=lambda: clock["t"])
+    limiter.check("echo-test")
+    with pytest.raises(RateLimited):
+        limiter.check("echo-test")
+    clock["t"] += 61.0
+    limiter.check("echo-test")  # new window, no raise
+
+
+@pytest.mark.unit
+def test_limits_are_per_provider() -> None:
+    clock = {"t": 1000.0}
+    limiter = FixedWindowRateLimiter(requests_per_minute=1, now=lambda: clock["t"])
+    limiter.check("a")
+    limiter.check("b")  # different provider, independent budget
+    with pytest.raises(RateLimited):
+        limiter.check("a")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_ratelimit.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the limiter**
+
+```python
+# gateway/app/providers/tool/ratelimit.py
+"""Per-provider fixed-window rate limiter for tool egress (ADR 0014).
+
+Self-contained, in-memory, per-provider. NOT the gateway's global
+``rate_limits`` (whose enforcement middleware is unwired). The clock is
+injectable so tests are deterministic without sleeping."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+_WINDOW_SECONDS = 60.0
+
+
+class RateLimited(Exception):
+    """Raised when a provider exceeds its per-minute request budget."""
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(f"rate limit exceeded for tool provider {provider!r}")
+        self.provider = provider
+
+
+class FixedWindowRateLimiter:
+    """Fixed 60-second window, ``requests_per_minute`` budget per provider."""
+
+    def __init__(
+        self, *, requests_per_minute: int, now: Callable[[], float] = time.monotonic
+    ) -> None:
+        self._limit = requests_per_minute
+        self._now = now
+        # provider -> (window_start, count)
+        self._windows: dict[str, tuple[float, int]] = {}
+
+    def check(self, provider: str) -> None:
+        """Record one request for ``provider``; raise :class:`RateLimited`
+        if it would exceed the budget for the current window."""
+        now = self._now()
+        start, count = self._windows.get(provider, (now, 0))
+        if now - start >= _WINDOW_SECONDS:
+            start, count = now, 0
+        if count >= self._limit:
+            raise RateLimited(provider)
+        self._windows[provider] = (start, count + 1)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_ratelimit.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add gateway/app/providers/tool/ratelimit.py gateway/tests/test_tool_ratelimit.py
+git commit -s -m "feat(gateway): per-provider tool egress rate limiter (ADR 0014)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `EchoToolAdapter` — the proof-of-path provider
+
+The echo adapter validates its target through `guarded_egress` but, being a test provider, returns its input rather than making a real call (so unit tests need no network). It proves the adapter contract + egress validation wiring end-to-end.
+
+**Files:**
+- Create: `gateway/app/providers/tool/echo.py`
+- Modify: `gateway/app/providers/tool/__init__.py` (re-export `EchoToolAdapter`)
+- Test: `gateway/tests/test_echo_tool_adapter.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# gateway/tests/test_echo_tool_adapter.py
+import pytest
+
+from app.config import ToolProviderConfig
+from app.providers.tool.base import ToolResult
+from app.providers.tool.echo import EchoToolAdapter
+from app.providers.tool.egress import EgressRefused
+
+
+def _cfg(**over) -> ToolProviderConfig:
+    base = {
+        "name": "echo-test",
+        "type": "echo",
+        "base_url": "https://example.test",
+        "egress_tier": 4,
+        "allowlist": {"hosts": ["example.test"]},
+    }
+    base.update(over)
+    return ToolProviderConfig.model_validate(base)
+
+
+@pytest.mark.unit
+async def test_echo_invoke_returns_input() -> None:
+    adapter = EchoToolAdapter.from_config(_cfg())
+    try:
+        result = await adapter.invoke_tool("echo", {"msg": "hi"}, request_id="req_1")
+    finally:
+        await adapter.aclose()
+    assert isinstance(result, ToolResult)
+    assert result.provider == "echo-test"
+    assert result.payload == {"echoed": {"msg": "hi"}}
+    assert result.bytes_out > 0
+
+
+@pytest.mark.unit
+async def test_echo_lists_one_tool() -> None:
+    adapter = EchoToolAdapter.from_config(_cfg())
+    try:
+        tools = await adapter.list_tools()
+    finally:
+        await adapter.aclose()
+    assert [t.name for t in tools] == ["echo"]
+    assert tools[0].read_only is True
+
+
+@pytest.mark.unit
+async def test_echo_rejects_unknown_tool() -> None:
+    from app.providers.tool.base import ToolProviderError
+
+    adapter = EchoToolAdapter.from_config(_cfg())
+    try:
+        with pytest.raises(ToolProviderError):
+            await adapter.invoke_tool("nope", {}, request_id="req_1")
+    finally:
+        await adapter.aclose()
+
+
+@pytest.mark.unit
+async def test_echo_base_url_must_pass_egress_policy() -> None:
+    # base_url host not in its own allowlist -> egress refusal at validation.
+    with pytest.raises(EgressRefused):
+        EchoToolAdapter.from_config(
+            _cfg(base_url="https://evil.test", allowlist={"hosts": ["example.test"]})
+        ).validate_base_url()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_echo_tool_adapter.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the adapter**
+
+```python
+# gateway/app/providers/tool/echo.py
+"""``echo`` tool provider — the PR1 proof-of-path adapter (ADR 0014).
+
+Implements the full :class:`ToolProviderAdapter` contract and exercises the
+egress-validation wiring, but returns its input instead of making a network
+call, so unit tests need no live endpoint. Replaced by real providers
+(CourtListener PR2, MCP PR4)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from app.config import ToolProviderConfig
+from app.providers.base import ProviderHealth
+from app.providers.tool.base import (
+    ToolProviderAdapter,
+    ToolProviderError,
+    ToolResult,
+    ToolSpec,
+)
+from app.providers.tool.egress import validate_egress_target
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+class EchoToolAdapter(ToolProviderAdapter):
+    def __init__(
+        self,
+        *,
+        name: str,
+        base_url: str,
+        allowlist: list[str],
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.name = name
+        self._base_url = base_url.rstrip("/")
+        self._allowlist = allowlist
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(base_url=self._base_url, timeout=DEFAULT_TIMEOUT_SECONDS)
+
+    @classmethod
+    def from_config(cls, provider: ToolProviderConfig) -> "EchoToolAdapter":
+        if provider.type != "echo":
+            raise ValueError(f"EchoToolAdapter built from non-echo provider {provider.type!r}")
+        return cls(
+            name=provider.name,
+            base_url=provider.base_url,
+            allowlist=provider.allowlist.hosts,
+        )
+
+    def validate_base_url(self) -> None:
+        """Confirm the configured base_url satisfies this provider's own
+        egress policy (called at build time so a misconfig fails at startup)."""
+        validate_egress_target(self._base_url + "/", allowlist=self._allowlist)
+
+    async def list_tools(self) -> list[ToolSpec]:
+        return [
+            ToolSpec(
+                name="echo",
+                description="Echoes its input arguments back. Test provider only.",
+                parameters={"type": "object", "additionalProperties": True},
+                read_only=True,
+            )
+        ]
+
+    async def invoke_tool(self, tool: str, args: dict[str, Any], *, request_id: str) -> ToolResult:
+        if tool != "echo":
+            raise ToolProviderError(f"unknown tool {tool!r} for echo provider")
+        encoded = json.dumps(args).encode("utf-8")
+        return ToolResult(
+            provider=self.name,
+            tool=tool,
+            payload={"echoed": args},
+            bytes_out=len(encoded),
+            bytes_in=len(encoded),
+        )
+
+    async def health_check(self) -> ProviderHealth:
+        return ProviderHealth(name=self.name, reachable=True, latency_ms=0)
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+```
+
+Add `EchoToolAdapter` to the `__init__.py` re-exports + `__all__`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_echo_tool_adapter.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add gateway/app/providers/tool/echo.py gateway/app/providers/tool/__init__.py gateway/tests/test_echo_tool_adapter.py
+git commit -s -m "feat(gateway): echo tool provider (PR1 proof-of-path)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Gateway-side `tool_egress_log` writer
+
+Mirror `gateway/app/routing_log.py` exactly: a dataclass row, a `Protocol`, and SQL/Null/Recording implementations. `write()` must never raise.
+
+**Files:**
+- Create: `gateway/app/tool_egress_log.py`
+- Test: `gateway/tests/test_tool_egress_log_writer.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# gateway/tests/test_tool_egress_log_writer.py
+import pytest
+
+from app.tool_egress_log import (
+    NullToolEgressLogWriter,
+    RecordingToolEgressLogWriter,
+    ToolEgressLogRow,
+)
+
+
+@pytest.mark.unit
+async def test_recording_writer_captures_rows() -> None:
+    writer = RecordingToolEgressLogWriter()
+    row = ToolEgressLogRow(provider="echo-test", tool="echo", tier=4, bytes_out=2, bytes_in=2)
+    await writer.write(row)
+    assert len(writer.rows) == 1
+    assert writer.rows[0].provider == "echo-test"
+
+
+@pytest.mark.unit
+async def test_null_writer_is_noop() -> None:
+    writer = NullToolEgressLogWriter()
+    await writer.write(ToolEgressLogRow(provider="x", tool="echo", tier=4))  # no raise
+
+
+@pytest.mark.unit
+async def test_row_defaults_to_not_refused_not_anonymized() -> None:
+    row = ToolEgressLogRow(provider="x", tool="echo", tier=4)
+    assert row.refused is False
+    assert row.anonymization_applied is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_egress_log_writer.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the writer** (copy the structure of `routing_log.py`)
+
+```python
+# gateway/app/tool_egress_log.py
+"""``tool_egress_log`` writer (ADR 0014 D3).
+
+Same design as ``app.routing_log``: the gateway is the only component that
+knows which tool provider was called, so the gateway writes the audit row —
+raw parameter-bound SQL (the table is api-owned; we don't double-up ORM
+models across services). Counts and types only, NEVER raw payloads.
+``write()`` must never raise: the egress data path takes priority over audit.
+Schema authority: ``api/alembic/versions/0048_tool_egress_log.py``."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Protocol, runtime_checkable
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "NullToolEgressLogWriter",
+    "RecordingToolEgressLogWriter",
+    "SQLToolEgressLogWriter",
+    "ToolEgressLogRow",
+    "ToolEgressLogWriter",
+]
+
+
+@dataclass
+class ToolEgressLogRow:
+    provider: str
+    tool: str
+    tier: int
+    request_id: str | None = None
+    bytes_out: int | None = None
+    bytes_in: int | None = None
+    anonymization_applied: bool = False
+    refused: bool = False
+    refusal_reason: str | None = None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+
+
+_INSERT_SQL = text(
+    """
+    INSERT INTO tool_egress_log (
+        timestamp, request_id, provider, tool, tier,
+        bytes_out, bytes_in, anonymization_applied, refused, refusal_reason
+    ) VALUES (
+        :timestamp, :request_id, :provider, :tool, :tier,
+        :bytes_out, :bytes_in, :anonymization_applied, :refused, :refusal_reason
+    )
+    """
+)
+
+
+def _to_params(row: ToolEgressLogRow) -> dict[str, object]:
+    return {
+        "timestamp": row.timestamp,
+        "request_id": row.request_id,
+        "provider": row.provider,
+        "tool": row.tool,
+        "tier": row.tier,
+        "bytes_out": row.bytes_out,
+        "bytes_in": row.bytes_in,
+        "anonymization_applied": row.anonymization_applied,
+        "refused": row.refused,
+        "refusal_reason": row.refusal_reason,
+    }
+
+
+@runtime_checkable
+class ToolEgressLogWriter(Protocol):
+    async def write(self, row: ToolEgressLogRow) -> None: ...
+
+
+class SQLToolEgressLogWriter:
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    async def write(self, row: ToolEgressLogRow) -> None:
+        try:
+            async with self._engine.begin() as conn:
+                await conn.execute(_INSERT_SQL, _to_params(row))
+        except Exception as exc:
+            logger.error("failed to write tool_egress_log row: %s", exc)
+
+
+class NullToolEgressLogWriter:
+    async def write(self, row: ToolEgressLogRow) -> None:
+        return None
+
+
+class RecordingToolEgressLogWriter:
+    """Test double; records rows in memory."""
+
+    def __init__(self) -> None:
+        self.rows: list[ToolEgressLogRow] = []
+
+    async def write(self, row: ToolEgressLogRow) -> None:
+        self.rows.append(row)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_egress_log_writer.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add gateway/app/tool_egress_log.py gateway/tests/test_tool_egress_log_writer.py
+git commit -s -m "feat(gateway): tool_egress_log writer (ADR 0014 D3)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `Router.route_tool_call` — the governed egress path
+
+Ties it together: resolve the provider, rate-limit, check egress tier, invoke the adapter, write the audit row. Refusals are audited too (a `refused=True` row), mirroring the inference path's `_write_unresolved`.
+
+**Files:**
+- Modify: `gateway/app/router.py`
+- Test: `gateway/tests/test_route_tool_call.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# gateway/tests/test_route_tool_call.py
+import pytest
+
+from app.config import GatewayConfig
+from app.providers.tool.echo import EchoToolAdapter
+from app.providers.tool.ratelimit import FixedWindowRateLimiter
+from app.router import Router, ToolEgressRefused
+from app.tool_egress_log import RecordingToolEgressLogWriter
+
+
+def _config() -> GatewayConfig:
+    return GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test",
+                    "type": "echo",
+                    "base_url": "https://example.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                    "rate_limit": {"requests_per_minute": 2},
+                }
+            ]
+        }
+    )
+
+
+def _router(writer, clock=None):
+    cfg = _config()
+    adapter = EchoToolAdapter.from_config(cfg.tool_providers[0])
+    limiter = FixedWindowRateLimiter(
+        requests_per_minute=2, now=(clock or (lambda: 1000.0))
+    )
+    return Router(
+        config=cfg,
+        adapters={},
+        tool_adapters={"echo-test": adapter},
+        tool_egress_log=writer,
+        tool_rate_limiter=limiter,
+    )
+
+
+@pytest.mark.unit
+async def test_route_tool_call_happy_path_writes_audit_row() -> None:
+    writer = RecordingToolEgressLogWriter()
+    router = _router(writer)
+    result = await router.route_tool_call(
+        "echo-test", "echo", {"msg": "hi"}, request_id="req_1", max_allowed_tier=4
+    )
+    assert result.payload == {"echoed": {"msg": "hi"}}
+    assert len(writer.rows) == 1
+    assert writer.rows[0].refused is False
+    assert writer.rows[0].tier == 4
+
+
+@pytest.mark.unit
+async def test_route_tool_call_refuses_when_egress_tier_exceeds_ceiling() -> None:
+    writer = RecordingToolEgressLogWriter()
+    router = _router(writer)
+    # Matter ceiling is tier 3 (privileged); provider egress_tier 4 is weaker.
+    with pytest.raises(ToolEgressRefused, match="egress_tier"):
+        await router.route_tool_call(
+            "echo-test", "echo", {"msg": "x"}, request_id="req_2", max_allowed_tier=3
+        )
+    assert writer.rows[-1].refused is True
+    assert writer.rows[-1].refusal_reason is not None
+
+
+@pytest.mark.unit
+async def test_route_tool_call_refuses_unknown_provider() -> None:
+    writer = RecordingToolEgressLogWriter()
+    router = _router(writer)
+    with pytest.raises(ToolEgressRefused, match="unknown"):
+        await router.route_tool_call(
+            "missing", "echo", {}, request_id="req_3", max_allowed_tier=5
+        )
+
+
+@pytest.mark.unit
+async def test_route_tool_call_enforces_rate_limit() -> None:
+    writer = RecordingToolEgressLogWriter()
+    router = _router(writer)
+    for i in range(2):
+        await router.route_tool_call(
+            "echo-test", "echo", {}, request_id=f"r{i}", max_allowed_tier=4
+        )
+    with pytest.raises(ToolEgressRefused, match="rate"):
+        await router.route_tool_call(
+            "echo-test", "echo", {}, request_id="r3", max_allowed_tier=4
+        )
+    assert writer.rows[-1].refused is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_route_tool_call.py -v`
+Expected: FAIL — `Router.__init__` got unexpected kwargs / `cannot import name 'ToolEgressRefused'`.
+
+- [ ] **Step 3: Extend the Router**
+
+In `gateway/app/router.py`: add imports near the top:
+
+```python
+from dataclasses import dataclass
+
+from app.providers.tool.base import ToolProviderAdapter, ToolResult
+from app.providers.tool.egress import EgressRefused
+from app.providers.tool.ratelimit import FixedWindowRateLimiter, RateLimited
+from app.tool_egress_log import (
+    NullToolEgressLogWriter,
+    ToolEgressLogRow,
+    ToolEgressLogWriter,
+)
+```
+
+Add the refusal error + result type (module level):
+
+```python
+class ToolEgressRefused(Exception):
+    """Raised when a tool call is refused (unknown provider, tier ceiling,
+    rate limit, or SSRF policy). Always paired with an audited refusal row."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class ToolCallRoutedResult:
+    provider: str
+    tool: str
+    payload: object
+    tier: int
+```
+
+Extend `Router.__init__` to accept the new (optional, keyword-only, defaulted) dependencies so existing inference construction is unchanged:
+
+```python
+    def __init__(
+        self,
+        *,
+        config: GatewayConfig,
+        adapters: dict[str, ProviderAdapter],
+        config_provider: Callable[[], GatewayConfig] | None = None,
+        tool_adapters: dict[str, ToolProviderAdapter] | None = None,
+        tool_egress_log: ToolEgressLogWriter | None = None,
+        tool_rate_limiter: FixedWindowRateLimiter | None = None,
+    ) -> None:
+        self._config = config
+        self._adapters = adapters
+        self._config_provider = config_provider
+        self._tool_adapters = tool_adapters or {}
+        self._tool_egress_log = tool_egress_log or NullToolEgressLogWriter()
+        # A single shared limiter; per-provider budgets are keyed inside it.
+        # If not injected, build one from the max configured rpm (the limiter
+        # is per-provider-keyed, so a single instance serves all providers).
+        if tool_rate_limiter is not None:
+            self._tool_rate_limiter = tool_rate_limiter
+        else:
+            max_rpm = max(
+                (tp.rate_limit.requests_per_minute for tp in config.tool_providers),
+                default=60,
+            )
+            self._tool_rate_limiter = FixedWindowRateLimiter(requests_per_minute=max_rpm)
+```
+
+Add the method:
+
+```python
+    async def route_tool_call(
+        self,
+        provider_name: str,
+        tool: str,
+        args: dict[str, object],
+        *,
+        request_id: str,
+        max_allowed_tier: int | None = None,
+    ) -> ToolCallRoutedResult:
+        """Govern + dispatch one tool call (ADR 0014 D2/D3/D4).
+
+        Order: resolve provider -> rate limit -> egress-tier ceiling ->
+        adapter invoke (which validates SSRF) -> write audit row. Every
+        refusal writes a ``refused=True`` row before raising."""
+        provider = self.config.tool_provider_by_name(provider_name)
+        adapter = self._tool_adapters.get(provider_name)
+        if provider is None or adapter is None:
+            await self._tool_egress_log.write(
+                ToolEgressLogRow(
+                    provider=provider_name, tool=tool, tier=0,
+                    refused=True, refusal_reason="unknown tool provider",
+                    request_id=request_id,
+                )
+            )
+            raise ToolEgressRefused(f"unknown tool provider {provider_name!r}")
+
+        # Rate limit (per-provider).
+        try:
+            self._tool_rate_limiter.check(provider_name)
+        except RateLimited as exc:
+            await self._tool_egress_log.write(
+                ToolEgressLogRow(
+                    provider=provider_name, tool=tool, tier=provider.egress_tier,
+                    refused=True, refusal_reason="rate limit exceeded",
+                    request_id=request_id,
+                )
+            )
+            raise ToolEgressRefused(str(exc)) from exc
+
+        # Egress-tier ceiling: refuse if the provider's egress tier is weaker
+        # (numerically greater) than the matter/skill ceiling allows.
+        if max_allowed_tier is not None and provider.egress_tier > max_allowed_tier:
+            await self._tool_egress_log.write(
+                ToolEgressLogRow(
+                    provider=provider_name, tool=tool, tier=provider.egress_tier,
+                    refused=True, refusal_reason="egress_tier exceeds policy ceiling",
+                    request_id=request_id,
+                )
+            )
+            raise ToolEgressRefused(
+                f"egress_tier {provider.egress_tier} exceeds ceiling {max_allowed_tier}"
+            )
+
+        # Invoke (adapter validates SSRF on any real outbound call).
+        try:
+            result: ToolResult = await adapter.invoke_tool(tool, args, request_id=request_id)
+        except EgressRefused as exc:
+            await self._tool_egress_log.write(
+                ToolEgressLogRow(
+                    provider=provider_name, tool=tool, tier=provider.egress_tier,
+                    refused=True, refusal_reason=f"ssrf: {exc.reason}",
+                    request_id=request_id,
+                )
+            )
+            raise ToolEgressRefused(f"egress refused: {exc.reason}") from exc
+
+        # Success audit row. anonymization_applied is honestly False in PR1
+        # (no outbound transform yet — see plan scope note).
+        await self._tool_egress_log.write(
+            ToolEgressLogRow(
+                provider=provider_name, tool=tool, tier=provider.egress_tier,
+                bytes_out=result.bytes_out, bytes_in=result.bytes_in,
+                anonymization_applied=False, refused=False, request_id=request_id,
+            )
+        )
+        return ToolCallRoutedResult(
+            provider=provider_name, tool=tool, payload=result.payload,
+            tier=provider.egress_tier,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_route_tool_call.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Run the full gateway suite to confirm no regression in inference construction**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest -q`
+Expected: PASS (existing `Router(...)` callers still work — the new params are keyword-only with defaults).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add gateway/app/router.py gateway/tests/test_route_tool_call.py
+git commit -s -m "feat(gateway): Router.route_tool_call governed egress path (ADR 0014)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Lifespan wiring + `build_tool_adapter` factory
+
+Build tool adapters at startup (validating each base_url against egress policy), hold them in `app.state.tool_adapters`, construct the SQL egress writer from the existing engine, and pass them into the `Router`.
+
+**Files:**
+- Modify: `gateway/app/main.py`
+- Test: `gateway/tests/test_tool_adapter_wiring.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# gateway/tests/test_tool_adapter_wiring.py
+import pytest
+
+from app.config import GatewayConfig
+from app.main import build_tool_adapter
+from app.providers.tool.echo import EchoToolAdapter
+from app.providers.tool.egress import EgressRefused
+
+
+@pytest.mark.unit
+def test_build_tool_adapter_echo() -> None:
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test", "type": "echo",
+                    "base_url": "https://example.test", "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    adapter = build_tool_adapter(cfg.tool_providers[0])
+    assert isinstance(adapter, EchoToolAdapter)
+
+
+@pytest.mark.unit
+def test_build_tool_adapter_rejects_base_url_outside_allowlist() -> None:
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "bad", "type": "echo",
+                    "base_url": "https://evil.test", "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    with pytest.raises(EgressRefused):
+        build_tool_adapter(cfg.tool_providers[0])
+
+
+@pytest.mark.unit
+def test_build_tool_adapter_disabled_returns_none() -> None:
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "off", "type": "echo", "enabled": False,
+                    "base_url": "https://example.test", "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    assert build_tool_adapter(cfg.tool_providers[0]) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_adapter_wiring.py -v`
+Expected: FAIL — `cannot import name 'build_tool_adapter'`.
+
+- [ ] **Step 3: Add the factory + wire the lifespan**
+
+In `gateway/app/main.py`, add the factory beside `build_adapter` (~line 96):
+
+```python
+def build_tool_adapter(provider: ToolProviderConfig) -> ToolProviderAdapter | None:
+    """Construct the tool adapter for one provider, or ``None`` if disabled
+    or no adapter exists for the type. Validates the base_url against the
+    provider's egress policy at build time so a misconfig fails at startup."""
+    if not provider.enabled:
+        return None
+    if provider.type == "echo":
+        adapter = EchoToolAdapter.from_config(provider)
+        adapter.validate_base_url()
+        return adapter
+    # courtlistener (PR2), mcp (PR4) land later.
+    return None
+```
+
+Add imports at the top of `main.py`:
+
+```python
+from app.config import ToolProviderConfig
+from app.providers.tool.base import ToolProviderAdapter
+from app.providers.tool.echo import EchoToolAdapter
+from app.tool_egress_log import (
+    NullToolEgressLogWriter,
+    SQLToolEgressLogWriter,
+)
+```
+
+In the lifespan startup (where `app.state.adapters` is built and the `Router` is constructed — find the block around the existing `Router(config=..., adapters=...)` construction), add:
+
+```python
+    tool_adapters: dict[str, ToolProviderAdapter] = {}
+    for tp in config.tool_providers:
+        adapter = build_tool_adapter(tp)
+        if adapter is not None:
+            tool_adapters[tp.name] = adapter
+    app.state.tool_adapters = tool_adapters
+
+    # Reuse the same engine the inference routing-log writer uses. If the
+    # gateway has no DB engine (DATABASE_URL unset), fall back to the no-op
+    # writer — same posture as NullRoutingLogWriter.
+    tool_egress_writer = (
+        SQLToolEgressLogWriter(engine) if engine is not None else NullToolEgressLogWriter()
+    )
+    app.state.tool_egress_log = tool_egress_writer
+```
+
+Then pass them into the `Router(...)` construction in that same block:
+
+```python
+    router = Router(
+        config=config,
+        adapters=adapters,
+        config_provider=...,            # keep the existing value
+        tool_adapters=tool_adapters,
+        tool_egress_log=tool_egress_writer,
+    )
+```
+
+And in the shutdown half of the lifespan, close the tool adapters alongside the inference adapters:
+
+```python
+    for adapter in tool_adapters.values():
+        await adapter.aclose()
+```
+
+*(Find the existing `engine` variable used by `SQLRoutingLogWriter` in this lifespan; reuse it verbatim. If the routing-log writer uses a different name, match it.)*
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_adapter_wiring.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full gateway suite + lifespan smoke (uses the example config)**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest -q`
+Expected: PASS. The `gateway_app` fixture starts the full lifespan against `gateway.yaml.example`; if that example has no `tool_providers`, the wiring is a no-op and existing tests stay green. (Task 10 adds the example block.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add gateway/app/main.py gateway/tests/test_tool_adapter_wiring.py
+git commit -s -m "feat(gateway): build + wire tool adapters and egress writer into lifespan
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: `gateway.yaml.example` block + boundary-register doc + gates
+
+**Files:**
+- Modify: `gateway.yaml.example`
+- Modify: `docs/security/boundary-registers.md`
+- Test: `gateway/tests/test_example_config_tool_providers.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# gateway/tests/test_example_config_tool_providers.py
+from pathlib import Path
+
+import pytest
+
+from app.config_loader import load_config
+
+EXAMPLE = Path(__file__).resolve().parents[2] / "gateway.yaml.example"
+
+
+@pytest.mark.unit
+def test_example_config_has_commented_tool_providers(example_env) -> None:
+    """The example loads cleanly; if a tool_providers block is uncommented it
+    must validate. PR1 ships it commented so the default stack is unchanged."""
+    cfg = load_config(EXAMPLE)
+    # Commented-out by default -> empty list, stack behavior unchanged.
+    assert cfg.tool_providers == []
+```
+
+*(The `example_env` fixture and `EXAMPLE` path mirror `gateway/tests/conftest.py`. If `conftest.py` already exposes an `EXAMPLE_CONFIG` constant, import it instead of recomputing the path.)*
+
+- [ ] **Step 2: Run test to verify it fails (or passes trivially), then add the example block**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_example_config_tool_providers.py -v`
+Expected: PASS already (no block yet → empty list). Now add the documented (commented) block so operators have the shape. Append to `gateway.yaml.example` after the `providers:` section:
+
+```yaml
+# ============================================================
+# TOOL / DATA-SOURCE PROVIDERS (ADR 0014) — third-party egress
+# ============================================================
+# A tool provider is third-party egress the gateway brokers and audits
+# (case-law APIs, MCP servers). Distinct from inference `providers:` above.
+# Every entry is SSRF/allowlist-guarded, tier-tagged, rate-limited, and
+# written to `tool_egress_log`. Uncomment and configure to enable.
+#
+# tool_providers:
+#   - name: courtlistener-prod
+#     type: courtlistener          # PR2 (not yet shipped); `echo` is the test type
+#     base_url: https://www.courtlistener.com/api/rest/v4
+#     api_key_env: COURTLISTENER_API_TOKEN   # OR api_key_encrypted (ADR 0011)
+#     egress_tier: 4               # data-egress tier (ADR 0014 D4)
+#     allowlist:
+#       hosts: [www.courtlistener.com]   # exact outbound host allowlist (SSRF)
+#     rate_limit:
+#       requests_per_minute: 60    # per-provider, enforced at the adapter
+#     anonymize_outbound: true     # default; transform lands in WS3/WS4
+```
+
+- [ ] **Step 3: Re-run the test + the full suite**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_example_config_tool_providers.py -q && docker compose run --rm gateway pytest -q`
+Expected: PASS.
+
+- [ ] **Step 4: Add the boundary-register entry**
+
+In `docs/security/boundary-registers.md`, add a register row/section for the **tool/data-source egress boundary**: what it guards (third-party egress), the controls (HTTPS-only, DNS-private block, host allowlist, no Host override, header validation, egress-tier ceiling, per-provider rate limit), the audit surface (`tool_egress_log`, counts-only), and a link to ADR 0014. Match the doc's existing entry format.
+
+- [ ] **Step 5: Run the gates (CLAUDE.md: both ruff gates + mypy --strict for gateway)**
+
+```bash
+cd ~/Code/lq-ai && docker compose run --rm gateway ruff format --check . \
+  && docker compose run --rm gateway ruff check . \
+  && docker compose run --rm gateway mypy --strict app
+```
+Expected: all clean. Fix any findings inline (re-run until green). Then the api gates for the migration/model:
+```bash
+cd ~/Code/lq-ai && docker compose run --rm api ruff format --check . && docker compose run --rm api ruff check .
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add gateway.yaml.example docs/security/boundary-registers.md gateway/tests/test_example_config_tool_providers.py
+git commit -s -m "docs(gateway): tool_providers example block + egress boundary register (ADR 0014)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: End-to-end integration test through the lifespan
+
+Prove the whole path with the example config carrying a (temporarily uncommented) echo provider, via the real lifespan-built router.
+
+**Files:**
+- Test: `gateway/tests/test_tool_egress_integration.py`
+
+- [ ] **Step 1: Write the integration test**
+
+```python
+# gateway/tests/test_tool_egress_integration.py
+import pytest
+
+from app.config import GatewayConfig
+from app.main import build_tool_adapter
+from app.router import Router
+from app.tool_egress_log import RecordingToolEgressLogWriter
+
+
+@pytest.mark.unit
+async def test_end_to_end_echo_through_router() -> None:
+    """Config -> build_tool_adapter -> Router.route_tool_call -> audit row.
+    Exercises every PR1 component together without a network call."""
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test", "type": "echo",
+                    "base_url": "https://example.test", "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                    "rate_limit": {"requests_per_minute": 10},
+                }
+            ]
+        }
+    )
+    adapter = build_tool_adapter(cfg.tool_providers[0])
+    assert adapter is not None
+    writer = RecordingToolEgressLogWriter()
+    router = Router(
+        config=cfg, adapters={},
+        tool_adapters={"echo-test": adapter}, tool_egress_log=writer,
+    )
+    try:
+        result = await router.route_tool_call(
+            "echo-test", "echo", {"q": "hello"}, request_id="req_e2e", max_allowed_tier=5
+        )
+    finally:
+        await adapter.aclose()
+    assert result.payload == {"echoed": {"q": "hello"}}
+    assert result.tier == 4
+    assert len(writer.rows) == 1
+    row = writer.rows[0]
+    assert row.refused is False
+    assert row.bytes_out and row.bytes_out > 0
+    assert row.anonymization_applied is False  # honest: no transform in PR1
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cd ~/Code/lq-ai && docker compose run --rm gateway pytest tests/test_tool_egress_integration.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Full suites green (gateway + api)**
+
+```bash
+cd ~/Code/lq-ai && docker compose run --rm gateway pytest -q && docker compose run --rm api pytest -q
+```
+Expected: PASS. (No `EXPECTED_PATHS`/`IMPLEMENTED_ROUTES` change in PR1 — no new HTTP route is added. That guard bumps in PR3.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/Code/lq-ai && git add gateway/tests/test_tool_egress_integration.py
+git commit -s -m "test(gateway): end-to-end tool egress path through router (ADR 0014)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Push, PR, security review
+
+- [ ] **Step 1: Push both remotes**
+
+```bash
+cd ~/Code/lq-ai && git push origin feat/legal-research-mcp-plan && git push tucuxi feat/legal-research-mcp-plan
+```
+
+- [ ] **Step 2: Open the PR** (base `main`), titled `feat(gateway): tool-provider egress boundary (WS1 / ADR 0014)`. In the body: link ADR 0014 + the mini-PRD; list the acceptance criteria from the PR1 row of the roadmap and check each; **flag the honest deferral** (no outbound anonymization transform yet; no CourtListener/MCP semantics; no HTTP route). Note this is security-sensitive (`gateway/**`).
+
+- [ ] **Step 3: Watch CI, route to security review.** Per CLAUDE.md merge-gating, `gateway/**` changes are **maintainer-reviewed + maintainer-merged** — do NOT self-merge. Offer the maintainer a review walkthrough. Address review feedback via the `superpowers:receiving-code-review` discipline (verify each point against the code, don't perform agreement).
+
+---
+
+## Self-Review (completed against the spec)
+
+**Spec coverage (WS1 section + ADR 0014):**
+- New tool-provider class → Tasks 2, 3, 6, 9. ✓
+- `tool_providers:` config block → Task 2 + Task 10 (example). ✓
+- SSRF/allowlist primitive (HTTPS, DNS-private-block, host allowlist, no Host override, header validation) → Task 4. ✓
+- `tool_egress_log` (counts only, refused+reason) → Tasks 1, 7, 8. ✓
+- Per-provider rate limiting at the adapter (C3) → Tasks 5, 8. ✓
+- Egress-tier refusal (ADR 0014 D4) → Task 8. ✓
+- Outbound anonymization (ADR 0014 D5) → **explicitly scoped out of PR1** with an honest seam (documented in Scope + Task 8 success row writes `anonymization_applied=False`). Flagged, not silently dropped. ✓
+- Echo/test provider proving the path (spec "What WS1 does NOT do") → Task 6 + Task 11. ✓
+- Boundary-register doc (WS6 rider) → Task 10. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code; the two "find the existing X in the lifespan" notes (Task 9) point at a real, named construct (`engine`, the `Router(...)` block) rather than hand-waving — the implementer locates a concrete symbol, not invents one.
+
+**Type consistency:** `ToolProviderConfig`, `ToolProviderAdapter`, `ToolSpec`, `ToolResult`, `ToolEgressLogRow`, `ToolEgressRefused`, `EgressRefused`, `RateLimited`, `FixedWindowRateLimiter`, `build_tool_adapter`, `Router.route_tool_call`, `ToolCallRoutedResult` are defined once and referenced with the same names/signatures across tasks. `route_tool_call(provider_name, tool, args, *, request_id, max_allowed_tier)` matches between Task 8 definition and Task 11 use. `ToolResult.bytes_out/bytes_in` consistent between Tasks 3, 6, 8.
+
+**Known seam to confirm at execution time (not a gap):** Task 9 reuses the lifespan's existing DB `engine` symbol for the egress writer; its exact variable name must be read from `gateway/app/main.py` at implementation time (it is whatever `SQLRoutingLogWriter` is constructed with). Called out in the task.

--- a/gateway.yaml.example
+++ b/gateway.yaml.example
@@ -197,6 +197,26 @@ providers:
     enabled: ${VLLM_ENABLED:-false}
 
 # ============================================================
+# TOOL / DATA-SOURCE PROVIDERS (ADR 0014) — third-party egress
+# ============================================================
+# A tool provider is third-party egress the gateway brokers and audits
+# (case-law APIs, MCP servers). Distinct from inference `providers:` above.
+# Every entry is SSRF/allowlist-guarded, tier-tagged, rate-limited, and
+# written to `tool_egress_log`. Uncomment and configure to enable.
+#
+# tool_providers:
+#   - name: courtlistener-prod
+#     type: courtlistener          # PR2 (not yet shipped); `echo` is the test type
+#     base_url: https://www.courtlistener.com/api/rest/v4
+#     api_key_env: COURTLISTENER_API_TOKEN   # OR api_key_encrypted (ADR 0011)
+#     egress_tier: 4               # data-egress tier (ADR 0014 D4)
+#     allowlist:
+#       hosts: [www.courtlistener.com]   # exact outbound host allowlist (SSRF)
+#     rate_limit:
+#       requests_per_minute: 60    # per-provider, enforced at the adapter
+#     anonymize_outbound: true     # default; transform lands in WS3/WS4
+
+# ============================================================
 # MODEL ALIASES — friendly names → specific provider/model
 # ============================================================
 # Skills and the backend reference models by alias rather than

--- a/gateway/app/config.py
+++ b/gateway/app/config.py
@@ -132,6 +132,71 @@ class ProviderConfig(BaseModel):
         return self
 
 
+# --- Tool / data-source providers (ADR 0014) ---------------------------------
+
+
+ToolProviderType = Literal["echo", "courtlistener", "mcp"]
+"""Tool-provider family. ``echo`` is the test/proof type (PR1); ``courtlistener``
+and ``mcp`` land in later PRs."""
+
+
+class EgressAllowlistConfig(BaseModel):
+    """Per-provider outbound host allowlist (the SSRF guard's allow set)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    hosts: list[str] = Field(min_length=1)
+    """Non-empty list of exact hostnames the provider may egress to. An empty
+    allowlist is a misconfiguration, not 'allow all' — reject at config load."""
+
+
+class ToolProviderRateLimitConfig(BaseModel):
+    """Per-provider rate limit, enforced at the adapter (ADR 0014).
+
+    NOT the gateway's global ``rate_limits`` (whose enforcement middleware is
+    unwired). This is a self-contained per-provider limit applied by
+    ``Router.route_tool_call`` before each outbound call."""
+
+    model_config = ConfigDict(extra="allow")
+
+    requests_per_minute: int = Field(default=60, ge=1)
+
+
+class ToolProviderConfig(BaseModel):
+    """One entry under ``tool_providers:`` (ADR 0014 D1).
+
+    Sibling of :class:`ProviderConfig`, not a subclass — a tool provider is
+    invoked via ``invoke_tool``, not ``chat_completion``. Reuses the same two
+    API-key sourcing paths as inference providers (ADR 0011)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(min_length=1)
+    type: ToolProviderType
+    base_url: str = Field(min_length=1)
+    api_key_env: str | None = None
+    api_key_encrypted: str | None = None
+    egress_tier: InferenceTier
+    """Data-egress tier (ADR 0014 D4). The gateway refuses a call whose
+    matter/skill ceiling is more restrictive (a lower tier number) than this
+    provider's egress_tier."""
+    allowlist: EgressAllowlistConfig
+    rate_limit: ToolProviderRateLimitConfig = Field(default_factory=ToolProviderRateLimitConfig)
+    anonymize_outbound: bool = True
+    """Default True per ADR 0014 D5. NOTE: PR1 parses but does not yet apply
+    the transform (no matter context exists); enforcement lands in WS3/WS4."""
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def _exactly_one_key_source(self) -> ToolProviderConfig:
+        if self.api_key_env and self.api_key_encrypted:
+            raise ValueError(
+                f"Tool provider {self.name!r}: set either api_key_env OR "
+                f"api_key_encrypted, not both."
+            )
+        return self
+
+
 # --- Model aliases ------------------------------------------------------------
 
 
@@ -423,6 +488,7 @@ class GatewayConfig(BaseModel):
     server: ServerConfig = Field(default_factory=ServerConfig)
     gateway_auth: GatewayAuthConfig = Field(default_factory=GatewayAuthConfig)
     providers: list[ProviderConfig] = Field(default_factory=list)
+    tool_providers: list[ToolProviderConfig] = Field(default_factory=list)
     model_aliases: dict[str, ModelAliasConfig] = Field(default_factory=dict)
     inference_tiers: InferenceTiersConfig = Field(default_factory=InferenceTiersConfig)
     tier_policy: TierPolicyConfig = Field(default_factory=TierPolicyConfig)
@@ -526,6 +592,13 @@ class GatewayConfig(BaseModel):
         """
 
         for provider in self.providers:
+            if provider.name == name:
+                return provider
+        return None
+
+    def tool_provider_by_name(self, name: str) -> ToolProviderConfig | None:
+        """Look up a configured tool provider by name; ``None`` if not found."""
+        for provider in self.tool_providers:
             if provider.name == name:
                 return provider
         return None

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -59,7 +59,7 @@ from app.clients.backend import (
     close_backend_client,
     configure_backend_client,
 )
-from app.config import GatewayConfig, ProviderConfig
+from app.config import GatewayConfig, ProviderConfig, ToolProviderConfig
 from app.config_holder import MutableConfigHolder, install_sighup_reload
 from app.config_loader import ConfigLoadError, load_config
 from app.db import engine_or_none
@@ -72,8 +72,11 @@ from app.providers import (
     OpenAIAdapter,
     ProviderAdapter,
 )
+from app.providers.tool.base import ToolProviderAdapter
+from app.providers.tool.echo import EchoToolAdapter
 from app.router import Router
 from app.routing_log import NullRoutingLogWriter, RoutingLogWriter, SQLRoutingLogWriter
+from app.tool_egress_log import NullToolEgressLogWriter, SQLToolEgressLogWriter
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +142,20 @@ def build_adapter(provider: ProviderConfig) -> ProviderAdapter | None:
         return OllamaAdapter.from_config(provider)
     # B6 lands the remaining adapters (Vertex, Bedrock); until then there
     # is no adapter for those types (or any unknown type).
+    return None
+
+
+def build_tool_adapter(provider: ToolProviderConfig) -> ToolProviderAdapter | None:
+    """Construct the tool adapter for one provider, or ``None`` if disabled
+    or no adapter exists for the type. Validates the base_url against the
+    provider's egress policy at build time so a misconfig fails at startup."""
+    if not provider.enabled:
+        return None
+    if provider.type == "echo":
+        adapter = EchoToolAdapter.from_config(provider)
+        adapter.validate_base_url()
+        return adapter
+    # courtlistener (PR2), mcp (PR4) land later.
     return None
 
 
@@ -231,19 +248,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # lock binds to the right loop.
     app.state.provider_key_lock = asyncio.Lock()
 
-    # B4: build the request router around the loaded config + adapter
-    # registry. Per-request handlers pull this off ``app.state.router``
-    # rather than reconstructing it on every call.
-    # D0.5: pass the holder's ``current`` so the router reads the live
-    # config snapshot on each call. After an admin alias edit lands,
-    # the very next request resolves against the new map without
-    # restart.
-    app.state.router = Router(
-        config=config,
-        adapters=adapters,
-        config_provider=config_holder.current,
-    )
-
     # B4: wire the inference_routing_log writer. ``DATABASE_URL`` is
     # optional — without it the gateway falls back to a no-op writer
     # so the data path keeps working in degraded deployments. The
@@ -261,6 +265,59 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.info("inference_routing_log writer wired against DATABASE_URL")
     app.state.routing_log = routing_log
     app.state.db_engine = engine  # held so shutdown can dispose
+
+    # ADR 0014: build tool adapters for every configured tool provider.
+    # Disabled providers and unsupported types return None and are skipped.
+    # base_url is validated against the provider's egress allowlist at
+    # build time so a misconfig fails fast at startup rather than at
+    # request time.
+    tool_adapters: dict[str, ToolProviderAdapter] = {}
+    for tp in config.tool_providers:
+        try:
+            tool_adapter = build_tool_adapter(tp)
+        except Exception:
+            logger.exception(
+                "skipping tool provider %r (type=%s): egress validation failed",
+                tp.name,
+                tp.type,
+            )
+            continue
+        if tool_adapter is not None:
+            tool_adapters[tp.name] = tool_adapter
+            logger.info(
+                "instantiated %s adapter for tool provider %r (type=%s)",
+                type(tool_adapter).__name__,
+                tp.name,
+                tp.type,
+            )
+    app.state.tool_adapters = tool_adapters
+
+    tool_egress_writer = (
+        SQLToolEgressLogWriter(engine) if engine is not None else NullToolEgressLogWriter()
+    )
+    app.state.tool_egress_log = tool_egress_writer
+    if engine is not None:
+        logger.info("tool_egress_log writer wired against DATABASE_URL")
+    else:
+        logger.warning(
+            "DATABASE_URL is not set; tool_egress_log writes are disabled "
+            "(tool calls still work, but no audit rows are persisted)"
+        )
+
+    # B4: build the request router around the loaded config + adapter
+    # registry. Per-request handlers pull this off ``app.state.router``
+    # rather than reconstructing it on every call.
+    # D0.5: pass the holder's ``current`` so the router reads the live
+    # config snapshot on each call. After an admin alias edit lands,
+    # the very next request resolves against the new map without
+    # restart.
+    app.state.router = Router(
+        config=config,
+        adapters=adapters,
+        config_provider=config_holder.current,
+        tool_adapters=tool_adapters,
+        tool_egress_log=tool_egress_writer,
+    )
 
     # C2: backend HTTP client + skill cache. The client reads
     # LQ_AI_API_URL / LQ_AI_GATEWAY_KEY / LQ_AI_SKILL_CACHE_TTL_SECONDS
@@ -308,6 +365,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                     await adapter.aclose()
                 except Exception:
                     logger.exception("error closing retired adapter")
+        # ADR 0014: close tool provider adapters.
+        if tool_adapters:
+            logger.info("closing %d tool adapters", len(tool_adapters))
+        for tool_name, tool_adapter in tool_adapters.items():
+            try:
+                await tool_adapter.aclose()
+            except Exception:
+                logger.exception("error closing tool adapter %r", tool_name)
         try:
             await close_backend_client()
         except Exception:

--- a/gateway/app/providers/tool/__init__.py
+++ b/gateway/app/providers/tool/__init__.py
@@ -14,8 +14,10 @@ from app.providers.tool.base import (
     ToolResult,
     ToolSpec,
 )
+from app.providers.tool.echo import EchoToolAdapter
 
 __all__ = [
+    "EchoToolAdapter",
     "ToolProviderAdapter",
     "ToolProviderAuthError",
     "ToolProviderError",

--- a/gateway/app/providers/tool/__init__.py
+++ b/gateway/app/providers/tool/__init__.py
@@ -1,0 +1,26 @@
+"""Tool / data-source provider egress class (ADR 0014).
+
+A tool provider is a sibling of the inference :class:`ProviderAdapter`,
+invoked via ``invoke_tool`` rather than ``chat_completion``. All outbound
+HTTP from a tool adapter MUST route through ``guarded_egress`` (ADR 0014 D2).
+"""
+
+from app.providers.tool.base import (
+    ToolProviderAdapter,
+    ToolProviderAuthError,
+    ToolProviderError,
+    ToolProviderHTTPError,
+    ToolProviderNetworkError,
+    ToolResult,
+    ToolSpec,
+)
+
+__all__ = [
+    "ToolProviderAdapter",
+    "ToolProviderAuthError",
+    "ToolProviderError",
+    "ToolProviderHTTPError",
+    "ToolProviderNetworkError",
+    "ToolResult",
+    "ToolSpec",
+]

--- a/gateway/app/providers/tool/base.py
+++ b/gateway/app/providers/tool/base.py
@@ -1,0 +1,117 @@
+"""Abstract :class:`ToolProviderAdapter` contract + shared types.
+
+Mirrors the design of :mod:`app.providers.base` (the inference adapter
+contract) but for non-inference egress: list the tools a provider offers,
+invoke one, return structured provenance. Errors follow the same
+public-safe, key-scrubbing discipline (CONTRIBUTING.md security rules).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.providers.base import ProviderHealth
+
+# --- Errors -------------------------------------------------------------------
+
+
+class ToolProviderError(Exception):
+    """Base class for tool-provider errors. Public-safe; never leak keys."""
+
+    code: str = "tool_provider_error"
+
+    def __init__(self, message: str, *, details: dict[str, object] | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.details = details or {}
+
+    def to_envelope(self) -> dict[str, object]:
+        return {
+            "error": {"code": self.code, "message": self.message, "details": dict(self.details)}
+        }
+
+
+class ToolProviderAuthError(ToolProviderError):
+    code = "unauthorized"
+
+
+class ToolProviderHTTPError(ToolProviderError):
+    code = "tool_provider_unavailable"
+
+    def __init__(
+        self, message: str, *, upstream_status: int, details: dict[str, object] | None = None
+    ) -> None:
+        merged: dict[str, object] = dict(details or {})
+        merged["upstream_status"] = upstream_status
+        super().__init__(message, details=merged)
+        self.upstream_status = upstream_status
+
+
+class ToolProviderNetworkError(ToolProviderError):
+    code = "tool_provider_unavailable"
+
+
+# --- Tool spec + result -------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """One model-callable tool a provider offers.
+
+    ``parameters`` is a JSON-schema object. The metadata flags map to
+    MikeOSS's ``readOnly``/``destructive``/``requiresConfirmation`` and are
+    carried through to WS4's confirmation gates (ADR 0015 D2/D4)."""
+
+    name: str
+    description: str
+    parameters: dict[str, Any]
+    read_only: bool = True
+    destructive: bool = False
+    requires_confirmation: bool = False
+
+
+@dataclass
+class ToolResult:
+    """Result of one tool invocation, with provenance + byte counts.
+
+    ``payload`` is the structured tool output. ``skip_anonymization`` marks
+    inbound public text (e.g. opinion bodies) that must reach the citation
+    engine verbatim (ADR 0014 D5); the echo provider leaves it False."""
+
+    provider: str
+    tool: str
+    payload: Any
+    bytes_in: int = 0
+    bytes_out: int = 0
+    skip_anonymization: bool = False
+    details: dict[str, object] = field(default_factory=dict)
+
+
+# --- Adapter contract ---------------------------------------------------------
+
+
+class ToolProviderAdapter(ABC):
+    """Abstract contract for a tool/data-source provider adapter.
+
+    Constructed once at startup, held in ``app.state.tool_adapters``, reused
+    across requests. All outbound HTTP MUST go through ``guarded_egress``."""
+
+    name: str
+
+    @abstractmethod
+    async def list_tools(self) -> list[ToolSpec]:
+        """Return the model-callable tools this provider offers."""
+
+    @abstractmethod
+    async def invoke_tool(self, tool: str, args: dict[str, Any], *, request_id: str) -> ToolResult:
+        """Invoke ``tool`` with ``args``; return structured provenance."""
+
+    @abstractmethod
+    async def health_check(self) -> ProviderHealth:
+        """Cheap reachability/credential probe."""
+
+    @abstractmethod
+    async def aclose(self) -> None:
+        """Release owned resources (HTTP clients, etc.)."""

--- a/gateway/app/providers/tool/echo.py
+++ b/gateway/app/providers/tool/echo.py
@@ -1,0 +1,87 @@
+"""``echo`` tool provider — the PR1 proof-of-path adapter (ADR 0014).
+
+Implements the full :class:`ToolProviderAdapter` contract and exercises the
+egress-validation wiring, but returns its input instead of making a network
+call, so unit tests need no live endpoint. Replaced by real providers
+(CourtListener PR2, MCP PR4)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from app.config import ToolProviderConfig
+from app.providers.base import ProviderHealth
+from app.providers.tool.base import (
+    ToolProviderAdapter,
+    ToolProviderError,
+    ToolResult,
+    ToolSpec,
+)
+from app.providers.tool.egress import validate_egress_target
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+class EchoToolAdapter(ToolProviderAdapter):
+    def __init__(
+        self,
+        *,
+        name: str,
+        base_url: str,
+        allowlist: list[str],
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.name = name
+        self._base_url = base_url.rstrip("/")
+        self._allowlist = allowlist
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            base_url=self._base_url, timeout=DEFAULT_TIMEOUT_SECONDS
+        )
+
+    @classmethod
+    def from_config(cls, provider: ToolProviderConfig) -> EchoToolAdapter:
+        if provider.type != "echo":
+            raise ValueError(f"EchoToolAdapter built from non-echo provider {provider.type!r}")
+        return cls(
+            name=provider.name,
+            base_url=provider.base_url,
+            allowlist=provider.allowlist.hosts,
+        )
+
+    def validate_base_url(self) -> None:
+        """Confirm the configured base_url satisfies this provider's own
+        egress policy (called at build time so a misconfig fails at startup)."""
+        validate_egress_target(self._base_url + "/", allowlist=self._allowlist)
+
+    async def list_tools(self) -> list[ToolSpec]:
+        return [
+            ToolSpec(
+                name="echo",
+                description="Echoes its input arguments back. Test provider only.",
+                parameters={"type": "object", "additionalProperties": True},
+                read_only=True,
+            )
+        ]
+
+    async def invoke_tool(self, tool: str, args: dict[str, Any], *, request_id: str) -> ToolResult:
+        if tool != "echo":
+            raise ToolProviderError(f"unknown tool {tool!r} for echo provider")
+        encoded = json.dumps(args).encode("utf-8")
+        return ToolResult(
+            provider=self.name,
+            tool=tool,
+            payload={"echoed": args},
+            bytes_out=len(encoded),
+            bytes_in=len(encoded),
+        )
+
+    async def health_check(self) -> ProviderHealth:
+        return ProviderHealth(name=self.name, reachable=True, latency_ms=0)
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()

--- a/gateway/app/providers/tool/egress.py
+++ b/gateway/app/providers/tool/egress.py
@@ -1,0 +1,69 @@
+"""SSRF-guarded outbound egress primitive (ADR 0014 D2).
+
+The gateway-native equivalent of MikeOSS's ``validateRemoteMcpUrl`` /
+``guardedFetch``. Every tool-provider adapter MUST validate its outbound URL
+through :func:`validate_egress_target` before issuing a request. Enforces:
+HTTPS-only; host in the per-provider allowlist; resolved IPs are public
+(blocks private/loopback/link-local/CGNAT, defeating DNS-rebind)."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+class EgressRefused(Exception):
+    """Raised when an outbound target violates egress policy."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _resolve_ips(host: str) -> list[str]:
+    """Resolve ``host`` to its IP addresses. Wrapped so tests can stub it."""
+    infos = socket.getaddrinfo(host, None)
+    return [str(info[4][0]) for info in infos]
+
+
+def _is_public_ip(ip: str) -> bool:
+    addr = ipaddress.ip_address(ip)
+    return not (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+def validate_egress_target(url: str, *, allowlist: list[str]) -> None:
+    """Validate ``url`` against egress policy. Raise :class:`EgressRefused`.
+
+    Checks, in order: scheme is https; host present; host is in ``allowlist``;
+    every resolved IP for the host is public (blocks IP-literal private hosts
+    and DNS-rebind of an allowlisted name to a private address)."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise EgressRefused(f"egress must use https, got scheme {parsed.scheme!r}")
+    host = parsed.hostname
+    if not host:
+        raise EgressRefused("egress target has no host")
+    if host not in allowlist:
+        raise EgressRefused(f"host {host!r} not in provider allowlist")
+    for ip in _resolve_ips(host):
+        if not _is_public_ip(ip):
+            raise EgressRefused(f"host {host!r} resolves to private/blocked address {ip}")
+
+
+# Headers a caller may never override on an outbound tool request.
+_FORBIDDEN_OUTBOUND_HEADERS = frozenset({"host", "x-lq-ai-gateway-key"})
+
+
+def validate_outbound_headers(headers: dict[str, str]) -> None:
+    """Reject caller-supplied Host overrides and smuggled gateway auth."""
+    for name in headers:
+        if name.lower() in _FORBIDDEN_OUTBOUND_HEADERS:
+            raise EgressRefused(f"outbound header {name!r} is not allowed")

--- a/gateway/app/providers/tool/egress.py
+++ b/gateway/app/providers/tool/egress.py
@@ -28,15 +28,10 @@ def _resolve_ips(host: str) -> list[str]:
 
 
 def _is_public_ip(ip: str) -> bool:
-    addr = ipaddress.ip_address(ip)
-    return not (
-        addr.is_private
-        or addr.is_loopback
-        or addr.is_link_local
-        or addr.is_reserved
-        or addr.is_multicast
-        or addr.is_unspecified
-    )
+    """True only if ``ip`` is a globally-routable public address. Fails closed:
+    private, loopback, link-local, CGNAT (100.64/10), reserved, multicast, and
+    unspecified addresses all return False."""
+    return ipaddress.ip_address(ip).is_global
 
 
 def validate_egress_target(url: str, *, allowlist: list[str]) -> None:
@@ -51,7 +46,7 @@ def validate_egress_target(url: str, *, allowlist: list[str]) -> None:
     host = parsed.hostname
     if not host:
         raise EgressRefused("egress target has no host")
-    if host not in allowlist:
+    if host not in {entry.lower() for entry in allowlist}:
         raise EgressRefused(f"host {host!r} not in provider allowlist")
     for ip in _resolve_ips(host):
         if not _is_public_ip(ip):

--- a/gateway/app/providers/tool/ratelimit.py
+++ b/gateway/app/providers/tool/ratelimit.py
@@ -1,0 +1,43 @@
+"""Per-provider fixed-window rate limiter for tool egress (ADR 0014).
+
+Self-contained, in-memory, per-provider. NOT the gateway's global
+``rate_limits`` (whose enforcement middleware is unwired). The clock is
+injectable so tests are deterministic without sleeping."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+_WINDOW_SECONDS = 60.0
+
+
+class RateLimited(Exception):
+    """Raised when a provider exceeds its per-minute request budget."""
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(f"rate limit exceeded for tool provider {provider!r}")
+        self.provider = provider
+
+
+class FixedWindowRateLimiter:
+    """Fixed 60-second window, ``requests_per_minute`` budget per provider."""
+
+    def __init__(
+        self, *, requests_per_minute: int, now: Callable[[], float] = time.monotonic
+    ) -> None:
+        self._limit = requests_per_minute
+        self._now = now
+        # provider -> (window_start, count)
+        self._windows: dict[str, tuple[float, int]] = {}
+
+    def check(self, provider: str) -> None:
+        """Record one request for ``provider``; raise :class:`RateLimited`
+        if it would exceed the budget for the current window."""
+        now = self._now()
+        start, count = self._windows.get(provider, (now, 0))
+        if now - start >= _WINDOW_SECONDS:
+            start, count = now, 0
+        if count >= self._limit:
+            raise RateLimited(provider)
+        self._windows[provider] = (start, count + 1)

--- a/gateway/app/router.py
+++ b/gateway/app/router.py
@@ -69,6 +69,14 @@ from app.providers import (
     ProviderHTTPError,
     ProviderNetworkError,
 )
+from app.providers.tool.base import ToolProviderAdapter, ToolResult
+from app.providers.tool.egress import EgressRefused
+from app.providers.tool.ratelimit import FixedWindowRateLimiter, RateLimited
+from app.tool_egress_log import (
+    NullToolEgressLogWriter,
+    ToolEgressLogRow,
+    ToolEgressLogWriter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +138,25 @@ class NoAdapterAvailableError(Exception):
         super().__init__(message)
         self.message = message
         self.last_error = last_error
+
+
+class ToolEgressRefused(Exception):
+    """Raised when a tool call is refused (unknown provider, tier ceiling,
+    rate limit, or SSRF policy). Always paired with an audited refusal row."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class ToolCallRoutedResult:
+    """The router's return value for a governed tool-call dispatch (ADR 0014)."""
+
+    provider: str
+    tool: str
+    payload: object
+    tier: int
 
 
 # --- Resolution data --------------------------------------------------------
@@ -563,6 +590,9 @@ class Router:
         config: GatewayConfig,
         adapters: dict[str, ProviderAdapter],
         config_provider: Callable[[], GatewayConfig] | None = None,
+        tool_adapters: dict[str, ToolProviderAdapter] | None = None,
+        tool_egress_log: ToolEgressLogWriter | None = None,
+        tool_rate_limiter: FixedWindowRateLimiter | None = None,
     ) -> None:
         self._config = config
         self._adapters = adapters
@@ -574,6 +604,18 @@ class Router:
         # without rebuilding the Router. Tests that don't wire the
         # holder still work — the static ``config`` is the fallback.
         self._config_provider = config_provider
+        # ADR 0014 tool-egress additions (keyword-only, defaulted so
+        # existing Router(...) call sites are untouched):
+        self._tool_adapters: dict[str, ToolProviderAdapter] = tool_adapters or {}
+        self._tool_egress_log: ToolEgressLogWriter = tool_egress_log or NullToolEgressLogWriter()
+        if tool_rate_limiter is not None:
+            self._tool_rate_limiter: FixedWindowRateLimiter = tool_rate_limiter
+        else:
+            max_rpm = max(
+                (tp.rate_limit.requests_per_minute for tp in config.tool_providers),
+                default=60,
+            )
+            self._tool_rate_limiter = FixedWindowRateLimiter(requests_per_minute=max_rpm)
 
     @property
     def config(self) -> GatewayConfig:
@@ -689,6 +731,100 @@ class Router:
         raise NoAdapterAvailableError(
             f"no adapter available for model {request.model!r}; tried "
             f"{[t.provider.name for t in candidates]}",
+        )
+
+    async def route_tool_call(
+        self,
+        provider_name: str,
+        tool: str,
+        args: dict[str, object],
+        *,
+        request_id: str,
+        max_allowed_tier: int | None = None,
+    ) -> ToolCallRoutedResult:
+        """Govern + dispatch one tool call (ADR 0014 D2/D3/D4).
+
+        Order: resolve provider -> rate limit -> egress-tier ceiling ->
+        adapter invoke (which validates SSRF) -> write audit row. Every
+        refusal writes a ``refused=True`` row before raising.
+        """
+        provider = self.config.tool_provider_by_name(provider_name)
+        adapter = self._tool_adapters.get(provider_name)
+        if provider is None or adapter is None:
+            await self._tool_egress_log.write(
+                ToolEgressLogRow(
+                    provider=provider_name,
+                    tool=tool,
+                    tier=0,
+                    refused=True,
+                    refusal_reason="unknown tool provider",
+                    request_id=request_id,
+                )
+            )
+            raise ToolEgressRefused(f"unknown tool provider {provider_name!r}")
+
+        try:
+            self._tool_rate_limiter.check(provider_name)
+        except RateLimited as exc:
+            await self._tool_egress_log.write(
+                ToolEgressLogRow(
+                    provider=provider_name,
+                    tool=tool,
+                    tier=provider.egress_tier,
+                    refused=True,
+                    refusal_reason="rate limit exceeded",
+                    request_id=request_id,
+                )
+            )
+            raise ToolEgressRefused(str(exc)) from exc
+
+        if max_allowed_tier is not None and provider.egress_tier > max_allowed_tier:
+            await self._tool_egress_log.write(
+                ToolEgressLogRow(
+                    provider=provider_name,
+                    tool=tool,
+                    tier=provider.egress_tier,
+                    refused=True,
+                    refusal_reason="egress_tier exceeds policy ceiling",
+                    request_id=request_id,
+                )
+            )
+            raise ToolEgressRefused(
+                f"egress_tier {provider.egress_tier} exceeds ceiling {max_allowed_tier}"
+            )
+
+        try:
+            result: ToolResult = await adapter.invoke_tool(tool, args, request_id=request_id)
+        except EgressRefused as exc:
+            await self._tool_egress_log.write(
+                ToolEgressLogRow(
+                    provider=provider_name,
+                    tool=tool,
+                    tier=provider.egress_tier,
+                    refused=True,
+                    refusal_reason=f"ssrf: {exc.reason}",
+                    request_id=request_id,
+                )
+            )
+            raise ToolEgressRefused(f"egress refused: {exc.reason}") from exc
+
+        await self._tool_egress_log.write(
+            ToolEgressLogRow(
+                provider=provider_name,
+                tool=tool,
+                tier=provider.egress_tier,
+                bytes_out=result.bytes_out,
+                bytes_in=result.bytes_in,
+                anonymization_applied=False,
+                refused=False,
+                request_id=request_id,
+            )
+        )
+        return ToolCallRoutedResult(
+            provider=provider_name,
+            tool=tool,
+            payload=result.payload,
+            tier=provider.egress_tier,
         )
 
 

--- a/gateway/app/tool_egress_log.py
+++ b/gateway/app/tool_egress_log.py
@@ -1,0 +1,163 @@
+"""``tool_egress_log`` writer (ADR 0014 D3).
+
+Same design as ``app.routing_log``: the gateway is the only component that
+knows which tool provider was called, so the gateway writes the audit row —
+raw parameter-bound SQL (the table is api-owned; we don't double-up ORM
+models across services). Counts and types only, NEVER raw payloads.
+``write()`` must never raise: the egress data path takes priority over audit.
+Schema authority: ``api/alembic/versions/0048_tool_egress_log.py``.
+
+Interface, not implementation
+-----------------------------
+
+The writer is split into a small protocol (:class:`ToolEgressLogWriter`)
+plus two implementations:
+
+* :class:`SQLToolEgressLogWriter` — the real writer; persists via
+  SQLAlchemy ``AsyncEngine``.
+* :class:`NullToolEgressLogWriter` — a no-op used when ``DATABASE_URL``
+  is unset (e.g., in unit tests or in a degraded gateway with no DB).
+
+The route handler depends on the protocol. Tests inject a
+:class:`RecordingToolEgressLogWriter` to assert exactly which fields the
+router populated for each scenario without spinning up Postgres.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Protocol, runtime_checkable
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "NullToolEgressLogWriter",
+    "RecordingToolEgressLogWriter",
+    "SQLToolEgressLogWriter",
+    "ToolEgressLogRow",
+    "ToolEgressLogWriter",
+]
+
+
+@dataclass
+class ToolEgressLogRow:
+    """One row to be written into ``tool_egress_log``.
+
+    Field names track the Alembic migration in
+    ``api/alembic/versions/0048_tool_egress_log.py`` exactly. Optional fields
+    are nullable here and in the schema. Counts and types only — never raw
+    payloads.
+    """
+
+    provider: str
+    tool: str
+    tier: int
+    request_id: str | None = None
+    bytes_out: int | None = None
+    bytes_in: int | None = None
+    anonymization_applied: bool = False
+    refused: bool = False
+    refusal_reason: str | None = None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+
+
+# Parameter-bound INSERT. ``id`` and DB-default columns are populated
+# server-side via the migration's ``server_default``; we name the columns
+# we set explicitly so a future ALTER doesn't break this writer.
+_INSERT_SQL = text(
+    """
+    INSERT INTO tool_egress_log (
+        timestamp, request_id, provider, tool, tier,
+        bytes_out, bytes_in, anonymization_applied, refused, refusal_reason
+    ) VALUES (
+        :timestamp, :request_id, :provider, :tool, :tier,
+        :bytes_out, :bytes_in, :anonymization_applied, :refused, :refusal_reason
+    )
+    """
+)
+
+
+@runtime_checkable
+class ToolEgressLogWriter(Protocol):
+    """Protocol the egress handler depends on.
+
+    Implementations promise: never raise out of :meth:`write` for a DB
+    error — the egress data path takes priority over the audit log.
+    Loggers / metrics are the right surface for "we tried to log and
+    couldn't"; the request itself must not fail because Postgres is
+    unreachable.
+    """
+
+    async def write(self, row: ToolEgressLogRow) -> None:
+        """Persist (or attempt to persist) one tool-egress-log row."""
+        ...
+
+
+class SQLToolEgressLogWriter:
+    """Real :class:`ToolEgressLogWriter` backed by SQLAlchemy ``AsyncEngine``."""
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    async def write(self, row: ToolEgressLogRow) -> None:
+        try:
+            async with self._engine.begin() as conn:
+                await conn.execute(_INSERT_SQL, _to_params(row))
+        except Exception as exc:
+            # Audit-log failures must not break the egress path. Log
+            # loud (operators care about these) but don't propagate.
+            logger.error(
+                "failed to write tool_egress_log row: %s",
+                exc,
+                extra={"tool_egress_log_row": row},
+            )
+
+
+class NullToolEgressLogWriter:
+    """No-op writer used when ``DATABASE_URL`` is unset.
+
+    The gateway logs a warning at startup so the gap is visible; here
+    we silently accept rows so the data-path code is uniform regardless
+    of DB availability.
+    """
+
+    async def write(self, row: ToolEgressLogRow) -> None:
+        return None
+
+
+class RecordingToolEgressLogWriter:
+    """In-memory writer used in tests.
+
+    Stores every row in :attr:`rows` so unit tests can assert exactly
+    which fields the egress handler populated. Like
+    :class:`NullToolEgressLogWriter` it never raises.
+    """
+
+    def __init__(self) -> None:
+        self.rows: list[ToolEgressLogRow] = []
+
+    async def write(self, row: ToolEgressLogRow) -> None:
+        self.rows.append(row)
+
+
+def _to_params(row: ToolEgressLogRow) -> dict[str, object]:
+    """Convert a row dataclass into the SQL bind-parameter dict."""
+
+    return {
+        "timestamp": row.timestamp,
+        "request_id": row.request_id,
+        "provider": row.provider,
+        "tool": row.tool,
+        "tier": row.tier,
+        "bytes_out": row.bytes_out,
+        "bytes_in": row.bytes_in,
+        "anonymization_applied": row.anonymization_applied,
+        "refused": row.refused,
+        "refusal_reason": row.refusal_reason,
+    }

--- a/gateway/tests/test_echo_tool_adapter.py
+++ b/gateway/tests/test_echo_tool_adapter.py
@@ -1,0 +1,63 @@
+import pytest
+
+from app.config import ToolProviderConfig
+from app.providers.tool.base import ToolResult
+from app.providers.tool.echo import EchoToolAdapter
+from app.providers.tool.egress import EgressRefused
+
+
+def _cfg(**over) -> ToolProviderConfig:
+    base = {
+        "name": "echo-test",
+        "type": "echo",
+        "base_url": "https://example.test",
+        "egress_tier": 4,
+        "allowlist": {"hosts": ["example.test"]},
+    }
+    base.update(over)
+    return ToolProviderConfig.model_validate(base)
+
+
+@pytest.mark.unit
+async def test_echo_invoke_returns_input() -> None:
+    adapter = EchoToolAdapter.from_config(_cfg())
+    try:
+        result = await adapter.invoke_tool("echo", {"msg": "hi"}, request_id="req_1")
+    finally:
+        await adapter.aclose()
+    assert isinstance(result, ToolResult)
+    assert result.provider == "echo-test"
+    assert result.payload == {"echoed": {"msg": "hi"}}
+    assert result.bytes_out > 0
+
+
+@pytest.mark.unit
+async def test_echo_lists_one_tool() -> None:
+    adapter = EchoToolAdapter.from_config(_cfg())
+    try:
+        tools = await adapter.list_tools()
+    finally:
+        await adapter.aclose()
+    assert [t.name for t in tools] == ["echo"]
+    assert tools[0].read_only is True
+
+
+@pytest.mark.unit
+async def test_echo_rejects_unknown_tool() -> None:
+    from app.providers.tool.base import ToolProviderError
+
+    adapter = EchoToolAdapter.from_config(_cfg())
+    try:
+        with pytest.raises(ToolProviderError):
+            await adapter.invoke_tool("nope", {}, request_id="req_1")
+    finally:
+        await adapter.aclose()
+
+
+@pytest.mark.unit
+async def test_echo_base_url_must_pass_egress_policy() -> None:
+    # base_url host not in its own allowlist -> egress refusal at validation.
+    with pytest.raises(EgressRefused):
+        EchoToolAdapter.from_config(
+            _cfg(base_url="https://evil.test", allowlist={"hosts": ["example.test"]})
+        ).validate_base_url()

--- a/gateway/tests/test_example_config_tool_providers.py
+++ b/gateway/tests/test_example_config_tool_providers.py
@@ -1,0 +1,27 @@
+"""Regression test: gateway.yaml.example ships with tool_providers commented out.
+
+The example file documents the tool_providers block (ADR 0014) but keeps it
+commented so the default stack is unchanged (empty list). This test guards that:
+
+1. The example loads cleanly with load_config (YAML is valid, no schema errors).
+2. tool_providers defaults to [] when the block is commented out.
+
+If a future contributor accidentally uncommenting the block without supplying
+real secrets, this test surfaces the failure at CI rather than at operator
+deploy time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config_loader import load_config
+from tests.conftest import EXAMPLE_CONFIG
+
+
+@pytest.mark.unit
+def test_example_config_has_commented_tool_providers(example_env: None) -> None:
+    """The example loads cleanly; the tool_providers block ships commented so
+    the default stack is unchanged (empty list)."""
+    cfg = load_config(EXAMPLE_CONFIG)
+    assert cfg.tool_providers == []

--- a/gateway/tests/test_guarded_egress.py
+++ b/gateway/tests/test_guarded_egress.py
@@ -47,6 +47,26 @@ def test_rejects_dns_rebind_to_private(monkeypatch) -> None:
 
 
 @pytest.mark.unit
+def test_rejects_cgnat_address(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.providers.tool.egress._resolve_ips",
+        lambda host: ["100.64.0.1"],  # RFC 6598 CGNAT — not globally routable
+    )
+    with pytest.raises(EgressRefused, match="private"):
+        validate_egress_target("https://example.test/x", allowlist=["example.test"])
+
+
+@pytest.mark.unit
+def test_allowlist_match_is_case_insensitive(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.providers.tool.egress._resolve_ips",
+        lambda host: ["93.184.216.34"],
+    )
+    # Allowlist entry is upper-case; urlparse lowercases the URL host.
+    validate_egress_target("https://example.test/x", allowlist=["EXAMPLE.TEST"])  # no raise
+
+
+@pytest.mark.unit
 def test_rejects_host_header_override() -> None:
     from app.providers.tool.egress import validate_outbound_headers
 

--- a/gateway/tests/test_guarded_egress.py
+++ b/gateway/tests/test_guarded_egress.py
@@ -1,0 +1,54 @@
+import pytest
+
+from app.providers.tool.egress import EgressRefused, validate_egress_target
+
+
+@pytest.mark.unit
+def test_rejects_non_https() -> None:
+    with pytest.raises(EgressRefused, match="https"):
+        validate_egress_target("http://example.test/x", allowlist=["example.test"])
+
+
+@pytest.mark.unit
+def test_rejects_host_not_in_allowlist() -> None:
+    with pytest.raises(EgressRefused, match="allowlist"):
+        validate_egress_target("https://evil.test/x", allowlist=["example.test"])
+
+
+@pytest.mark.unit
+def test_rejects_private_ip_literal_host() -> None:
+    with pytest.raises(EgressRefused, match="private"):
+        validate_egress_target("https://127.0.0.1/x", allowlist=["127.0.0.1"])
+
+
+@pytest.mark.unit
+def test_rejects_link_local_and_metadata_ip() -> None:
+    with pytest.raises(EgressRefused, match="private"):
+        validate_egress_target("https://169.254.169.254/latest", allowlist=["169.254.169.254"])
+
+
+@pytest.mark.unit
+def test_allows_public_host_in_allowlist(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.providers.tool.egress._resolve_ips",
+        lambda host: ["93.184.216.34"],
+    )
+    validate_egress_target("https://example.test/x", allowlist=["example.test"])
+
+
+@pytest.mark.unit
+def test_rejects_dns_rebind_to_private(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.providers.tool.egress._resolve_ips",
+        lambda host: ["10.0.0.5"],
+    )
+    with pytest.raises(EgressRefused, match="private"):
+        validate_egress_target("https://example.test/x", allowlist=["example.test"])
+
+
+@pytest.mark.unit
+def test_rejects_host_header_override() -> None:
+    from app.providers.tool.egress import validate_outbound_headers
+
+    with pytest.raises(EgressRefused, match="Host"):
+        validate_outbound_headers({"Host": "evil.test"})

--- a/gateway/tests/test_route_tool_call.py
+++ b/gateway/tests/test_route_tool_call.py
@@ -1,0 +1,85 @@
+"""Tests for Router.route_tool_call — governed egress path (ADR 0014 D2/D3/D4)."""
+
+import pytest
+
+from app.config import GatewayConfig
+from app.providers.tool.echo import EchoToolAdapter
+from app.providers.tool.ratelimit import FixedWindowRateLimiter
+from app.router import Router, ToolEgressRefused
+from app.tool_egress_log import RecordingToolEgressLogWriter
+
+
+def _config() -> GatewayConfig:
+    return GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test",
+                    "type": "echo",
+                    "base_url": "https://example.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                    "rate_limit": {"requests_per_minute": 2},
+                }
+            ]
+        }
+    )
+
+
+def _router(writer, clock=None):
+    cfg = _config()
+    adapter = EchoToolAdapter.from_config(cfg.tool_providers[0])
+    limiter = FixedWindowRateLimiter(requests_per_minute=2, now=(clock or (lambda: 1000.0)))
+    return Router(
+        config=cfg,
+        adapters={},
+        tool_adapters={"echo-test": adapter},
+        tool_egress_log=writer,
+        tool_rate_limiter=limiter,
+    )
+
+
+@pytest.mark.unit
+async def test_route_tool_call_happy_path_writes_audit_row() -> None:
+    writer = RecordingToolEgressLogWriter()
+    router = _router(writer)
+    result = await router.route_tool_call(
+        "echo-test", "echo", {"msg": "hi"}, request_id="req_1", max_allowed_tier=4
+    )
+    assert result.payload == {"echoed": {"msg": "hi"}}
+    assert len(writer.rows) == 1
+    assert writer.rows[0].refused is False
+    assert writer.rows[0].tier == 4
+
+
+@pytest.mark.unit
+async def test_route_tool_call_refuses_when_egress_tier_exceeds_ceiling() -> None:
+    writer = RecordingToolEgressLogWriter()
+    router = _router(writer)
+    with pytest.raises(ToolEgressRefused, match="egress_tier"):
+        await router.route_tool_call(
+            "echo-test", "echo", {"msg": "x"}, request_id="req_2", max_allowed_tier=3
+        )
+    assert writer.rows[-1].refused is True
+    assert writer.rows[-1].refusal_reason is not None
+
+
+@pytest.mark.unit
+async def test_route_tool_call_refuses_unknown_provider() -> None:
+    writer = RecordingToolEgressLogWriter()
+    router = _router(writer)
+    with pytest.raises(ToolEgressRefused, match="unknown"):
+        await router.route_tool_call("missing", "echo", {}, request_id="req_3", max_allowed_tier=5)
+
+
+@pytest.mark.unit
+async def test_route_tool_call_enforces_rate_limit() -> None:
+    writer = RecordingToolEgressLogWriter()
+    router = _router(writer)
+    for i in range(2):
+        await router.route_tool_call(
+            "echo-test", "echo", {}, request_id=f"r{i}", max_allowed_tier=4
+        )
+    with pytest.raises(ToolEgressRefused, match="rate"):
+        await router.route_tool_call("echo-test", "echo", {}, request_id="r3", max_allowed_tier=4)
+    assert writer.rows[-1].refused is True

--- a/gateway/tests/test_tool_adapter_wiring.py
+++ b/gateway/tests/test_tool_adapter_wiring.py
@@ -1,0 +1,77 @@
+"""Unit tests for the ``build_tool_adapter`` factory in ``app.main``.
+
+Verifies:
+* echo provider → ``EchoToolAdapter`` instance.
+* base_url outside the allowlist → ``EgressRefused`` at build time.
+* disabled provider → ``None`` (no adapter built).
+"""
+
+import pytest
+
+from app.config import GatewayConfig
+from app.main import build_tool_adapter
+from app.providers.tool.echo import EchoToolAdapter
+from app.providers.tool.egress import EgressRefused
+
+
+@pytest.mark.unit
+def test_build_tool_adapter_echo(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Stub DNS resolution so this unit test works offline / in CI without a
+    # live DNS lookup for the synthetic ``example.test`` domain.
+    monkeypatch.setattr(
+        "app.providers.tool.egress._resolve_ips",
+        lambda host: ["93.184.216.34"],
+    )
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test",
+                    "type": "echo",
+                    "base_url": "https://example.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    adapter = build_tool_adapter(cfg.tool_providers[0])
+    assert isinstance(adapter, EchoToolAdapter)
+
+
+@pytest.mark.unit
+def test_build_tool_adapter_rejects_base_url_outside_allowlist() -> None:
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "bad",
+                    "type": "echo",
+                    "base_url": "https://evil.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    with pytest.raises(EgressRefused):
+        build_tool_adapter(cfg.tool_providers[0])
+
+
+@pytest.mark.unit
+def test_build_tool_adapter_disabled_returns_none() -> None:
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "off",
+                    "type": "echo",
+                    "enabled": False,
+                    "base_url": "https://example.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    assert build_tool_adapter(cfg.tool_providers[0]) is None

--- a/gateway/tests/test_tool_egress_integration.py
+++ b/gateway/tests/test_tool_egress_integration.py
@@ -1,0 +1,59 @@
+"""End-to-end integration test for the PR1 tool-egress path (ADR 0014).
+
+Exercises the full chain without a network call:
+    config → build_tool_adapter → Router.route_tool_call → audit row
+"""
+
+import pytest
+
+from app.config import GatewayConfig
+from app.main import build_tool_adapter
+from app.router import Router
+from app.tool_egress_log import RecordingToolEgressLogWriter
+
+
+@pytest.mark.unit
+async def test_end_to_end_echo_through_router(monkeypatch) -> None:
+    """Config -> build_tool_adapter -> Router.route_tool_call -> audit row.
+    Exercises every PR1 component together without a network call."""
+    # build_tool_adapter validates base_url via DNS; example.test isn't real.
+    monkeypatch.setattr(
+        "app.providers.tool.egress._resolve_ips",
+        lambda host: ["93.184.216.34"],
+    )
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test",
+                    "type": "echo",
+                    "base_url": "https://example.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                    "rate_limit": {"requests_per_minute": 10},
+                }
+            ]
+        }
+    )
+    adapter = build_tool_adapter(cfg.tool_providers[0])
+    assert adapter is not None
+    writer = RecordingToolEgressLogWriter()
+    router = Router(
+        config=cfg,
+        adapters={},
+        tool_adapters={"echo-test": adapter},
+        tool_egress_log=writer,
+    )
+    try:
+        result = await router.route_tool_call(
+            "echo-test", "echo", {"q": "hello"}, request_id="req_e2e", max_allowed_tier=5
+        )
+    finally:
+        await adapter.aclose()
+    assert result.payload == {"echoed": {"q": "hello"}}
+    assert result.tier == 4
+    assert len(writer.rows) == 1
+    row = writer.rows[0]
+    assert row.refused is False
+    assert row.bytes_out and row.bytes_out > 0
+    assert row.anonymization_applied is False  # honest: no transform in PR1

--- a/gateway/tests/test_tool_egress_log_writer.py
+++ b/gateway/tests/test_tool_egress_log_writer.py
@@ -1,0 +1,29 @@
+import pytest
+
+from app.tool_egress_log import (
+    NullToolEgressLogWriter,
+    RecordingToolEgressLogWriter,
+    ToolEgressLogRow,
+)
+
+
+@pytest.mark.unit
+async def test_recording_writer_captures_rows() -> None:
+    writer = RecordingToolEgressLogWriter()
+    row = ToolEgressLogRow(provider="echo-test", tool="echo", tier=4, bytes_out=2, bytes_in=2)
+    await writer.write(row)
+    assert len(writer.rows) == 1
+    assert writer.rows[0].provider == "echo-test"
+
+
+@pytest.mark.unit
+async def test_null_writer_is_noop() -> None:
+    writer = NullToolEgressLogWriter()
+    await writer.write(ToolEgressLogRow(provider="x", tool="echo", tier=4))  # no raise
+
+
+@pytest.mark.unit
+async def test_row_defaults_to_not_refused_not_anonymized() -> None:
+    row = ToolEgressLogRow(provider="x", tool="echo", tier=4)
+    assert row.refused is False
+    assert row.anonymization_applied is False

--- a/gateway/tests/test_tool_provider_base.py
+++ b/gateway/tests/test_tool_provider_base.py
@@ -1,0 +1,48 @@
+import pytest
+
+from app.providers.tool.base import (
+    ToolProviderAdapter,
+    ToolProviderError,
+    ToolResult,
+    ToolSpec,
+)
+
+
+@pytest.mark.unit
+def test_tool_provider_adapter_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        ToolProviderAdapter()  # type: ignore[abstract]
+
+
+@pytest.mark.unit
+def test_tool_result_holds_provenance_and_counts() -> None:
+    result = ToolResult(
+        provider="echo-test",
+        tool="echo",
+        payload={"echoed": "hi"},
+        bytes_in=2,
+        bytes_out=2,
+    )
+    assert result.provider == "echo-test"
+    assert result.payload == {"echoed": "hi"}
+    assert result.bytes_in == 2
+
+
+@pytest.mark.unit
+def test_tool_spec_carries_metadata_flags() -> None:
+    spec = ToolSpec(
+        name="echo",
+        description="echoes its input",
+        parameters={"type": "object"},
+        read_only=True,
+        destructive=False,
+        requires_confirmation=False,
+    )
+    assert spec.read_only is True
+    assert spec.destructive is False
+
+
+@pytest.mark.unit
+def test_tool_provider_error_envelope() -> None:
+    err = ToolProviderError("boom", details={"k": "v"})
+    assert err.to_envelope()["error"]["code"] == "tool_provider_error"

--- a/gateway/tests/test_tool_provider_config.py
+++ b/gateway/tests/test_tool_provider_config.py
@@ -1,0 +1,76 @@
+import pytest
+
+from app.config import GatewayConfig, ToolProviderConfig
+
+
+@pytest.mark.unit
+def test_tool_provider_config_parses_minimal() -> None:
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test",
+                    "type": "echo",
+                    "base_url": "https://example.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    assert len(cfg.tool_providers) == 1
+    tp = cfg.tool_providers[0]
+    assert isinstance(tp, ToolProviderConfig)
+    assert tp.name == "echo-test"
+    assert tp.egress_tier == 4
+    assert tp.allowlist.hosts == ["example.test"]
+    assert tp.anonymize_outbound is True  # default per ADR 0014 D5
+
+
+@pytest.mark.unit
+def test_tool_provider_rejects_both_key_sources() -> None:
+    with pytest.raises(ValueError, match="api_key_env OR"):
+        ToolProviderConfig.model_validate(
+            {
+                "name": "x",
+                "type": "echo",
+                "base_url": "https://example.test",
+                "egress_tier": 4,
+                "allowlist": {"hosts": ["example.test"]},
+                "api_key_env": "FOO",
+                "api_key_encrypted": "gAAAA",
+            }
+        )
+
+
+@pytest.mark.unit
+def test_tool_provider_requires_nonempty_allowlist() -> None:
+    with pytest.raises(ValueError):
+        ToolProviderConfig.model_validate(
+            {
+                "name": "x",
+                "type": "echo",
+                "base_url": "https://example.test",
+                "egress_tier": 4,
+                "allowlist": {"hosts": []},
+            }
+        )
+
+
+@pytest.mark.unit
+def test_tool_provider_by_name_accessor() -> None:
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "echo-test",
+                    "type": "echo",
+                    "base_url": "https://example.test",
+                    "egress_tier": 4,
+                    "allowlist": {"hosts": ["example.test"]},
+                }
+            ]
+        }
+    )
+    assert cfg.tool_provider_by_name("echo-test") is not None
+    assert cfg.tool_provider_by_name("missing") is None

--- a/gateway/tests/test_tool_ratelimit.py
+++ b/gateway/tests/test_tool_ratelimit.py
@@ -1,0 +1,34 @@
+import pytest
+
+from app.providers.tool.ratelimit import FixedWindowRateLimiter, RateLimited
+
+
+@pytest.mark.unit
+def test_allows_up_to_limit_then_refuses() -> None:
+    clock = {"t": 1000.0}
+    limiter = FixedWindowRateLimiter(requests_per_minute=3, now=lambda: clock["t"])
+    for _ in range(3):
+        limiter.check("echo-test")  # no raise
+    with pytest.raises(RateLimited):
+        limiter.check("echo-test")
+
+
+@pytest.mark.unit
+def test_window_resets_after_60s() -> None:
+    clock = {"t": 1000.0}
+    limiter = FixedWindowRateLimiter(requests_per_minute=1, now=lambda: clock["t"])
+    limiter.check("echo-test")
+    with pytest.raises(RateLimited):
+        limiter.check("echo-test")
+    clock["t"] += 61.0
+    limiter.check("echo-test")  # new window, no raise
+
+
+@pytest.mark.unit
+def test_limits_are_per_provider() -> None:
+    clock = {"t": 1000.0}
+    limiter = FixedWindowRateLimiter(requests_per_minute=1, now=lambda: clock["t"])
+    limiter.check("a")
+    limiter.check("b")  # different provider, independent budget
+    with pytest.raises(RateLimited):
+        limiter.check("a")


### PR DESCRIPTION
## What this is

First slice of the **legal-research + MCP** milestone (`docs/proposals/legal-research-and-mcp.md`). Adds a first-class **tool-provider / data-source egress class** to the Inference Gateway so third-party tool calls (CourtListener, MCP servers — later PRs) flow through the single audited gateway boundary, never backend-direct. Discharges **ADR 0014**.

This PR bundles the milestone's design docs (it's the first PR) + the WS1 implementation:
- **ADR 0014** — gateway egress boundary for tool/data-source providers
- **ADR 0015** — governed tool-calling model (closed-intent posture extended) — design only; implemented in WS4
- **Mini-PRD** — code-grounded, decomposed into 6 PRs
- **WS1/PR1 plan** — `docs/superpowers/plans/2026-06-16-ws1-gateway-egress-boundary.md`

## ⚠️ Security review required (`gateway/**`)

This is the egress security boundary. **Do not self-merge** — maintainer review + merge per CODEOWNERS / project merge-gating.

## Acceptance criteria (PR1 row of the roadmap)

- [x] `tool_providers:` block parses from `gateway.yaml` (`ToolProviderConfig`)
- [x] `ToolProviderAdapter` base + an `echo` test/proof provider type
- [x] Guarded-egress primitive: HTTPS-only, DNS private/loopback/link-local/**CGNAT** block (via `ipaddress.is_global`), per-provider host allowlist (case-insensitive), no `Host` override, header validation — SSRF attempts unit-tested
- [x] `tool_egress_log` migration (0048) + ORM model + **gateway-side writer** (raw SQL, mirrors `inference_routing_log`); counts/types only, never payloads
- [x] Per-provider rate limit at the adapter
- [x] Egress-tier refusal path (`provider.egress_tier > matter ceiling` → refuse + audited)
- [x] Lifespan wiring + `Router.route_tool_call`; end-to-end test through the router
- [x] Gateway mypy `--strict` clean

## Honest scope (deliberately deferred — NOT in this PR)

- **No CourtListener / MCP semantics** — `echo` is the only concrete type (PR2 / PR4).
- **No outbound anonymization transform** — ADR 0014 D5 makes it the default, but it needs the M2 mapper + real matter context. PR1 parses the `anonymize_outbound` flag and writes an honest `anonymization_applied = False`; transform lands in WS3/WS4. Boundary-register doc marks this PARTIAL.
- **No HTTP route** exposing tool calls to the backend — that's PR3 (`/api/v1/research`).

## Review already applied

A pre-submission review found and we fixed: (1) **audit bug** — unknown-provider refusals wrote `tier=0` but the CHECK was `1..5`, so the prod writer silently dropped them; constraint now `0..5` with a persistence test; (2) `is_global` SSRF hardening (CGNAT/NAT64); (3) case-insensitive allowlist; (4) doc accuracy. Deferred to WS3: aligning tool-provider error codes with the recent inference `invalid_request` reclassification (#155) — no real HTTP calls in PR1.

## Test evidence

- Gateway: **600 passed**, 1 skipped; `mypy --strict` clean; ruff clean.
- API: collision guards (`test_openapi`/`test_endpoints`) + `tool_egress_log` model tests pass against a throwaway pgvector; `mypy` clean (143 files); ruff clean.
- Rebased on current `main` (merged Jaime's #154–157 cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)