### PR TITLE
WS3b-follow: research-surface refinements for Donna (typed verify-citations, text_field_used, /capabilities)

### DIFF
--- a/api/app/api/research.py
+++ b/api/app/api/research.py
@@ -16,6 +16,7 @@ from app.schemas.research import (
     FindInCaseResponse,
     FindMatch,
     OpinionText,
+    ResearchCapabilities,
     SearchRequest,
     SearchResponse,
     VerifyCitationsRequest,
@@ -23,6 +24,11 @@ from app.schemas.research import (
 )
 
 router = APIRouter(prefix="/research", tags=["research"])
+
+
+@router.get("/capabilities", response_model=ResearchCapabilities)
+async def capabilities(user: ActiveUser) -> ResearchCapabilities:
+    return ResearchCapabilities(**await service.get_capabilities())
 
 
 @router.post("/verify-citations", response_model=VerifyCitationsResponse)

--- a/api/app/clients/gateway.py
+++ b/api/app/clients/gateway.py
@@ -913,6 +913,35 @@ class GatewayClient:
             request_id=request_id,
         )
 
+    async def list_tool_providers(
+        self,
+        *,
+        request_id: str | None = None,
+    ) -> list[dict[str, str]]:
+        """GET /admin/v1/config; return configured tool providers as [{name, type}].
+
+        The api holds the gateway key (stamped on every request), so it can read
+        the gateway's sanitized config (env-var names only, never secret values).
+        Used by the research capabilities signal + provider-name resolution.
+
+        Extra fields (base_url, api_key_env, …) are stripped — the capabilities
+        consumer needs only name and type, and we don't want to widen the surface.
+        Malformed entries (non-dict, missing name/type) are silently filtered.
+        """
+
+        config = await self._admin_request(
+            method="GET",
+            path="/admin/v1/config",
+            op="list_tool_providers",
+            request_id=request_id,
+        )
+        providers = config.get("tool_providers") or []
+        return [
+            {"name": p["name"], "type": p["type"]}
+            for p in providers
+            if isinstance(p, dict) and "name" in p and "type" in p
+        ]
+
     async def get_tier_config(
         self,
         *,

--- a/api/app/clients/gateway.py
+++ b/api/app/clients/gateway.py
@@ -929,12 +929,7 @@ class GatewayClient:
         Malformed entries (non-dict, missing name/type) are silently filtered.
         """
 
-        config = await self._admin_request(
-            method="GET",
-            path="/admin/v1/config",
-            op="list_tool_providers",
-            request_id=request_id,
-        )
+        config = await self.get_admin_config(request_id=request_id)
         providers = config.get("tool_providers") or []
         return [
             {"name": p["name"], "type": p["type"]}

--- a/api/app/errors.py
+++ b/api/app/errors.py
@@ -66,6 +66,7 @@ CODE_PASSWORD_CHANGE_REQUIRED = "password_change_required"
 CODE_PAYLOAD_TOO_LARGE = "payload_too_large"
 CODE_CONFLICT = "conflict"
 CODE_MFA_ENROLLMENT_REQUIRED = "mfa_enrollment_required"
+CODE_RESEARCH_NOT_CONFIGURED = "research_not_configured"
 
 # Backend↔gateway crossing codes (also declared in gateway/app/errors.py).
 # These propagate from gateway responses into backend exceptions; the
@@ -242,6 +243,15 @@ class MfaEnrollmentRequired(LQAIError):
 
     code = CODE_MFA_ENROLLMENT_REQUIRED
     http_status = status.HTTP_403_FORBIDDEN
+
+
+class ResearchNotConfigured(LQAIError):
+    """No CourtListener tool-provider is configured in the gateway, so the
+    case-law research surface is unavailable. Distinct from a transient
+    gateway outage so the UI renders a calm 'not enabled' gate, not an error."""
+
+    code = CODE_RESEARCH_NOT_CONFIGURED
+    http_status = status.HTTP_503_SERVICE_UNAVAILABLE
 
 
 class PayloadTooLarge(LQAIError):
@@ -540,6 +550,7 @@ __all__ = [
     "CODE_PAYLOAD_TOO_LARGE",
     "CODE_PROVIDER_UNAVAILABLE",
     "CODE_RATE_LIMITED",
+    "CODE_RESEARCH_NOT_CONFIGURED",
     "CODE_SKILL_FETCH_FAILED",
     "CODE_SKILL_INPUT_MISSING",
     "CODE_SKILL_NOT_FOUND",
@@ -562,6 +573,7 @@ __all__ = [
     "PayloadTooLarge",
     "ProviderUnavailable",
     "RateLimited",
+    "ResearchNotConfigured",
     "SessionHalted",
     "SkillFetchFailed",
     "SkillInputMissing",

--- a/api/app/research/service.py
+++ b/api/app/research/service.py
@@ -48,6 +48,10 @@ async def get_capabilities(*, request_id: str | None = None) -> dict[str, Any]:
 async def _resolve_provider(*, request_id: str | None = None) -> str:
     """Return the configured CourtListener provider name, caching after first call.
 
+    The resolved name is cached at process level after the first successful
+    call; a config change (e.g. renaming the provider in gateway.yaml) takes
+    effect only after an api restart or an explicit reset_provider_cache() call.
+
     Raises ResearchNotConfigured (503) when no courtlistener provider is wired
     in gateway.yaml.  In the rare window between get_capabilities returning
     enabled=True and this call executing, a provider that just disappeared

--- a/api/app/research/service.py
+++ b/api/app/research/service.py
@@ -14,24 +14,73 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.clients.gateway import get_gateway_client
-from app.errors import NotFound
+from app.errors import NotFound, ResearchNotConfigured
 from app.models.research import ResearchClusterMetadata, ResearchOpinionMetadata
 from app.research.html import html_to_text
 from app.storage import stream_download, upload_bytes
 
-_PROVIDER = "courtlistener-prod"
+# The type string that identifies a CourtListener tool-provider in gateway.yaml.
+_COURTLISTENER_TYPE = "courtlistener"
+
+# Process-level cache for the resolved provider name.  A config change requires
+# an api restart, which is already true for how gateway config is loaded — the
+# gateway itself must restart to pick up a yaml change, so the api restarting
+# too is no extra burden.  Use reset_provider_cache() in tests to ensure
+# isolation.
+_resolved_provider: str | None = None
+
+
+async def _courtlistener_providers(*, request_id: str | None = None) -> list[dict[str, str]]:
+    providers = await get_gateway_client().list_tool_providers(request_id=request_id)
+    return [p for p in providers if p.get("type") == _COURTLISTENER_TYPE]
+
+
+async def get_capabilities(*, request_id: str | None = None) -> dict[str, Any]:
+    """Return {enabled, providers} — always reads fresh from the gateway.
+
+    This is the live signal for the UI; it does not use the cached provider
+    name so it reflects the current gateway config without an api restart.
+    """
+    cl = await _courtlistener_providers(request_id=request_id)
+    return {"enabled": bool(cl), "providers": cl}
+
+
+async def _resolve_provider(*, request_id: str | None = None) -> str:
+    """Return the configured CourtListener provider name, caching after first call.
+
+    Raises ResearchNotConfigured (503) when no courtlistener provider is wired
+    in gateway.yaml.  In the rare window between get_capabilities returning
+    enabled=True and this call executing, a provider that just disappeared
+    would also raise here — a transient 503 is correct in that case.
+    """
+    global _resolved_provider
+    if _resolved_provider is not None:
+        return _resolved_provider
+    cl = await _courtlistener_providers(request_id=request_id)
+    if not cl:
+        raise ResearchNotConfigured("Case-law research is not enabled on this server.")
+    _resolved_provider = cl[0]["name"]
+    return _resolved_provider
+
+
+def reset_provider_cache() -> None:
+    """Test/admin hook: clear the cached resolved provider name."""
+    global _resolved_provider
+    _resolved_provider = None
 
 
 async def verify_citations(text: str, *, request_id: str | None = None) -> dict[str, Any]:
+    provider = await _resolve_provider(request_id=request_id)
     result = await get_gateway_client().call_tool(
-        _PROVIDER, "verify_citations", {"text": text}, request_id=request_id
+        provider, "verify_citations", {"text": text}, request_id=request_id
     )
     return result["payload"]
 
 
 async def search_case_law(args: dict[str, Any], *, request_id: str | None = None) -> dict[str, Any]:
+    provider = await _resolve_provider(request_id=request_id)
     result = await get_gateway_client().call_tool(
-        _PROVIDER, "search_case_law", args, request_id=request_id
+        provider, "search_case_law", args, request_id=request_id
     )
     return result["payload"]
 
@@ -84,8 +133,9 @@ async def get_cluster(
         )
         return _cluster_view(cached, ops)
 
+    provider = await _resolve_provider(request_id=request_id)
     result = await get_gateway_client().call_tool(
-        _PROVIDER, "get_cases", {"cluster_id": cluster_id}, request_id=request_id
+        provider, "get_cases", {"cluster_id": cluster_id}, request_id=request_id
     )
     payload = result["payload"]
     cluster = payload["cluster"]

--- a/api/app/schemas/research.py
+++ b/api/app/schemas/research.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+# Closed set of opinion text fields, in the adapter's preference order.
+# MUST stay in sync with _OPINION_TEXT_FIELDS in
+# gateway/app/providers/tool/courtlistener.py.
+OpinionTextField = Literal[
+    "html_with_citations",
+    "html_columbia",
+    "html_lawbox",
+    "xml_harvard",
+    "html_anon_2020",
+    "html",
+    "plain_text",
+]
 
 
 class VerifyCitationsRequest(BaseModel):
@@ -12,8 +25,22 @@ class VerifyCitationsRequest(BaseModel):
     text: str = Field(min_length=1, max_length=64000)
 
 
+class CitationCluster(BaseModel):
+    id: int | None = None
+    case_name: str | None = None
+    absolute_url: str | None = None
+
+
+class VerifiedCitation(BaseModel):
+    citation: str | None = None
+    normalized_citations: list[str] = Field(default_factory=list)
+    status: int | None = None
+    error_message: str | None = None
+    clusters: list[CitationCluster] = Field(default_factory=list)
+
+
 class VerifyCitationsResponse(BaseModel):
-    citations: list[dict[str, Any]] = Field(default_factory=list)
+    citations: list[VerifiedCitation] = Field(default_factory=list)
 
 
 class SearchRequest(BaseModel):
@@ -49,7 +76,7 @@ class ClusterMeta(BaseModel):
 
 class OpinionMeta(BaseModel):
     opinion_id: int
-    text_field_used: str | None = None
+    text_field_used: OpinionTextField | None = None
     char_length: int
 
 
@@ -61,7 +88,7 @@ class ClusterView(BaseModel):
 class OpinionText(BaseModel):
     opinion_id: int
     cluster_id: int
-    text_field_used: str | None = None
+    text_field_used: OpinionTextField | None = None
     text: str
 
 

--- a/api/app/schemas/research.py
+++ b/api/app/schemas/research.py
@@ -107,3 +107,13 @@ class FindMatch(BaseModel):
 class FindInCaseResponse(BaseModel):
     opinion_id: int
     matches: list[FindMatch] = Field(default_factory=list)
+
+
+class ResearchProvider(BaseModel):
+    name: str
+    type: str
+
+
+class ResearchCapabilities(BaseModel):
+    enabled: bool
+    providers: list[ResearchProvider] = Field(default_factory=list)

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -305,6 +305,7 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("DELETE", "/api/v1/autonomous/watches/{watch_id}"),
     ("PATCH", "/api/v1/autonomous/watches/{watch_id}"),
     # WS3b — case-law research surface
+    ("GET", "/api/v1/research/capabilities"),
     ("POST", "/api/v1/research/verify-citations"),
     ("POST", "/api/v1/research/search"),
     ("GET", "/api/v1/research/clusters/{cluster_id}"),

--- a/api/tests/test_gateway_client.py
+++ b/api/tests/test_gateway_client.py
@@ -953,6 +953,129 @@ async def test_ensemble_config_failed_fetch_is_cached(client: GatewayClient) -> 
     assert route.call_count == 1
 
 
+# ---------------------------------------------------------------------------
+# list_tool_providers (research capabilities signal, WS3b-follow)
+#
+# Reads GET /admin/v1/config (gateway-key gated, sanitized — env-var names
+# only, never secret values) and extracts the configured tool providers as
+# [{name, type}].  Extra fields (base_url, api_key_env, …) are stripped so
+# callers don't accidentally widen the surface.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_list_tool_providers_happy_path(client: GatewayClient) -> None:
+    """Two valid provider entries → [{name, type}] with extras stripped."""
+
+    config_payload = {
+        "tool_providers": [
+            {
+                "name": "courtlistener-prod",
+                "type": "courtlistener",
+                "base_url": "https://www.courtlistener.com/api/rest/v4",
+                "api_key_env": "COURTLISTENER_API_TOKEN",
+            },
+            {
+                "name": "echo",
+                "type": "echo",
+                "base_url": "http://localhost:9999",
+            },
+        ]
+    }
+    respx.get(f"{GATEWAY_BASE}/admin/v1/config").mock(
+        return_value=httpx.Response(200, json=config_payload)
+    )
+
+    result = await client.list_tool_providers()
+
+    assert result == [
+        {"name": "courtlistener-prod", "type": "courtlistener"},
+        {"name": "echo", "type": "echo"},
+    ]
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_list_tool_providers_sends_gateway_key_header(client: GatewayClient) -> None:
+    """The gateway-key default header is stamped on the admin config request."""
+
+    route = respx.get(f"{GATEWAY_BASE}/admin/v1/config").mock(
+        return_value=httpx.Response(200, json={"tool_providers": []})
+    )
+
+    await client.list_tool_providers()
+
+    assert route.calls.last.request.headers.get(GATEWAY_KEY_HEADER) == GATEWAY_KEY
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_list_tool_providers_empty_list_when_key_absent(client: GatewayClient) -> None:
+    """Config without a ``tool_providers`` key → empty list, no error."""
+
+    respx.get(f"{GATEWAY_BASE}/admin/v1/config").mock(
+        return_value=httpx.Response(200, json={"aliases": []})
+    )
+
+    result = await client.list_tool_providers()
+
+    assert result == []
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_list_tool_providers_empty_list_when_key_present_but_empty(
+    client: GatewayClient,
+) -> None:
+    """Explicit empty ``tool_providers`` list → empty result."""
+
+    respx.get(f"{GATEWAY_BASE}/admin/v1/config").mock(
+        return_value=httpx.Response(200, json={"tool_providers": []})
+    )
+
+    result = await client.list_tool_providers()
+
+    assert result == []
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_list_tool_providers_filters_malformed_entries(client: GatewayClient) -> None:
+    """Non-dict entries and dicts missing required keys are silently dropped;
+    valid entries are preserved."""
+
+    config_payload = {
+        "tool_providers": [
+            "not-a-dict",  # filtered: not a dict
+            {"name": "no-type"},  # filtered: missing "type"
+            {"type": "no-name"},  # filtered: missing "name"
+            {"name": "valid", "type": "echo"},  # kept
+        ]
+    }
+    respx.get(f"{GATEWAY_BASE}/admin/v1/config").mock(
+        return_value=httpx.Response(200, json=config_payload)
+    )
+
+    result = await client.list_tool_providers()
+
+    assert result == [{"name": "valid", "type": "echo"}]
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_list_tool_providers_forwards_request_id(client: GatewayClient) -> None:
+    """request_id kwarg is forwarded as X-Request-Id."""
+
+    route = respx.get(f"{GATEWAY_BASE}/admin/v1/config").mock(
+        return_value=httpx.Response(200, json={"tool_providers": []})
+    )
+
+    await client.list_tool_providers(request_id="req-abc")
+
+    assert route.calls.last.request.headers.get("X-Request-Id") == "req-abc"
+
+
 # Suppress the "task pending" warning that respx can emit on cancellation.
 @pytest.fixture(autouse=True)
 def _suppress_pending_task_warnings() -> None:

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -191,6 +191,7 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         # Phase 1 §4.4 — one-off manual session spawn (run a skill/playbook now)
         "/api/v1/autonomous/run-now",
         # WS3b — case-law research surface
+        "/api/v1/research/capabilities",
         "/api/v1/research/verify-citations",
         "/api/v1/research/search",
         "/api/v1/research/clusters/{cluster_id}",
@@ -293,7 +294,7 @@ async def test_openapi_paths_match_sketch() -> None:
     # /api/v1/autonomous/sessions/{session_id}/findings
     # Artifacts read-model (Donna #8) adds one new path:
     # /api/v1/autonomous/sessions/{session_id}/artifacts
-    assert len(actual) == 123
+    assert len(actual) == 124
 
 
 @pytest.mark.unit

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -294,6 +294,8 @@ async def test_openapi_paths_match_sketch() -> None:
     # /api/v1/autonomous/sessions/{session_id}/findings
     # Artifacts read-model (Donna #8) adds one new path:
     # /api/v1/autonomous/sessions/{session_id}/artifacts
+    # WS3b-follow adds one new path (123 -> 124):
+    # /api/v1/research/capabilities
     assert len(actual) == 124
 
 

--- a/api/tests/test_research_endpoints.py
+++ b/api/tests/test_research_endpoints.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.session import get_db
 from app.main import app
 from app.models.user import User
+from app.research import service as research_service
 from app.security import create_access_token, hash_password
 
 GW = "http://localhost:8001"  # default settings.lq_ai_gateway_url
@@ -35,6 +36,15 @@ GW = "http://localhost:8001"  # default settings.lq_ai_gateway_url
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _prime_and_reset_provider_cache() -> None:
+    """Prime the resolved-provider cache so existing tool-path tests don't
+    need to mock GET /admin/v1/config, then reset after to prevent leaks."""
+    research_service._resolved_provider = "courtlistener-prod"
+    yield
+    research_service.reset_provider_cache()
 
 
 @pytest_asyncio.fixture
@@ -356,3 +366,52 @@ async def test_find_in_case_404_when_not_cached(
         headers=_h(db_user),
     )
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /capabilities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_capabilities_unauthenticated_returns_401(client: AsyncClient) -> None:
+    resp = await client.get("/api/v1/research/capabilities")
+    assert resp.status_code == 401
+
+
+@pytest.mark.integration
+async def test_capabilities_enabled_when_courtlistener_configured(
+    client: AsyncClient, db_user: User, monkeypatch
+) -> None:
+    from app.research import service
+
+    async def _mock_get_capabilities(**_kwargs):
+        return {
+            "enabled": True,
+            "providers": [{"name": "courtlistener-prod", "type": "courtlistener"}],
+        }
+
+    monkeypatch.setattr(service, "get_capabilities", _mock_get_capabilities)
+    resp = await client.get("/api/v1/research/capabilities", headers=_h(db_user))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    assert len(body["providers"]) == 1
+    assert body["providers"][0]["name"] == "courtlistener-prod"
+
+
+@pytest.mark.integration
+async def test_capabilities_disabled_when_not_configured(
+    client: AsyncClient, db_user: User, monkeypatch
+) -> None:
+    from app.research import service
+
+    async def _mock_get_capabilities(**_kwargs):
+        return {"enabled": False, "providers": []}
+
+    monkeypatch.setattr(service, "get_capabilities", _mock_get_capabilities)
+    resp = await client.get("/api/v1/research/capabilities", headers=_h(db_user))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is False
+    assert body["providers"] == []

--- a/api/tests/test_research_endpoints.py
+++ b/api/tests/test_research_endpoints.py
@@ -15,7 +15,7 @@ the same fake_storage fixture pattern established in test_research_service.py.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 
 import httpx
 import pytest
@@ -39,7 +39,7 @@ GW = "http://localhost:8001"  # default settings.lq_ai_gateway_url
 
 
 @pytest.fixture(autouse=True)
-def _prime_and_reset_provider_cache() -> None:
+def _prime_and_reset_provider_cache() -> Iterator[None]:
     """Prime the resolved-provider cache so existing tool-path tests don't
     need to mock GET /admin/v1/config, then reset after to prevent leaks."""
     research_service._resolved_provider = "courtlistener-prod"

--- a/api/tests/test_research_models.py
+++ b/api/tests/test_research_models.py
@@ -6,11 +6,25 @@ migration runs.
 
 Tests run against the same SAVEPOINT-rolled-back per-test session as
 the rest of the API tests (per ``tests/conftest.py``).
+
+Also covers schema-layer typing added in WS3b-follow (Donna asks 2 & 3):
+- VerifiedCitation / CitationCluster round-trips the adapter's exact emitted shape.
+- OpinionTextField Literal accepts all 7 values (incl xml_harvard) and is used
+  on OpinionMeta and OpinionText.
 """
 
 from __future__ import annotations
 
+import pytest
+
 from app.models.research import ResearchClusterMetadata, ResearchOpinionMetadata
+from app.schemas.research import (
+    CitationCluster,
+    OpinionMeta,
+    OpinionText,
+    VerifiedCitation,
+    VerifyCitationsResponse,
+)
 
 
 async def test_research_metadata_roundtrips(db_session) -> None:
@@ -34,3 +48,126 @@ async def test_research_metadata_roundtrips(db_session) -> None:
     await db_session.flush()
     assert op.opinion_id == 3247759
     assert cluster.case_name == "Obergefell v. Hodges"
+
+
+# ---------------------------------------------------------------------------
+# VerifiedCitation / CitationCluster schema typing (Donna ask #2)
+# ---------------------------------------------------------------------------
+
+
+def test_verified_citation_roundtrips_adapter_shape() -> None:
+    """VerifyCitationsResponse coerces the adapter's exact emitted dict shape."""
+    adapter_item = {
+        "citation": "576 U.S. 644",
+        "normalized_citations": ["576 U.S. 644"],
+        "status": 200,
+        "error_message": None,
+        "clusters": [
+            {
+                "id": 2812209,
+                "case_name": "Obergefell v. Hodges",
+                "absolute_url": "/opinion/2812209/",
+            }
+        ],
+    }
+    resp = VerifyCitationsResponse(citations=[adapter_item])
+    assert len(resp.citations) == 1
+    vc = resp.citations[0]
+    assert isinstance(vc, VerifiedCitation)
+    assert vc.citation == "576 U.S. 644"
+    assert vc.normalized_citations == ["576 U.S. 644"]
+    assert vc.status == 200
+    assert vc.error_message is None
+    assert len(vc.clusters) == 1
+    cl = vc.clusters[0]
+    assert isinstance(cl, CitationCluster)
+    assert cl.id == 2812209
+    assert cl.case_name == "Obergefell v. Hodges"
+    assert cl.absolute_url == "/opinion/2812209/"
+
+
+def test_verified_citation_not_found_item() -> None:
+    """404 / error_message item with empty clusters is accepted."""
+    adapter_item = {
+        "citation": "999 F.3d 999",
+        "normalized_citations": [],
+        "status": 404,
+        "error_message": "not found",
+        "clusters": [],
+    }
+    resp = VerifyCitationsResponse(citations=[adapter_item])
+    vc = resp.citations[0]
+    assert vc.status == 404
+    assert vc.error_message == "not found"
+    assert vc.clusters == []
+
+
+def test_verified_citation_none_fields_accepted() -> None:
+    """Fields that can be None (citation, status, id) accept None defensively."""
+    adapter_item = {
+        "citation": None,
+        "normalized_citations": [],
+        "status": None,
+        "error_message": None,
+        "clusters": [{"id": None, "case_name": None, "absolute_url": None}],
+    }
+    resp = VerifyCitationsResponse(citations=[adapter_item])
+    vc = resp.citations[0]
+    assert vc.citation is None
+    assert vc.status is None
+    assert vc.clusters[0].id is None
+
+
+def test_verify_citations_response_empty_default() -> None:
+    """VerifyCitationsResponse defaults to an empty list."""
+    resp = VerifyCitationsResponse()
+    assert resp.citations == []
+
+
+# ---------------------------------------------------------------------------
+# OpinionTextField Literal (Donna ask #3)
+# ---------------------------------------------------------------------------
+
+_ALL_TEXT_FIELDS = [
+    "html_with_citations",
+    "html_columbia",
+    "html_lawbox",
+    "xml_harvard",
+    "html_anon_2020",
+    "html",
+    "plain_text",
+]
+
+
+@pytest.mark.parametrize("field", _ALL_TEXT_FIELDS)
+def test_opinion_meta_accepts_all_text_fields(field: str) -> None:
+    """OpinionMeta validates all 7 OpinionTextField values incl xml_harvard."""
+    meta = OpinionMeta(opinion_id=1, char_length=100, text_field_used=field)
+    assert meta.text_field_used == field
+
+
+@pytest.mark.parametrize("field", _ALL_TEXT_FIELDS)
+def test_opinion_text_accepts_all_text_fields(field: str) -> None:
+    """OpinionText validates all 7 OpinionTextField values incl xml_harvard."""
+    ot = OpinionText(opinion_id=1, cluster_id=2, text_field_used=field, text="Sample text.")
+    assert ot.text_field_used == field
+
+
+def test_opinion_meta_text_field_used_none() -> None:
+    """text_field_used=None is valid on OpinionMeta."""
+    meta = OpinionMeta(opinion_id=1, char_length=0, text_field_used=None)
+    assert meta.text_field_used is None
+
+
+def test_opinion_text_text_field_used_none() -> None:
+    """text_field_used=None is valid on OpinionText."""
+    ot = OpinionText(opinion_id=1, cluster_id=2, text_field_used=None, text="x")
+    assert ot.text_field_used is None
+
+
+def test_opinion_meta_rejects_invalid_text_field() -> None:
+    """OpinionMeta rejects values outside the closed Literal set."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        OpinionMeta(opinion_id=1, char_length=0, text_field_used="raw_text")

--- a/api/tests/test_research_models.py
+++ b/api/tests/test_research_models.py
@@ -15,13 +15,17 @@ Also covers schema-layer typing added in WS3b-follow (Donna asks 2 & 3):
 
 from __future__ import annotations
 
+from typing import get_args
+
 import pytest
+from pydantic import ValidationError
 
 from app.models.research import ResearchClusterMetadata, ResearchOpinionMetadata
 from app.schemas.research import (
     CitationCluster,
     OpinionMeta,
     OpinionText,
+    OpinionTextField,
     VerifiedCitation,
     VerifyCitationsResponse,
 )
@@ -128,15 +132,7 @@ def test_verify_citations_response_empty_default() -> None:
 # OpinionTextField Literal (Donna ask #3)
 # ---------------------------------------------------------------------------
 
-_ALL_TEXT_FIELDS = [
-    "html_with_citations",
-    "html_columbia",
-    "html_lawbox",
-    "xml_harvard",
-    "html_anon_2020",
-    "html",
-    "plain_text",
-]
+_ALL_TEXT_FIELDS = list(get_args(OpinionTextField))
 
 
 @pytest.mark.parametrize("field", _ALL_TEXT_FIELDS)
@@ -167,7 +163,11 @@ def test_opinion_text_text_field_used_none() -> None:
 
 def test_opinion_meta_rejects_invalid_text_field() -> None:
     """OpinionMeta rejects values outside the closed Literal set."""
-    import pydantic
-
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(ValidationError):
         OpinionMeta(opinion_id=1, char_length=0, text_field_used="raw_text")
+
+
+def test_opinion_text_rejects_invalid_text_field() -> None:
+    """OpinionText rejects values outside the closed Literal set."""
+    with pytest.raises(ValidationError):
+        OpinionText(opinion_id=1, cluster_id=2, text_field_used="raw_text", text="x")

--- a/api/tests/test_research_service.py
+++ b/api/tests/test_research_service.py
@@ -3,10 +3,28 @@ import pytest
 import respx
 from sqlalchemy import select
 
+from app.errors import ResearchNotConfigured
 from app.models.research import ResearchOpinionMetadata
 from app.research import service
 
 GW = "http://localhost:8001"  # default settings.lq_ai_gateway_url
+
+# ---------------------------------------------------------------------------
+# Provider-cache isolation — MUST run around every test so a cached name from
+# one test cannot leak into another (the cache is a process-level global).
+# ---------------------------------------------------------------------------
+
+_CL_CONFIG_RESP = {"tool_providers": [{"name": "courtlistener-prod", "type": "courtlistener"}]}
+
+
+@pytest.fixture(autouse=True)
+def _prime_and_reset_provider_cache() -> None:
+    """Prime the resolved-provider cache before each test so existing tests
+    that call the tool path work without mocking /admin/v1/config, then reset
+    it after so no state leaks between tests."""
+    service._resolved_provider = "courtlistener-prod"
+    yield
+    service.reset_provider_cache()
 
 
 @pytest.fixture
@@ -125,3 +143,66 @@ async def test_verify_citations_passthrough(db_session) -> None:
         )
         out = await service.verify_citations("347 U.S. 483")
     assert out["citations"][0]["citation"] == "347 U.S. 483"
+
+
+# ---------------------------------------------------------------------------
+# get_capabilities tests (always reads fresh from gateway)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_enabled_when_courtlistener_configured() -> None:
+    service.reset_provider_cache()
+    with respx.mock:
+        respx.get(f"{GW}/admin/v1/config").mock(
+            return_value=httpx.Response(200, json=_CL_CONFIG_RESP)
+        )
+        caps = await service.get_capabilities()
+    assert caps["enabled"] is True
+    assert len(caps["providers"]) == 1
+    assert caps["providers"][0]["name"] == "courtlistener-prod"
+    assert caps["providers"][0]["type"] == "courtlistener"
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_disabled_when_no_courtlistener_configured() -> None:
+    service.reset_provider_cache()
+    with respx.mock:
+        respx.get(f"{GW}/admin/v1/config").mock(
+            return_value=httpx.Response(200, json={"tool_providers": []})
+        )
+        caps = await service.get_capabilities()
+    assert caps["enabled"] is False
+    assert caps["providers"] == []
+
+
+# ---------------------------------------------------------------------------
+# _resolve_provider tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_provider_returns_configured_name_and_caches() -> None:
+    service.reset_provider_cache()
+    with respx.mock:
+        route = respx.get(f"{GW}/admin/v1/config").mock(
+            return_value=httpx.Response(200, json=_CL_CONFIG_RESP)
+        )
+        name1 = await service._resolve_provider()
+        name2 = await service._resolve_provider()  # second call uses the cache
+
+    assert name1 == "courtlistener-prod"
+    assert name2 == "courtlistener-prod"
+    # The gateway should only have been called once — second call uses the cache.
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_provider_raises_when_none_configured() -> None:
+    service.reset_provider_cache()
+    with respx.mock:
+        respx.get(f"{GW}/admin/v1/config").mock(
+            return_value=httpx.Response(200, json={"tool_providers": []})
+        )
+        with pytest.raises(ResearchNotConfigured):
+            await service._resolve_provider()

--- a/api/tests/test_research_service.py
+++ b/api/tests/test_research_service.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 import httpx
 import pytest
 import respx
@@ -18,7 +20,7 @@ _CL_CONFIG_RESP = {"tool_providers": [{"name": "courtlistener-prod", "type": "co
 
 
 @pytest.fixture(autouse=True)
-def _prime_and_reset_provider_cache() -> None:
+def _prime_and_reset_provider_cache() -> Iterator[None]:
     """Prime the resolved-provider cache before each test so existing tests
     that call the tool path work without mocking /admin/v1/config, then reset
     it after so no state leaks between tests."""

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4546,6 +4546,29 @@ Two bulk operations as originally written in the M3-C4 spec:
 
 ---
 
+#### DE-336 — Document the `503` responses on the `/api/v1/research/*` OpenAPI entries
+
+**Priority:** P3 · **Effort:** XS
+
+**Context:** Every `/api/v1/research/*` path in `docs/api/backend-openapi.yaml` documents `401` but omits the `503` cases, even though the surface fails with `503` in two distinct, client-meaningful ways: `gateway_unreachable` (transient outage) and `research_not_configured` (no CourtListener tool-provider wired — added in the WS3b-follow capabilities work). The new `/api/v1/research/capabilities` endpoint exists *specifically* to let a UI distinguish "research off" from "research broken," so the missing `503` documentation is most conspicuous there. Surfaced during the WS3b-follow code-quality review (2026-06-17). Deferred rather than absorbed because it's a uniform doc gap across all sibling research endpoints, best fixed in one pass; the typed `code` field already disambiguates the two cases at runtime.
+
+**Specific scope:** Add `503` responses (referencing the shared `Error` schema) to the research entries in `backend-openapi.yaml`, mirroring the existing inference-endpoint pattern (`503`/`504` → `#/components/schemas/Error`). The set of codes differs per endpoint — only the endpoints that actually call the gateway can `503`, and only those that resolve the provider can emit `research_not_configured`:
+
+| Endpoint | Calls gateway? | `503` codes to document |
+|---|---|---|
+| `GET /capabilities` | yes (reads `/admin/v1/config`) | `gateway_unreachable` |
+| `POST /verify-citations` | yes | `gateway_unreachable`, `research_not_configured` |
+| `POST /search` | yes | `gateway_unreachable`, `research_not_configured` |
+| `GET /clusters/{cluster_id}` | yes (on cache miss) | `gateway_unreachable`, `research_not_configured` |
+| `GET /opinions/{opinion_id}` | no (cache read; `404` if absent) | — none |
+| `POST /find-in-case` | no (cache read) | — none |
+
+No code change — the runtime already returns these with the correct typed `code`; this is documentation/contract honesty so consumers (e.g. Donna) can derive both failure modes (`research_not_configured` = feature off vs `gateway_unreachable` = transient outage) from `gen:api`. Do NOT add `503` to the two cache-read endpoints — they never reach the gateway, so it would be inaccurate. `test_openapi.py` pins the path *set* and count, not per-path response codes, so these additions are not test-enforced — review by hand.
+
+**When to ship:** Whenever the research surface's OpenAPI is next revised, or alongside the PR6 transparency work that touches these endpoints.
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -4747,6 +4747,44 @@ paths:
         '422':
           description: Invalid target (need exactly one of playbook_id/skill_ref)
 
+  /api/v1/research/capabilities:
+    get:
+      tags: [research]
+      summary: Report whether case-law research is enabled on this server
+      description: |
+        WS3b. Returns a positive "research enabled?" signal derived from the
+        gateway's sanitised config.  ``enabled`` is ``true`` when at least one
+        ``courtlistener`` tool-provider is declared in ``gateway.yaml``;
+        ``false`` otherwise.  The UI uses this to render a calm "not configured"
+        gate rather than treating an absent CourtListener as an outage.
+        Requires an authenticated user (bearer token).
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Research capability status
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [enabled, providers]
+                properties:
+                  enabled:
+                    type: boolean
+                  providers:
+                    type: array
+                    items:
+                      type: object
+                      required: [name, type]
+                      properties:
+                        name: {type: string}
+                        type: {type: string}
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+
   /api/v1/research/verify-citations:
     post:
       tags: [research]


### PR DESCRIPTION
## Summary

Three api-only refinements to the `/api/v1/research` surface, requested by the Donna UI team (`docs/proposals/lq-ai-research-surface-donna-refinements.md`) to finalize the contract **before** the larger MCP PR (PR4) lands — so Donna builds against the final shape and drops two hand-parsers + a heuristic "is research enabled?" gate. None require a gateway change; all self-merge per the api-only/docs gating rule.

**Ask 1 — explicit "is research enabled?" signal.** New `GET /api/v1/research/capabilities` → `{enabled, providers:[{name,type}]}`, read live from the gateway's already-sanitized `GET /admin/v1/config` (env-var names only, never secrets; gateway-key gated, which the api holds). Also **retires the hardcoded `_PROVIDER="courtlistener-prod"`** — the service now resolves the configured `courtlistener` provider (process-cached) and raises a typed `ResearchNotConfigured` (503, distinct from `gateway_unreachable`) when none is wired. New `GatewayClient.list_tool_providers()` (delegates to the existing `get_admin_config`).

**Ask 2 — typed verify-citations.** `VerifyCitationsResponse.citations` promoted from `list[dict]` to typed `VerifiedCitation` / `CitationCluster` models (the gateway adapter already emits exactly this shape).

**Ask 3 — typed `text_field_used`.** Promoted to a closed `OpinionTextField` `Literal[...]`, kept in sync with the adapter's `_OPINION_TEXT_FIELDS` — **including `xml_harvard`**, which the original proposal's value set omitted (the adapter is authoritative).

Also files **DE-336** (PRD §9): the research OpenAPI entries document `401` but not the `503` cases — a doc-only gap, deferred to ship alongside PR6, with a per-endpoint table (only gateway-calling endpoints `503`; only provider-resolving ones emit `research_not_configured`).

Each commit was spec- and quality-reviewed; a final holistic review returned READY-TO-MERGE.

## Test Plan
- [x] Full api suite: **2000 passed, 1 skipped** (host venv, throwaway pgvector :15433)
- [x] `ruff format --check` + `ruff check` clean (CI's two separate gates)
- [x] `mypy app` clean (149 files)
- [x] Collision guards updated together: `IMPLEMENTED_ROUTES` + `EXPECTED_PATHS` + pinned count 123→124 + `backend-openapi.yaml`
- [x] New tests: capabilities enabled/disabled, resolver caches (single config fetch) + raises `ResearchNotConfigured`, typed-schema round-trips, `list_tool_providers` filtering, endpoint 401 gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)