### PR TITLE
PR4d: per-user MCP OAuth UX surface (return_url + connections list + auth field)

### DIFF
--- a/api/alembic/versions/0052_mcp_oauth_state_return_url.py
+++ b/api/alembic/versions/0052_mcp_oauth_state_return_url.py
@@ -1,0 +1,34 @@
+"""mcp_oauth_state: add return_url column for PR4d BFF redirect
+
+Adds a nullable ``return_url`` column to ``mcp_oauth_state`` so the callback
+handler can 302 the browser back to the BFF frontend after authorization.  The
+column is populated at authorize-time after origin-allowlist validation and read
+at callback-time; the callback never accepts a redirect target from its own
+query string (server-side binding enforces no-open-redirect).
+
+Revision ID: 0052
+Revises: 0051
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0052"
+down_revision: str | None = "0051"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mcp_oauth_state",
+        sa.Column("return_url", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_oauth_state", "return_url")

--- a/api/app/api/admin_mcp.py
+++ b/api/app/api/admin_mcp.py
@@ -39,6 +39,7 @@ async def list_mcp(
             MCPServerView(
                 name=s["name"],
                 type=s["type"],
+                auth=s["auth"],
                 tools=[MCPToolView(**t) for t in tools],
             )
         )

--- a/api/app/api/admin_mcp.py
+++ b/api/app/api/admin_mcp.py
@@ -6,7 +6,7 @@ AdminUser-gated. The api never speaks MCP directly (ADR 0014)."""
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Literal, cast
 
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,7 +39,7 @@ async def list_mcp(
             MCPServerView(
                 name=s["name"],
                 type=s["type"],
-                auth=s["auth"],
+                auth=cast(Literal["none", "bearer", "oauth"], s["auth"]),
                 tools=[MCPToolView(**t) for t in tools],
             )
         )

--- a/api/app/api/mcp_oauth.py
+++ b/api/app/api/mcp_oauth.py
@@ -36,7 +36,12 @@ from app.api.dependencies import ActiveUser
 from app.audit import audit_action
 from app.config import get_settings, is_allowed_return_url
 from app.db.session import get_db
-from app.errors import MCPOAuthExchangeError, MCPOAuthStateError, ValidationError
+from app.errors import (
+    MCPOAuthExchangeError,
+    MCPOAuthNotConfigured,
+    MCPOAuthStateError,
+    ValidationError,
+)
 from app.mcp import oauth
 from app.schemas.mcp_oauth import MCPOAuthCallbackResponse, MCPOAuthStatusResponse
 
