### PR TITLE
Carry #163's typed research shapes into backend-openapi.yaml (unblock Donna gen:api)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4569,6 +4569,18 @@ No code change — the runtime already returns these with the correct typed `cod
 
 ---
 
+#### DE-337 — Generate `backend-openapi.yaml` from `app.openapi()` so the published contract can't drift from the typed models
+
+**Priority:** P2 · **Effort:** M
+
+**Context:** `docs/api/backend-openapi.yaml` is **hand-maintained**, while the FastAPI app derives its live schema from the typed Pydantic models. The two drift: #163 (`38dbbb0`) typed `VerifyCitationsResponse`/`OpinionTextField` in code but left the yaml's `verify-citations` and `text_field_used` entries loose, so the typed shapes never reached a consumer's `gen:api` (which reads the yaml, not the live app) until a follow-up doc fix. This is the second drift incident (cf. the pre-existing note that the yaml doesn't even `yaml.safe_load` cleanly and `test_openapi.py` is the authoritative conformance check). The hand-maintained file also carries rich prose `description:` blocks that a naive `app.openapi()` dump would lose.
+
+**Specific scope:** Make the typed models the single source of truth. Options to weigh in design: (a) a `make openapi` target that dumps `app.openapi()` to the yaml + a CI check that fails on drift (mirrors the `EXPECTED_PATHS`/`test_openapi.py` machinery), keeping descriptions in the models via `Field(description=...)`/route docstrings; or (b) keep the hand-maintained file but add a CI conformance test that asserts each documented response schema matches the live `response_model` (catches drift without regenerating). Either ends the manual-sync burden. Coordinate with the consumer (Donna) since their `gen:api` pins this file.
+
+**When to ship:** Before the research/MCP OpenAPI surface grows much further (PR4b/PR4c add `/admin/mcp` + `/mcp/oauth/*`); doing it then avoids re-hand-maintaining the new entries.
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -4820,7 +4820,21 @@ paths:
                     type: array
                     items:
                       type: object
-                      additionalProperties: true
+                      properties:
+                        citation: {type: string, nullable: true}
+                        normalized_citations:
+                          type: array
+                          items: {type: string}
+                        status: {type: integer, nullable: true}
+                        error_message: {type: string, nullable: true}
+                        clusters:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id: {type: integer, nullable: true}
+                              case_name: {type: string, nullable: true}
+                              absolute_url: {type: string, nullable: true}
         '401':
           description: Not authenticated
           content:
@@ -4923,7 +4937,10 @@ paths:
                       required: [opinion_id, char_length]
                       properties:
                         opinion_id: {type: integer}
-                        text_field_used: {type: string, nullable: true}
+                        text_field_used:
+                          type: string
+                          nullable: true
+                          enum: [html_with_citations, html_columbia, html_lawbox, xml_harvard, html_anon_2020, html, plain_text]
                         char_length: {type: integer}
         '401':
           description: Not authenticated
@@ -4960,7 +4977,10 @@ paths:
                 properties:
                   opinion_id: {type: integer}
                   cluster_id: {type: integer}
-                  text_field_used: {type: string, nullable: true}
+                  text_field_used:
+                    type: string
+                    nullable: true
+                    enum: [html_with_citations, html_columbia, html_lawbox, xml_harvard, html_anon_2020, html, plain_text]
                   text: {type: string}
         '401':
           description: Not authenticated


### PR DESCRIPTION
## Summary

Closes a drift Donna (consumer) caught while pinning #163 (`38dbbb0`): that PR typed the Pydantic models (`VerifiedCitation`, `OpinionTextField`) but the **hand-maintained** `docs/api/backend-openapi.yaml` — which `gen:api` actually reads — still carried loose shapes, so asks 2 & 3 never reached the generated client types. Documentation is part of the change; this is the missed half of #163.

Three inline edits (matching the research block's existing inline style — no structural change):
- **verify-citations** 200 `citations[]` → typed `{citation, normalized_citations[], status, error_message, clusters:[{id, case_name, absolute_url}]}` (was `additionalProperties: true`).
- **`text_field_used`** → 7-value `enum` (`html_with_citations, html_columbia, html_lawbox, xml_harvard, html_anon_2020, html, plain_text`) on **both** `/research/clusters/{cluster_id}` (opinions list) and `/research/opinions/{opinion_id}`.

`openapi-typescript` will now emit a structured `VerifiedCitation` type and a 7-member string union in Donna's `backend.d.ts`.

Also files **DE-337** (PRD §9): generate `backend-openapi.yaml` from `app.openapi()` (or add a CI drift-check) so the published contract can't lag the typed models again — this is the second drift incident. Per Donna's durable-fix suggestion.

## Test Plan
- [x] `test_openapi.py` (the authoritative conformance check — the file doesn't plain-`safe_load` by design) passes: 3 passed
- [x] Confirmed the pre-existing `safe_load` failure is at line 1173, far from the edited region (4788–4985)
- [x] docs-only (yaml + PRD); no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)