### PR TITLE
feat(api): governed chat tool-loop + human confirmation gate (PR5b-ii)

### DIFF
--- a/api/alembic/versions/0054_pending_tool_call.py
+++ b/api/alembic/versions/0054_pending_tool_call.py
@@ -1,0 +1,62 @@
+"""pending_tool_call — paused human-gated chat tool calls (PR5b-ii / WS4)
+
+One row per chat tool call awaiting approval (spec L3 persist-and-resume).
+Single-use (deleted on resolve) + TTL-bounded (``expires_at``), mirroring
+``mcp_oauth_state``. ``payload_cipher`` holds the Fernet-encrypted resume
+payload (tool args + conversation-so-far) — NEVER plaintext, since it can
+carry user content.
+
+Revision ID: 0054
+Revises: 0053
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0054"
+down_revision: str | None = "0053"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pending_tool_call",
+        sa.Column("pending_call_id", sa.Text(), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE", name="fk_pending_tool_call_user"),
+            nullable=False,
+        ),
+        sa.Column(
+            "chat_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("chats.id", ondelete="CASCADE", name="fk_pending_tool_call_chat"),
+            nullable=False,
+        ),
+        sa.Column("message_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("tool", sa.Text(), nullable=False),
+        sa.Column("destructive", sa.Boolean(), nullable=False),
+        sa.Column("payload_cipher", sa.LargeBinary(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    # Resolve + ownership lookups are by (chat_id) for the resume endpoint.
+    op.create_index("ix_pending_tool_call_chat_id", "pending_tool_call", ["chat_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pending_tool_call_chat_id", table_name="pending_tool_call")
+    op.drop_table("pending_tool_call")

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -73,6 +73,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies import ActiveUser
 from app.api.skills import _resolve_skill_for_user
 from app.audit import audit_action
+from app.chat.tool_loop import (
+    AssembledTools,
+    ToolConfirmationRequired,
+    assemble_mcp_tools,
+    confirmation_notice_response,
+    run_tool_loop,
+    run_tool_loop_as_stream,
+)
 from app.citation import extract_citations, verify
 from app.citation.cost import estimate_judge_call_cost_usd
 from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
@@ -1533,6 +1541,11 @@ async def send_message(
         },
     )
 
+    # PR5b-ii: assemble the per-turn tool allowlist from operator-enabled MCP
+    # tools. Empty (the default deployment) → the loop is not engaged and the
+    # send path is byte-for-byte the pre-PR5b single-shot completion.
+    tools = await assemble_mcp_tools(db, request_id=request_id)
+
     if payload.stream:
         return await _stream_response(
             db=db,
@@ -1547,6 +1560,7 @@ async def send_message(
             http_request=request,
             attached_skill_provenance=attached_skill_provenance,
             project_ensemble_verification=project_ensemble_verification,
+            tools=tools,
         )
     return await _non_streaming_response(
         db=db,
@@ -1563,6 +1577,7 @@ async def send_message(
         slash_unresolved=slash_unresolved,
         attached_skill_provenance=attached_skill_provenance,
         project_ensemble_verification=project_ensemble_verification,
+        tools=tools,
     )
 
 
@@ -2159,16 +2174,37 @@ async def _non_streaming_response(
     slash_unresolved: bool = False,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
     project_ensemble_verification: bool = False,
+    tools: AssembledTools | None = None,
 ) -> JSONResponse:
     """Run the non-streaming path: forward, persist, return JSON.
 
     Wave D.2 Task 2.7 — ``attached_skill_names`` and ``slash_unresolved``
     are propagated from :func:`send_message`'s slash-fallback path.
     Defaults preserve the pre-Task-2.7 wire contract for any caller
-    that doesn't pass them in."""
+    that doesn't pass them in.
+
+    PR5b-ii — when ``tools`` is non-empty the governed tool-loop runs
+    (read-only tools execute inline + feed back); otherwise this is the
+    unchanged single-shot completion."""
 
     try:
-        response = await gateway.chat_completion(request, request_id=request_id)
+        if tools:
+            try:
+                response = await run_tool_loop(
+                    db,
+                    gateway=gateway,
+                    base_request=request,
+                    tools=tools,
+                    user_id=user.id,
+                    chat_id=chat.id,
+                    message_id=assistant_message_id,
+                    request_id=request_id,
+                )
+            except ToolConfirmationRequired as confirm_exc:
+                # PR5b-ii part 3 will run the real persist-and-resume gate here.
+                response = confirmation_notice_response(confirm_exc, model=request.model)
+        else:
+            response = await gateway.chat_completion(request, request_id=request_id)
     except LQAIError as exc:
         # Gateway-side failure: the user message is already persisted.
         # We do NOT persist an assistant row — the assistant produced
@@ -2280,8 +2316,14 @@ async def _stream_response(
     http_request: Request | None = None,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
     project_ensemble_verification: bool = False,
+    tools: AssembledTools | None = None,
 ) -> StreamingResponse:
-    """Run the streaming path: forward, stream SSE, persist at end."""
+    """Run the streaming path: forward, stream SSE, persist at end.
+
+    PR5b-ii — when ``tools`` is non-empty the governed tool-loop resolves tool
+    calls server-side and the final answer is re-emitted through the same SSE
+    frames (so the accumulate / persist / citation / audit logic below is
+    unchanged); otherwise this relays the gateway's token stream as before."""
 
     async def _generate() -> AsyncIterator[bytes]:
         accumulated: list[str] = []
@@ -2303,8 +2345,25 @@ async def _stream_response(
         }
         yield f"data: {_json.dumps(opening, separators=(',', ':'))}\n\n".encode()
 
+        # PR5b-ii: when tools are offered, the loop resolves them server-side
+        # and re-emits the final answer as chunks; otherwise relay the token
+        # stream. Either way the accumulate/persist logic below is identical.
+        stream_source = (
+            run_tool_loop_as_stream(
+                db,
+                gateway=gateway,
+                base_request=request,
+                tools=tools,
+                user_id=user.id,
+                chat_id=chat.id,
+                message_id=assistant_message_id,
+                request_id=request_id,
+            )
+            if tools
+            else gateway.chat_completion_stream(request, request_id=request_id)
+        )
         try:
-            async for chunk in gateway.chat_completion_stream(request, request_id=request_id):
+            async for chunk in stream_source:
                 last_tier = chunk.routed_inference_tier or last_tier
                 last_provider = chunk.routed_provider or last_provider
                 last_model = chunk.model
