### PR TITLE
PR5a/WS4: tool-governance substrate + autonomous tool intents (tool_call_log + governed_tool_invocation + retrieve_caselaw/call_mcp_tool)

### DIFF
--- a/api/alembic/versions/0053_tool_call_log.py
+++ b/api/alembic/versions/0053_tool_call_log.py
@@ -1,0 +1,83 @@
+"""tool_call_log — per-call governance audit for chat and autonomous tool calls
+
+One row per governed tool call (PR5a).  Records counts/types only —
+NEVER raw arguments or tool results (mirrors ``tool_egress_log`` discipline).
+
+``origin`` distinguishes chat-triggered from autonomous-triggered calls.
+``user_id`` FK cascades so deleting a user erases their audit rows.
+``outcome`` progresses: pending → executed | refused_tier | error | denied.
+
+Revision ID: 0053
+Revises: 0052
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0053"
+down_revision: str | None = "0052"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tool_call_log",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("origin", sa.Text(), nullable=False),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE", name="fk_tool_call_log_user"),
+            nullable=True,
+        ),
+        sa.Column("chat_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("message_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("intent", sa.Text(), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("tool", sa.Text(), nullable=False),
+        sa.Column("tier", sa.Integer(), nullable=False),
+        sa.Column(
+            "confirmation_state",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'not_required'"),
+        ),
+        sa.Column("outcome", sa.Text(), nullable=False),
+        sa.Column("cost_usd", sa.Numeric(12, 6), nullable=True),
+        sa.Column("args_digest", sa.Text(), nullable=True),
+        sa.Column("request_id", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_tool_call_log_user_id", "tool_call_log", ["user_id"])
+    op.create_index("ix_tool_call_log_created_at", "tool_call_log", ["created_at"])
+    op.create_index("ix_tool_call_log_provider", "tool_call_log", ["provider"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tool_call_log_provider", table_name="tool_call_log")
+    op.drop_index("ix_tool_call_log_created_at", table_name="tool_call_log")
+    op.drop_index("ix_tool_call_log_user_id", table_name="tool_call_log")
+    op.drop_table("tool_call_log")

--- a/api/app/autonomous/cost.py
+++ b/api/app/autonomous/cost.py
@@ -15,6 +15,11 @@ Cost model (per M4 implementation plan)
   with no provider inference; marginal cost is zero for R4 pre-flight
   purposes (``emit_artifact`` writes storage + DB rows but burns no
   provider tokens, exactly like ``emit_finding``).
+* ``retrieve_caselaw`` / ``call_mcp_tool`` — gateway-brokered external
+  lookups (PR5a, granted at analysis phase per D-a4); they burn no
+  provider-inference tokens so marginal cost is zero (D-a3). A real
+  per-provider tool-cost model that accounts for CourtListener API fees
+  and MCP provider charges is deferred to DE-344.
 
 Usage::
 
@@ -55,9 +60,11 @@ async def estimate_tool_cost(
 
     All other intents (``retrieve_chunks``, ``propose_memory``,
     ``propose_precedent``, ``emit_finding``, ``emit_artifact``,
-    ``notify``) are local-only operations with no provider inference;
-    this function returns :data:`decimal.Decimal` ``"0"`` for them
-    without querying the DB.
+    ``notify``, ``retrieve_caselaw``, ``call_mcp_tool``) are
+    local-only or gateway-brokered operations with no provider
+    inference; this function returns :data:`decimal.Decimal` ``"0"``
+    for them without querying the DB. A per-provider cost model for
+    ``retrieve_caselaw`` and ``call_mcp_tool`` is deferred to DE-344.
 
     Args:
         intent: The :class:`~app.autonomous.enums.ToolIntent` being considered.

--- a/api/app/autonomous/enums.py
+++ b/api/app/autonomous/enums.py
@@ -49,6 +49,8 @@ class ToolIntent(StrEnum):
     emit_finding = "emit_finding"
     emit_artifact = "emit_artifact"
     notify = "notify"
+    retrieve_caselaw = "retrieve_caselaw"
+    call_mcp_tool = "call_mcp_tool"
 
 
 PHASE_GRANTS: dict[Phase, frozenset[ToolIntent]] = {
@@ -61,6 +63,10 @@ PHASE_GRANTS: dict[Phase, frozenset[ToolIntent]] = {
             # propose_precedent at analysis: document/clause patterns are
             # observed while reading docs (M4-B2, Decision B2-b).
             ToolIntent.propose_precedent,
+            # retrieve_caselaw + call_mcp_tool: gateway-brokered external
+            # lookups; granted at analysis only (PR5a D-a4).
+            ToolIntent.retrieve_caselaw,
+            ToolIntent.call_mcp_tool,
         }
     ),
     Phase.drafting: frozenset(

--- a/api/app/autonomous/guard.py
+++ b/api/app/autonomous/guard.py
@@ -625,9 +625,11 @@ async def _handle_call_mcp_tool(
     **ADR 0015 D4 enforcement (FIRST, before any gateway call):** load the
     cached :class:`~app.models.mcp.MCPToolCache` row for
     ``(params["provider"], params["tool"])``.  If the row is **missing**, or
-    its ``destructive`` is true, or its ``requires_confirmation`` is true,
-    raise :exc:`~app.errors.ToolNotGranted` and make NO gateway call — the
-    autonomous layer in v1 NEVER fires a human-gated or unknown tool.
+    its ``destructive`` is true, or its ``requires_confirmation`` is true, or
+    its ``enabled`` is false (operator-disabled toggle), raise
+    :exc:`~app.errors.ToolNotGranted` and make NO gateway call — the
+    autonomous layer in v1 NEVER fires a human-gated, operator-disabled, or
+    unknown tool.
 
     Otherwise call the gateway's
     :meth:`~app.clients.gateway.GatewayClient.call_tool` with no per-user
@@ -641,8 +643,9 @@ async def _handle_call_mcp_tool(
     Zero cost in v1 (D-a3 / DE-344).
 
     Raises:
-        ToolNotGranted: the tool is unknown to the cache, ``destructive``, or
-            ``requires_confirmation`` (D4 — no gateway call is made).
+        ToolNotGranted: the tool is unknown to the cache, ``destructive``,
+            ``requires_confirmation``, or operator-disabled (``enabled=False``)
+            (D4 — no gateway call is made).
     """
     provider = str(params["provider"])
     tool = str(params["tool"])
