### PR TITLE
chore: pin ruff==0.15.17 (api + gateway) to stop CI/local formatter drift

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -141,7 +141,11 @@ dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "httpx>=0.27",
-    "ruff>=0.6",
+    # Pinned exactly: ruff's formatter output changes across releases, so an
+    # unpinned floor let CI (which resolves latest) drift ahead of dev venvs
+    # and fail `ruff format --check` on code that was clean locally. Pin so
+    # local == CI. Bump deliberately (and reformat) when upgrading.
+    "ruff==0.15.17",
     "mypy>=1.11",
     # PyYAML type stubs — pyyaml has no inline typings, so mypy needs the
     # types-PyYAML package to type-check `app.skills.loader` etc.

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -85,7 +85,11 @@ dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "respx>=0.21",
-    "ruff>=0.6",
+    # Pinned exactly: ruff's formatter output changes across releases, so an
+    # unpinned floor let CI (which resolves latest) drift ahead of dev venvs
+    # and fail `ruff format --check` on code that was clean locally. Pin so
+    # local == CI. Bump deliberately (and reformat) when upgrading.
+    "ruff==0.15.17",
     "mypy>=1.11",
     "types-PyYAML>=6.0",
 ]


### PR DESCRIPTION
## Summary

Pins `ruff==0.15.17` exactly in `api/pyproject.toml` and `gateway/pyproject.toml` dev deps (was an unpinned `ruff>=0.6` floor in both).

**Why:** ruff's formatter output changes across releases. The unpinned floor let CI — which `pip install -e ".[dev]"` resolves to *latest* — drift ahead of dev venvs. PR4b (#166) was committed under ruff 0.15.14 but CI ran 0.15.17, whose formatter rewraps a `.scalars().all()` chain differently, so `ruff format --check` failed on code that was clean locally. Pinning exactly makes local == CI for both the formatter and the linter, killing this class of failure.

Both trees are already 0.15.17-clean (no reformatting in this PR); `pip check` clean in both venvs. Bump deliberately (and reformat in the same commit) when upgrading ruff.

## ⚠️ Review note
Touches `gateway/pyproject.toml` (under `gateway/**`), so it routes to you — but it's config-only (a dev-dependency pin), no code or runtime change.

## Test Plan
- [x] `ruff --version` == 0.15.17 in both venvs
- [x] `ruff format --check` + `ruff check` clean in both api and gateway (no reformatting needed)
- [x] `pip check` clean in both venvs

🤖 Generated with [Claude Code](https://claude.com/claude-code)