@@ -2334,6 +2393,23 @@ async def _stream_response(
                     if last_applied_skills is not None:
                         frame["applied_skills"] = list(last_applied_skills)
                     yield f"data: {_json.dumps(frame, separators=(',', ':'))}\n\n".encode()
+        except ToolConfirmationRequired as confirm_exc:
+            # PR5b-ii part 3 will persist a pending_tool_call row and emit a
+            # ``tool_confirmation_required`` SSE event here. Part 2 degrades to
+            # an honest notice streamed as the answer so the turn completes.
+            notice = (
+                confirmation_notice_response(confirm_exc, model=request.model)
+                .choices[0]
+                .message.content
+                or ""
+            )
+            accumulated.append(notice)
+            notice_frame = {
+                "type": "delta",
+                "delta": notice,
+                "lq_ai_message_id": str(assistant_message_id),
+            }
+            yield f"data: {_json.dumps(notice_frame, separators=(',', ':'))}\n\n".encode()
         except LQAIError as exc:
             # Stream ended in failure. We persist a partial assistant
             # row with whatever content the client already saw, and

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -59,7 +59,7 @@ import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, Query, Request, Response, status
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -73,20 +73,27 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies import ActiveUser
 from app.api.skills import _resolve_skill_for_user
 from app.audit import audit_action
+from app.chat.pending import (
+    PendingToolCallUnavailable,
+    consume_pending_tool_call,
+    create_pending_tool_call,
+)
 from app.chat.tool_loop import (
     AssembledTools,
     ToolConfirmationRequired,
+    ToolMeta,
     assemble_mcp_tools,
-    confirmation_notice_response,
+    execute_mcp_tool,
     run_tool_loop,
     run_tool_loop_as_stream,
+    tool_result_content,
 )
 from app.citation import extract_citations, verify
 from app.citation.cost import estimate_judge_call_cost_usd
 from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
 from app.config import get_settings
 from app.db.session import get_db
-from app.errors import LQAIError, NotFound, ValidationError
+from app.errors import Conflict, LQAIError, NotFound, ValidationError
 from app.knowledge.embed import DEFAULT_EMBEDDING_MODEL, request_embedding_vector
 from app.knowledge.retrieval import HybridSearchResult, hybrid_search
 from app.models.chat import Chat, Message, MessageCitation
@@ -2109,6 +2116,308 @@ async def _persist_assistant_message(
     return row
 
 
+async def _persist_pending_tool_call(
+    db: AsyncSession,
+    *,
+    user: User,
+    request: ChatCompletionRequest,
+    confirm_exc: ToolConfirmationRequired,
+    chat: Chat,
+    assistant_message_id: uuid.UUID,
+) -> dict[str, Any]:
+    """PR5b-ii: persist a human-gated tool call + a placeholder assistant row,
+    and return the ``tool_confirmation_required`` envelope (SSE frame / JSON
+    body). ``_persist_assistant_message`` commits, so the encrypted pending row
+    and the placeholder land in the same transaction. No raw args in the
+    envelope — only the arg key names (``args_summary``)."""
+
+    resume_request = request.model_copy(
+        update={
+            "messages": confirm_exc.messages_so_far,
+            "stream": False,
+            "tools": None,
+            "tool_choice": None,
+        }
+    )
+    pending_id = await create_pending_tool_call(
+        db,
+        user_id=user.id,
+        chat_id=chat.id,
+        message_id=assistant_message_id,
+        provider=confirm_exc.provider,
+        tool=confirm_exc.tool,
+        destructive=confirm_exc.destructive,
+        args=confirm_exc.tool_args,
+        tool_call_id=confirm_exc.tool_call_id,
+        resume_request=resume_request,
+        max_allowed_tier=None,
+    )
+    await _persist_assistant_message(
+        db,
+        message_id=assistant_message_id,
+        chat_id=chat.id,
+        content="",
+        requested_model=request.model,
+        routed_provider=None,
+        routed_model=None,
+        routed_inference_tier=None,
+        prompt_tokens=None,
+        completion_tokens=None,
+        cost_estimate_usd=None,
+        applied_skills=[],
+        error_code=None,
+    )
+    return {
+        "type": "tool_confirmation_required",
+        "lq_ai_message_id": str(assistant_message_id),
+        "pending_call_id": pending_id,
+        "provider": confirm_exc.provider,
+        "tool": confirm_exc.tool,
+        "args_summary": sorted(confirm_exc.tool_args.keys()),
+        "destructive": confirm_exc.destructive,
+    }
+
+
+class ToolCallDecisionRequest(BaseModel):
+    """Body for the confirmation-gate resolve endpoint (PR5b-ii)."""
+
+    decision: Literal["approve", "deny"]
+
+
+@router.post(
+    "/{chat_id}/tool-calls/{pending_call_id}",
+    summary="Approve or deny a pending chat tool call (PR5b-ii confirmation gate)",
+)
+async def resolve_tool_call(
+    chat_id: str,
+    pending_call_id: str,
+    body: ToolCallDecisionRequest,
+    user: ActiveUser,
+    http_request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    gateway: Annotated[GatewayClient, Depends(get_gateway_client)],
+) -> StreamingResponse:
+    """Resolve a human-gated tool call and resume the assistant turn (spec L3).
+
+    ActiveUser-gated + chat-owner-checked (404 cross-user). Single-use + TTL:
+    an unknown / foreign / already-resolved / expired ``pending_call_id`` → 410.
+    ``approve`` executes the tool and continues the loop; ``deny`` tells the
+    model the user declined and lets it finalize. Streams the continued answer.
+    """
+
+    cid = _validate_chat_id(chat_id)
+    chat = await _load_visible_chat(db, cid, user.id, include_archived=False)
+    try:
+        payload = await consume_pending_tool_call(
+            db, pending_call_id=pending_call_id, chat_id=cid, user_id=user.id
+        )
+    except PendingToolCallUnavailable as exc:
+        raise Conflict(
+            "This tool-call request is no longer available (already resolved or expired).",
+            http_status=status.HTTP_410_GONE,
+        ) from exc
+
+    request_id = (
+        http_request.headers.get("x-request-id")
+        or http_request.headers.get("x-correlation-id")
+        or f"req_{uuid.uuid4().hex}"
+    )
+    return await _resume_stream_response(
+        db=db,
+        user=user,
+        gateway=gateway,
+        payload=payload,
+        decision=body.decision,
+        chat=chat,
+        request_id=request_id,
+        http_request=http_request,
+    )
+
+
+async def _resume_stream_response(
+    *,
+    db: AsyncSession,
+    user: User,
+    gateway: GatewayClient,
+    payload: Any,  # app.chat.pending.ResumePayload
+    decision: str,
+    chat: Chat,
+    request_id: str,
+    http_request: Request | None = None,
+) -> StreamingResponse:
+    """Continue a gated assistant turn after approve/deny, streaming the result."""
+
+    assistant_message_id = payload.message_id
+
+    async def _generate() -> AsyncIterator[bytes]:
+        accumulated: list[str] = []
+        last_tier: int | None = None
+        last_provider: str | None = None
+        last_model: str | None = None
+        prompt_tokens: int | None = None
+        completion_tokens: int | None = None
+        error_code: str | None = None
+        error_envelope: dict[str, Any] | None = None
+        cont_req = payload.request
+
+        opening = {
+            "type": "start",
+            "lq_ai_message_id": str(assistant_message_id),
+            "chat_id": str(chat.id),
+        }
+        yield f"data: {_json.dumps(opening, separators=(',', ':'))}\n\n".encode()
+
+        try:
+            messages = list(payload.request.messages)
+            if decision == "approve":
+                meta = ToolMeta(
+                    provider=payload.provider,
+                    tool=payload.tool,
+                    read_only=False,
+                    destructive=payload.destructive,
+                    requires_confirmation=True,
+                )
+                result = await execute_mcp_tool(
+                    db,
+                    gateway=gateway,
+                    meta=meta,
+                    args=payload.args,
+                    user_id=user.id,
+                    chat_id=chat.id,
+                    message_id=assistant_message_id,
+                    request_id=request_id,
+                    max_allowed_tier=payload.max_allowed_tier,
+                    confirmation_state="approved",
+                )
+                messages.append(
+                    ChatCompletionMessage(
+                        role="tool",
+                        tool_call_id=payload.tool_call_id,
+                        content=tool_result_content(result),
+                    )
+                )
+            else:
+                messages.append(
+                    ChatCompletionMessage(
+                        role="tool",
+                        tool_call_id=payload.tool_call_id,
+                        content=_json.dumps(
+                            {"status": "denied", "note": "The user denied this tool."}
+                        ),
+                    )
+                )
+            cont_req = payload.request.model_copy(update={"messages": messages, "stream": False})
+            tools = await assemble_mcp_tools(db, request_id=request_id)
+            if tools:
+                resp = await run_tool_loop(
+                    db,
+                    gateway=gateway,
+                    base_request=cont_req,
+                    tools=tools,
+                    user_id=user.id,
+                    chat_id=chat.id,
+                    message_id=assistant_message_id,
+                    request_id=request_id,
+                    max_allowed_tier=payload.max_allowed_tier,
+                )
+            else:
+                resp = await gateway.chat_completion(cont_req, request_id=request_id)
+            choice = resp.choices[0] if resp.choices else None
+            text = (choice.message.content or "") if choice is not None else ""
+            last_tier = resp.routed_inference_tier
+            last_provider = resp.routed_provider
+            last_model = resp.model
+            if resp.usage is not None:
+                prompt_tokens = resp.usage.prompt_tokens
+                completion_tokens = resp.usage.completion_tokens
+            if text:
+                accumulated.append(text)
+                delta_frame = {
+                    "type": "delta",
+                    "delta": text,
+                    "lq_ai_message_id": str(assistant_message_id),
+                }
+                yield f"data: {_json.dumps(delta_frame, separators=(',', ':'))}\n\n".encode()
+        except ToolConfirmationRequired as confirm_exc:
+            # A follow-on gated tool: persist a new pending call + re-emit.
+            try:
+                info = await _persist_pending_tool_call(
+                    db,
+                    user=user,
+                    request=cont_req,
+                    confirm_exc=confirm_exc,
+                    chat=chat,
+                    assistant_message_id=assistant_message_id,
+                )
+            except Exception:
+                log.error("tool_confirmation_persist_failed", exc_info=True)
+                info = {
+                    "type": "tool_confirmation_required",
+                    "lq_ai_message_id": str(assistant_message_id),
+                    "pending_call_id": None,
+                    "provider": confirm_exc.provider,
+                    "tool": confirm_exc.tool,
+                    "args_summary": sorted(confirm_exc.tool_args.keys()),
+                    "destructive": confirm_exc.destructive,
+                }
+            yield f"data: {_json.dumps(info, separators=(',', ':'))}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+            return
+        except LQAIError as exc:
+            error_code = exc.effective_code
+            error_envelope = exc.to_envelope()
+
+        try:
+            await _persist_assistant_message(
+                db,
+                message_id=assistant_message_id,
+                chat_id=chat.id,
+                content="".join(accumulated),
+                requested_model=payload.request.model,
+                routed_provider=last_provider,
+                routed_model=last_model,
+                routed_inference_tier=last_tier,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                cost_estimate_usd=None,
+                applied_skills=[],
+                error_code=error_code,
+            )
+        except Exception:
+            log.error("resume_persist_failed", exc_info=True)
+
+        if error_envelope is not None:
+            yield f"data: {_json.dumps(error_envelope, separators=(',', ':'))}\n\n".encode()
+        else:
+            complete: dict[str, Any] = {
+                "type": "complete",
+                "lq_ai_message_id": str(assistant_message_id),
+                "message": {
+                    "id": str(assistant_message_id),
+                    "chat_id": str(chat.id),
+                    "role": "assistant",
+                    "content": "".join(accumulated),
+                    "model": last_model,
+                    "provider": last_provider,
+                    "routed_inference_tier": last_tier,
+                    "tokens_in": prompt_tokens,
+                    "tokens_out": completion_tokens,
+                    "created_at": datetime.now(tz=UTC).isoformat(),
+                },
+                "citations": [],
+                "routed_inference_tier": last_tier,
+                "routed_provider": last_provider,
+            }
+            yield f"data: {_json.dumps(complete, separators=(',', ':'))}\n\n".encode()
+        yield b"data: [DONE]\n\n"
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
 async def _write_work_product_attribution(
     db: AsyncSession,
     *,
@@ -2201,8 +2510,18 @@ async def _non_streaming_response(
                     request_id=request_id,
                 )
             except ToolConfirmationRequired as confirm_exc:
-                # PR5b-ii part 3 will run the real persist-and-resume gate here.
-                response = confirmation_notice_response(confirm_exc, model=request.model)
+                # Persist the pending call + placeholder assistant row, then
+                # return the confirmation envelope. The client approves/denies
+                # via POST /chats/{id}/tool-calls/{pending_call_id}.
+                info = await _persist_pending_tool_call(
+                    db,
+                    user=user,
+                    request=request,
+                    confirm_exc=confirm_exc,
+                    chat=chat,
+                    assistant_message_id=assistant_message_id,
+                )
+                return JSONResponse(status_code=status.HTTP_200_OK, content=info)
         else:
             response = await gateway.chat_completion(request, request_id=request_id)
     except LQAIError as exc:
@@ -2394,22 +2713,34 @@ async def _stream_response(
                         frame["applied_skills"] = list(last_applied_skills)
                     yield f"data: {_json.dumps(frame, separators=(',', ':'))}\n\n".encode()
         except ToolConfirmationRequired as confirm_exc:
-            # PR5b-ii part 3 will persist a pending_tool_call row and emit a
-            # ``tool_confirmation_required`` SSE event here. Part 2 degrades to
-            # an honest notice streamed as the answer so the turn completes.
-            notice = (
-                confirmation_notice_response(confirm_exc, model=request.model)
-                .choices[0]
-                .message.content
-                or ""
-            )
-            accumulated.append(notice)
-            notice_frame = {
-                "type": "delta",
-                "delta": notice,
-                "lq_ai_message_id": str(assistant_message_id),
-            }
-            yield f"data: {_json.dumps(notice_frame, separators=(',', ':'))}\n\n".encode()
+            # Human-gated tool: persist the pending call (encrypted) + a
+            # placeholder assistant row, emit a terminal
+            # ``tool_confirmation_required`` event, and end the turn (spec L3
+            # persist-and-resume). The client resolves it via
+            # POST /chats/{id}/tool-calls/{pending_call_id}.
+            try:
+                info = await _persist_pending_tool_call(
+                    db,
+                    user=user,
+                    request=request,
+                    confirm_exc=confirm_exc,
+                    chat=chat,
+                    assistant_message_id=assistant_message_id,
+                )
+            except Exception:
+                log.error("tool_confirmation_persist_failed", exc_info=True)
+                info = {
+                    "type": "tool_confirmation_required",
+                    "lq_ai_message_id": str(assistant_message_id),
+                    "pending_call_id": None,
+                    "provider": confirm_exc.provider,
+                    "tool": confirm_exc.tool,
+                    "args_summary": sorted(confirm_exc.tool_args.keys()),
+                    "destructive": confirm_exc.destructive,
+                }
+            yield f"data: {_json.dumps(info, separators=(',', ':'))}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+            return
         except LQAIError as exc:
             # Stream ended in failure. We persist a partial assistant
             # row with whatever content the client already saw, and

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -2125,11 +2125,13 @@ async def _persist_pending_tool_call(
     chat: Chat,
     assistant_message_id: uuid.UUID,
 ) -> dict[str, Any]:
-    """PR5b-ii: persist a human-gated tool call + a placeholder assistant row,
-    and return the ``tool_confirmation_required`` envelope (SSE frame / JSON
-    body). ``_persist_assistant_message`` commits, so the encrypted pending row
-    and the placeholder land in the same transaction. No raw args in the
-    envelope — only the arg key names (``args_summary``)."""
+    """PR5b-ii: persist a human-gated tool call and return the
+    ``tool_confirmation_required`` envelope (SSE frame / JSON body). Commits the
+    encrypted pending row. Does **not** write a placeholder assistant message —
+    the resume path creates the assistant row exactly once when the turn
+    finalizes; writing it here too would duplicate-key on the resume's INSERT
+    (the re-gate / final-save crash this avoids). No raw args in the envelope —
+    only the arg key names (``args_summary``)."""
 
     resume_request = request.model_copy(
         update={
@@ -2152,21 +2154,11 @@ async def _persist_pending_tool_call(
         resume_request=resume_request,
         max_allowed_tier=None,
     )
-    await _persist_assistant_message(
-        db,
-        message_id=assistant_message_id,
-        chat_id=chat.id,
-        content="",
-        requested_model=request.model,
-        routed_provider=None,
-        routed_model=None,
-        routed_inference_tier=None,
-        prompt_tokens=None,
-        completion_tokens=None,
-        cost_estimate_usd=None,
-        applied_skills=[],
-        error_code=None,
-    )
+    # Commit the encrypted pending row. We deliberately do NOT persist a
+    # placeholder assistant message here — the resume path creates that row once
+    # when the turn finalizes; writing it twice violates messages_pkey (the
+    # re-gate / final-save crash this avoids).
+    await db.commit()
     return {
         "type": "tool_confirmation_required",
         "lq_ai_message_id": str(assistant_message_id),

--- a/api/app/chat/__init__.py
+++ b/api/app/chat/__init__.py
@@ -1,0 +1,6 @@
+"""Chat-side helpers that sit above the gateway client.
+
+PR5b-ii: the governed chat tool-loop (``tool_loop``) — assembles the per-turn
+tool allowlist, runs the read-only execute-and-loop over the gateway, and
+surfaces a confirmation signal for human-gated tools.
+"""

--- a/api/app/chat/pending.py
+++ b/api/app/chat/pending.py
@@ -1,0 +1,142 @@
+"""Persist-and-resume store for human-gated chat tool calls (PR5b-ii / WS4).
+
+Backs the confirmation gate (spec L3): when the tool-loop proposes a
+``destructive`` / ``requires_confirmation`` tool, :func:`create_pending_tool_call`
+stores an encrypted, TTL-bounded, single-use row; the approve/deny endpoint
+calls :func:`consume_pending_tool_call` to atomically claim + decrypt it.
+
+The resume payload (tool args + the conversation-so-far) is Fernet-encrypted
+via :class:`app.security.encryption.MCPTokenEncryptor` — it can carry user
+content, so it is never stored in plaintext (contrast the payload-free
+``tool_call_log`` audit row).
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pending_tool_call import PendingToolCall
+from app.schemas.gateway import ChatCompletionMessage
+from app.security.encryption import MCPTokenEncryptor
+
+PENDING_TTL = timedelta(minutes=15)
+"""How long an unresolved pending call stays claimable before it is rejected."""
+
+
+class PendingToolCallUnavailable(Exception):
+    """Pending call is unknown, not owned by the caller, already resolved, or
+    expired. The endpoint maps this to HTTP 410 Gone (id-probing-safe: the same
+    error for every not-resolvable reason)."""
+
+
+def _now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+@dataclass
+class ResumePayload:
+    """Everything the resume path needs to continue the assistant turn."""
+
+    provider: str
+    tool: str
+    destructive: bool
+    args: dict[str, Any]
+    tool_call_id: str
+    messages: list[ChatCompletionMessage]
+    max_allowed_tier: int | None
+
+
+async def create_pending_tool_call(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    chat_id: UUID,
+    message_id: UUID,
+    provider: str,
+    tool: str,
+    destructive: bool,
+    args: dict[str, Any],
+    tool_call_id: str,
+    messages: list[ChatCompletionMessage],
+    max_allowed_tier: int | None,
+) -> str:
+    """Persist an encrypted pending tool call; return its opaque handle.
+
+    Flushes (does not commit) — the caller owns the transaction boundary, like
+    the rest of the chat send path.
+    """
+
+    token = secrets.token_urlsafe(32)
+    payload = {
+        "args": args,
+        "tool_call_id": tool_call_id,
+        "messages": [m.model_dump(mode="json") for m in messages],
+        "max_allowed_tier": max_allowed_tier,
+    }
+    cipher = MCPTokenEncryptor.from_environ().encrypt(json.dumps(payload))
+    db.add(
+        PendingToolCall(
+            pending_call_id=token,
+            user_id=user_id,
+            chat_id=chat_id,
+            message_id=message_id,
+            provider=provider,
+            tool=tool,
+            destructive=destructive,
+            payload_cipher=cipher,
+            expires_at=_now() + PENDING_TTL,
+        )
+    )
+    await db.flush()
+    return token
+
+
+async def consume_pending_tool_call(
+    db: AsyncSession,
+    *,
+    pending_call_id: str,
+    chat_id: UUID,
+    user_id: UUID,
+) -> ResumePayload:
+    """Atomically claim a pending call: validate owner, delete (single-use),
+    check TTL, decrypt. Raises :class:`PendingToolCallUnavailable` for any
+    unknown / foreign / already-consumed / expired row (→ 410).
+
+    Single-use is enforced by deleting the row *before* the expiry check, so a
+    replay of the same handle always finds nothing.
+    """
+
+    row = (
+        await db.execute(
+            select(PendingToolCall).where(PendingToolCall.pending_call_id == pending_call_id)
+        )
+    ).scalar_one_or_none()
+    if row is None or row.chat_id != chat_id or row.user_id != user_id:
+        raise PendingToolCallUnavailable("pending tool call not found")
+
+    # Single-use: claim by deletion before doing anything else.
+    await db.execute(
+        delete(PendingToolCall).where(PendingToolCall.pending_call_id == pending_call_id)
+    )
+
+    if row.expires_at < _now():
+        raise PendingToolCallUnavailable("pending tool call expired")
+
+    data = json.loads(MCPTokenEncryptor.from_environ().decrypt(row.payload_cipher))
+    return ResumePayload(
+        provider=row.provider,
+        tool=row.tool,
+        destructive=row.destructive,
+        args=data["args"],
+        tool_call_id=data["tool_call_id"],
+        messages=[ChatCompletionMessage.model_validate(m) for m in data["messages"]],
+        max_allowed_tier=data.get("max_allowed_tier"),
+    )

--- a/api/app/chat/pending.py
+++ b/api/app/chat/pending.py
@@ -24,7 +24,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.pending_tool_call import PendingToolCall
-from app.schemas.gateway import ChatCompletionMessage
+from app.schemas.gateway import ChatCompletionRequest
 from app.security.encryption import MCPTokenEncryptor
 
 PENDING_TTL = timedelta(minutes=15)
@@ -45,12 +45,15 @@ def _now() -> datetime:
 class ResumePayload:
     """Everything the resume path needs to continue the assistant turn."""
 
+    message_id: UUID
     provider: str
     tool: str
     destructive: bool
     args: dict[str, Any]
     tool_call_id: str
-    messages: list[ChatCompletionMessage]
+    request: ChatCompletionRequest
+    """The resume request: the original send request with ``messages`` set to
+    the conversation-so-far (incl. the assistant tool-call turn that gated)."""
     max_allowed_tier: int | None
 
 
@@ -65,20 +68,22 @@ async def create_pending_tool_call(
     destructive: bool,
     args: dict[str, Any],
     tool_call_id: str,
-    messages: list[ChatCompletionMessage],
+    resume_request: ChatCompletionRequest,
     max_allowed_tier: int | None,
 ) -> str:
     """Persist an encrypted pending tool call; return its opaque handle.
 
     Flushes (does not commit) — the caller owns the transaction boundary, like
-    the rest of the chat send path.
+    the rest of the chat send path. ``resume_request`` is the full send request
+    with ``messages`` already set to the conversation-so-far, so the resume path
+    can continue the turn faithfully (model, skills, tier floors all preserved).
     """
 
     token = secrets.token_urlsafe(32)
     payload = {
         "args": args,
         "tool_call_id": tool_call_id,
-        "messages": [m.model_dump(mode="json") for m in messages],
+        "request": resume_request.model_dump(mode="json"),
         "max_allowed_tier": max_allowed_tier,
     }
     cipher = MCPTokenEncryptor.from_environ().encrypt(json.dumps(payload))
@@ -132,11 +137,12 @@ async def consume_pending_tool_call(
 
     data = json.loads(MCPTokenEncryptor.from_environ().decrypt(row.payload_cipher))
     return ResumePayload(
+        message_id=row.message_id,
         provider=row.provider,
         tool=row.tool,
         destructive=row.destructive,
         args=data["args"],
         tool_call_id=data["tool_call_id"],
-        messages=[ChatCompletionMessage.model_validate(m) for m in data["messages"]],
+        request=ChatCompletionRequest.model_validate(data["request"]),
         max_allowed_tier=data.get("max_allowed_tier"),
     )

--- a/api/app/chat/tool_loop.py
+++ b/api/app/chat/tool_loop.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any
@@ -51,6 +52,10 @@ from app.autonomous.guard import ToolResult
 from app.clients.gateway import GatewayClient
 from app.mcp import service as mcp_service
 from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
+    ChatCompletionDelta,
     ChatCompletionMessage,
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -115,6 +120,35 @@ class ToolConfirmationRequired(Exception):
         self.destructive = destructive
         self.messages_so_far = messages_so_far
         super().__init__(f"tool {provider}/{tool} requires confirmation")
+
+
+def confirmation_notice_response(
+    exc: ToolConfirmationRequired, *, model: str
+) -> ChatCompletionResponse:
+    """Interim final answer when a confirm-gated tool is proposed (PR5b-ii part 2).
+
+    Part 3 replaces this with the real persist-and-resume gate (a
+    ``tool_confirmation_required`` SSE event + the approve/deny endpoint). Until
+    then the loop degrades to an honest notice rather than crashing or silently
+    skipping a human-gated action.
+    """
+
+    notice = (
+        f'I started to use the "{exc.tool}" tool, but it needs your approval before it can run, '
+        "and the approval step isn't available in this interface yet."
+    )
+    return ChatCompletionResponse(
+        id="chatcmpl-confirm",
+        created=0,
+        model=model,
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=notice),
+                finish_reason="stop",
+            )
+        ],
+    )
 
 
 def args_digest(args: dict[str, Any]) -> str:
@@ -363,3 +397,67 @@ async def run_tool_loop(
                     content=_tool_result_content(result),
                 )
             )
+
+
+async def run_tool_loop_as_stream(
+    db: AsyncSession,
+    *,
+    gateway: GatewayClient,
+    base_request: ChatCompletionRequest,
+    tools: AssembledTools,
+    user_id: UUID,
+    chat_id: UUID,
+    message_id: UUID,
+    request_id: str | None = None,
+    max_allowed_tier: int | None = None,
+    max_tool_calls: int = DEFAULT_MAX_TOOL_CALLS,
+) -> AsyncIterator[ChatCompletionChunk]:
+    """Run the loop, then re-emit the final answer as OpenAI streaming chunks.
+
+    The chat streaming path relays chunks from a source iterator; this adapter
+    lets that path swap in the tool-loop without changing its accumulate /
+    persist / citation / audit logic. Tool-resolving turns run server-side
+    (non-streaming); the final answer is delivered as a role chunk, one content
+    chunk, and a terminal chunk carrying usage + finish_reason.
+
+    :class:`ToolConfirmationRequired` propagates out of the first iteration so
+    the caller can run the confirmation gate (the chat endpoint owns the
+    custom SSE event).
+    """
+
+    resp = await run_tool_loop(
+        db,
+        gateway=gateway,
+        base_request=base_request,
+        tools=tools,
+        user_id=user_id,
+        chat_id=chat_id,
+        message_id=message_id,
+        request_id=request_id,
+        max_allowed_tier=max_allowed_tier,
+        max_tool_calls=max_tool_calls,
+    )
+    text = resp.choices[0].message.content if resp.choices else ""
+    common: dict[str, Any] = {
+        "id": resp.id,
+        "created": resp.created,
+        "model": resp.model,
+        "routed_inference_tier": resp.routed_inference_tier,
+        "routed_provider": resp.routed_provider,
+    }
+    yield ChatCompletionChunk(
+        choices=[ChatCompletionChunkChoice(index=0, delta=ChatCompletionDelta(role="assistant"))],
+        **common,
+    )
+    if text:
+        yield ChatCompletionChunk(
+            choices=[ChatCompletionChunkChoice(index=0, delta=ChatCompletionDelta(content=text))],
+            **common,
+        )
+    yield ChatCompletionChunk(
+        choices=[
+            ChatCompletionChunkChoice(index=0, delta=ChatCompletionDelta(), finish_reason="stop")
+        ],
+        usage=resp.usage,
+        **common,
+    )

--- a/api/app/chat/tool_loop.py
+++ b/api/app/chat/tool_loop.py
@@ -252,6 +252,15 @@ async def execute_mcp_tool(
 
     Shared by the inline read-only path and the confirmation-gate resume path
     (which passes ``confirmation_state="approved"``).
+
+    Known limitation / follow-up (deferred): callers currently pass
+    ``max_allowed_tier=None``, so the api imposes no *extra* per-chat tier
+    ceiling on tool egress — it relies on the gateway's own per-provider
+    ``egress_tier`` + SSRF host-allowlist enforcement, which IS applied to every
+    call (the gateway is the egress boundary). Deriving an api-side ceiling from
+    the chat/skill tier (spec §"Tier ceiling source") is defense-in-depth to add
+    later; it is not a bypass — `governed_tool_invocation` still tier-checks
+    against ``provider_tier`` whenever ``max_allowed_tier`` is non-None.
     """
 
     provider_tier = await resolve_provider_tier(meta.provider, request_id=request_id)

--- a/api/app/chat/tool_loop.py
+++ b/api/app/chat/tool_loop.py
@@ -285,7 +285,7 @@ async def execute_mcp_tool(
     )
 
 
-def _tool_result_content(result: ToolResult) -> str:
+def tool_result_content(result: ToolResult) -> str:
     """Render a tool result for the ``role="tool"`` reply message."""
 
     data = result.data
@@ -394,7 +394,7 @@ async def run_tool_loop(
                 ChatCompletionMessage(
                     role="tool",
                     tool_call_id=call_id,
-                    content=_tool_result_content(result),
+                    content=tool_result_content(result),
                 )
             )
 

--- a/api/app/chat/tool_loop.py
+++ b/api/app/chat/tool_loop.py
@@ -1,0 +1,365 @@
+"""Governed chat tool-loop (PR5b-ii / WS4).
+
+Turns PR5b-i's gateway tool-passthrough into a usable chat capability: assemble
+an operator-enabled tool allowlist, hand it to the model, and when the model
+asks to call a tool, run it under the PR5a governance substrate
+(:func:`app.tools.governance.governed_tool_invocation`) and feed the result
+back — looping until the model produces a final answer or the per-turn cap is
+hit.
+
+Scope of this module
+--------------------
+
+* **Allowlist assembly** — :func:`assemble_mcp_tools` reads the operator's
+  enabled MCP tools (``mcp_tools`` cache) and renders OpenAI function schemas,
+  alongside a registry that carries each tool's ``read_only`` /
+  ``destructive`` / ``requires_confirmation`` flags for the loop's gating.
+* **The loop** — :func:`run_tool_loop` drives the conversation with
+  non-streaming gateway calls: read-only tools execute inline and feed back;
+  a tool flagged ``destructive`` / ``requires_confirmation`` raises
+  :class:`ToolConfirmationRequired` so the caller can run the persist-and-resume
+  confirmation gate (built in the chat endpoint, not here). The streaming chat
+  path streams only the final answer turn.
+
+Research (CourtListener) tools are assembled by a sibling helper when that
+provider is configured; this module focuses on the MCP path that the
+DeepWiki demo source exercises. Both share the same governance substrate.
+
+Security invariants
+-------------------
+
+* Tool arguments are digested (types + key names only) for the audit row — the
+  raw payload is fed into the conversation but never written to ``tool_call_log``
+  (mirrors ``app.autonomous.guard._args_digest``; invariant spec §112).
+* Every call passes through ``governed_tool_invocation`` (tier → cost → audit),
+  so the gateway still tier-checks and SSRF/allowlist-guards each egress.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.guard import ToolResult
+from app.clients.gateway import GatewayClient
+from app.mcp import service as mcp_service
+from app.schemas.gateway import (
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    FunctionDefinition,
+    ToolDefinition,
+)
+from app.tools.governance import governed_tool_invocation, resolve_provider_tier
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MAX_TOOL_CALLS = 8
+"""Per-turn tool-call cap (spec L4). Operator-overridable via settings; the
+loop stops engaging tools at the cap and lets the model finalize with what it
+has, so a model that loops forever cannot run unbounded egress."""
+
+
+@dataclass(frozen=True)
+class ToolMeta:
+    """Dispatch + governance metadata for one allowlisted tool."""
+
+    provider: str
+    tool: str
+    read_only: bool
+    destructive: bool
+    requires_confirmation: bool
+
+
+@dataclass
+class AssembledTools:
+    """The per-turn tool surface: OpenAI schemas + a name→metadata registry."""
+
+    schemas: list[ToolDefinition] = field(default_factory=list)
+    registry: dict[str, ToolMeta] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:  # truthy iff at least one tool is offered
+        return bool(self.schemas)
+
+
+class ToolConfirmationRequired(Exception):
+    """Raised mid-loop when the model proposes a human-gated tool.
+
+    Carries everything the confirmation gate needs to persist the pending call
+    and the conversation-so-far resume state. The chat endpoint catches this,
+    persists a ``pending_tool_call`` row, emits the ``tool_confirmation_required``
+    SSE event, and ends the turn (spec L3 persist-and-resume).
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        tool: str,
+        args: dict[str, Any],
+        tool_call_id: str,
+        destructive: bool,
+        messages_so_far: list[ChatCompletionMessage],
+    ) -> None:
+        self.provider = provider
+        self.tool = tool
+        self.tool_args = args  # NOT ``self.args`` — that shadows BaseException.args (a tuple)
+        self.tool_call_id = tool_call_id
+        self.destructive = destructive
+        self.messages_so_far = messages_so_far
+        super().__init__(f"tool {provider}/{tool} requires confirmation")
+
+
+def args_digest(args: dict[str, Any]) -> str:
+    """Stable 16-hex digest of arg TYPES + KEY NAMES only (never values).
+
+    Mirrors ``app.autonomous.guard._args_digest`` so chat-origin audit rows
+    carry the same payload-free correlation handle as autonomous ones.
+    """
+
+    shape = {k: type(v).__name__ for k, v in sorted(args.items())}
+    canonical = json.dumps(shape, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+async def assemble_mcp_tools(
+    db: AsyncSession,
+    *,
+    request_id: str | None = None,
+) -> AssembledTools:
+    """Build the per-turn MCP tool allowlist from operator-enabled tools.
+
+    Walks the configured MCP servers (gateway config) and, for each, the cached
+    tools that are ``enabled``. Renders an OpenAI function schema per tool and a
+    registry entry carrying the provider + governance flags. Tools whose name
+    collides across providers keep the first seen (logged) — OpenAI tool names
+    must be unique within a request.
+    """
+
+    assembled = AssembledTools()
+    try:
+        servers = await mcp_service.list_servers(request_id=request_id)
+    except Exception:  # pragma: no cover - config/gateway unavailable
+        log.warning("mcp_tool_assembly: list_servers failed", exc_info=True)
+        return assembled
+
+    for server in servers:
+        provider = server["name"]
+        try:
+            tools = await mcp_service.list_cached_tools(db, provider=provider)
+        except Exception:  # pragma: no cover - defensive per-provider guard
+            log.warning("mcp_tool_assembly: list_cached_tools failed", extra={"provider": provider})
+            continue
+        for tool in tools:
+            if not tool.get("enabled"):
+                continue
+            name = tool["name"]
+            if name in assembled.registry:
+                log.warning(
+                    "mcp_tool_assembly: duplicate tool name across providers; keeping first",
+                    extra={"tool": name, "provider": provider},
+                )
+                continue
+            params = tool.get("parameters") or {"type": "object", "properties": {}}
+            assembled.schemas.append(
+                ToolDefinition(
+                    function=FunctionDefinition(
+                        name=name,
+                        description=tool.get("description"),
+                        parameters=params,
+                    )
+                )
+            )
+            assembled.registry[name] = ToolMeta(
+                provider=provider,
+                tool=name,
+                read_only=bool(tool.get("read_only")),
+                destructive=bool(tool.get("destructive")),
+                requires_confirmation=bool(tool.get("requires_confirmation", True)),
+            )
+    return assembled
+
+
+def _parse_tool_args(raw: Any) -> dict[str, Any]:
+    """OpenAI carries tool-call arguments as a JSON string; degrade to {}."""
+
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+async def execute_mcp_tool(
+    db: AsyncSession,
+    *,
+    gateway: GatewayClient,
+    meta: ToolMeta,
+    args: dict[str, Any],
+    user_id: UUID,
+    chat_id: UUID,
+    message_id: UUID,
+    request_id: str | None,
+    max_allowed_tier: int | None,
+    confirmation_state: str = "not_required",
+) -> ToolResult:
+    """Run one MCP tool through the governance substrate + gateway egress.
+
+    Shared by the inline read-only path and the confirmation-gate resume path
+    (which passes ``confirmation_state="approved"``).
+    """
+
+    provider_tier = await resolve_provider_tier(meta.provider, request_id=request_id)
+
+    async def _dispatch() -> ToolResult:
+        payload = await gateway.call_tool(
+            meta.provider,
+            meta.tool,
+            args,
+            max_allowed_tier=max_allowed_tier,
+            request_id=request_id,
+        )
+        return ToolResult(cost_usd=Decimal("0"), data=payload)
+
+    return await governed_tool_invocation(
+        db,
+        origin="chat",
+        provider=meta.provider,
+        tool=meta.tool,
+        intent=None,
+        provider_tier=provider_tier,
+        max_allowed_tier=max_allowed_tier,
+        estimated_cost=Decimal("0"),
+        dispatch=_dispatch,
+        confirmation_state=confirmation_state,
+        user_id=user_id,
+        chat_id=chat_id,
+        message_id=message_id,
+        request_id=request_id,
+        args_digest=args_digest(args),
+    )
+
+
+def _tool_result_content(result: ToolResult) -> str:
+    """Render a tool result for the ``role="tool"`` reply message."""
+
+    data = result.data
+    if isinstance(data, dict) and "payload" in data:
+        data = data["payload"]
+    try:
+        return json.dumps(data)
+    except (TypeError, ValueError):
+        return str(data)
+
+
+async def run_tool_loop(
+    db: AsyncSession,
+    *,
+    gateway: GatewayClient,
+    base_request: ChatCompletionRequest,
+    tools: AssembledTools,
+    user_id: UUID,
+    chat_id: UUID,
+    message_id: UUID,
+    request_id: str | None = None,
+    max_allowed_tier: int | None = None,
+    max_tool_calls: int = DEFAULT_MAX_TOOL_CALLS,
+) -> ChatCompletionResponse:
+    """Drive the read-only execute-and-loop and return the final response.
+
+    Non-streaming gateway calls decide tool use; read-only tools execute inline
+    and feed back. A ``destructive`` / ``requires_confirmation`` tool raises
+    :class:`ToolConfirmationRequired` (the caller runs the gate). At the
+    per-turn cap, one final call is made WITHOUT tools so the model finalizes.
+
+    Assumes ``tools`` is non-empty — callers skip the loop entirely (single-shot)
+    when the allowlist is empty, preserving the pre-PR5b path.
+    """
+
+    messages: list[ChatCompletionMessage] = list(base_request.messages)
+    calls_used = 0
+
+    while True:
+        offer_tools = calls_used < max_tool_calls
+        req = base_request.model_copy(
+            update={
+                "messages": messages,
+                "stream": False,
+                "tools": [t.model_dump(mode="json") for t in tools.schemas]
+                if offer_tools
+                else None,
+                "tool_choice": "auto" if offer_tools else None,
+            }
+        )
+        resp = await gateway.chat_completion(req, request_id=request_id)
+        if not resp.choices:
+            return resp
+        choice = resp.choices[0]
+        tool_calls = choice.message.tool_calls or []
+        if choice.finish_reason != "tool_calls" or not tool_calls or not offer_tools:
+            return resp  # final answer
+
+        # Replay the assistant's tool-call turn into the conversation.
+        messages.append(
+            ChatCompletionMessage(
+                role="assistant",
+                content=choice.message.content,
+                tool_calls=tool_calls,
+            )
+        )
+
+        for call in tool_calls:
+            calls_used += 1
+            fn = call.get("function") or {}
+            name = str(fn.get("name") or "")
+            call_id = str(call.get("id") or "")
+            args = _parse_tool_args(fn.get("arguments"))
+            meta = tools.registry.get(name)
+            if meta is None:
+                # Model hallucinated a tool not in the allowlist — tell it so.
+                messages.append(
+                    ChatCompletionMessage(
+                        role="tool",
+                        tool_call_id=call_id,
+                        content=json.dumps({"error": f"unknown tool {name!r}"}),
+                    )
+                )
+                continue
+            if meta.destructive or meta.requires_confirmation:
+                raise ToolConfirmationRequired(
+                    provider=meta.provider,
+                    tool=meta.tool,
+                    args=args,
+                    tool_call_id=call_id,
+                    destructive=meta.destructive,
+                    messages_so_far=messages,
+                )
+            result = await execute_mcp_tool(
+                db,
+                gateway=gateway,
+                meta=meta,
+                args=args,
+                user_id=user_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                request_id=request_id,
+                max_allowed_tier=max_allowed_tier,
+            )
+            messages.append(
+                ChatCompletionMessage(
+                    role="tool",
+                    tool_call_id=call_id,
+                    content=_tool_result_content(result),
+                )
+            )

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -28,6 +28,7 @@ from app.models.knowledge import KnowledgeBase, KnowledgeBaseFile
 from app.models.mcp import MCPToolCache
 from app.models.mcp_oauth import MCPOAuthState, MCPOAuthToken
 from app.models.organization_profile import OrganizationProfile
+from app.models.pending_tool_call import PendingToolCall
 from app.models.playbook import Playbook, PlaybookExecution, PlaybookPosition
 from app.models.project import Project, ProjectFile, ProjectSkill
 from app.models.project_knowledge_base import ProjectKnowledgeBase
@@ -64,6 +65,7 @@ __all__ = [
     "MCPToolCache",
     "Message",
     "OrganizationProfile",
+    "PendingToolCall",
     "Playbook",
     "PlaybookExecution",
     "PlaybookPosition",

--- a/api/app/models/pending_tool_call.py
+++ b/api/app/models/pending_tool_call.py
@@ -1,0 +1,72 @@
+"""``pending_tool_call`` — a paused, human-gated chat tool call (PR5b-ii / WS4).
+
+When the chat tool-loop proposes a ``destructive`` / ``requires_confirmation``
+tool, the turn ends and one of these rows is written (spec L3 persist-and-resume).
+A separate ``POST /chats/{chat_id}/tool-calls/{pending_call_id}`` approves or
+denies it and resumes the assistant turn.
+
+The row is **single-use** (deleted when resolved) and **TTL-bounded**
+(``expires_at``) — the same discipline as :class:`MCPOAuthState`. The pending
+call's arguments + the conversation-so-far resume state are **Fernet-encrypted
+at rest** in ``payload_cipher`` (via :class:`app.security.encryption.MCPTokenEncryptor`):
+they can carry user content, so — unlike the payload-free ``tool_call_log``
+audit row — they never sit in plaintext.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, LargeBinary, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class PendingToolCall(Base):
+    """A chat tool call awaiting human approval. Server-side only; single-use."""
+
+    __tablename__ = "pending_tool_call"
+
+    pending_call_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    """Opaque URL-safe random token; the handle the client approves/denies."""
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE", name="fk_pending_tool_call_user"),
+        nullable=False,
+    )
+    """Owner of the chat that proposed the call; cascade-deleted with the user."""
+
+    chat_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chats.id", ondelete="CASCADE", name="fk_pending_tool_call_chat"),
+        nullable=False,
+    )
+    """Chat the pending call belongs to; the resume endpoint re-checks ownership."""
+
+    message_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    """The assistant message id the resumed turn continues."""
+
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    """Tool provider (matches gateway config name)."""
+
+    tool: Mapped[str] = mapped_column(Text, nullable=False)
+    """Tool name within the provider."""
+
+    destructive: Mapped[bool] = mapped_column(nullable=False)
+    """Whether the proposed tool is flagged destructive (vs confirm-only)."""
+
+    payload_cipher: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    """Fernet ciphertext of the resume payload JSON: the tool args, the
+    tool_call_id, and the conversation-so-far messages. NEVER plaintext — it can
+    contain user content (contrast ``tool_call_log``, which is payload-free)."""
+
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    """TTL horizon; the resume endpoint rejects expired rows (410)."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )

--- a/api/app/schemas/gateway.py
+++ b/api/app/schemas/gateway.py
@@ -93,6 +93,33 @@ class InlineSkillRef(BaseModel):
     """Provenance tag (``wizard-tryout``, etc.) — surfaced on audit logs."""
 
 
+class FunctionDefinition(BaseModel):
+    """A single function-tool the model may call (OpenAI ``function`` shape).
+
+    Mirrors :class:`gateway.app.providers.openai_schema.FunctionDefinition`.
+    PR5b: the backend assembles these from operator-enabled research / MCP
+    tools and forwards them to the gateway.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(min_length=1, max_length=128)
+    description: str | None = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolDefinition(BaseModel):
+    """One entry in the request's ``tools`` allowlist (OpenAI ``function`` type).
+
+    Mirrors :class:`gateway.app.providers.openai_schema.ToolDefinition`.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["function"] = "function"
+    function: FunctionDefinition
+
+
 class ChatCompletionRequest(BaseModel):
     """OpenAI Chat Completions request body, plus LQ.AI extensions.
 
@@ -112,6 +139,16 @@ class ChatCompletionRequest(BaseModel):
     stream: bool = False
     stop: list[str] | str | None = None
     n: int | None = Field(default=None, ge=1, le=1)
+
+    # --- PR5b: governed tool-calling (WS4) -----------------------------------
+    tools: list[ToolDefinition] | None = Field(default=None, max_length=64)
+    """Model-visible tool allowlist for this turn (PR5b). Assembled by the
+    chat tool-loop from operator-enabled research + MCP tools and forwarded
+    to the gateway. ``None`` preserves the pre-PR5b single-shot wire shape."""
+
+    tool_choice: str | dict[str, Any] | None = None
+    """How the model chooses among ``tools`` (OpenAI shape:
+    ``auto`` / ``none`` / ``required`` or a specific function)."""
 
     # --- LQ.AI extensions (per gateway-openapi.yaml) -------------------------
     minimum_inference_tier: int | None = Field(default=None, ge=1, le=5)

--- a/api/tests/integration/test_tool_call_confirmation.py
+++ b/api/tests/integration/test_tool_call_confirmation.py
@@ -228,3 +228,59 @@ async def test_replay_after_resolve_returns_410(
     assert first.status_code == 200
     replay = await client.post(path, json={"decision": "deny"}, headers=headers)
     assert replay.status_code == 410
+
+
+@pytest.mark.integration
+async def test_gate_does_not_write_placeholder_message(
+    db_session: AsyncSession, chat: Chat, db_user: User
+) -> None:
+    """Regression: the gate must NOT persist a placeholder assistant message.
+
+    It used to write a content="" assistant row at gate time; the resume path's
+    re-gate / final-save then tried to INSERT the same message_id again ->
+    ``UniqueViolationError messages_pkey`` (surfaced as a null pending_call_id
+    + a 410 on the next approve). The resume path owns the single message write.
+    """
+
+    from app.api.chats import _persist_pending_tool_call
+    from app.chat.tool_loop import ToolConfirmationRequired
+    from app.models.chat import Message
+
+    assistant_message_id = uuid.uuid4()
+    request = ChatCompletionRequest(
+        model="claude-haiku-4-5",
+        messages=[ChatCompletionMessage(role="user", content="hi")],
+    )
+    exc = ToolConfirmationRequired(
+        provider="deepwiki",
+        tool="ask_question",
+        args={"q": "x"},
+        tool_call_id="call_1",
+        destructive=False,
+        messages_so_far=[ChatCompletionMessage(role="user", content="hi")],
+    )
+
+    info = await _persist_pending_tool_call(
+        db_session,
+        user=db_user,
+        request=request,
+        confirm_exc=exc,
+        chat=chat,
+        assistant_message_id=assistant_message_id,
+    )
+
+    assert info["pending_call_id"]  # a real handle, not None
+    # No placeholder assistant message row — the resume path writes it once.
+    msg = (
+        await db_session.execute(select(Message).where(Message.id == assistant_message_id))
+    ).scalar_one_or_none()
+    assert msg is None
+    # The pending row IS persisted.
+    pending = (
+        await db_session.execute(
+            select(PendingToolCall).where(
+                PendingToolCall.pending_call_id == info["pending_call_id"]
+            )
+        )
+    ).scalar_one_or_none()
+    assert pending is not None

--- a/api/tests/integration/test_tool_call_confirmation.py
+++ b/api/tests/integration/test_tool_call_confirmation.py
@@ -1,0 +1,230 @@
+"""Integration tests for the PR5b-ii confirmation-gate endpoint.
+
+``POST /api/v1/chats/{chat_id}/tool-calls/{pending_call_id}`` — the approve/deny
+resolve path. Exercises the real DB (migration 0054 / ``pending_tool_call``),
+owner-checking, single-use + TTL semantics, and the deny-resume stream.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.chat.pending import create_pending_tool_call
+from app.clients.gateway import GatewayClient, set_gateway_client
+from app.db.session import get_db
+from app.main import app
+from app.models.chat import Chat
+from app.models.pending_tool_call import PendingToolCall
+from app.models.user import User
+from app.schemas.gateway import ChatCompletionMessage, ChatCompletionRequest
+from app.security import create_access_token, hash_password
+from app.security.encryption import MCP_MASTER_KEY_ENV, generate_master_key
+
+GATEWAY_BASE = "http://test-gateway"
+GATEWAY_KEY = "test-gw-key"
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest.fixture(autouse=True)
+def _mcp_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The gate encrypts the resume payload; the encryptor needs the MCP key.
+    monkeypatch.setenv(MCP_MASTER_KEY_ENV, generate_master_key())
+
+
+@pytest_asyncio.fixture
+async def db_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"gate-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Gate Test User",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def other_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"other-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Other User",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def chat(db_session: AsyncSession, db_user: User) -> Chat:
+    row = Chat(owner_id=db_user.id, title="Gate test chat")
+    db_session.add(row)
+    await db_session.flush()
+    return row
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    gw = GatewayClient(base_url=GATEWAY_BASE, gateway_key=GATEWAY_KEY)
+    set_gateway_client(gw)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+    set_gateway_client(None)
+    await gw.aclose()
+    app.dependency_overrides.pop(get_db, None)
+
+
+def _bearer(user: User) -> str:
+    return create_access_token(user.id, user.email, is_admin=user.is_admin)
+
+
+async def _make_pending(db_session: AsyncSession, *, user: User, chat: Chat) -> str:
+    resume_request = ChatCompletionRequest(
+        model="claude-haiku-4-5",
+        messages=[
+            ChatCompletionMessage(role="user", content="make a doc"),
+            ChatCompletionMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "create_doc", "arguments": "{}"},
+                    }
+                ],
+            ),
+        ],
+    )
+    return await create_pending_tool_call(
+        db_session,
+        user_id=user.id,
+        chat_id=chat.id,
+        message_id=uuid.uuid4(),
+        provider="office",
+        tool="create_doc",
+        destructive=True,
+        args={"title": "X"},
+        tool_call_id="call_1",
+        resume_request=resume_request,
+        max_allowed_tier=None,
+    )
+
+
+_FINAL = {
+    "id": "chatcmpl-final",
+    "object": "chat.completion",
+    "created": 1_700_000_000,
+    "model": "claude-haiku-4-5",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "Understood — I won't create it."},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 5, "completion_tokens": 4, "total_tokens": 9},
+    "routed_inference_tier": 3,
+    "routed_provider": "anthropic-prod",
+}
+
+
+@pytest.mark.integration
+async def test_unknown_pending_call_returns_410(
+    client: AsyncClient, chat: Chat, db_user: User
+) -> None:
+    resp = await client.post(
+        f"/api/v1/chats/{chat.id}/tool-calls/does-not-exist",
+        json={"decision": "approve"},
+        headers={"Authorization": f"Bearer {_bearer(db_user)}"},
+    )
+    assert resp.status_code == 410
+
+
+@pytest.mark.integration
+async def test_nonowner_returns_404(
+    client: AsyncClient, db_session: AsyncSession, chat: Chat, db_user: User, other_user: User
+) -> None:
+    pending_id = await _make_pending(db_session, user=db_user, chat=chat)
+    resp = await client.post(
+        f"/api/v1/chats/{chat.id}/tool-calls/{pending_id}",
+        json={"decision": "deny"},
+        headers={"Authorization": f"Bearer {_bearer(other_user)}"},  # not the owner
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_deny_resumes_and_finalizes(
+    client: AsyncClient, db_session: AsyncSession, chat: Chat, db_user: User
+) -> None:
+    # No MCP tool providers configured -> assemble_mcp_tools empty -> deny path
+    # finalizes via a single gateway chat_completion.
+    respx.get(f"{GATEWAY_BASE}/admin/v1/config").mock(
+        return_value=httpx.Response(200, json={"tool_providers": []})
+    )
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_FINAL)
+    )
+    pending_id = await _make_pending(db_session, user=db_user, chat=chat)
+
+    resp = await client.post(
+        f"/api/v1/chats/{chat.id}/tool-calls/{pending_id}",
+        json={"decision": "deny"},
+        headers={"Authorization": f"Bearer {_bearer(db_user)}"},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    assert '"type":"complete"' in body or '"type": "complete"' in body
+    assert "won't create it" in body
+    # single-use: the pending row is gone.
+    gone = (
+        await db_session.execute(
+            select(PendingToolCall).where(PendingToolCall.pending_call_id == pending_id)
+        )
+    ).scalar_one_or_none()
+    assert gone is None
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_replay_after_resolve_returns_410(
+    client: AsyncClient, db_session: AsyncSession, chat: Chat, db_user: User
+) -> None:
+    respx.get(f"{GATEWAY_BASE}/admin/v1/config").mock(
+        return_value=httpx.Response(200, json={"tool_providers": []})
+    )
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_FINAL)
+    )
+    pending_id = await _make_pending(db_session, user=db_user, chat=chat)
+    headers = {"Authorization": f"Bearer {_bearer(db_user)}"}
+    path = f"/api/v1/chats/{chat.id}/tool-calls/{pending_id}"
+
+    first = await client.post(path, json={"decision": "deny"}, headers=headers)
+    assert first.status_code == 200
+    replay = await client.post(path, json={"decision": "deny"}, headers=headers)
+    assert replay.status_code == 410