@@ -120,7 +125,7 @@ async def mcp_oauth_callback(
 
     try:
         token = await oauth.exchange_code(db, state=state, code=code, iss=iss)
-    except (MCPOAuthStateError, MCPOAuthExchangeError) as exc:
+    except (MCPOAuthStateError, MCPOAuthExchangeError, MCPOAuthNotConfigured) as exc:
         if return_url is not None:
             # Redirect to frontend with a non-secret error slug; never include
             # the code, state, verifier, or any token value in the redirect.

--- a/api/app/api/mcp_oauth.py
+++ b/api/app/api/mcp_oauth.py
@@ -13,11 +13,20 @@ Auth posture (LOCKED, decided 2026-06-18 — do NOT re-litigate):
 
 The router is registered WITHOUT a router-level dependency so the callback
 stays public.  The three authenticated handlers take ActiveUser explicitly.
+
+PR4d: ``/authorize`` accepts an optional ``return_url`` (validated against
+``lq_ai_cors_origins``; stored server-side on the state row).  After callback
+the browser is 302-redirected to ``{return_url}?mcp_connected={server}`` on
+success, or ``{return_url}?mcp_error={code}&server={server}`` on an exchange
+error.  When no ``return_url`` was supplied the callback returns 200 JSON
+(back-compat).  The callback NEVER reads a redirect target from its own query
+string — origin-validated, state-bound only.
 """
 
 from __future__ import annotations
 
 from typing import Annotated
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, Request, Response, status
 from fastapi.responses import RedirectResponse
@@ -25,7 +34,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import ActiveUser
 from app.audit import audit_action
+from app.config import get_settings, is_allowed_return_url
 from app.db.session import get_db
+from app.errors import MCPOAuthExchangeError, MCPOAuthStateError, ValidationError
 from app.mcp import oauth
 from app.schemas.mcp_oauth import MCPOAuthCallbackResponse, MCPOAuthStatusResponse
 
@@ -38,23 +49,44 @@ async def authorize_mcp_oauth(
     user: ActiveUser,
     request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
+    return_url: str | None = None,
 ) -> RedirectResponse:
     """GET /api/v1/mcp/oauth/{server}/authorize — start the OAuth flow.
 
     Builds the PKCE authorize URL for *server* and redirects the user's browser
     to the authorization server.  Audit happens on successful callback, not here.
+
+    ``return_url`` (optional) is an operator-allowlisted frontend URL.  When
+    supplied, the callback 302-redirects the browser back to that URL on
+    completion (success or exchange error).  The origin of *return_url* MUST be
+    in ``lq_ai_cors_origins``; unrecognised origins are rejected with 400 (no
+    open redirect).
     """
+    if return_url is not None and not is_allowed_return_url(return_url, get_settings()):
+        raise ValidationError(
+            message="return_url origin not allowed",
+            details={"return_url": return_url},
+        )
+
     redirect_uri = str(request.url_for("mcp_oauth_callback", server=server))
     url = await oauth.build_authorize_url(
-        db, user_id=user.id, server=server, redirect_uri=redirect_uri
+        db,
+        user_id=user.id,
+        server=server,
+        redirect_uri=redirect_uri,
+        return_url=return_url,
     )
     return RedirectResponse(url, status_code=status.HTTP_302_FOUND)
 
 
 @router.get(
     "/{server}/callback",
-    response_model=MCPOAuthCallbackResponse,
+    response_model=None,
     name="mcp_oauth_callback",
+    responses={
+        200: {"model": MCPOAuthCallbackResponse, "description": "Token exchanged (no return_url)"},
+        302: {"description": "Browser redirected to return_url (return_url was supplied)"},
+    },
 )
 async def mcp_oauth_callback(
     server: str,
@@ -63,14 +95,42 @@ async def mcp_oauth_callback(
     request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     iss: str | None = None,
-) -> MCPOAuthCallbackResponse:
+) -> MCPOAuthCallbackResponse | RedirectResponse:
     """GET /api/v1/mcp/oauth/{server}/callback — receive the AS redirect.
 
     PUBLIC — no bearer auth.  The user is bound to the exchange via the
     single-use, TTL-bounded mcp_oauth_state row inside exchange_code.
-    On success, writes a mcp.oauth_connected audit row and returns 200.
+
+    When a ``return_url`` was stored on the state row (set at authorize-time):
+    * Success → 302 to ``{return_url}?mcp_connected={server}``
+    * Exchange error → 302 to ``{return_url}?mcp_error={code}&server={server}``
+
+    When no ``return_url`` was stored (back-compat):
+    * Success → 200 ``MCPOAuthCallbackResponse``
+    * Exchange error → raises the exception (existing JSON-error behaviour)
+
+    The callback NEVER reads a redirect target from its own query string.  The
+    only trusted ``return_url`` is the one read from the state row (validated
+    + stored at authorize-time).  If the state row is unknown, ``return_url``
+    is None and we fall back to JSON error (fail safe — no trusted target).
     """
-    token = await oauth.exchange_code(db, state=state, code=code, iss=iss)
+    # Peek at return_url BEFORE consuming the state row.  get_state_return_url
+    # is a read-only select; exchange_code does the consume (single-use delete).
+    return_url = await oauth.get_state_return_url(db, state=state)
+
+    try:
+        token = await oauth.exchange_code(db, state=state, code=code, iss=iss)
+    except (MCPOAuthStateError, MCPOAuthExchangeError) as exc:
+        if return_url is not None:
+            # Redirect to frontend with a non-secret error slug; never include
+            # the code, state, verifier, or any token value in the redirect.
+            qs = urlencode({"mcp_error": exc.effective_code, "server": server})
+            return RedirectResponse(
+                f"{return_url}?{qs}",
+                status_code=status.HTTP_302_FOUND,
+            )
+        raise  # back-compat: re-raise → global handler returns JSON error
+
     await audit_action(
         db,
         user_id=token.user_id,
@@ -81,6 +141,14 @@ async def mcp_oauth_callback(
         details={"scope_count": len(token.scopes)},
     )
     await db.commit()
+
+    if return_url is not None:
+        qs = urlencode({"mcp_connected": server})
+        return RedirectResponse(
+            f"{return_url}?{qs}",
+            status_code=status.HTTP_302_FOUND,
+        )
+
     return MCPOAuthCallbackResponse(
         connected=True,
         server=server,

--- a/api/app/api/mcp_oauth.py
+++ b/api/app/api/mcp_oauth.py
@@ -26,7 +26,7 @@ string — origin-validated, state-bound only.
 from __future__ import annotations
 
 from typing import Annotated
-from urllib.parse import urlencode
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, Request, Response, status
 from fastapi.responses import RedirectResponse
@@ -49,6 +49,28 @@ from app.schemas.mcp_oauth import (
     MCPOAuthServerStatus,
     MCPOAuthStatusResponse,
 )
+
+
+def _append_query_params(url: str, **params: str) -> str:
+    """Append *params* to *url* without corrupting existing query or fragment.
+
+    Handles three tricky cases that naive ``f"{url}?{qs}"`` misses:
+
+    * ``url`` already has a query string → params are merged, not doubled.
+    * ``url`` has a ``#fragment`` → params land in the query component,
+      never inside the fragment (where they'd be invisible to the server).
+    * Both present → existing query merged, fragment preserved after params.
+
+    The fragment is intentionally preserved so callers that store an anchor
+    in their ``return_url`` (e.g. ``/settings#mcp``) still land in the right
+    place after the status param is appended to the query.
+    """
+    split = urlsplit(url)
+    existing = parse_qsl(split.query, keep_blank_values=True)
+    combined = existing + list(params.items())
+    new_query = urlencode(combined)
+    return urlunsplit((split.scheme, split.netloc, split.path, new_query, split.fragment))
+
 
 router = APIRouter(prefix="/mcp/oauth", tags=["mcp-oauth"])
 
@@ -150,9 +172,10 @@ async def mcp_oauth_callback(
         if return_url is not None:
             # Redirect to frontend with a non-secret error slug; never include
             # the code, state, verifier, or any token value in the redirect.
-            qs = urlencode({"mcp_error": exc.effective_code, "server": server})
+            # _append_query_params handles an existing query string or fragment
+            # on return_url so we never produce a malformed Location header.
             return RedirectResponse(
-                f"{return_url}?{qs}",
+                _append_query_params(return_url, mcp_error=exc.effective_code, server=server),
                 status_code=status.HTTP_302_FOUND,
             )
         raise  # back-compat: re-raise → global handler returns JSON error
@@ -169,9 +192,8 @@ async def mcp_oauth_callback(
     await db.commit()
 
     if return_url is not None:
-        qs = urlencode({"mcp_connected": server})
         return RedirectResponse(
-            f"{return_url}?{qs}",
+            _append_query_params(return_url, mcp_connected=server),
             status_code=status.HTTP_302_FOUND,
         )
 

--- a/api/app/api/mcp_oauth.py
+++ b/api/app/api/mcp_oauth.py
@@ -43,9 +43,30 @@ from app.errors import (
     ValidationError,
 )
 from app.mcp import oauth
-from app.schemas.mcp_oauth import MCPOAuthCallbackResponse, MCPOAuthStatusResponse
+from app.schemas.mcp_oauth import (
+    MCPOAuthCallbackResponse,
+    MCPOAuthServersResponse,
+    MCPOAuthServerStatus,
+    MCPOAuthStatusResponse,
+)
 
 router = APIRouter(prefix="/mcp/oauth", tags=["mcp-oauth"])
+
+
+@router.get("", response_model=MCPOAuthServersResponse)
+async def list_mcp_oauth(
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> MCPOAuthServersResponse:
+    """GET /api/v1/mcp/oauth — per-user OAuth connection status for all connectable servers.
+
+    PR4d Ask 1.  ActiveUser-gated (bearer).  Returns one entry per configured
+    OAuth-type MCP server with the calling user's connection state
+    (``connected``, ``scopes``, ``expires_at``).  Token bytes are NEVER
+    returned — this is a status-only surface.
+    """
+    statuses = await oauth.list_connection_status(db, user_id=user.id)
+    return MCPOAuthServersResponse(servers=[MCPOAuthServerStatus(**s) for s in statuses])
 
 
 @router.get("/{server}/authorize", status_code=status.HTTP_302_FOUND)

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -443,3 +443,35 @@ def get_settings() -> Settings:
     monkeypatching environment variables.
     """
     return Settings()
+
+
+def is_allowed_return_url(url: str, settings: Settings) -> bool:
+    """Return True iff *url*'s origin is in the operator's CORS allowlist.
+
+    Parses ``settings.lq_ai_cors_origins`` the same way ``app/main.py`` does —
+    comma-split, strip, drop empties.  Builds the origin
+    (``{scheme}://{netloc}``) from *url* and checks membership.
+
+    Security invariants:
+    * Only ``http`` and ``https`` schemes are accepted; ``javascript:``,
+      ``data:``, etc. always return False.
+    * An empty allowlist returns False (fail closed — no redirect allowed when
+      the operator has not configured any origins).
+    * The check is exact origin membership, not substring/prefix matching.
+
+    Callers (the ``/authorize`` handler) validate BEFORE storing ``return_url``
+    on the state row; the callback reads from the row, never from the query
+    string — so this validator is the only enforcement point needed.
+    """
+    from urllib.parse import urlparse  # stdlib — no new dependency
+
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    if not parsed.netloc:
+        return False
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    allowed = [o.strip() for o in (settings.lq_ai_cors_origins or "").split(",") if o.strip()]
+    if not allowed:
+        return False
+    return origin in allowed

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -474,4 +474,5 @@ def is_allowed_return_url(url: str, settings: Settings) -> bool:
     allowed = [o.strip() for o in (settings.lq_ai_cors_origins or "").split(",") if o.strip()]
     if not allowed:
         return False
+    # Case-sensitive exact membership — intentional, matches CORS-allowlist semantics.
     return origin in allowed

--- a/api/app/mcp/oauth.py
+++ b/api/app/mcp/oauth.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import cast
+from typing import Any, cast
 from urllib.parse import urlencode
 from uuid import UUID
 
@@ -99,6 +99,7 @@ __all__ = [
     "get_state_return_url",
     "get_status",
     "get_valid_token",
+    "list_connection_status",
 ]
 
 
@@ -450,6 +451,46 @@ async def get_valid_token(
 
     await db.commit()
     return enc.decrypt(updated.access_token)
+
+
+async def list_connection_status(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+) -> list[dict[str, Any]]:
+    """Return per-user connection status for every configured OAuth MCP server.
+
+    Fetches the list of OAuth-type MCP servers from the gateway config and
+    cross-references the user's stored token rows (loaded once, then mapped in
+    memory).  Returns one entry per configured OAuth server, ordered by name.
+
+    Token bytes (``access_token``, ``refresh_token``) are NEVER read or
+    returned — only the non-secret status fields (``connected``,
+    ``scopes``, ``expires_at``).
+    """
+    servers = await get_gateway_client().list_mcp_oauth_config()
+
+    # Load ALL of the user's token rows in a single query — map by provider_name.
+    rows = (
+        (await db.execute(select(MCPOAuthToken).where(MCPOAuthToken.user_id == user_id)))
+        .scalars()
+        .all()
+    )
+    token_map: dict[str, MCPOAuthToken] = {r.provider_name: r for r in rows}
+
+    result: list[dict[str, Any]] = []
+    for srv in sorted(servers, key=lambda s: s["name"]):
+        name = srv["name"]
+        row = token_map.get(name)
+        result.append(
+            {
+                "server": name,
+                "connected": row is not None,
+                "scopes": row.scopes if row is not None else [],
+                "expires_at": row.expires_at if row is not None else None,
+            }
+        )
+    return result
 
 
 async def get_status(

--- a/api/app/mcp/oauth.py
+++ b/api/app/mcp/oauth.py
@@ -96,6 +96,7 @@ __all__ = [
     "build_authorize_url",
     "disconnect",
     "exchange_code",
+    "get_state_return_url",
     "get_status",
     "get_valid_token",
 ]
@@ -140,6 +141,7 @@ async def build_authorize_url(
     user_id: UUID,
     server: str,
     redirect_uri: str,
+    return_url: str | None = None,
 ) -> str:
     """Mint PKCE state and build the AS authorize URL for *server*.
 
@@ -147,6 +149,13 @@ async def build_authorize_url(
     PKCE ``code_verifier``, the discovered issuer / token endpoint / resource,
     and whether the AS supports the RFC 9207 ``iss`` parameter — then returns
     the authorize URL the caller redirects the user to.
+
+    *return_url* is an optional operator-allowlisted frontend URL that the
+    callback will 302 the browser back to after authorization.  It MUST be
+    validated (origin in ``lq_ai_cors_origins``) by the caller BEFORE this
+    function is invoked; this function stores it as-is on the state row.  When
+    *return_url* is ``None`` the callback falls back to the old 200-JSON
+    response (back-compat).
     """
     provider = await _resolve_oauth_provider(server)
     gw = get_gateway_client()
@@ -187,10 +196,33 @@ async def build_authorize_url(
             redirect_uri=redirect_uri,
             as_iss_supported=bool(meta.get("authorization_response_iss_parameter_supported")),
             expires_at=_now() + STATE_TTL,
+            return_url=return_url,
         )
     )
     await db.commit()
     return authorize_url
+
+
+async def get_state_return_url(db: AsyncSession, *, state: str) -> str | None:
+    """Peek at the ``return_url`` on the state row without consuming it.
+
+    Returns the ``return_url`` stored at authorize-time, or ``None`` when the
+    row does not exist or carries no ``return_url``.  Does NOT validate, TTL-
+    check, or delete the state row — the full consume happens in
+    :func:`exchange_code` immediately after this peek.
+
+    The callback uses this to decide whether to 302 or return JSON before
+    calling ``exchange_code``, so that on a state-error the handler knows
+    whether it can redirect to a trusted frontend with an error query, or
+    must fall back to JSON (the state row is gone, so there is no trusted
+    return_url to redirect to).
+    """
+    row = (
+        await db.execute(select(MCPOAuthState).where(MCPOAuthState.state == state))
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return row.return_url
 
 
 async def exchange_code(

--- a/api/app/mcp/service.py
+++ b/api/app/mcp/service.py
@@ -21,9 +21,27 @@ _MCP_TYPE = "mcp"
 
 
 async def list_servers(*, request_id: str | None = None) -> list[dict[str, str]]:
-    """Configured MCP servers, from gateway config (name + type)."""
-    providers = await get_gateway_client().list_tool_providers(request_id=request_id)
-    return [p for p in providers if p.get("type") == _MCP_TYPE]
+    """Configured MCP servers from gateway config (name, type, auth).
+
+    Reads the full ``/admin/v1/config`` payload so the ``auth`` mode is
+    available alongside ``name`` and ``type``.  ``list_tool_providers`` is NOT
+    used here — that helper strips to name+type for its own callers; we need the
+    extra field without changing that helper's contract.
+
+    Malformed entries (non-dict, missing name/type) are silently filtered,
+    mirroring ``list_tool_providers``'s guard.
+    """
+    config = await get_gateway_client().get_admin_config(request_id=request_id)
+    providers = config.get("tool_providers") or []
+    return [
+        {
+            "name": p["name"],
+            "type": p["type"],
+            "auth": p.get("auth", "none"),
+        }
+        for p in providers
+        if isinstance(p, dict) and "name" in p and "type" in p and p.get("type") == _MCP_TYPE
+    ]
 
 
 def _tool_dict(row: MCPToolCache) -> dict[str, Any]:

--- a/api/app/models/mcp_oauth.py
+++ b/api/app/models/mcp_oauth.py
@@ -123,6 +123,12 @@ class MCPOAuthState(Base):
     Captured from discovery so the callback can enforce "iss is REQUIRED when
     the AS supports it" (RFC 9207 §3) — not just "iss must match when present".
     No server_default: the app always sets it from discovery metadata."""
+    return_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    """Operator-allowlisted frontend URL to 302-redirect the browser to after
+    the callback.  Validated at authorize-time against ``lq_ai_cors_origins``
+    (origin match); stored here so the callback reads it from the state row —
+    NOT from its own query string.  NULL when the caller omits ``return_url``
+    (back-compat: callback returns 200 JSON)."""
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/api/app/schemas/mcp.py
+++ b/api/app/schemas/mcp.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -20,7 +20,7 @@ class MCPToolView(BaseModel):
 class MCPServerView(BaseModel):
     name: str
     type: str
-    auth: str
+    auth: Literal["none", "bearer", "oauth"]
     tools: list[MCPToolView] = Field(default_factory=list)
 
 

--- a/api/app/schemas/mcp.py
+++ b/api/app/schemas/mcp.py
@@ -20,6 +20,7 @@ class MCPToolView(BaseModel):
 class MCPServerView(BaseModel):
     name: str
     type: str
+    auth: str
     tools: list[MCPToolView] = Field(default_factory=list)
 
 

--- a/api/app/schemas/mcp_oauth.py
+++ b/api/app/schemas/mcp_oauth.py
@@ -1,4 +1,4 @@
-"""Pydantic v2 response schemas for the MCP OAuth REST surface (PR4c)."""
+"""Pydantic v2 response schemas for the MCP OAuth REST surface (PR4c / PR4d)."""
 
 from __future__ import annotations
 
@@ -22,3 +22,21 @@ class MCPOAuthStatusResponse(BaseModel):
     connected: bool
     scopes: list[str]
     expires_at: datetime | None = None
+
+
+class MCPOAuthServerStatus(BaseModel):
+    """Per-server connection status in the per-user list endpoint (PR4d Ask 1).
+
+    Token bytes are NEVER included — only the non-secret status fields.
+    """
+
+    server: str
+    connected: bool
+    scopes: list[str]
+    expires_at: datetime | None = None
+
+
+class MCPOAuthServersResponse(BaseModel):
+    """Response body for GET /api/v1/mcp/oauth — list of all connectable OAuth servers."""
+
+    servers: list[MCPOAuthServerStatus]

--- a/api/tests/test_admin_mcp.py
+++ b/api/tests/test_admin_mcp.py
@@ -130,7 +130,7 @@ async def test_list_mcp_returns_servers_with_tools(
 
     # Mock service.list_servers so no gateway call is needed.
     async def _fake_list_servers(**_: Any) -> list[dict[str, str]]:
-        return [{"name": "acme-mcp", "type": "mcp"}]
+        return [{"name": "acme-mcp", "type": "mcp", "auth": "none"}]
 
     monkeypatch.setattr("app.api.admin_mcp.service.list_servers", _fake_list_servers)
 
@@ -145,6 +145,7 @@ async def test_list_mcp_returns_servers_with_tools(
     srv = body["servers"][0]
     assert srv["name"] == "acme-mcp"
     assert srv["type"] == "mcp"
+    assert srv["auth"] == "none"
     tool_names = {t["name"] for t in srv["tools"]}
     assert tool_names == {"read_doc", "write_doc"}
     enabled_map = {t["name"]: t["enabled"] for t in srv["tools"]}
@@ -170,7 +171,8 @@ async def test_list_mcp_empty_when_no_servers(
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200, res.text
-    assert res.json()["servers"] == []
+    body = res.json()
+    assert body["servers"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -383,7 +385,7 @@ async def test_non_admin_gets_403_on_list(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def _fake_list_servers(**_: Any) -> list[dict[str, str]]:
-        return []
+        return []  # won't be reached — 403 fires before handler body
 
     monkeypatch.setattr("app.api.admin_mcp.service.list_servers", _fake_list_servers)
 
@@ -418,3 +420,88 @@ async def test_non_admin_gets_403_on_patch(
         json={"enabled": False},
     )
     assert res.status_code == 403, res.text
+
+
+# ---------------------------------------------------------------------------
+# PR4d Ask 3 — auth field on MCPServerView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_list_mcp_carries_auth_field(
+    admin_client: tuple[AsyncClient, str],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /admin/mcp returns auth for each server (oauth / bearer / none)."""
+    db_session.add(_tool_row(provider="oauth-server", tool="read_doc"))
+    db_session.add(_tool_row(provider="bearer-server", tool="fetch_data"))
+    db_session.add(_tool_row(provider="plain-server", tool="query"))
+    await db_session.commit()
+
+    async def _fake_list_servers(**_: Any) -> list[dict[str, str]]:
+        return [
+            {"name": "oauth-server", "type": "mcp", "auth": "oauth"},
+            {"name": "bearer-server", "type": "mcp", "auth": "bearer"},
+            {"name": "plain-server", "type": "mcp", "auth": "none"},
+        ]
+
+    monkeypatch.setattr("app.api.admin_mcp.service.list_servers", _fake_list_servers)
+
+    ac, token = admin_client
+    res = await ac.get(
+        "/api/v1/admin/mcp",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    auth_map = {s["name"]: s["auth"] for s in body["servers"]}
+    assert auth_map["oauth-server"] == "oauth"
+    assert auth_map["bearer-server"] == "bearer"
+    assert auth_map["plain-server"] == "none"
+
+
+@pytest.mark.unit
+async def test_list_servers_reads_auth_from_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_servers returns auth field from the full gateway config.
+
+    Unit-level check: the service reads auth from get_admin_config (not the
+    stripped list_tool_providers helper, which drops all fields beyond name/type).
+    """
+    from app.mcp import service
+
+    fake_config: dict[str, Any] = {
+        "tool_providers": [
+            {
+                "name": "oauth-mcp",
+                "type": "mcp",
+                "auth": "oauth",
+                "base_url": "https://o.example.com",
+            },
+            {
+                "name": "bearer-mcp",
+                "type": "mcp",
+                "auth": "bearer",
+                "base_url": "https://b.example.com",
+            },
+            {"name": "no-auth-mcp", "type": "mcp", "base_url": "https://n.example.com"},
+            {"name": "non-mcp-tool", "type": "http"},  # filtered out — not an MCP provider
+        ]
+    }
+
+    async def _fake_get_admin_config(*, request_id: str | None = None) -> dict[str, Any]:
+        return fake_config
+
+    class _FakeGW:
+        get_admin_config = staticmethod(_fake_get_admin_config)
+
+    monkeypatch.setattr("app.mcp.service.get_gateway_client", lambda: _FakeGW())
+
+    result = await service.list_servers()
+
+    assert len(result) == 3
+    by_name = {r["name"]: r for r in result}
+    assert by_name["oauth-mcp"]["auth"] == "oauth"
+    assert by_name["bearer-mcp"]["auth"] == "bearer"
+    assert by_name["no-auth-mcp"]["auth"] == "none"  # defaults to "none" when absent
+    assert "non-mcp-tool" not in by_name

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -323,6 +323,8 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("GET", "/api/v1/mcp/oauth/{server}/callback"),
     ("GET", "/api/v1/mcp/oauth/{server}/status"),
     ("DELETE", "/api/v1/mcp/oauth/{server}"),
+    # PR4d Ask 1 — per-user OAuth connections list
+    ("GET", "/api/v1/mcp/oauth"),
 }
 
 

--- a/api/tests/test_mcp_oauth_endpoints.py
+++ b/api/tests/test_mcp_oauth_endpoints.py
@@ -1020,3 +1020,178 @@ async def test_list_mcp_oauth_empty_when_no_servers_configured(
     )
     assert res.status_code == 200, res.text
     assert res.json()["servers"] == []
+
+
+# ---------------------------------------------------------------------------
+# PR4d robustness: redirect URL composer (_append_query_params regression)
+# ---------------------------------------------------------------------------
+#
+# These tests verify that the callback builds a well-formed Location header
+# when the stored return_url already carries a query string or a fragment.
+# Both the success path (mcp_connected) and the error path (mcp_error) are
+# covered for each case.
+#
+# They stub the same oauth helpers used by the existing PR4d tests above and
+# do NOT hit the database — they run as regular (non-@integration) tests so
+# they will always be collected regardless of marks.
+
+
+_RETURN_URL_WITH_QUERY = "https://frontend.example.com/settings/connections?tab=mcp"
+_RETURN_URL_WITH_FRAGMENT = "https://frontend.example.com/settings#mcp"
+
+
+@pytest.mark.integration
+async def test_callback_success_return_url_with_existing_query(
+    authed_client: tuple[AsyncClient, str, User],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Success redirect: return_url with existing query → Location merges params, exactly one '?'."""
+    ac, _token, user = authed_client
+
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return _RETURN_URL_WITH_QUERY
+
+    token_row = _make_token_row(user.id)
+
+    async def _fake_exchange_code(
+        db: Any, *, state: str, code: str, iss: str | None
+    ) -> MCPOAuthToken:
+        return token_row
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
+
+    res = await ac.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/callback",
+        params={"code": "c", "state": "s"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302, res.text
+    location = res.headers["location"]
+
+    # Both the original query param AND the new status param must be present.
+    assert "tab=mcp" in location, f"existing query param missing: {location!r}"
+    assert "mcp_connected=" in location, f"mcp_connected missing: {location!r}"
+    assert _SERVER in location
+
+    # Exactly one '?' — no double-query-marker.
+    assert location.count("?") == 1, f"malformed URL (multiple '?'): {location!r}"
+
+
+@pytest.mark.integration
+async def test_callback_error_return_url_with_existing_query(
+    anon_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Error redirect: return_url with existing query → Location merges params, exactly one '?'."""
+    from app.errors import MCPOAuthExchangeError
+
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return _RETURN_URL_WITH_QUERY
+
+    async def _fake_exchange_code(
+        db: Any, *, state: str, code: str, iss: str | None
+    ) -> MCPOAuthToken:
+        raise MCPOAuthExchangeError(
+            message="token exchange failed",
+            details={"as_error": "invalid_client", "server": _SERVER},
+        )
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
+
+    res = await anon_client.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/callback",
+        params={"code": "bad", "state": "s"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302, res.text
+    location = res.headers["location"]
+
+    assert "tab=mcp" in location, f"existing query param missing: {location!r}"
+    assert "mcp_error=" in location, f"mcp_error missing: {location!r}"
+    assert "server=" in location
+
+    assert location.count("?") == 1, f"malformed URL (multiple '?'): {location!r}"
+
+
+@pytest.mark.integration
+async def test_callback_success_return_url_with_fragment(
+    authed_client: tuple[AsyncClient, str, User],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Success redirect: return_url with #fragment → status param lands in query, not fragment."""
+    ac, _token, user = authed_client
+
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return _RETURN_URL_WITH_FRAGMENT
+
+    token_row = _make_token_row(user.id)
+
+    async def _fake_exchange_code(
+        db: Any, *, state: str, code: str, iss: str | None
+    ) -> MCPOAuthToken:
+        return token_row
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
+
+    res = await ac.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/callback",
+        params={"code": "c", "state": "s"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302, res.text
+    location = res.headers["location"]
+
+    # Fragment must be preserved at the end.
+    assert "#mcp" in location, f"fragment missing: {location!r}"
+
+    # The status param must appear in the query (before the fragment, or at least
+    # not inside the fragment text).  The fragment must be the last component.
+    fragment_start = location.index("#")
+    query_part = location[:fragment_start]
+    assert "mcp_connected=" in query_part, (
+        f"mcp_connected swallowed into fragment — should be in query: {location!r}"
+    )
+    assert _SERVER in query_part
+
+
+@pytest.mark.integration
+async def test_callback_error_return_url_with_fragment(
+    anon_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Error redirect: return_url with #fragment → status param lands in query, not fragment."""
+    from app.errors import MCPOAuthExchangeError
+
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return _RETURN_URL_WITH_FRAGMENT
+
+    async def _fake_exchange_code(
+        db: Any, *, state: str, code: str, iss: str | None
+    ) -> MCPOAuthToken:
+        raise MCPOAuthExchangeError(
+            message="token exchange failed",
+            details={"as_error": "invalid_client", "server": _SERVER},
+        )
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
+
+    res = await anon_client.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/callback",
+        params={"code": "bad", "state": "s"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302, res.text
+    location = res.headers["location"]
+
+    assert "#mcp" in location, f"fragment missing: {location!r}"
+
+    fragment_start = location.index("#")
+    query_part = location[:fragment_start]
+    assert "mcp_error=" in query_part, (
+        f"mcp_error swallowed into fragment — should be in query: {location!r}"
+    )
+    assert "server=" in query_part

--- a/api/tests/test_mcp_oauth_endpoints.py
+++ b/api/tests/test_mcp_oauth_endpoints.py
@@ -541,6 +541,28 @@ def test_allowed_return_url_http_allowed(monkeypatch: pytest.MonkeyPatch) -> Non
     assert is_allowed_return_url("http://localhost:3000/connect", s) is True
 
 
+def test_allowed_return_url_userinfo_smuggling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Userinfo-smuggling attack: https://app.example.com@evil.com/steal → False.
+
+    The URL looks like it starts with the allowlisted host but the actual
+    authority (netloc) is ``evil.com``.  The validator must reject it.
+    """
+    from app.config import Settings, is_allowed_return_url
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "https://app.example.com")
+    s = Settings()
+    assert is_allowed_return_url("https://app.example.com@evil.com/steal", s) is False
+
+
+def test_allowed_return_url_data_scheme_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """data: URI scheme is rejected — not http(s), so never allowed."""
+    from app.config import Settings, is_allowed_return_url
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "https://app.example.com")
+    s = Settings()
+    assert is_allowed_return_url("data:text/html,<script>alert(1)</script>", s) is False
+
+
 # ---------------------------------------------------------------------------
 # PR4d: /authorize with return_url
 # ---------------------------------------------------------------------------
@@ -834,3 +856,51 @@ async def test_callback_unknown_state_no_return_url_returns_json_error(
     assert res.status_code == 400, res.text
     body = res.json()
     assert body["detail"]["code"] == "mcp_oauth_state_error"
+
+
+@pytest.mark.integration
+async def test_callback_not_configured_with_return_url_redirects_with_error(
+    anon_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MCPOAuthNotConfigured with a return_url → 302 to return_url?mcp_error=...&server=...
+
+    When the OAuth service raises MCPOAuthNotConfigured (e.g. the server has no
+    OAuth config in gateway.yaml), and a return_url was stored on the state row,
+    the browser must be redirected to the frontend error URL — not to a JSON
+    response from the global error handler.  No token, code, or state value may
+    appear in the Location header.
+    """
+    from app.errors import MCPOAuthNotConfigured
+
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return _RETURN_URL
+
+    async def _fake_exchange_code(
+        db: Any,
+        *,
+        state: str,
+        code: str,
+        iss: str | None,
+    ) -> MCPOAuthToken:
+        raise MCPOAuthNotConfigured(
+            message="MCP server 'acme-mcp' has no OAuth configuration",
+            details={"server": _SERVER},
+        )
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
+
+    res = await anon_client.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/callback",
+        params={"code": "some-code", "state": "some-state"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302, res.text
+    location = res.headers["location"]
+    assert location.startswith(_RETURN_URL), f"Location={location!r}"
+    assert "mcp_error=" in location
+    assert "server=" in location
+    # Must NOT contain the auth code, state, or any token material.
+    assert "some-code" not in location
+    assert "some-state" not in location

--- a/api/tests/test_mcp_oauth_endpoints.py
+++ b/api/tests/test_mcp_oauth_endpoints.py
@@ -904,3 +904,119 @@ async def test_callback_not_configured_with_return_url_redirects_with_error(
     # Must NOT contain the auth code, state, or any token material.
     assert "some-code" not in location
     assert "some-state" not in location
+
+
+# ---------------------------------------------------------------------------
+# PR4d Ask 1: GET /api/v1/mcp/oauth — per-user OAuth connections list
+# ---------------------------------------------------------------------------
+
+_SERVER2 = "beta-mcp"
+
+_OAUTH_CONFIG = [
+    {"name": _SERVER, "server_url": "https://acme.example.com", "oauth_client_id": "client-a"},
+    {"name": _SERVER2, "server_url": "https://beta.example.com", "oauth_client_id": "client-b"},
+]
+
+
+@pytest.mark.integration
+async def test_list_mcp_oauth_one_connected_one_not(
+    authed_client: tuple[AsyncClient, str, User],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /mcp/oauth authed → lists every configured oauth server.
+
+    One server is connected (token row present), the other is not.
+    Response must contain no token bytes.
+    """
+    ac, token, user = authed_client
+
+    # Seed a token row for _SERVER only (not _SERVER2).
+    token_row = _make_token_row(user.id, server=_SERVER)
+    db_session.add(token_row)
+    await db_session.commit()
+
+    # Patch list_connection_status directly — this is the function the route calls.
+    async def _fake_list_connection_status(db: Any, *, user_id: Any) -> list[dict]:
+        return [
+            {
+                "server": _SERVER,
+                "connected": True,
+                "scopes": ["read", "write"],
+                "expires_at": token_row.expires_at,
+            },
+            {
+                "server": _SERVER2,
+                "connected": False,
+                "scopes": [],
+                "expires_at": None,
+            },
+        ]
+
+    monkeypatch.setattr(
+        "app.api.mcp_oauth.oauth.list_connection_status",
+        _fake_list_connection_status,
+    )
+
+    res = await ac.get(
+        "/api/v1/mcp/oauth",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    servers = body["servers"]
+
+    assert len(servers) == 2
+    assert servers[0]["server"] == _SERVER
+    assert servers[1]["server"] == _SERVER2
+
+    # acme-mcp is connected.
+    acme = servers[0]
+    assert acme["connected"] is True
+    assert "read" in acme["scopes"]
+    assert acme["expires_at"] is not None
+
+    # beta-mcp is not connected.
+    beta = servers[1]
+    assert beta["connected"] is False
+    assert beta["scopes"] == []
+    assert beta["expires_at"] is None
+
+    # No token bytes in response — access_token / refresh_token must be absent.
+    raw_text = res.text
+    assert "access_token" not in raw_text
+    assert "refresh_token" not in raw_text
+    assert "fake-access-token" not in raw_text
+
+
+@pytest.mark.integration
+async def test_list_mcp_oauth_unauthed_returns_401(
+    anon_client: AsyncClient,
+) -> None:
+    """GET /mcp/oauth without auth → 401."""
+    res = await anon_client.get("/api/v1/mcp/oauth")
+    assert res.status_code == 401, res.text
+
+
+@pytest.mark.integration
+async def test_list_mcp_oauth_empty_when_no_servers_configured(
+    authed_client: tuple[AsyncClient, str, User],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /mcp/oauth when gateway has no OAuth servers → empty list."""
+    ac, token, _user = authed_client
+
+    async def _fake_list_connection_status(db: Any, *, user_id: Any) -> list[dict]:
+        return []
+
+    monkeypatch.setattr(
+        "app.api.mcp_oauth.oauth.list_connection_status",
+        _fake_list_connection_status,
+    )
+
+    res = await ac.get(
+        "/api/v1/mcp/oauth",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["servers"] == []

--- a/api/tests/test_mcp_oauth_endpoints.py
+++ b/api/tests/test_mcp_oauth_endpoints.py
@@ -180,6 +180,7 @@ async def test_authorize_authed_returns_302(
         user_id: Any,
         server: str,
         redirect_uri: str,
+        return_url: str | None = None,
     ) -> str:
         return _AUTHORIZE_URL
 
@@ -228,6 +229,9 @@ async def test_callback_valid_state_returns_200_and_audit(
     # Build the token row that exchange_code will return.
     token_row = _make_token_row(user.id)
 
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return None  # no return_url → back-compat 200 JSON path
+
     async def _fake_exchange_code(
         db: Any,
         *,
@@ -237,6 +241,7 @@ async def test_callback_valid_state_returns_200_and_audit(
     ) -> MCPOAuthToken:
         return token_row
 
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
     monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
 
     res = await ac.get(
@@ -277,6 +282,9 @@ async def test_callback_bad_state_returns_400(
     """Unknown/expired state → 400 (MCPOAuthStateError maps to 400)."""
     from app.errors import MCPOAuthStateError
 
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return None  # state unknown → no return_url → JSON error path
+
     async def _fake_exchange_code(
         db: Any,
         *,
@@ -286,6 +294,7 @@ async def test_callback_bad_state_returns_400(
     ) -> MCPOAuthToken:
         raise MCPOAuthStateError(message="unknown state")
 
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
     monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
 
     res = await anon_client.get(
@@ -305,6 +314,9 @@ async def test_callback_no_bearer_reaches_handler(
     """A request without a bearer token is judged by state, not auth — public endpoint."""
     from app.errors import MCPOAuthStateError
 
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return None
+
     async def _fake_exchange_code(
         db: Any,
         *,
@@ -315,6 +327,7 @@ async def test_callback_no_bearer_reaches_handler(
         # Reaches the handler; state is bad → 400 (not 401).
         raise MCPOAuthStateError(message="unknown state")
 
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
     monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
 
     res = await anon_client.get(
@@ -467,3 +480,357 @@ async def test_disconnect_unauthed_returns_401(
     """No bearer token → 401 on DELETE."""
     res = await anon_client.delete(f"/api/v1/mcp/oauth/{_SERVER}")
     assert res.status_code == 401, res.text
+
+
+# ---------------------------------------------------------------------------
+# PR4d: is_allowed_return_url unit tests (validator correctness)
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_return_url_matching_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A return_url whose origin exactly matches an allowlisted origin → True."""
+    from app.config import Settings, is_allowed_return_url
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "https://app.example.com")
+    s = Settings()
+    assert is_allowed_return_url("https://app.example.com/oauth/callback", s) is True
+
+
+def test_allowed_return_url_different_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A return_url whose origin is NOT in the allowlist → False."""
+    from app.config import Settings, is_allowed_return_url
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "https://app.example.com")
+    s = Settings()
+    assert is_allowed_return_url("https://evil.example.com/steal", s) is False
+
+
+def test_allowed_return_url_different_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same host but different port is a different origin → False."""
+    from app.config import Settings, is_allowed_return_url
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "https://app.example.com")
+    s = Settings()
+    assert is_allowed_return_url("https://app.example.com:9000/callback", s) is False
+
+
+def test_allowed_return_url_empty_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty lq_ai_cors_origins → always False (fail closed)."""
+    from app.config import Settings, is_allowed_return_url
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "")
+    s = Settings()
+    assert is_allowed_return_url("https://app.example.com/callback", s) is False
+
+
+def test_allowed_return_url_non_http_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-http(s) scheme is rejected even if it would otherwise match."""
+    from app.config import Settings, is_allowed_return_url
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "javascript://app.example.com")
+    s = Settings()
+    assert is_allowed_return_url("javascript://app.example.com/evil", s) is False
+
+
+def test_allowed_return_url_http_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """http (non-TLS) origin is accepted when the operator explicitly allows it."""
+    from app.config import Settings, is_allowed_return_url
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "http://localhost:3000")
+    s = Settings()
+    assert is_allowed_return_url("http://localhost:3000/connect", s) is True
+
+
+# ---------------------------------------------------------------------------
+# PR4d: /authorize with return_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_authorize_with_allowed_return_url_stores_on_state_row(
+    authed_client: tuple[AsyncClient, str, User],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authed /authorize with an allowed return_url → 302 to AS AND state row stores return_url."""
+    ac, token, _user = authed_client
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "https://frontend.example.com")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    captured_state: dict[str, Any] = {}
+
+    async def _fake_build_authorize_url(
+        db: Any,
+        *,
+        user_id: Any,
+        server: str,
+        redirect_uri: str,
+        return_url: str | None = None,
+    ) -> str:
+        captured_state["return_url"] = return_url
+        return _AUTHORIZE_URL
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.build_authorize_url", _fake_build_authorize_url)
+
+    res = await ac.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/authorize",
+        params={"return_url": "https://frontend.example.com/connect"},
+        headers={"Authorization": f"Bearer {token}"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302, res.text
+    assert res.headers["location"] == _AUTHORIZE_URL
+    assert captured_state["return_url"] == "https://frontend.example.com/connect"
+
+    get_settings.cache_clear()
+
+
+@pytest.mark.integration
+async def test_authorize_with_disallowed_return_url_returns_400(
+    authed_client: tuple[AsyncClient, str, User],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disallowed return_url origin → 400, no state row written."""
+    ac, token, _user = authed_client
+
+    monkeypatch.setenv("LQ_AI_CORS_ORIGINS", "https://frontend.example.com")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    build_called = {"called": False}
+
+    async def _fake_build_authorize_url(db: Any, **_kwargs: Any) -> str:
+        build_called["called"] = True
+        return _AUTHORIZE_URL
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.build_authorize_url", _fake_build_authorize_url)
+
+    res = await ac.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/authorize",
+        params={"return_url": "https://evil.example.com/steal"},
+        headers={"Authorization": f"Bearer {token}"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 400, res.text
+    body = res.json()
+    assert body["detail"]["code"] == "validation_error"
+    # build_authorize_url must NOT have been called — no state row written.
+    assert not build_called["called"]
+
+    get_settings.cache_clear()
+
+
+@pytest.mark.integration
+async def test_authorize_without_return_url_state_row_return_url_is_none(
+    authed_client: tuple[AsyncClient, str, User],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No return_url query param → build_authorize_url called with return_url=None (back-compat)."""
+    ac, token, _user = authed_client
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_build_authorize_url(
+        db: Any,
+        *,
+        user_id: Any,
+        server: str,
+        redirect_uri: str,
+        return_url: str | None = None,
+    ) -> str:
+        captured["return_url"] = return_url
+        return _AUTHORIZE_URL
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.build_authorize_url", _fake_build_authorize_url)
+
+    res = await ac.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/authorize",
+        headers={"Authorization": f"Bearer {token}"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302, res.text
+    assert captured["return_url"] is None
+
+
+# ---------------------------------------------------------------------------
+# PR4d: callback with return_url (redirect branching)
+# ---------------------------------------------------------------------------
+
+_RETURN_URL = "https://frontend.example.com/connect"
+
+
+@pytest.mark.integration
+async def test_callback_success_with_return_url_redirects(
+    authed_client: tuple[AsyncClient, str, User],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Callback with return_url stored on state → 302 to return_url?mcp_connected=server."""
+    ac, _token, user = authed_client
+
+    state_val = "state-with-return-url"
+
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return _RETURN_URL
+
+    token_row = _make_token_row(user.id)
+
+    async def _fake_exchange_code(
+        db: Any,
+        *,
+        state: str,
+        code: str,
+        iss: str | None,
+    ) -> MCPOAuthToken:
+        return token_row
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
+
+    res = await ac.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/callback",
+        params={"code": "auth-code-123", "state": state_val},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302, res.text
+    location = res.headers["location"]
+    assert location.startswith(_RETURN_URL), f"Location={location!r}"
+    assert "mcp_connected=" in location
+    assert _SERVER in location
+
+    # Ensure no token/code/state material leaked into the redirect.
+    assert "auth-code-123" not in location
+    assert state_val not in location
+
+    # Audit row was written.
+    await db_session.rollback()
+    audit_rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.action == "mcp.oauth_connected",
+                    AuditLog.resource_id == _SERVER,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audit_rows) == 1
+
+
+@pytest.mark.integration
+async def test_callback_success_without_return_url_returns_200_json(
+    authed_client: tuple[AsyncClient, str, User],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Callback with no return_url on state → 200 JSON (back-compat preserved)."""
+    ac, _token, user = authed_client
+
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return None
+
+    token_row = _make_token_row(user.id)
+
+    async def _fake_exchange_code(
+        db: Any,
+        *,
+        state: str,
+        code: str,
+        iss: str | None,
+    ) -> MCPOAuthToken:
+        return token_row
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
+
+    res = await ac.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/callback",
+        params={"code": "c", "state": "s"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["connected"] is True
+    assert body["server"] == _SERVER
+
+
+@pytest.mark.integration
+async def test_callback_exchange_error_with_return_url_redirects_with_error(
+    anon_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exchange error with return_url → 302 to return_url?mcp_error=...&server=...; no secrets."""
+    from app.errors import MCPOAuthExchangeError
+
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return _RETURN_URL
+
+    async def _fake_exchange_code(
+        db: Any,
+        *,
+        state: str,
+        code: str,
+        iss: str | None,
+    ) -> MCPOAuthToken:
+        raise MCPOAuthExchangeError(
+            message="OAuth token exchange failed for 'acme-mcp': invalid_client",
+            details={"as_error": "invalid_client", "server": _SERVER},
+        )
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
+
+    res = await anon_client.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/callback",
+        params={"code": "bad-code", "state": "some-state"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302, res.text
+    location = res.headers["location"]
+    assert location.startswith(_RETURN_URL), f"Location={location!r}"
+    assert "mcp_error=" in location
+    assert "server=" in location
+    # Must NOT contain the code, state, or any secret in the redirect.
+    assert "bad-code" not in location
+    assert "some-state" not in location
+    # The error code is the stable slug — check it's present and non-empty.
+    assert "mcp_oauth_exchange_error" in location
+
+
+@pytest.mark.integration
+async def test_callback_unknown_state_no_return_url_returns_json_error(
+    anon_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown/expired state (return_url unrecoverable) → JSON error, not a redirect."""
+    from app.errors import MCPOAuthStateError
+
+    # State row not found → get_state_return_url returns None.
+    async def _fake_get_state_return_url(db: Any, *, state: str) -> str | None:
+        return None
+
+    async def _fake_exchange_code(
+        db: Any,
+        *,
+        state: str,
+        code: str,
+        iss: str | None,
+    ) -> MCPOAuthToken:
+        raise MCPOAuthStateError(message="unknown state")
+
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.get_state_return_url", _fake_get_state_return_url)
+    monkeypatch.setattr("app.api.mcp_oauth.oauth.exchange_code", _fake_exchange_code)
+
+    res = await anon_client.get(
+        f"/api/v1/mcp/oauth/{_SERVER}/callback",
+        params={"code": "c", "state": "nonexistent"},
+    )
+    assert res.status_code == 400, res.text
+    body = res.json()
+    assert body["detail"]["code"] == "mcp_oauth_state_error"

--- a/api/tests/test_mcp_service.py
+++ b/api/tests/test_mcp_service.py
@@ -167,22 +167,30 @@ async def test_refresh_none_bearer_server_passes_no_token(db_session, monkeypatc
 
 
 # ---------------------------------------------------------------------------
-# Original tests (unchanged, except that we patch list_mcp_oauth_config in the
-# respx-based tests so they still pass without a gateway /admin/v1/config route)
+# Original tests (updated to patch get_admin_config now that list_servers reads
+# the full config dict instead of calling list_tool_providers)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_list_servers_filters_mcp(monkeypatch) -> None:
-    async def fake_list(*, request_id=None):
-        return [{"name": "acme-mcp", "type": "mcp"}, {"name": "cl", "type": "courtlistener"}]
+    """list_servers returns only MCP-type providers WITH auth field populated."""
 
-    monkeypatch.setattr(
-        "app.mcp.service.get_gateway_client",
-        lambda: type("C", (), {"list_tool_providers": staticmethod(fake_list)})(),
-    )
+    async def _fake_get_admin_config(*, request_id=None):
+        return {
+            "tool_providers": [
+                {"name": "acme-mcp", "type": "mcp", "auth": "none"},
+                {"name": "cl", "type": "courtlistener"},
+            ]
+        }
+
+    class _FakeGW:
+        get_admin_config = staticmethod(_fake_get_admin_config)
+
+    monkeypatch.setattr("app.mcp.service.get_gateway_client", lambda: _FakeGW())
     servers = await service.list_servers()
     assert [s["name"] for s in servers] == ["acme-mcp"]
+    assert servers[0]["auth"] == "none"
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -206,6 +206,8 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/mcp/oauth/{server}/callback",
         "/api/v1/mcp/oauth/{server}/status",
         "/api/v1/mcp/oauth/{server}",
+        # PR4d Ask 1 — per-user OAuth connections list
+        "/api/v1/mcp/oauth",
     }
 )
 
@@ -314,7 +316,9 @@ async def test_openapi_paths_match_sketch() -> None:
     # /api/v1/mcp/oauth/{server}/callback
     # /api/v1/mcp/oauth/{server}/status
     # /api/v1/mcp/oauth/{server}
-    assert len(actual) == 131
+    # PR4d Ask 1 adds one new path (131 -> 132):
+    # /api/v1/mcp/oauth
+    assert len(actual) == 132
 
 
 @pytest.mark.unit

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -8103,6 +8103,7 @@ components:
         type: {type: string}
         auth:
           type: string
+          enum: [none, bearer, oauth]
           description: |
             Authentication mode for this MCP server. One of ``none``,
             ``bearer``, or ``oauth``. Read from the gateway config

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -5174,6 +5174,31 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/Error'}
 
+  # PR4d Ask 1 — per-user OAuth connections list
+  /api/v1/mcp/oauth:
+    get:
+      tags: [mcp-oauth]
+      summary: List OAuth connection status for all connectable MCP servers (per-user)
+      description: |
+        PR4d Ask 1. ActiveUser-gated (bearer). Returns one entry per
+        configured OAuth-type MCP server together with the calling user's
+        connection state (``connected``, ``scopes``, ``expires_at``).
+        Token bytes are never exposed. Results are ordered by server name
+        for stable output.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Per-user OAuth connection list
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/MCPOAuthServersResponse'}
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+
   # PR4c — per-user MCP OAuth surface
   /api/v1/mcp/oauth/{server}/authorize:
     parameters:
@@ -8072,10 +8097,16 @@ components:
 
     MCPServerView:
       type: object
-      required: [name, type, tools]
+      required: [name, type, auth, tools]
       properties:
         name: {type: string}
         type: {type: string}
+        auth:
+          type: string
+          description: |
+            Authentication mode for this MCP server. One of ``none``,
+            ``bearer``, or ``oauth``. Read from the gateway config
+            ``auth`` field; defaults to ``none`` when absent.
         tools:
           type: array
           items: {$ref: '#/components/schemas/MCPToolView'}
@@ -8130,6 +8161,34 @@ components:
           type: string
           format: date-time
           nullable: true
+
+    MCPOAuthServerStatus:
+      type: object
+      required: [server, connected, scopes]
+      description: |
+        PR4d Ask 1. Per-server OAuth connection status for a single user.
+        Token bytes are never included.
+      properties:
+        server: {type: string}
+        connected: {type: boolean}
+        scopes:
+          type: array
+          items: {type: string}
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    MCPOAuthServersResponse:
+      type: object
+      required: [servers]
+      description: |
+        PR4d Ask 1. Response body for GET /api/v1/mcp/oauth — list of all
+        connectable OAuth MCP servers with the calling user's connection state.
+      properties:
+        servers:
+          type: array
+          items: {$ref: '#/components/schemas/MCPOAuthServerStatus'}
 
     ProviderKeyStatus:
       type: object


### PR DESCRIPTION
## PR4d — per-user MCP OAuth UX surface (make PR4c consumable from a frontend/BFF)

Three small additions so Donna's BFF (and any browser frontend) can surface the per-user MCP OAuth flow shipped in PR4c (#170). The PR4c auth posture is **unchanged** (authorize/status/disconnect = `ActiveUser`; callback = public, bound by the single-use `state` row). Filed in response to Donna's ask doc (2026-06-18).

### ⚠️ Security-review surface
The `return_url` (Ask 2) adds a browser redirect off the OAuth callback → an open-redirect surface. It's gated on an operator allowlist; see the invariants below.

### Ask 2 (the security core) — allowlisted `return_url` on `/authorize`
- `/authorize` accepts an optional `return_url`. It's validated at authorize-time against the operator's existing **`lq_ai_cors_origins`** allowlist (**exact-origin** match — scheme+host+port; rejects userinfo-smuggling / scheme-relative / `javascript:`/`data:` / substring evasions; **fail-closed** on an empty allowlist) and **stored server-side** on the single-use, TTL'd `mcp_oauth_state` row (migration **0052**).
- The public callback reads `return_url` **from the state row, never from its own query string**, and 302-redirects the browser back: success → `{return_url}?mcp_connected={server}`, error → `{return_url}?mcp_error={code}&server={server}` (a non-secret error slug — no code/state/token ever appears). Existing query/fragment on the `return_url` are preserved correctly.
- **Back-compat:** when no `return_url` is supplied, the callback returns today's 200 JSON unchanged.

### Ask 1 — `GET /api/v1/mcp/oauth` (ActiveUser) per-user connections list
Returns `{servers: [{server, connected, scopes, expires_at}]}` for the configured oauth-type MCP servers, with the **calling user's** connection state — the list-shaped sibling of `/{server}/status`, no admin access needed, **no token bytes** returned. Lets Donna render a "Connections" view.

### Ask 3 — `auth` on `MCPServerView`
`MCPServerView.auth: "none" | "bearer" | "oauth"` (read from the gateway admin config), so the admin `/settings/mcp` page can label which servers need a per-user connection. `list_tool_providers` is untouched (other callers depend on its stripped shape).

### Tests / gates
- Full **api suite: 2109 passed, 1 skipped**; `ruff format --check` + `ruff check` clean; `mypy app` clean. **api-only** — no `gateway/` or `web/` changes.
- Built subagent-driven (2 tasks + fixes), each spec- + quality-reviewed; the `return_url` security core got a focused review; **opus whole-branch review verdict: ready to merge** (no Critical/Important — open-redirect boundary verified bypass-resistant; no secret in any redirect; auth posture unchanged; migration 0052 linear; collision guards `EXPECTED_PATHS` 131→132).

### Notes
- `EXPECTED_PATHS` 131 → **132** (the new list endpoint); migration head **0051 → 0052**.
- Operators using a BFF set `lq_ai_cors_origins` to their frontend origin(s) (the same list that already governs CORS); `return_url` is validated against it.
- This unblocks **connect-on-demand in chat** (PR5b): when a chat tool-call hits an `auth: oauth` server with no token, the loop emits `mcp_authorization_required {server, authorize_url}` and the browser round-trips back via `return_url` (added to the PR5 spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