@@ -652,14 +655,16 @@ async def _handle_call_mcp_tool(
     from app.models.mcp import MCPToolCache
 
     cached = await db.get(MCPToolCache, (provider, tool))
-    if cached is None or cached.destructive or cached.requires_confirmation:
+    if cached is None or cached.destructive or cached.requires_confirmation or not cached.enabled:
         # Counts/types only in the reason — never the args.
         if cached is None:
             reason = "tool_not_cached"
         elif cached.destructive:
             reason = "destructive"
-        else:
+        elif cached.requires_confirmation:
             reason = "requires_confirmation"
+        else:
+            reason = "tool_disabled"
         raise ToolNotGranted(
             "MCP tool refused for the autonomous layer (D4)",
             intent=str(ToolIntent.call_mcp_tool),
@@ -668,6 +673,8 @@ async def _handle_call_mcp_tool(
         )
 
     # ── gateway call — no per-user OAuth token (D-a5) ───────────────────────
+    # call_tool carries no per-user token (D-a5); auth:oauth MCP servers
+    # therefore fail at the gateway.
     from app.clients.gateway import get_gateway_client
 
     result = await get_gateway_client().call_tool(provider, tool, args, max_allowed_tier=None)

--- a/api/app/autonomous/guard.py
+++ b/api/app/autonomous/guard.py
@@ -378,6 +378,7 @@ async def _governed_external_dispatch(
         user_id=session.user_id,
         session_id=session.id,
         args_digest=_args_digest(params),
+        denied_on=(ToolNotGranted,),  # D4 policy refusals → outcome="denied", not "error"
     )
 
 

--- a/api/app/autonomous/guard.py
+++ b/api/app/autonomous/guard.py
@@ -72,6 +72,8 @@ and what the session is charged.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import uuid
 from dataclasses import dataclass, field
@@ -110,6 +112,29 @@ _DEFAULT_RETRIEVE_ALPHA: float = 0.5
 # content is clamped (truncated, flagged in the result data) rather than
 # rejected — a partial memo in the KB beats a lost run.
 _ARTIFACT_MAX_CHARS: int = 1_000_000
+
+# External-tool intents (PR5a): these reach OUTSIDE the operator's environment
+# through the gateway, so they are governed per-call by
+# ``governed_tool_invocation`` (a ``tool_call_log`` row + the egress-tier
+# pre-check + span annotation). Every OTHER intent is a local write or a local
+# retrieval and stays on ``autonomous_audit`` only — no ``tool_call_log`` noise.
+_EXTERNAL_TOOL_INTENTS: frozenset[ToolIntent] = frozenset(
+    {ToolIntent.retrieve_caselaw, ToolIntent.call_mcp_tool}
+)
+
+
+def _args_digest(params: dict[str, Any]) -> str:
+    """Return a short, stable digest of *params* for the audit row.
+
+    COUNTS/TYPES ONLY — never the raw args. The digest is a sha256 over a
+    canonical (sorted-key) JSON projection of the param TYPES and the
+    top-level KEY NAMES, never the values; values that are not JSON-stable
+    fall back to their type name. Truncated to 16 hex chars — enough to
+    correlate two identical calls without ever reconstructing the payload.
+    """
+    shape = {k: type(v).__name__ for k, v in sorted(params.items())}
+    blob = json.dumps(shape, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
 
 @dataclass
@@ -234,9 +259,30 @@ async def guarded_tool_call(
 
         # ── dispatch ────────────────────────────────────────────────────────
         await autonomous_audit(db, session, "tool_call", tool=str(intent), outcome="started")
-        result = await _dispatch(
-            intent, params, gateway=gateway, db=db, session=session, estimated_cost=estimate
-        )
+        if intent in _EXTERNAL_TOOL_INTENTS:
+            # External tools reach outside the operator's environment via the
+            # gateway, so they flow through the shared governance substrate:
+            # a tool_call_log row + the egress-tier pre-check + span
+            # annotation. The single R4 estimate computed above is forwarded
+            # as estimated_cost — the helper NEVER re-estimates (single-estimate
+            # invariant). The dispatch closure runs the same per-intent handler
+            # every other intent uses; this only ADDS the external-tool audit.
+            result = await _governed_external_dispatch(
+                intent,
+                params,
+                db=db,
+                session=session,
+                gateway=gateway,
+                estimate=estimate,
+                span=span,
+            )
+        else:
+            # Local writes (emit_finding/propose_memory/…) and local retrieval
+            # (retrieve_chunks) are NOT external tool calls — they stay on
+            # autonomous_audit only, exactly as before. No tool_call_log row.
+            result = await _dispatch(
+                intent, params, gateway=gateway, db=db, session=session, estimated_cost=estimate
+            )
 
         # ── record cost + outcome ────────────────────────────────────────────
         session.cost_total_usd += result.cost_usd
@@ -257,6 +303,82 @@ async def guarded_tool_call(
             cost_usd=float(result.cost_usd),
         )
         return result
+
+
+async def _resolve_external_call(intent: ToolIntent, params: dict[str, Any]) -> tuple[str, str]:
+    """Resolve the ``(provider, tool)`` marker for a governed external call.
+
+    For ``retrieve_caselaw`` the provider is the configured CourtListener
+    provider name (resolved via the research service's provider-resolution
+    helper — PR3b retired the hardcoded name) and the ``tool`` is the research
+    op (e.g. ``"search_case_law"``).  For ``call_mcp_tool`` the provider/tool
+    come straight from the params the model supplied.
+
+    These markers are the ``provider``/``tool`` columns on the ``tool_call_log``
+    row and the key into ``resolve_provider_tier`` — counts/types only, never
+    raw args.
+    """
+    if intent == ToolIntent.retrieve_caselaw:
+        from app.research import service as research_service
+
+        provider = await research_service._resolve_provider()
+        op = str(params.get("op") or "")
+        return provider, op
+    if intent == ToolIntent.call_mcp_tool:
+        return str(params["provider"]), str(params["tool"])
+    raise ValueError(f"_resolve_external_call: not an external intent {intent!r}")
+
+
+async def _governed_external_dispatch(
+    intent: ToolIntent,
+    params: dict[str, Any],
+    *,
+    db: AsyncSession,
+    session: AutonomousSession,
+    gateway: Any,
+    estimate: Decimal,
+    span: Any,
+) -> ToolResult:
+    """Route an external-tool intent through ``governed_tool_invocation``.
+
+    Resolves ``provider``/``tool`` + ``provider_tier``, then delegates the
+    tier-check → ``tool_call_log`` row → dispatch → record primitives to the
+    shared helper, annotating the caller-owned ``autonomous.tool_call`` span
+    (D-a1).  The ``estimate`` from R4 is forwarded verbatim as
+    ``estimated_cost`` (single-estimate invariant — the helper never
+    re-estimates).  ``max_allowed_tier=None`` because an
+    :class:`~app.models.autonomous.AutonomousSession` carries no per-session
+    tier ceiling in v1 (the gateway still enforces the ceiling on the actual
+    call — defence in depth).  ``origin="autonomous"`` and there is no
+    per-user OAuth token (D-a5).
+    """
+    # Local import: governance.py imports ToolResult from this module, so a
+    # top-level import here would be circular.
+    from app.tools.governance import governed_tool_invocation, resolve_provider_tier
+
+    provider, tool = await _resolve_external_call(intent, params)
+    provider_tier = await resolve_provider_tier(provider)
+
+    async def _dispatch_closure() -> ToolResult:
+        return await _dispatch(
+            intent, params, gateway=gateway, db=db, session=session, estimated_cost=estimate
+        )
+
+    return await governed_tool_invocation(
+        db,
+        origin="autonomous",
+        provider=provider,
+        tool=tool,
+        intent=intent,
+        provider_tier=provider_tier,
+        max_allowed_tier=None,  # AutonomousSession has no tier ceiling in v1
+        estimated_cost=estimate,  # single-estimate — forwarded, never re-estimated
+        dispatch=_dispatch_closure,
+        span=span,
+        user_id=session.user_id,
+        session_id=session.id,
+        args_digest=_args_digest(params),
+    )
 
 
 async def _dispatch(
@@ -428,8 +550,127 @@ async def _dispatch(
             intent, params, gateway=gateway, estimated_cost=estimated_cost
         )
 
+    if intent == ToolIntent.retrieve_caselaw:
+        return await _handle_retrieve_caselaw(params, db=db)
+
+    if intent == ToolIntent.call_mcp_tool:
+        return await _handle_call_mcp_tool(params, db=db)
+
     # Should be unreachable: PHASE_GRANTS + R6 prevent unknown intents.
     raise ValueError(f"_dispatch: unhandled intent {intent!r}")
+
+
+async def _handle_retrieve_caselaw(
+    params: dict[str, Any],
+    *,
+    db: AsyncSession,
+) -> ToolResult:
+    """Handle ``retrieve_caselaw`` — gateway-brokered case-law research (PR5a).
+
+    Routes ``params["op"]`` to the already-built research service
+    (:mod:`app.research.service`, ADR 0014: the backend never calls
+    CourtListener directly — every op goes through the gateway):
+
+    - ``verify_citations`` → ``{text}``
+    - ``search_case_law``  → ``{args}`` (or the remaining params as the search args)
+    - ``get_cluster``      → ``{cluster_id}``
+    - ``read_opinion``     → ``{opinion_id}``
+    - ``find_in_case``     → ``{opinion_id, query[, max_matches]}``
+
+    Zero cost in v1 (D-a3: no provider-inference tokens; a per-provider
+    external-tool cost model is DE-344).  The provider/tool/tier audit was
+    already written by ``governed_tool_invocation``; this handler only does
+    the call.
+
+    Raises:
+        ValueError: if ``op`` is missing or not a recognised research op.
+            (Unreachable via the executor, which only emits valid ops.)
+    """
+    from app.research import service as research_service
+
+    op = str(params.get("op") or "")
+    if op == "verify_citations":
+        data = await research_service.verify_citations(params["text"])
+    elif op == "search_case_law":
+        args = params.get("args")
+        if args is None:
+            args = {k: v for k, v in params.items() if k != "op"}
+        data = await research_service.search_case_law(args)
+    elif op == "get_cluster":
+        data = await research_service.get_cluster(db, cluster_id=int(params["cluster_id"]))
+    elif op == "read_opinion":
+        data = await research_service.read_opinion(db, opinion_id=int(params["opinion_id"]))
+    elif op == "find_in_case":
+        matches = await research_service.find_in_case(
+            db,
+            opinion_id=int(params["opinion_id"]),
+            query=str(params["query"]),
+            max_matches=int(params.get("max_matches", 3)),
+        )
+        data = {"matches": matches}
+    else:
+        raise ValueError(f"_handle_retrieve_caselaw: unknown research op {op!r}")
+
+    return ToolResult(cost_usd=Decimal("0"), data=data)
+
+
+async def _handle_call_mcp_tool(
+    params: dict[str, Any],
+    *,
+    db: AsyncSession,
+) -> ToolResult:
+    """Handle ``call_mcp_tool`` — a gateway-brokered MCP tool call (PR5a).
+
+    **ADR 0015 D4 enforcement (FIRST, before any gateway call):** load the
+    cached :class:`~app.models.mcp.MCPToolCache` row for
+    ``(params["provider"], params["tool"])``.  If the row is **missing**, or
+    its ``destructive`` is true, or its ``requires_confirmation`` is true,
+    raise :exc:`~app.errors.ToolNotGranted` and make NO gateway call — the
+    autonomous layer in v1 NEVER fires a human-gated or unknown tool.
+
+    Otherwise call the gateway's
+    :meth:`~app.clients.gateway.GatewayClient.call_tool` with no per-user
+    OAuth token (D-a5: the autonomous layer has no interactive user; an
+    ``auth: oauth`` MCP server therefore raises
+    :exc:`~app.errors.MCPAuthorizationRequired` from the gateway adapter,
+    which is left to propagate — correct, autonomous cannot use per-user-OAuth
+    servers).  ``max_allowed_tier=None`` (no per-session ceiling in v1; the
+    gateway still enforces its configured ceiling).
+
+    Zero cost in v1 (D-a3 / DE-344).
+
+    Raises:
+        ToolNotGranted: the tool is unknown to the cache, ``destructive``, or
+            ``requires_confirmation`` (D4 — no gateway call is made).
+    """
+    provider = str(params["provider"])
+    tool = str(params["tool"])
+    args: dict[str, Any] = params.get("args") or {}
+
+    # ── D4: load cached metadata FIRST; refuse before any gateway call ──────
+    from app.models.mcp import MCPToolCache
+
+    cached = await db.get(MCPToolCache, (provider, tool))
+    if cached is None or cached.destructive or cached.requires_confirmation:
+        # Counts/types only in the reason — never the args.
+        if cached is None:
+            reason = "tool_not_cached"
+        elif cached.destructive:
+            reason = "destructive"
+        else:
+            reason = "requires_confirmation"
+        raise ToolNotGranted(
+            "MCP tool refused for the autonomous layer (D4)",
+            intent=str(ToolIntent.call_mcp_tool),
+            phase="analysis",
+            details={"provider": provider, "tool": tool, "reason": reason},
+        )
+
+    # ── gateway call — no per-user OAuth token (D-a5) ───────────────────────
+    from app.clients.gateway import get_gateway_client
+
+    result = await get_gateway_client().call_tool(provider, tool, args, max_allowed_tier=None)
+    return ToolResult(cost_usd=Decimal("0"), data=result.get("payload"))
 
 
 def _sanitize_artifact_name(raw: Any) -> str:

--- a/api/app/errors.py
+++ b/api/app/errors.py
@@ -97,6 +97,7 @@ CODE_SKILL_INPUT_MISSING = "skill_input_missing"
 CODE_AUTONOMOUS_HALTED = "autonomous_halted"
 CODE_AUTONOMOUS_TOOL_NOT_GRANTED = "autonomous_tool_not_granted"
 CODE_AUTONOMOUS_COST_CAP_REACHED = "autonomous_cost_cap_reached"
+CODE_TOOL_TIER_REFUSED = "tool_tier_refused"
 
 
 # --- Base class --------------------------------------------------------------
@@ -384,6 +385,40 @@ class CostCapReached(AutonomousBrake):
         super().__init__(message, details=merged, http_status=http_status, code=code)
 
 
+class ToolTierRefused(LQAIError):
+    """A tool call was refused because the provider's egress tier exceeds the
+    caller's ceiling (PR5a D-a2).
+
+    Raised by :func:`~app.tools.governance.governed_tool_invocation` when
+    ``provider_tier > max_allowed_tier``.  An audit row with
+    ``outcome="refused_tier"`` is written before the raise so the refusal
+    is always persisted regardless of how the caller handles the exception.
+
+    Carries ONLY tier integers — no args or result payload.  Maps to 403
+    (the tier ceiling is an authorization boundary, not a server error).
+    """
+
+    code = CODE_TOOL_TIER_REFUSED
+    http_status = status.HTTP_403_FORBIDDEN
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        tool: str,
+        tier: int,
+        ceiling: int,
+    ) -> None:
+        message = (
+            f"Tool call refused: provider '{provider}' tool '{tool}' "
+            f"requires tier {tier} but ceiling is {ceiling}"
+        )
+        super().__init__(
+            message,
+            details={"provider": provider, "tool": tool, "tier": tier, "ceiling": ceiling},
+        )
+
+
 # --- Gateway-crossing subclasses ---------------------------------------------
 # Raised by the GatewayClient (or by handlers that translate gateway
 # responses) when the backend↔gateway hop fails or surfaces a structured
@@ -610,6 +645,7 @@ __all__ = [
     "CODE_SKILL_INPUT_MISSING",
     "CODE_SKILL_NOT_FOUND",
     "CODE_TIER_BELOW_MINIMUM",
+    "CODE_TOOL_TIER_REFUSED",
     "CODE_UNAUTHORIZED",
     "CODE_VALIDATION_ERROR",
     "AutonomousBrake",
@@ -639,6 +675,7 @@ __all__ = [
     "SkillNotFound",
     "TierBelowMinimum",
     "ToolNotGranted",
+    "ToolTierRefused",
     "Unauthorized",
     "ValidationError",
     "map_gateway_error_code",

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -37,6 +37,7 @@ from app.models.slack_workspace import SlackWorkspace
 from app.models.tabular import TabularExecution
 from app.models.team import Team, TeamMember
 from app.models.teams_tenant import TeamsTenant
+from app.models.tool_call_log import ToolCallLog
 from app.models.tool_egress import ToolEgressLog
 from app.models.user import User, UserSession
 from app.models.user_export import UserExportJob
@@ -79,6 +80,7 @@ __all__ = [
     "Team",
     "TeamMember",
     "TeamsTenant",
+    "ToolCallLog",
     "ToolEgressLog",
     "User",
     "UserExportJob",

--- a/api/app/models/tool_call_log.py
+++ b/api/app/models/tool_call_log.py
@@ -1,0 +1,110 @@
+"""ORM model for the tool-call governance audit log (PR5a).
+
+One row per governed tool call — chat or autonomous origin. Records
+counts/types only: provider, tool, tier, outcome, estimated cost, a
+short args digest.  NEVER stores raw arguments or tool results (mirrors
+``tool_egress_log`` discipline).
+
+``confirmation_state`` tracks the human-gate lifecycle for calls that
+require confirmation before execution.  ``outcome`` progresses from
+``pending`` → ``executed`` | ``refused_tier`` | ``error`` | ``denied``.
+
+The ``user_id`` FK cascades so that deleting a user removes their audit
+rows (GDPR erasure path).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ToolCallLog(Base):
+    """Per-call governance audit log — counts/types only, never raw payloads."""
+
+    __tablename__ = "tool_call_log"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    origin: Mapped[str] = mapped_column(Text, nullable=False)
+    """'chat' | 'autonomous' — which execution context fired the tool."""
+
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE", name="fk_tool_call_log_user"),
+        nullable=True,
+    )
+    """FK to users.id; NULL when the call originates from a headless job."""
+
+    chat_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    """Set for chat-origin calls; NULL for autonomous."""
+
+    message_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    """Chat message that triggered this call; NULL for autonomous."""
+
+    session_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    """Autonomous session id; NULL for chat-origin calls."""
+
+    intent: Mapped[str | None] = mapped_column(Text, nullable=True)
+    """ToolIntent value for autonomous calls; NULL for chat-origin marker."""
+
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    """Logical provider name from gateway config (e.g. 'courtlistener')."""
+
+    tool: Mapped[str] = mapped_column(Text, nullable=False)
+    """Tool / function name within the provider."""
+
+    tier: Mapped[int] = mapped_column(Integer, nullable=False)
+    """Provider egress tier (0-5) at call time."""
+
+    confirmation_state: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default=text("'not_required'"),
+    )
+    """not_required | pending_confirmation | approved | denied."""
+
+    outcome: Mapped[str] = mapped_column(Text, nullable=False)
+    """pending | executed | refused_tier | error | denied."""
+
+    cost_usd: Mapped[Decimal | None] = mapped_column(
+        Numeric(12, 6),
+        nullable=True,
+    )
+    """Estimated / actual cost in USD.  Serialised as a JSON string per the
+    project-wide Decimal-as-string convention (CLAUDE.md)."""
+
+    args_digest: Mapped[str | None] = mapped_column(Text, nullable=True)
+    """Short hash/summary of the call arguments — NEVER raw args."""
+
+    request_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    """Propagated request-id for cross-service trace correlation."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    """App-bumped on every state transition (pending → executed/error/denied)."""
+
+    def __repr__(self) -> str:
+        return (
+            f"<ToolCallLog id={self.id} origin={self.origin!r}"
+            f" provider={self.provider!r} tool={self.tool!r}"
+            f" outcome={self.outcome!r}>"
+        )

--- a/api/app/tools/__init__.py
+++ b/api/app/tools/__init__.py
@@ -1,0 +1,7 @@
+"""Tool-governance package (PR5a).
+
+The :mod:`app.tools.governance` module provides the shared
+``governed_tool_invocation`` helper — the security-critical per-call
+governance substrate consumed by both the chat loop (PR5b) and the
+autonomous layer (Task 4).
+"""

--- a/api/app/tools/governance.py
+++ b/api/app/tools/governance.py
@@ -152,6 +152,7 @@ async def governed_tool_invocation(
     session_id: UUID | None = None,
     request_id: str | None = None,
     args_digest: str | None = None,
+    denied_on: tuple[type[Exception], ...] = (),
 ) -> ToolResult:
     """Shared per-call governance: tier-check → audit row → dispatch → record.
 
@@ -194,6 +195,16 @@ async def governed_tool_invocation(
         request_id: Cross-service trace correlation header value.
         args_digest: A short hash/summary of the call arguments produced
             by the caller.  NEVER the raw args.
+        denied_on: A tuple of exception types (supplied by the caller)
+            that represent a **policy refusal** rather than a tool
+            failure.  When ``dispatch`` raises an exception that is an
+            instance of one of these types, the audit row is labeled
+            ``outcome="denied"`` instead of ``outcome="error"`` before
+            the exception is re-raised.  Passing the empty tuple
+            (default) preserves the existing behaviour: all dispatch
+            exceptions → ``"error"``.  Callers pass the specific
+            exception classes — this module never imports autonomous
+            symbols directly (no circular-import risk).
 
     Returns:
         The :class:`~app.autonomous.guard.ToolResult` from ``dispatch``.
@@ -204,7 +215,9 @@ async def governed_tool_invocation(
             ``outcome="refused_tier"`` is written and flushed before
             the raise.
         Any exception raised by ``dispatch`` is re-raised after updating
-        the audit row to ``outcome="error"`` and flushing.
+        the audit row to ``outcome="denied"`` (if the exception type is
+        listed in ``denied_on``) or ``outcome="error"`` (all other
+        exceptions) and flushing.
     """
     # ── D-a2 tier check ────────────────────────────────────────────────────
     if max_allowed_tier is not None and provider_tier > max_allowed_tier:
@@ -266,15 +279,16 @@ async def governed_tool_invocation(
     # ── Dispatch ────────────────────────────────────────────────────────────
     try:
         result = await dispatch()
-    except Exception:
-        row.outcome = "error"
+    except Exception as exc:
+        outcome = "denied" if (denied_on and isinstance(exc, denied_on)) else "error"
+        row.outcome = outcome
         row.updated_at = datetime.now(UTC)
         await db.flush()
         if span is not None:
             record_attributes(
                 span,
                 **{
-                    "tool_call.outcome": "error",
+                    "tool_call.outcome": outcome,
                     "tool_call.provider": provider,
                     "tool_call.tool": tool,
                     "tool_call.tier": provider_tier,

--- a/api/app/tools/governance.py
+++ b/api/app/tools/governance.py
@@ -1,0 +1,301 @@
+"""Per-call tool-governance substrate — PR5a Task 2.
+
+Provides the shared ``governed_tool_invocation`` helper that BOTH the
+chat loop (PR5b) and the autonomous layer use for every external tool
+call.  The helper enforces:
+
+1. **Tier check (D-a2):** api-side pre-flight check against the caller's
+   supplied ceiling.  A refusal writes a ``refused_tier`` audit row and
+   raises :exc:`~app.errors.ToolTierRefused` — dispatch is never called.
+
+2. **Audit row:** writes a ``tool_call_log`` row with ``outcome="pending"``
+   before dispatch (counts/types only — no raw args or results, ever).
+
+3. **Dispatch:** runs the caller-supplied closure; updates the row to
+   ``outcome="executed"`` on success or ``outcome="error"`` on exception.
+
+4. **OTel annotation (D-a1):** annotates the *caller's* span (if
+   provided) with counts/types.  Does NOT open its own span.
+
+5. **Flush-not-commit:** all DB mutations go through ``db.flush()``.
+   The caller (chat handler / executor) owns the commit boundary.
+
+Security invariants (enforced, never relaxed):
+
+- Raw args and tool results are NEVER written to any DB row or log
+  statement.  Only ``args_digest`` (a caller-supplied short hash) and
+  outcome labels flow into the audit row.
+- Estimated cost is accepted as a parameter; the helper never calls
+  ``estimate_tool_cost`` itself (single-estimate invariant, prevents
+  double-charge / divergence).
+- ``resolve_provider_tier`` fails safe to the **most-restrictive tier**
+  (5) when the gateway config is absent or the provider is not found.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.enums import ToolIntent
+from app.autonomous.guard import ToolResult
+from app.clients.gateway import get_gateway_client
+from app.errors import ToolTierRefused
+from app.models.tool_call_log import ToolCallLog
+from app.observability_helpers import record_attributes
+
+log = logging.getLogger(__name__)
+
+# The most-restrictive egress tier — used as a fail-safe when the
+# provider is missing from the gateway config (D-a2: fail restrictive).
+_MAX_TIER: int = 5
+
+# Process-level cache: provider name → egress_tier.
+# Gateway config is treated as immutable per process lifetime (same
+# lifecycle as GatewayClient's citation-engine cache).
+_provider_tier_cache: dict[str, int] = {}
+_provider_tier_cache_loaded: bool = False
+
+
+async def resolve_provider_tier(
+    provider: str,
+    *,
+    request_id: str | None = None,
+) -> int:
+    """Return the configured egress tier for *provider*.
+
+    Reads ``GET /admin/v1/config`` via :func:`~app.clients.gateway.get_gateway_client`
+    once per process and caches the entire ``tool_providers`` map.
+    On any failure (network, non-200, missing key) returns ``_MAX_TIER``
+    (5) — the most-restrictive tier — so the system fails safe rather
+    than failing open.
+
+    Args:
+        provider: The logical provider name as it appears in
+            ``gateway.yaml`` (e.g. ``"courtlistener-prod"``).
+        request_id: Optional request-id for cross-service trace
+            correlation.
+
+    Returns:
+        The provider's ``egress_tier`` (int 0-5), or ``_MAX_TIER`` (5)
+        when the provider is absent or the lookup fails.
+    """
+    global _provider_tier_cache_loaded
+
+    if not _provider_tier_cache_loaded:
+        await _load_provider_tier_cache(request_id=request_id)
+
+    return _provider_tier_cache.get(provider, _MAX_TIER)
+
+
+async def _load_provider_tier_cache(*, request_id: str | None = None) -> None:
+    """Populate the process-level provider-tier cache from gateway config.
+
+    Best-effort: any exception leaves the cache empty (all lookups then
+    fall back to ``_MAX_TIER``).  Marks the cache as loaded regardless
+    so a repeated broken gateway is not re-polled on every call.
+    """
+    global _provider_tier_cache_loaded
+
+    try:
+        config = await get_gateway_client().get_admin_config(request_id=request_id)
+        providers = config.get("tool_providers") or []
+        for entry in providers:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            tier_raw = entry.get("egress_tier")
+            if name and tier_raw is not None:
+                with contextlib.suppress(TypeError, ValueError):
+                    _provider_tier_cache[str(name)] = int(tier_raw)
+    except Exception:
+        log.warning(
+            "resolve_provider_tier: gateway config fetch failed; "
+            "all providers default to max tier (%d)",
+            _MAX_TIER,
+            extra={"event": "tool_governance_tier_cache_load_failed"},
+        )
+    finally:
+        _provider_tier_cache_loaded = True
+
+
+def _reset_provider_tier_cache_for_tests() -> None:
+    """Drop the tier cache.  Tests use this to force a fresh fetch."""
+    global _provider_tier_cache_loaded
+    _provider_tier_cache.clear()
+    _provider_tier_cache_loaded = False
+
+
+async def governed_tool_invocation(
+    db: AsyncSession,
+    *,
+    origin: str,
+    provider: str,
+    tool: str,
+    intent: ToolIntent | None,
+    provider_tier: int,
+    max_allowed_tier: int | None,
+    estimated_cost: Decimal,
+    dispatch: Callable[[], Awaitable[ToolResult]],
+    span: Any | None = None,
+    confirmation_state: str = "not_required",
+    user_id: UUID | None = None,
+    chat_id: UUID | None = None,
+    message_id: UUID | None = None,
+    session_id: UUID | None = None,
+    request_id: str | None = None,
+    args_digest: str | None = None,
+) -> ToolResult:
+    """Shared per-call governance: tier-check → audit row → dispatch → record.
+
+    Flush-not-commit.  Raises :exc:`~app.errors.ToolTierRefused` before
+    dispatch when the tier ceiling is exceeded.
+
+    **Security invariants (never weaken):**
+
+    - No raw args or result payloads are written to any row or log line.
+      Only ``args_digest`` (caller-supplied) and counts/labels flow into
+      the audit row.
+    - The helper never calls ``estimate_tool_cost``; it accepts
+      ``estimated_cost`` from the caller (single-estimate invariant).
+    - The helper never commits; the caller owns the commit boundary.
+
+    Args:
+        db: An open :class:`~sqlalchemy.ext.asyncio.AsyncSession`.
+        origin: ``"chat"`` or ``"autonomous"`` — which execution context
+            is firing the tool.
+        provider: Logical provider name (e.g. ``"courtlistener-prod"``).
+        tool: Tool / function name within the provider.
+        intent: :class:`~app.autonomous.enums.ToolIntent` for autonomous
+            calls; ``None`` for chat-origin calls.
+        provider_tier: The provider's egress tier, resolved by the caller
+            via :func:`resolve_provider_tier` before this call.
+        max_allowed_tier: The ceiling this caller is operating under.
+            ``None`` means unconstrained (no tier check performed).
+        estimated_cost: Pre-computed cost estimate in USD; recorded on
+            the audit row as-is — the helper never re-estimates.
+        dispatch: Zero-argument async callable that performs the actual
+            tool call and returns a :class:`~app.autonomous.guard.ToolResult`.
+        span: Optional OTel span to annotate with counts/types (D-a1).
+            The helper does NOT open its own span.
+        confirmation_state: Human-gate lifecycle label for the row.
+            Defaults to ``"not_required"``.
+        user_id: FK to ``users.id``; ``None`` for headless/autonomous.
+        chat_id: Set for chat-origin calls.
+        message_id: Chat message id.
+        session_id: Autonomous session id.
+        request_id: Cross-service trace correlation header value.
+        args_digest: A short hash/summary of the call arguments produced
+            by the caller.  NEVER the raw args.
+
+    Returns:
+        The :class:`~app.autonomous.guard.ToolResult` from ``dispatch``.
+
+    Raises:
+        ToolTierRefused: If ``max_allowed_tier is not None`` and
+            ``provider_tier > max_allowed_tier``.  An audit row with
+            ``outcome="refused_tier"`` is written and flushed before
+            the raise.
+        Any exception raised by ``dispatch`` is re-raised after updating
+        the audit row to ``outcome="error"`` and flushing.
+    """
+    # ── D-a2 tier check ────────────────────────────────────────────────────
+    if max_allowed_tier is not None and provider_tier > max_allowed_tier:
+        row = ToolCallLog(
+            origin=origin,
+            provider=provider,
+            tool=tool,
+            tier=provider_tier,
+            intent=str(intent) if intent is not None else None,
+            confirmation_state=confirmation_state,
+            outcome="refused_tier",
+            cost_usd=None,
+            args_digest=args_digest,
+            request_id=request_id,
+            user_id=user_id,
+            chat_id=chat_id,
+            message_id=message_id,
+            session_id=session_id,
+        )
+        db.add(row)
+        await db.flush()
+        if span is not None:
+            record_attributes(
+                span,
+                **{
+                    "tool_call.outcome": "refused_tier",
+                    "tool_call.provider": provider,
+                    "tool_call.tool": tool,
+                    "tool_call.tier": provider_tier,
+                },
+            )
+        raise ToolTierRefused(
+            provider=provider,
+            tool=tool,
+            tier=provider_tier,
+            ceiling=max_allowed_tier,
+        )
+
+    # ── Write pending row ───────────────────────────────────────────────────
+    row = ToolCallLog(
+        origin=origin,
+        provider=provider,
+        tool=tool,
+        tier=provider_tier,
+        intent=str(intent) if intent is not None else None,
+        confirmation_state=confirmation_state,
+        outcome="pending",
+        cost_usd=estimated_cost,
+        args_digest=args_digest,
+        request_id=request_id,
+        user_id=user_id,
+        chat_id=chat_id,
+        message_id=message_id,
+        session_id=session_id,
+    )
+    db.add(row)
+    await db.flush()
+
+    # ── Dispatch ────────────────────────────────────────────────────────────
+    try:
+        result = await dispatch()
+    except Exception:
+        row.outcome = "error"
+        row.updated_at = datetime.now(UTC)
+        await db.flush()
+        if span is not None:
+            record_attributes(
+                span,
+                **{
+                    "tool_call.outcome": "error",
+                    "tool_call.provider": provider,
+                    "tool_call.tool": tool,
+                    "tool_call.tier": provider_tier,
+                },
+            )
+        raise
+
+    # ── Record success ──────────────────────────────────────────────────────
+    row.outcome = "executed"
+    row.cost_usd = result.cost_usd
+    row.updated_at = datetime.now(UTC)
+    await db.flush()
+    if span is not None:
+        record_attributes(
+            span,
+            **{
+                "tool_call.outcome": "executed",
+                "tool_call.provider": provider,
+                "tool_call.tool": tool,
+                "tool_call.tier": provider_tier,
+                "tool_call.cost_usd": float(result.cost_usd),
+            },
+        )
+    return result

--- a/api/tests/autonomous/test_executor_skeleton.py
+++ b/api/tests/autonomous/test_executor_skeleton.py
@@ -124,6 +124,10 @@ def test_phase_grants_exact_membership() -> None:
             # M4-B2: propose_precedent granted at analysis (patterns observed
             # while reading docs).
             ToolIntent.propose_precedent,
+            # PR5a D-a4: the two external-tool intents are granted at analysis
+            # ONLY (gateway-brokered case-law + MCP lookups).
+            ToolIntent.retrieve_caselaw,
+            ToolIntent.call_mcp_tool,
         }
     )
 
@@ -155,8 +159,9 @@ def test_phase_grants_covers_all_phases() -> None:
 
 @pytest.mark.unit
 def test_tool_intent_members() -> None:
-    """ToolIntent has exactly the eight members specified (M4-B2 adds
-    propose_precedent; Donna #8 adds emit_artifact)."""
+    """ToolIntent has exactly the ten members specified (M4-B2 adds
+    propose_precedent; Donna #8 adds emit_artifact; PR5a adds the two
+    external-tool intents retrieve_caselaw + call_mcp_tool)."""
     expected = {
         "retrieve_chunks",
         "run_skill",
@@ -166,6 +171,9 @@ def test_tool_intent_members() -> None:
         "emit_finding",
         "emit_artifact",
         "notify",
+        # PR5a: gateway-brokered external-tool intents.
+        "retrieve_caselaw",
+        "call_mcp_tool",
     }
     actual = {m.value for m in ToolIntent}
     assert actual == expected

--- a/api/tests/autonomous/test_guard_external_tool_intents.py
+++ b/api/tests/autonomous/test_guard_external_tool_intents.py
@@ -1,0 +1,409 @@
+"""Guard integration tests for the external-tool intents — PR5a Task 4.
+
+The two external-tool intents (``retrieve_caselaw``, ``call_mcp_tool``) flow
+through ``governed_tool_invocation`` from inside ``guarded_tool_call``, so each
+governed call writes a ``tool_call_log`` row in addition to the unchanged
+``autonomous_audit`` session-event trail.  Local intents stay on
+``autonomous_audit`` only.
+
+Coverage
+--------
+* ``retrieve_caselaw`` granted in ``analysis`` executes (research service mocked)
+  and writes a ``tool_call_log`` row.
+* ``retrieve_caselaw`` refused (R6 ``ToolNotGranted``) in every non-analysis phase.
+* ``call_mcp_tool`` in ``analysis`` with a cached **read_only** tool executes
+  (``call_tool`` mocked) and writes a row.
+* ``call_mcp_tool`` D4 exclusion: a **destructive** cached tool → ``ToolNotGranted``
+  AND no gateway call; a ``requires_confirmation`` tool → ``ToolNotGranted``;
+  an **unknown** tool → ``ToolNotGranted``.
+* The single-estimate invariant: the helper records the SAME estimate the
+  guard computed for R4 (no re-estimate / no double-charge).
+
+The existing R5/R6/R4 brake tests live in ``test_brakes.py`` and are unchanged
+by this refactor.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.enums import Phase, ToolIntent
+from app.errors import ToolNotGranted
+from app.models.autonomous import AutonomousSession
+from app.models.mcp import MCPToolCache
+from app.models.tool_call_log import ToolCallLog
+from app.models.user import User
+from app.security import hash_password
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        email=f"u-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_session(
+    db: AsyncSession,
+    *,
+    user: User,
+    current_phase: str = "analysis",
+) -> AutonomousSession:
+    sess = AutonomousSession(
+        user_id=user.id,
+        trigger_kind="manual",
+        current_phase=current_phase,
+        halt_state="running",
+        max_cost_usd=None,
+        cost_total_usd=Decimal("0"),
+    )
+    db.add(sess)
+    await db.flush()
+    await db.refresh(sess)
+    return sess
+
+
+async def _make_mcp_tool(
+    db: AsyncSession,
+    *,
+    provider: str = "acme-mcp",
+    tool: str = "read_doc",
+    read_only: bool = True,
+    destructive: bool = False,
+    requires_confirmation: bool = False,
+) -> MCPToolCache:
+    row = MCPToolCache(
+        provider_name=provider,
+        tool_name=tool,
+        read_only=read_only,
+        destructive=destructive,
+        requires_confirmation=requires_confirmation,
+        enabled=True,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+class _StubGateway:
+    """No-op gateway — the external dispatch goes through patched seams."""
+
+
+async def _tool_call_rows(db: AsyncSession, session_id: uuid.UUID) -> list[ToolCallLog]:
+    return list(
+        (await db.execute(select(ToolCallLog).where(ToolCallLog.session_id == session_id)))
+        .scalars()
+        .all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# retrieve_caselaw
+# ---------------------------------------------------------------------------
+
+
+async def test_retrieve_caselaw_executes_and_writes_tool_call_log(
+    db_session: AsyncSession,
+) -> None:
+    """retrieve_caselaw in analysis executes and writes one tool_call_log row."""
+    from app.autonomous import guard as guard_mod
+
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user, current_phase="analysis")
+
+    with (
+        patch(
+            "app.research.service._resolve_provider",
+            new=AsyncMock(return_value="courtlistener-prod"),
+        ),
+        patch(
+            "app.research.service.search_case_law",
+            new=AsyncMock(return_value={"results": [{"cluster_id": 42}]}),
+        ),
+        patch(
+            "app.tools.governance.resolve_provider_tier",
+            new=AsyncMock(return_value=2),
+        ),
+    ):
+        result = await guard_mod.guarded_tool_call(
+            sess,
+            ToolIntent.retrieve_caselaw,
+            {"op": "search_case_law", "args": {"q": "fair use"}},
+            db_session,
+            _StubGateway(),
+        )
+
+    assert result.cost_usd == Decimal("0")
+    assert result.data == {"results": [{"cluster_id": 42}]}
+
+    rows = await _tool_call_rows(db_session, sess.id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.origin == "autonomous"
+    assert row.provider == "courtlistener-prod"
+    assert row.tool == "search_case_law"
+    assert row.tier == 2
+    assert row.intent == "retrieve_caselaw"
+    assert row.outcome == "executed"
+    assert row.cost_usd == Decimal("0")
+    # counts/types only — never raw args
+    assert row.args_digest is not None
+    assert "fair use" not in (row.args_digest or "")
+
+
+@pytest.mark.parametrize(
+    "phase",
+    [p.value for p in Phase if p is not Phase.analysis],
+)
+async def test_retrieve_caselaw_refused_outside_analysis(
+    db_session: AsyncSession, phase: str
+) -> None:
+    """retrieve_caselaw is granted only in analysis (R6 refuses elsewhere)."""
+    from app.autonomous import guard as guard_mod
+
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user, current_phase=phase)
+
+    with pytest.raises(ToolNotGranted) as exc_info:
+        await guard_mod.guarded_tool_call(
+            sess,
+            ToolIntent.retrieve_caselaw,
+            {"op": "search_case_law", "args": {"q": "x"}},
+            db_session,
+            _StubGateway(),
+        )
+    assert exc_info.value.details["intent"] == "retrieve_caselaw"
+
+    # R6 fires before dispatch → NO tool_call_log row was written.
+    assert await _tool_call_rows(db_session, sess.id) == []
+
+
+# ---------------------------------------------------------------------------
+# call_mcp_tool — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_call_mcp_tool_read_only_executes_and_writes_row(
+    db_session: AsyncSession,
+) -> None:
+    """call_mcp_tool with a cached read_only tool executes + writes a row."""
+    from app.autonomous import guard as guard_mod
+
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user, current_phase="analysis")
+    await _make_mcp_tool(
+        db_session,
+        provider="acme-mcp",
+        tool="read_doc",
+        read_only=True,
+        destructive=False,
+        requires_confirmation=False,
+    )
+
+    call_tool_mock = AsyncMock(
+        return_value={
+            "provider": "acme-mcp",
+            "tool": "read_doc",
+            "payload": {"text": "hi"},
+            "tier": 3,
+        }
+    )
+
+    class _Client:
+        call_tool = call_tool_mock
+
+    with (
+        patch("app.clients.gateway.get_gateway_client", return_value=_Client()),
+        patch(
+            "app.tools.governance.resolve_provider_tier",
+            new=AsyncMock(return_value=3),
+        ),
+    ):
+        result = await guard_mod.guarded_tool_call(
+            sess,
+            ToolIntent.call_mcp_tool,
+            {"provider": "acme-mcp", "tool": "read_doc", "args": {"id": "doc-1"}},
+            db_session,
+            _StubGateway(),
+        )
+
+    call_tool_mock.assert_awaited_once()
+    # No per-user OAuth token (D-a5): call_tool has no user_token param at all.
+    _, kwargs = call_tool_mock.call_args
+    assert kwargs.get("max_allowed_tier") is None
+    assert result.cost_usd == Decimal("0")
+    assert result.data == {"text": "hi"}
+
+    rows = await _tool_call_rows(db_session, sess.id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.provider == "acme-mcp"
+    assert row.tool == "read_doc"
+    assert row.intent == "call_mcp_tool"
+    assert row.outcome == "executed"
+    assert row.tier == 3
+
+
+# ---------------------------------------------------------------------------
+# call_mcp_tool — D4 exclusions (NO gateway call)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flags,expected_reason",
+    [
+        ({"destructive": True}, "destructive"),
+        ({"requires_confirmation": True}, "requires_confirmation"),
+    ],
+)
+async def test_call_mcp_tool_d4_refuses_gated_tool_no_gateway_call(
+    db_session: AsyncSession, flags: dict[str, bool], expected_reason: str
+) -> None:
+    """D4: a destructive / confirmation-required cached tool → ToolNotGranted,
+    and the gateway is NEVER called."""
+    from app.autonomous import guard as guard_mod
+
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user, current_phase="analysis")
+    await _make_mcp_tool(
+        db_session,
+        provider="acme-mcp",
+        tool="danger_op",
+        read_only=False,
+        destructive=flags.get("destructive", False),
+        requires_confirmation=flags.get("requires_confirmation", False),
+    )
+
+    call_tool_mock = AsyncMock()
+
+    class _Client:
+        call_tool = call_tool_mock
+
+    with (
+        patch("app.clients.gateway.get_gateway_client", return_value=_Client()),
+        patch(
+            "app.tools.governance.resolve_provider_tier",
+            new=AsyncMock(return_value=2),
+        ),
+        pytest.raises(ToolNotGranted) as exc_info,
+    ):
+        await guard_mod.guarded_tool_call(
+            sess,
+            ToolIntent.call_mcp_tool,
+            {"provider": "acme-mcp", "tool": "danger_op", "args": {}},
+            db_session,
+            _StubGateway(),
+        )
+
+    assert exc_info.value.details["reason"] == expected_reason
+    # D4: NO gateway call.
+    call_tool_mock.assert_not_called()
+
+    # The governance helper wrote a pending row then marked it error
+    # (the dispatch closure raised ToolNotGranted inside the helper).
+    rows = await _tool_call_rows(db_session, sess.id)
+    assert len(rows) == 1
+    assert rows[0].outcome == "error"
+
+
+async def test_call_mcp_tool_unknown_tool_refused_no_gateway_call(
+    db_session: AsyncSession,
+) -> None:
+    """D4: a tool absent from the mcp_tools cache → ToolNotGranted, no call."""
+    from app.autonomous import guard as guard_mod
+
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user, current_phase="analysis")
+    # No MCPToolCache row inserted → unknown.
+
+    call_tool_mock = AsyncMock()
+
+    class _Client:
+        call_tool = call_tool_mock
+
+    with (
+        patch("app.clients.gateway.get_gateway_client", return_value=_Client()),
+        patch(
+            "app.tools.governance.resolve_provider_tier",
+            new=AsyncMock(return_value=2),
+        ),
+        pytest.raises(ToolNotGranted) as exc_info,
+    ):
+        await guard_mod.guarded_tool_call(
+            sess,
+            ToolIntent.call_mcp_tool,
+            {"provider": "acme-mcp", "tool": "ghost", "args": {}},
+            db_session,
+            _StubGateway(),
+        )
+
+    assert exc_info.value.details["reason"] == "tool_not_cached"
+    call_tool_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# single-estimate invariant
+# ---------------------------------------------------------------------------
+
+
+async def test_external_intent_records_single_estimate(db_session: AsyncSession) -> None:
+    """The tool_call_log row's cost is the SAME estimate the guard computed for
+    R4 — the helper never re-estimates (single-estimate invariant)."""
+    from app.autonomous import guard as guard_mod
+
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user, current_phase="analysis")
+
+    # Force a non-zero estimate so a re-estimate would diverge visibly.
+    mock_estimate = AsyncMock(return_value=Decimal("0.07"))
+
+    with (
+        patch.object(guard_mod, "estimate_tool_cost", mock_estimate),
+        patch(
+            "app.research.service._resolve_provider",
+            new=AsyncMock(return_value="courtlistener-prod"),
+        ),
+        patch(
+            "app.research.service.verify_citations",
+            new=AsyncMock(return_value={"citations": []}),
+        ),
+        patch(
+            "app.tools.governance.resolve_provider_tier",
+            new=AsyncMock(return_value=2),
+        ),
+    ):
+        await guard_mod.guarded_tool_call(
+            sess,
+            ToolIntent.retrieve_caselaw,
+            {"op": "verify_citations", "text": "See Roe."},
+            db_session,
+            _StubGateway(),
+        )
+
+    # estimate_tool_cost called exactly once (the guard's single R4 estimate).
+    mock_estimate.assert_awaited_once()
+    rows = await _tool_call_rows(db_session, sess.id)
+    assert len(rows) == 1
+    # The handler returns Decimal("0") (D-a3); the executed row records the
+    # ToolResult cost, which is the handler's 0 — NOT a divergent re-estimate.
+    assert rows[0].cost_usd == Decimal("0")

--- a/api/tests/autonomous/test_guard_external_tool_intents.py
+++ b/api/tests/autonomous/test_guard_external_tool_intents.py
@@ -328,6 +328,58 @@ async def test_call_mcp_tool_d4_refuses_gated_tool_no_gateway_call(
     assert rows[0].outcome == "denied"
 
 
+async def test_call_mcp_tool_d4_refuses_disabled_tool_no_gateway_call(
+    db_session: AsyncSession,
+) -> None:
+    """D4: an operator-disabled cached tool (enabled=False) → ToolNotGranted,
+    no gateway call, and the tool_call_log row has outcome="denied"."""
+    from app.autonomous import guard as guard_mod
+
+    user = await _make_user(db_session)
+    sess = await _make_session(db_session, user=user, current_phase="analysis")
+    # read_only, non-destructive — disabled only via the operator toggle.
+    row = MCPToolCache(
+        provider_name="acme-mcp",
+        tool_name="disabled_op",
+        read_only=True,
+        destructive=False,
+        requires_confirmation=False,
+        enabled=False,
+    )
+    db_session.add(row)
+    await db_session.flush()
+
+    call_tool_mock = AsyncMock()
+
+    class _Client:
+        call_tool = call_tool_mock
+
+    with (
+        patch("app.clients.gateway.get_gateway_client", return_value=_Client()),
+        patch(
+            "app.tools.governance.resolve_provider_tier",
+            new=AsyncMock(return_value=2),
+        ),
+        pytest.raises(ToolNotGranted) as exc_info,
+    ):
+        await guard_mod.guarded_tool_call(
+            sess,
+            ToolIntent.call_mcp_tool,
+            {"provider": "acme-mcp", "tool": "disabled_op", "args": {}},
+            db_session,
+            _StubGateway(),
+        )
+
+    assert exc_info.value.details["reason"] == "tool_disabled"
+    # D4: the gateway must NEVER be called for a disabled tool.
+    call_tool_mock.assert_not_called()
+
+    # The governance helper wrote a pending row then marked it "denied".
+    rows = await _tool_call_rows(db_session, sess.id)
+    assert len(rows) == 1
+    assert rows[0].outcome == "denied"
+
+
 async def test_call_mcp_tool_unknown_tool_refused_no_gateway_call(
     db_session: AsyncSession,
 ) -> None:

--- a/api/tests/autonomous/test_guard_external_tool_intents.py
+++ b/api/tests/autonomous/test_guard_external_tool_intents.py
@@ -319,11 +319,13 @@ async def test_call_mcp_tool_d4_refuses_gated_tool_no_gateway_call(
     # D4: NO gateway call.
     call_tool_mock.assert_not_called()
 
-    # The governance helper wrote a pending row then marked it error
-    # (the dispatch closure raised ToolNotGranted inside the helper).
+    # The governance helper wrote a pending row then marked it "denied"
+    # (the dispatch closure raised ToolNotGranted inside the helper, and
+    # the caller passed denied_on=(ToolNotGranted,) — D4 is a policy
+    # refusal, not a tool failure).
     rows = await _tool_call_rows(db_session, sess.id)
     assert len(rows) == 1
-    assert rows[0].outcome == "error"
+    assert rows[0].outcome == "denied"
 
 
 async def test_call_mcp_tool_unknown_tool_refused_no_gateway_call(
@@ -359,6 +361,12 @@ async def test_call_mcp_tool_unknown_tool_refused_no_gateway_call(
 
     assert exc_info.value.details["reason"] == "tool_not_cached"
     call_tool_mock.assert_not_called()
+
+    # D4: governance helper wrote a pending row then marked it "denied"
+    # (unknown tool is a policy refusal, not a tool failure).
+    rows = await _tool_call_rows(db_session, sess.id)
+    assert len(rows) == 1
+    assert rows[0].outcome == "denied"
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/autonomous/test_guard_helpers.py
+++ b/api/tests/autonomous/test_guard_helpers.py
@@ -275,6 +275,68 @@ async def test_notify_returns_zero_no_estimator_call() -> None:
     assert result == Decimal("0")
 
 
+@pytest.mark.unit
+def test_retrieve_caselaw_intent_exists() -> None:
+    """retrieve_caselaw is a member of ToolIntent."""
+    assert ToolIntent.retrieve_caselaw == "retrieve_caselaw"
+
+
+@pytest.mark.unit
+def test_call_mcp_tool_intent_exists() -> None:
+    """call_mcp_tool is a member of ToolIntent."""
+    assert ToolIntent.call_mcp_tool == "call_mcp_tool"
+
+
+@pytest.mark.unit
+def test_retrieve_caselaw_granted_only_in_analysis() -> None:
+    """retrieve_caselaw is in PHASE_GRANTS[analysis] and NO other phase."""
+    from app.autonomous.enums import PHASE_GRANTS, Phase
+
+    assert ToolIntent.retrieve_caselaw in PHASE_GRANTS[Phase.analysis]
+    for phase in Phase:
+        if phase is not Phase.analysis:
+            assert ToolIntent.retrieve_caselaw not in PHASE_GRANTS[phase], (
+                f"retrieve_caselaw must not be granted in phase {phase!r}"
+            )
+
+
+@pytest.mark.unit
+def test_call_mcp_tool_granted_only_in_analysis() -> None:
+    """call_mcp_tool is in PHASE_GRANTS[analysis] and NO other phase."""
+    from app.autonomous.enums import PHASE_GRANTS, Phase
+
+    assert ToolIntent.call_mcp_tool in PHASE_GRANTS[Phase.analysis]
+    for phase in Phase:
+        if phase is not Phase.analysis:
+            assert ToolIntent.call_mcp_tool not in PHASE_GRANTS[phase], (
+                f"call_mcp_tool must not be granted in phase {phase!r}"
+            )
+
+
+@pytest.mark.unit
+async def test_retrieve_caselaw_returns_zero_no_estimator_call() -> None:
+    """retrieve_caselaw → Decimal("0"), estimator NOT called (D-a3 / DE-344 deferral)."""
+    from app.autonomous.cost import estimate_tool_cost
+
+    mock_estimator = AsyncMock(return_value=Decimal("9.99"))
+    with patch("app.autonomous.cost.estimate_judge_call_cost_usd", mock_estimator):
+        result = await estimate_tool_cost(ToolIntent.retrieve_caselaw, {}, db=None)
+    mock_estimator.assert_not_called()
+    assert result == Decimal("0")
+
+
+@pytest.mark.unit
+async def test_call_mcp_tool_returns_zero_no_estimator_call() -> None:
+    """call_mcp_tool → Decimal("0"), estimator NOT called (D-a3 / DE-344 deferral)."""
+    from app.autonomous.cost import estimate_tool_cost
+
+    mock_estimator = AsyncMock(return_value=Decimal("9.99"))
+    with patch("app.autonomous.cost.estimate_judge_call_cost_usd", mock_estimator):
+        result = await estimate_tool_cost(ToolIntent.call_mcp_tool, {}, db=None)
+    mock_estimator.assert_not_called()
+    assert result == Decimal("0")
+
+
 # ===========================================================================
 # Piece 3 — autonomous_audit (closed-enum audit wrapper)
 # ===========================================================================

--- a/api/tests/test_tool_call_log_model.py
+++ b/api/tests/test_tool_call_log_model.py
@@ -1,0 +1,225 @@
+"""Model + migration tests for tool_call_log (PR5a / 0053).
+
+Verifies:
+
+* Table exists with the expected columns and PK after the 0053 migration runs.
+* No raw-payload columns: the schema contains only counts/types/digest fields —
+  no 'args', 'result', 'response', or 'payload' columns (counts/types only).
+* FK cascade: deleting the user removes owned ``tool_call_log`` rows.
+* Nullable columns (user_id, chat_id, message_id, session_id, intent,
+  cost_usd, args_digest, request_id) are genuinely nullable.
+* confirmation_state defaults to 'not_required'.
+
+Tests use the session-scoped migrated DB + per-test rollback from conftest.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.tool_call_log import ToolCallLog
+from app.models.user import User
+from app.security.passwords import hash_password
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user() -> User:
+    """Return an unsaved User with a unique email."""
+    return User(
+        email=f"tcl-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("test-pass"),
+        is_admin=False,
+        mfa_enabled=False,
+    )
+
+
+def _make_log(user_id: uuid.UUID | None = None) -> ToolCallLog:
+    """Return an unsaved ToolCallLog row (chat-origin, no raw payloads)."""
+    return ToolCallLog(
+        origin="chat",
+        user_id=user_id,
+        provider="courtlistener",
+        tool="search_case_law",
+        tier=2,
+        outcome="pending",
+        args_digest="sha256:abcd1234",  # digest only — never raw args
+    )
+
+
+# ---------------------------------------------------------------------------
+# Column / schema tests (unit — no DB required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_tool_call_log_columns() -> None:
+    """All spec'd columns are present on the ORM model."""
+    cols = ToolCallLog.__table__.columns.keys()
+    expected = {
+        "id",
+        "origin",
+        "user_id",
+        "chat_id",
+        "message_id",
+        "session_id",
+        "intent",
+        "provider",
+        "tool",
+        "tier",
+        "confirmation_state",
+        "outcome",
+        "cost_usd",
+        "args_digest",
+        "request_id",
+        "created_at",
+        "updated_at",
+    }
+    assert set(cols) >= expected
+
+
+@pytest.mark.unit
+def test_tool_call_log_primary_key() -> None:
+    """PK is 'id' only (single UUID column)."""
+    pk = {c.name for c in ToolCallLog.__table__.primary_key.columns}
+    assert pk == {"id"}
+
+
+@pytest.mark.unit
+def test_tool_call_log_no_raw_payload_columns() -> None:
+    """Ensure no raw-payload column names exist (counts/types only discipline)."""
+    cols = set(ToolCallLog.__table__.columns.keys())
+    forbidden = {"args", "result", "response", "payload", "raw_args", "raw_result"}
+    assert cols.isdisjoint(forbidden), (
+        f"Raw-payload columns found in tool_call_log: {cols & forbidden}"
+    )
+
+
+@pytest.mark.unit
+def test_tool_call_log_user_fk_cascade() -> None:
+    """The user_id FK is defined with ON DELETE CASCADE and the expected name."""
+    fk_col = ToolCallLog.__table__.columns["user_id"]
+    fks = list(fk_col.foreign_keys)
+    assert len(fks) == 1
+    fk = fks[0]
+    assert fk.column.table.name == "users"
+    assert fk.ondelete == "CASCADE"
+    assert fk.name == "fk_tool_call_log_user"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require migrated DB via conftest)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_tool_call_log_row_roundtrips(db_session: AsyncSession) -> None:
+    """A log row persists and reads back with all fields intact."""
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    log = ToolCallLog(
+        origin="autonomous",
+        user_id=user.id,
+        session_id=uuid.uuid4(),
+        intent="retrieve_caselaw",
+        provider="courtlistener",
+        tool="search_case_law",
+        tier=2,
+        confirmation_state="not_required",
+        outcome="executed",
+        cost_usd=Decimal("0.001234"),
+        args_digest="sha256:deadbeef",
+        request_id="req-abc123",
+    )
+    db_session.add(log)
+    await db_session.flush()
+
+    result = await db_session.execute(select(ToolCallLog).where(ToolCallLog.id == log.id))
+    row = result.scalar_one()
+    assert row.origin == "autonomous"
+    assert row.user_id == user.id
+    assert row.intent == "retrieve_caselaw"
+    assert row.provider == "courtlistener"
+    assert row.tool == "search_case_law"
+    assert row.tier == 2
+    assert row.outcome == "executed"
+    assert row.cost_usd == Decimal("0.001234")
+    assert row.args_digest == "sha256:deadbeef"
+    assert row.request_id == "req-abc123"
+    assert row.created_at is not None
+    assert row.updated_at is not None
+
+
+@pytest.mark.integration
+async def test_tool_call_log_confirmation_state_default(db_session: AsyncSession) -> None:
+    """confirmation_state defaults to 'not_required' when not supplied."""
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    log = _make_log(user_id=user.id)
+    db_session.add(log)
+    await db_session.flush()
+
+    result = await db_session.execute(select(ToolCallLog).where(ToolCallLog.id == log.id))
+    row = result.scalar_one()
+    assert row.confirmation_state == "not_required"
+
+
+@pytest.mark.integration
+async def test_tool_call_log_nullable_columns(db_session: AsyncSession) -> None:
+    """Nullable columns (user_id, chat_id, ...) accept None."""
+    log = ToolCallLog(
+        origin="chat",
+        user_id=None,
+        chat_id=None,
+        message_id=None,
+        session_id=None,
+        intent=None,
+        provider="internal",
+        tool="noop",
+        tier=0,
+        outcome="pending",
+        cost_usd=None,
+        args_digest=None,
+        request_id=None,
+    )
+    db_session.add(log)
+    await db_session.flush()
+
+    result = await db_session.execute(select(ToolCallLog).where(ToolCallLog.id == log.id))
+    row = result.scalar_one()
+    assert row.user_id is None
+    assert row.chat_id is None
+    assert row.cost_usd is None
+    assert row.args_digest is None
+
+
+@pytest.mark.integration
+async def test_tool_call_log_user_cascade_delete(db_session: AsyncSession) -> None:
+    """Deleting a user CASCADE-deletes their tool_call_log rows."""
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+    user_id = user.id
+
+    log = _make_log(user_id=user_id)
+    db_session.add(log)
+    await db_session.flush()
+    log_id = log.id
+
+    # Delete via raw SQL to bypass ORM; FK ON DELETE CASCADE fires at DB level.
+    await db_session.execute(text("DELETE FROM users WHERE id = :uid"), {"uid": user_id})
+    await db_session.flush()
+
+    result = await db_session.execute(select(ToolCallLog).where(ToolCallLog.id == log_id))
+    assert result.scalars().all() == []

--- a/api/tests/test_tool_governance.py
+++ b/api/tests/test_tool_governance.py
@@ -520,6 +520,78 @@ async def test_dispatch_raises_writes_error_row_and_reraises(db_session: AsyncSe
 
 
 @pytest.mark.asyncio
+async def test_denied_on_matching_exception_writes_denied_row(db_session: AsyncSession):
+    """When dispatch raises an exception listed in denied_on, outcome='denied' (not 'error')."""
+
+    class PolicyRefusal(Exception):
+        pass
+
+    exc = PolicyRefusal("D4 policy block")
+    dispatch = _make_failing_dispatch(exc)
+
+    with pytest.raises(PolicyRefusal):
+        await governed_tool_invocation(
+            db_session,
+            origin="autonomous",
+            provider="acme-mcp",
+            tool="danger_op",
+            intent=ToolIntent.run_skill,
+            provider_tier=2,
+            max_allowed_tier=5,
+            estimated_cost=Decimal("0.02"),
+            dispatch=dispatch,
+            args_digest="sha256:denieddigest",
+            denied_on=(PolicyRefusal,),
+        )
+
+    dispatch.assert_called_once()
+
+    rows = (await db_session.execute(select(ToolCallLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == "denied", (
+        f"expected outcome='denied' for a policy-refusal exception; got {row.outcome!r}"
+    )
+    assert row.args_digest == "sha256:denieddigest"
+
+
+@pytest.mark.asyncio
+async def test_denied_on_non_matching_exception_writes_error_row(db_session: AsyncSession):
+    """When dispatch raises an exception NOT in denied_on, outcome='error' (unchanged)."""
+
+    class PolicyRefusal(Exception):
+        pass
+
+    exc = RuntimeError("genuine tool failure")
+    dispatch = _make_failing_dispatch(exc)
+
+    with pytest.raises(RuntimeError):
+        await governed_tool_invocation(
+            db_session,
+            origin="autonomous",
+            provider="acme-mcp",
+            tool="danger_op",
+            intent=ToolIntent.run_skill,
+            provider_tier=2,
+            max_allowed_tier=5,
+            estimated_cost=Decimal("0.02"),
+            dispatch=dispatch,
+            args_digest="sha256:errordigest",
+            denied_on=(PolicyRefusal,),  # RuntimeError is NOT in this tuple
+        )
+
+    dispatch.assert_called_once()
+
+    rows = (await db_session.execute(select(ToolCallLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == "error", (
+        f"expected outcome='error' for a non-policy exception; got {row.outcome!r}"
+    )
+    assert row.args_digest == "sha256:errordigest"
+
+
+@pytest.mark.asyncio
 async def test_dispatch_raises_annotates_span(db_session: AsyncSession):
     """On dispatch failure the span is annotated with outcome=error (not the exception)."""
     exc = ValueError("inner error")

--- a/api/tests/test_tool_governance.py
+++ b/api/tests/test_tool_governance.py
@@ -1,0 +1,591 @@
+"""Tests for the governed_tool_invocation helper and resolve_provider_tier.
+
+TDD acceptance bar — these tests define the security-critical governance
+substrate.
+
+Coverage:
+- tier-refusal: writes a ``refused_tier`` row + raises ``ToolTierRefused``;
+  dispatch is never called; no raw args/results in any row.
+- happy path: writes ``pending`` row then updates to ``executed`` with the
+  correct cost; dispatch called exactly once.
+- dispatch-raises: writes ``pending`` row then updates to ``error``; the
+  original exception is re-raised; no raw args/results in any row.
+- ``resolve_provider_tier``: returns the configured tier from a mocked
+  gateway config; returns ``_MAX_TIER`` (5) as the fail-safe default
+  when the provider is absent or the fetch fails.
+- span annotations: only counts/types (outcome, tier, provider name, tool
+  name, cost_usd) — never raw args or results.
+- no raw args/results assertion: asserts ``args_digest`` is a short hash,
+  not the original args structure; ``cost_usd`` on the row is a Decimal,
+  not a result payload.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.enums import ToolIntent
+from app.autonomous.guard import ToolResult
+from app.errors import ToolTierRefused
+from app.models.tool_call_log import ToolCallLog
+from app.models.user import User
+from app.security import hash_password
+from app.tools.governance import (
+    _MAX_TIER,
+    _reset_provider_tier_cache_for_tests,
+    governed_tool_invocation,
+    resolve_provider_tier,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_dispatch(
+    cost: Decimal = Decimal("0.05"),
+    outcome: str = "success",
+    data: Any = None,
+) -> AsyncMock:
+    """Return a fake dispatch closure returning a ToolResult."""
+    result = ToolResult(cost_usd=cost, outcome=outcome, data=data)
+    return AsyncMock(return_value=result)
+
+
+def _make_failing_dispatch(exc: Exception) -> AsyncMock:
+    """Return a fake dispatch closure that raises ``exc``."""
+    return AsyncMock(side_effect=exc)
+
+
+def _make_span() -> MagicMock:
+    """Return a mock OTel span that records ``is_recording() == True``."""
+    span = MagicMock()
+    span.is_recording.return_value = True
+    return span
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_tier_cache():
+    """Reset the process-level tier cache before every test."""
+    _reset_provider_tier_cache_for_tests()
+    yield
+    _reset_provider_tier_cache_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# resolve_provider_tier tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_provider_tier_returns_configured_tier(monkeypatch):
+    """resolve_provider_tier returns the egress_tier from the gateway config."""
+
+    async def _fake_get_admin_config(*, request_id=None):
+        return {
+            "tool_providers": [
+                {"name": "courtlistener-prod", "type": "courtlistener", "egress_tier": 4},
+                {"name": "acme-mcp", "type": "mcp", "egress_tier": 2},
+            ]
+        }
+
+    class _FakeGW:
+        get_admin_config = staticmethod(_fake_get_admin_config)
+
+    monkeypatch.setattr("app.tools.governance.get_gateway_client", lambda: _FakeGW())
+
+    tier = await resolve_provider_tier("courtlistener-prod")
+    assert tier == 4
+
+    tier2 = await resolve_provider_tier("acme-mcp")
+    assert tier2 == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_provider_tier_fail_safe_for_unknown_provider(monkeypatch):
+    """resolve_provider_tier returns _MAX_TIER when the provider is not listed."""
+
+    async def _fake_get_admin_config(*, request_id=None):
+        return {"tool_providers": [{"name": "other", "type": "mcp", "egress_tier": 1}]}
+
+    class _FakeGW:
+        get_admin_config = staticmethod(_fake_get_admin_config)
+
+    monkeypatch.setattr("app.tools.governance.get_gateway_client", lambda: _FakeGW())
+
+    tier = await resolve_provider_tier("does-not-exist")
+    assert tier == _MAX_TIER
+
+
+@pytest.mark.asyncio
+async def test_resolve_provider_tier_fail_safe_on_gateway_error(monkeypatch):
+    """resolve_provider_tier returns _MAX_TIER when the gateway is unreachable."""
+
+    async def _fail_get_admin_config(*, request_id=None):
+        raise RuntimeError("gateway down")
+
+    class _FakeGW:
+        get_admin_config = staticmethod(_fail_get_admin_config)
+
+    monkeypatch.setattr("app.tools.governance.get_gateway_client", lambda: _FakeGW())
+
+    tier = await resolve_provider_tier("courtlistener-prod")
+    assert tier == _MAX_TIER
+
+
+@pytest.mark.asyncio
+async def test_resolve_provider_tier_process_cached(monkeypatch):
+    """resolve_provider_tier only calls get_admin_config once per process."""
+    call_count = 0
+
+    async def _counting_get_admin_config(*, request_id=None):
+        nonlocal call_count
+        call_count += 1
+        return {"tool_providers": [{"name": "cl", "type": "courtlistener", "egress_tier": 3}]}
+
+    class _FakeGW:
+        get_admin_config = staticmethod(_counting_get_admin_config)
+
+    monkeypatch.setattr("app.tools.governance.get_gateway_client", lambda: _FakeGW())
+
+    await resolve_provider_tier("cl")
+    await resolve_provider_tier("cl")
+    await resolve_provider_tier("cl")
+
+    assert call_count == 1, "gateway config must be fetched exactly once per process"
+
+
+# ---------------------------------------------------------------------------
+# governed_tool_invocation tests — tier refusal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tier_refusal_writes_row_and_raises(db_session: AsyncSession):
+    """Tier refusal writes a refused_tier row, flushes, and raises ToolTierRefused.
+
+    Dispatch must NOT be called.
+    """
+    dispatch = _make_dispatch()
+
+    with pytest.raises(ToolTierRefused) as exc_info:
+        await governed_tool_invocation(
+            db_session,
+            origin="chat",
+            provider="acme-mcp",
+            tool="read_doc",
+            intent=None,
+            provider_tier=4,
+            max_allowed_tier=2,
+            estimated_cost=Decimal("0.10"),
+            dispatch=dispatch,
+            args_digest="sha256:abcdef",
+        )
+
+    # dispatch must never have been called
+    dispatch.assert_not_called()
+
+    # exception carries no raw args or result
+    err = exc_info.value
+    assert err.details["provider"] == "acme-mcp"
+    assert err.details["tool"] == "read_doc"
+    assert err.details["tier"] == 4
+    assert err.details["ceiling"] == 2
+
+    # DB row must exist with refused_tier
+    rows = (await db_session.execute(select(ToolCallLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == "refused_tier"
+    assert row.provider == "acme-mcp"
+    assert row.tool == "read_doc"
+    assert row.tier == 4
+    # No raw args in the row — only args_digest
+    assert row.args_digest == "sha256:abcdef"
+    # cost_usd is None on a refused_tier row (no dispatch happened)
+    assert row.cost_usd is None
+
+
+@pytest.mark.asyncio
+async def test_tier_refusal_no_dispatch_when_no_ceiling(db_session: AsyncSession):
+    """When max_allowed_tier is None, no tier check is performed."""
+    dispatch = _make_dispatch(cost=Decimal("0.05"))
+
+    result = await governed_tool_invocation(
+        db_session,
+        origin="autonomous",
+        provider="acme-mcp",
+        tool="read_doc",
+        intent=ToolIntent.retrieve_chunks,
+        provider_tier=5,  # very high tier
+        max_allowed_tier=None,  # no ceiling
+        estimated_cost=Decimal("0.05"),
+        dispatch=dispatch,
+    )
+
+    dispatch.assert_called_once()
+    assert result.outcome == "success"
+
+
+@pytest.mark.asyncio
+async def test_tier_refusal_no_raise_when_tier_eq_ceiling(db_session: AsyncSession):
+    """provider_tier == max_allowed_tier is allowed (equal is not exceeding)."""
+    dispatch = _make_dispatch(cost=Decimal("0.01"))
+
+    result = await governed_tool_invocation(
+        db_session,
+        origin="chat",
+        provider="acme-mcp",
+        tool="read_doc",
+        intent=None,
+        provider_tier=3,
+        max_allowed_tier=3,
+        estimated_cost=Decimal("0.01"),
+        dispatch=dispatch,
+    )
+
+    dispatch.assert_called_once()
+    assert result.outcome == "success"
+
+
+@pytest.mark.asyncio
+async def test_tier_refusal_annotates_span(db_session: AsyncSession):
+    """On tier refusal the caller-supplied span is annotated (no raw args)."""
+    dispatch = _make_dispatch()
+    span = _make_span()
+
+    with pytest.raises(ToolTierRefused):
+        await governed_tool_invocation(
+            db_session,
+            origin="chat",
+            provider="acme-mcp",
+            tool="read_doc",
+            intent=None,
+            provider_tier=5,
+            max_allowed_tier=1,
+            estimated_cost=Decimal("0"),
+            dispatch=dispatch,
+            span=span,
+            args_digest="sha256:digest",
+        )
+
+    # span.set_attribute must have been called; inspect the calls for safe keys
+    call_kwargs = {call.args[0]: call.args[1] for call in span.set_attribute.call_args_list}
+    assert call_kwargs.get("tool_call.outcome") == "refused_tier"
+    assert call_kwargs.get("tool_call.tier") == 5
+    # Must NOT contain any raw-args or raw-result key
+    for key in call_kwargs:
+        assert "args" not in key.lower() or key == "tool_call.tier"
+        assert "result" not in key.lower()
+
+
+# ---------------------------------------------------------------------------
+# governed_tool_invocation tests — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_writes_pending_then_executed(db_session: AsyncSession):
+    """Happy path: pending row written, updated to executed with cost."""
+    cost = Decimal("0.0312")
+    dispatch = _make_dispatch(cost=cost)
+
+    result = await governed_tool_invocation(
+        db_session,
+        origin="autonomous",
+        provider="courtlistener-prod",
+        tool="search_cases",
+        intent=ToolIntent.run_skill,
+        provider_tier=4,
+        max_allowed_tier=4,
+        estimated_cost=cost,
+        dispatch=dispatch,
+        confirmation_state="not_required",
+        session_id=uuid.uuid4(),
+        args_digest="sha256:testdigest",
+    )
+
+    dispatch.assert_called_once()
+    assert result.outcome == "success"
+    assert result.cost_usd == cost
+
+    rows = (await db_session.execute(select(ToolCallLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == "executed"
+    assert row.cost_usd == cost
+    assert row.origin == "autonomous"
+    assert row.provider == "courtlistener-prod"
+    assert row.tool == "search_cases"
+    assert row.tier == 4
+    assert row.intent == "run_skill"
+    assert row.args_digest == "sha256:testdigest"
+    # Confirm no raw args or result payload in the row
+    # (the row has no field for raw args or raw results, only the digest)
+    assert not hasattr(row, "args") or row.args_digest == "sha256:testdigest"
+
+
+@pytest.mark.asyncio
+async def test_happy_path_no_raw_args_in_row(db_session: AsyncSession):
+    """No raw args or result payload must appear in the tool_call_log row."""
+    # The caller never passes raw args to governed_tool_invocation; only a digest.
+    digest = "sha256:abc123"  # the caller summarizes args to a digest
+
+    dispatch = _make_dispatch(
+        cost=Decimal("0.01"),
+        data={"secret": "should-never-appear-in-db"},
+    )
+
+    await governed_tool_invocation(
+        db_session,
+        origin="chat",
+        provider="acme-mcp",
+        tool="lookup",
+        intent=None,
+        provider_tier=1,
+        max_allowed_tier=5,
+        estimated_cost=Decimal("0.01"),
+        dispatch=dispatch,
+        args_digest=digest,
+    )
+
+    rows = (await db_session.execute(select(ToolCallLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+
+    # args_digest is the hash, not the raw args
+    assert row.args_digest == digest
+    # Confirm none of the sensitive content appears in ANY string field
+    row_str = repr(row)
+    for sensitive in ["Acme Corp", "123-45-6789", "should-never-appear-in-db"]:
+        assert sensitive not in row_str, f"Sensitive value {sensitive!r} leaked into row repr"
+
+
+@pytest.mark.asyncio
+async def test_happy_path_span_annotation(db_session: AsyncSession):
+    """On success the span receives outcome/tier/cost_usd — no raw payloads."""
+    cost = Decimal("0.05")
+    dispatch = _make_dispatch(cost=cost)
+    span = _make_span()
+
+    await governed_tool_invocation(
+        db_session,
+        origin="chat",
+        provider="courtlistener-prod",
+        tool="search_cases",
+        intent=None,
+        provider_tier=4,
+        max_allowed_tier=5,
+        estimated_cost=cost,
+        dispatch=dispatch,
+        span=span,
+    )
+
+    call_kwargs = {call.args[0]: call.args[1] for call in span.set_attribute.call_args_list}
+    assert call_kwargs.get("tool_call.outcome") == "executed"
+    assert call_kwargs.get("tool_call.cost_usd") == float(cost)
+    assert call_kwargs.get("tool_call.tier") == 4
+    for key in call_kwargs:
+        assert "args" not in key.lower() or key.startswith("tool_call.")
+        assert "result" not in key.lower()
+
+
+# ---------------------------------------------------------------------------
+# governed_tool_invocation tests — dispatch raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_raises_writes_error_row_and_reraises(db_session: AsyncSession):
+    """When dispatch raises, the row is updated to error and the exception re-raised."""
+    exc = RuntimeError("tool exploded")
+    dispatch = _make_failing_dispatch(exc)
+
+    with pytest.raises(RuntimeError, match="tool exploded"):
+        await governed_tool_invocation(
+            db_session,
+            origin="autonomous",
+            provider="acme-mcp",
+            tool="write_doc",
+            intent=ToolIntent.run_skill,
+            provider_tier=2,
+            max_allowed_tier=5,
+            estimated_cost=Decimal("0.02"),
+            dispatch=dispatch,
+            args_digest="sha256:faildigest",
+        )
+
+    dispatch.assert_called_once()
+
+    rows = (await db_session.execute(select(ToolCallLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == "error"
+    # args_digest still only the short hash, never the raw exception payload
+    assert row.args_digest == "sha256:faildigest"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_raises_annotates_span(db_session: AsyncSession):
+    """On dispatch failure the span is annotated with outcome=error (not the exception)."""
+    exc = ValueError("inner error")
+    dispatch = _make_failing_dispatch(exc)
+    span = _make_span()
+
+    with pytest.raises(ValueError):
+        await governed_tool_invocation(
+            db_session,
+            origin="chat",
+            provider="acme-mcp",
+            tool="read_doc",
+            intent=None,
+            provider_tier=1,
+            max_allowed_tier=5,
+            estimated_cost=Decimal("0"),
+            dispatch=dispatch,
+            span=span,
+        )
+
+    call_kwargs = {call.args[0]: call.args[1] for call in span.set_attribute.call_args_list}
+    assert call_kwargs.get("tool_call.outcome") == "error"
+    # Must not expose the exception message in span attributes
+    for value in call_kwargs.values():
+        assert "inner error" not in str(value)
+
+
+# ---------------------------------------------------------------------------
+# flush-not-commit invariant (structural check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flush_not_commit_no_commit_called(db_session: AsyncSession):
+    """governed_tool_invocation must call flush() but never commit()."""
+    commit_calls: list[Any] = []
+    original_commit = db_session.commit
+
+    async def _tracking_commit(*args: Any, **kwargs: Any) -> Any:
+        commit_calls.append(("commit", args, kwargs))
+        return await original_commit(*args, **kwargs)
+
+    db_session.commit = _tracking_commit  # type: ignore[method-assign]
+
+    dispatch = _make_dispatch(cost=Decimal("0.01"))
+    await governed_tool_invocation(
+        db_session,
+        origin="chat",
+        provider="acme-mcp",
+        tool="read_doc",
+        intent=None,
+        provider_tier=1,
+        max_allowed_tier=5,
+        estimated_cost=Decimal("0.01"),
+        dispatch=dispatch,
+    )
+
+    assert not commit_calls, (
+        "governed_tool_invocation must not commit — the caller owns the commit boundary"
+    )
+
+
+# ---------------------------------------------------------------------------
+# single-estimate invariant (structural check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_estimate_not_reimposed(db_session: AsyncSession, monkeypatch):
+    """governed_tool_invocation must never call estimate_tool_cost itself."""
+    estimate_calls: list[Any] = []
+
+    async def _fake_estimate(*args: Any, **kwargs: Any) -> Decimal:
+        estimate_calls.append(args)
+        return Decimal("99")
+
+    # Patch the cost estimator in the governance module's namespace
+    monkeypatch.setattr(
+        "app.tools.governance.estimate_tool_cost",
+        _fake_estimate,
+        raising=False,
+    )
+
+    dispatch = _make_dispatch(cost=Decimal("0.01"))
+    await governed_tool_invocation(
+        db_session,
+        origin="chat",
+        provider="acme-mcp",
+        tool="read_doc",
+        intent=None,
+        provider_tier=1,
+        max_allowed_tier=5,
+        estimated_cost=Decimal("0.01"),
+        dispatch=dispatch,
+    )
+
+    assert not estimate_calls, "governed_tool_invocation must not call estimate_tool_cost"
+
+
+# ---------------------------------------------------------------------------
+# Optional IDs are passed through correctly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_optional_ids_stored_in_row(db_session: AsyncSession):
+    """chat_id, message_id, session_id, request_id land on the row."""
+    # user_id has a FK to users — create a real user row
+    user = User(
+        email=f"gov-test-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    chat_id = uuid.uuid4()
+    message_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+
+    dispatch = _make_dispatch(cost=Decimal("0"))
+
+    await governed_tool_invocation(
+        db_session,
+        origin="chat",
+        provider="acme-mcp",
+        tool="read_doc",
+        intent=None,
+        provider_tier=1,
+        max_allowed_tier=5,
+        estimated_cost=Decimal("0"),
+        dispatch=dispatch,
+        user_id=user.id,
+        chat_id=chat_id,
+        message_id=message_id,
+        session_id=session_id,
+        request_id="req-abc",
+    )
+
+    rows = (await db_session.execute(select(ToolCallLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.chat_id == chat_id
+    assert row.message_id == message_id
+    assert row.session_id == session_id
+    assert row.user_id == user.id
+    assert row.request_id == "req-abc"

--- a/api/tests/test_tool_governance.py
+++ b/api/tests/test_tool_governance.py
@@ -18,10 +18,20 @@ Coverage:
 - no raw args/results assertion: asserts ``args_digest`` is a short hash,
   not the original args structure; ``cost_usd`` on the row is a Decimal,
   not a result payload.
+- single-estimate invariant: the module must not define or call
+  ``estimate_tool_cost``; the ``cost_usd`` recorded on the row equals the
+  ``estimated_cost`` passed by the caller (never recomputed).
+- flush-not-commit: ``commit`` is never called on ANY path (happy, tier-
+  refusal, dispatch-raises); ``flush`` IS called on each path.
+- no-payload leak: the sentinel secret must not appear in ANY mapped column
+  value of the persisted row (not just repr).
+- no-log leak: the sentinel secret must not appear in ANY log record emitted
+  at DEBUG level or above.
 """
 
 from __future__ import annotations
 
+import logging
 import uuid
 from decimal import Decimal
 from typing import Any
@@ -32,6 +42,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import app.tools.governance as gov
 from app.autonomous.enums import ToolIntent
 from app.autonomous.guard import ToolResult
 from app.errors import ToolTierRefused
@@ -340,13 +351,19 @@ async def test_happy_path_writes_pending_then_executed(db_session: AsyncSession)
 
 @pytest.mark.asyncio
 async def test_happy_path_no_raw_args_in_row(db_session: AsyncSession):
-    """No raw args or result payload must appear in the tool_call_log row."""
+    """No raw args or result payload must appear in ANY mapped column of the row.
+
+    M3 hardening: scans every SQLAlchemy-mapped column value (not just repr,
+    which only renders a handful of fields).  Uses a distinctive sentinel that
+    cannot plausibly collide with benign content.
+    """
     # The caller never passes raw args to governed_tool_invocation; only a digest.
     digest = "sha256:abc123"  # the caller summarizes args to a digest
+    sentinel = "SENTINEL-SECRET-PAYLOAD-xyz"
 
     dispatch = _make_dispatch(
         cost=Decimal("0.01"),
-        data={"secret": "should-never-appear-in-db"},
+        data={"secret": sentinel},
     )
 
     await governed_tool_invocation(
@@ -368,10 +385,74 @@ async def test_happy_path_no_raw_args_in_row(db_session: AsyncSession):
 
     # args_digest is the hash, not the raw args
     assert row.args_digest == digest
-    # Confirm none of the sensitive content appears in ANY string field
-    row_str = repr(row)
-    for sensitive in ["Acme Corp", "123-45-6789", "should-never-appear-in-db"]:
-        assert sensitive not in row_str, f"Sensitive value {sensitive!r} leaked into row repr"
+
+    # Scan EVERY mapped column value — not just what repr() renders.
+    # repr() only emits id/origin/provider/tool/outcome; this catches leaks
+    # in intent, request_id, args_digest, confirmation_state, etc.
+    all_column_values = {c.name: getattr(row, c.name) for c in row.__table__.columns}
+    for col_name, col_value in all_column_values.items():
+        assert sentinel not in str(col_value), (
+            f"Sentinel secret leaked into column {col_name!r}: {col_value!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_sentinel_in_logs(db_session: AsyncSession, caplog: pytest.LogCaptureFixture):
+    """Sentinel secret must not appear in ANY log record emitted at DEBUG or above.
+
+    M4 hardening: drives both the happy path and the error path with the
+    sentinel present in args/result, and asserts caplog contains no trace of
+    it at any log level.
+    """
+    sentinel = "SENTINEL-SECRET-PAYLOAD-xyz"
+
+    # ── Happy path: sentinel in dispatch result.data ────────────────────────
+    with caplog.at_level(logging.DEBUG, logger="app.tools.governance"):
+        caplog.clear()
+        dispatch_happy = _make_dispatch(
+            cost=Decimal("0.01"),
+            data={"secret": sentinel},
+        )
+        await governed_tool_invocation(
+            db_session,
+            origin="chat",
+            provider="acme-mcp",
+            tool="lookup",
+            intent=None,
+            provider_tier=1,
+            max_allowed_tier=5,
+            estimated_cost=Decimal("0.01"),
+            dispatch=dispatch_happy,
+            args_digest="sha256:happy",
+        )
+
+    for record in caplog.records:
+        assert sentinel not in record.getMessage(), (
+            f"Sentinel leaked into log record on happy path: {record.getMessage()!r}"
+        )
+
+    # ── Error path: sentinel in exc message, args_digest kept clean ─────────
+    with caplog.at_level(logging.DEBUG, logger="app.tools.governance"):
+        caplog.clear()
+        dispatch_err = _make_failing_dispatch(RuntimeError(f"err with {sentinel}"))
+        with pytest.raises(RuntimeError):
+            await governed_tool_invocation(
+                db_session,
+                origin="chat",
+                provider="acme-mcp",
+                tool="lookup",
+                intent=None,
+                provider_tier=1,
+                max_allowed_tier=5,
+                estimated_cost=Decimal("0.01"),
+                dispatch=dispatch_err,
+                args_digest="sha256:err",
+            )
+
+    for record in caplog.records:
+        assert sentinel not in record.getMessage(), (
+            f"Sentinel leaked into log record on error path: {record.getMessage()!r}"
+        )
 
 
 @pytest.mark.asyncio
@@ -467,60 +548,38 @@ async def test_dispatch_raises_annotates_span(db_session: AsyncSession):
 
 
 # ---------------------------------------------------------------------------
-# flush-not-commit invariant (structural check)
+# flush-not-commit invariant — tested on ALL THREE paths (M2 hardening)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_flush_not_commit_no_commit_called(db_session: AsyncSession):
-    """governed_tool_invocation must call flush() but never commit()."""
+def _make_flush_commit_trackers(
+    db: AsyncSession,
+) -> tuple[list[Any], list[Any]]:
+    """Wrap db.flush and db.commit with tracking lists; return (flush_calls, commit_calls)."""
+    flush_calls: list[Any] = []
     commit_calls: list[Any] = []
-    original_commit = db_session.commit
+
+    original_flush = db.flush
+    original_commit = db.commit
+
+    async def _tracking_flush(*args: Any, **kwargs: Any) -> Any:
+        flush_calls.append(("flush", args, kwargs))
+        return await original_flush(*args, **kwargs)
 
     async def _tracking_commit(*args: Any, **kwargs: Any) -> Any:
         commit_calls.append(("commit", args, kwargs))
         return await original_commit(*args, **kwargs)
 
-    db_session.commit = _tracking_commit  # type: ignore[method-assign]
+    db.flush = _tracking_flush  # type: ignore[method-assign]
+    db.commit = _tracking_commit  # type: ignore[method-assign]
 
-    dispatch = _make_dispatch(cost=Decimal("0.01"))
-    await governed_tool_invocation(
-        db_session,
-        origin="chat",
-        provider="acme-mcp",
-        tool="read_doc",
-        intent=None,
-        provider_tier=1,
-        max_allowed_tier=5,
-        estimated_cost=Decimal("0.01"),
-        dispatch=dispatch,
-    )
-
-    assert not commit_calls, (
-        "governed_tool_invocation must not commit — the caller owns the commit boundary"
-    )
-
-
-# ---------------------------------------------------------------------------
-# single-estimate invariant (structural check)
-# ---------------------------------------------------------------------------
+    return flush_calls, commit_calls
 
 
 @pytest.mark.asyncio
-async def test_single_estimate_not_reimposed(db_session: AsyncSession, monkeypatch):
-    """governed_tool_invocation must never call estimate_tool_cost itself."""
-    estimate_calls: list[Any] = []
-
-    async def _fake_estimate(*args: Any, **kwargs: Any) -> Decimal:
-        estimate_calls.append(args)
-        return Decimal("99")
-
-    # Patch the cost estimator in the governance module's namespace
-    monkeypatch.setattr(
-        "app.tools.governance.estimate_tool_cost",
-        _fake_estimate,
-        raising=False,
-    )
+async def test_flush_not_commit_happy_path(db_session: AsyncSession):
+    """Happy path: flush IS called, commit is NEVER called."""
+    flush_calls, commit_calls = _make_flush_commit_trackers(db_session)
 
     dispatch = _make_dispatch(cost=Decimal("0.01"))
     await governed_tool_invocation(
@@ -535,7 +594,118 @@ async def test_single_estimate_not_reimposed(db_session: AsyncSession, monkeypat
         dispatch=dispatch,
     )
 
-    assert not estimate_calls, "governed_tool_invocation must not call estimate_tool_cost"
+    assert flush_calls, "flush must be called on the happy path"
+    assert not commit_calls, (
+        "governed_tool_invocation must not commit on happy path — caller owns the boundary"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flush_not_commit_tier_refusal(db_session: AsyncSession):
+    """Tier-refusal path: flush IS called before the raise, commit is NEVER called."""
+    flush_calls, commit_calls = _make_flush_commit_trackers(db_session)
+
+    dispatch = _make_dispatch()
+    with pytest.raises(ToolTierRefused):
+        await governed_tool_invocation(
+            db_session,
+            origin="chat",
+            provider="acme-mcp",
+            tool="read_doc",
+            intent=None,
+            provider_tier=4,
+            max_allowed_tier=2,
+            estimated_cost=Decimal("0.10"),
+            dispatch=dispatch,
+        )
+
+    assert flush_calls, "flush must be called on the tier-refusal path"
+    assert not commit_calls, (
+        "governed_tool_invocation must not commit on tier-refusal — caller owns the boundary"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flush_not_commit_dispatch_raises(db_session: AsyncSession):
+    """Dispatch-raises path: flush IS called before the re-raise, commit is NEVER called."""
+    flush_calls, commit_calls = _make_flush_commit_trackers(db_session)
+
+    dispatch = _make_failing_dispatch(RuntimeError("boom"))
+    with pytest.raises(RuntimeError):
+        await governed_tool_invocation(
+            db_session,
+            origin="chat",
+            provider="acme-mcp",
+            tool="read_doc",
+            intent=None,
+            provider_tier=1,
+            max_allowed_tier=5,
+            estimated_cost=Decimal("0.01"),
+            dispatch=dispatch,
+        )
+
+    assert flush_calls, "flush must be called on the dispatch-raises path"
+    assert not commit_calls, (
+        "governed_tool_invocation must not commit on dispatch-raises — caller owns the boundary"
+    )
+
+
+# ---------------------------------------------------------------------------
+# single-estimate invariant (structural checks — M1 hardening)
+# ---------------------------------------------------------------------------
+
+
+def test_governance_module_has_no_estimate_tool_cost() -> None:
+    """The governance module must NOT define or import estimate_tool_cost.
+
+    The helper accepts ``estimated_cost`` from the caller (single-estimate
+    invariant).  If a cost-estimator symbol ever leaks in, this test
+    catches it before any runtime path is needed.
+    """
+    assert not hasattr(gov, "estimate_tool_cost"), (
+        "app.tools.governance must not define or import estimate_tool_cost — "
+        "the single-estimate invariant requires the caller to supply the cost"
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_estimate_cost_recorded_verbatim(db_session: AsyncSession):
+    """The helper records the caller's estimated_cost verbatim — never recomputes.
+
+    Passes a distinctive estimated_cost and verifies the row's cost_usd equals
+    it exactly, proving no internal re-estimation occurred.
+    """
+    caller_estimate = Decimal("0.031415")
+    # dispatch returns a *different* cost to ensure the row reflects the
+    # caller's estimate on the pending write path, then the dispatch result
+    # on the executed update.  We verify the executed cost_usd == dispatch cost.
+    dispatch_cost = Decimal(
+        "0.031415"
+    )  # same here — the contract is the row stores dispatch result
+    dispatch = _make_dispatch(cost=dispatch_cost)
+
+    await governed_tool_invocation(
+        db_session,
+        origin="chat",
+        provider="acme-mcp",
+        tool="read_doc",
+        intent=None,
+        provider_tier=1,
+        max_allowed_tier=5,
+        estimated_cost=caller_estimate,
+        dispatch=dispatch,
+    )
+
+    rows = (await db_session.execute(select(ToolCallLog))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    # The final cost_usd on the row comes from the dispatch result, which the
+    # helper records as-is.  Critically it must NOT be something other than
+    # what dispatch returned (i.e. no internal re-estimation to a third value).
+    assert row.cost_usd == dispatch_cost, (
+        f"cost_usd on the row ({row.cost_usd!r}) does not match the dispatch "
+        f"result ({dispatch_cost!r}); the helper must never recompute cost"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4619,6 +4619,16 @@ No code change — the runtime already returns these with the correct typed `cod
 
 **When to ship:** When an MCP OAuth server that enforces RFC 8707 on refresh is encountered, or proactively before GA.
 
+#### DE-344 — Per-provider external-tool cost model for `retrieve_caselaw` / `call_mcp_tool`
+
+**Priority:** P3 · **Effort:** M
+
+**Context:** PR5a wired the two external-tool intents (`retrieve_caselaw`, `call_mcp_tool`) into the autonomous governance path, but their cost estimator (`api/app/autonomous/cost.py`) returns `Decimal("0")` in v1 — they burn no provider-inference tokens (CourtListener is free-tier; MCP tool cost is provider-specific and unknown), so the R4 economic brake does not throttle them. The per-turn tool-call cap (PR5b, chat) and the autonomous session cost cap (inference) bound spend meanwhile, but a tool that proxies a metered/paid third-party API (a future MCP server, or CourtListener rate-tier overages) would not register cost against R4. Surfaced in the PR5a plan (2026-06-19).
+
+**Specific scope:** Add a per-provider external-tool cost model (e.g. a configured cost-per-call or cost-per-unit on the gateway `tool_providers` / `mcp.yaml` entry, or a rolling-average like the inference estimator) so `estimate_tool_cost` returns a real projection for `retrieve_caselaw` / `call_mcp_tool` and the R4 brake throttles expensive external tools. Record the realized cost on the `tool_call_log` row.
+
+**When to ship:** Before the autonomous layer (or chat) is pointed at a metered/paid third-party tool provider.
+
 ---
 
 ## 10. Appendices

--- a/docs/superpowers/plans/2026-06-19-pr5a-tool-governance-substrate.md
+++ b/docs/superpowers/plans/2026-06-19-pr5a-tool-governance-substrate.md
@@ -1,0 +1,163 @@
+# PR5a — Tool-governance substrate + autonomous tool intents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Build the shared per-call tool-governance substrate (`tool_call_log` + a `governed_tool_invocation` helper doing tier-check → audit → OTel) and add the two bounded autonomous `ToolIntent`s (`retrieve_caselaw`, `call_mcp_tool`) under the existing R5→R6→R4 brakes — the foundation PR5b's chat tool-loop builds on.
+
+**Architecture:** One governance path for chat AND the autonomous layer. A new `governed_tool_invocation` helper writes the `tool_call_log` row, does the per-call egress-tier check, opens/annotates the `*.tool_call` OTel span, runs the caller-supplied dispatch closure, and records cost/outcome — flush-not-commit. The autonomous chokepoint `guarded_tool_call` keeps its R5→R6→R4 brakes + session audit and **delegates** the tier/audit/dispatch primitives to this helper. The two new intents dispatch to the already-built research service (`retrieve_caselaw`) and `GatewayClient.call_tool` (`call_mcp_tool`); destructive/confirmation-required MCP tools are refused for the autonomous layer (ADR 0015 D4).
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2 async, Alembic, Pydantic v2, OpenTelemetry (`app.observability_helpers`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-18-pr5-governed-chat-tool-loop-design.md` (§PR5a). **ADR:** 0015 (D2/D3/D4/D5).
+
+## Global Constraints
+- **Brake order is R5 (temporal/halt) → R6 (contextual/phase-grant) → R4 (economic/cost).** `guarded_tool_call` (`api/app/autonomous/guard.py`) already implements this; do not reorder.
+- **Counts/types only in `tool_call_log` — never raw payloads.** Args are summarized to a digest; tool results are never written to the audit row (mirrors `tool_egress_log`).
+- **Cost is estimated ONCE per call.** `guarded_tool_call` computes the estimate for the R4 cap check and passes it to the helper; the helper never re-estimates (no double-charge / no divergence — preserve the existing comment at `guard.py:213-217`).
+- **Flush-not-commit.** Neither the helper nor `guarded_tool_call` commits — the executor (autonomous) / the chat handler (PR5b) owns the commit boundary.
+- **ADR 0015 D4:** a tool whose cached metadata is `destructive` or `requires_confirmation` is NEVER fired by the autonomous layer in v1.
+- ruff pinned **0.15.17** (`ruff format` + `ruff check`); `mypy app` clean (api standard mode). Tests: host venv + throwaway pgvector :15433 (`DATABASE_URL='postgresql+asyncpg://lq_ai:test@127.0.0.1:15433/lq_ai' .venv/bin/pytest …`); NEVER `alembic upgrade` the dev DB on :15432.
+- Commit `-s` + the trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`; stage explicitly, never `git add -A`.
+- **Migration head is 0052** (PR4d); this PR's migration is **0053**.
+- **Gate:** touches `api/app/autonomous/guard.py` (the autonomous guard) → **security review (Kevin merges).**
+
+## Locked design decisions
+- **D-a1 — span ownership:** `guarded_tool_call` keeps owning the `autonomous.tool_call` span (it must cover the R-brake outcomes that fire before dispatch). The helper is span-agnostic: it accepts an optional span and records `tool`-level attributes on it; it does NOT open its own span. PR5b's chat loop opens a `chat.tool_call` span and passes it in.
+- **D-a2 — tier check:** the helper does an explicit api-side pre-check: `if max_allowed_tier is not None and provider_tier > max_allowed_tier → refuse`. The caller resolves `provider_tier` from the gateway admin config via a new cached `resolve_provider_tier(provider)`. The gateway still enforces the ceiling on the actual call (defense in depth).
+- **D-a3 — cost of the new intents:** `retrieve_caselaw` and `call_mcp_tool` burn no provider-inference tokens, so `estimate_tool_cost` returns `Decimal("0")` for them in v1 (same treatment as local intents). A per-provider external-tool cost model is a deferred enhancement (file **DE-344**). R4 therefore does not brake on these in v1; the autonomous session cost cap still bounds inference, and PR5b's per-turn cap bounds chat.
+- **D-a4 — `call_mcp_tool` grant:** granted in the `analysis` phase only (conservative). The `call_mcp_tool` dispatch handler enforces D4 per-tool: it loads the cached `mcp_tools` row and **refuses** (raises `ToolNotGranted`) any tool whose `destructive` or `requires_confirmation` is true. `retrieve_caselaw` is granted in `analysis`.
+- **D-a5 — autonomous MCP token:** in v1 the autonomous layer has no interactive user to drive OAuth, so the `call_mcp_tool` handler passes `user_token=None`; an `auth: oauth` MCP server therefore raises `MCPAuthorizationRequired` from the gateway adapter (correct — autonomous cannot use per-user-OAuth servers). Only `none`/`bearer` MCP servers are autonomously callable. Documented; not a blocker.
+
+## File structure
+| File | Responsibility |
+|---|---|
+| `api/app/models/tool_call_log.py` (create) | `ToolCallLog` ORM model |
+| `api/app/models/__init__.py` (modify) | register it |
+| `api/alembic/versions/0053_tool_call_log.py` (create) | the table |
+| `api/app/tools/governance.py` (create) | `governed_tool_invocation` helper + `ToolTierRefused` + `resolve_provider_tier` + the `tool_call_log` writer |
+| `api/app/autonomous/enums.py` (modify) | add `retrieve_caselaw`, `call_mcp_tool` to `ToolIntent` + `PHASE_GRANTS` |
+| `api/app/autonomous/cost.py` (modify) | cost estimators (Decimal 0) for the two intents |
+| `api/app/autonomous/guard.py` (modify) | `guarded_tool_call` delegates tier/audit/dispatch to the helper; `_dispatch` handlers for the two intents (with D4 exclusion) |
+| `api/app/errors.py` (modify) | `ToolTierRefused` (if modeled as LQAIError) — or define in governance.py per the codebase idiom |
+| tests | model/migration, helper, enums/cost, guard integration |
+
+---
+
+## Task 1: `tool_call_log` table + model
+
+**Files:** `api/app/models/tool_call_log.py`, `api/app/models/__init__.py`, `api/alembic/versions/0053_tool_call_log.py`, `api/tests/test_tool_call_log_model.py`
+
+Mirror `tool_egress_log` (migration `0048_tool_egress_log.py`) for the migration style and the "counts/types only" discipline, and `api/app/models/mcp.py` for the ORM model style.
+
+**Table `tool_call_log`** (counts/types only — never raw args or results):
+```
+id                 uuid    PK   (server_default gen_random_uuid() or app-set, match existing uuid PK pattern)
+origin             text    NOT NULL          -- "chat" | "autonomous"
+user_id            uuid    NULL  FK users.id ON DELETE CASCADE  (name fk_tool_call_log_user)
+chat_id            uuid    NULL              -- set for chat-origin
+message_id         uuid    NULL
+session_id         uuid    NULL              -- set for autonomous-origin
+intent             text    NULL              -- ToolIntent value (autonomous) or NULL (chat-origin marker)
+provider           text    NOT NULL
+tool               text    NOT NULL
+tier               int     NOT NULL
+confirmation_state text    NOT NULL default 'not_required'  -- not_required|pending_confirmation|approved|denied
+outcome            text    NOT NULL          -- pending|executed|refused_tier|error|denied
+cost_usd           numeric(12,6)  NULL       -- serialize as JSON string (Decimal)
+args_digest        text    NULL              -- a short hash/summary, NEVER raw args
+request_id         text    NULL
+created_at         timestamptz NOT NULL default now()
+updated_at         timestamptz NOT NULL default now()   -- app-bumped
+```
+
+- [ ] Model `ToolCallLog` (`Mapped[...]`, the FK with `ondelete="CASCADE", name="fk_tool_call_log_user"`); register in `__init__.py` (`__all__` + import). Decimal column typed for string JSON serialization (see CLAUDE.md: cost fields serialize as JSON strings).
+- [ ] Migration 0053 (`revision="0053"`, `down_revision="0052"`); `op.create_table` + the users FK; `downgrade()` drops it. Confirm `alembic history` linear 0053→0052.
+- [ ] Test: table + columns + PK + the users-FK CASCADE (insert user + row, delete user, assert row gone) — mirror the PR4c `test_mcp_oauth_models.py` cascade test. **Commit.**
+
+## Task 2: the `governed_tool_invocation` helper
+
+**Files:** `api/app/tools/governance.py`, `api/app/tools/__init__.py` (create the package), `api/tests/test_tool_governance.py`
+
+**Produces (the interface PR5b + Task 4 consume):**
+```python
+class ToolTierRefused(LQAIError):  # or a module exception; map to 403-ish. code "tool_tier_refused"
+    def __init__(self, *, provider: str, tool: str, tier: int, ceiling: int) -> None: ...
+
+async def resolve_provider_tier(provider: str, *, request_id: str | None = None) -> int:
+    """The provider's egress_tier from the gateway admin config (process-cached).
+    Reads get_admin_config(); returns the tool_providers entry's egress_tier
+    (default to the most-restrictive tier if absent — fail safe)."""
+
+async def governed_tool_invocation(
+    db: AsyncSession,
+    *,
+    origin: str,                      # "chat" | "autonomous"
+    provider: str,
+    tool: str,
+    intent: ToolIntent | None,
+    provider_tier: int,
+    max_allowed_tier: int | None,
+    estimated_cost: Decimal,
+    dispatch: Callable[[], Awaitable[ToolResult]],
+    span: Any | None = None,          # optional OTel span to annotate (D-a1)
+    confirmation_state: str = "not_required",
+    user_id: UUID | None = None,
+    chat_id: UUID | None = None,
+    message_id: UUID | None = None,
+    session_id: UUID | None = None,
+    request_id: str | None = None,
+    args_digest: str | None = None,
+) -> ToolResult:
+    """Shared per-call governance: tier-check → tool_call_log row → dispatch → record.
+    Flush-not-commit. Raises ToolTierRefused before dispatch if the ceiling is exceeded."""
+```
+
+Behavior:
+1. **Tier check:** if `max_allowed_tier is not None and provider_tier > max_allowed_tier` → write a `tool_call_log` row `outcome="refused_tier"`, annotate `span` (`tool_call.outcome="refused_tier"`, counts/types only), raise `ToolTierRefused`.
+2. Write a `tool_call_log` row `outcome="pending"` (carrying origin/provider/tool/tier/intent/cost=estimated_cost/confirmation_state/ids/args_digest); `await db.flush()`.
+3. `try: result = await dispatch()` — on exception: update the row `outcome="error"`, annotate span, flush, re-raise.
+4. Update the row `outcome="executed"`, `cost_usd=result.cost_usd`, bump `updated_at`; annotate span (`tool_call.cost_usd`, `tool_call.outcome`); flush; return `result`.
+
+- [ ] TDD: failing tests using a **fake dispatch** returning a `ToolResult` and a fake `db` (or the real test DB): tier-refusal writes a refused_tier row + raises (no dispatch called); happy path writes pending→executed with the cost; a dispatch that raises writes an error row + re-raises; **no raw args/results in any row** (assert the row fields contain only the digest/counts); span annotations are counts/types only. `resolve_provider_tier` returns the configured tier (respx/mock the gateway config) and the fail-safe default when absent.
+- [ ] Implement; gates (pytest, ruff, mypy). **Commit.** (This is the security-critical shared substrate — it will get focused review.)
+
+## Task 3: the two `ToolIntent`s + grants + cost
+
+**Files:** `api/app/autonomous/enums.py`, `api/app/autonomous/cost.py`, `api/tests/test_autonomous_enums.py` (+ extend `test` for cost)
+
+- [ ] `ToolIntent`: add `retrieve_caselaw = "retrieve_caselaw"` and `call_mcp_tool = "call_mcp_tool"`.
+- [ ] `PHASE_GRANTS`: add `retrieve_caselaw` AND `call_mcp_tool` to `Phase.analysis`'s frozenset (D-a4). No other phase grants them.
+- [ ] `cost.py`: the two new intents return `Decimal("0")` (D-a3) — extend the docstring; they are NOT in `_INFERENCE_INTENTS`. (Current code already returns 0 for non-inference intents, so this may be a no-op + a doc update + a test — verify and add the explicit tests.)
+- [ ] Tests: the two intents exist; `retrieve_caselaw`/`call_mcp_tool` ∈ `PHASE_GRANTS[Phase.analysis]` and ∉ every other phase; `estimate_tool_cost` returns 0 for both. **Commit.**
+
+## Task 4: `guarded_tool_call` refactor + dispatch handlers (the integration heart)
+
+**Files:** `api/app/autonomous/guard.py`, `api/tests/test_autonomous_guard_tool_intents.py`
+
+### 4a — route the EXTERNAL-tool intents through the helper
+- [ ] In `guarded_tool_call`, keep R5/R6/R4 + the `autonomous.tool_call` span + `autonomous_audit` exactly as-is. The change is only at the dispatch line (guard.py:237): **for the external-tool intents (`retrieve_caselaw`, `call_mcp_tool`)**, route the dispatch through `governed_tool_invocation` (so they get a `tool_call_log` row + the tier check + span annotation); **for all existing intents (`run_skill`, `run_playbook`, `retrieve_chunks`, and the local writes), dispatch exactly as today** via `_dispatch(...)` — they are not external tool calls and stay on `autonomous_audit` only (no `tool_call_log` noise). `tool_call_log` is the external-tool audit; the autonomous session event log (`autonomous_audit`) is unchanged for every intent.
+  - For the routed intents: resolve `provider`/`tool` (4b) + `provider_tier` (`resolve_provider_tier`), pass the existing `estimate` as `estimated_cost` (single-estimate invariant — do NOT re-estimate in the helper), `span=span`, `origin="autonomous"`, `session_id=session.id`, `intent=intent`, `max_allowed_tier=<session ceiling or None>`, and a `dispatch` closure that calls the existing per-intent handler. The helper writes the `tool_call_log` row; `autonomous_audit` still records the session "tool_call" event as today.
+
+### 4b — dispatch handlers for the two intents (in `_dispatch`)
+- [ ] `retrieve_caselaw`: call the research service (`app.research.service`) — map params (e.g. `{op, ...}`) to `verify_citations`/`search_case_law`/`get_cluster`/`read_opinion`/`find_in_case`; return a `ToolResult(outcome="ok", cost_usd=Decimal("0"), ...)` (match the existing `ToolResult` shape used by other handlers). provider marker = the configured courtlistener provider name.
+- [ ] `call_mcp_tool`: params carry `{provider, tool, args}`. **D4 enforcement:** load the cached `mcp_tools` row for `(provider, tool)`; if it is missing OR `destructive` OR `requires_confirmation` → raise `ToolNotGranted` (the autonomous layer cannot fire a human-gated/unknown tool). Else call `GatewayClient.call_tool(provider, tool, args, max_allowed_tier=…, request_id=…)` with `user_token=None` (D-a5) and return a `ToolResult`. (If the gateway raises `MCPAuthorizationRequired` for an oauth server, let it propagate — autonomous can't use per-user OAuth servers.)
+
+### 4c — tests
+- [ ] `retrieve_caselaw` granted in `analysis` executes (mock the research service) and writes a `tool_call_log` row; refused (R6 `ToolNotGranted`) in `intake`/`drafting`/etc.
+- [ ] `call_mcp_tool` in `analysis` with a cached **read_only** tool executes (mock `call_tool`) + writes a row; with a **destructive** cached tool → `ToolNotGranted` (D4) — and NO gateway call made; with `requires_confirmation` → `ToolNotGranted`; unknown tool → `ToolNotGranted`.
+- [ ] the existing `guarded_tool_call` brake tests (R5 halt, R6 grant, R4 cap) still pass after the refactor; a `tool_call_log` row is written for an existing intent (e.g. `retrieve_chunks`) too.
+- [ ] **Commit.**
+
+## Task 5: full gates + DE + ship
+
+- [ ] File **DE-344** (per-provider external-tool cost model; v1 estimates 0 for `retrieve_caselaw`/`call_mcp_tool`) in PRD §9.
+- [ ] Full api suite (`pytest -q`), `ruff format --check` + `ruff check`, `mypy app`. Final holistic review focused on: single-estimate invariant preserved; no raw args/results in `tool_call_log`; the brakes unchanged; D4 destructive-exclusion airtight (no gateway call for a destructive tool); flush-not-commit preserved. Push both remotes; PR vs `main`; CI; **Kevin reviews/merges** (autonomous guard). Report the squash SHA.
+
+## Definition of done (PR5a)
+- `tool_call_log` (migration 0053) records every governed tool call (chat + autonomous), counts/types only.
+- `governed_tool_invocation` is the shared tier→audit→dispatch substrate; `guarded_tool_call` delegates to it without changing R5→R6→R4 or the single-estimate discipline.
+- `retrieve_caselaw` + `call_mcp_tool` exist, granted only in `analysis`, dispatch to the research service / `call_tool`; destructive/confirmation-required MCP tools are refused for the autonomous layer (D4), proven by test.
+- Full api + gates green. **Gate:** security review.
+
+## Self-review notes (coverage vs spec §PR5a)
+- tool_call_log ✓ (Task 1) · shared helper w/ tier+audit+OTel ✓ (Task 2) · guarded_tool_call delegates ✓ (Task 4a) · 2 intents + grants + cost ✓ (Task 3) · destructive-exclusion D4 ✓ (Task 4b/c) · OTel span D5 ✓ (D-a1 + helper annotations). Deferred per spec: chat loop + confirmation gate + gateway tools-passthrough + connect-on-demand = **PR5b**; external-source citations/pills/UI = PR6; per-provider tool-cost = DE-344.


### PR DESCRIPTION
## PR5a / WS4 — Tool-governance substrate + autonomous tool intents

First half of the governed chat tool-loop (ADR 0015 / approved spec `docs/superpowers/specs/2026-06-18-pr5-governed-chat-tool-loop-design.md` §PR5a). Builds the **shared per-call tool-governance substrate** that PR5b's chat tool-loop will reuse, and adds the two bounded autonomous `ToolIntent`s under the existing R5→R6→R4 brakes. Plan: `docs/superpowers/plans/2026-06-19-pr5a-tool-governance-substrate.md`.

### ⚠️ Security-review surface
Touches the **autonomous guard** (`api/app/autonomous/guard.py`) and adds the shared governance substrate → security-gated.

### What shipped
- **`tool_call_log` table** (migration **0053**) — one row per governed tool call (chat + autonomous); **counts/types only, never raw payloads** (mirrors `tool_egress_log`; `args_digest` is a sha256-of-keys+value-types hash, never values).
- **`governed_tool_invocation` helper** (`api/app/tools/governance.py`) — the shared substrate both chat and autonomous use: tier-check → `tool_call_log` row → run the caller's dispatch closure → record cost/outcome. **Flush-not-commit**, **single-estimate** (caller passes the R4 estimate; the helper never re-estimates), **span-agnostic** (annotates a passed-in OTel span — D-a1), `resolve_provider_tier` (process-cached, **fail-safe to the most-restrictive tier**). A `denied_on` param labels policy refusals `outcome="denied"` vs genuine failures `"error"`.
- **Two `ToolIntent`s** — `retrieve_caselaw`, `call_mcp_tool` — granted **only in the `analysis` phase** (maintainer-confirmed), cost `Decimal(0)` in v1 (a per-provider cost model is **DE-344**).
- **`guarded_tool_call`** routes ONLY these two external intents through the helper; the **R5→R6→R4 brakes, the `autonomous.tool_call` span, and `autonomous_audit` are byte-unchanged**; local/inference intents keep their direct path (no `tool_call_log` noise).
- **ADR-0015 D4** (`call_mcp_tool`): a `destructive` / `requires_confirmation` / **operator-disabled** / unknown MCP tool is refused (`ToolNotGranted`, **NO gateway call**, `tool_call_log` `outcome="denied"`). Autonomous sends **no per-user token** (D-a5) — `auth: oauth` servers therefore fail at the gateway (autonomous has no interactive OAuth).

### Tests / gates
- Full **api suite: 2159 passed, 1 skipped**; ruff + mypy clean. **api-only** — no `gateway/` or `web/` changes.
- Built subagent-driven (5 tasks), each spec- + quality-reviewed; the shared helper + the guard integration reviewed on opus. **Opus whole-branch review: ready to merge** (no Critical; the one Important — D4 missing the `enabled=False` check — was fixed before ship; raw-payload non-leakage, brake-preservation, single-estimate, D4-no-gateway-call all verified end-to-end with sentinel-scanned tests).

### Notes
- Migration head **0052 → 0053**.
- The helper's interface (`origin`, chat ids, `confirmation_state`, `denied_on`, optional span) is deliberately general so **PR5b's chat loop reuses it unmodified** (it opens a `chat.tool_call` span, passes `origin="chat"`, and the per-turn confirmation gate uses `confirmation_state`).
- A D4 refusal's authoritative record is the `tool_call_log` `denied` row (the session event log keeps its `started` event; the terminal status is on the session) — by design.
- DE-344 filed (per-provider external-tool cost model so R4 can throttle metered/paid tools).

### Next: PR5b
The chat tool-loop + persist-and-resume confirmation gate + the gateway `tools`/`tool_choice` passthrough + connect-on-demand, built on this substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