--- a/api/tests/test_chat_tool_loop.py
+++ b/api/tests/test_chat_tool_loop.py
@@ -1,0 +1,286 @@
+"""Unit tests for the governed chat tool-loop (PR5b-ii) — :mod:`app.chat.tool_loop`.
+
+Covers allowlist assembly from the MCP cache, the read-only execute-and-loop,
+the per-turn cap, the unknown-tool guard, and the confirmation-required signal.
+The gateway and the governance/egress layer are faked so these are pure unit
+tests (no network, no DB).
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.autonomous.guard import ToolResult
+from app.chat import tool_loop
+from app.chat.tool_loop import (
+    AssembledTools,
+    ToolConfirmationRequired,
+    ToolMeta,
+    assemble_mcp_tools,
+    run_tool_loop,
+)
+from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+)
+
+_UID = uuid.uuid4()
+_CID = uuid.uuid4()
+_MID = uuid.uuid4()
+
+
+def _resp(
+    *, content: str | None, tool_calls: list[dict[str, Any]] | None, finish: str
+) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        id="chatcmpl-x",
+        created=0,
+        model="claude-haiku-4-5",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatCompletionMessage(
+                    role="assistant", content=content, tool_calls=tool_calls
+                ),
+                finish_reason=finish,  # type: ignore[arg-type]
+            )
+        ],
+    )
+
+
+def _tool_call(name: str, args: str, call_id: str = "call_1") -> dict[str, Any]:
+    return {"id": call_id, "type": "function", "function": {"name": name, "arguments": args}}
+
+
+def _base_request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="claude-haiku-4-5",
+        messages=[ChatCompletionMessage(role="user", content="hi")],
+    )
+
+
+class _FakeGateway:
+    """Scripted gateway: returns queued responses; records each request."""
+
+    def __init__(self, responses: list[ChatCompletionResponse]) -> None:
+        self._responses = list(responses)
+        self.requests: list[ChatCompletionRequest] = []
+        self.call_tool_calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def chat_completion(
+        self, request: ChatCompletionRequest, *, request_id: str | None = None
+    ) -> ChatCompletionResponse:
+        self.requests.append(request)
+        return self._responses.pop(0)
+
+    async def call_tool(
+        self,
+        provider: str,
+        tool: str,
+        args: dict[str, Any],
+        *,
+        max_allowed_tier=None,
+        request_id=None,
+    ):
+        self.call_tool_calls.append((provider, tool, args))
+        return {"provider": provider, "tool": tool, "payload": {"ok": True}, "tier": 2}
+
+
+# --- assemble_mcp_tools --------------------------------------------------------
+
+
+async def test_assemble_mcp_tools_renders_enabled_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _servers(*, request_id=None):
+        return [{"name": "deepwiki", "type": "mcp", "auth": "none"}]
+
+    async def _cached(db, *, provider):
+        return [
+            {
+                "name": "ask_question",
+                "description": "Ask",
+                "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+                "read_only": True,
+                "destructive": False,
+                "requires_confirmation": False,
+                "enabled": True,
+            },
+            {
+                "name": "disabled_tool",
+                "description": "x",
+                "parameters": {},
+                "read_only": True,
+                "destructive": False,
+                "requires_confirmation": False,
+                "enabled": False,
+            },
+        ]
+
+    monkeypatch.setattr(tool_loop.mcp_service, "list_servers", _servers)
+    monkeypatch.setattr(tool_loop.mcp_service, "list_cached_tools", _cached)
+
+    assembled = await assemble_mcp_tools(object())  # type: ignore[arg-type]
+    assert len(assembled.schemas) == 1
+    assert assembled.schemas[0].function.name == "ask_question"
+    assert "ask_question" in assembled.registry
+    assert assembled.registry["ask_question"].read_only is True
+    assert "disabled_tool" not in assembled.registry
+    assert bool(assembled) is True
+
+
+# --- run_tool_loop: read-only happy path --------------------------------------
+
+
+async def test_run_tool_loop_executes_readonly_then_finalizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gw = _FakeGateway(
+        [
+            _resp(
+                content="let me look",
+                tool_calls=[_tool_call("ask_question", '{"q": "what is X"}')],
+                finish="tool_calls",
+            ),
+            _resp(content="X is a thing.", tool_calls=None, finish="stop"),
+        ]
+    )
+    executed: list[dict[str, Any]] = []
+
+    async def _fake_exec(db, *, gateway, meta, args, **kw):
+        executed.append(args)
+        return ToolResult(cost_usd=Decimal("0"), data={"payload": {"answer": "X is a thing"}})
+
+    monkeypatch.setattr(tool_loop, "execute_mcp_tool", _fake_exec)
+
+    tools = AssembledTools(
+        schemas=[],
+        registry={
+            "ask_question": ToolMeta(
+                "deepwiki",
+                "ask_question",
+                read_only=True,
+                destructive=False,
+                requires_confirmation=False,
+            )
+        },
+    )
+    # give it a schema so it's truthy / offered
+    from app.schemas.gateway import FunctionDefinition, ToolDefinition
+
+    tools.schemas.append(
+        ToolDefinition(function=FunctionDefinition(name="ask_question", parameters={}))
+    )
+
+    final = await run_tool_loop(
+        object(),  # type: ignore[arg-type]
+        gateway=gw,  # type: ignore[arg-type]
+        base_request=_base_request(),
+        tools=tools,
+        user_id=_UID,
+        chat_id=_CID,
+        message_id=_MID,
+    )
+    assert final.choices[0].message.content == "X is a thing."
+    assert final.choices[0].finish_reason == "stop"
+    assert executed == [{"q": "what is X"}]
+    # second gateway request carried the assistant tool-call turn + tool result
+    second = gw.requests[1]
+    roles = [m.role for m in second.messages]
+    assert "assistant" in roles and "tool" in roles
+
+
+# --- run_tool_loop: confirmation-required raises -------------------------------
+
+
+async def test_run_tool_loop_raises_on_confirmation_required() -> None:
+    gw = _FakeGateway(
+        [_resp(content=None, tool_calls=[_tool_call("create_doc", "{}")], finish="tool_calls")]
+    )
+    from app.schemas.gateway import FunctionDefinition, ToolDefinition
+
+    tools = AssembledTools(
+        schemas=[ToolDefinition(function=FunctionDefinition(name="create_doc", parameters={}))],
+        registry={
+            "create_doc": ToolMeta(
+                "office",
+                "create_doc",
+                read_only=False,
+                destructive=True,
+                requires_confirmation=True,
+            )
+        },
+    )
+    with pytest.raises(ToolConfirmationRequired) as exc:
+        await run_tool_loop(
+            object(),  # type: ignore[arg-type]
+            gateway=gw,  # type: ignore[arg-type]
+            base_request=_base_request(),
+            tools=tools,
+            user_id=_UID,
+            chat_id=_CID,
+            message_id=_MID,
+        )
+    assert exc.value.provider == "office"
+    assert exc.value.tool == "create_doc"
+    assert exc.value.destructive is True
+
+
+# --- run_tool_loop: per-turn cap forces finalize -------------------------------
+
+
+async def test_run_tool_loop_cap_forces_finalize(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Loopy:
+        def __init__(self) -> None:
+            self.requests: list[ChatCompletionRequest] = []
+            self._n = 0
+
+        async def chat_completion(self, request, *, request_id=None):
+            self.requests.append(request)
+            if request.tools:
+                self._n += 1
+                return _resp(
+                    content=None,
+                    tool_calls=[_tool_call("ask_question", "{}", f"c{self._n}")],
+                    finish="tool_calls",
+                )
+            return _resp(content="forced final", tool_calls=None, finish="stop")
+
+    gw = _Loopy()
+
+    async def _fake_exec(db, *, gateway, meta, args, **kw):
+        return ToolResult(cost_usd=Decimal("0"), data={"payload": {}})
+
+    monkeypatch.setattr(tool_loop, "execute_mcp_tool", _fake_exec)
+
+    from app.schemas.gateway import FunctionDefinition, ToolDefinition
+
+    tools = AssembledTools(
+        schemas=[ToolDefinition(function=FunctionDefinition(name="ask_question", parameters={}))],
+        registry={
+            "ask_question": ToolMeta(
+                "deepwiki",
+                "ask_question",
+                read_only=True,
+                destructive=False,
+                requires_confirmation=False,
+            )
+        },
+    )
+    final = await run_tool_loop(
+        object(),  # type: ignore[arg-type]
+        gateway=gw,  # type: ignore[arg-type]
+        base_request=_base_request(),
+        tools=tools,
+        user_id=_UID,
+        chat_id=_CID,
+        message_id=_MID,
+        max_tool_calls=2,
+    )
+    assert final.choices[0].message.content == "forced final"
+    # last request offered no tools (cap reached -> forced finalize)
+    assert gw.requests[-1].tools is None

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -51,6 +51,7 @@ _PARAM_VALUES: dict[str, str] = {
     "project_id": _DUMMY_UUID,
     "chat_id": _DUMMY_UUID,
     "message_id": _DUMMY_UUID,
+    "pending_call_id": "pending-test-token",  # opaque token (not a UUID)
     "file_id": _DUMMY_UUID,
     "kb_id": _DUMMY_UUID,
     "prompt_id": _DUMMY_UUID,
@@ -127,6 +128,7 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("DELETE", "/api/v1/chats/{chat_id}"),
     ("GET", "/api/v1/chats/{chat_id}/messages"),
     ("POST", "/api/v1/chats/{chat_id}/messages"),
+    ("POST", "/api/v1/chats/{chat_id}/tool-calls/{pending_call_id}"),
     ("GET", "/api/v1/chats/{chat_id}/messages/{message_id}/citations"),
     # C1 — Skill Service: filesystem loading
     ("GET", "/api/v1/skills"),

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -52,6 +52,7 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/chats/{chat_id}",
         "/api/v1/chats/{chat_id}/messages",
         "/api/v1/chats/{chat_id}/messages/{message_id}/citations",
+        "/api/v1/chats/{chat_id}/tool-calls/{pending_call_id}",
         # skills
         "/api/v1/skills",
         "/api/v1/skills/{skill_name}",
@@ -318,7 +319,7 @@ async def test_openapi_paths_match_sketch() -> None:
     # /api/v1/mcp/oauth/{server}
     # PR4d Ask 1 adds one new path (131 -> 132):
     # /api/v1/mcp/oauth
-    assert len(actual) == 132
+    assert len(actual) == 133
 
 
 @pytest.mark.unit

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -900,6 +900,49 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/Error'}
 
+  /api/v1/chats/{chat_id}/tool-calls/{pending_call_id}:
+    parameters:
+      - name: chat_id
+        in: path
+        required: true
+        schema: {type: string, format: uuid}
+      - name: pending_call_id
+        in: path
+        required: true
+        schema: {type: string}
+        description: Opaque single-use token for the pending tool call.
+    post:
+      tags: [messages]
+      summary: Approve or deny a human-gated chat tool call (PR5b-ii confirmation gate)
+      description: |
+        Resolves a `tool_confirmation_required` pending call and resumes the
+        assistant turn (SSE stream). ActiveUser-gated + chat-owner-checked
+        (404 cross-user). Single-use + TTL: an unknown / already-resolved /
+        expired token returns 410.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [decision]
+              properties:
+                decision: {type: string, enum: [approve, deny]}
+      responses:
+        '200':
+          description: SSE stream resuming the assistant turn (text/event-stream)
+        '404':
+          description: Chat not found for this user
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
+        '410':
+          description: Pending tool call unknown, already resolved, or expired
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
   /api/v1/chats/{chat_id}/messages:
     parameters:
       - name: chat_id

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -1012,6 +1012,40 @@ components:
         temperature: {type: number, minimum: 0, maximum: 2}
         top_p: {type: number}
         stream: {type: boolean, default: false}
+        # PR5b: governed tool-calling (WS4)
+        tools:
+          type: array
+          maxItems: 64
+          description: |
+            Model-visible tool allowlist for this turn (PR5b). The backend
+            assembles this from operator-enabled research + MCP tools; the
+            gateway forwards it to the provider (OpenAI verbatim; Anthropic
+            translated to `input_schema` blocks). Omitted preserves the
+            pre-PR5b single-shot wire shape.
+          items:
+            type: object
+            required: [type, function]
+            properties:
+              type: {type: string, enum: [function], default: function}
+              function:
+                type: object
+                required: [name]
+                properties:
+                  name: {type: string, maxLength: 128}
+                  description: {type: string}
+                  parameters:
+                    type: object
+                    description: JSON Schema for the tool's arguments.
+        tool_choice:
+          description: |
+            How the model chooses among `tools` (OpenAI shape): `auto`,
+            `none`, `required`, or a specific
+            `{type: function, function: {name}}`. Translated to Anthropic's
+            `auto` / `any` / `tool` shape.
+          oneOf:
+            - type: string
+              enum: [auto, none, required]
+            - type: object
         # LQ.AI extensions
         minimum_inference_tier:
           type: integer

--- a/gateway/app/providers/anthropic.py
+++ b/gateway/app/providers/anthropic.py
@@ -64,6 +64,7 @@ from app.providers.openai_schema import (
     EmbeddingsRequest,
     EmbeddingsResponse,
     FinishReason,
+    ToolDefinition,
 )
 from app.secrets import ProviderKeyResolver
 
@@ -357,10 +358,12 @@ def _to_anthropic_request(
       Anthropic uses its defaults.
     * ``stop`` (OpenAI) becomes ``stop_sequences`` (Anthropic, list-only).
 
-    Tool calls (DE-XXX, future): full OpenAI tool-call/tool-result bridging
-    requires translating to Anthropic's ``tool_use``/``tool_result``
-    content blocks. B3 ships text-only translation; tool-call coverage
-    arrives with the skills work in M1 Phase C.
+    Tool calling (PR5b / WS4): when ``request.tools`` is set, each OpenAI
+    function-tool becomes an Anthropic tool block (``input_schema``) and
+    ``tool_choice`` is translated to Anthropic's shape. Assistant messages
+    that carry ``tool_calls`` (the multi-step loop replaying its own prior
+    calls) are rebuilt as ``tool_use`` content blocks, and ``role="tool"``
+    results are sent as ``tool_result`` blocks (already handled below).
     """
 
     system_chunks: list[str] = []
