### PR TITLE
PR4a/WS2: gateway MCP tool-provider adapter (streamable_http, per-call OAuth token, discovery)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4581,6 +4581,18 @@ No code change — the runtime already returns these with the correct typed `cod
 
 ---
 
+#### DE-338 — Bound MCP session teardown against a hung server
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** `MCPToolProviderAdapter`'s default session factory (`gateway/app/providers/tool/mcp.py`, PR4a) opens the streamable_http session inside an `AsyncExitStack` and bounds `session.initialize()` with `anyio.fail_after(10)`. But teardown (`AsyncExitStack.__aexit__`) runs inline with **no timeout** — a hung/half-dead MCP server could block the closing task during stream shutdown. The web stub this was ported from (`web/backend/open_webui/utils/mcp/client.py`) carried an explicit ~5s disconnect timeout for exactly this reason (its `disconnect()` comments document the cancel-scope discipline). The port deliberately kept enter+exit lexically scoped (which avoids the stub's cross-task-exit hazard — see the PR4a Task 3 review), so the hang risk is lower, but an unbounded teardown is still a latent availability foot-gun. Surfaced during the PR4a code review (2026-06-17).
+
+**Specific scope:** Bound the session teardown with a timeout that does NOT violate the MCP SDK's same-task cancel-scope requirement (the stub's comments enumerate what NOT to use — no `asyncio.shield`/`wait_for`, no new `anyio.CancelScope`/`fail_after` around the inner `TaskGroup` exit). Likely a connect-level timeout on the transport, or a watchdog that abandons the connection rather than wrapping `aclose()`. Add a test with a fake session whose teardown hangs.
+
+**When to ship:** Before MCP is used against untrusted/flaky servers at scale; the `initialize` bound covers the common connect-failure case meanwhile.
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -340,6 +340,59 @@ paths:
               schema: {$ref: '#/components/schemas/GatewayError'}
 
   # ----------- TOOLS (WS3 / ADR 0014 — tool-call HTTP transport) -----------
+  /v1/tools/{provider}:
+    get:
+      tags: [tools]
+      summary: Discover a tool provider's available tools
+      description: |
+        Returns the live ``list_tools()`` response from the named tool provider.
+        Callers use this to discover available tools and their parameter schemas
+        before invoking via ``POST /v1/tools/{provider}/{tool}``.
+
+        The ``user_token`` query parameter allows an ``auth: oauth`` MCP server
+        to be discovered using the end-user's OAuth token (PR4c supplies it).
+        For ``none`` / ``bearer`` providers the token is ignored and
+        **never logged**.
+
+        Gated by the gateway key (same as the invoke transport).
+      security:
+        - apiKeyAuth: []
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          schema: {type: string}
+          description: Name of a configured tool provider (e.g. ``courtlistener``).
+        - name: user_token
+          in: query
+          required: false
+          schema: {type: string}
+          description: |
+            Optional OAuth token forwarded to the adapter for ``auth: oauth``
+            MCP servers. Ignored for ``none`` / ``bearer``. Never logged.
+      responses:
+        '200':
+          description: Tool list returned successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolDiscoveryResponse'
+        '401':
+          description: Missing or invalid X-LQ-AI-Gateway-Key
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+        '404':
+          description: Provider name not in the tool-provider registry
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+        '502':
+          description: Upstream tool provider returned an error during list_tools
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/GatewayError'}
+
   /v1/tools/{provider}/{tool}:
     post:
       tags: [tools]
@@ -1270,6 +1323,53 @@ components:
             Optional egress-tier ceiling. If the provider's ``egress_tier``
             is higher than this value the gateway refuses with 403
             (``egress_refused``). Omit to allow any tier.
+        user_token:
+          type: string
+          nullable: true
+          description: |
+            Per-call OAuth token for ``auth: oauth`` MCP servers (PR4c).
+            Forwarded to the tool adapter and **never logged**. Ignored for
+            ``none`` / ``bearer`` auth providers.
+
+    ToolDiscoveryResponse:
+      type: object
+      required: [provider, tools]
+      properties:
+        provider:
+          type: string
+          description: The configured tool provider name.
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolSpec'
+
+    ToolSpec:
+      type: object
+      required: [name, description, parameters, read_only, destructive, requires_confirmation]
+      properties:
+        name:
+          type: string
+          description: Tool name, unique within the provider.
+        description:
+          type: string
+          description: Human-readable description of what the tool does.
+        parameters:
+          type: object
+          additionalProperties: true
+          description: |
+            JSON Schema describing the tool's argument object. Callers
+            use this to validate args before invoking via POST.
+        read_only:
+          type: boolean
+          description: True if the tool only reads data (no side-effects).
+        destructive:
+          type: boolean
+          description: True if the tool may permanently destroy or modify data.
+        requires_confirmation:
+          type: boolean
+          description: |
+            True if the tool should prompt the user for confirmation before
+            invoking (e.g. filing a document, sending a message).
 
     ToolCallResponse:
       type: object
@@ -1331,6 +1431,10 @@ components:
                 - internal_error
                 # Runtime provider-key management (Donna #7)
                 - failed_precondition
+                # Tool-call HTTP transport (WS3 / PR4a — ADR 0014)
+                - egress_refused
+                - unknown_provider
+                - tool_provider_unavailable
             message: {type: string}
             details: {type: object, additionalProperties: true}
 

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -349,9 +349,11 @@ paths:
         Callers use this to discover available tools and their parameter schemas
         before invoking via ``POST /v1/tools/{provider}/{tool}``.
 
-        The ``user_token`` query parameter allows an ``auth: oauth`` MCP server
-        to be discovered using the end-user's OAuth token (PR4c supplies it).
-        For ``none`` / ``bearer`` providers the token is ignored and
+        The per-user OAuth token for ``auth: oauth`` MCP servers is supplied via
+        the ``X-LQ-AI-User-Token`` request header (PR4c supplies it). A header
+        is used instead of a query parameter because query strings are written
+        to uvicorn access logs in plaintext; this token must never appear in
+        logs. For ``none`` / ``bearer`` providers the token is ignored and
         **never logged**.
 
         Gated by the gateway key (same as the invoke transport).
@@ -363,13 +365,15 @@ paths:
           required: true
           schema: {type: string}
           description: Name of a configured tool provider (e.g. ``courtlistener``).
-        - name: user_token
-          in: query
+        - name: X-LQ-AI-User-Token
+          in: header
           required: false
           schema: {type: string}
           description: |
-            Optional OAuth token forwarded to the adapter for ``auth: oauth``
-            MCP servers. Ignored for ``none`` / ``bearer``. Never logged.
+            Optional per-user OAuth token forwarded to the adapter for
+            ``auth: oauth`` MCP servers. Carried as a header (not a query
+            param) so it is never written to access logs. Ignored for
+            ``none`` / ``bearer`` auth providers. Never logged.
       responses:
         '200':
           description: Tool list returned successfully
@@ -423,6 +427,16 @@ paths:
           required: true
           schema: {type: string}
           description: Tool name within the provider (e.g. ``search_opinions``).
+        - name: X-LQ-AI-User-Token
+          in: header
+          required: false
+          schema: {type: string}
+          description: |
+            Optional per-user OAuth token forwarded to the adapter for
+            ``auth: oauth`` MCP servers. Carried as a header (not a query
+            param or request body field) so it is never written to access
+            logs. Ignored for ``none`` / ``bearer`` auth providers. Never
+            logged.
       requestBody:
         required: true
         content:
@@ -1323,13 +1337,6 @@ components:
             Optional egress-tier ceiling. If the provider's ``egress_tier``
             is higher than this value the gateway refuses with 403
             (``egress_refused``). Omit to allow any tier.
-        user_token:
-          type: string
-          nullable: true
-          description: |
-            Per-call OAuth token for ``auth: oauth`` MCP servers (PR4c).
-            Forwarded to the tool adapter and **never logged**. Ignored for
-            ``none`` / ``bearer`` auth providers.
 
     ToolDiscoveryResponse:
       type: object

--- a/docs/superpowers/plans/2026-06-17-pr4a-gateway-mcp-adapter.md
+++ b/docs/superpowers/plans/2026-06-17-pr4a-gateway-mcp-adapter.md
@@ -1,0 +1,935 @@
+# PR4a — Gateway MCP tool-provider adapter (WS2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `type: mcp` tool-provider to the gateway — a `streamable_http` MCP-protocol client, `mcp.yaml` loading, a live tool-discovery endpoint, and per-call `user_token` plumbing — so the api (PR4b/c) can broker MCP tools through the existing ADR-0014 egress boundary, with the gateway as the sole egress and MCP-protocol speaker.
+
+**Architecture:** New `MCPToolProviderAdapter(ToolProviderAdapter)` in `gateway/app/providers/tool/mcp.py` ports the proven `web/backend/open_webui/utils/mcp/client.py` session logic (the `mcp` SDK becomes a gateway dependency). Each `mcp.yaml` entry is parsed and synthesized into a `type: mcp` `ToolProviderConfig` merged into `GatewayConfig.tool_providers` at load. `build_tool_adapter` gains an `mcp` branch. `route_tool_call` + the adapter contract gain an optional per-call `user_token` (for `auth: oauth` servers; never logged). A new `GET /v1/tools/{provider}` returns live `list_tools`. Every outbound call passes `validate_egress_target`.
+
+**Tech Stack:** Python 3.12, FastAPI, httpx, the `mcp` SDK **1.28.x** (streamable_http client; `mcp.types.ToolAnnotations` for `readOnlyHint`/`destructiveHint`), Pydantic v2, pytest + respx. mypy `--strict` (gateway).
+
+**Scope:** PR4a is the gateway slice only (security review → Kevin merges). PR4b (api registry/cache/admin) and PR4c (api per-user OAuth) are separate plans written against PR4a as merged. Per the spec `docs/superpowers/specs/2026-06-17-mcp-client-ws2-design.md`.
+
+**Pre-flight facts (from main-loop research; subagents have no network):**
+- The `mcp` SDK client API to port is exactly what `web/backend/open_webui/utils/mcp/client.py` already uses: `from mcp import ClientSession`, `from mcp.client.streamable_http import streamablehttp_client`; `session.initialize()`, `session.list_tools()` → `result.tools` (each `tool.name`, `tool.description`, `tool.inputSchema`, `tool.annotations`), `session.call_tool(name, args)` → `result.content` / `result.isError`. The stub's `disconnect()` cancel-scope discipline (lines 141-172) is load-bearing — port it verbatim.
+- Tool safety flags live on `tool.annotations` (a `mcp.types.ToolAnnotations | None`): `.readOnlyHint`, `.destructiveHint` (both `bool | None`).
+- Gateway integration seams (exact): factory `build_tool_adapter` at `gateway/app/main.py:150-165`; startup loop `gateway/app/main.py:275-299`; `Router.route_tool_call` at `gateway/app/router.py:736-828`; `invoke_tool` abstract sig `gateway/app/providers/tool/base.py:125`; HTTP layer `gateway/app/api/tools.py:33-37,64-100`; config loader `gateway/app/config_loader.py:122-158`; config-path resolution `gateway/app/main.py:92-98,176-179`; `validate_egress_target` `gateway/app/providers/tool/egress.py:37-53`; `ToolProviderType` `gateway/app/config.py:150`; `tool_provider_by_name` `gateway/app/config.py:611-616`.
+- Test patterns: adapter unit tests `gateway/tests/test_courtlistener_adapter.py` (respx + injected client + monkeypatched `app.providers.tool.egress._resolve_ips`); router tests `gateway/tests/test_route_tool_call.py` (`RecordingToolEgressLogWriter`); route tests `gateway/tests/test_tools_route.py`.
+
+**Run-everything reminders (from the milestone handoff):**
+- Gateway tests via host venv: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/<file>.py -q`. NOT docker compose.
+- Gateway gates: `cd gateway && .venv/bin/ruff format --check app tests && .venv/bin/ruff check app tests && .venv/bin/mypy app` (mypy is `--strict`).
+- Commit `-s` + trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. Stage files explicitly (never `git add -A`).
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `gateway/pyproject.toml` (modify) | Add `mcp>=1.28,<2` dependency |
+| `gateway/app/config.py` (modify) | New `MCPServerConfig` Pydantic model + `MCPAuthType` literal; helper to synthesize a `ToolProviderConfig` from it |
+| `gateway/app/config_loader.py` (modify) | Load an optional second `MCP_CONFIG_PATH` YAML, parse to `MCPServerConfig[]`, merge synthesized `type: mcp` providers into `GatewayConfig.tool_providers` |
+| `gateway/app/main.py` (modify) | `build_tool_adapter` gains `mcp` branch; `_resolve_config_path` companion `_resolve_mcp_config_path`; lifespan passes the mcp path to the loader |
+| `gateway/app/providers/tool/mcp.py` (create) | `MCPToolProviderAdapter` — connect/list_tools/invoke_tool/health_check/aclose, annotation→flags mapping, per-call token auth, egress guard |
+| `gateway/app/router.py` (modify) | `route_tool_call` + threading of optional `user_token` to `invoke_tool` |
+| `gateway/app/providers/tool/base.py` (modify) | Add `user_token: str | None = None` kwarg to the `invoke_tool` / (new) `list_tools` discovery contract |
+| `gateway/app/api/tools.py` (modify) | `ToolCallRequest.user_token`; new `GET /v1/tools/{provider}` discovery handler |
+| `gateway.yaml.example` / `mcp.yaml.example` (modify/create) | Document the `mcp.yaml` shape |
+| `docs/api/gateway-openapi.yaml` (modify) | Document `GET /v1/tools/{provider}` + the `user_token` body field |
+| `gateway/tests/test_mcp_adapter.py` (create) | Adapter unit tests with a fake injected session |
+| `gateway/tests/test_mcp_config.py` (create) | `mcp.yaml` load+merge tests |
+| `gateway/tests/test_tools_route.py` (modify) | Discovery endpoint + `user_token` plumbing tests |
+
+---
+
+## Task 1: Add the `mcp` SDK dependency
+
+**Files:**
+- Modify: `gateway/pyproject.toml` (dependencies list, ~line 13-69)
+- Test: `gateway/tests/test_mcp_import.py` (create, temporary smoke)
+
+- [ ] **Step 1: Add the dependency**
+
+In `gateway/pyproject.toml`, add to the `dependencies = [...]` list (alongside `"httpx>=0.27,<0.29"`), keeping the existing pinning style:
+
+```toml
+    "mcp>=1.28,<2",
+```
+
+- [ ] **Step 2: Install into the gateway venv**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pip install 'mcp>=1.28,<2'`
+Expected: installs `mcp` 1.28.x and its deps (anyio, httpx-sse, pydantic, etc.) with no conflicts.
+
+- [ ] **Step 3: Write an import smoke test**
+
+```python
+# gateway/tests/test_mcp_import.py
+import pytest
+
+
+@pytest.mark.unit
+def test_mcp_sdk_importable() -> None:
+    from mcp import ClientSession  # noqa: F401
+    from mcp.client.streamable_http import streamablehttp_client  # noqa: F401
+    from mcp.types import ToolAnnotations  # noqa: F401
+```
+
+- [ ] **Step 4: Run it**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_mcp_import.py -q`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kevinkeller/Code/lq-ai && git add gateway/pyproject.toml gateway/tests/test_mcp_import.py && git commit -s -m "PR4a: add mcp SDK dependency to the gateway
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `mcp.yaml` config schema + loader merge
+
+**Files:**
+- Modify: `gateway/app/config.py` (add models near `ToolProviderConfig`, ~line 210)
+- Modify: `gateway/app/config_loader.py` (`load_config`, ~line 122-158)
+- Modify: `gateway/app/main.py` (`_resolve_config_path` companion, lifespan)
+- Create: `mcp.yaml.example`
+- Test: `gateway/tests/test_mcp_config.py`
+
+**Design:** `mcp.yaml` is a list under `mcp_servers:`. Each entry parses to `MCPServerConfig`, then `to_tool_provider_config()` synthesizes a `ToolProviderConfig` with `type="mcp"`, `base_url=server_url`, carrying `auth`, `egress_tier`, `allowlist`, `rate_limit`. The loader reads `MCP_CONFIG_PATH` (optional; absent ⇒ no MCP providers) and appends the synthesized providers to `tool_providers`.
+
+- [ ] **Step 1: Write the failing config-model test**
+
+```python
+# gateway/tests/test_mcp_config.py
+import pytest
+
+from app.config import MCPServerConfig
+
+
+@pytest.mark.unit
+def test_mcp_server_config_synthesizes_tool_provider() -> None:
+    s = MCPServerConfig(
+        name="acme-mcp",
+        server_url="https://mcp.acme.example/sse",
+        auth="bearer",
+        api_key_env="ACME_MCP_TOKEN",
+        egress_tier=2,
+        allowlist={"hosts": ["mcp.acme.example"]},
+    )
+    tp = s.to_tool_provider_config()
+    assert tp.type == "mcp"
+    assert tp.name == "acme-mcp"
+    assert tp.base_url == "https://mcp.acme.example/sse"
+    assert tp.egress_tier == 2
+    assert tp.allowlist.hosts == ["mcp.acme.example"]
+    # auth carried through extra fields (ToolProviderConfig is extra="allow")
+    assert tp.auth == "bearer"
+
+
+@pytest.mark.unit
+def test_mcp_server_config_oauth_needs_no_static_key() -> None:
+    s = MCPServerConfig(
+        name="oauth-mcp",
+        server_url="https://o.example/sse",
+        auth="oauth",
+        egress_tier=2,
+        allowlist={"hosts": ["o.example"]},
+    )
+    assert s.to_tool_provider_config().auth == "oauth"
+```
+
+- [ ] **Step 2: Run it (fails — model not defined)**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_mcp_config.py -q`
+Expected: FAIL — `ImportError: cannot import name 'MCPServerConfig'`.
+
+- [ ] **Step 3: Implement the models**
+
+In `gateway/app/config.py`, after `ToolProviderConfig` (~line 210):
+
+```python
+MCPAuthType = Literal["none", "bearer", "oauth"]
+"""How the gateway authenticates to an MCP server. ``none``/``bearer`` use
+operator-static config; ``oauth`` uses a per-call user token supplied by the
+api (the gateway stays user-unaware — spec D4)."""
+
+
+class MCPServerConfig(BaseModel):
+    """One entry under ``mcp_servers:`` in ``mcp.yaml``. Synthesized into a
+    ``type: mcp`` :class:`ToolProviderConfig` at load (spec D2)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    server_url: str = Field(min_length=1)
+    auth: MCPAuthType = "none"
+    api_key_env: str | None = None
+    api_key_encrypted: str | None = None
+    egress_tier: InferenceTier
+    allowlist: EgressAllowlistConfig
+    rate_limit: ToolProviderRateLimitConfig = Field(default_factory=ToolProviderRateLimitConfig)
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def _bearer_needs_key(self) -> MCPServerConfig:
+        if self.auth == "bearer" and not (self.api_key_env or self.api_key_encrypted):
+            raise ValueError(
+                f"MCP server {self.name!r}: auth 'bearer' requires api_key_env or api_key_encrypted."
+            )
+        if self.auth in ("none", "oauth") and (self.api_key_env or self.api_key_encrypted):
+            raise ValueError(
+                f"MCP server {self.name!r}: api_key_* is only valid with auth 'bearer'."
+            )
+        return self
+
+    def to_tool_provider_config(self) -> ToolProviderConfig:
+        return ToolProviderConfig(
+            name=self.name,
+            type="mcp",
+            base_url=self.server_url,
+            api_key_env=self.api_key_env,
+            api_key_encrypted=self.api_key_encrypted,
+            egress_tier=self.egress_tier,
+            allowlist=self.allowlist,
+            rate_limit=self.rate_limit,
+            enabled=self.enabled,
+            auth=self.auth,  # extra field; ToolProviderConfig is extra="allow"
+        )
+```
+
+- [ ] **Step 4: Run the model test (passes)**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_mcp_config.py -q`
+Expected: 2 passed.
+
+- [ ] **Step 5: Write the loader-merge failing test**
+
+```python
+# append to gateway/tests/test_mcp_config.py
+from pathlib import Path
+
+from app.config_loader import load_config
+
+
+@pytest.mark.unit
+def test_load_config_merges_mcp_yaml(tmp_path: Path, monkeypatch) -> None:
+    gw = tmp_path / "gateway.yaml"
+    gw.write_text(Path("gateway.yaml.example").read_text())
+    mcp = tmp_path / "mcp.yaml"
+    mcp.write_text(
+        "mcp_servers:\n"
+        "  - name: acme-mcp\n"
+        "    server_url: https://mcp.acme.example/sse\n"
+        "    auth: none\n"
+        "    egress_tier: 2\n"
+        "    allowlist: {hosts: [mcp.acme.example]}\n"
+    )
+    cfg = load_config(gw, mcp_path=mcp)
+    names = {tp.name: tp for tp in cfg.tool_providers}
+    assert "acme-mcp" in names
+    assert names["acme-mcp"].type == "mcp"
+
+
+@pytest.mark.unit
+def test_load_config_without_mcp_yaml_is_fine(tmp_path: Path) -> None:
+    gw = tmp_path / "gateway.yaml"
+    gw.write_text(Path("gateway.yaml.example").read_text())
+    cfg = load_config(gw, mcp_path=tmp_path / "does-not-exist.yaml")
+    assert all(tp.type != "mcp" for tp in cfg.tool_providers)
+```
+
+- [ ] **Step 6: Run it (fails — `load_config` has no `mcp_path`)**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_mcp_config.py -q`
+Expected: FAIL — `TypeError: load_config() got an unexpected keyword argument 'mcp_path'`.
+
+- [ ] **Step 7: Extend `load_config`**
+
+In `gateway/app/config_loader.py`, change the signature to `def load_config(path: Path, *, mcp_path: Path | None = None) -> GatewayConfig:`. After the `GatewayConfig` is built and validated, if `mcp_path is not None and mcp_path.exists()`: read it with the same `${VAR}`-expansion path the main config uses, parse `mcp_servers:` into `list[MCPServerConfig]`, call `.to_tool_provider_config()` on each, and append to `config.tool_providers` (re-validate the merged `GatewayConfig` so a duplicate name / bad merge fails at load). Import `MCPServerConfig` from `app.config`. Keep the env-expansion DRY — reuse the existing helper that `load_config` already applies to the main YAML.
+
+- [ ] **Step 8: Run the loader tests (pass)**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_mcp_config.py -q`
+Expected: 4 passed.
+
+- [ ] **Step 9: Wire the path in `main.py` + add `mcp.yaml.example`**
+
+In `gateway/app/main.py`: add `_resolve_mcp_config_path()` mirroring `_resolve_config_path()` (env `MCP_CONFIG_PATH`; default = `mcp.yaml` sibling of the gateway config, returned only if it exists). In the lifespan (~line 176-179) pass `mcp_path=_resolve_mcp_config_path()` to `load_config(...)`. Create `mcp.yaml.example`:
+
+```yaml
+# mcp.yaml — operator-allowlisted MCP servers (spec D2). Loaded by the gateway
+# (MCP_CONFIG_PATH; defaults to ./mcp.yaml). Each entry becomes a type: mcp
+# tool-provider behind the same egress boundary as gateway.yaml tool_providers.
+mcp_servers:
+  - name: example-mcp
+    server_url: https://mcp.example.com/sse
+    auth: none              # none | bearer | oauth
+    egress_tier: 2
+    allowlist:
+      hosts: [mcp.example.com]
+    # auth: bearer -> also set api_key_env: EXAMPLE_MCP_TOKEN
+    # auth: oauth  -> per-user token supplied by the api at call time (PR4c)
+```
+
+- [ ] **Step 10: Run the full config test module + commit**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_mcp_config.py -q`
+Expected: 4 passed.
+
+```bash
+cd /Users/kevinkeller/Code/lq-ai && git add gateway/app/config.py gateway/app/config_loader.py gateway/app/main.py mcp.yaml.example gateway/tests/test_mcp_config.py && git commit -s -m "PR4a: mcp.yaml schema + loader merge into tool_providers
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `MCPToolProviderAdapter` (core: connect / list_tools / invoke_tool)
+
+**Files:**
+- Create: `gateway/app/providers/tool/mcp.py`
+- Test: `gateway/tests/test_mcp_adapter.py`
+
+**Design:** Mirror `CourtListenerToolAdapter` structure (`from_config`, `validate_base_url`, `_result`, `aclose`). The MCP session is reached through an **injectable async factory** `session_factory(url, headers) -> async context manager yielding a connected `ClientSession`` so unit tests pass a fake and never touch the network. The default factory ports the web stub's `streamablehttp_client` + `ClientSession` + `initialize()` + the verbatim disconnect discipline. `validate_egress_target(server_url, allowlist=...)` runs before every connect. Annotation→flags mapping per spec §2.
+
+- [ ] **Step 1: Write the failing adapter tests (fake session)**
+
+```python
+# gateway/tests/test_mcp_adapter.py
+import pytest
+
+from app.config import ToolProviderConfig
+from app.providers.tool.base import ToolSpec
+from app.providers.tool.mcp import MCPToolProviderAdapter
+
+
+class _FakeTool:
+    def __init__(self, name, description, input_schema, annotations=None):
+        self.name = name
+        self.description = description
+        self.inputSchema = input_schema
+        self.annotations = annotations
+
+
+class _Ann:
+    def __init__(self, read_only=None, destructive=None):
+        self.readOnlyHint = read_only
+        self.destructiveHint = destructive
+
+
+class _FakeResult:
+    def __init__(self, tools=None, content=None, is_error=False):
+        self.tools = tools or []
+        self.content = content
+        self.isError = is_error
+
+    def model_dump(self, mode="json"):
+        return {"content": self.content}
+
+
+class _FakeSession:
+    def __init__(self, tools=None, call_result=None):
+        self._tools = tools or []
+        self._call_result = call_result
+
+    async def initialize(self):
+        return None
+
+    async def list_tools(self):
+        return _FakeResult(tools=self._tools)
+
+    async def call_tool(self, name, args):
+        return self._call_result
+
+
+def _cfg() -> ToolProviderConfig:
+    return ToolProviderConfig(
+        name="acme-mcp",
+        type="mcp",
+        base_url="https://mcp.acme.example/sse",
+        egress_tier=2,
+        allowlist={"hosts": ["mcp.acme.example"]},
+        auth="none",
+    )
+
+
+def _adapter(session: _FakeSession) -> MCPToolProviderAdapter:
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def factory(url, headers):
+        yield session
+
+    return MCPToolProviderAdapter.from_config(_cfg(), session_factory=factory)
+
+
+@pytest.mark.unit
+async def test_list_tools_maps_annotations() -> None:
+    tools = [
+        _FakeTool("read_doc", "reads", {"type": "object"}, _Ann(read_only=True)),
+        _FakeTool("delete_doc", "deletes", {"type": "object"}, _Ann(destructive=True)),
+        _FakeTool("mystery", "no hints", {"type": "object"}, None),
+    ]
+    specs = await _adapter(_FakeSession(tools=tools)).list_tools()
+    by = {s.name: s for s in specs}
+    assert by["read_doc"].read_only and not by["read_doc"].requires_confirmation
+    assert by["delete_doc"].destructive and by["delete_doc"].requires_confirmation
+    # un-annotated -> safe default: not auto-runnable
+    assert by["mystery"].requires_confirmation and not by["mystery"].read_only
+
+
+@pytest.mark.unit
+async def test_invoke_tool_returns_tool_result() -> None:
+    res = _FakeResult(content=[{"type": "text", "text": "hi"}], is_error=False)
+    out = await _adapter(_FakeSession(call_result=res)).invoke_tool(
+        "read_doc", {"q": "x"}, request_id="r1"
+    )
+    assert out.provider == "acme-mcp"
+    assert out.tool == "read_doc"
+    assert out.payload == [{"type": "text", "text": "hi"}]
+
+
+@pytest.mark.unit
+async def test_invoke_tool_error_raises() -> None:
+    from app.providers.tool.base import ToolProviderError
+
+    res = _FakeResult(content=[{"type": "text", "text": "boom"}], is_error=True)
+    with pytest.raises(ToolProviderError):
+        await _adapter(_FakeSession(call_result=res)).invoke_tool("x", {}, request_id="r1")
+
+
+@pytest.mark.unit
+async def test_validate_base_url_rejects_non_allowlisted(monkeypatch) -> None:
+    from app.providers.tool import egress
+    monkeypatch.setattr(egress, "_resolve_ips", lambda host: ["93.184.216.34"])
+    bad = ToolProviderConfig(
+        name="x", type="mcp", base_url="https://evil.example/sse",
+        egress_tier=2, allowlist={"hosts": ["mcp.acme.example"]}, auth="none",
+    )
+    a = MCPToolProviderAdapter.from_config(bad)
+    from app.providers.tool.egress import EgressRefused
+    with pytest.raises(EgressRefused):
+        a.validate_base_url()
+```
+
+- [ ] **Step 2: Run (fails — module missing)**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_mcp_adapter.py -q`
+Expected: FAIL — `ModuleNotFoundError: app.providers.tool.mcp`.
+
+- [ ] **Step 3: Implement the adapter**
+
+Create `gateway/app/providers/tool/mcp.py`:
+
+```python
+"""``mcp`` tool provider — Model Context Protocol egress (ADR 0014, WS2/PR4a).
+
+The gateway is the sole egress AND the only MCP-protocol speaker (spec D1):
+streamable_http sessions are stateful, so the holder of the connection must
+speak MCP. Ports the proven client logic from
+``web/backend/open_webui/utils/mcp/client.py`` behind an injectable session
+factory so unit tests never touch the network. Every connect passes
+``validate_egress_target`` (SSRF/allowlist)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Callable
+
+from app.config import ToolProviderConfig
+from app.providers.base import ProviderHealth
+from app.providers.tool.base import (
+    ToolProviderAdapter,
+    ToolProviderError,
+    ToolProviderNetworkError,
+    ToolResult,
+    ToolSpec,
+)
+from app.providers.tool.egress import validate_egress_target
+from app.secrets import ProviderKeyResolver
+
+SessionFactory = Callable[..., Any]  # (url, headers) -> async ctx mgr yielding a ClientSession
+
+
+def _default_session_factory() -> SessionFactory:
+    @asynccontextmanager
+    async def factory(url: str, headers: dict[str, str] | None) -> AsyncIterator[Any]:
+        # Port of web/backend/open_webui/utils/mcp/client.py connect/disconnect.
+        from contextlib import AsyncExitStack
+
+        import anyio
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+
+        async with AsyncExitStack() as stack:
+            transport = await stack.enter_async_context(
+                streamablehttp_client(url, headers=headers)
+            )
+            read_stream, write_stream, _ = transport
+            session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
+            with anyio.fail_after(10):
+                await session.initialize()
+            yield session
+
+    return factory
+
+
+def _map_flags(annotations: Any) -> tuple[bool, bool, bool]:
+    """(read_only, destructive, requires_confirmation) from MCP tool annotations.
+
+    Safe default for un-annotated tools: not read-only, not destructive, but
+    requires_confirmation=True (treat unknown as needing the PR5 gate)."""
+    read_only = bool(getattr(annotations, "readOnlyHint", False)) if annotations else False
+    destructive = bool(getattr(annotations, "destructiveHint", False)) if annotations else False
+    if read_only and not destructive:
+        return True, False, False
+    if destructive:
+        return False, True, True
+    return False, False, True  # un-annotated / ambiguous -> confirm
+
+
+class MCPToolProviderAdapter(ToolProviderAdapter):
+    def __init__(
+        self,
+        *,
+        name: str,
+        server_url: str,
+        auth: str,
+        api_key: str | None,
+        allowlist: list[str],
+        session_factory: SessionFactory | None = None,
+    ) -> None:
+        self.name = name
+        self._server_url = server_url
+        self._auth = auth
+        self._api_key = api_key
+        self._allowlist = allowlist
+        self._session_factory = session_factory or _default_session_factory()
+
+    @classmethod
+    def from_config(
+        cls,
+        provider: ToolProviderConfig,
+        *,
+        key_resolver: ProviderKeyResolver | None = None,
+        session_factory: SessionFactory | None = None,
+    ) -> MCPToolProviderAdapter:
+        if provider.type != "mcp":
+            raise ValueError(f"MCPToolProviderAdapter from non-mcp {provider.type!r}")
+        auth = getattr(provider, "auth", "none")
+        api_key: str | None = None
+        if auth == "bearer":
+            resolver = key_resolver or ProviderKeyResolver.from_environ()
+            api_key = resolver.resolve(
+                provider_name=provider.name,
+                api_key_env=provider.api_key_env,
+                api_key_encrypted=provider.api_key_encrypted,
+            )
+            if not api_key:
+                raise ValueError(f"MCP provider {provider.name!r}: bearer auth but no token resolved.")
+        return cls(
+            name=provider.name,
+            server_url=provider.base_url,
+            auth=auth,
+            api_key=api_key,
+            allowlist=provider.allowlist.hosts,
+            session_factory=session_factory,
+        )
+
+    def validate_base_url(self) -> None:
+        validate_egress_target(self._server_url, allowlist=self._allowlist)
+
+    def _headers(self, user_token: str | None) -> dict[str, str] | None:
+        if self._auth == "bearer" and self._api_key:
+            return {"Authorization": f"Bearer {self._api_key}"}
+        if self._auth == "oauth":
+            if not user_token:
+                raise ToolProviderError(
+                    f"MCP server {self.name!r} requires per-user authorization",
+                    details={"code": "mcp_authorization_required"},
+                )
+            return {"Authorization": f"Bearer {user_token}"}
+        return None
+
+    @asynccontextmanager
+    async def _session(self, user_token: str | None) -> AsyncIterator[Any]:
+        validate_egress_target(self._server_url, allowlist=self._allowlist)
+        try:
+            async with self._session_factory(self._server_url, self._headers(user_token)) as s:
+                yield s
+        except ToolProviderError:
+            raise
+        except Exception as exc:  # transport/protocol failure
+            raise ToolProviderNetworkError(f"mcp session error: {exc}") from exc
+
+    async def list_tools(self, *, user_token: str | None = None) -> list[ToolSpec]:
+        async with self._session(user_token) as session:
+            result = await session.list_tools()
+        specs: list[ToolSpec] = []
+        for tool in result.tools:
+            read_only, destructive, requires_confirmation = _map_flags(
+                getattr(tool, "annotations", None)
+            )
+            specs.append(
+                ToolSpec(
+                    name=tool.name,
+                    description=tool.description or "",
+                    parameters=tool.inputSchema or {"type": "object"},
+                    read_only=read_only,
+                    destructive=destructive,
+                    requires_confirmation=requires_confirmation,
+                )
+            )
+        return specs
+
+    async def invoke_tool(
+        self, tool: str, args: dict[str, Any], *, request_id: str, user_token: str | None = None
+    ) -> ToolResult:
+        async with self._session(user_token) as session:
+            result = await session.call_tool(tool, args)
+        dumped = result.model_dump(mode="json")
+        content = dumped.get("content")
+        if getattr(result, "isError", False):
+            raise ToolProviderError("mcp tool returned an error", details={"content": content})
+        return ToolResult(
+            provider=self.name,
+            tool=tool,
+            payload=content,
+            bytes_out=len(json.dumps(args).encode("utf-8")),
+            bytes_in=len(json.dumps(content).encode("utf-8")),
+            skip_anonymization=False,
+        )
+
+    async def health_check(self) -> ProviderHealth:
+        try:
+            async with self._session(None):
+                pass
+        except ToolProviderError as exc:
+            return ProviderHealth(name=self.name, reachable=False, error=str(exc))
+        return ProviderHealth(name=self.name, reachable=True, latency_ms=0)
+
+    async def aclose(self) -> None:
+        return None
+```
+
+NOTE on the abstract contract: this adds an optional `user_token` kwarg to `list_tools`/`invoke_tool`. Task 4 updates the ABC in `base.py` and the other two adapters (echo, courtlistener) to accept-and-ignore `user_token` so the contract stays uniform and mypy `--strict` passes.
+
+- [ ] **Step 4: Run adapter tests**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_mcp_adapter.py -q`
+Expected: 4 passed (the `validate_base_url` test needs Task 4's signature only if `list_tools` is called; it isn't here, so it passes now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kevinkeller/Code/lq-ai && git add gateway/app/providers/tool/mcp.py gateway/tests/test_mcp_adapter.py && git commit -s -m "PR4a: MCPToolProviderAdapter (streamable_http, annotation->flags, egress-guarded)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Uniform `user_token` in the adapter contract + factory wiring
+
+**Files:**
+- Modify: `gateway/app/providers/tool/base.py` (abstract `list_tools`/`invoke_tool` sigs, ~line 120-126)
+- Modify: `gateway/app/providers/tool/echo.py`, `gateway/app/providers/tool/courtlistener.py` (accept-and-ignore `user_token`)
+- Modify: `gateway/app/main.py` (`build_tool_adapter` mcp branch, ~line 150-165)
+- Test: `gateway/tests/test_tool_adapter_wiring.py` (extend)
+
+- [ ] **Step 1: Write the failing wiring test**
+
+```python
+# add to gateway/tests/test_tool_adapter_wiring.py
+import pytest
+
+from app.config import ToolProviderConfig
+from app.main import build_tool_adapter
+from app.providers.tool.mcp import MCPToolProviderAdapter
+
+
+@pytest.mark.unit
+def test_build_tool_adapter_mcp(monkeypatch) -> None:
+    from app.providers.tool import egress
+    monkeypatch.setattr(egress, "_resolve_ips", lambda host: ["93.184.216.34"])
+    cfg = ToolProviderConfig(
+        name="acme-mcp", type="mcp", base_url="https://mcp.acme.example/sse",
+        egress_tier=2, allowlist={"hosts": ["mcp.acme.example"]}, auth="none",
+    )
+    adapter = build_tool_adapter(cfg)
+    assert isinstance(adapter, MCPToolProviderAdapter)
+```
+
+- [ ] **Step 2: Run (fails — mcp branch returns None)**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_tool_adapter_wiring.py::test_build_tool_adapter_mcp -q`
+Expected: FAIL — `assert None is MCPToolProviderAdapter` (build returns `None` today).
+
+- [ ] **Step 3: Update the ABC + the two existing adapters + the factory**
+
+In `gateway/app/providers/tool/base.py`, change the abstract methods to:
+```python
+    @abstractmethod
+    async def list_tools(self, *, user_token: str | None = None) -> list[ToolSpec]: ...
+
+    @abstractmethod
+    async def invoke_tool(
+        self, tool: str, args: dict[str, Any], *, request_id: str, user_token: str | None = None
+    ) -> ToolResult: ...
+```
+In `echo.py` and `courtlistener.py`, add `user_token: str | None = None` to both method signatures (ignore it — those providers don't use per-user auth). In `gateway/app/main.py` `build_tool_adapter`, replace the `# mcp (PR4) lands later. return None` tail with:
+```python
+    if provider.type == "mcp":
+        from app.providers.tool.mcp import MCPToolProviderAdapter
+
+        mcp_adapter = MCPToolProviderAdapter.from_config(provider)
+        mcp_adapter.validate_base_url()
+        return mcp_adapter
+    return None
+```
+
+- [ ] **Step 4: Run wiring + existing adapter tests**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_tool_adapter_wiring.py tests/test_courtlistener_adapter.py tests/test_mcp_adapter.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kevinkeller/Code/lq-ai && git add gateway/app/providers/tool/base.py gateway/app/providers/tool/echo.py gateway/app/providers/tool/courtlistener.py gateway/app/main.py gateway/tests/test_tool_adapter_wiring.py && git commit -s -m "PR4a: wire mcp into build_tool_adapter; uniform user_token in adapter contract
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Thread `user_token` through `route_tool_call` + the transport
+
+**Files:**
+- Modify: `gateway/app/router.py` (`route_tool_call`, ~line 736-828)
+- Modify: `gateway/app/api/tools.py` (`ToolCallRequest`, `call_tool` handler)
+- Test: `gateway/tests/test_route_tool_call.py`, `gateway/tests/test_tools_route.py`
+
+- [ ] **Step 1: Write the failing router test**
+
+```python
+# add to gateway/tests/test_route_tool_call.py — assert user_token reaches the adapter
+# and never appears in the audit row.
+import pytest
+
+
+class _CaptureAdapter:
+    name = "acme-mcp"
+    captured_token = None
+
+    async def invoke_tool(self, tool, args, *, request_id, user_token=None):
+        type(self).captured_token = user_token
+        from app.providers.tool.base import ToolResult
+        return ToolResult(provider=self.name, tool=tool, payload={"ok": True})
+
+    async def list_tools(self, *, user_token=None):
+        return []
+
+
+@pytest.mark.unit
+async def test_route_tool_call_threads_user_token() -> None:
+    # Build a Router whose tool_provider config has an mcp provider named acme-mcp
+    # (reuse the _router(...) helper already in this file; add a type: mcp provider
+    # to its config + register _CaptureAdapter() in the adapters dict).
+    router, recorder = _router_with_mcp_capture()  # helper added below
+    await router.route_tool_call(
+        "acme-mcp", "read_doc", {"q": "x"}, request_id="r1", user_token="secret-user-token"
+    )
+    assert _CaptureAdapter.captured_token == "secret-user-token"
+    # audit row must NOT contain the token anywhere
+    row = recorder.rows[-1]
+    assert "secret-user-token" not in str(row.__dict__)
+```
+
+Add a `_router_with_mcp_capture()` helper next to the existing `_router(...)` in the file: build a `GatewayConfig` with a `type: mcp` `ToolProviderConfig` named `acme-mcp` (egress_tier 2, allowlist hosts `["mcp.acme.example"]`, `auth="none"`), an adapters dict `{"acme-mcp": _CaptureAdapter()}`, and a `RecordingToolEgressLogWriter`.
+
+- [ ] **Step 2: Run (fails — `route_tool_call` has no `user_token`)**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_route_tool_call.py::test_route_tool_call_threads_user_token -q`
+Expected: FAIL — `TypeError: unexpected keyword argument 'user_token'`.
+
+- [ ] **Step 3: Add `user_token` to `route_tool_call`**
+
+In `gateway/app/router.py`, add `user_token: str | None = None` to the `route_tool_call` keyword-only args, and pass it to the adapter at the invoke site (`router.py:797`):
+```python
+result = await adapter.invoke_tool(tool, args, request_id=request_id, user_token=user_token)
+```
+Do NOT add `user_token` to any `ToolEgressLogRow` (it must never be persisted). Confirm by inspection that no log-row construction references it.
+
+- [ ] **Step 4: Run router test (passes)**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_route_tool_call.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Add `user_token` to the transport body + handler**
+
+In `gateway/app/api/tools.py`, add to `ToolCallRequest`:
+```python
+    user_token: str | None = Field(default=None)
+```
+and pass `user_token=body.user_token` into `gw_router.route_tool_call(...)` in the `call_tool` handler.
+
+- [ ] **Step 6: Write + run the transport test**
+
+```python
+# add to gateway/tests/test_tools_route.py — POST with user_token reaches route_tool_call.
+# Use the existing app/AsyncClient fixture; monkeypatch the router's route_tool_call
+# to capture kwargs, POST {"args": {...}, "user_token": "t"} and assert it was forwarded.
+```
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_tools_route.py -q`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/kevinkeller/Code/lq-ai && git add gateway/app/router.py gateway/app/api/tools.py gateway/tests/test_route_tool_call.py gateway/tests/test_tools_route.py && git commit -s -m "PR4a: thread optional per-call user_token transport->router->adapter (never logged)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `GET /v1/tools/{provider}` discovery endpoint
+
+**Files:**
+- Modify: `gateway/app/api/tools.py` (new handler)
+- Modify: `docs/api/gateway-openapi.yaml` (document the route + `user_token`)
+- Test: `gateway/tests/test_tools_route.py`
+
+- [ ] **Step 1: Write the failing discovery test**
+
+```python
+# add to gateway/tests/test_tools_route.py
+@pytest.mark.unit
+async def test_discovery_lists_tools(gateway_app) -> None:
+    # The example config wires an echo tool-provider; GET its tools.
+    async with httpx_async_client(gateway_app) as client:  # match the file's client helper
+        resp = await client.get("/v1/tools/echo-test", headers=_key_headers())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == "echo-test"
+    assert any(t["name"] == "echo" for t in body["tools"])
+
+
+@pytest.mark.unit
+async def test_discovery_unknown_provider_404(gateway_app) -> None:
+    async with httpx_async_client(gateway_app) as client:
+        resp = await client.get("/v1/tools/nope", headers=_key_headers())
+    assert resp.status_code == 404
+```
+(Use the same app fixture, key headers, and client helper the other tests in this file use — match them exactly; the echo provider name in `gateway.yaml.example` is the one already used by the POST happy-path test.)
+
+- [ ] **Step 2: Run (fails — no GET route)**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_tools_route.py -k discovery -q`
+Expected: FAIL — 405/404 (route not registered).
+
+- [ ] **Step 3: Implement the handler**
+
+In `gateway/app/api/tools.py`, add (same `require_gateway_key` router, so it's key-gated):
+```python
+@router.get("/tools/{provider}")
+async def list_provider_tools(
+    provider: str, request: Request, user_token: str | None = None
+) -> JSONResponse:
+    # user_token is an optional query param so an `auth: oauth` server can be
+    # discovered with the user's token (PR4c supplies it). For none/bearer
+    # servers it is ignored. Never logged.
+    gw_router = _router(request)
+    adapter = gw_router._tool_adapters.get(provider)
+    if adapter is None:
+        return _error(404, "unknown_provider", f"tool provider {provider!r} not found")
+    try:
+        specs = await adapter.list_tools(user_token=user_token)
+    except ToolProviderError as exc:
+        return _error(502, "tool_provider_unavailable", exc.message, exc.details)
+    return JSONResponse(
+        content={
+            "provider": provider,
+            "tools": [
+                {
+                    "name": s.name,
+                    "description": s.description,
+                    "parameters": s.parameters,
+                    "read_only": s.read_only,
+                    "destructive": s.destructive,
+                    "requires_confirmation": s.requires_confirmation,
+                }
+                for s in specs
+            ],
+        }
+    )
+```
+(Accessing `gw_router._tool_adapters` mirrors how `route_tool_call` reaches them; if the Router exposes a public accessor, prefer it — check `router.py` and match the existing style.)
+
+- [ ] **Step 4: Run discovery tests**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest tests/test_tools_route.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Document in `gateway-openapi.yaml`**
+
+Add `GET /v1/tools/{provider}` (key-gated; 200 → `{provider, tools:[{name, description, parameters, read_only, destructive, requires_confirmation}]}`; 404 unknown provider; 502 provider unavailable) next to the existing `POST /v1/tools/{provider}/{tool}` entry, and add the optional `user_token` field to the POST request-body schema. Match the file's existing style. If the gateway test-suite has a route-count/conformance guard (mirror of the api's `test_openapi.py` — check `gateway/tests/`), update it in this commit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/kevinkeller/Code/lq-ai && git add gateway/app/api/tools.py docs/api/gateway-openapi.yaml gateway/tests/test_tools_route.py && git commit -s -m "PR4a: GET /v1/tools/{provider} discovery endpoint
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full-suite gates + retire-stub note
+
+**Files:** none (verification) — plus a one-line note that the `web/` stub is retired in PR4c (not here; it's still imported by web/ until then).
+
+- [ ] **Step 1: Run the full gateway gates**
+
+Run:
+```
+cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/pytest -q
+cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/ruff format --check app tests && .venv/bin/ruff check app tests
+cd /Users/kevinkeller/Code/lq-ai/gateway && .venv/bin/mypy app
+```
+Expected: all green (mypy `--strict` clean — pay attention to the `Any` session-factory types; add precise `# type:` or `cast` where the `mcp` SDK lacks stubs, rather than blanket `ignore`).
+
+- [ ] **Step 2: Confirm no secret leakage**
+
+Grep the diff: `git diff main...HEAD | grep -i -E "user_token|api_key|Authorization"` and confirm `user_token`/tokens never reach a `ToolEgressLogRow`, a `log.*`, or the discovery payload.
+
+- [ ] **Step 3: Final commit (if any formatting fixups)**
+
+```bash
+cd /Users/kevinkeller/Code/lq-ai && git add -p   # stage only intended hunks
+git commit -s -m "PR4a: gate fixups
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Definition of done (PR4a)
+- `mcp.yaml.example` parses; an `mcp_servers:` entry becomes a `type: mcp` tool-provider at gateway startup (config test).
+- `MCPToolProviderAdapter` connects via streamable_http (injectable factory), maps annotations→`ToolSpec` flags (un-annotated ⇒ `requires_confirmation`), invokes tools, guards egress.
+- `none`/`bearer` auth fully functional; `oauth` refuses with `mcp_authorization_required` when no `user_token` is supplied (PR4c will supply it).
+- `GET /v1/tools/{provider}` returns live discovery; `POST /v1/tools/{provider}/{tool}` accepts an optional `user_token`; tokens are never logged.
+- Gateway `pytest` + `ruff` (format & check) + `mypy --strict` all green.
+- **Gate:** `gateway/**` → security review → **Kevin reviews/merges** (offer review-vs-self).
+
+## Follow-on (separate plans, written against PR4a as merged)
+- **PR4b (api, self-merge):** `api/app/mcp/` registry (filter `list_tool_providers` to `type==mcp`), discovery DB-cache (migration 0050 `mcp_tools`), per-tool enable/disable, `/api/v1/admin/mcp` list/refresh. Works for `none`/`bearer` servers.
+- **PR4c (api, security review):** per-user OAuth (authz-code+PKCE `authorize`/`callback`), Fernet-encrypted `mcp_oauth_tokens`, refresh, per-call `user_token` plumbing to the gateway. Retire `web/backend/open_webui/utils/mcp/client.py`.
+</content>

--- a/docs/superpowers/specs/2026-06-17-mcp-client-ws2-design.md
+++ b/docs/superpowers/specs/2026-06-17-mcp-client-ws2-design.md
@@ -1,0 +1,123 @@
+# Design — MCP Client subsystem (WS2 / PR4), gateway-brokered + governed + per-user OAuth
+
+**Date:** 2026-06-17 · **Milestone:** legal-research + MCP · **Workstream:** WS2 (DE-200, PRD §8.5)
+**Spec source:** [`docs/proposals/legal-research-and-mcp.md`](../../proposals/legal-research-and-mcp.md) · **ADRs:** [0014](../../adr/0014-gateway-egress-boundary-for-tool-providers.md) (egress boundary), [0015](../../adr/0015-governed-tool-calling-model.md) (governed tool-calling)
+
+> Brings an **MCP client** to LQ.AI with MikeOSS parity (`streamable_http` only, no stdio), re-seated on LQ.AI's boundaries: the **gateway is the sole egress** and the only MCP-protocol speaker; the **api owns the user**, the discovery cache, per-tool policy, and per-user OAuth. PR4 is WS2; PR5 (the governed chat tool-loop + `ToolIntent`s) and PR6 (transparency UI) consume what this builds.
+
+---
+
+## 1. Decisions (locked 2026-06-17)
+
+| # | Decision | Rationale |
+|---|---|---|
+| **D1** | **The gateway owns the MCP `streamable_http` client.** New `MCPToolProviderAdapter` in `gateway/`; the `mcp` SDK is a gateway dependency. | MCP `streamable_http` is a *stateful session* (connect → `initialize` → JSON-RPC over SSE). Whoever holds the outbound connection must speak MCP. ADR 0014 makes the gateway the sole egress → the protocol client lives there. This reinterprets the proposal's "port the stub into `api/`" as "port into the gateway adapter." |
+| **D2** | **Separate `mcp.yaml`, loaded by the gateway** alongside `gateway.yaml`; each entry is synthesized into a `type: mcp` `ToolProviderConfig` internally. | Keeps the (potentially long) MCP server + tool-policy list out of `gateway.yaml`; matches the proposal/handoff. `ToolProviderType` already includes `mcp`. |
+| **D3** | **Ship per-user OAuth** (not a stub): `none` / `bearer` / `oauth` auth modes. | Operator's MCP servers often require user identity. |
+| **D4** | **The api drives + stores OAuth; the gateway takes a per-call token.** The api runs the authz-code+PKCE flow, stores per-user tokens Fernet-encrypted in the api DB, refreshes them, and passes the user's access token to the gateway per tool-call. The gateway stays user-unaware. | The gateway has no user DB ("the gateway has no user" — ADR 0007); user secrets live where user data lives (the api). Egress stays in the gateway. Reuses the audited `api/app/security/encryption.py` (Fernet) — **no new crypto**. |
+| **D5** | **Backend OAuth in PR4; polished consent UI in PR6.** PR4 ships the api `authorize`/`callback` endpoints (testable headless); the `web/` connect button + provenance pills land in PR6/WS5 where all MCP UI lives. | Keeps PR4 backend-focused; keeps the `web/` surface in one place. |
+| **D6** | **3-PR decomposition** (PR4a gateway / PR4b api-registry / PR4c api-OAuth), mirroring WS3's gateway→transport→api split. | Isolates the security-review surfaces; each is independently shippable behind a flag. |
+
+---
+
+## 2. Architecture & data flow
+
+```
+          mcp.yaml (operator) ──loaded by──►  GATEWAY  (sole egress, MCP-protocol speaker)
+                                              │  MCPToolProviderAdapter (mcp SDK, streamable_http)
+ MCP server ◄── streamable_http (initialize → JSON-RPC) ──┤  every call: validate_egress_target (SSRF/allowlist)
+                                              │  GET  /v1/tools/{provider}            → list_tools (discovery)   [NEW]
+                                              │  POST /v1/tools/{provider}/{tool}     {args, user_token?}        [EXTENDED]
+                                              ▲
+   api/app/mcp/ :  registry • discovery-cache (DB) • per-tool enable/disable • OAuth flow • token store (DB, Fernet)
+                                              ▲
+   user ── consent ──► api OAuth (authz-code + PKCE) ─► encrypted per-user token ─► supplied per-call to the gateway
+                                              ▲
+                                 chat / autonomous governed tool-loop  (PR5, out of scope here)
+```
+
+**Auth resolution per server (`mcp.yaml` `auth:`):**
+- `none` — no credential; operator vouches for the server.
+- `bearer` — operator-static token (gateway-side, sourced like other provider keys: `api_key_env` / `api_key_encrypted`).
+- `oauth` — the gateway uses the **per-call `user_token`** the api supplies for that session; if absent for an `oauth` server, the call is refused with a typed "mcp_authorization_required" error so the UI can prompt consent.
+
+**Tool metadata mapping.** MCP tool annotations (`readOnlyHint`, `destructiveHint`) map onto the existing `ToolSpec` flags `read_only` / `destructive` / `requires_confirmation`. **Safe default for un-annotated tools** (a server that omits hints): `read_only=False`, `destructive=False`, `requires_confirmation=True` — treat unknown tools as confirmation-required rather than auto-runnable; PR5 enforces the gate. A tool that explicitly declares `readOnlyHint=true` maps to `read_only=True, requires_confirmation=False`; `destructiveHint=true` maps to `destructive=True, requires_confirmation=True`. These flags are cached api-side and carried to PR5.
+
+---
+
+## 3. Components & boundaries
+
+### 3.1 Gateway (PR4a) — `gateway/app/providers/tool/mcp.py`
+- **`MCPToolProviderAdapter(ToolProviderAdapter)`** — implements the existing 4-method contract:
+  - `list_tools()` → opens a streamable_http session, calls MCP `list_tools`, maps each to a `ToolSpec` (with the annotation→flags mapping above). Live discovery; not static.
+  - `invoke_tool(tool, args, *, request_id)` → opens a session, calls MCP `call_tool`, returns a `ToolResult` (payload = MCP result content; byte counts; `skip_anonymization` left at the ADR-0014 default for tool egress, i.e. **False** unless a future policy says otherwise).
+  - `health_check()` → cheap `initialize`-only probe.
+  - `aclose()` → release any pooled client.
+  - Ported from `web/backend/open_webui/utils/mcp/client.py` (the disconnect/cancel-scope discipline in that stub is load-bearing — preserve it). All outbound HTTP through the egress guard.
+- **`mcp.yaml` schema + loader** — a Pydantic `MCPServerConfig` (name, `server_url`, `auth: none|bearer|oauth`, `egress_tier`, `allowlist.hosts`, optional `tool_policy`, `rate_limit`). The gateway config loader reads `MCP_CONFIG_PATH` (default sibling of `gateway.yaml`) and synthesizes each into a `type: mcp` `ToolProviderConfig` merged into `tool_providers`. `mcp.yaml.example` documents the shape.
+- **Discovery endpoint** — `GET /v1/tools/{provider}` → `adapter.list_tools()` as JSON; gateway-key gated like the invoke transport; `GatewayError`-enveloped.
+- **Per-call token** — extend `ToolCallRequest` (and the discovery path) with an optional `user_token`; `route_tool_call` threads it to the adapter for `oauth` servers. **Never logged**; never written to `tool_egress_log` (counts only).
+- **New dep:** `mcp` SDK — one SBOM entry, gateway only. Justified: it *is* the client.
+
+### 3.2 api registry/cache/admin (PR4b) — `api/app/mcp/`
+- **registry** — enumerates configured MCP servers via the existing `GatewayClient.list_tool_providers()` filtered to `type == "mcp"` (no second config read api-side).
+- **discovery cache** — calls the gateway discovery endpoint, upserts `mcp_tools` rows; refresh on demand. Per-tool `enabled` toggle is persisted api-side and is authoritative for what PR5 exposes to the model.
+- **admin surface** — `/api/v1/admin/mcp`: list servers (+ cached tools + enabled state), `POST .../refresh` (re-discover), `PATCH .../tools/{...}` (enable/disable). `AdminUser`-gated.
+- Works **end-to-end for `none`/`bearer` servers** without PR4c.
+
+### 3.3 api OAuth (PR4c) — `api/app/mcp/oauth.py` + token store
+- **Flow** — `GET /api/v1/mcp/oauth/{server}/authorize` (active user) → builds the authz-code+PKCE redirect to the MCP server's authorization endpoint, stashes the PKCE verifier + state server-side; `GET /api/v1/mcp/oauth/{server}/callback` → validates state, exchanges code → access/refresh tokens.
+- **Token store** — `mcp_oauth_tokens`, tokens Fernet-encrypted via `app.security.encryption` (same pattern as Slack/Teams tenant secrets). Refresh on expiry before a tool call; revoke on disconnect.
+- **Per-call plumbing** — the research/tool path supplies the decrypted access token to the gateway as `user_token`. Retire the `web/` stub here (its role is fully replaced).
+- **Security review** — auth + secret-storage path → CODEOWNERS routes to security reviewers.
+
+---
+
+## 4. Data model (api, migration 0050; head is 0049)
+
+```
+mcp_tools                                   -- discovery cache (operator/global, not per-user)
+  provider_name   text     ┐ PK
+  tool_name       text     ┘
+  description     text
+  parameters      jsonb              -- JSON-schema for the tool's args
+  read_only       boolean
+  destructive     boolean
+  requires_confirmation boolean
+  enabled         boolean  default true   -- operator toggle; authoritative for PR5 exposure
+  discovered_at   timestamptz
+
+mcp_oauth_tokens                            -- per-user (PR4c)
+  user_id         uuid     ┐ PK  (FK users)
+  provider_name   text     ┘
+  access_token    bytea              -- Fernet ciphertext
+  refresh_token   bytea              -- Fernet ciphertext (nullable)
+  expires_at      timestamptz
+  scopes          text[]
+```
+
+OpenAPI: `docs/api/backend-openapi.yaml` gains `/api/v1/admin/mcp*` (PR4b) and `/api/v1/mcp/oauth/*` (PR4c). Gateway OpenAPI gains `GET /v1/tools/{provider}` (PR4a). Collision guards: `IMPLEMENTED_ROUTES` + `EXPECTED_PATHS` + pinned count (currently **124**) bumped per route, in the same commit.
+
+## 5. Feature flags / shippability
+- MCP is **off** until `mcp.yaml` declares a server (no servers → `list_tool_providers` returns none → admin surface lists nothing, no egress).
+- OAuth engages **only** for `auth: oauth` servers; `none`/`bearer` servers are fully functional after PR4b.
+- PR4a ships behind the config gate; PR4b is usable with token-/no-auth servers; PR4c layers OAuth on top. Each is independently revertible.
+
+## 6. Testing
+- **Gateway (PR4a):** an in-memory / fake MCP server (the `mcp` SDK ships an in-memory transport usable in tests) exercising `list_tools`/`invoke_tool` mapping, annotation→flags defaults, egress-tier refusal, SSRF allowlist refusal, the three auth modes (incl. missing-token refusal for `oauth`), and `user_token` never appearing in `tool_egress_log`. Optional live `-m provider` test against a reference MCP server.
+- **api (PR4b):** discovery-cache upsert/refresh, enable/disable, `/admin/mcp` surface, registry filtering to `type==mcp`.
+- **api (PR4c):** authz-code+PKCE happy path + state/verifier validation (mock gateway + mock MCP authz server), token encrypt/decrypt round-trip, refresh-on-expiry, per-call token plumbing to the gateway, decrypted tokens never logged.
+
+## 7. Out of scope (explicit)
+- stdio transport (parity is `streamable_http` only).
+- The governed chat tool-loop + `retrieve_caselaw`/`call_mcp_tool` `ToolIntent`s + per-turn cap + confirmation-gate SSE pause/resume → **PR5**.
+- MCP provenance pills, the consent UI, destructive-confirm prompts → **PR6/WS5**.
+- Tool-path OpenTelemetry spans → deferred enhancement (filed; ADR 0014 D3 / 0015 D5).
+
+## 8. Confirm-in-planning (grounded, not forks)
+- Exact `mcp` SDK package name + pinned version for the gateway SBOM; its in-memory test transport API.
+- The MCP authorization spec flow specifics (dynamic client registration vs pre-registered client; PKCE S256) and how `mcp.yaml` declares the client id/secret or DCR.
+- The gateway config-loader extension for `MCP_CONFIG_PATH` (merge vs sibling holder; reload semantics via `MutableConfigHolder`).
+- Whether the discovery endpoint should be `GET /v1/tools/{provider}` or `/v1/tools/{provider}/specs` (avoid collision with a future per-provider resource).
+</content>
+</invoke>

--- a/gateway/app/api/tools.py
+++ b/gateway/app/api/tools.py
@@ -35,8 +35,6 @@ class ToolCallRequest(BaseModel):
 
     args: dict[str, Any] = Field(default_factory=dict)
     max_allowed_tier: int | None = Field(default=None, ge=1, le=5)
-    user_token: str | None = Field(default=None)
-    """Per-call OAuth token for ``auth: oauth`` MCP servers. Never logged."""
 
 
 def _router(request: Request) -> Router:
@@ -54,6 +52,15 @@ def _request_id(request: Request) -> str:
     return synthesize_request_id(None)
 
 
+_USER_TOKEN_HEADER = "X-LQ-AI-User-Token"
+
+
+def _user_token(request: Request) -> str | None:
+    """Per-user MCP token (auth: oauth). A header, NOT a query param/body —
+    query strings land in access logs; this must not. Never logged."""
+    return request.headers.get(_USER_TOKEN_HEADER)
+
+
 def _error(
     status_code: int, code: str, message: str, details: dict[str, Any] | None = None
 ) -> JSONResponse:
@@ -64,15 +71,16 @@ def _error(
 
 
 @router.get("/tools/{provider}")
-async def list_provider_tools(
-    provider: str, request: Request, user_token: str | None = None
-) -> JSONResponse:
+async def list_provider_tools(provider: str, request: Request) -> JSONResponse:
     """Return the live ``list_tools()`` for a configured tool provider.
 
-    ``user_token`` is an optional query parameter so an ``auth: oauth`` MCP
-    server can be discovered with the user's token (PR4c supplies it).  For
-    ``none`` / ``bearer`` providers it is ignored and **never logged**.
+    The per-user OAuth token for ``auth: oauth`` MCP servers is supplied via
+    the ``X-LQ-AI-User-Token`` request header (PR4c supplies it). Using a
+    header instead of a query parameter ensures the token is never written to
+    uvicorn access logs. For ``none`` / ``bearer`` providers the token is
+    ignored and **never logged**.
     """
+    user_token = _user_token(request)
     gw_router = _router(request)
     adapter = gw_router._tool_adapters.get(provider)
     if adapter is None:
@@ -105,6 +113,7 @@ async def call_tool(
 ) -> JSONResponse:
     gw_router = _router(request)
     request_id = _request_id(request)
+    user_token = _user_token(request)
     try:
         result = await gw_router.route_tool_call(
             provider,
@@ -112,7 +121,7 @@ async def call_tool(
             body.args,
             request_id=request_id,
             max_allowed_tier=body.max_allowed_tier,
-            user_token=body.user_token,
+            user_token=user_token,
         )
     except ToolEgressRefused as exc:
         return _error(403, "egress_refused", exc.reason)

--- a/gateway/app/api/tools.py
+++ b/gateway/app/api/tools.py
@@ -63,6 +63,42 @@ def _error(
     )
 
 
+@router.get("/tools/{provider}")
+async def list_provider_tools(
+    provider: str, request: Request, user_token: str | None = None
+) -> JSONResponse:
+    """Return the live ``list_tools()`` for a configured tool provider.
+
+    ``user_token`` is an optional query parameter so an ``auth: oauth`` MCP
+    server can be discovered with the user's token (PR4c supplies it).  For
+    ``none`` / ``bearer`` providers it is ignored and **never logged**.
+    """
+    gw_router = _router(request)
+    adapter = gw_router._tool_adapters.get(provider)
+    if adapter is None:
+        return _error(404, "unknown_provider", f"tool provider {provider!r} not found")
+    try:
+        specs = await adapter.list_tools(user_token=user_token)
+    except ToolProviderError as exc:
+        return _error(502, "tool_provider_unavailable", exc.message, exc.details)
+    return JSONResponse(
+        content={
+            "provider": provider,
+            "tools": [
+                {
+                    "name": s.name,
+                    "description": s.description,
+                    "parameters": s.parameters,
+                    "read_only": s.read_only,
+                    "destructive": s.destructive,
+                    "requires_confirmation": s.requires_confirmation,
+                }
+                for s in specs
+            ],
+        }
+    )
+
+
 @router.post("/tools/{provider}/{tool}")
 async def call_tool(
     provider: str, tool: str, body: ToolCallRequest, request: Request

--- a/gateway/app/api/tools.py
+++ b/gateway/app/api/tools.py
@@ -35,6 +35,8 @@ class ToolCallRequest(BaseModel):
 
     args: dict[str, Any] = Field(default_factory=dict)
     max_allowed_tier: int | None = Field(default=None, ge=1, le=5)
+    user_token: str | None = Field(default=None)
+    """Per-call OAuth token for ``auth: oauth`` MCP servers. Never logged."""
 
 
 def _router(request: Request) -> Router:
@@ -74,6 +76,7 @@ async def call_tool(
             body.args,
             request_id=request_id,
             max_allowed_tier=body.max_allowed_tier,
+            user_token=body.user_token,
         )
     except ToolEgressRefused as exc:
         return _error(403, "egress_refused", exc.reason)

--- a/gateway/app/config.py
+++ b/gateway/app/config.py
@@ -209,6 +209,62 @@ class ToolProviderConfig(BaseModel):
         return self
 
 
+# --- MCP server config (PR4a) ------------------------------------------------
+
+
+MCPAuthType = Literal["none", "bearer", "oauth"]
+"""How the gateway authenticates to an MCP server. ``none``/``bearer`` use
+operator-static config; ``oauth`` uses a per-call user token supplied by the
+api (the gateway stays user-unaware — WS2 spec D4)."""
+
+
+class MCPServerConfig(BaseModel):
+    """One entry under ``mcp_servers:`` in ``mcp.yaml``. Synthesized into a
+    ``type: mcp`` :class:`ToolProviderConfig` at load (WS2 spec D2)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    server_url: str = Field(min_length=1)
+    auth: MCPAuthType = "none"
+    api_key_env: str | None = None
+    api_key_encrypted: str | None = None
+    egress_tier: InferenceTier
+    allowlist: EgressAllowlistConfig
+    rate_limit: ToolProviderRateLimitConfig = Field(default_factory=ToolProviderRateLimitConfig)
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def _bearer_needs_key(self) -> MCPServerConfig:
+        if self.auth == "bearer" and not (self.api_key_env or self.api_key_encrypted):
+            raise ValueError(
+                f"MCP server {self.name!r}: auth 'bearer' requires api_key_env or api_key_encrypted."
+            )
+        if self.auth in ("none", "oauth") and (self.api_key_env or self.api_key_encrypted):
+            raise ValueError(
+                f"MCP server {self.name!r}: api_key_* is only valid with auth 'bearer'."
+            )
+        return self
+
+    def to_tool_provider_config(self) -> ToolProviderConfig:
+        # Build via model_validate so the extra ``auth`` field (permitted by
+        # ToolProviderConfig's ``extra="allow"``) passes mypy's strict check.
+        return ToolProviderConfig.model_validate(
+            {
+                "name": self.name,
+                "type": "mcp",
+                "base_url": self.server_url,
+                "api_key_env": self.api_key_env,
+                "api_key_encrypted": self.api_key_encrypted,
+                "egress_tier": self.egress_tier,
+                "allowlist": self.allowlist.model_dump(),
+                "rate_limit": self.rate_limit.model_dump(),
+                "enabled": self.enabled,
+                "auth": self.auth,  # extra field; ToolProviderConfig is extra="allow"
+            }
+        )
+
+
 # --- Model aliases ------------------------------------------------------------
 
 

--- a/gateway/app/config.py
+++ b/gateway/app/config.py
@@ -249,6 +249,10 @@ class MCPServerConfig(BaseModel):
     def to_tool_provider_config(self) -> ToolProviderConfig:
         # Build via model_validate so the extra ``auth`` field (permitted by
         # ToolProviderConfig's ``extra="allow"``) passes mypy's strict check.
+        # MCP providers intentionally inherit ToolProviderConfig's
+        # ``anonymize_outbound=True`` default (conservative; no field on
+        # MCPServerConfig — the safe posture is always on until WS3/WS4
+        # enforcement lands).
         return ToolProviderConfig.model_validate(
             {
                 "name": self.name,
@@ -568,6 +572,31 @@ class GatewayConfig(BaseModel):
     circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig)
     request_validation: RequestValidationConfig = Field(default_factory=RequestValidationConfig)
     dev_mode: DevModeConfig = Field(default_factory=DevModeConfig)
+
+    @model_validator(mode="after")
+    def _tool_provider_names_unique(self) -> GatewayConfig:
+        """Reject duplicate tool-provider names.
+
+        ``tool_provider_by_name`` is a linear scan that returns the first
+        match, so a duplicate name would silently shadow the second entry.
+        Catch it at config load — same pattern as inference ``providers``
+        which would also shadow on duplicate names.
+        """
+        names = [tp.name for tp in self.tool_providers]
+        unique_names = {tp.name for tp in self.tool_providers}
+        if len(unique_names) < len(names):
+            seen: set[str] = set()
+            dupes: list[str] = []
+            for name in names:
+                if name in seen:
+                    dupes.append(name)
+                else:
+                    seen.add(name)
+            raise ValueError(
+                f"tool_providers contains duplicate name(s): {sorted(dupes)}. "
+                "Each tool provider must have a unique name."
+            )
+        return self
 
     @model_validator(mode="after")
     def _aliases_reference_known_providers(self) -> GatewayConfig:

--- a/gateway/app/config_loader.py
+++ b/gateway/app/config_loader.py
@@ -35,7 +35,7 @@ from typing import Any
 import yaml
 from pydantic import ValidationError
 
-from app.config import GatewayConfig
+from app.config import GatewayConfig, MCPServerConfig
 
 __all__ = ["ConfigLoadError", "expand_env_vars", "load_config"]
 
@@ -119,8 +119,13 @@ def expand_env_vars(value: Any) -> Any:
     return value
 
 
-def load_config(path: Path) -> GatewayConfig:
+def load_config(path: Path, *, mcp_path: Path | None = None) -> GatewayConfig:
     """Read, expand, and validate the gateway config at ``path``.
+
+    If ``mcp_path`` is provided and the file exists, load ``mcp_servers``
+    from it, synthesize each into a ``type: mcp`` :class:`ToolProviderConfig`,
+    and merge them into the returned :class:`GatewayConfig`.  The same
+    ``${VAR}`` expansion is applied to the MCP yaml as to the main config.
 
     Raises :class:`ConfigLoadError` for any failure mode. Callers should let
     that bubble out of FastAPI's lifespan so the process exits non-zero — the
@@ -150,9 +155,62 @@ def load_config(path: Path) -> GatewayConfig:
             f"(got {type(parsed).__name__})"
         )
 
-    expanded = expand_env_vars(parsed)
+    expanded: dict[str, Any] = expand_env_vars(parsed)
 
     try:
-        return GatewayConfig.model_validate(expanded)
+        config = GatewayConfig.model_validate(expanded)
     except ValidationError as exc:
         raise ConfigLoadError(f"gateway config {path} failed schema validation:\n{exc}") from exc
+
+    # --- mcp.yaml merge (PR4a Task 2) ----------------------------------------
+
+    if mcp_path is not None and mcp_path.exists():
+        try:
+            mcp_raw_text = mcp_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ConfigLoadError(f"failed to read mcp config {mcp_path}: {exc}") from exc
+
+        try:
+            mcp_parsed: Any = yaml.safe_load(mcp_raw_text)
+        except yaml.YAMLError as exc:
+            raise ConfigLoadError(f"mcp config {mcp_path} is not valid YAML: {exc}") from exc
+
+        if mcp_parsed is not None:
+            if not isinstance(mcp_parsed, dict):
+                raise ConfigLoadError(
+                    f"mcp config {mcp_path} must be a YAML mapping at the top level "
+                    f"(got {type(mcp_parsed).__name__})"
+                )
+
+            mcp_expanded: dict[str, Any] = expand_env_vars(mcp_parsed)
+            raw_servers: Any = mcp_expanded.get("mcp_servers", [])
+            if not isinstance(raw_servers, list):
+                raise ConfigLoadError(
+                    f"mcp config {mcp_path}: 'mcp_servers' must be a list "
+                    f"(got {type(raw_servers).__name__})"
+                )
+
+            try:
+                mcp_tool_providers = [
+                    MCPServerConfig.model_validate(entry).to_tool_provider_config()
+                    for entry in raw_servers
+                ]
+            except ValidationError as exc:
+                raise ConfigLoadError(
+                    f"mcp config {mcp_path} failed schema validation:\n{exc}"
+                ) from exc
+
+            if mcp_tool_providers:
+                merged_dict = config.model_dump()
+                merged_dict["tool_providers"] = (merged_dict.get("tool_providers") or []) + [
+                    tp.model_dump() for tp in mcp_tool_providers
+                ]
+                try:
+                    config = GatewayConfig.model_validate(merged_dict)
+                except ValidationError as exc:
+                    raise ConfigLoadError(
+                        f"gateway config failed validation after merging mcp config "
+                        f"{mcp_path}:\n{exc}"
+                    ) from exc
+
+    return config

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -113,6 +113,14 @@ def _resolve_mcp_config_path() -> Path | None:
     override = os.environ.get("MCP_CONFIG_PATH")
     if override:
         candidate = Path(override)
+        if not candidate.exists():
+            logger.warning(
+                "MCP_CONFIG_PATH is set to %r but the file does not exist; "
+                "MCP server config will not be loaded",
+                str(candidate),
+            )
+            return None
+        return candidate
     else:
         gateway_path = _resolve_config_path()
         candidate = gateway_path.parent / DEFAULT_MCP_CONFIG_NAME

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -88,6 +88,10 @@ DEFAULT_CONFIG_PATH = Path("gateway.yaml")
 """Default path the gateway looks for its config when ``GATEWAY_CONFIG_PATH``
 is unset. Resolved relative to the process cwd."""
 
+DEFAULT_MCP_CONFIG_NAME = "mcp.yaml"
+"""Default filename for the MCP server config, resolved as a sibling of the
+gateway config file. Overridden by ``MCP_CONFIG_PATH``."""
+
 
 def _resolve_config_path() -> Path:
     """Return the effective config path for this process."""
@@ -96,6 +100,23 @@ def _resolve_config_path() -> Path:
     if override:
         return Path(override)
     return DEFAULT_CONFIG_PATH
+
+
+def _resolve_mcp_config_path() -> Path | None:
+    """Return the effective MCP config path, or ``None`` if not found.
+
+    Checks ``MCP_CONFIG_PATH`` first; falls back to ``mcp.yaml`` as a sibling
+    of the resolved gateway config file. Returns the :class:`Path` only when
+    the file exists so callers don't need to guard themselves.
+    """
+
+    override = os.environ.get("MCP_CONFIG_PATH")
+    if override:
+        candidate = Path(override)
+    else:
+        gateway_path = _resolve_config_path()
+        candidate = gateway_path.parent / DEFAULT_MCP_CONFIG_NAME
+    return candidate if candidate.exists() else None
 
 
 def build_adapter(provider: ProviderConfig) -> ProviderAdapter | None:
@@ -174,9 +195,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """
 
     config_path = _resolve_config_path()
+    mcp_config_path = _resolve_mcp_config_path()
     logger.info("loading gateway config from %s", config_path)
+    if mcp_config_path is not None:
+        logger.info("loading mcp server config from %s", mcp_config_path)
     try:
-        config = load_config(config_path)
+        config = load_config(config_path, mcp_path=mcp_config_path)
     except ConfigLoadError:
         logger.exception("gateway config load failed; refusing to start")
         raise

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -190,7 +190,12 @@ def build_tool_adapter(provider: ToolProviderConfig) -> ToolProviderAdapter | No
         cl_adapter = CourtListenerToolAdapter.from_config(provider)
         cl_adapter.validate_base_url()
         return cl_adapter
-    # mcp (PR4) lands later.
+    if provider.type == "mcp":
+        from app.providers.tool.mcp import MCPToolProviderAdapter
+
+        mcp_adapter = MCPToolProviderAdapter.from_config(provider)
+        mcp_adapter.validate_base_url()
+        return mcp_adapter
     return None
 
 

--- a/gateway/app/providers/tool/base.py
+++ b/gateway/app/providers/tool/base.py
@@ -118,11 +118,13 @@ class ToolProviderAdapter(ABC):
     name: str
 
     @abstractmethod
-    async def list_tools(self) -> list[ToolSpec]:
+    async def list_tools(self, *, user_token: str | None = None) -> list[ToolSpec]:
         """Return the model-callable tools this provider offers."""
 
     @abstractmethod
-    async def invoke_tool(self, tool: str, args: dict[str, Any], *, request_id: str) -> ToolResult:
+    async def invoke_tool(
+        self, tool: str, args: dict[str, Any], *, request_id: str, user_token: str | None = None
+    ) -> ToolResult:
         """Invoke ``tool`` with ``args``; return structured provenance."""
 
     @abstractmethod

--- a/gateway/app/providers/tool/courtlistener.py
+++ b/gateway/app/providers/tool/courtlistener.py
@@ -144,7 +144,7 @@ class CourtListenerToolAdapter(ToolProviderAdapter):
             )
         return resp
 
-    async def list_tools(self) -> list[ToolSpec]:
+    async def list_tools(self, *, user_token: str | None = None) -> list[ToolSpec]:
         return [
             ToolSpec(
                 name="verify_citations",
@@ -185,7 +185,9 @@ class CourtListenerToolAdapter(ToolProviderAdapter):
             ),
         ]
 
-    async def invoke_tool(self, tool: str, args: dict[str, Any], *, request_id: str) -> ToolResult:
+    async def invoke_tool(
+        self, tool: str, args: dict[str, Any], *, request_id: str, user_token: str | None = None
+    ) -> ToolResult:
         if tool == "verify_citations":
             return await self._verify_citations(args)
         if tool == "search_case_law":

--- a/gateway/app/providers/tool/echo.py
+++ b/gateway/app/providers/tool/echo.py
@@ -57,7 +57,7 @@ class EchoToolAdapter(ToolProviderAdapter):
         egress policy (called at build time so a misconfig fails at startup)."""
         validate_egress_target(self._base_url + "/", allowlist=self._allowlist)
 
-    async def list_tools(self) -> list[ToolSpec]:
+    async def list_tools(self, *, user_token: str | None = None) -> list[ToolSpec]:
         return [
             ToolSpec(
                 name="echo",
@@ -67,7 +67,9 @@ class EchoToolAdapter(ToolProviderAdapter):
             )
         ]
 
-    async def invoke_tool(self, tool: str, args: dict[str, Any], *, request_id: str) -> ToolResult:
+    async def invoke_tool(
+        self, tool: str, args: dict[str, Any], *, request_id: str, user_token: str | None = None
+    ) -> ToolResult:
         if tool != "echo":
             raise ToolProviderError(f"unknown tool {tool!r} for echo provider")
         encoded = json.dumps(args).encode("utf-8")

--- a/gateway/app/providers/tool/mcp.py
+++ b/gateway/app/providers/tool/mcp.py
@@ -1,0 +1,197 @@
+"""``mcp`` tool provider — Model Context Protocol egress (ADR 0014, WS2/PR4a).
+
+The gateway is the sole egress AND the only MCP-protocol speaker (spec D1):
+streamable_http sessions are stateful, so the holder of the connection must
+speak MCP. Ports the proven client logic from
+``web/backend/open_webui/utils/mcp/client.py`` behind an injectable session
+factory so unit tests never touch the network. Every connect passes
+``validate_egress_target`` (SSRF/allowlist)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from typing import Any
+
+from app.config import ToolProviderConfig
+from app.providers.base import ProviderHealth
+from app.providers.tool.base import (
+    ToolProviderAdapter,
+    ToolProviderError,
+    ToolProviderNetworkError,
+    ToolResult,
+    ToolSpec,
+)
+from app.providers.tool.egress import validate_egress_target
+from app.secrets import ProviderKeyResolver
+
+SessionFactory = Callable[..., Any]  # (url, headers) -> async ctx mgr yielding a ClientSession
+
+
+def _default_session_factory() -> SessionFactory:
+    @asynccontextmanager
+    async def factory(url: str, headers: dict[str, str] | None) -> AsyncIterator[Any]:
+        # Port of web/backend/open_webui/utils/mcp/client.py connect/disconnect.
+        from contextlib import AsyncExitStack
+
+        import anyio
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+
+        async with AsyncExitStack() as stack:
+            transport = await stack.enter_async_context(streamablehttp_client(url, headers=headers))
+            read_stream, write_stream, _ = transport
+            session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
+            with anyio.fail_after(10):
+                await session.initialize()
+            yield session
+
+    return factory
+
+
+def _map_flags(annotations: Any) -> tuple[bool, bool, bool]:
+    """(read_only, destructive, requires_confirmation) from MCP tool annotations.
+
+    Safe default for un-annotated tools: not read-only, not destructive, but
+    requires_confirmation=True (treat unknown as needing the PR5 gate)."""
+    read_only = bool(getattr(annotations, "readOnlyHint", False)) if annotations else False
+    destructive = bool(getattr(annotations, "destructiveHint", False)) if annotations else False
+    if read_only and not destructive:
+        return True, False, False
+    if destructive:
+        return False, True, True
+    return False, False, True  # un-annotated / ambiguous -> confirm
+
+
+class MCPToolProviderAdapter(ToolProviderAdapter):
+    def __init__(
+        self,
+        *,
+        name: str,
+        server_url: str,
+        auth: str,
+        api_key: str | None,
+        allowlist: list[str],
+        session_factory: SessionFactory | None = None,
+    ) -> None:
+        self.name = name
+        self._server_url = server_url
+        self._auth = auth
+        self._api_key = api_key
+        self._allowlist = allowlist
+        self._session_factory = session_factory or _default_session_factory()
+
+    @classmethod
+    def from_config(
+        cls,
+        provider: ToolProviderConfig,
+        *,
+        key_resolver: ProviderKeyResolver | None = None,
+        session_factory: SessionFactory | None = None,
+    ) -> MCPToolProviderAdapter:
+        if provider.type != "mcp":
+            raise ValueError(f"MCPToolProviderAdapter from non-mcp {provider.type!r}")
+        auth = getattr(provider, "auth", "none")
+        api_key: str | None = None
+        if auth == "bearer":
+            resolver = key_resolver or ProviderKeyResolver.from_environ()
+            api_key = resolver.resolve(
+                provider_name=provider.name,
+                api_key_env=provider.api_key_env,
+                api_key_encrypted=provider.api_key_encrypted,
+            )
+            if not api_key:
+                raise ValueError(
+                    f"MCP provider {provider.name!r}: bearer auth but no token resolved."
+                )
+        return cls(
+            name=provider.name,
+            server_url=provider.base_url,
+            auth=auth,
+            api_key=api_key,
+            allowlist=provider.allowlist.hosts,
+            session_factory=session_factory,
+        )
+
+    def validate_base_url(self) -> None:
+        validate_egress_target(self._server_url, allowlist=self._allowlist)
+
+    def _headers(self, user_token: str | None) -> dict[str, str] | None:
+        if self._auth == "bearer" and self._api_key:
+            return {"Authorization": f"Bearer {self._api_key}"}
+        if self._auth == "oauth":
+            if not user_token:
+                raise ToolProviderError(
+                    f"MCP server {self.name!r} requires per-user authorization",
+                    details={"code": "mcp_authorization_required"},
+                )
+            return {"Authorization": f"Bearer {user_token}"}
+        return None
+
+    @asynccontextmanager
+    async def _session(self, user_token: str | None) -> AsyncIterator[Any]:
+        validate_egress_target(self._server_url, allowlist=self._allowlist)
+        try:
+            async with self._session_factory(self._server_url, self._headers(user_token)) as s:
+                yield s
+        except ToolProviderError:
+            raise
+        except Exception as exc:  # transport/protocol failure
+            raise ToolProviderNetworkError(f"mcp session error: {exc}") from exc
+
+    async def list_tools(self, *, user_token: str | None = None) -> list[ToolSpec]:
+        # user_token extends the ABC signature; base ABC updated in PR4a Task 4
+        async with self._session(user_token) as session:
+            result = await session.list_tools()
+        specs: list[ToolSpec] = []
+        for tool in result.tools:
+            read_only, destructive, requires_confirmation = _map_flags(
+                getattr(tool, "annotations", None)
+            )
+            specs.append(
+                ToolSpec(
+                    name=tool.name,
+                    description=tool.description or "",
+                    parameters=tool.inputSchema or {"type": "object"},
+                    read_only=read_only,
+                    destructive=destructive,
+                    requires_confirmation=requires_confirmation,
+                )
+            )
+        return specs
+
+    async def invoke_tool(
+        self,
+        tool: str,
+        args: dict[str, Any],
+        *,
+        request_id: str,
+        user_token: str | None = None,
+    ) -> ToolResult:
+        # user_token extends the ABC signature; base ABC updated in PR4a Task 4
+        async with self._session(user_token) as session:
+            result = await session.call_tool(tool, args)
+        dumped = result.model_dump(mode="json")
+        content = dumped.get("content")
+        if getattr(result, "isError", False):
+            raise ToolProviderError("mcp tool returned an error", details={"content": content})
+        return ToolResult(
+            provider=self.name,
+            tool=tool,
+            payload=content,
+            bytes_out=len(json.dumps(args).encode("utf-8")),
+            bytes_in=len(json.dumps(content).encode("utf-8")),
+            skip_anonymization=False,
+        )
+
+    async def health_check(self) -> ProviderHealth:
+        try:
+            async with self._session(None):
+                pass
+        except ToolProviderError as exc:
+            return ProviderHealth(name=self.name, reachable=False, error=str(exc))
+        return ProviderHealth(name=self.name, reachable=True, latency_ms=0)
+
+    async def aclose(self) -> None:
+        return None

--- a/gateway/app/router.py
+++ b/gateway/app/router.py
@@ -741,6 +741,7 @@ class Router:
         *,
         request_id: str,
         max_allowed_tier: int | None = None,
+        user_token: str | None = None,
     ) -> ToolCallRoutedResult:
         """Govern + dispatch one tool call (ADR 0014 D2/D3/D4).
 
@@ -794,7 +795,9 @@ class Router:
             )
 
         try:
-            result: ToolResult = await adapter.invoke_tool(tool, args, request_id=request_id)
+            result: ToolResult = await adapter.invoke_tool(
+                tool, args, request_id=request_id, user_token=user_token
+            )
         except EgressRefused as exc:
             await self._tool_egress_log.write(
                 ToolEgressLogRow(

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -66,6 +66,18 @@ dependencies = [
     "presidio-analyzer~=2.2",
     "presidio-anonymizer~=2.2",
     "spacy~=3.7",
+    # WS2/PR4a — Model Context Protocol client. The gateway is the sole egress
+    # and the only MCP-protocol speaker (ADR 0014 + spec D1): streamable_http
+    # sessions are stateful, so the connection holder must speak MCP. This is
+    # the official MCP SDK — not reasonably hand-rollable (it implements the
+    # full JSON-RPC-over-SSE session + auth handshake). Client-only use here.
+    "mcp>=1.28,<2",
+    # mcp pulls sse-starlette, whose latest (3.4.x) requires starlette 1.x —
+    # which conflicts with fastapi 0.116's starlette<0.49 pin. We use only the
+    # MCP *client* (ClientSession + streamablehttp_client), not the server, so
+    # pin starlette to fastapi's supported range; pip then resolves sse-starlette
+    # to a compatible (3.0.x) build. Lift when fastapi supports starlette 1.x.
+    "starlette>=0.40,<0.49",
 ]
 
 [project.optional-dependencies]

--- a/gateway/tests/test_mcp_adapter.py
+++ b/gateway/tests/test_mcp_adapter.py
@@ -139,3 +139,71 @@ async def test_validate_base_url_rejects_non_allowlisted(monkeypatch: pytest.Mon
     a = MCPToolProviderAdapter.from_config(bad)
     with pytest.raises(EgressRefused):
         a.validate_base_url()
+
+
+# ---------------------------------------------------------------------------
+# Auth header tests (cover MCPToolProviderAdapter._headers branches)
+# ---------------------------------------------------------------------------
+
+
+def _capturing_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    auth: str,
+    api_key: str | None = None,
+) -> tuple[MCPToolProviderAdapter, dict]:
+    """Build an adapter whose session factory captures the headers it receives."""
+    from app.providers.tool import egress
+
+    monkeypatch.setattr(egress, "_resolve_ips", lambda host: ["93.184.216.34"])
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def factory(url: str, headers: object):  # type: ignore[misc]
+        captured["headers"] = headers
+        yield _FakeSession(tools=[])
+
+    a = MCPToolProviderAdapter(
+        name="acme-mcp",
+        server_url="https://mcp.acme.example/sse",
+        auth=auth,
+        api_key=api_key,
+        allowlist=["mcp.acme.example"],
+        session_factory=factory,
+    )
+    return a, captured
+
+
+@pytest.mark.unit
+async def test_oauth_without_user_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """oauth auth with no user_token must raise ToolProviderError with the right code."""
+    from app.providers.tool.base import ToolProviderError
+
+    adapter, _ = _capturing_adapter(monkeypatch, auth="oauth")
+    with pytest.raises(ToolProviderError) as exc_info:
+        await adapter.list_tools()
+    assert exc_info.value.details["code"] == "mcp_authorization_required"
+
+
+@pytest.mark.unit
+async def test_oauth_with_user_token_sets_bearer_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """oauth auth with a user_token must forward it as a Bearer Authorization header."""
+    adapter, captured = _capturing_adapter(monkeypatch, auth="oauth")
+    await adapter.list_tools(user_token="user-tok")
+    assert captured["headers"] == {"Authorization": "Bearer user-tok"}
+
+
+@pytest.mark.unit
+async def test_bearer_auth_sets_operator_key_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """bearer auth must inject the operator api_key as a Bearer Authorization header."""
+    adapter, captured = _capturing_adapter(monkeypatch, auth="bearer", api_key="op-secret")
+    await adapter.list_tools()
+    assert captured["headers"] == {"Authorization": "Bearer op-secret"}
+
+
+@pytest.mark.unit
+async def test_none_auth_sends_no_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """auth=none must pass None as headers (no Authorization header sent)."""
+    adapter, captured = _capturing_adapter(monkeypatch, auth="none")
+    await adapter.list_tools()
+    assert captured["headers"] is None

--- a/gateway/tests/test_mcp_adapter.py
+++ b/gateway/tests/test_mcp_adapter.py
@@ -1,0 +1,141 @@
+"""Unit tests for MCPToolProviderAdapter (Task 3 — injected fake session, no network)."""
+
+from contextlib import asynccontextmanager
+
+import pytest
+
+from app.config import ToolProviderConfig
+from app.providers.tool.mcp import MCPToolProviderAdapter
+
+
+class _FakeTool:
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        input_schema: dict,
+        annotations: object = None,
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.inputSchema = input_schema
+        self.annotations = annotations
+
+
+class _Ann:
+    def __init__(self, read_only: bool | None = None, destructive: bool | None = None) -> None:
+        self.readOnlyHint = read_only
+        self.destructiveHint = destructive
+
+
+class _FakeResult:
+    def __init__(
+        self,
+        tools: list | None = None,
+        content: object = None,
+        is_error: bool = False,
+    ) -> None:
+        self.tools = tools or []
+        self.content = content
+        self.isError = is_error
+
+    def model_dump(self, mode: str = "json") -> dict:
+        return {"content": self.content}
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        tools: list | None = None,
+        call_result: _FakeResult | None = None,
+    ) -> None:
+        self._tools = tools or []
+        self._call_result = call_result
+
+    async def initialize(self) -> None:
+        return None
+
+    async def list_tools(self) -> _FakeResult:
+        return _FakeResult(tools=self._tools)
+
+    async def call_tool(self, name: str, args: dict) -> _FakeResult | None:
+        return self._call_result
+
+
+def _cfg() -> ToolProviderConfig:
+    return ToolProviderConfig(
+        name="acme-mcp",
+        type="mcp",
+        base_url="https://mcp.acme.example/sse",
+        egress_tier=2,
+        allowlist={"hosts": ["mcp.acme.example"]},
+        auth="none",
+    )
+
+
+def _adapter(session: _FakeSession, monkeypatch: pytest.MonkeyPatch) -> MCPToolProviderAdapter:
+    from app.providers.tool import egress
+
+    monkeypatch.setattr(egress, "_resolve_ips", lambda host: ["93.184.216.34"])
+
+    @asynccontextmanager
+    async def factory(url: str, headers: object):  # type: ignore[misc]
+        yield session
+
+    return MCPToolProviderAdapter.from_config(_cfg(), session_factory=factory)
+
+
+@pytest.mark.unit
+async def test_list_tools_maps_annotations(monkeypatch: pytest.MonkeyPatch) -> None:
+    tools = [
+        _FakeTool("read_doc", "reads", {"type": "object"}, _Ann(read_only=True)),
+        _FakeTool("delete_doc", "deletes", {"type": "object"}, _Ann(destructive=True)),
+        _FakeTool("mystery", "no hints", {"type": "object"}, None),
+    ]
+    specs = await _adapter(_FakeSession(tools=tools), monkeypatch).list_tools()
+    by = {s.name: s for s in specs}
+    assert by["read_doc"].read_only and not by["read_doc"].requires_confirmation
+    assert by["delete_doc"].destructive and by["delete_doc"].requires_confirmation
+    # un-annotated -> safe default: not auto-runnable
+    assert by["mystery"].requires_confirmation and not by["mystery"].read_only
+
+
+@pytest.mark.unit
+async def test_invoke_tool_returns_tool_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    res = _FakeResult(content=[{"type": "text", "text": "hi"}], is_error=False)
+    out = await _adapter(_FakeSession(call_result=res), monkeypatch).invoke_tool(
+        "read_doc", {"q": "x"}, request_id="r1"
+    )
+    assert out.provider == "acme-mcp"
+    assert out.tool == "read_doc"
+    assert out.payload == [{"type": "text", "text": "hi"}]
+
+
+@pytest.mark.unit
+async def test_invoke_tool_error_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.providers.tool.base import ToolProviderError
+
+    res = _FakeResult(content=[{"type": "text", "text": "boom"}], is_error=True)
+    with pytest.raises(ToolProviderError):
+        await _adapter(_FakeSession(call_result=res), monkeypatch).invoke_tool(
+            "x", {}, request_id="r1"
+        )
+
+
+@pytest.mark.unit
+async def test_validate_base_url_rejects_non_allowlisted(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.providers.tool import egress
+    from app.providers.tool.egress import EgressRefused
+
+    monkeypatch.setattr(egress, "_resolve_ips", lambda host: ["93.184.216.34"])
+    bad = ToolProviderConfig(
+        name="x",
+        type="mcp",
+        base_url="https://evil.example/sse",
+        egress_tier=2,
+        allowlist={"hosts": ["mcp.acme.example"]},
+        auth="none",
+    )
+    a = MCPToolProviderAdapter.from_config(bad)
+    with pytest.raises(EgressRefused):
+        a.validate_base_url()

--- a/gateway/tests/test_mcp_config.py
+++ b/gateway/tests/test_mcp_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from app.config import MCPServerConfig
 from app.config_loader import load_config
@@ -70,3 +71,81 @@ def test_load_config_without_mcp_yaml_is_fine(tmp_path: Path, example_env: None)
     gw.write_text(EXAMPLE_CONFIG.read_text())
     cfg = load_config(gw, mcp_path=tmp_path / "does-not-exist.yaml")
     assert all(tp.type != "mcp" for tp in cfg.tool_providers)
+
+
+# --- Negative-path validator tests (F1) ---------------------------------------
+
+
+@pytest.mark.unit
+def test_mcp_server_bearer_without_key_raises() -> None:
+    """auth='bearer' with no api_key_env or api_key_encrypted must raise."""
+    with pytest.raises(ValidationError, match="api_key_env or api_key_encrypted"):
+        MCPServerConfig(
+            name="bearer-no-key",
+            server_url="https://mcp.example/sse",
+            auth="bearer",
+            egress_tier=2,
+            allowlist={"hosts": ["mcp.example"]},
+        )
+
+
+@pytest.mark.unit
+def test_mcp_server_none_auth_with_key_raises() -> None:
+    """auth='none' + api_key_env is a misconfiguration and must raise."""
+    with pytest.raises(ValidationError, match="only valid with auth 'bearer'"):
+        MCPServerConfig(
+            name="none-with-key",
+            server_url="https://mcp.example/sse",
+            auth="none",
+            api_key_env="SOME_TOKEN",
+            egress_tier=2,
+            allowlist={"hosts": ["mcp.example"]},
+        )
+
+
+@pytest.mark.unit
+def test_mcp_server_oauth_with_key_raises() -> None:
+    """auth='oauth' + api_key_env is a misconfiguration and must raise."""
+    with pytest.raises(ValidationError, match="only valid with auth 'bearer'"):
+        MCPServerConfig(
+            name="oauth-with-key",
+            server_url="https://mcp.example/sse",
+            auth="oauth",
+            api_key_env="SOME_TOKEN",
+            egress_tier=2,
+            allowlist={"hosts": ["mcp.example"]},
+        )
+
+
+# --- Duplicate tool_provider name detection (F2) ------------------------------
+
+
+@pytest.mark.unit
+def test_load_config_duplicate_mcp_server_name_raises(tmp_path: Path, example_env: None) -> None:
+    """Two mcp_servers with the same name must raise at config load time.
+
+    Uses two mcp_servers with identical names — the simplest way to trigger
+    the duplicate-name guard in GatewayConfig._tool_provider_names_unique
+    without needing a pre-existing tool_provider in gateway.yaml.example
+    (the example's tool_providers block is commented out).
+    """
+    gw = tmp_path / "gateway.yaml"
+    gw.write_text(EXAMPLE_CONFIG.read_text())
+    mcp = tmp_path / "mcp.yaml"
+    mcp.write_text(
+        "mcp_servers:\n"
+        "  - name: acme-mcp\n"
+        "    server_url: https://mcp.acme.example/sse\n"
+        "    auth: none\n"
+        "    egress_tier: 2\n"
+        "    allowlist: {hosts: [mcp.acme.example]}\n"
+        "  - name: acme-mcp\n"
+        "    server_url: https://mcp2.acme.example/sse\n"
+        "    auth: none\n"
+        "    egress_tier: 2\n"
+        "    allowlist: {hosts: [mcp2.acme.example]}\n"
+    )
+    from app.config_loader import ConfigLoadError
+
+    with pytest.raises(ConfigLoadError, match="acme-mcp"):
+        load_config(gw, mcp_path=mcp)

--- a/gateway/tests/test_mcp_config.py
+++ b/gateway/tests/test_mcp_config.py
@@ -1,0 +1,72 @@
+"""Tests for MCPServerConfig and the mcp.yaml loader merge (PR4a Task 2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.config import MCPServerConfig
+from app.config_loader import load_config
+
+# gateway/tests/ -> gateway/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONFIG = REPO_ROOT / "gateway.yaml.example"
+
+
+@pytest.mark.unit
+def test_mcp_server_config_synthesizes_tool_provider() -> None:
+    s = MCPServerConfig(
+        name="acme-mcp",
+        server_url="https://mcp.acme.example/sse",
+        auth="bearer",
+        api_key_env="ACME_MCP_TOKEN",
+        egress_tier=2,
+        allowlist={"hosts": ["mcp.acme.example"]},
+    )
+    tp = s.to_tool_provider_config()
+    assert tp.type == "mcp"
+    assert tp.name == "acme-mcp"
+    assert tp.base_url == "https://mcp.acme.example/sse"
+    assert tp.egress_tier == 2
+    assert tp.allowlist.hosts == ["mcp.acme.example"]
+    assert tp.auth == "bearer"
+
+
+@pytest.mark.unit
+def test_mcp_server_config_oauth_needs_no_static_key() -> None:
+    s = MCPServerConfig(
+        name="oauth-mcp",
+        server_url="https://o.example/sse",
+        auth="oauth",
+        egress_tier=2,
+        allowlist={"hosts": ["o.example"]},
+    )
+    assert s.to_tool_provider_config().auth == "oauth"
+
+
+@pytest.mark.unit
+def test_load_config_merges_mcp_yaml(tmp_path: Path, example_env: None) -> None:
+    gw = tmp_path / "gateway.yaml"
+    gw.write_text(EXAMPLE_CONFIG.read_text())
+    mcp = tmp_path / "mcp.yaml"
+    mcp.write_text(
+        "mcp_servers:\n"
+        "  - name: acme-mcp\n"
+        "    server_url: https://mcp.acme.example/sse\n"
+        "    auth: none\n"
+        "    egress_tier: 2\n"
+        "    allowlist: {hosts: [mcp.acme.example]}\n"
+    )
+    cfg = load_config(gw, mcp_path=mcp)
+    names = {tp.name: tp for tp in cfg.tool_providers}
+    assert "acme-mcp" in names
+    assert names["acme-mcp"].type == "mcp"
+
+
+@pytest.mark.unit
+def test_load_config_without_mcp_yaml_is_fine(tmp_path: Path, example_env: None) -> None:
+    gw = tmp_path / "gateway.yaml"
+    gw.write_text(EXAMPLE_CONFIG.read_text())
+    cfg = load_config(gw, mcp_path=tmp_path / "does-not-exist.yaml")
+    assert all(tp.type != "mcp" for tp in cfg.tool_providers)

--- a/gateway/tests/test_mcp_import.py
+++ b/gateway/tests/test_mcp_import.py
@@ -1,0 +1,15 @@
+"""Smoke test: the mcp SDK is installed and the client surface imports.
+
+PR4a depends on the official MCP SDK (client-only: the gateway speaks MCP as
+the sole egress, ADR 0014 + WS2 spec D1). This guards the dependency pin so a
+botched resolution (e.g. sse-starlette pulling starlette 1.x and breaking
+fastapi) fails loudly here rather than deep in adapter tests."""
+
+import pytest
+
+
+@pytest.mark.unit
+def test_mcp_client_surface_importable() -> None:
+    from mcp import ClientSession  # noqa: F401
+    from mcp.client.streamable_http import streamablehttp_client  # noqa: F401
+    from mcp.types import ToolAnnotations  # noqa: F401

--- a/gateway/tests/test_route_tool_call.py
+++ b/gateway/tests/test_route_tool_call.py
@@ -83,3 +83,93 @@ async def test_route_tool_call_enforces_rate_limit() -> None:
     with pytest.raises(ToolEgressRefused, match="rate"):
         await router.route_tool_call("echo-test", "echo", {}, request_id="r3", max_allowed_tier=4)
     assert writer.rows[-1].refused is True
+
+
+# ---------------------------------------------------------------------------
+# user_token threading tests (PR4a Task 5)
+# ---------------------------------------------------------------------------
+
+
+class _CaptureAdapter:
+    """Minimal adapter that records the user_token it received."""
+
+    name = "acme-mcp"
+    captured_token: str | None = None
+
+    async def invoke_tool(
+        self,
+        tool: str,
+        args: dict[str, object],
+        *,
+        request_id: str,
+        user_token: str | None = None,
+    ) -> object:
+        type(self).captured_token = user_token
+        from app.providers.tool.base import ToolResult
+
+        return ToolResult(provider=self.name, tool=tool, payload={"ok": True})
+
+    async def list_tools(self, *, user_token: str | None = None) -> list[object]:
+        return []
+
+
+def _mcp_router(writer: RecordingToolEgressLogWriter) -> Router:
+    """Build a Router with a ``type:mcp`` provider named ``acme-mcp``."""
+    cfg = GatewayConfig.model_validate(
+        {
+            "tool_providers": [
+                {
+                    "name": "acme-mcp",
+                    "type": "mcp",
+                    "base_url": "https://mcp.acme.example",
+                    "egress_tier": 2,
+                    "allowlist": {"hosts": ["mcp.acme.example"]},
+                    "auth": "none",
+                }
+            ]
+        }
+    )
+    capture = _CaptureAdapter()
+    limiter = FixedWindowRateLimiter(requests_per_minute=60, now=(lambda: 1000.0))
+    return Router(
+        config=cfg,
+        adapters={},
+        tool_adapters={"acme-mcp": capture},
+        tool_egress_log=writer,
+        tool_rate_limiter=limiter,
+    )
+
+
+@pytest.mark.unit
+async def test_route_tool_call_threads_user_token_to_adapter() -> None:
+    """user_token is forwarded to adapter.invoke_tool (not dropped or logged)."""
+    _CaptureAdapter.captured_token = None
+    writer = RecordingToolEgressLogWriter()
+    router = _mcp_router(writer)
+
+    await router.route_tool_call(
+        "acme-mcp",
+        "read_doc",
+        {"q": "x"},
+        request_id="r1",
+        user_token="secret-user-token",
+    )
+
+    # Token reached the adapter.
+    assert _CaptureAdapter.captured_token == "secret-user-token"
+
+    # Token must NOT appear in any audit-log row.
+    assert len(writer.rows) == 1
+    assert "secret-user-token" not in str(writer.rows[-1].__dict__)
+
+
+@pytest.mark.unit
+async def test_route_tool_call_user_token_none_by_default() -> None:
+    """Omitting user_token passes None to the adapter (backward-compatible)."""
+    _CaptureAdapter.captured_token = "sentinel"
+    writer = RecordingToolEgressLogWriter()
+    router = _mcp_router(writer)
+
+    await router.route_tool_call("acme-mcp", "read_doc", {}, request_id="r2")
+
+    assert _CaptureAdapter.captured_token is None

--- a/gateway/tests/test_tool_adapter_wiring.py
+++ b/gateway/tests/test_tool_adapter_wiring.py
@@ -4,11 +4,12 @@ Verifies:
 * echo provider → ``EchoToolAdapter`` instance.
 * base_url outside the allowlist → ``EgressRefused`` at build time.
 * disabled provider → ``None`` (no adapter built).
+* mcp provider → ``MCPToolProviderAdapter`` instance.
 """
 
 import pytest
 
-from app.config import GatewayConfig
+from app.config import GatewayConfig, ToolProviderConfig
 from app.main import build_tool_adapter
 from app.providers.tool.echo import EchoToolAdapter
 from app.providers.tool.egress import EgressRefused
@@ -75,6 +76,26 @@ def test_build_tool_adapter_disabled_returns_none() -> None:
         }
     )
     assert build_tool_adapter(cfg.tool_providers[0]) is None
+
+
+@pytest.mark.unit
+def test_build_tool_adapter_mcp(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.providers.tool import egress
+    from app.providers.tool.mcp import MCPToolProviderAdapter
+
+    monkeypatch.setattr(egress, "_resolve_ips", lambda host: ["93.184.216.34"])
+    cfg = ToolProviderConfig.model_validate(
+        {
+            "name": "acme-mcp",
+            "type": "mcp",
+            "base_url": "https://mcp.acme.example/sse",
+            "egress_tier": 2,
+            "allowlist": {"hosts": ["mcp.acme.example"]},
+            "auth": "none",
+        }
+    )
+    adapter = build_tool_adapter(cfg)
+    assert isinstance(adapter, MCPToolProviderAdapter)
 
 
 @pytest.mark.unit

--- a/gateway/tests/test_tools_route.py
+++ b/gateway/tests/test_tools_route.py
@@ -117,6 +117,63 @@ async def test_tools_route_registered_on_app(gateway_app) -> None:
     paths = gateway_app.openapi()["paths"]
     assert "/v1/tools/{provider}/{tool}" in paths
     assert "post" in paths["/v1/tools/{provider}/{tool}"]
+    assert "/v1/tools/{provider}" in paths
+    assert "get" in paths["/v1/tools/{provider}"]
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/tools/{provider} — discovery endpoint (PR4a Task 6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_discovery_lists_tools(monkeypatch) -> None:
+    """GET /v1/tools/{provider} returns 200 with provider name and tool list."""
+    app, adapter = _make_app(monkeypatch)
+    try:
+        async with _client(app) as c:
+            resp = await c.get("/v1/tools/echo-test")
+    finally:
+        await adapter.aclose()
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == "echo-test"
+    tools = body["tools"]
+    assert isinstance(tools, list)
+    assert len(tools) >= 1
+    names = [t["name"] for t in tools]
+    assert "echo" in names
+
+
+@pytest.mark.unit
+async def test_discovery_unknown_provider_404(monkeypatch) -> None:
+    """GET /v1/tools/{unknown} returns 404 with unknown_provider error code."""
+    app, adapter = _make_app(monkeypatch)
+    try:
+        async with _client(app) as c:
+            resp = await c.get("/v1/tools/nope")
+    finally:
+        await adapter.aclose()
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "unknown_provider"
+
+
+@pytest.mark.unit
+async def test_discovery_requires_gateway_key_when_configured(monkeypatch) -> None:
+    """GET /v1/tools/{provider} is gated by the gateway key when LQ_AI_GATEWAY_KEY is set."""
+    monkeypatch.setenv("LQ_AI_GATEWAY_KEY", "secret-key")
+    app, adapter = _make_app(monkeypatch)
+    try:
+        async with _client(app) as c:
+            missing = await c.get("/v1/tools/echo-test")
+            ok = await c.get(
+                "/v1/tools/echo-test",
+                headers={"X-LQ-AI-Gateway-Key": "secret-key"},
+            )
+    finally:
+        await adapter.aclose()
+    assert missing.status_code == 401
+    assert ok.status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/tests/test_tools_route.py
+++ b/gateway/tests/test_tools_route.py
@@ -117,3 +117,43 @@ async def test_tools_route_registered_on_app(gateway_app) -> None:
     paths = gateway_app.openapi()["paths"]
     assert "/v1/tools/{provider}/{tool}" in paths
     assert "post" in paths["/v1/tools/{provider}/{tool}"]
+
+
+# ---------------------------------------------------------------------------
+# user_token transport test (PR4a Task 5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_tool_call_forwards_user_token_to_route_tool_call(monkeypatch) -> None:
+    """user_token in the JSON body is forwarded to Router.route_tool_call."""
+    captured: dict[str, object] = {}
+
+    async def _fake_route_tool_call(
+        provider_name: str,
+        tool: str,
+        args: dict[str, object],
+        *,
+        request_id: str,
+        max_allowed_tier: int | None = None,
+        user_token: str | None = None,
+    ) -> object:
+        captured["user_token"] = user_token
+        from app.router import ToolCallRoutedResult
+
+        return ToolCallRoutedResult(provider=provider_name, tool=tool, payload={"ok": True}, tier=2)
+
+    app, adapter = _make_app(monkeypatch)
+    app.state.router.route_tool_call = _fake_route_tool_call  # type: ignore[method-assign]
+
+    try:
+        async with _client(app) as c:
+            resp = await c.post(
+                "/v1/tools/echo-test/echo",
+                json={"args": {"q": "x"}, "user_token": "t"},
+            )
+    finally:
+        await adapter.aclose()
+
+    assert resp.status_code == 200
+    assert captured["user_token"] == "t"

--- a/gateway/tests/test_tools_route.py
+++ b/gateway/tests/test_tools_route.py
@@ -183,7 +183,7 @@ async def test_discovery_requires_gateway_key_when_configured(monkeypatch) -> No
 
 @pytest.mark.unit
 async def test_tool_call_forwards_user_token_to_route_tool_call(monkeypatch) -> None:
-    """user_token in the JSON body is forwarded to Router.route_tool_call."""
+    """user_token sent via X-LQ-AI-User-Token header is forwarded to Router.route_tool_call."""
     captured: dict[str, object] = {}
 
     async def _fake_route_tool_call(
@@ -207,10 +207,33 @@ async def test_tool_call_forwards_user_token_to_route_tool_call(monkeypatch) -> 
         async with _client(app) as c:
             resp = await c.post(
                 "/v1/tools/echo-test/echo",
-                json={"args": {"q": "x"}, "user_token": "t"},
+                json={"args": {"q": "x"}},
+                headers={"X-LQ-AI-User-Token": "t"},
             )
     finally:
         await adapter.aclose()
 
     assert resp.status_code == 200
     assert captured["user_token"] == "t"
+
+
+@pytest.mark.unit
+async def test_discovery_returns_502_on_tool_provider_error(monkeypatch) -> None:
+    """GET /v1/tools/{provider} returns 502 with tool_provider_unavailable when list_tools raises."""
+    from app.providers.tool.base import ToolProviderError
+
+    app, adapter = _make_app(monkeypatch)
+
+    async def _failing_list_tools(*, user_token: str | None = None):  # type: ignore[override]
+        raise ToolProviderError("upstream exploded")
+
+    adapter.list_tools = _failing_list_tools  # type: ignore[method-assign]
+
+    try:
+        async with _client(app) as c:
+            resp = await c.get("/v1/tools/echo-test")
+    finally:
+        await adapter.aclose()
+
+    assert resp.status_code == 502
+    assert resp.json()["error"]["code"] == "tool_provider_unavailable"

--- a/mcp.yaml.example
+++ b/mcp.yaml.example
@@ -1,0 +1,13 @@
+# mcp.yaml — operator-allowlisted MCP servers (WS2 spec D2). Loaded by the
+# gateway (MCP_CONFIG_PATH; defaults to ./mcp.yaml). Each entry becomes a
+# type: mcp tool-provider behind the same egress boundary as gateway.yaml
+# tool_providers. The gateway is the sole egress + MCP-protocol speaker.
+mcp_servers:
+  - name: example-mcp
+    server_url: https://mcp.example.com/sse
+    auth: none              # none | bearer | oauth
+    egress_tier: 2
+    allowlist:
+      hosts: [mcp.example.com]
+    # auth: bearer -> also set api_key_env: EXAMPLE_MCP_TOKEN
+    # auth: oauth  -> per-user token supplied by the api at call time (PR4c)


### PR DESCRIPTION
## Summary

First slice of the MCP client subsystem (WS2 / DE-200). The **gateway** becomes the sole egress *and* the only MCP-protocol speaker (ADR 0014 + the WS2 design spec, D1) — because MCP `streamable_http` is a stateful session, the connection holder must speak MCP. The api (PR4b/PR4c) brokers MCP tools through this gateway slice.

Design spec: `docs/superpowers/specs/2026-06-17-mcp-client-ws2-design.md` · Plan: `docs/superpowers/plans/2026-06-17-pr4a-gateway-mcp-adapter.md`

### What's in PR4a (gateway only)
- **`mcp` SDK dependency** (1.28.x, client-only). Pins `starlette<0.49`: mcp's `sse-starlette` would otherwise pull starlette 1.x and break fastapi 0.116 — we don't use the MCP *server*, so the older `sse-starlette` (3.0.3) pip resolves is fine. `pip check` clean.
- **`mcp.yaml`** schema (`MCPServerConfig`; `auth: none|bearer|oauth`) + loader merge into `tool_providers`; `GatewayConfig` now enforces tool-provider **name uniqueness** (across `gateway.yaml` + `mcp.yaml`). `mcp.yaml.example` added.
- **`MCPToolProviderAdapter`** — streamable_http client (ported from the `web/` stub) behind an **injectable session factory** (unit tests never touch the network). MCP tool annotations → `ToolSpec` flags (`readOnlyHint`→read_only; `destructiveHint`→destructive+confirm; **un-annotated ⇒ requires_confirmation**, safe-by-default for PR5's gate). `validate_egress_target` on **every** connect.
- **`build_tool_adapter`** mcp branch; `user_token` added uniformly to the adapter contract.
- **Per-call `user_token`** threaded transport→router→adapter, carried in the **`X-LQ-AI-User-Token` header** (not query/body — keeps the per-user OAuth token out of uvicorn access logs), and **never** written to `tool_egress_log`. For `oauth` servers a missing token fails closed (`mcp_authorization_required`).
- **`GET /v1/tools/{provider}`** discovery endpoint (key-gated; optional user-token header for oauth discovery in PR4c).
- mcp providers flow through the **same `route_tool_call`** → egress-tier ceiling, per-provider rate limit, and the `tool_egress_log` audit row all apply exactly as for CourtListener (no bypass).

### Security invariants (verified in a final holistic review)
- **Egress (ADR 0014):** no path (`list_tools`/`invoke_tool`/`health_check`/factory) reaches the network without `validate_egress_target` (first line of the single `_session()` chokepoint).
- **Secrets:** operator key + per-user token end only in an in-memory `Authorization` header; never logged, never in `tool_egress_log` (the row has no field for them), never echoed.
- **No auth bypass:** bearer-without-key rejected at config load *and* adapter build; oauth-without-token fails closed.

### ⚠️ Why this needs your review
`gateway/**` (security boundary) + a new SBOM dependency (`mcp`, with the `starlette` pin). Built via subagent-driven TDD; each task got spec + quality review, plus the final whole-PR review above.

### Known non-blocking follow-ups (your call during review)
- Test gaps: explicit cross-file (gateway.yaml vs mcp.yaml) name-collision test, `enabled: false` mcp server, malformed `mcp.yaml` (paths exist + covered transitively; happy to add).
- `health_check()` for `oauth` servers always reports `reachable=False` (fail-safe: no unauthenticated probe) — uninformative; candidate to pair with DE-338.
- **DE-338** (filed): MCP session *teardown* is unbounded (only `initialize()` is bounded by `fail_after(10)`).

## Test Plan
- [x] Full gateway suite: **669 passed, 3 skipped**
- [x] `ruff format --check` + `ruff check` clean; **mypy --strict** clean (48 files)
- [x] Adapter: annotation→flags mapping, invoke success/isError, egress refusal, all 3 auth-header branches, oauth missing-token fail-closed
- [x] Config: model synthesis, validator negative paths, loader merge, name-uniqueness, missing-file no-op
- [x] Router/transport: `user_token` reaches adapter + absent from audit row; header forwarding; discovery 200/404/502/key-gated
- [x] `pip check` clean (mcp 1.28.0 / sse-starlette 3.0.3 / starlette 0.48.0 / fastapi 0.116.2)

Follow-ons (separate plans, against PR4a as merged): **PR4b** (api registry/cache/admin, self-merge) · **PR4c** (api per-user OAuth + Fernet token store, security review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)