### PR TITLE
research: accept a search cursor for /research/search pagination (Donna)

### DIFF
--- a/api/app/schemas/research.py
+++ b/api/app/schemas/research.py
@@ -48,6 +48,7 @@ class SearchRequest(BaseModel):
     q: str = Field(min_length=1)
     court: str | None = None
     order_by: str | None = None
+    cursor: str | None = None
 
 
 class SearchResultItem(BaseModel):

--- a/api/tests/test_research_models.py
+++ b/api/tests/test_research_models.py
@@ -11,6 +11,9 @@ Also covers schema-layer typing added in WS3b-follow (Donna asks 2 & 3):
 - VerifiedCitation / CitationCluster round-trips the adapter's exact emitted shape.
 - OpinionTextField Literal accepts all 7 values (incl xml_harvard) and is used
   on OpinionMeta and OpinionText.
+
+And cursor pagination (Donna ask — Slice A "load more"):
+- SearchRequest accepts an optional cursor field and flows it through model_dump.
 """
 
 from __future__ import annotations
@@ -26,6 +29,7 @@ from app.schemas.research import (
     OpinionMeta,
     OpinionText,
     OpinionTextField,
+    SearchRequest,
     VerifiedCitation,
     VerifyCitationsResponse,
 )
@@ -171,3 +175,41 @@ def test_opinion_text_rejects_invalid_text_field() -> None:
     """OpinionText rejects values outside the closed Literal set."""
     with pytest.raises(ValidationError):
         OpinionText(opinion_id=1, cluster_id=2, text_field_used="raw_text", text="x")
+
+
+# ---------------------------------------------------------------------------
+# SearchRequest cursor pagination (Donna ask — Slice A "load more")
+# ---------------------------------------------------------------------------
+
+
+def test_search_request_accepts_cursor() -> None:
+    """SearchRequest accepts a cursor and exposes it on the model."""
+    req = SearchRequest(q="privacy", cursor="abc")
+    assert req.cursor == "abc"
+
+
+def test_search_request_cursor_in_model_dump_when_set() -> None:
+    """model_dump(exclude_none=True) includes cursor when it is set."""
+    req = SearchRequest(q="privacy", cursor="abc")
+    dumped = req.model_dump(exclude_none=True)
+    assert dumped["cursor"] == "abc"
+    assert dumped["q"] == "privacy"
+
+
+def test_search_request_cursor_omitted_from_model_dump_when_none() -> None:
+    """model_dump(exclude_none=True) omits cursor when it is None (default)."""
+    req = SearchRequest(q="privacy")
+    dumped = req.model_dump(exclude_none=True)
+    assert "cursor" not in dumped
+
+
+def test_search_request_cursor_default_none() -> None:
+    """cursor defaults to None when not supplied."""
+    req = SearchRequest(q="contract")
+    assert req.cursor is None
+
+
+def test_search_request_rejects_extra_field() -> None:
+    """extra='forbid' is preserved — unknown fields still raise."""
+    with pytest.raises(ValidationError):
+        SearchRequest(q="x", unknown_field="y")

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -4869,6 +4869,10 @@ paths:
                 order_by:
                   type: string
                   nullable: true
+                cursor:
+                  type: string
+                  nullable: true
+                  description: "Opaque pagination cursor from a prior response's next_cursor; fetch the next page."
       responses:
         '200':
           description: Search results

--- a/gateway/app/providers/tool/courtlistener.py
+++ b/gateway/app/providers/tool/courtlistener.py
@@ -235,6 +235,8 @@ class CourtListenerToolAdapter(ToolProviderAdapter):
             params["court"] = args["court"]
         if isinstance(args.get("order_by"), str):
             params["order_by"] = args["order_by"]
+        if isinstance(args.get("cursor"), str) and args["cursor"]:
+            params["cursor"] = args["cursor"]
         resp = await self._request("GET", "/search/", params=params)
         data = resp.json()
         results = [

--- a/gateway/tests/test_courtlistener_adapter.py
+++ b/gateway/tests/test_courtlistener_adapter.py
@@ -227,6 +227,41 @@ async def test_get_cases_requires_integer_cluster_id(monkeypatch) -> None:
 
 
 @pytest.mark.unit
+async def test_search_case_law_forwards_cursor_param(monkeypatch) -> None:
+    """When cursor is in args, it is forwarded as ?cursor= to CourtListener."""
+    adapter = _adapter(monkeypatch)
+    api_resp = {"count": 0, "next": None, "results": []}
+    with respx.mock:
+        route = respx.get(f"{BASE}/search/").mock(return_value=httpx.Response(200, json=api_resp))
+        try:
+            await adapter.invoke_tool(
+                "search_case_law", {"q": "privacy", "cursor": "CUR"}, request_id="r1"
+            )
+        finally:
+            await adapter.aclose()
+    assert route.called
+    params = route.calls.last.request.url.params
+    assert params["cursor"] == "CUR"
+    assert params["q"] == "privacy"
+
+
+@pytest.mark.unit
+async def test_search_case_law_omits_cursor_param_when_absent(monkeypatch) -> None:
+    """When cursor is not in args, no cursor param is sent to CourtListener."""
+    adapter = _adapter(monkeypatch)
+    api_resp = {"count": 0, "next": None, "results": []}
+    with respx.mock:
+        route = respx.get(f"{BASE}/search/").mock(return_value=httpx.Response(200, json=api_resp))
+        try:
+            await adapter.invoke_tool("search_case_law", {"q": "privacy"}, request_id="r1")
+        finally:
+            await adapter.aclose()
+    assert route.called
+    params = route.calls.last.request.url.params
+    assert "cursor" not in params
+
+
+@pytest.mark.unit
 async def test_courtlistener_through_router_writes_audit(monkeypatch) -> None:
     from app.config import GatewayConfig
     from app.router import Router


### PR DESCRIPTION
## Summary

Makes `/api/v1/research/search` pagination consumable. The endpoint already **returns** `next_cursor` but had no way to **send one back**, so a client couldn't fetch page 2. This threads a `cursor` through end-to-end. Reported by Donna (consumer) for Slice A search "load more". Verified against `e2cc311`/`main`.

- **`SearchRequest`** (`api/app/schemas/research.py`) gains `cursor: str | None = None` (keeps `extra="forbid"`).
- **No service change** — the endpoint already forwards `payload.model_dump(exclude_none=True)` to the gateway tool `args` verbatim, so `cursor` flows through.
- **CL adapter** `_search_case_law` (`gateway/app/providers/tool/courtlistener.py`) forwards a non-empty string `cursor` as CourtListener's native `?cursor=` query param.
- **OpenAPI** — `cursor` added to the `/research/search` request schema (so Donna's `gen:api` picks it up).

`next_cursor` already returns the right value; this just lets a client send it back to page forward.

### Security (egress boundary)
The cursor is passed via httpx `params=` (URL-encoded) — not string-concatenated — so no query/host injection. `validate_egress_target` still pins the host/path; the cursor only affects the query string. No SSRF angle. (Confirmed in review.)

### ⚠️ Why this needs your review
Touches `gateway/app/providers/tool/courtlistener.py` (the egress boundary). Built + reviewed via the subagent loop (spec + quality + security pass, no findings).

## Test Plan
- [x] api: `test_research_models.py` (cursor accepted; in `model_dump` when set, omitted when None; `extra="forbid"` preserved) — 28 passed
- [x] gateway: `test_courtlistener_adapter.py` (cursor forwarded as `?cursor=` when set; absent when not — asserted on the actual outbound httpx params) — 14 passed
- [x] `test_openapi.py` conformance passes with the new request field
- [x] ruff format --check + ruff check + mypy clean (both subsystems; ruff 0.15.17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)