### PR TITLE
feat(gateway): tools/tool_choice passthrough + Anthropic tool-call bridge (PR5b-i)

### DIFF
--- a/api/app/schemas/gateway.py
+++ b/api/app/schemas/gateway.py
@@ -93,6 +93,33 @@ class InlineSkillRef(BaseModel):
     """Provenance tag (``wizard-tryout``, etc.) — surfaced on audit logs."""
 
 
+class FunctionDefinition(BaseModel):
+    """A single function-tool the model may call (OpenAI ``function`` shape).
+
+    Mirrors :class:`gateway.app.providers.openai_schema.FunctionDefinition`.
+    PR5b: the backend assembles these from operator-enabled research / MCP
+    tools and forwards them to the gateway.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(min_length=1, max_length=128)
+    description: str | None = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolDefinition(BaseModel):
+    """One entry in the request's ``tools`` allowlist (OpenAI ``function`` type).
+
+    Mirrors :class:`gateway.app.providers.openai_schema.ToolDefinition`.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["function"] = "function"
+    function: FunctionDefinition
+
+
 class ChatCompletionRequest(BaseModel):
     """OpenAI Chat Completions request body, plus LQ.AI extensions.
 
@@ -112,6 +139,16 @@ class ChatCompletionRequest(BaseModel):
     stream: bool = False
     stop: list[str] | str | None = None
     n: int | None = Field(default=None, ge=1, le=1)
+
+    # --- PR5b: governed tool-calling (WS4) -----------------------------------
+    tools: list[ToolDefinition] | None = Field(default=None, max_length=64)
+    """Model-visible tool allowlist for this turn (PR5b). Assembled by the
+    chat tool-loop from operator-enabled research + MCP tools and forwarded
+    to the gateway. ``None`` preserves the pre-PR5b single-shot wire shape."""
+
+    tool_choice: str | dict[str, Any] | None = None
+    """How the model chooses among ``tools`` (OpenAI shape:
+    ``auto`` / ``none`` / ``required`` or a specific function)."""
 
     # --- LQ.AI extensions (per gateway-openapi.yaml) -------------------------
     minimum_inference_tier: int | None = Field(default=None, ge=1, le=5)

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -1012,6 +1012,40 @@ components:
         temperature: {type: number, minimum: 0, maximum: 2}
         top_p: {type: number}
         stream: {type: boolean, default: false}
+        # PR5b: governed tool-calling (WS4)
+        tools:
+          type: array
+          maxItems: 64
+          description: |
+            Model-visible tool allowlist for this turn (PR5b). The backend
+            assembles this from operator-enabled research + MCP tools; the
+            gateway forwards it to the provider (OpenAI verbatim; Anthropic
+            translated to `input_schema` blocks). Omitted preserves the
+            pre-PR5b single-shot wire shape.
+          items:
+            type: object
+            required: [type, function]
+            properties:
+              type: {type: string, enum: [function], default: function}
+              function:
+                type: object
+                required: [name]
+                properties:
+                  name: {type: string, maxLength: 128}
+                  description: {type: string}
+                  parameters:
+                    type: object
+                    description: JSON Schema for the tool's arguments.
+        tool_choice:
+          description: |
+            How the model chooses among `tools` (OpenAI shape): `auto`,
+            `none`, `required`, or a specific
+            `{type: function, function: {name}}`. Translated to Anthropic's
+            `auto` / `any` / `tool` shape.
+          oneOf:
+            - type: string
+              enum: [auto, none, required]
+            - type: object
         # LQ.AI extensions
         minimum_inference_tier:
           type: integer

--- a/gateway/app/providers/anthropic.py
+++ b/gateway/app/providers/anthropic.py
@@ -64,6 +64,7 @@ from app.providers.openai_schema import (
     EmbeddingsRequest,
     EmbeddingsResponse,
     FinishReason,
+    ToolDefinition,
 )
 from app.secrets import ProviderKeyResolver
 
@@ -357,10 +358,12 @@ def _to_anthropic_request(
       Anthropic uses its defaults.
     * ``stop`` (OpenAI) becomes ``stop_sequences`` (Anthropic, list-only).
 
-    Tool calls (DE-XXX, future): full OpenAI tool-call/tool-result bridging
-    requires translating to Anthropic's ``tool_use``/``tool_result``
-    content blocks. B3 ships text-only translation; tool-call coverage
-    arrives with the skills work in M1 Phase C.
+    Tool calling (PR5b / WS4): when ``request.tools`` is set, each OpenAI
+    function-tool becomes an Anthropic tool block (``input_schema``) and
+    ``tool_choice`` is translated to Anthropic's shape. Assistant messages
+    that carry ``tool_calls`` (the multi-step loop replaying its own prior
+    calls) are rebuilt as ``tool_use`` content blocks, and ``role="tool"``
+    results are sent as ``tool_result`` blocks (already handled below).
     """
 
     system_chunks: list[str] = []