@@ -387,7 +390,18 @@ def _to_anthropic_request(
                 }
             )
             continue
-        # user / assistant
+        if msg.role == "assistant" and msg.tool_calls:
+            # Assistant turn that issued tool calls (multi-step loop): rebuild
+            # Anthropic ``tool_use`` content blocks so the model sees its own
+            # prior calls. Any leading assistant text is preserved first.
+            assistant_blocks: list[dict[str, Any]] = []
+            if content:
+                assistant_blocks.append({"type": "text", "text": content})
+            for call in msg.tool_calls:
+                assistant_blocks.append(_tool_call_to_tool_use(call))
+            chat_messages.append({"role": "assistant", "content": assistant_blocks})
+            continue
+        # user / assistant (text only)
         chat_messages.append({"role": msg.role, "content": content})
 
     body: dict[str, Any] = {
@@ -406,7 +420,93 @@ def _to_anthropic_request(
         body["stop_sequences"] = (
             [request.stop] if isinstance(request.stop, str) else list(request.stop)
         )
+    # PR5b: tool allowlist + choice. ``tool_choice="none"`` means "don't use
+    # tools this turn", so we omit the tools block entirely rather than send
+    # an unusable Anthropic ``tool_choice``.
+    if request.tools and request.tool_choice != "none":
+        body["tools"] = [_tool_to_anthropic(tool) for tool in request.tools]
+        choice = _tool_choice_to_anthropic(request.tool_choice)
+        if choice is not None:
+            body["tool_choice"] = choice
     return body
+
+
+def _tool_to_anthropic(tool: ToolDefinition) -> dict[str, Any]:
+    """Translate an OpenAI function-tool to an Anthropic tool block.
+
+    Anthropic requires an ``input_schema`` (JSON Schema object); we pass the
+    OpenAI ``parameters`` through and substitute an empty-object schema when
+    the caller omits it (a no-argument tool).
+    """
+
+    schema = tool.function.parameters or {"type": "object", "properties": {}}
+    block: dict[str, Any] = {"name": tool.function.name, "input_schema": schema}
+    if tool.function.description:
+        block["description"] = tool.function.description
+    return block
+
+
+def _tool_choice_to_anthropic(choice: str | dict[str, Any] | None) -> dict[str, Any] | None:
+    """Translate an OpenAI ``tool_choice`` to Anthropic's shape.
+
+    ``auto`` / ``None`` -> Anthropic default (auto), so we return ``None`` and
+    omit the field. ``required`` -> ``{"type": "any"}``. A specific
+    ``{"type": "function", "function": {"name": N}}`` -> ``{"type": "tool",
+    "name": N}``. (``"none"`` is handled by the caller, which drops tools.)
+    """
+
+    if choice is None or choice == "auto":
+        return None
+    if choice == "required":
+        return {"type": "any"}
+    if isinstance(choice, dict):
+        fn = choice.get("function")
+        if isinstance(fn, dict) and isinstance(fn.get("name"), str):
+            return {"type": "tool", "name": fn["name"]}
+    return None
+
+
+def _tool_call_to_tool_use(call: dict[str, Any]) -> dict[str, Any]:
+    """Rebuild an Anthropic ``tool_use`` block from an OpenAI tool_call dict.
+
+    OpenAI carries arguments as a JSON *string*; Anthropic wants a parsed
+    object in ``input``. A malformed/empty arguments string degrades to an
+    empty object rather than failing the whole turn.
+    """
+
+    fn = call.get("function") or {}
+    raw_args = fn.get("arguments")
+    parsed_args: Any
+    if isinstance(raw_args, str):
+        try:
+            parsed_args = json.loads(raw_args) if raw_args else {}
+        except json.JSONDecodeError:
+            parsed_args = {}
+    elif isinstance(raw_args, dict):
+        parsed_args = raw_args
+    else:
+        parsed_args = {}
+    return {
+        "type": "tool_use",
+        "id": str(call.get("id") or ""),
+        "name": str(fn.get("name") or ""),
+        "input": parsed_args,
+    }
+
+
+def _tool_use_to_tool_call(block: dict[str, Any]) -> dict[str, Any]:
+    """Translate an Anthropic ``tool_use`` content block to an OpenAI tool_call.
+
+    Anthropic carries ``input`` as a parsed object; OpenAI wants arguments as
+    a JSON string. A missing id is synthesized so downstream correlation (the
+    chat loop's ``tool_result`` reply) always has a handle.
+    """
+
+    call_id = str(block.get("id") or f"call_{uuid.uuid4().hex}")
+    name = str(block.get("name") or "")
+    raw_input = block.get("input")
+    arguments = json.dumps(raw_input if isinstance(raw_input, dict) else {})
+    return {"id": call_id, "type": "function", "function": {"name": name, "arguments": arguments}}
 
 
 # --- Translation: Anthropic -> OpenAI (non-streaming) -------------------------
@@ -421,9 +521,15 @@ def _from_anthropic_response(
 
     blocks = payload.get("content") or []
     text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
     for block in blocks:
-        if isinstance(block, dict) and block.get("type") == "text":
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
             text_parts.append(str(block.get("text", "")))
+        elif block_type == "tool_use":
+            tool_calls.append(_tool_use_to_tool_call(block))
     text = "".join(text_parts)
 
     stop_reason_raw = payload.get("stop_reason")
@@ -450,7 +556,14 @@ def _from_anthropic_response(
         choices=[
             ChatCompletionChoice(
                 index=0,
-                message=ChatCompletionMessage(role="assistant", content=text),
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    # OpenAI convention: ``content`` may be null on a pure
+                    # tool-call turn. Preserve "" for ordinary text responses
+                    # (no behavior change) but null it when only tool calls.
+                    content=text if text else (None if tool_calls else ""),
+                    tool_calls=tool_calls or None,
+                ),
                 finish_reason=finish_reason,
             )
         ],
@@ -518,6 +631,9 @@ async def _anthropic_stream_iter(
     prompt_tokens = 0
     completion_tokens = 0
     role_emitted = False
+    # PR5b: accumulate streamed tool_use blocks keyed by Anthropic content
+    # block index; emit an OpenAI tool_calls delta when each block stops.
+    tool_uses: dict[int, dict[str, Any]] = {}
 
     try:
         async with client.stream("POST", "/v1/messages", json=body, headers=headers) as response:
@@ -560,6 +676,26 @@ async def _anthropic_stream_iter(
                         )
                     continue
 
+                if kind == "content_block_start":
+                    cb = parsed.get("content_block") or {}
+                    idx = parsed.get("index")
+                    if cb.get("type") == "tool_use" and isinstance(idx, int):
+                        if not role_emitted:
+                            role_emitted = True
+                            yield _make_chunk(
+                                response_id=response_id,
+                                created=created,
+                                model=response_model,
+                                delta=ChatCompletionDelta(role="assistant"),
+                            )
+                        tool_uses[idx] = {
+                            "ordinal": len(tool_uses),
+                            "id": str(cb.get("id") or f"call_{uuid.uuid4().hex}"),
+                            "name": str(cb.get("name") or ""),
+                            "args": "",
+                        }
+                    continue
+
                 if kind == "content_block_delta":
                     delta_block = parsed.get("delta") or {}
                     if delta_block.get("type") == "text_delta":
@@ -571,6 +707,34 @@ async def _anthropic_stream_iter(
                                 model=response_model,
                                 delta=ChatCompletionDelta(content=text),
                             )
+                    elif delta_block.get("type") == "input_json_delta":
+                        idx = parsed.get("index")
+                        if isinstance(idx, int) and idx in tool_uses:
+                            tool_uses[idx]["args"] += str(delta_block.get("partial_json", ""))
+                    continue
+
+                if kind == "content_block_stop":
+                    idx = parsed.get("index")
+                    if isinstance(idx, int) and idx in tool_uses:
+                        tu = tool_uses[idx]
+                        yield _make_chunk(
+                            response_id=response_id,
+                            created=created,
+                            model=response_model,
+                            delta=ChatCompletionDelta(
+                                tool_calls=[
+                                    {
+                                        "index": tu["ordinal"],
+                                        "id": tu["id"],
+                                        "type": "function",
+                                        "function": {
+                                            "name": tu["name"],
+                                            "arguments": tu["args"] or "",
+                                        },
+                                    }
+                                ]
+                            ),
+                        )
                     continue
 
                 if kind == "message_delta":

--- a/gateway/app/providers/ollama.py
+++ b/gateway/app/providers/ollama.py
@@ -471,15 +471,14 @@ def _to_ollama_request(
 
     # Tool calls / tool choice forward through ``tools`` per Ollama's
     # 0.4+ tool-use surface. The OpenAI ``tools`` schema maps directly:
-    # both use the OpenAI tool-definition shape. ``tool_choice``
-    # similarly forwards verbatim.
-    extra = request.model_extra or {}
-    tools = extra.get("tools")
-    if tools is not None:
-        body["tools"] = tools
-    tool_choice = extra.get("tool_choice")
-    if tool_choice is not None:
-        body["tool_choice"] = tool_choice
+    # both use the OpenAI tool-definition shape, so we dump the typed
+    # ``ToolDefinition`` models straight back to their OpenAI dict form.
+    # ``tool_choice`` similarly forwards verbatim. (PR5b promoted ``tools`` /
+    # ``tool_choice`` from extra-allow fields to typed request fields.)
+    if request.tools is not None:
+        body["tools"] = [tool.model_dump(mode="json", exclude_none=True) for tool in request.tools]
+    if request.tool_choice is not None:
+        body["tool_choice"] = request.tool_choice
 
     return body
 

--- a/gateway/app/providers/openai_schema.py
+++ b/gateway/app/providers/openai_schema.py
@@ -141,6 +141,35 @@ class InlineSkillRef(BaseModel):
     metadata."""
 
 
+class FunctionDefinition(BaseModel):
+    """A single function-tool the model may call (OpenAI ``function`` shape).
+
+    PR5b: carries the JSON-schema ``parameters`` the model fills in. The
+    gateway forwards this to OpenAI verbatim and translates it to
+    Anthropic's ``input_schema`` shape for the Messages API.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(min_length=1, max_length=128)
+    description: str | None = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolDefinition(BaseModel):
+    """One entry in the request's ``tools`` allowlist (OpenAI ``function`` type).
+
+    PR5b only models ``type="function"``; other OpenAI tool types
+    (``code_interpreter`` etc.) are out of scope for the governed
+    legal-research / MCP loop and would not pass the closed-set governance.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["function"] = "function"
+    function: FunctionDefinition
+
+
 class ChatCompletionRequest(BaseModel):
     """OpenAI Chat Completions request body, plus LQ.AI extensions.
 
@@ -165,6 +194,24 @@ class ChatCompletionRequest(BaseModel):
     Anthropic Messages doesn't expose an equivalent and supporting it
     multiplies cost without a corresponding skill use case (PRD §7).
     """
+
+    # --- PR5b: governed tool-calling (WS4) -----------------------------------
+    tools: list[ToolDefinition] | None = Field(default=None, max_length=64)
+    """Model-visible tool allowlist for this turn (PR5b). The backend
+    assembles this from operator-enabled research + MCP tools; the gateway
+    forwards it to the provider (OpenAI verbatim; Anthropic translated to
+    ``input_schema`` blocks). Capped at 64 entries as a defense-in-depth
+    bound on the prompt-multiplication surface — the operator allowlist is
+    far smaller in practice. ``None`` (the default) preserves the pre-PR5b
+    single-shot wire shape exactly."""
+
+    tool_choice: str | dict[str, Any] | None = None
+    """How the model should choose among ``tools`` (OpenAI shape):
+    ``"auto"`` / ``"none"`` / ``"required"``, or a specific
+    ``{"type": "function", "function": {"name": ...}}``. Forwarded to
+    OpenAI verbatim; translated to Anthropic's ``tool_choice`` shape
+    (``auto`` / ``any`` / ``tool``). ``None`` lets the provider default
+    (``auto`` when ``tools`` is present)."""
 
     # --- LQ.AI extensions (per gateway-openapi.yaml) -------------------------
     minimum_inference_tier: int | None = Field(default=None, ge=1, le=5)

--- a/gateway/tests/test_anthropic_adapter.py
+++ b/gateway/tests/test_anthropic_adapter.py
@@ -562,3 +562,268 @@ def test_from_config_succeeds_with_env_set() -> None:
     )
     adapter = AnthropicAdapter.from_config(provider, env={"ANTHROPIC_API_KEY": "sk-ant-x"})
     assert adapter.name == "anthropic-test"
+
+
+# --- PR5b: tool-calling bridge ------------------------------------------------
+
+
+_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Look up the weather.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_translates_tools_and_auto_choice() -> None:
+    """OpenAI ``tools`` become Anthropic tool blocks (name / description /
+    input_schema). ``tool_choice="auto"`` is Anthropic's default, so it is
+    omitted from the body."""
+
+    req = _basic_request(tools=[_WEATHER_TOOL], tool_choice="auto")
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert body["tools"] == [
+        {
+            "name": "get_weather",
+            "description": "Look up the weather.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    assert "tool_choice" not in body
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_tool_choice_required_and_specific() -> None:
+    """``required`` -> Anthropic ``any``; a specific function -> ``tool``."""
+
+    req = _basic_request(tools=[_WEATHER_TOOL], tool_choice="required")
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert body["tool_choice"] == {"type": "any"}
+
+    req2 = _basic_request(
+        tools=[_WEATHER_TOOL],
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+    )
+    body2 = _to_anthropic_request(req2, model="claude-sonnet-4-6", stream=False)
+    assert body2["tool_choice"] == {"type": "tool", "name": "get_weather"}
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_tool_choice_none_drops_tools() -> None:
+    """``tool_choice="none"`` means do not use tools this turn; we omit the
+    tools block entirely rather than send an unusable Anthropic choice."""
+
+    req = _basic_request(tools=[_WEATHER_TOOL], tool_choice="none")
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert "tools" not in body
+    assert "tool_choice" not in body
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_tool_without_params_gets_empty_schema() -> None:
+    """A no-argument tool still needs a valid Anthropic ``input_schema``."""
+
+    tool = {"type": "function", "function": {"name": "ping"}}
+    req = _basic_request(tools=[tool])
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert body["tools"] == [{"name": "ping", "input_schema": {"type": "object", "properties": {}}}]
+
+
+@pytest.mark.unit
+def test_to_anthropic_request_assistant_tool_calls_become_tool_use() -> None:
+    """An assistant message replaying its own tool_calls (the multi-step
+    loop) becomes Anthropic ``tool_use`` blocks; JSON-string arguments are
+    parsed into ``input``. The following ``tool`` result stays a
+    ``tool_result`` block."""
+
+    req = ChatCompletionRequest.model_validate(
+        {
+            "model": "claude-sonnet-4-6",
+            "messages": [
+                {"role": "user", "content": "weather in Paris?"},
+                {
+                    "role": "assistant",
+                    "content": "Let me check.",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "Paris"}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "Sunny", "tool_call_id": "call_1"},
+            ],
+        }
+    )
+    body = _to_anthropic_request(req, model="claude-sonnet-4-6", stream=False)
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "tool_use",
+                "id": "call_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+            },
+        ],
+    }
+    assert body["messages"][2]["content"][0]["type"] == "tool_result"
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_from_anthropic_response_reconstructs_tool_calls() -> None:
+    """A ``tool_use`` content block becomes an OpenAI ``tool_calls`` entry
+    with JSON-string arguments; ``content`` is null on a pure tool turn and
+    ``finish_reason`` is ``tool_calls``."""
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "msg_tool",
+                "model": "claude-sonnet-4-6",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01",
+                        "name": "get_weather",
+                        "input": {"city": "Paris"},
+                    }
+                ],
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 10, "output_tokens": 4},
+            },
+        )
+    )
+    adapter = _make_adapter()
+    try:
+        result = await adapter.chat_completion(
+            _basic_request(), model="claude-sonnet-4-6", stream=False
+        )
+    finally:
+        await adapter.aclose()
+    assert isinstance(result, ChatCompletionResponse)
+    msg = result.choices[0].message
+    assert msg.content is None
+    assert result.choices[0].finish_reason == "tool_calls"
+    assert msg.tool_calls is not None
+    assert len(msg.tool_calls) == 1
+    call = msg.tool_calls[0]
+    assert call["id"] == "toolu_01"
+    assert call["type"] == "function"
+    assert call["function"]["name"] == "get_weather"
+    assert json.loads(call["function"]["arguments"]) == {"city": "Paris"}
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_from_anthropic_response_text_plus_tool_call() -> None:
+    """Text *and* a tool call both survive: ``content`` is the text,
+    ``tool_calls`` carries the call."""
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "msg_mix",
+                "model": "claude-sonnet-4-6",
+                "content": [
+                    {"type": "text", "text": "Checking the weather."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_02",
+                        "name": "get_weather",
+                        "input": {"city": "Lyon"},
+                    },
+                ],
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 8, "output_tokens": 6},
+            },
+        )
+    )
+    adapter = _make_adapter()
+    try:
+        result = await adapter.chat_completion(
+            _basic_request(), model="claude-sonnet-4-6", stream=False
+        )
+    finally:
+        await adapter.aclose()
+    assert isinstance(result, ChatCompletionResponse)
+    msg = result.choices[0].message
+    assert msg.content == "Checking the weather."
+    assert msg.tool_calls is not None and len(msg.tool_calls) == 1
+
+
+SSE_TOOL_FIXTURE_BODY = (
+    "event: message_start\n"
+    'data: {"type":"message_start","message":{"id":"msg_tstream","model":"claude-sonnet-4-6",'
+    '"usage":{"input_tokens":9,"output_tokens":0}}}\n\n'
+    "event: content_block_start\n"
+    'data: {"type":"content_block_start","index":0,"content_block":'
+    '{"type":"tool_use","id":"toolu_s1","name":"get_weather","input":{}}}\n\n'
+    "event: content_block_delta\n"
+    'data: {"type":"content_block_delta","index":0,"delta":'
+    '{"type":"input_json_delta","partial_json":"{\\"city\\":"}}\n\n'
+    "event: content_block_delta\n"
+    'data: {"type":"content_block_delta","index":0,"delta":'
+    '{"type":"input_json_delta","partial_json":" \\"Paris\\"}"}}\n\n'
+    "event: content_block_stop\n"
+    'data: {"type":"content_block_stop","index":0}\n\n'
+    "event: message_delta\n"
+    'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},'
+    '"usage":{"output_tokens":12}}\n\n'
+    "event: message_stop\n"
+    'data: {"type":"message_stop"}\n\n'
+)
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_streaming_accumulates_tool_use_into_tool_calls_delta() -> None:
+    """Streamed ``tool_use`` (content_block_start + input_json_delta chunks +
+    stop) becomes ONE OpenAI ``tool_calls`` delta carrying the full
+    accumulated JSON arguments; the final chunk reports
+    ``finish_reason="tool_calls"``."""
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            text=SSE_TOOL_FIXTURE_BODY,
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+    adapter = _make_adapter()
+    try:
+        result = await adapter.chat_completion(
+            _basic_request(stream=True), model="claude-sonnet-4-6", stream=True
+        )
+        assert not isinstance(result, ChatCompletionResponse)
+        chunks = [chunk async for chunk in result]
+    finally:
+        await adapter.aclose()
+
+    tool_chunks = [c for c in chunks if c.choices[0].delta.tool_calls]
+    assert len(tool_chunks) == 1
+    call = tool_chunks[0].choices[0].delta.tool_calls[0]
+    assert call["index"] == 0
+    assert call["id"] == "toolu_s1"
+    assert call["function"]["name"] == "get_weather"
+    assert json.loads(call["function"]["arguments"]) == {"city": "Paris"}
+    assert chunks[-1].choices[0].finish_reason == "tool_calls"


### PR DESCRIPTION
## PR5b-ii — governed chat tool-loop + human confirmation gate (WS4)

Second of the two security-gated PRs for **PR5b** (the governed chat tool-loop), per the merged design spec `docs/superpowers/specs/2026-06-18-pr5-governed-chat-tool-loop-design.md` and the PR5a substrate. Gives interactive chat a real, multi-step tool-calling loop over an operator-enabled allowlist of research + MCP tools, governed per call (tier → cost → audit), with a **human confirmation gate** for write/destructive tools.

> **Stacked on #185** (PR5b-i — gateway `tools` passthrough + Anthropic bridge). The first commit here (`ba5de35`) is #185's; review/merge that first. The diff collapses to the api-only changes once #185 lands.

### What it does (backend-only, per locked decision L2)
- **Loop engine** (`api/app/chat/tool_loop.py`): assembles the per-turn tool allowlist from operator-enabled MCP tools (`mcp_tools` cache) into OpenAI function schemas; runs the loop on top of the PR5a substrate (`governed_tool_invocation`, `origin="chat"`). Read-only tools execute inline and feed back; the per-turn cap (8) forces finalize.
- **Chat integration** (`api/app/api/chats.py`): both the streaming and non-streaming send paths route through the loop when tools are present; empty allowlist = the byte-for-byte single-shot path (no behavior change for deployments without tools).
- **Confirmation gate** (spec L3 persist-and-resume): a `destructive`/`requires_confirmation` tool persists an encrypted, single-use, TTL-bounded `pending_tool_call` row (migration **0054**) + emits a terminal `tool_confirmation_required` SSE event and ends the turn. New route **`POST /api/v1/chats/{chat_id}/tool-calls/{pending_call_id}`** `{decision: approve|deny}` (ActiveUser + chat-owner-checked → 404 cross-user; single-use+TTL → 410) executes the tool and resumes the assistant turn, or denies and finalizes.

### Tests / verification
- Loop unit tests (`api/tests/test_chat_tool_loop.py`); **DB-backed gate integration tests** (`api/tests/integration/test_tool_call_confirmation.py`) — unknown→410, non-owner→404, deny resumes+finalizes+consumes, replay→410 — green against real Postgres (exercises migration 0054).
- Surface guards: `backend-openapi.yaml` + `EXPECTED_PATHS` 132→133 + `IMPLEMENTED_ROUTES`/`_PARAM_VALUES`.
- **Verified live end-to-end** against real Claude + a real MCP tool: chat → Claude calls the tool → gate fires → approve → resume → grounded answer.
- `ruff` + `mypy` clean; no raw args/tokens in any `tool_call_log` row or log line.

### Operator note
The gate encrypts the pending-call payload via `MCPTokenEncryptor`, so the api process needs **`LQ_AI_MCP_MASTER_KEY`** set (same key MCP per-user OAuth uses). Pass it to the api container (`LQ_AI_MCP_MASTER_KEY: ${LQ_AI_MCP_MASTER_KEY:-}` in compose / your deploy env).

### Out of scope (PR6/WS5)
All `web/` UI — the confirmation-prompt rendering / provenance pills — is deferred to PR6 (a small frontend follow-up renders the `tool_confirmation_required` event as an Approve/Deny prompt). Read-only tools are already visible inline with no frontend change.

### Security posture
Built to reuse LQ's existing security substrate, not to open a new surface: **all egress goes through the gateway** (the loop's only outbound call is `GatewayClient.call_tool`; the api never speaks to MCP/external hosts directly); **every call is governed** (`resolve_provider_tier` → `governed_tool_invocation`: tier → cost → audit); the model is confined to the **operator-enabled allowlist** (`mcp_tools.enabled`); **no raw payloads** in `tool_call_log` (digest) or the SSE envelope (arg key-names only); the pending-call resume state is **Fernet-encrypted at rest**, single-use, TTL-bounded, owner-checked (404 cross-user); write/confirm tools require **human approval**; OAuth MCP servers use the **per-user** token.

### Known limitations / deferred follow-ups
- **Api-side per-chat tier ceiling:** the chat loop currently passes `max_allowed_tier=None` to `execute_mcp_tool`, so it relies on the **gateway's** per-provider `egress_tier` + SSRF host-allowlist enforcement (always applied — the gateway is the egress boundary). Deriving an *additional* api-side ceiling from the chat/skill tier (spec §"Tier ceiling source") is defense-in-depth to wire next — not a bypass (`governed_tool_invocation` tier-checks whenever a ceiling is set). Noted in `execute_mcp_tool`'s docstring.
- **CourtListener research tools** in the allowlist are scaffolded but only assembled when that provider is configured; the demo here exercised the MCP path.

Security-sensitive surface: governance-adjacent (`governed_tool_invocation`) + the `gateway/**` passthrough from #185 → routes to security review.

`Closes #184`