@@ -387,7 +390,18 @@ def _to_anthropic_request(
                 }
             )
             continue
-        # user / assistant
+        if msg.role == "assistant" and msg.tool_calls:
+            # Assistant turn that issued tool calls (multi-step loop): rebuild
+            # Anthropic ``tool_use`` content blocks so the model sees its own
+            # prior calls. Any leading assistant text is preserved first.
+            assistant_blocks: list[dict[str, Any]] = []
+            if content:
+                assistant_blocks.append({"type": "text", "text": content})
+            for call in msg.tool_calls:
+                assistant_blocks.append(_tool_call_to_tool_use(call))
+            chat_messages.append({"role": "assistant", "content": assistant_blocks})
+            continue
+        # user / assistant (text only)
         chat_messages.append({"role": msg.role, "content": content})
 
     body: dict[str, Any] = {
@@ -406,7 +420,93 @@ def _to_anthropic_request(
         body["stop_sequences"] = (
             [request.stop] if isinstance(request.stop, str) else list(request.stop)
         )
+    # PR5b: tool allowlist + choice. ``tool_choice="none"`` means "don't use
+    # tools this turn", so we omit the tools block entirely rather than send
+    # an unusable Anthropic ``tool_choice``.
+    if request.tools and request.tool_choice != "none":
+        body["tools"] = [_tool_to_anthropic(tool) for tool in request.tools]
+        choice = _tool_choice_to_anthropic(request.tool_choice)
+        if choice is not None:
+            body["tool_choice"] = choice
     return body
+
+
+def _tool_to_anthropic(tool: ToolDefinition) -> dict[str, Any]:
+    """Translate an OpenAI function-tool to an Anthropic tool block.
+
+    Anthropic requires an ``input_schema`` (JSON Schema object); we pass the
+    OpenAI ``parameters`` through and substitute an empty-object schema when
+    the caller omits it (a no-argument tool).
+    """
+
+    schema = tool.function.parameters or {"type": "object", "properties": {}}
+    block: dict[str, Any] = {"name": tool.function.name, "input_schema": schema}
+    if tool.function.description:
+        block["description"] = tool.function.description
+    return block
+
+
+def _tool_choice_to_anthropic(choice: str | dict[str, Any] | None) -> dict[str, Any] | None:
+    """Translate an OpenAI ``tool_choice`` to Anthropic's shape.
+
+    ``auto`` / ``None`` -> Anthropic default (auto), so we return ``None`` and
+    omit the field. ``required`` -> ``{"type": "any"}``. A specific
+    ``{"type": "function", "function": {"name": N}}`` -> ``{"type": "tool",
+    "name": N}``. (``"none"`` is handled by the caller, which drops tools.)
+    """
+
+    if choice is None or choice == "auto":
+        return None
+    if choice == "required":
+        return {"type": "any"}
+    if isinstance(choice, dict):
+        fn = choice.get("function")
+        if isinstance(fn, dict) and isinstance(fn.get("name"), str):
+            return {"type": "tool", "name": fn["name"]}
+    return None
+
+
+def _tool_call_to_tool_use(call: dict[str, Any]) -> dict[str, Any]:
+    """Rebuild an Anthropic ``tool_use`` block from an OpenAI tool_call dict.
+
+    OpenAI carries arguments as a JSON *string*; Anthropic wants a parsed
+    object in ``input``. A malformed/empty arguments string degrades to an
+    empty object rather than failing the whole turn.
+    """
+
+    fn = call.get("function") or {}
+    raw_args = fn.get("arguments")
+    parsed_args: Any
+    if isinstance(raw_args, str):
+        try:
+            parsed_args = json.loads(raw_args) if raw_args else {}
+        except json.JSONDecodeError:
+            parsed_args = {}
+    elif isinstance(raw_args, dict):
+        parsed_args = raw_args
+    else:
+        parsed_args = {}
+    return {
+        "type": "tool_use",
+        "id": str(call.get("id") or ""),
+        "name": str(fn.get("name") or ""),
+        "input": parsed_args,
+    }
+
+
+def _tool_use_to_tool_call(block: dict[str, Any]) -> dict[str, Any]:
+    """Translate an Anthropic ``tool_use`` content block to an OpenAI tool_call.
+
+    Anthropic carries ``input`` as a parsed object; OpenAI wants arguments as
+    a JSON string. A missing id is synthesized so downstream correlation (the
+    chat loop's ``tool_result`` reply) always has a handle.
+    """
+
+    call_id = str(block.get("id") or f"call_{uuid.uuid4().hex}")
+    name = str(block.get("name") or "")
+    raw_input = block.get("input")
+    arguments = json.dumps(raw_input if isinstance(raw_input, dict) else {})
+    return {"id": call_id, "type": "function", "function": {"name": name, "arguments": arguments}}
 
 
 # --- Translation: Anthropic -> OpenAI (non-streaming) -------------------------
@@ -421,9 +521,15 @@ def _from_anthropic_response(
 
     blocks = payload.get("content") or []
     text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
     for block in blocks:
-        if isinstance(block, dict) and block.get("type") == "text":
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
             text_parts.append(str(block.get("text", "")))
+        elif block_type == "tool_use":
+            tool_calls.append(_tool_use_to_tool_call(block))
     text = "".join(text_parts)
 
     stop_reason_raw = payload.get("stop_reason")
@@ -450,7 +556,14 @@ def _from_anthropic_response(
         choices=[
             ChatCompletionChoice(
                 index=0,
-                message=ChatCompletionMessage(role="assistant", content=text),
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    # OpenAI convention: ``content`` may be null on a pure
+                    # tool-call turn. Preserve "" for ordinary text responses
+                    # (no behavior change) but null it when only tool calls.
+                    content=text if text else (None if tool_calls else ""),
+                    tool_calls=tool_calls or None,
+                ),
                 finish_reason=finish_reason,
             )
         ],
@@ -518,6 +631,9 @@ async def _anthropic_stream_iter(
     prompt_tokens = 0
     completion_tokens = 0
     role_emitted = False
+    # PR5b: accumulate streamed tool_use blocks keyed by Anthropic content
+    # block index; emit an OpenAI tool_calls delta when each block stops.
+    tool_uses: dict[int, dict[str, Any]] = {}
 
     try:
         async with client.stream("POST", "/v1/messages", json=body, headers=headers) as response:
@@ -560,6 +676,26 @@ async def _anthropic_stream_iter(
                         )
                     continue
 
+                if kind == "content_block_start":
+                    cb = parsed.get("content_block") or {}
+                    idx = parsed.get("index")
+                    if cb.get("type") == "tool_use" and isinstance(idx, int):
+                        if not role_emitted:
+                            role_emitted = True
+                            yield _make_chunk(
+                                response_id=response_id,
+                                created=created,
+                                model=response_model,
+                                delta=ChatCompletionDelta(role="assistant"),
+                            )
+                        tool_uses[idx] = {
+                            "ordinal": len(tool_uses),
+                            "id": str(cb.get("id") or f"call_{uuid.uuid4().hex}"),
+                            "name": str(cb.get("name") or ""),
+                            "args": "",
+                        }
+                    continue
+
                 if kind == "content_block_delta":
                     delta_block = parsed.get("delta") or {}
                     if delta_block.get("type") == "text_delta":
@@ -571,6 +707,34 @@ async def _anthropic_stream_iter(
                                 model=response_model,
                                 delta=ChatCompletionDelta(content=text),
                             )
+                    elif delta_block.get("type") == "input_json_delta":
+                        idx = parsed.get("index")
+                        if isinstance(idx, int) and idx in tool_uses:
+                            tool_uses[idx]["args"] += str(delta_block.get("partial_json", ""))
+                    continue
+
+                if kind == "content_block_stop":
+                    idx = parsed.get("index")
+                    if isinstance(idx, int) and idx in tool_uses:
+                        tu = tool_uses[idx]
+                        yield _make_chunk(
+                            response_id=response_id,
+                            created=created,
+                            model=response_model,
+                            delta=ChatCompletionDelta(
+                                tool_calls=[
+                                    {
+                                        "index": tu["ordinal"],
+                                        "id": tu["id"],
+                                        "type": "function",
+                                        "function": {
+                                            "name": tu["name"],
+                                            "arguments": tu["args"] or "",
+                                        },
+                                    }
+                                ]
+                            ),
+                        )
                     continue
 
                 if kind == "message_delta":

--- a/gateway/app/providers/ollama.py
+++ b/gateway/app/providers/ollama.py
@@ -471,15 +471,14 @@ def _to_ollama_request(
 
     # Tool calls / tool choice forward through ``tools`` per Ollama's
     # 0.4+ tool-use surface. The OpenAI ``tools`` schema maps directly:
-    # both use the OpenAI tool-definition shape. ``tool_choice``
-    # similarly forwards verbatim.
-    extra = request.model_extra or {}
-    tools = extra.get("tools")
-    if tools is not None:
-        body["tools"] = tools
-    tool_choice = extra.get("tool_choice")
-    if tool_choice is not None:
-        body["tool_choice"] = tool_choice
+    # both use the OpenAI tool-definition shape, so we dump the typed
+    # ``ToolDefinition`` models straight back to their OpenAI dict form.
+    # ``tool_choice`` similarly forwards verbatim. (PR5b promoted ``tools`` /
+    # ``tool_choice`` from extra-allow fields to typed request fields.)
+    if request.tools is not None:
+        body["tools"] = [tool.model_dump(mode="json", exclude_none=True) for tool in request.tools]
+    if request.tool_choice is not None:
+        body["tool_choice"] = request.tool_choice
 
     return body
 

--- a/gateway/app/providers/openai_schema.py
+++ b/gateway/app/providers/openai_schema.py
@@ -141,6 +141,35 @@ class InlineSkillRef(BaseModel):
     metadata."""
 
 
+class FunctionDefinition(BaseModel):
+    """A single function-tool the model may call (OpenAI ``function`` shape).
+
+    PR5b: carries the JSON-schema ``parameters`` the model fills in. The
+    gateway forwards this to OpenAI verbatim and translates it to
+    Anthropic's ``input_schema`` shape for the Messages API.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(min_length=1, max_length=128)
+    description: str | None = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolDefinition(BaseModel):
+    """One entry in the request's ``tools`` allowlist (OpenAI ``function`` type).
+
+    PR5b only models ``type="function"``; other OpenAI tool types
+    (``code_interpreter`` etc.) are out of scope for the governed
+    legal-research / MCP loop and would not pass the closed-set governance.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["function"] = "function"
+    function: FunctionDefinition
+
+
 class ChatCompletionRequest(BaseModel):
     """OpenAI Chat Completions request body, plus LQ.AI extensions.
 
@@ -165,6 +194,24 @@ class ChatCompletionRequest(BaseModel):
     Anthropic Messages doesn't expose an equivalent and supporting it
     multiplies cost without a corresponding skill use case (PRD §7).
     """
+
+    # --- PR5b: governed tool-calling (WS4) -----------------------------------
+    tools: list[ToolDefinition] | None = Field(default=None, max_length=64)
+    """Model-visible tool allowlist for this turn (PR5b). The backend
+    assembles this from operator-enabled research + MCP tools; the gateway
+    forwards it to the provider (OpenAI verbatim; Anthropic translated to
+    ``input_schema`` blocks). Capped at 64 entries as a defense-in-depth
+    bound on the prompt-multiplication surface — the operator allowlist is
+    far smaller in practice. ``None`` (the default) preserves the pre-PR5b
+    single-shot wire shape exactly."""
+
+    tool_choice: str | dict[str, Any] | None = None
+    """How the model should choose among ``tools`` (OpenAI shape):
+    ``"auto"`` / ``"none"`` / ``"required"``, or a specific
+    ``{"type": "function", "function": {"name": ...}}``. Forwarded to
+    OpenAI verbatim; translated to Anthropic's ``tool_choice`` shape
+    (``auto`` / ``any`` / ``tool``). ``None`` lets the provider default
+    (``auto`` when ``tools`` is present)."""
 
     # --- LQ.AI extensions (per gateway-openapi.yaml) -------------------------
     minimum_inference_tier: int | None = Field(default=None, ge=1, le=5)

--- a/gateway/tests/test_anthropic_adapter.py
+++ b/gateway/tests/test_anthropic_adapter.py
@@ -562,3 +562,268 @@ def test_from_config_succeeds_with_env_set() -> None:
     )
     adapter = AnthropicAdapter.from_config(provider, env={"ANTHROPIC_API_KEY": "sk-ant-x"})
     assert adapter.name == "anthropic-test"
+
+
+# --- PR5b: tool-calling bridge ------------------------------------------------
+
+
+_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Look up the weather.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_translates_tools_and_auto_choice() -> None:
+    """OpenAI ``tools`` become Anthropic tool blocks (name / description /
+    input_schema). ``tool_choice="auto"`` is Anthropic's default, so it is
+    omitted from the body."""
+
+    req = _basic_request(tools=[_WEATHER_TOOL], tool_choice="auto")
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert body["tools"] == [
+        {
+            "name": "get_weather",
+            "description": "Look up the weather.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    assert "tool_choice" not in body
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_tool_choice_required_and_specific() -> None:
+    """``required`` -> Anthropic ``any``; a specific function -> ``tool``."""
+
+    req = _basic_request(tools=[_WEATHER_TOOL], tool_choice="required")
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert body["tool_choice"] == {"type": "any"}
+
+    req2 = _basic_request(
+        tools=[_WEATHER_TOOL],
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+    )
+    body2 = _to_anthropic_request(req2, model="claude-sonnet-4-6", stream=False)
+    assert body2["tool_choice"] == {"type": "tool", "name": "get_weather"}
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_tool_choice_none_drops_tools() -> None:
+    """``tool_choice="none"`` means do not use tools this turn; we omit the
+    tools block entirely rather than send an unusable Anthropic choice."""
+
+    req = _basic_request(tools=[_WEATHER_TOOL], tool_choice="none")
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert "tools" not in body
+    assert "tool_choice" not in body
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_tool_without_params_gets_empty_schema() -> None:
+    """A no-argument tool still needs a valid Anthropic ``input_schema``."""
+
+    tool = {"type": "function", "function": {"name": "ping"}}
+    req = _basic_request(tools=[tool])
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert body["tools"] == [{"name": "ping", "input_schema": {"type": "object", "properties": {}}}]
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_assistant_tool_calls_become_tool_use() -> None:
+    """An assistant message replaying its own tool_calls (the multi-step
+    loop) becomes Anthropic ``tool_use`` blocks; JSON-string arguments are
+    parsed into ``input``. The following ``tool`` result stays a
+    ``tool_result`` block."""
+
+    req = ChatCompletionRequest.model_validate(
+        {
+            "model": "claude-sonnet-4-6",
+            "messages": [
+                {"role": "user", "content": "weather in Paris?"},
+                {
+                    "role": "assistant",
+                    "content": "Let me check.",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "Paris"}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "Sunny", "tool_call_id": "call_1"},
+            ],
+        }
+    )
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "tool_use",
+                "id": "call_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+            },
+        ],
+    }
+    assert body["messages"][2]["content"][0]["type"] == "tool_result"
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_from_anthropic_response_reconstructs_tool_calls() -> None:
+    """A ``tool_use`` content block becomes an OpenAI ``tool_calls`` entry
+    with JSON-string arguments; ``content`` is null on a pure tool turn and
+    ``finish_reason`` is ``tool_calls``."""
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "msg_tool",
+                "model": "claude-sonnet-4-6",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01",
+                        "name": "get_weather",
+                        "input": {"city": "Paris"},
+                    }
+                ],
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 10, "output_tokens": 4},
+            },
+        )
+    )
+    adapter = _make_adapter()
+    try:
+        result = await adapter.chat_completion(
+            _basic_request(), model="claude-sonnet-4-6", stream=False
+        )
+    finally:
+        await adapter.aclose()
+    assert isinstance(result, ChatCompletionResponse)
+    msg = result.choices[0].message
+    assert msg.content is None
+    assert result.choices[0].finish_reason == "tool_calls"
+    assert msg.tool_calls is not None
+    assert len(msg.tool_calls) == 1
+    call = msg.tool_calls[0]
+    assert call["id"] == "toolu_01"
+    assert call["type"] == "function"
+    assert call["function"]["name"] == "get_weather"
+    assert json.loads(call["function"]["arguments"]) == {"city": "Paris"}
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_from_anthropic_response_text_plus_tool_call() -> None:
+    """Text *and* a tool call both survive: ``content`` is the text,
+    ``tool_calls`` carries the call."""
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "msg_mix",
+                "model": "claude-sonnet-4-6",
+                "content": [
+                    {"type": "text", "text": "Checking the weather."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_02",
+                        "name": "get_weather",
+                        "input": {"city": "Lyon"},
+                    },
+                ],
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 8, "output_tokens": 6},
+            },
+        )
+    )
+    adapter = _make_adapter()
+    try:
+        result = await adapter.chat_completion(
+            _basic_request(), model="claude-sonnet-4-6", stream=False
+        )
+    finally:
+        await adapter.aclose()
+    assert isinstance(result, ChatCompletionResponse)
+    msg = result.choices[0].message
+    assert msg.content == "Checking the weather."
+    assert msg.tool_calls is not None and len(msg.tool_calls) == 1
+
+
+SSE_TOOL_FIXTURE_BODY = (
+    "event: message_start\n"
+    'data: {"type":"message_start","message":{"id":"msg_tstream","model":"claude-sonnet-4-6",'
+    '"usage":{"input_tokens":9,"output_tokens":0}}}\n\n'
+    "event: content_block_start\n"
+    'data: {"type":"content_block_start","index":0,"content_block":'
+    '{"type":"tool_use","id":"toolu_s1","name":"get_weather","input":{}}}\n\n'
+    "event: content_block_delta\n"
+    'data: {"type":"content_block_delta","index":0,"delta":'
+    '{"type":"input_json_delta","partial_json":"{\\"city\\":"}}\n\n'
+    "event: content_block_delta\n"
+    'data: {"type":"content_block_delta","index":0,"delta":'
+    '{"type":"input_json_delta","partial_json":" \\"Paris\\"}"}}\n\n'
+    "event: content_block_stop\n"
+    'data: {"type":"content_block_stop","index":0}\n\n'
+    "event: message_delta\n"
+    'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},'
+    '"usage":{"output_tokens":12}}\n\n'
+    "event: message_stop\n"
+    'data: {"type":"message_stop"}\n\n'
+)
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_streaming_accumulates_tool_use_into_tool_calls_delta() -> None:
+    """Streamed ``tool_use`` (content_block_start + input_json_delta chunks +
+    stop) becomes ONE OpenAI ``tool_calls`` delta carrying the full
+    accumulated JSON arguments; the final chunk reports
+    ``finish_reason="tool_calls"``."""
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            text=SSE_TOOL_FIXTURE_BODY,
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+    adapter = _make_adapter()
+    try:
+        result = await adapter.chat_completion(
+            _basic_request(stream=True), model="claude-sonnet-4-6", stream=True
+        )
+        assert not isinstance(result, ChatCompletionResponse)
+        chunks = [chunk async for chunk in result]
+    finally:
+        await adapter.aclose()
+
+    tool_chunks = [c for c in chunks if c.choices[0].delta.tool_calls]
+    assert len(tool_chunks) == 1
+    call = tool_chunks[0].choices[0].delta.tool_calls[0]
+    assert call["index"] == 0
+    assert call["id"] == "toolu_s1"
+    assert call["function"]["name"] == "get_weather"
+    assert json.loads(call["function"]["arguments"]) == {"city": "Paris"}
+    assert chunks[-1].choices[0].finish_reason == "tool_calls"


### PR DESCRIPTION
## PR5b-i — gateway `tools`/`tool_choice` passthrough + Anthropic tool-call bridge

First of two security-gated PRs for **PR5b** (governed chat tool-loop, WS4), per the merged design spec `docs/superpowers/specs/2026-06-18-pr5-governed-chat-tool-loop-design.md` (spec §125 recommends this as PR5b's first task). Builds on the PR5a substrate (#181).

This PR adds the gateway capability the chat loop (PR5b-ii) will consume: a `tools`/`tool_choice` request surface forwarded to every provider. While verifying, I found the spec's assumption that all adapters already map tool calls was wrong for **Anthropic** (it deferred `tool_use` translation in both directions); since LQ chat defaults to Claude, that bridge is built here.

### Changes
- **Schema** (`gateway/app/providers/openai_schema.py`, `api/app/schemas/gateway.py`): typed `ToolDefinition`/`FunctionDefinition` + `tools`/`tool_choice` on `ChatCompletionRequest`. Capped at 64 tools (defense-in-depth on the prompt-multiplication surface). `None` preserves the pre-PR5b single-shot wire shape exactly.
- **Anthropic adapter** (`gateway/app/providers/anthropic.py`): full bidirectional bridge —
  - request: OpenAI `tools` → Anthropic tool blocks (`input_schema`); `tool_choice` → `auto`/`any`/`tool`; `"none"` drops the tools block; assistant `tool_calls` → `tool_use` blocks (multi-step loop replaying its own calls).
  - response + streaming: Anthropic `tool_use` → OpenAI `tool_calls` (streaming accumulates `input_json_delta` into one `tool_calls` delta at `content_block_stop`).
- **Ollama adapter** (`gateway/app/providers/ollama.py`): read the now-typed fields (were extra-allow passthrough before).
- **OpenAI adapter**: unchanged — already forwards via `model_dump` passthrough.
- **Contract**: `docs/api/gateway-openapi.yaml` `ChatCompletionRequest` gains `tools`/`tool_choice`.

### Tests / gates
- New Anthropic request/response/streaming tool coverage in `gateway/tests/test_anthropic_adapter.py`.
- Full gateway suite green (**681 passed**, not-provider/not-slow); api gateway-client units green (**50 passed**). `ruff format` + `ruff check` + `mypy` clean on touched files.

### Security review
Touches `gateway/**` (the egress boundary) → routes to security review per CODEOWNERS. **No new egress path**: `tools` are forwarded to the already-configured provider; per-call tier checks and SSRF/allowlist guards are unchanged. No raw payloads added to any log.

Practicing-attorney attestation: **N/A** (pure code, no legal-substance skill).

Refs #184 (PR5b-ii — the loop + confirmation gate — closes it).
