### PR TITLE
PR5b/WS4: governed chat tool-loop + persist-and-resume confirmation gate (tools passthrough + Anthropic tool_use + migration 0054)

### DIFF
--- a/api/alembic/versions/0054_chat_pending_tool_call.py
+++ b/api/alembic/versions/0054_chat_pending_tool_call.py
@@ -1,0 +1,124 @@
+"""chat_pending_tool_call — persist-and-resume state for the chat confirmation gate
+
+Stores the per-turn pending-tool-call payload that the backend persists when
+the model proposes a destructive / requires_confirmation tool, before the user
+confirms.  The row id is the ``pending_call_id`` returned in the SSE event.
+
+Security / data-separation rationale (mirrors model docstring):
+``tool_call_args`` and ``resume_state`` hold conversation/tool payloads needed
+to resume the tool-loop.  They live here — deliberately NOT on
+``tool_call_log`` — to preserve ``tool_call_log``'s counts/types-only
+invariant (PR5a).  ``resume_state`` has the same sensitivity class as
+``messages.content`` (plaintext conversation store): it MUST NEVER be emitted
+to logs, tracing spans, or audit fields.  Rows are TTL-bounded by
+``expires_at`` and are CASCADE-deleted when their parent chat or user is
+deleted.
+
+Revision ID: 0054
+Revises: 0053
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0054"
+down_revision: str | None = "0053"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_pending_tool_call",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "chat_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "chats.id",
+                ondelete="CASCADE",
+                name="fk_chat_pending_tool_call_chat",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "users.id",
+                ondelete="CASCADE",
+                name="fk_chat_pending_tool_call_user",
+            ),
+            nullable=False,
+        ),
+        sa.Column("assistant_message_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "tool_call_log_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "tool_call_log.id",
+                ondelete="SET NULL",
+                name="fk_chat_pending_tool_call_log",
+            ),
+            nullable=True,
+        ),
+        sa.Column("function_name", sa.Text(), nullable=False),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("tool", sa.Text(), nullable=False),
+        sa.Column("destructive", sa.Boolean(), nullable=False),
+        sa.Column("tier", sa.Integer(), nullable=False),
+        sa.Column("tool_call_args", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("resume_state", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_chat_pending_tool_call_chat_id",
+        "chat_pending_tool_call",
+        ["chat_id"],
+    )
+    op.create_index(
+        "ix_chat_pending_tool_call_user_id",
+        "chat_pending_tool_call",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_chat_pending_tool_call_expires_at",
+        "chat_pending_tool_call",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chat_pending_tool_call_expires_at", table_name="chat_pending_tool_call")
+    op.drop_index("ix_chat_pending_tool_call_user_id", table_name="chat_pending_tool_call")
+    op.drop_index("ix_chat_pending_tool_call_chat_id", table_name="chat_pending_tool_call")
+    op.drop_table("chat_pending_tool_call")

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -81,7 +81,7 @@ from app.citation.cost import estimate_judge_call_cost_usd
 from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
 from app.config import get_settings
 from app.db.session import get_db
-from app.errors import InternalError, LQAIError, NotFound, ValidationError
+from app.errors import Conflict, InternalError, LQAIError, NotFound, ValidationError
 from app.knowledge.embed import DEFAULT_EMBEDDING_MODEL, request_embedding_vector
 from app.knowledge.retrieval import HybridSearchResult, hybrid_search
 from app.models.chat import Chat, Message, MessageCitation
@@ -1698,6 +1698,414 @@ async def get_citations(
 
 
 # ---------------------------------------------------------------------------
+# PR5b Task 7 — resume pending tool-call gate
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{chat_id}/tool-calls/{pending_call_id}",
+    response_model=None,
+    summary="Approve or deny a pending destructive chat tool-call; resumes the turn",
+)
+async def resume_tool_call(
+    chat_id: str,
+    pending_call_id: str,
+    request: Request,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    gateway: Annotated[GatewayClient, Depends(get_gateway_client)],
+) -> StreamingResponse:
+    """POST /{chat_id}/tool-calls/{pending_call_id} — approve or deny a pending tool call.
+
+    Loads the pending row (owner-scoped, single-use), resolves the decision,
+    executes the tool or feeds a denial message, then resumes run_chat_tool_loop
+    and streams the outcome as SSE frames.
+    """
+    from app.chat.tool_loop import _tool_error_message, execute_tool, tool_result_message
+    from app.mcp.service import list_servers
+    from app.schemas.chats import ToolCallDecisionRequest
+
+    cid = _validate_chat_id(chat_id)
+
+    # Validate pending_call_id as UUID — 404 on malformed (id-probing-safe).
+    try:
+        pid = uuid.UUID(pending_call_id)
+    except ValueError as exc:
+        raise NotFound(
+            "pending tool-call not found",
+            details={"pending_call_id": pending_call_id},
+        ) from exc
+
+    # Owner-scoped chat load — 404 on cross-user.
+    await _load_visible_chat(db, cid, user.id, include_archived=False)
+
+    # Parse decision body.
+    try:
+        raw_body = await request.json()
+    except Exception as exc:
+        raise ValidationError("Request body is not valid JSON") from exc
+
+    from pydantic import ValidationError as PydanticValidationError
+
+    try:
+        body = ToolCallDecisionRequest.model_validate(raw_body)
+    except PydanticValidationError as exc:
+        raise ValidationError(
+            "Request body failed schema validation",
+            details={
+                "errors": exc.errors(include_context=False, include_url=False, include_input=False)
+            },
+        ) from exc
+
+    # Load the pending row owner-scoped (id-probing-safe).
+    pending = (
+        await db.execute(
+            select(ChatPendingToolCall).where(
+                ChatPendingToolCall.id == pid,
+                ChatPendingToolCall.chat_id == cid,
+                ChatPendingToolCall.user_id == user.id,
+            )
+        )
+    ).scalar_one_or_none()
+    if pending is None:
+        raise NotFound("pending tool-call not found", details={"pending_call_id": pending_call_id})
+    if pending.status != "pending":
+        raise Conflict("tool-call already resolved")
+    now = datetime.now(UTC)
+    if pending.expires_at < now:
+        pending.status = "resolved"
+        await db.commit()
+        raise Conflict("tool-call confirmation expired")
+
+    # Mark resolved BEFORE doing work — single-use gate.
+    pending.status = "resolved"
+    await db.flush()
+
+    # Extract resume state.
+    resume_state: dict = pending.resume_state
+    messages: list[dict] = list(resume_state.get("messages", []))
+    calls_used: int = int(resume_state.get("calls_used", 0))
+    model: str = str(resume_state.get("model", "smart"))
+
+    request_id = (
+        request.headers.get("x-request-id")
+        or request.headers.get("x-correlation-id")
+        or f"req_{uuid.uuid4().hex}"
+    )
+
+    assistant_message_id = pending.assistant_message_id
+
+    async def _generate() -> AsyncIterator[bytes]:
+        # Opening frame — same shape as the initial send path.
+        opening: dict[str, Any] = {
+            "type": "start",
+            "lq_ai_message_id": str(assistant_message_id),
+            "chat_id": str(cid),
+        }
+        yield f"data: {_json.dumps(opening, separators=(',', ':'))}\n\n".encode()
+
+        tool_call_id = str(uuid.uuid4())  # synthetic tc_id for the denial/approval message
+
+        # ── Approve path ─────────────────────────────────────────────────────
+        if body.decision == "approve":
+            # Re-assemble the allowlist to resolve the spec (tool may have been
+            # removed since the gate; treat that as denial-style).
+            try:
+                current_allowlist = await assemble_allowlist(db, request_id=request_id)
+            except Exception:
+                current_allowlist = ChatToolAllowlist(specs={})
+
+            spec = current_allowlist.resolve(pending.function_name)
+
+            if spec is None:
+                # Tool was removed/disabled since the gate — feed an error message.
+                log.warning(
+                    "resume_tool_call: approved but spec %r no longer in allowlist — feeding error",
+                    pending.function_name,
+                    extra={
+                        "event": "resume_tool_call_spec_gone",
+                        "function_name": pending.function_name,
+                    },
+                )
+                messages.append(_tool_error_message(tool_call_id, "tool no longer available"))
+            else:
+                # Build server_auth_map (needed by execute_tool → _dispatch_mcp).
+                try:
+                    raw_servers = await list_servers(request_id=request_id)
+                    server_auth_map: dict[str, str] = {
+                        s["name"]: s.get("auth", "none") for s in raw_servers
+                    }
+                except Exception:
+                    server_auth_map = {}
+
+                # Execute the pending tool call.
+                try:
+                    result = await execute_tool(
+                        db,
+                        user=user,
+                        gateway=gateway,
+                        spec=spec,
+                        args=dict(pending.tool_call_args),
+                        cluster_cache={},
+                        server_auth_map=server_auth_map,
+                        assistant_message_id=assistant_message_id,
+                        chat_id=cid,
+                        request_id=request_id,
+                    )
+                    # Update the gate ToolCallLog to approved.
+                    if pending.tool_call_log_id is not None:
+                        gate_tcl = await db.get(ToolCallLog, pending.tool_call_log_id)
+                        if gate_tcl is not None:
+                            gate_tcl.confirmation_state = "approved"
+                            gate_tcl.outcome = "executed"
+                            await db.flush()
+
+                    # Build the tool result message with a synthetic tc_id.
+                    tr_msg = tool_result_message(tool_call_id, result)
+                    messages.append(tr_msg)
+
+                except Exception as exec_exc:
+                    log.warning(
+                        "resume_tool_call: approved execute_tool failed — feeding error",
+                        extra={"event": "resume_tool_call_execute_failed", "error": repr(exec_exc)},
+                    )
+                    messages.append(_tool_error_message(tool_call_id, "tool execution failed"))
+
+        # ── Deny path ────────────────────────────────────────────────────────
+        else:
+            # Feed a denial tool message so the model can finalize.
+            messages.append(_tool_error_message(tool_call_id, "user denied this tool call"))
+
+            # Update the gate ToolCallLog to denied.
+            if pending.tool_call_log_id is not None:
+                gate_tcl = await db.get(ToolCallLog, pending.tool_call_log_id)
+                if gate_tcl is not None:
+                    gate_tcl.confirmation_state = "denied"
+                    gate_tcl.outcome = "denied"
+                    await db.flush()
+
+        await db.commit()
+
+        # Rebuild the base_request from resume_state messages + model.
+        msg_objects = [
+            ChatCompletionMessage(**m) if not isinstance(m, ChatCompletionMessage) else m
+            for m in messages
+        ]
+        base_request = ChatCompletionRequest(
+            model=model,
+            messages=msg_objects,
+            stream=False,
+            chat_id=str(cid),
+            lq_ai_chat_id=str(cid),
+            lq_ai_message_id=str(assistant_message_id),
+        )
+
+        # Re-assemble allowlist for the resumed loop.
+        try:
+            resume_allowlist = await assemble_allowlist(db, request_id=request_id)
+        except Exception:
+            resume_allowlist = ChatToolAllowlist(specs={})
+
+        # Run the tool loop with remaining budget.
+        loop_outcome: LoopFinal | LoopConfirmation | LoopMcpAuth | None = None
+        error_code: str | None = None
+        error_envelope: dict[str, Any] | None = None
+        try:
+            loop_outcome = await run_chat_tool_loop(
+                db,
+                user=user,
+                gateway=gateway,
+                base_request=base_request,
+                allowlist=resume_allowlist,
+                assistant_message_id=assistant_message_id,
+                calls_used=calls_used,
+                cluster_cache={},
+                request_id=request_id,
+            )
+        except LQAIError as exc:
+            error_code = exc.effective_code
+            error_envelope = exc.to_envelope()
+            log.warning(
+                "resume_tool_call: tool-loop failed",
+                extra={"event": "resume_tool_call_loop_failed", "error_code": error_code},
+            )
+
+        # Render the outcome — mirrors _stream_response's outcome rendering.
+        accumulated: list[str] = []
+        last_tier: int | None = None
+        last_provider: str | None = None
+        last_model: str | None = None
+        last_applied_skills: list[str] | None = None
+        prompt_tokens: int | None = None
+        completion_tokens: int | None = None
+
+        if loop_outcome is not None and isinstance(loop_outcome, LoopFinal):
+            last_tier = loop_outcome.tier
+            last_provider = loop_outcome.provider
+            last_model = loop_outcome.model
+            last_applied_skills = list(loop_outcome.applied_skills or [])
+            prompt_tokens = loop_outcome.usage_prompt or None
+            completion_tokens = loop_outcome.usage_completion or None
+            accumulated = [loop_outcome.text]
+            delta_frame: dict[str, Any] = {
+                "type": "delta",
+                "delta": loop_outcome.text,
+                "lq_ai_message_id": str(assistant_message_id),
+            }
+            if last_tier is not None:
+                delta_frame["routed_inference_tier"] = last_tier
+            if last_applied_skills:
+                delta_frame["applied_skills"] = list(last_applied_skills)
+            yield f"data: {_json.dumps(delta_frame, separators=(',', ':'))}\n\n".encode()
+
+        elif loop_outcome is not None and isinstance(loop_outcome, LoopConfirmation):
+            # Another confirmation gate arose — persist and emit.
+            spec2 = loop_outcome.spec
+            tier_val2 = loop_outcome.tier if loop_outcome.tier is not None else 0
+            try:
+                pending_row2 = ChatPendingToolCall(
+                    chat_id=cid,
+                    user_id=user.id,
+                    assistant_message_id=assistant_message_id,
+                    function_name=spec2.function_name,
+                    kind=spec2.kind,
+                    provider=spec2.provider,
+                    tool=spec2.tool,
+                    destructive=spec2.destructive,
+                    tier=tier_val2,
+                    tool_call_args=loop_outcome.args,
+                    resume_state={
+                        "messages": loop_outcome.messages,
+                        "calls_used": loop_outcome.calls_used,
+                        "model": model,
+                    },
+                    status="pending",
+                    expires_at=datetime.now(UTC) + CONFIRM_TTL,
+                )
+                db.add(pending_row2)
+                await db.flush()
+
+                tcl_row2 = ToolCallLog(
+                    origin="chat",
+                    provider=spec2.provider,
+                    tool=spec2.tool,
+                    tier=tier_val2,
+                    intent=None,
+                    confirmation_state="pending_confirmation",
+                    outcome="pending",
+                    cost_usd=None,
+                    args_digest=_args_digest(loop_outcome.args),
+                    user_id=user.id,
+                    chat_id=cid,
+                    message_id=assistant_message_id,
+                )
+                db.add(tcl_row2)
+                await db.flush()
+                pending_row2.tool_call_log_id = tcl_row2.id
+                await db.commit()
+
+                gate_frame2: dict[str, Any] = {
+                    "type": "tool_confirmation_required",
+                    "lq_ai_message_id": str(assistant_message_id),
+                    "pending_call_id": str(pending_row2.id),
+                    "provider": spec2.provider,
+                    "tool": spec2.tool,
+                    "function_name": spec2.function_name,
+                    "args_summary": _safe_args_summary(loop_outcome.args),
+                    "tier": tier_val2,
+                    "destructive": spec2.destructive,
+                }
+                yield (f"data: {_json.dumps(gate_frame2, separators=(',', ':'))}\n\n".encode())
+            except Exception as gate_exc2:
+                log.error(
+                    "resume_tool_call: failed to persist second confirmation gate",
+                    extra={"error": repr(gate_exc2)},
+                )
+                _err2 = InternalError("Failed to record tool confirmation; please retry.")
+                yield (
+                    f"data: {_json.dumps(_err2.to_envelope(), separators=(',', ':'))}\n\n"
+                ).encode()
+            yield b"data: [DONE]\n\n"
+            return
+
+        elif loop_outcome is not None and isinstance(loop_outcome, LoopMcpAuth):
+            mcp_frame2: dict[str, Any] = {
+                "type": "mcp_authorization_required",
+                "lq_ai_message_id": str(assistant_message_id),
+                "server": loop_outcome.server,
+                "authorize_url": f"/api/v1/mcp/oauth/{loop_outcome.server}/authorize",
+            }
+            yield (f"data: {_json.dumps(mcp_frame2, separators=(',', ':'))}\n\n".encode())
+            yield b"data: [DONE]\n\n"
+            return
+
+        # Persist the assistant message (LoopFinal or error path).
+        try:
+            await _load_visible_chat(db, cid, user.id, include_archived=False)
+        except NotFound:
+            # Chat was deleted; nothing to persist.
+            yield b"data: [DONE]\n\n"
+            return
+
+        try:
+            await _persist_assistant_message(
+                db,
+                message_id=assistant_message_id,
+                chat_id=cid,
+                content="".join(accumulated),
+                requested_model=model,
+                routed_provider=last_provider,
+                routed_model=last_model,
+                routed_inference_tier=last_tier,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                cost_estimate_usd=None,
+                applied_skills=last_applied_skills or [],
+                error_code=error_code,
+            )
+        except Exception as persist_exc:
+            log.error(
+                "resume_tool_call: failed to persist assistant row",
+                extra={"error": repr(persist_exc)},
+            )
+
+        # Final frames.
+        if error_envelope is not None:
+            yield (f"data: {_json.dumps(error_envelope, separators=(',', ':'))}\n\n".encode())
+        else:
+            complete: dict[str, Any] = {
+                "type": "complete",
+                "lq_ai_message_id": str(assistant_message_id),
+                "message": {
+                    "id": str(assistant_message_id),
+                    "chat_id": str(cid),
+                    "role": "assistant",
+                    "content": "".join(accumulated),
+                    "model": last_model,
+                    "provider": last_provider,
+                    "routed_inference_tier": last_tier,
+                    "tokens_in": prompt_tokens,
+                    "tokens_out": completion_tokens,
+                    "created_at": datetime.now(tz=UTC).isoformat(),
+                },
+                "applied_skills": last_applied_skills or [],
+                "applied_file_ids": [],
+                "citations": [],
+                "routed_inference_tier": last_tier,
+                "routed_provider": last_provider,
+            }
+            yield f"data: {_json.dumps(complete, separators=(',', ':'))}\n\n".encode()
+
+        yield b"data: [DONE]\n\n"
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Internal: persistence flow for non-streaming and streaming
 # ---------------------------------------------------------------------------
 
@@ -2335,6 +2743,7 @@ async def _non_streaming_response(
                 resume_state={
                     "messages": outcome.messages,
                     "calls_used": outcome.calls_used,
+                    "model": request.model,
                 },
                 status="pending",
                 expires_at=datetime.now(UTC) + CONFIRM_TTL,
@@ -2643,6 +3052,7 @@ async def _stream_response(
                         resume_state={
                             "messages": loop_outcome.messages,
                             "calls_used": loop_outcome.calls_used,
+                            "model": request.model,
                         },
                         status="pending",
                         expires_at=datetime.now(UTC) + CONFIRM_TTL,
@@ -3037,6 +3447,7 @@ __all__ = [
     "get_citations",
     "list_chats",
     "list_messages",
+    "resume_tool_call",
     "router",
     "run_inference_override",
     "send_message",

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -75,13 +75,13 @@ from app.api.skills import _resolve_skill_for_user
 from app.audit import audit_action
 from app.autonomous.guard import _args_digest
 from app.chat.tool_loop import LoopConfirmation, LoopFinal, LoopMcpAuth, run_chat_tool_loop
-from app.chat.tool_schemas import assemble_allowlist
+from app.chat.tool_schemas import ChatToolAllowlist, assemble_allowlist
 from app.citation import extract_citations, verify
 from app.citation.cost import estimate_judge_call_cost_usd
 from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
 from app.config import get_settings
 from app.db.session import get_db
-from app.errors import LQAIError, NotFound, ValidationError
+from app.errors import InternalError, LQAIError, NotFound, ValidationError
 from app.knowledge.embed import DEFAULT_EMBEDDING_MODEL, request_embedding_vector
 from app.knowledge.retrieval import HybridSearchResult, hybrid_search
 from app.models.chat import Chat, Message, MessageCitation
@@ -1577,13 +1577,11 @@ async def send_message(
     try:
         allowlist = await assemble_allowlist(db, request_id=request_id)
     except Exception:
-        log.debug(
+        log.warning(
             "chat send_message: assemble_allowlist failed — falling back to empty allowlist",
             exc_info=True,
         )
-        from app.chat.tool_schemas import ChatToolAllowlist as _ChatToolAllowlist
-
-        allowlist = _ChatToolAllowlist(specs={})
+        allowlist = ChatToolAllowlist(specs={})
 
     if payload.stream:
         return await _stream_response(
@@ -2213,7 +2211,7 @@ async def _non_streaming_response(
     slash_unresolved: bool = False,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
     project_ensemble_verification: bool = False,
-    allowlist: Any = None,
+    allowlist: ChatToolAllowlist | None = None,
 ) -> JSONResponse:
     """Run the non-streaming path: forward, persist, return JSON.
 
@@ -2229,10 +2227,7 @@ async def _non_streaming_response(
     """
 
     # ── PR5b Task 6: tool-loop branch ──────────────────────────────────────
-    from app.chat.tool_schemas import ChatToolAllowlist
-
-    _allowlist: ChatToolAllowlist | None = allowlist
-    if _allowlist is not None and _allowlist.specs:
+    if allowlist is not None and allowlist.specs:
         # Non-empty allowlist → run the agentic loop.
         try:
             outcome = await run_chat_tool_loop(
@@ -2240,7 +2235,7 @@ async def _non_streaming_response(
                 user=user,
                 gateway=gateway,
                 base_request=request,
-                allowlist=_allowlist,
+                allowlist=allowlist,
                 assistant_message_id=assistant_message_id,
                 cluster_cache={},
                 request_id=request_id,
@@ -2549,7 +2544,7 @@ async def _stream_response(
     http_request: Request | None = None,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
     project_ensemble_verification: bool = False,
-    allowlist: Any = None,
+    allowlist: ChatToolAllowlist | None = None,
 ) -> StreamingResponse:
     """Run the streaming path: forward, stream SSE, persist at end.
 
@@ -2579,10 +2574,7 @@ async def _stream_response(
         yield f"data: {_json.dumps(opening, separators=(',', ':'))}\n\n".encode()
 
         # ── PR5b Task 6: tool-loop branch ─────────────────────────────────────
-        from app.chat.tool_schemas import ChatToolAllowlist
-
-        _allowlist: ChatToolAllowlist | None = allowlist
-        if _allowlist is not None and _allowlist.specs:
+        if allowlist is not None and allowlist.specs:
             # Non-empty allowlist → agentic loop (non-streaming internally).
             loop_outcome = None
             try:
@@ -2591,7 +2583,7 @@ async def _stream_response(
                     user=user,
                     gateway=gateway,
                     base_request=request,
-                    allowlist=_allowlist,
+                    allowlist=allowlist,
                     assistant_message_id=assistant_message_id,
                     cluster_cache={},
                     request_id=request_id,
@@ -2702,6 +2694,18 @@ async def _stream_response(
                             "error": repr(gate_persist_exc),
                         },
                     )
+                    # Persist failure — no gate frame was emitted, no tool was
+                    # executed.  Emit a generic error frame so the client is not
+                    # left with a silent dead-end.  Never leak exception internals
+                    # or tool args into the message.
+                    _gate_persist_err = InternalError(
+                        "Failed to record tool confirmation; please retry.",
+                        details={"event": "chat_gate_persist_failed"},
+                    )
+                    _gate_persist_envelope = _gate_persist_err.to_envelope()
+                    yield (
+                        f"data: {_json.dumps(_gate_persist_envelope, separators=(',', ':'))}\n\n"
+                    ).encode()
                 # Do NOT persist a final assistant Message — Task 7 (resume) does.
                 yield b"data: [DONE]\n\n"
                 return

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -1832,7 +1832,30 @@ async def resume_tool_call(
         }
         yield f"data: {_json.dumps(opening, separators=(',', ':'))}\n\n".encode()
 
-        tool_call_id = str(uuid.uuid4())  # synthetic tc_id for the denial/approval message
+        # One shared tool_call_id is used for BOTH the reconstructed assistant
+        # turn and the trailing tool result/denial message.  Real providers
+        # (Anthropic, OpenAI) reject an orphaned role="tool" message that is
+        # not a response to a preceding assistant tool_calls turn — the
+        # resume_state.messages saved at gate-time contain only the user turn
+        # and the pre-gate conversation; they do NOT contain the assistant turn
+        # that proposed the gated call.  We reconstruct it here so the
+        # conversation is valid before handing it to run_chat_tool_loop.
+        tool_call_id = str(uuid.uuid4())
+        assistant_turn: dict[str, Any] = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": tool_call_id,
+                    "type": "function",
+                    "function": {
+                        "name": pending.function_name,
+                        "arguments": _json.dumps(dict(pending.tool_call_args)),
+                    },
+                }
+            ],
+        }
+        messages.append(assistant_turn)
 
         # ── Approve path ─────────────────────────────────────────────────────
         if body.decision == "approve":

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -67,7 +67,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 # `trace` is for add_event() on the active span; spans use app.observability_helpers.
 from opentelemetry import trace
 from pydantic import BaseModel, ValidationError as PydanticValidationError
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import ActiveUser
@@ -1757,29 +1757,57 @@ async def resume_tool_call(
             },
         ) from exc
 
-    # Load the pending row owner-scoped (id-probing-safe).
-    pending = (
-        await db.execute(
-            select(ChatPendingToolCall).where(
-                ChatPendingToolCall.id == pid,
-                ChatPendingToolCall.chat_id == cid,
-                ChatPendingToolCall.user_id == user.id,
-            )
-        )
-    ).scalar_one_or_none()
-    if pending is None:
-        raise NotFound("pending tool-call not found", details={"pending_call_id": pending_call_id})
-    if pending.status != "pending":
-        raise Conflict("tool-call already resolved")
+    # Atomically claim the pending row — single-use gate, concurrency-safe.
+    #
+    # Under PostgreSQL READ COMMITTED, an uncommitted UPDATE is invisible to
+    # a concurrent transaction, so two simultaneous approve POSTs would BOTH
+    # read status="pending" if we used SELECT-then-flush.  Instead, we use a
+    # conditional UPDATE with WHERE status='pending' AND expires_at >= now and
+    # commit the status flip BEFORE doing any tool work.  Only ONE concurrent
+    # caller can win the DB-side atomic claim; the other gets claimed_id=None.
     now = datetime.now(UTC)
-    if pending.expires_at < now:
-        pending.status = "resolved"
-        await db.commit()
-        raise Conflict("tool-call confirmation expired")
+    claim = await db.execute(
+        update(ChatPendingToolCall)
+        .where(
+            ChatPendingToolCall.id == pid,
+            ChatPendingToolCall.chat_id == cid,
+            ChatPendingToolCall.user_id == user.id,
+            ChatPendingToolCall.status == "pending",
+            ChatPendingToolCall.expires_at >= now,
+        )
+        .values(status="resolved", updated_at=now)
+        .returning(ChatPendingToolCall.id)
+    )
+    claimed_id = claim.scalar_one_or_none()
+    # Durably commit the claim BEFORE any tool execution / gateway call.
+    await db.commit()
 
-    # Mark resolved BEFORE doing work — single-use gate.
-    pending.status = "resolved"
-    await db.flush()
+    if claimed_id is None:
+        # Did not win the claim — disambiguate 404 vs 409.
+        # Owner-scoped follow-up SELECT: if the row exists it was either
+        # already-resolved or expired (409); if it does not exist at all
+        # (unknown id or non-owner) → 404 (id-probing-safe).
+        check = (
+            await db.execute(
+                select(ChatPendingToolCall).where(
+                    ChatPendingToolCall.id == pid,
+                    ChatPendingToolCall.chat_id == cid,
+                    ChatPendingToolCall.user_id == user.id,
+                )
+            )
+        ).scalar_one_or_none()
+        if check is None:
+            raise NotFound(
+                "pending tool-call not found", details={"pending_call_id": pending_call_id}
+            )
+        # Row exists but was non-pending or expired → conflict.
+        raise Conflict("tool-call already resolved or expired")
+
+    # We won the claim — re-load the full row (now status="resolved") to get
+    # resume_state, tool_call_args, function_name, provider, tool, etc.
+    pending = (
+        await db.execute(select(ChatPendingToolCall).where(ChatPendingToolCall.id == claimed_id))
+    ).scalar_one()
 
     # Extract resume state.
     resume_state: dict = pending.resume_state
@@ -1839,6 +1867,15 @@ async def resume_tool_call(
                     server_auth_map = {}
 
                 # Execute the pending tool call.
+                #
+                # Two-row audit model:
+                # - Gate row (pending.tool_call_log_id): the confirmation-request
+                #   lifecycle record (pending_confirmation → approved | denied).
+                #   Its outcome stays as-is; we only flip confirmation_state.
+                # - Execute_tool row (written inside governed_tool_invocation):
+                #   the actual approved execution, stamped confirmation_state=
+                #   "approved" / outcome="executed".  This is the authoritative
+                #   record that the tool ran with user approval.
                 try:
                     result = await execute_tool(
                         db,
@@ -1851,13 +1888,19 @@ async def resume_tool_call(
                         assistant_message_id=assistant_message_id,
                         chat_id=cid,
                         request_id=request_id,
+                        confirmation_state="approved",
                     )
-                    # Update the gate ToolCallLog to approved.
+                    # Update the gate row's confirmation_state to "approved"
+                    # (the confirmation-REQUEST lifecycle: pending_confirmation →
+                    # approved).  We do NOT set outcome="executed" here — that
+                    # would misrepresent the gate row as the execution record.
+                    # The execution record is the separate row written above by
+                    # governed_tool_invocation with confirmation_state="approved"
+                    # and outcome="executed".
                     if pending.tool_call_log_id is not None:
                         gate_tcl = await db.get(ToolCallLog, pending.tool_call_log_id)
                         if gate_tcl is not None:
                             gate_tcl.confirmation_state = "approved"
-                            gate_tcl.outcome = "executed"
                             await db.flush()
 
                     # Build the tool result message with a synthetic tc_id.

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -57,7 +57,7 @@ import logging
 import re
 import uuid
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Annotated, Any
 
@@ -73,6 +73,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies import ActiveUser
 from app.api.skills import _resolve_skill_for_user
 from app.audit import audit_action
+from app.autonomous.guard import _args_digest
+from app.chat.tool_loop import LoopConfirmation, LoopFinal, LoopMcpAuth, run_chat_tool_loop
+from app.chat.tool_schemas import assemble_allowlist
 from app.citation import extract_citations, verify
 from app.citation.cost import estimate_judge_call_cost_usd
 from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
@@ -82,12 +85,14 @@ from app.errors import LQAIError, NotFound, ValidationError
 from app.knowledge.embed import DEFAULT_EMBEDDING_MODEL, request_embedding_vector
 from app.knowledge.retrieval import HybridSearchResult, hybrid_search
 from app.models.chat import Chat, Message, MessageCitation
+from app.models.chat_pending_tool_call import ChatPendingToolCall
 from app.models.document import Document
 from app.models.file import File
 from app.models.inference import InferenceRoutingLog
 from app.models.knowledge import KnowledgeBase
 from app.models.project import Project
 from app.models.project_knowledge_base import ProjectKnowledgeBase
+from app.models.tool_call_log import ToolCallLog
 from app.models.user import User
 from app.observability_helpers import get_tracer, record_attributes
 from app.schemas.chats import (
@@ -116,6 +121,37 @@ from app.skills.registry import MutableSkillRegistry, SkillRegistry
 
 router = APIRouter(prefix="/chats", tags=["chats"])
 log = logging.getLogger(__name__)
+
+# PR5b Task 6 — TTL for pending confirmation rows.
+CONFIRM_TTL: timedelta = timedelta(minutes=15)
+
+
+def _safe_args_summary(args: dict[str, Any]) -> dict[str, Any]:
+    """Shallow, size-bounded view of tool-call args for SSE gate frames.
+
+    Returns a dict with the same keys but values truncated/redacted:
+    - str / int / float / bool / None scalars are kept (strings capped at
+      80 chars).
+    - Nested containers (dict, list) are replaced with their type name so
+      large payloads never flow to the client.
+    Never includes raw sensitive data — the primary purpose is to let the
+    UI render a human-readable "what is about to happen" summary without
+    exposing the full argument payload.
+    """
+    _MAX_STR = 80
+    out: dict[str, Any] = {}
+    for k, v in args.items():
+        if isinstance(v, str):
+            out[k] = v[:_MAX_STR] + "…" if len(v) > _MAX_STR else v
+        elif isinstance(v, (int, float, bool)) or v is None:
+            out[k] = v
+        elif isinstance(v, dict):
+            out[k] = f"<dict({len(v)} keys)>"
+        elif isinstance(v, list):
+            out[k] = f"<list({len(v)} items)>"
+        else:
+            out[k] = f"<{type(v).__name__}>"
+    return out
 
 
 def _estimate_tokens(text: str) -> int:
@@ -1533,6 +1569,22 @@ async def send_message(
         },
     )
 
+    # PR5b Task 6 — assemble the per-turn tool allowlist.  Empty when no
+    # research / MCP is configured; non-empty drives the agentic loop.
+    # Fail safe: if the gateway config endpoint is unreachable (e.g. during
+    # deployment or in environments without research/MCP), return an empty
+    # allowlist so the existing single-shot path runs unchanged.
+    try:
+        allowlist = await assemble_allowlist(db, request_id=request_id)
+    except Exception:
+        log.debug(
+            "chat send_message: assemble_allowlist failed — falling back to empty allowlist",
+            exc_info=True,
+        )
+        from app.chat.tool_schemas import ChatToolAllowlist as _ChatToolAllowlist
+
+        allowlist = _ChatToolAllowlist(specs={})
+
     if payload.stream:
         return await _stream_response(
             db=db,
@@ -1547,6 +1599,7 @@ async def send_message(
             http_request=request,
             attached_skill_provenance=attached_skill_provenance,
             project_ensemble_verification=project_ensemble_verification,
+            allowlist=allowlist,
         )
     return await _non_streaming_response(
         db=db,
@@ -1563,6 +1616,7 @@ async def send_message(
         slash_unresolved=slash_unresolved,
         attached_skill_provenance=attached_skill_provenance,
         project_ensemble_verification=project_ensemble_verification,
+        allowlist=allowlist,
     )
 
 
@@ -2159,14 +2213,229 @@ async def _non_streaming_response(
     slash_unresolved: bool = False,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
     project_ensemble_verification: bool = False,
+    allowlist: Any = None,
 ) -> JSONResponse:
     """Run the non-streaming path: forward, persist, return JSON.
 
     Wave D.2 Task 2.7 — ``attached_skill_names`` and ``slash_unresolved``
     are propagated from :func:`send_message`'s slash-fallback path.
     Defaults preserve the pre-Task-2.7 wire contract for any caller
-    that doesn't pass them in."""
+    that doesn't pass them in.
 
+    PR5b Task 6 — when ``allowlist`` is non-empty, drives the agentic
+    tool-loop (``run_chat_tool_loop``) instead of the single-shot gateway
+    call.  Empty allowlist → existing single-shot path, byte-for-byte
+    unchanged.
+    """
+
+    # ── PR5b Task 6: tool-loop branch ──────────────────────────────────────
+    from app.chat.tool_schemas import ChatToolAllowlist
+
+    _allowlist: ChatToolAllowlist | None = allowlist
+    if _allowlist is not None and _allowlist.specs:
+        # Non-empty allowlist → run the agentic loop.
+        try:
+            outcome = await run_chat_tool_loop(
+                db,
+                user=user,
+                gateway=gateway,
+                base_request=request,
+                allowlist=_allowlist,
+                assistant_message_id=assistant_message_id,
+                cluster_cache={},
+                request_id=request_id,
+            )
+        except LQAIError as exc:
+            log.warning(
+                "chat send_message tool-loop failed (non-streaming)",
+                extra={
+                    "event": "chat_send_message_loop_failed",
+                    "user_id": str(user.id),
+                    "chat_id": str(chat.id),
+                    "assistant_message_id": str(assistant_message_id),
+                    "request_id": request_id,
+                    "error_code": getattr(exc, "effective_code", "internal_error"),
+                },
+            )
+            raise
+
+        if isinstance(outcome, LoopFinal):
+            # Normal completion — persist exactly like the single-shot path.
+            applied_skills = list(outcome.applied_skills or [])
+            persisted = await _persist_assistant_message(
+                db,
+                message_id=assistant_message_id,
+                chat_id=chat.id,
+                content=outcome.text,
+                requested_model=request.model,
+                routed_provider=outcome.provider,
+                routed_model=outcome.model,
+                routed_inference_tier=outcome.tier,
+                prompt_tokens=outcome.usage_prompt or None,
+                completion_tokens=outcome.usage_completion or None,
+                cost_estimate_usd=None,
+                applied_skills=applied_skills,
+                error_code=None,
+            )
+            await _persist_message_citations(
+                db,
+                message_id=assistant_message_id,
+                assistant_text=outcome.text,
+                retrieved_chunks=retrieved_chunks or [],
+                gateway=gateway,
+                applied_skills=applied_skills,
+                project_ensemble_verification=project_ensemble_verification,
+                skill_registry=_skill_registry_from_request(http_request),
+            )
+            await _audit_message_sent(
+                db,
+                user=user,
+                chat=chat,
+                assistant_message_id=assistant_message_id,
+                user_message_id=user_message_id,
+                routed_inference_tier=outcome.tier,
+                routed_provider=outcome.provider,
+                applied_skills=applied_skills,
+                error_code=None,
+                request=http_request,
+                attached_skill_provenance=attached_skill_provenance,
+            )
+            body = MessagePostResponse(
+                message=message_to_response(persisted),
+                citations=[],
+                routed_inference_tier=outcome.tier,
+                routed_provider=outcome.provider,
+                cost_estimate=None,
+                applied_skills=applied_skills,
+                applied_file_ids=list(request.lq_ai_file_ids),
+                attached_skill_names=list(attached_skill_names or []),
+                slash_unresolved=slash_unresolved,
+            )
+            loop_headers: dict[str, str] = {}
+            if outcome.tier is not None:
+                loop_headers["X-LQ-AI-Routed-Inference-Tier"] = str(outcome.tier)
+            if outcome.provider is not None:
+                loop_headers["X-LQ-AI-Routed-Provider"] = outcome.provider
+            return JSONResponse(
+                status_code=status.HTTP_200_OK,
+                content=body.model_dump(mode="json"),
+                headers=loop_headers,
+            )
+
+        if isinstance(outcome, LoopConfirmation):
+            # Confirmation gate — persist pending rows and return gate payload.
+            spec = outcome.spec
+            tier_val = outcome.tier if outcome.tier is not None else 0
+            pending_row = ChatPendingToolCall(
+                chat_id=chat.id,
+                user_id=user.id,
+                assistant_message_id=assistant_message_id,
+                function_name=spec.function_name,
+                kind=spec.kind,
+                provider=spec.provider,
+                tool=spec.tool,
+                destructive=spec.destructive,
+                tier=tier_val,
+                tool_call_args=outcome.args,
+                resume_state={
+                    "messages": outcome.messages,
+                    "calls_used": outcome.calls_used,
+                },
+                status="pending",
+                expires_at=datetime.now(UTC) + CONFIRM_TTL,
+            )
+            db.add(pending_row)
+            await db.flush()
+
+            tcl_row = ToolCallLog(
+                origin="chat",
+                provider=spec.provider,
+                tool=spec.tool,
+                tier=tier_val,
+                intent=None,
+                confirmation_state="pending_confirmation",
+                outcome="pending",
+                cost_usd=None,
+                args_digest=_args_digest(outcome.args),
+                user_id=user.id,
+                chat_id=chat.id,
+                message_id=assistant_message_id,
+            )
+            db.add(tcl_row)
+            await db.flush()
+
+            # Link the pending row to its tool-call-log row.
+            pending_row.tool_call_log_id = tcl_row.id
+            await db.commit()
+
+            gate_payload: dict[str, Any] = {
+                "type": "tool_confirmation_required",
+                "lq_ai_message_id": str(assistant_message_id),
+                "pending_call_id": str(pending_row.id),
+                "provider": spec.provider,
+                "tool": spec.tool,
+                "function_name": spec.function_name,
+                "args_summary": _safe_args_summary(outcome.args),
+                "tier": tier_val,
+                "destructive": spec.destructive,
+            }
+            # Construct a minimal placeholder message for MessagePostResponse.
+            # The resume path (Task 7) persists the real assistant row.
+            # MessageResponse.content is a required str; use "" since the
+            # gate response carries the payload in pending_tool_call.
+            from app.schemas.chats import MessageResponse
+
+            placeholder_msg = MessageResponse(
+                id=assistant_message_id,
+                chat_id=chat.id,
+                role="assistant",
+                content="",
+                created_at=datetime.now(UTC),
+            )
+            body_conf = MessagePostResponse(
+                message=placeholder_msg,
+                citations=[],
+                applied_file_ids=list(request.lq_ai_file_ids),
+                attached_skill_names=list(attached_skill_names or []),
+                slash_unresolved=slash_unresolved,
+                pending_tool_call=gate_payload,
+            )
+            return JSONResponse(
+                status_code=status.HTTP_200_OK,
+                content=body_conf.model_dump(mode="json"),
+            )
+
+        if isinstance(outcome, LoopMcpAuth):
+            # OAuth gate — no persistence, return authorize URL.
+            mcp_payload: dict[str, Any] = {
+                "type": "mcp_authorization_required",
+                "lq_ai_message_id": str(assistant_message_id),
+                "server": outcome.server,
+                "authorize_url": f"/api/v1/mcp/oauth/{outcome.server}/authorize",
+            }
+            from app.schemas.chats import MessageResponse
+
+            placeholder_mcp = MessageResponse(
+                id=assistant_message_id,
+                chat_id=chat.id,
+                role="assistant",
+                content="",
+                created_at=datetime.now(UTC),
+            )
+            body_mcp = MessagePostResponse(
+                message=placeholder_mcp,
+                citations=[],
+                applied_file_ids=list(request.lq_ai_file_ids),
+                attached_skill_names=list(attached_skill_names or []),
+                slash_unresolved=slash_unresolved,
+                mcp_authorization_required=mcp_payload,
+            )
+            return JSONResponse(
+                status_code=status.HTTP_200_OK,
+                content=body_mcp.model_dump(mode="json"),
+            )
+
+    # ── Existing single-shot path (empty allowlist) ─────────────────────────
     try:
         response = await gateway.chat_completion(request, request_id=request_id)
     except LQAIError as exc:
@@ -2280,8 +2549,14 @@ async def _stream_response(
     http_request: Request | None = None,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
     project_ensemble_verification: bool = False,
+    allowlist: Any = None,
 ) -> StreamingResponse:
-    """Run the streaming path: forward, stream SSE, persist at end."""
+    """Run the streaming path: forward, stream SSE, persist at end.
+
+    PR5b Task 6 — when ``allowlist`` is non-empty, drives the agentic
+    tool-loop instead of the single-shot ``chat_completion_stream`` call.
+    Empty allowlist → existing single-shot path, byte-for-byte unchanged.
+    """
 
     async def _generate() -> AsyncIterator[bytes]:
         accumulated: list[str] = []
@@ -2303,55 +2578,200 @@ async def _stream_response(
         }
         yield f"data: {_json.dumps(opening, separators=(',', ':'))}\n\n".encode()
 
-        try:
-            async for chunk in gateway.chat_completion_stream(request, request_id=request_id):
-                last_tier = chunk.routed_inference_tier or last_tier
-                last_provider = chunk.routed_provider or last_provider
-                last_model = chunk.model
-                if chunk.lq_ai_applied_skills is not None:
-                    last_applied_skills = list(chunk.lq_ai_applied_skills)
-                if chunk.usage is not None:
-                    if chunk.usage.prompt_tokens:
-                        prompt_tokens = chunk.usage.prompt_tokens
-                    if chunk.usage.completion_tokens:
-                        completion_tokens = chunk.usage.completion_tokens
+        # ── PR5b Task 6: tool-loop branch ─────────────────────────────────────
+        from app.chat.tool_schemas import ChatToolAllowlist
 
-                for choice in chunk.choices:
-                    delta = choice.delta.content or ""
-                    if not delta:
-                        continue
-                    accumulated.append(delta)
-                    frame: dict[str, Any] = {
-                        "type": "delta",
-                        "delta": delta,
+        _allowlist: ChatToolAllowlist | None = allowlist
+        if _allowlist is not None and _allowlist.specs:
+            # Non-empty allowlist → agentic loop (non-streaming internally).
+            loop_outcome = None
+            try:
+                loop_outcome = await run_chat_tool_loop(
+                    db,
+                    user=user,
+                    gateway=gateway,
+                    base_request=request,
+                    allowlist=_allowlist,
+                    assistant_message_id=assistant_message_id,
+                    cluster_cache={},
+                    request_id=request_id,
+                )
+            except LQAIError as exc:
+                error_code = exc.effective_code
+                error_envelope = exc.to_envelope()
+                log.warning(
+                    "chat send_message tool-loop failed (streaming)",
+                    extra={
+                        "event": "chat_send_message_loop_failed_stream",
+                        "user_id": str(user.id),
+                        "chat_id": str(chat.id),
+                        "assistant_message_id": str(assistant_message_id),
+                        "request_id": request_id,
+                        "error_code": error_code,
+                    },
+                )
+
+            if loop_outcome is not None and isinstance(loop_outcome, LoopFinal):
+                # Emit final text as a single delta frame, then persist.
+                last_tier = loop_outcome.tier
+                last_provider = loop_outcome.provider
+                last_model = loop_outcome.model
+                last_applied_skills = list(loop_outcome.applied_skills or [])
+                prompt_tokens = loop_outcome.usage_prompt or None
+                completion_tokens = loop_outcome.usage_completion or None
+                accumulated = [loop_outcome.text]
+                delta_frame: dict[str, Any] = {
+                    "type": "delta",
+                    "delta": loop_outcome.text,
+                    "lq_ai_message_id": str(assistant_message_id),
+                }
+                if last_tier is not None:
+                    delta_frame["routed_inference_tier"] = last_tier
+                if last_applied_skills:
+                    delta_frame["applied_skills"] = list(last_applied_skills)
+                yield f"data: {_json.dumps(delta_frame, separators=(',', ':'))}\n\n".encode()
+                # Fall through to the persistence + complete-frame tail below.
+
+            elif loop_outcome is not None and isinstance(loop_outcome, LoopConfirmation):
+                # Confirmation gate — persist pending rows, emit terminal event.
+                spec = loop_outcome.spec
+                tier_val = loop_outcome.tier if loop_outcome.tier is not None else 0
+                try:
+                    pending_row = ChatPendingToolCall(
+                        chat_id=chat.id,
+                        user_id=user.id,
+                        assistant_message_id=assistant_message_id,
+                        function_name=spec.function_name,
+                        kind=spec.kind,
+                        provider=spec.provider,
+                        tool=spec.tool,
+                        destructive=spec.destructive,
+                        tier=tier_val,
+                        tool_call_args=loop_outcome.args,
+                        resume_state={
+                            "messages": loop_outcome.messages,
+                            "calls_used": loop_outcome.calls_used,
+                        },
+                        status="pending",
+                        expires_at=datetime.now(UTC) + CONFIRM_TTL,
+                    )
+                    db.add(pending_row)
+                    await db.flush()
+
+                    tcl_row = ToolCallLog(
+                        origin="chat",
+                        provider=spec.provider,
+                        tool=spec.tool,
+                        tier=tier_val,
+                        intent=None,
+                        confirmation_state="pending_confirmation",
+                        outcome="pending",
+                        cost_usd=None,
+                        args_digest=_args_digest(loop_outcome.args),
+                        user_id=user.id,
+                        chat_id=chat.id,
+                        message_id=assistant_message_id,
+                    )
+                    db.add(tcl_row)
+                    await db.flush()
+
+                    # Link the pending row to its tool-call-log row.
+                    pending_row.tool_call_log_id = tcl_row.id
+                    await db.commit()
+
+                    gate_frame: dict[str, Any] = {
+                        "type": "tool_confirmation_required",
                         "lq_ai_message_id": str(assistant_message_id),
+                        "pending_call_id": str(pending_row.id),
+                        "provider": spec.provider,
+                        "tool": spec.tool,
+                        "function_name": spec.function_name,
+                        "args_summary": _safe_args_summary(loop_outcome.args),
+                        "tier": tier_val,
+                        "destructive": spec.destructive,
                     }
-                    # Per ADR 0007 / C3 brief: surface the LQ.AI extension
-                    # fields on each chunk so header-blind clients can
-                    # observe routing without a separate request.
-                    if last_tier is not None:
-                        frame["routed_inference_tier"] = last_tier
-                    if last_applied_skills is not None:
-                        frame["applied_skills"] = list(last_applied_skills)
-                    yield f"data: {_json.dumps(frame, separators=(',', ':'))}\n\n".encode()
-        except LQAIError as exc:
-            # Stream ended in failure. We persist a partial assistant
-            # row with whatever content the client already saw, and
-            # ``error_code`` populated. This is the audit-friendly
-            # decision documented inline in the C3 brief.
-            error_code = exc.effective_code
-            error_envelope = exc.to_envelope()
-            log.warning(
-                "chat send_message failed mid-stream",
-                extra={
-                    "event": "chat_send_message_failed_mid_stream",
-                    "user_id": str(user.id),
-                    "chat_id": str(chat.id),
-                    "assistant_message_id": str(assistant_message_id),
-                    "request_id": request_id,
-                    "error_code": error_code,
-                },
-            )
+                    yield (f"data: {_json.dumps(gate_frame, separators=(',', ':'))}\n\n".encode())
+                except Exception as gate_persist_exc:
+                    log.error(
+                        "chat send_message: failed to persist confirmation gate rows",
+                        extra={
+                            "event": "chat_gate_persist_failed",
+                            "user_id": str(user.id),
+                            "chat_id": str(chat.id),
+                            "assistant_message_id": str(assistant_message_id),
+                            "error": repr(gate_persist_exc),
+                        },
+                    )
+                # Do NOT persist a final assistant Message — Task 7 (resume) does.
+                yield b"data: [DONE]\n\n"
+                return
+
+            elif loop_outcome is not None and isinstance(loop_outcome, LoopMcpAuth):
+                # OAuth gate — no persistence, emit terminal event.
+                mcp_frame: dict[str, Any] = {
+                    "type": "mcp_authorization_required",
+                    "lq_ai_message_id": str(assistant_message_id),
+                    "server": loop_outcome.server,
+                    "authorize_url": (f"/api/v1/mcp/oauth/{loop_outcome.server}/authorize"),
+                }
+                yield (f"data: {_json.dumps(mcp_frame, separators=(',', ':'))}\n\n".encode())
+                yield b"data: [DONE]\n\n"
+                return
+
+            # If loop_outcome is None (error path), fall through to the
+            # persistence + error-frame tail with accumulated=[], error_code set.
+
+        else:
+            # ── Existing single-shot path (empty allowlist) ───────────────────
+            try:
+                async for chunk in gateway.chat_completion_stream(request, request_id=request_id):
+                    last_tier = chunk.routed_inference_tier or last_tier
+                    last_provider = chunk.routed_provider or last_provider
+                    last_model = chunk.model
+                    if chunk.lq_ai_applied_skills is not None:
+                        last_applied_skills = list(chunk.lq_ai_applied_skills)
+                    if chunk.usage is not None:
+                        if chunk.usage.prompt_tokens:
+                            prompt_tokens = chunk.usage.prompt_tokens
+                        if chunk.usage.completion_tokens:
+                            completion_tokens = chunk.usage.completion_tokens
+
+                    for choice in chunk.choices:
+                        delta = choice.delta.content or ""
+                        if not delta:
+                            continue
+                        accumulated.append(delta)
+                        frame: dict[str, Any] = {
+                            "type": "delta",
+                            "delta": delta,
+                            "lq_ai_message_id": str(assistant_message_id),
+                        }
+                        # Per ADR 0007 / C3 brief: surface the LQ.AI extension
+                        # fields on each chunk so header-blind clients can
+                        # observe routing without a separate request.
+                        if last_tier is not None:
+                            frame["routed_inference_tier"] = last_tier
+                        if last_applied_skills is not None:
+                            frame["applied_skills"] = list(last_applied_skills)
+                        yield f"data: {_json.dumps(frame, separators=(',', ':'))}\n\n".encode()
+            except LQAIError as exc:
+                # Stream ended in failure. We persist a partial assistant
+                # row with whatever content the client already saw, and
+                # ``error_code`` populated. This is the audit-friendly
+                # decision documented inline in the C3 brief.
+                error_code = exc.effective_code
+                error_envelope = exc.to_envelope()
+                log.warning(
+                    "chat send_message failed mid-stream",
+                    extra={
+                        "event": "chat_send_message_failed_mid_stream",
+                        "user_id": str(user.id),
+                        "chat_id": str(chat.id),
+                        "assistant_message_id": str(assistant_message_id),
+                        "request_id": request_id,
+                        "error_code": error_code,
+                    },
+                )
 
         # Persist the assistant row exactly once. Even if everything
         # failed, we record what we got so operators see the full

--- a/api/app/chat/__init__.py
+++ b/api/app/chat/__init__.py
@@ -1,0 +1,1 @@
+"""Chat package — PR5b tool-loop and schema helpers."""

--- a/api/app/chat/tool_loop.py
+++ b/api/app/chat/tool_loop.py
@@ -280,6 +280,7 @@ async def execute_tool(
     assistant_message_id: UUID,
     chat_id: UUID | None = None,
     request_id: str | None = None,
+    confirmation_state: str = "not_required",
 ) -> ToolResult:
     """Execute a single approved read_only tool call through the governance substrate.
 
@@ -299,6 +300,13 @@ async def execute_tool(
         assistant_message_id: The chat message id for the audit row.
         chat_id: Chat id for the audit row (optional).
         request_id: Correlation header value (optional).
+        confirmation_state: Human-gate lifecycle label written to the
+            ``tool_call_log`` row.  Default ``"not_required"`` preserves
+            all existing callers (the loop's read_only inline path).
+            Pass ``"approved"`` from the resume route's approve path so
+            the EXECUTING audit row is stamped ``approved``/``executed``
+            (separate from the gate row, which is the confirmation-request
+            lifecycle record).
 
     Returns:
         :class:`~app.autonomous.guard.ToolResult` on success.
@@ -332,7 +340,7 @@ async def execute_tool(
         estimated_cost=estimated_cost,
         dispatch=_dispatch,
         span=None,  # OTel for chat tool-path is a follow-on DE
-        confirmation_state="not_required",
+        confirmation_state=confirmation_state,
         user_id=user.id,
         chat_id=chat_id,
         message_id=assistant_message_id,

--- a/api/app/chat/tool_loop.py
+++ b/api/app/chat/tool_loop.py
@@ -1,0 +1,598 @@
+"""Chat tool-loop engine — PR5b Task 5.
+
+Implements the agentic tool-calling loop for chat turns. The loop calls the
+gateway in NON-streaming mode each round; when the model requests tool calls,
+this module dispatches them through the governance substrate
+(:func:`~app.tools.governance.governed_tool_invocation`) and feeds results
+back to the model. The loop terminates on one of three outcomes:
+
+- :class:`LoopFinal` — model produced a final text answer (no more tools).
+- :class:`LoopConfirmation` — model requested a destructive / confirmation-
+  gated tool; the loop surfaces the gate to the caller (Task 6/7) which
+  handles the human-approval flow and resumes by calling back with
+  ``calls_used`` and ``messages`` from the partial outcome. **Only the FIRST
+  such call in a round triggers the gate; remaining proposed calls are
+  abandoned for this turn** (the model re-plans after the human decision).
+- :class:`LoopMcpAuth` — model requested an OAuth MCP tool but no valid token
+  is stored; the caller redirects the user through the authorize flow.
+
+When ``calls_used >= settings.chat_tool_call_cap`` the loop issues ONE final
+gateway round WITHOUT tools (``tool_choice="none"``) so the model can
+synthesise what it has gathered before returning :class:`LoopFinal`.
+
+**OTel note:** span annotation for the chat tool-path is a follow-on DE (DE-XXX);
+pass ``span=None`` throughout.
+
+Security invariants (never weaken):
+- Raw args are NEVER written to audit rows or logs.  Only ``args_digest`` flows
+  into :func:`~app.tools.governance.governed_tool_invocation`.
+- Per-user OAuth token is threaded from :func:`~app.mcp.oauth.get_valid_token`
+  to :meth:`~app.clients.gateway.GatewayClient.call_tool` header-only; it never
+  touches the DB row or any log line.
+- Estimated cost is always ``Decimal("0")`` for both ``retrieve_caselaw`` and
+  ``call_mcp_tool`` (DE-344: per-provider tool cost model deferred).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.cost import estimate_tool_cost
+from app.autonomous.enums import ToolIntent
+from app.autonomous.guard import ToolResult, _args_digest
+from app.chat.tool_schemas import ChatToolAllowlist, ToolSpec
+from app.config import get_settings
+from app.errors import MCPAuthorizationRequired, ToolTierRefused
+from app.mcp.oauth import get_valid_token
+from app.mcp.service import list_servers
+from app.models.user import User
+from app.research import service as research_service
+from app.schemas.gateway import ChatCompletionMessage, ChatCompletionRequest
+from app.tools.governance import governed_tool_invocation, resolve_provider_tier
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Outcome dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LoopFinal:
+    """The model produced a final text answer; no more tool calls needed.
+
+    Carries the full message list so the caller can persist the turn.
+    """
+
+    text: str
+    usage_prompt: int = 0
+    usage_completion: int = 0
+    tier: int | None = None
+    provider: str | None = None
+    model: str | None = None
+    applied_skills: list[str] | None = None
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    calls_used: int = 0
+
+
+@dataclass
+class LoopConfirmation:
+    """A destructive or requires_confirmation tool was requested.
+
+    Task 6/7 persists the partial state and emits the human gate.
+    ``messages`` and ``calls_used`` are included so the caller can resume
+    the loop after the user confirms or cancels.
+
+    **Note:** Only the first such call in a round triggers the gate;
+    remaining proposed calls in the same round are abandoned. The model
+    re-plans after the human decision is relayed back.
+    """
+
+    spec: ToolSpec
+    args: dict[str, Any]
+    tier: int | None
+    args_summary: str  # the args_digest — counts/types only, never raw args
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    calls_used: int = 0
+
+
+@dataclass
+class LoopMcpAuth:
+    """An OAuth MCP server was called but no valid token is stored.
+
+    The caller should redirect the user through the authorize flow at
+    ``/api/v1/mcp/oauth/{server}/authorize``.
+    ``messages`` and ``calls_used`` allow resuming after authorization.
+    """
+
+    server: str
+    authorize_url: str | None = None  # populated by Task 6/7 if needed
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    calls_used: int = 0
+
+
+LoopOutcome = LoopFinal | LoopConfirmation | LoopMcpAuth
+
+
+# ---------------------------------------------------------------------------
+# tool_result_message helper
+# ---------------------------------------------------------------------------
+
+
+def tool_result_message(tool_call_id: str, result: ToolResult) -> dict[str, Any]:
+    """Build the ``role="tool"`` message fed back to the model.
+
+    The ``content`` field serialises the tool's ``data`` payload as JSON
+    so the model can parse structured results.  On ``None`` data, an empty
+    JSON object is returned.
+    """
+    data = result.data if result.data is not None else {}
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": json.dumps(data, default=str),
+    }
+
+
+def _tool_error_message(tool_call_id: str, error: str) -> dict[str, Any]:
+    """Build a ``role="tool"`` error message for a refused / failed call."""
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": json.dumps({"error": error}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Research dispatch
+# ---------------------------------------------------------------------------
+
+
+async def _dispatch_research(
+    db: AsyncSession,
+    spec: ToolSpec,
+    args: dict[str, Any],
+    cluster_cache: dict[Any, Any],
+    request_id: str | None,
+) -> ToolResult:
+    """Dispatch a research (CourtListener) tool call.
+
+    Checks/fills ``cluster_cache`` for ``get_cluster`` and ``read_opinion``
+    to avoid redundant gateway round-trips within a single turn.
+
+    Cost is ``Decimal("0")`` in v1 — DE-344 defers per-provider tool cost.
+    """
+    op = spec.tool
+    data: Any
+    if op == "verify_citations":
+        data = await research_service.verify_citations(args["text"], request_id=request_id)
+    elif op == "search_case_law":
+        data = await research_service.search_case_law(args, request_id=request_id)
+    elif op == "get_cluster":
+        key = ("cluster", int(args["cluster_id"]))
+        cached = cluster_cache.get(key)
+        if cached is None:
+            data = await research_service.get_cluster(
+                db, cluster_id=int(args["cluster_id"]), request_id=request_id
+            )
+            cluster_cache[key] = data
+        else:
+            data = cached
+    elif op == "read_opinion":
+        key = ("opinion", int(args["opinion_id"]))
+        cached = cluster_cache.get(key)
+        if cached is None:
+            data = await research_service.read_opinion(db, opinion_id=int(args["opinion_id"]))
+            cluster_cache[key] = data
+        else:
+            data = cached
+    elif op == "find_in_case":
+        data = await research_service.find_in_case(
+            db,
+            opinion_id=int(args["opinion_id"]),
+            query=args["query"],
+            max_matches=int(args.get("max_matches", 3)),
+        )
+    else:
+        from app.errors import ToolNotGranted
+
+        raise ToolNotGranted(
+            f"_dispatch_research: unknown research op {op!r}",
+            intent=str(ToolIntent.retrieve_caselaw),
+            phase="chat",
+        )
+    return ToolResult(cost_usd=Decimal("0"), data=data, outcome="success")
+
+
+# ---------------------------------------------------------------------------
+# MCP dispatch
+# ---------------------------------------------------------------------------
+
+
+async def _dispatch_mcp(
+    db: AsyncSession,
+    user: User,
+    gateway: Any,
+    spec: ToolSpec,
+    args: dict[str, Any],
+    server_auth_map: dict[str, str],
+    request_id: str | None,
+) -> ToolResult:
+    """Dispatch an MCP tool call through the gateway.
+
+    Resolves the per-user OAuth token when ``auth == "oauth"`` for the server.
+    Returns ``None`` token (raises :class:`MCPAuthorizationRequired`) when no
+    valid token is stored.
+
+    For ``none``/``bearer`` servers, ``user_token=None`` is passed to the
+    gateway call.
+
+    Cost is ``Decimal("0")`` in v1 — DE-344 defers per-provider tool cost.
+    """
+    auth_mode = server_auth_map.get(spec.provider, "none")
+    user_token: str | None = None
+
+    if auth_mode == "oauth":
+        token = await get_valid_token(db, user_id=user.id, server=spec.provider)
+        if token is None:
+            # No stored token — direct the user through the authorize flow.
+            raise MCPAuthorizationRequired(
+                message=(
+                    f"MCP server {spec.provider!r} requires authorization; "
+                    f"connect via /api/v1/mcp/oauth/{spec.provider}/authorize"
+                ),
+                details={"server": spec.provider},
+            )
+        user_token = token
+
+    result = await gateway.call_tool(
+        spec.provider,
+        spec.tool,
+        args,
+        max_allowed_tier=None,
+        user_token=user_token,
+        request_id=request_id,
+    )
+    return ToolResult(cost_usd=Decimal("0"), data=result.get("payload"), outcome="success")
+
+
+# ---------------------------------------------------------------------------
+# execute_tool
+# ---------------------------------------------------------------------------
+
+
+async def execute_tool(
+    db: AsyncSession,
+    *,
+    user: User,
+    gateway: Any,
+    spec: ToolSpec,
+    args: dict[str, Any],
+    cluster_cache: dict[Any, Any],
+    server_auth_map: dict[str, str],
+    assistant_message_id: UUID,
+    chat_id: UUID | None = None,
+    request_id: str | None = None,
+) -> ToolResult:
+    """Execute a single approved read_only tool call through the governance substrate.
+
+    Wraps the appropriate dispatch closure in
+    :func:`~app.tools.governance.governed_tool_invocation` with
+    ``origin="chat"``.
+
+    Args:
+        db: Active async ORM session.
+        user: Authenticated user owning the turn.
+        gateway: Gateway client (used for MCP dispatch).
+        spec: The resolved :class:`~app.chat.tool_schemas.ToolSpec`.
+        args: Parsed arguments from the model's ``tool_calls`` entry.
+        cluster_cache: Request-scoped cache for research cluster/opinion data.
+        server_auth_map: ``{server_name: auth_mode}`` — built once per turn
+            from :func:`~app.mcp.service.list_servers`.
+        assistant_message_id: The chat message id for the audit row.
+        chat_id: Chat id for the audit row (optional).
+        request_id: Correlation header value (optional).
+
+    Returns:
+        :class:`~app.autonomous.guard.ToolResult` on success.
+
+    Raises:
+        :class:`~app.errors.ToolTierRefused`: When the provider's tier exceeds
+            ``max_allowed_tier`` (``None`` in the chat path, so this only fires
+            when the governance config explicitly blocks the call).
+        :class:`~app.errors.MCPAuthorizationRequired`: When the MCP server
+            requires OAuth and no valid token is stored.
+    """
+    intent = ToolIntent.retrieve_caselaw if spec.kind == "research" else ToolIntent.call_mcp_tool
+
+    estimated_cost = await estimate_tool_cost(intent, args, db)
+    provider_tier = await resolve_provider_tier(spec.provider, request_id=request_id)
+
+    async def _dispatch() -> ToolResult:
+        if spec.kind == "research":
+            return await _dispatch_research(db, spec, args, cluster_cache, request_id)
+        else:
+            return await _dispatch_mcp(db, user, gateway, spec, args, server_auth_map, request_id)
+
+    return await governed_tool_invocation(
+        db,
+        origin="chat",
+        provider=spec.provider,
+        tool=spec.tool,
+        intent=intent,
+        provider_tier=provider_tier,
+        max_allowed_tier=None,  # chat path: no per-session tier ceiling in v1
+        estimated_cost=estimated_cost,
+        dispatch=_dispatch,
+        span=None,  # OTel for chat tool-path is a follow-on DE
+        confirmation_state="not_required",
+        user_id=user.id,
+        chat_id=chat_id,
+        message_id=assistant_message_id,
+        args_digest=_args_digest(args),
+        denied_on=(),
+        request_id=request_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_chat_tool_loop
+# ---------------------------------------------------------------------------
+
+
+async def run_chat_tool_loop(
+    db: AsyncSession,
+    *,
+    user: User,
+    gateway: Any,
+    base_request: ChatCompletionRequest,
+    allowlist: ChatToolAllowlist,
+    assistant_message_id: UUID,
+    calls_used: int = 0,
+    cluster_cache: dict[Any, Any] | None = None,
+    request_id: str | None = None,
+) -> LoopOutcome:
+    """Run the agentic chat tool-loop until a terminal outcome is reached.
+
+    Each round:
+    1. Call the gateway (NON-streaming) with the current message list and
+       ``tools=allowlist.function_schemas()`` / ``tool_choice="auto"``.
+    2. If ``finish_reason != "tool_calls"`` or no ``tool_calls`` on the
+       message → return :class:`LoopFinal`.
+    3. For each tool call in the round:
+       a. Resolve ``spec = allowlist.resolve(fn_name)``.
+       b. If ``spec is None`` (model hallucinated) → append a policy-refusal
+          ``role="tool"`` error message for that ``tool_call_id``; continue.
+       c. If ``spec.destructive or spec.requires_confirmation`` → return
+          :class:`LoopConfirmation` for the first such call (remaining calls
+          in the round are abandoned; documented above).
+       d. Otherwise (read_only & not destructive & not requires_confirmation)
+          → call :func:`execute_tool`; on :class:`~app.errors.ToolTierRefused`
+          append an error tool message and continue; on
+          :class:`~app.errors.MCPAuthorizationRequired` → return
+          :class:`LoopMcpAuth`.
+    4. Append the assistant tool_calls message + the collected tool result
+       messages to ``messages``; increment ``calls_used``.
+    5. If ``calls_used >= settings.chat_tool_call_cap`` → fire one final
+       round WITHOUT tools to let the model synthesise.
+
+    Args:
+        db: Active async ORM session.
+        user: Authenticated user owning the turn.
+        gateway: Gateway client (must implement ``chat_completion``).
+        base_request: The base :class:`~app.schemas.gateway.ChatCompletionRequest`
+            used for this turn. Rebuilt each round with the growing ``messages``
+            list. The caller sets ``model``, ``stream=False``, and any LQ.AI
+            extensions; the loop handles ``tools`` and ``tool_choice``.
+        allowlist: The per-turn :class:`~app.chat.tool_schemas.ChatToolAllowlist`
+            assembled by Task 3.
+        assistant_message_id: UUID of the assistant message row (used as
+            ``message_id`` in the governance audit row).
+        calls_used: Number of tool calls already executed this turn (non-zero
+            when resuming after :class:`LoopConfirmation`).
+        cluster_cache: Request-scoped cache for research cluster/opinion data.
+            ``None`` initialises to an empty dict.
+        request_id: Correlation header value forwarded to gateway / services.
+
+    Returns:
+        One of :class:`LoopFinal`, :class:`LoopConfirmation`, or
+        :class:`LoopMcpAuth`.
+    """
+    settings = get_settings()
+
+    if cluster_cache is None:
+        cluster_cache = {}
+
+    # Build the server-auth map once per turn from list_servers.  Only
+    # ``auth == "oauth"`` servers need per-user token resolution; for
+    # ``none``/``bearer`` we pass user_token=None to the gateway.
+    raw_servers = await list_servers(request_id=request_id)
+    server_auth_map: dict[str, str] = {s["name"]: s.get("auth", "none") for s in raw_servers}
+
+    # Working message list — grows as tool results are appended.
+    messages: list[dict[str, Any]] = [
+        m.model_dump(exclude_none=True) for m in base_request.messages
+    ]
+
+    while True:
+        # ── Check cap BEFORE calling gateway ─────────────────────────────────
+        # When the cap is already reached (e.g. resuming from a confirmed
+        # destructive call that pushed us to the limit), fire the final round
+        # immediately without tools.
+        if calls_used >= settings.chat_tool_call_cap:
+            final_resp = await gateway.chat_completion(
+                _build_request(base_request, messages, tools=None, tool_choice="none"),
+                request_id=request_id,
+            )
+            return _build_loop_final(final_resp, messages, calls_used)
+
+        # ── Build this round's request with tools ──────────────────────────
+        round_request = _build_request(
+            base_request,
+            messages,
+            tools=allowlist.function_schemas(),
+            tool_choice="auto",
+        )
+        resp = await gateway.chat_completion(round_request, request_id=request_id)
+
+        choice = resp.choices[0]
+        finish_reason = choice.finish_reason
+        msg = choice.message
+
+        # ── Terminal: no tool calls ──────────────────────────────────────────
+        if finish_reason != "tool_calls" or not msg.tool_calls:
+            return _build_loop_final(resp, messages, calls_used)
+
+        # ── Process tool calls in this round ─────────────────────────────────
+        # The assistant message (with its tool_calls) goes into the working
+        # message list AFTER we collect all result messages for this round.
+        # (We collect results first, then append the assistant message + all
+        #  results at once per the OpenAI multi-turn tool pattern.)
+        tool_result_msgs: list[dict[str, Any]] = []
+
+        for tc in msg.tool_calls:
+            tc_id: str = tc["id"]
+            fn_name: str = tc["function"]["name"]
+            try:
+                tc_args: dict[str, Any] = json.loads(tc["function"]["arguments"])
+            except (json.JSONDecodeError, KeyError):
+                tc_args = {}
+
+            # ── (b.2) Hallucinated tool name — policy refusal ──────────────
+            spec = allowlist.resolve(fn_name)
+            if spec is None:
+                log.warning(
+                    "chat_tool_loop: hallucinated tool %r — appending policy refusal",
+                    fn_name,
+                    extra={"event": "chat_tool_loop_hallucinated_tool", "tool": fn_name},
+                )
+                tool_result_msgs.append(_tool_error_message(tc_id, "tool not permitted"))
+                continue
+
+            # ── (b.3) Destructive / requires_confirmation gate ────────────
+            if spec.destructive or spec.requires_confirmation:
+                # Only the FIRST such call in a round triggers the gate;
+                # remaining proposed calls are abandoned for this turn.
+                tier = await resolve_provider_tier(spec.provider, request_id=request_id)
+                return LoopConfirmation(
+                    spec=spec,
+                    args=tc_args,
+                    tier=tier,
+                    args_summary=_args_digest(tc_args),
+                    # Carry current messages (BEFORE appending assistant msg)
+                    # so Task 6/7 can resume correctly.
+                    messages=messages,
+                    calls_used=calls_used,
+                )
+
+            # ── (b.4) Read-only — execute ─────────────────────────────────
+            try:
+                result = await execute_tool(
+                    db,
+                    user=user,
+                    gateway=gateway,
+                    spec=spec,
+                    args=tc_args,
+                    cluster_cache=cluster_cache,
+                    server_auth_map=server_auth_map,
+                    assistant_message_id=assistant_message_id,
+                    request_id=request_id,
+                )
+                tool_result_msgs.append(tool_result_message(tc_id, result))
+            except MCPAuthorizationRequired:
+                return LoopMcpAuth(
+                    server=spec.provider,
+                    authorize_url=None,
+                    messages=messages,
+                    calls_used=calls_used,
+                )
+            except ToolTierRefused:
+                log.info(
+                    "chat_tool_loop: ToolTierRefused for %r/%r — appending error message",
+                    spec.provider,
+                    spec.tool,
+                    extra={
+                        "event": "chat_tool_loop_tier_refused",
+                        "provider": spec.provider,
+                        "tool": spec.tool,
+                    },
+                )
+                tool_result_msgs.append(_tool_error_message(tc_id, "tool tier refused"))
+
+        # ── Append assistant tool_calls message + all result messages ─────
+        # Convert the assistant message to dict, preserving tool_calls.
+        asst_dict = msg.model_dump(exclude_none=True)
+        messages.append(asst_dict)
+        messages.extend(tool_result_msgs)
+
+        # Increment by the number of tool calls that produced a result
+        # (refusals / tier-refused also count: we attempted the resolution).
+        calls_used += len(msg.tool_calls)
+
+        # ── Cap check AFTER incrementing ─────────────────────────────────
+        if calls_used >= settings.chat_tool_call_cap:
+            final_resp = await gateway.chat_completion(
+                _build_request(base_request, messages, tools=None, tool_choice="none"),
+                request_id=request_id,
+            )
+            return _build_loop_final(final_resp, messages, calls_used)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_request(
+    base: ChatCompletionRequest,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+    tool_choice: str | None,
+) -> ChatCompletionRequest:
+    """Rebuild the request for each gateway round.
+
+    Copies all fields from ``base`` but replaces ``messages``, ``tools``,
+    and ``tool_choice``.  Uses ``model_copy`` (Pydantic v2) so LQ.AI
+    extension fields (skill refs, anonymize, etc.) are preserved.
+    """
+    # Reconstruct the message objects from dicts
+    msg_objects = [
+        ChatCompletionMessage(**m) if not isinstance(m, ChatCompletionMessage) else m
+        for m in messages
+    ]
+    return base.model_copy(
+        update={
+            "messages": msg_objects,
+            "tools": tools,
+            "tool_choice": tool_choice,
+            "stream": False,
+        }
+    )
+
+
+def _build_loop_final(
+    resp: Any,
+    messages: list[dict[str, Any]],
+    calls_used: int,
+) -> LoopFinal:
+    """Build a :class:`LoopFinal` from a gateway response."""
+    choice = resp.choices[0]
+    usage = resp.usage
+    return LoopFinal(
+        text=choice.message.content or "",
+        usage_prompt=usage.prompt_tokens if usage else 0,
+        usage_completion=usage.completion_tokens if usage else 0,
+        tier=resp.routed_inference_tier,
+        provider=resp.routed_provider,
+        model=resp.model,
+        applied_skills=resp.lq_ai_applied_skills,
+        messages=messages,
+        calls_used=calls_used,
+    )

--- a/api/app/chat/tool_loop.py
+++ b/api/app/chat/tool_loop.py
@@ -457,6 +457,14 @@ async def run_chat_tool_loop(
         #  results at once per the OpenAI multi-turn tool pattern.)
         tool_result_msgs: list[dict[str, Any]] = []
 
+        # governed_count: number of calls routed to execute_tool this round
+        # (both successfully executed AND ToolTierRefused counts — those calls
+        # DID reach governance and wrote an audit row).  Hallucinated calls
+        # (spec is None) are NOT counted: they never reached governance, so
+        # they must not consume cap budget.  This ensures the cap bounds real
+        # governed tool work, not model confusion about available tools.
+        governed_count: int = 0
+
         for tc in msg.tool_calls:
             tc_id: str = tc["id"]
             fn_name: str = tc["function"]["name"]
@@ -492,7 +500,8 @@ async def run_chat_tool_loop(
                     calls_used=calls_used,
                 )
 
-            # ── (b.4) Read-only — execute ─────────────────────────────────
+            # ── (b.4) Read-only — execute (counts as governed) ───────────
+            governed_count += 1
             try:
                 result = await execute_tool(
                     db,
@@ -514,6 +523,8 @@ async def run_chat_tool_loop(
                     calls_used=calls_used,
                 )
             except ToolTierRefused:
+                # ToolTierRefused still counts as governed: governed_tool_invocation
+                # was called and wrote an audit row before raising.
                 log.info(
                     "chat_tool_loop: ToolTierRefused for %r/%r — appending error message",
                     spec.provider,
@@ -532,9 +543,22 @@ async def run_chat_tool_loop(
         messages.append(asst_dict)
         messages.extend(tool_result_msgs)
 
-        # Increment by the number of tool calls that produced a result
-        # (refusals / tier-refused also count: we attempted the resolution).
-        calls_used += len(msg.tool_calls)
+        # Increment by governed calls only (executed + tier-refused).
+        # Hallucinated calls (unknown function names) are excluded: they never
+        # reached governance so they must not consume the per-turn cap budget.
+        calls_used += governed_count
+
+        # ── Termination guard: all-hallucination round ────────────────────
+        # If every proposed call this round was hallucinated (governed_count
+        # == 0) the model made no progress toward the cap and would loop
+        # forever.  Break out immediately to the final no-tools round so the
+        # model synthesises from whatever it has gathered so far.
+        if governed_count == 0:
+            final_resp = await gateway.chat_completion(
+                _build_request(base_request, messages, tools=None, tool_choice="none"),
+                request_id=request_id,
+            )
+            return _build_loop_final(final_resp, messages, calls_used)
 
         # ── Cap check AFTER incrementing ─────────────────────────────────
         if calls_used >= settings.chat_tool_call_cap:

--- a/api/app/chat/tool_schemas.py
+++ b/api/app/chat/tool_schemas.py
@@ -1,0 +1,172 @@
+"""Per-turn chat tool allowlist (PR5b).
+
+Assembles the closed set of function schemas the chat model may call this
+turn — fixed CourtListener research ops (when enabled) + operator-enabled
+MCP tools — and resolves a model-emitted function name back to a typed
+:class:`ToolSpec`. The allowlist IS the closed set (ADR 0015, alt A): the
+model picks among allowed tools and cannot reach beyond them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp.service import list_cached_tools, list_servers
+from app.research.service import _resolve_provider as research_resolve_provider, get_capabilities
+
+MCP_NAME_PREFIX = "mcp__"
+_MCP_SEP = "__"
+
+# Fixed CourtListener research function schemas (OpenAI `parameters` shape).
+# All are read_only. `op` is the research-service op name AND the
+# tool_call_log `tool` column value.
+RESEARCH_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "verify_citations": {
+        "description": "Verify legal citations in text against CourtListener; "
+        "returns each citation's match status.",
+        "parameters": {
+            "type": "object",
+            "properties": {"text": {"type": "string", "description": "Text containing citations."}},
+            "required": ["text"],
+        },
+    },
+    "search_case_law": {
+        "description": "Search CourtListener case law. Returns matching clusters.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "q": {"type": "string", "description": "Search query."},
+                "cursor": {"type": "string", "description": "Pagination cursor (optional)."},
+            },
+            "required": ["q"],
+        },
+    },
+    "get_cluster": {
+        "description": "Fetch a CourtListener opinion cluster's metadata and opinions by cluster id.",
+        "parameters": {
+            "type": "object",
+            "properties": {"cluster_id": {"type": "integer"}},
+            "required": ["cluster_id"],
+        },
+    },
+    "read_opinion": {
+        "description": "Read the full plaintext of a fetched opinion by opinion id "
+        "(the cluster must have been fetched via get_cluster first).",
+        "parameters": {
+            "type": "object",
+            "properties": {"opinion_id": {"type": "integer"}},
+            "required": ["opinion_id"],
+        },
+    },
+    "find_in_case": {
+        "description": "Find snippets matching a query within a fetched opinion.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "opinion_id": {"type": "integer"},
+                "query": {"type": "string"},
+                "max_matches": {"type": "integer", "default": 3},
+            },
+            "required": ["opinion_id", "query"],
+        },
+    },
+}
+RESEARCH_OPS: frozenset[str] = frozenset(RESEARCH_TOOL_SCHEMAS)
+
+
+def mcp_function_name(server: str, tool: str) -> str:
+    """Model-visible function name for an MCP tool: ``mcp__{server}__{tool}``."""
+    return f"{MCP_NAME_PREFIX}{server}{_MCP_SEP}{tool}"
+
+
+def parse_mcp_function_name(name: str) -> tuple[str, str] | None:
+    """Inverse of :func:`mcp_function_name`; returns ``(server, tool)`` or None."""
+    if not name.startswith(MCP_NAME_PREFIX):
+        return None
+    rest = name[len(MCP_NAME_PREFIX) :]
+    server, sep, tool = rest.partition(_MCP_SEP)
+    if not sep or not server or not tool:
+        return None
+    return server, tool
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    function_name: str
+    kind: Literal["research", "mcp"]
+    provider: str
+    tool: str
+    read_only: bool
+    destructive: bool
+    requires_confirmation: bool
+    parameters: dict[str, Any]
+    description: str = ""
+
+
+@dataclass
+class ChatToolAllowlist:
+    specs: dict[str, ToolSpec]
+
+    def resolve(self, function_name: str) -> ToolSpec | None:
+        return self.specs.get(function_name)
+
+    def function_schemas(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": s.function_name,
+                    "description": s.description,
+                    "parameters": s.parameters,
+                },
+            }
+            for s in self.specs.values()
+        ]
+
+
+async def assemble_allowlist(
+    db: AsyncSession, *, request_id: str | None = None
+) -> ChatToolAllowlist:
+    """Build the per-turn allowlist. Empty when no research/MCP is configured."""
+    specs: dict[str, ToolSpec] = {}
+
+    caps = await get_capabilities(request_id=request_id)
+    if caps.get("enabled"):
+        provider = await research_resolve_provider(request_id=request_id)
+        for op, schema in RESEARCH_TOOL_SCHEMAS.items():
+            specs[op] = ToolSpec(
+                function_name=op,
+                kind="research",
+                provider=provider,
+                tool=op,
+                read_only=True,
+                destructive=False,
+                requires_confirmation=False,
+                parameters=schema["parameters"],
+                description=schema["description"],
+            )
+
+    for server in await list_servers(request_id=request_id):
+        name = server.get("name")
+        if not name:
+            continue
+        for t in await list_cached_tools(db, provider=name):
+            if not t.get("enabled"):
+                continue
+            fn = mcp_function_name(name, t["name"])
+            specs[fn] = ToolSpec(
+                function_name=fn,
+                kind="mcp",
+                provider=name,
+                tool=t["name"],
+                read_only=bool(t.get("read_only")),
+                destructive=bool(t.get("destructive")),
+                requires_confirmation=bool(t.get("requires_confirmation")),
+                parameters=t.get("parameters") or {"type": "object", "properties": {}},
+                description=t.get("description") or "",
+            )
+
+    return ChatToolAllowlist(specs=specs)

--- a/api/app/clients/gateway.py
+++ b/api/app/clients/gateway.py
@@ -693,14 +693,24 @@ class GatewayClient:
         args: dict[str, Any],
         *,
         max_allowed_tier: int | None = None,
+        user_token: str | None = None,
         request_id: str | None = None,
     ) -> dict[str, Any]:
         """POST /v1/tools/{provider}/{tool} on the gateway (ADR 0014 transport).
 
         Returns the gateway's ``{provider, tool, payload, tier}`` dict. Errors
         translate exactly like ``list_models``: timeout -> GatewayTimeout,
-        transport -> GatewayUnreachable, structured 4xx -> mapped LQAIError."""
+        transport -> GatewayUnreachable, structured 4xx -> mapped LQAIError.
+
+        ``user_token`` (for ``auth: oauth`` MCP servers, PR4c) is sent in the
+        ``X-LQ-AI-User-Token`` header — never a query param or body field (it
+        would land in access logs). Mirrors ``discover_tools``."""
         headers = self._build_headers(request_id=request_id)
+        if user_token is not None:
+            # Per-user OAuth token for `auth: oauth` MCP servers. Header,
+            # never query/body (PR4c discipline — keeps it out of access
+            # logs and never written to tool_egress_log).
+            headers["X-LQ-AI-User-Token"] = user_token
         body: dict[str, Any] = {"args": args}
         if max_allowed_tier is not None:
             body["max_allowed_tier"] = max_allowed_tier

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -369,6 +369,23 @@ class Settings(BaseSettings):
         ),
     )
 
+    # ----- Chat tool-loop (PR5b / L4) -----
+    # Hard cap on tool-call rounds per chat turn. Once calls_used reaches this
+    # limit the loop issues one final gateway round WITHOUT tools (tool_choice
+    # "none") so the model can synthesise what it has gathered, then returns
+    # LoopFinal. Operator-overridable; 8 is the conservative M1 default that
+    # keeps turn latency bounded while allowing multi-hop research workflows.
+    # Referenced in docs/PRD.md §L4 (chat tool-loop).
+    chat_tool_call_cap: int = Field(
+        default=8,
+        ge=1,
+        description=(
+            "Maximum number of tool calls the chat tool-loop will execute in a "
+            "single turn before issuing a final no-tools round (PRD §L4). "
+            "Default: 8. Operator-overridable via LQ_AI_CHAT_TOOL_CALL_CAP."
+        ),
+    )
+
     # ----- Operational -----
     log_level: LogLevel = Field(default="info", description="Log level for the api/ service.")
     lq_ai_dev_mode: bool = Field(

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.autonomous import (
     PrecedentEntry,
 )
 from app.models.chat import Chat, Message
+from app.models.chat_pending_tool_call import ChatPendingToolCall
 from app.models.document import Document, DocumentChunk
 from app.models.enhance_prompt import EnhancePromptInteraction
 from app.models.file import File
@@ -52,6 +53,7 @@ __all__ = [
     "AutonomousSession",
     "AutonomousWatch",
     "Chat",
+    "ChatPendingToolCall",
     "Document",
     "DocumentChunk",
     "EnhancePromptInteraction",

--- a/api/app/models/chat_pending_tool_call.py
+++ b/api/app/models/chat_pending_tool_call.py
@@ -1,0 +1,145 @@
+"""ORM model for the chat tool-loop confirmation gate persist-and-resume state.
+
+One row per pending destructive-tool call that has been proposed by the
+assistant but not yet confirmed (or denied) by the user.  The row id IS
+the ``pending_call_id`` carried in the SSE event and the resume route.
+
+Security / data-separation rationale
+-------------------------------------
+``tool_call_args`` and ``resume_state`` hold the full conversation payload
+needed to resume the tool-loop after the user confirms.  They live here —
+deliberately NOT on ``tool_call_log`` — to preserve ``tool_call_log``'s
+counts/types-only invariant (see PR5a).
+
+``resume_state`` has the same sensitivity class as ``messages.content``
+(the existing plaintext conversation store): it contains the conversation
+history up to the gate, including any tool results already executed in this
+turn.  It MUST NEVER be emitted to logs, tracing spans, or structured audit
+fields.  Treat it exactly like a chat message body.
+
+``status`` is single-use: once set to ``resolved`` the row MUST NOT be used
+to replay a tool call.
+
+Rows expire at ``expires_at`` (TTL, typically 15 minutes); a background job
+or query filter prunes them.  The ``user_id`` and ``chat_id`` FKs cascade so
+that deleting a user or a chat removes their pending-call rows (GDPR erasure /
+chat deletion paths).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ChatPendingToolCall(Base):
+    """Persist-and-resume state for the chat confirmation gate — payloads only.
+
+    See module docstring for the security / data-separation rationale.
+    ``tool_call_args`` and ``resume_state`` are NEVER logged.
+    """
+
+    __tablename__ = "chat_pending_tool_call"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    """The pending_call_id — this PK is returned to the client in the SSE event."""
+
+    chat_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chats.id", ondelete="CASCADE", name="fk_chat_pending_tool_call_chat"),
+        nullable=False,
+    )
+    """FK to chats.id — cascades so deleting a chat removes its pending calls."""
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE", name="fk_chat_pending_tool_call_user"),
+        nullable=False,
+    )
+    """FK to users.id — cascades for GDPR erasure."""
+
+    assistant_message_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=False,
+    )
+    """The in-flight assistant message id allocated up front for this turn."""
+
+    tool_call_log_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "tool_call_log.id",
+            ondelete="SET NULL",
+            name="fk_chat_pending_tool_call_log",
+        ),
+        nullable=True,
+    )
+    """FK to tool_call_log.id — nullable; SET NULL on log-row deletion."""
+
+    function_name: Mapped[str] = mapped_column(Text, nullable=False)
+    """Fully-qualified function name as seen in the tool call (e.g. mcp__files__delete_doc)."""
+
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    """'research' | 'mcp' — which execution pathway owns this tool."""
+
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    """Logical provider name from gateway config."""
+
+    tool: Mapped[str] = mapped_column(Text, nullable=False)
+    """Tool / function name within the provider."""
+
+    destructive: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    """True when the tool is flagged destructive in the governance config."""
+
+    tier: Mapped[int] = mapped_column(Integer, nullable=False)
+    """Provider egress tier (0-5) at call time."""
+
+    tool_call_args: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    """Full args for the pending call — payload class; NEVER logged."""
+
+    resume_state: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    """Conversation-so-far: {"messages": [...], "calls_used": int}.
+    Same sensitivity as messages.content; NEVER emitted to logs or spans."""
+
+    status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default=text("'pending'"),
+    )
+    """'pending' | 'resolved' — single-use gate; once resolved MUST NOT replay."""
+
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    """TTL timestamp; background pruner removes rows past this time."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+    """App-bumped on every state transition (pending → resolved)."""
+
+    def __repr__(self) -> str:
+        return (
+            f"<ChatPendingToolCall id={self.id}"
+            f" chat_id={self.chat_id}"
+            f" function_name={self.function_name!r}"
+            f" status={self.status!r}>"
+        )

--- a/api/app/schemas/chats.py
+++ b/api/app/schemas/chats.py
@@ -614,6 +614,13 @@ def decode_cursor(value: str) -> Cursor:
     return Cursor.decode(value)
 
 
+class ToolCallDecisionRequest(BaseModel):
+    """Request body for POST /api/v1/chats/{chat_id}/tool-calls/{pending_call_id}."""
+
+    model_config = ConfigDict(extra="forbid")
+    decision: Literal["approve", "deny"]
+
+
 __all__ = [
     "ATTACHED_SKILLS_MAX_LEN",
     "AUTO_RENAME_MAX_CHARS",
@@ -635,6 +642,7 @@ __all__ = [
     "MessageListResponse",
     "MessagePostResponse",
     "MessageResponse",
+    "ToolCallDecisionRequest",
     "decode_cursor",
     "derive_chat_title",
     "encode_cursor",

--- a/api/app/schemas/chats.py
+++ b/api/app/schemas/chats.py
@@ -585,6 +585,19 @@ class MessagePostResponse(BaseModel):
     this flag lets the UI surface a "couldn't resolve /foo" hint so
     typos don't silently produce non-skill answers."""
 
+    pending_tool_call: dict[str, Any] | None = None
+    """PR5b Task 6 — populated when the chat tool-loop surfaces a
+    confirmation gate (``LoopConfirmation``).  Carries the
+    ``tool_confirmation_required`` payload (``pending_call_id``,
+    ``provider``, ``tool``, ``function_name``, ``args_summary``,
+    ``tier``, ``destructive``).  ``None`` on all normal (non-gate) turns
+    so the existing wire shape is preserved."""
+
+    mcp_authorization_required: dict[str, Any] | None = None
+    """PR5b Task 6 — populated when the chat tool-loop surfaces an OAuth
+    gate (``LoopMcpAuth``).  Carries ``server`` and ``authorize_url``.
+    ``None`` on all normal turns."""
+
 
 # --- Internal: helpers exposed for tests -------------------------------------
 

--- a/api/app/schemas/gateway.py
+++ b/api/app/schemas/gateway.py
@@ -112,6 +112,11 @@ class ChatCompletionRequest(BaseModel):
     stream: bool = False
     stop: list[str] | str | None = None
     n: int | None = Field(default=None, ge=1, le=1)
+    tools: list[dict[str, Any]] | None = None
+    """PR5b: per-turn closed allowlist of function schemas the backend
+    assembles (research + operator-enabled MCP tools). Forwarded to the
+    gateway, which forwards to the provider."""
+    tool_choice: str | dict[str, Any] | None = None
 
     # --- LQ.AI extensions (per gateway-openapi.yaml) -------------------------
     minimum_inference_tier: int | None = Field(default=None, ge=1, le=5)

--- a/api/tests/chat/conftest.py
+++ b/api/tests/chat/conftest.py
@@ -1,0 +1,16 @@
+"""Fixtures for the chat package tests.
+
+Provides a ``db`` alias for the root ``db_session`` fixture so the
+brief-specified test code can use the shorter name without modification.
+"""
+
+from __future__ import annotations
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest_asyncio.fixture
+async def db(db_session: AsyncSession) -> AsyncSession:
+    """Alias for the root ``db_session`` fixture."""
+    return db_session

--- a/api/tests/chat/test_tool_loop.py
+++ b/api/tests/chat/test_tool_loop.py
@@ -623,3 +623,130 @@ async def test_loop_mcp_oauth_no_token_returns_auth(db: AsyncSession, user: User
     # messages and calls_used present for Task 6/7 resume
     assert outcome.messages is not None
     assert outcome.calls_used == 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario (i): hallucination-only round — cap NOT consumed, terminates via guard
+# ---------------------------------------------------------------------------
+
+
+def _resp_tool_call_multi(calls: list[tuple[str, dict, str]]) -> ChatCompletionResponse:
+    """Build a response that requests multiple tool calls (arbitrary count)."""
+    tool_calls = [
+        {
+            "id": call_id,
+            "type": "function",
+            "function": {"name": fn, "arguments": json.dumps(args)},
+        }
+        for fn, args, call_id in calls
+    ]
+    return ChatCompletionResponse(
+        id=f"chatcmpl-{uuid.uuid4().hex[:8]}",
+        created=1_700_000_000,
+        model="claude-opus-4",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                finish_reason="tool_calls",
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content=None,
+                    tool_calls=tool_calls,
+                ),
+            )
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        routed_inference_tier=2,
+        routed_provider="anthropic",
+    )
+
+
+@pytest.mark.asyncio
+async def test_loop_hallucinated_calls_do_not_increment_cap(db: AsyncSession, user: User) -> None:
+    """Hallucinated tool names (spec is None) do not advance calls_used toward the cap.
+
+    A round where the model proposes only unknown function names must:
+    - NOT increment calls_used (no governed calls were made).
+    - Trigger the zero-governed termination guard, yielding LoopFinal.
+    - NOT write any tool_call_log rows (hallucinated calls never reach governance).
+    """
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    gateway = AsyncMock()
+    # Round 1: model proposes two hallucinated tool names not in the allowlist.
+    # The zero-governed guard fires after this round and issues the final round.
+    # Round 2 (final, no-tools): model returns a text answer.
+    gateway.chat_completion.side_effect = [
+        _resp_tool_call_multi(
+            [
+                ("nonexistent_tool_alpha", {"x": 1}, "h1"),
+                ("nonexistent_tool_beta", {"y": 2}, "h2"),
+            ]
+        ),
+        _resp_final("I could not find the right tools."),
+    ]
+
+    al = _research_allowlist(provider="cl-prod")  # only search_case_law is valid
+
+    with patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=[])):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("do something")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopFinal)
+    # cap was NOT consumed by hallucinated calls
+    assert outcome.calls_used == 0
+    # Exactly two gateway calls: one tool round + one final no-tools round
+    assert gateway.chat_completion.call_count == 2
+    # Confirm the final call had no tools (zero-governed guard fired)
+    final_call_req: ChatCompletionRequest = gateway.chat_completion.call_args_list[1].args[0]
+    assert final_call_req.tools is None or final_call_req.tool_choice == "none"
+
+    # No tool_call_log rows should exist — hallucinated calls never reached governance
+    rows = (
+        (await db.execute(select(ToolCallLog).where(ToolCallLog.origin == "chat"))).scalars().all()
+    )
+    assert len(rows) == 0
+
+
+@pytest.mark.asyncio
+async def test_loop_hallucination_only_round_terminates_finitely(
+    db: AsyncSession, user: User
+) -> None:
+    """A hallucination-only round must terminate via the zero-governed guard, not loop forever.
+
+    The gateway side_effect list is finite.  If the loop were infinite, it would
+    exhaust the list and raise StopIteration — the test passing proves termination.
+    """
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    gateway = AsyncMock()
+    # Only two responses: one hallucinated round + one final answer.
+    # An infinite loop would consume more than two and raise StopIteration.
+    gateway.chat_completion.side_effect = [
+        _resp_tool_call("ghost_tool", {"arg": "val"}, call_id="hx1"),
+        _resp_final("Terminating gracefully."),
+    ]
+
+    al = _research_allowlist(provider="cl-prod")  # ghost_tool not in allowlist
+
+    with patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=[])):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("try ghost tool")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    # Must terminate as LoopFinal (not raise StopIteration, not loop infinitely)
+    assert isinstance(outcome, LoopFinal)
+    assert outcome.calls_used == 0
+    # Exactly two gateway calls consumed — no extras that would signal infinite loop
+    assert gateway.chat_completion.call_count == 2

--- a/api/tests/chat/test_tool_loop.py
+++ b/api/tests/chat/test_tool_loop.py
@@ -1,0 +1,625 @@
+"""Tests for api/app/chat/tool_loop.py — PR5b Task 5.
+
+Eight scenarios per the task brief (TDD: written RED first, then GREEN).
+
+(a) Immediate final answer (no tools) -> LoopFinal
+(b) One read_only research call -> execute -> LoopFinal; tool_call_log row written
+(c) MCP read_only with token threaded (assert call_tool got user_token)
+(d) Cap reached after settings.chat_tool_call_cap -> final-without-tools -> LoopFinal
+(e) Cluster cache hit (second get_cluster does NOT re-call the service)
+(f) ToolTierRefused -> error tool message appended, loop continues to LoopFinal
+(g) Destructive tool -> LoopConfirmation (first call triggers; siblings abandoned)
+(h) MCP oauth no token -> LoopMcpAuth
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.chat.tool_schemas import ChatToolAllowlist, ToolSpec
+from app.errors import ToolTierRefused
+from app.models.tool_call_log import ToolCallLog
+from app.models.user import User
+from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+from app.security import hash_password
+
+# ---------------------------------------------------------------------------
+# Test builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _user_msg(content: str) -> ChatCompletionMessage:
+    return ChatCompletionMessage(role="user", content=content)
+
+
+def _req(messages: list[ChatCompletionMessage]) -> ChatCompletionRequest:
+    return ChatCompletionRequest(model="smart", messages=messages)
+
+
+def _resp_final(text: str) -> ChatCompletionResponse:
+    """Build a response that terminates the loop (no tool_calls)."""
+    return ChatCompletionResponse(
+        id=f"chatcmpl-{uuid.uuid4().hex[:8]}",
+        created=1_700_000_000,
+        model="claude-opus-4",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(role="assistant", content=text),
+            )
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        routed_inference_tier=2,
+        routed_provider="anthropic",
+    )
+
+
+def _resp_tool_call(
+    fn_name: str,
+    args: dict,
+    call_id: str = "c1",
+) -> ChatCompletionResponse:
+    """Build a response that requests a single tool call."""
+    tool_calls = [
+        {
+            "id": call_id,
+            "type": "function",
+            "function": {
+                "name": fn_name,
+                "arguments": json.dumps(args),
+            },
+        }
+    ]
+    return ChatCompletionResponse(
+        id=f"chatcmpl-{uuid.uuid4().hex[:8]}",
+        created=1_700_000_000,
+        model="claude-opus-4",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                finish_reason="tool_calls",
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content=None,
+                    tool_calls=tool_calls,
+                ),
+            )
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        routed_inference_tier=2,
+        routed_provider="anthropic",
+    )
+
+
+def _resp_two_tool_calls(
+    fn1: str,
+    args1: dict,
+    fn2: str,
+    args2: dict,
+) -> ChatCompletionResponse:
+    """Build a response that requests two tool calls in one round."""
+    tool_calls = [
+        {
+            "id": "c1",
+            "type": "function",
+            "function": {"name": fn1, "arguments": json.dumps(args1)},
+        },
+        {
+            "id": "c2",
+            "type": "function",
+            "function": {"name": fn2, "arguments": json.dumps(args2)},
+        },
+    ]
+    return ChatCompletionResponse(
+        id=f"chatcmpl-{uuid.uuid4().hex[:8]}",
+        created=1_700_000_000,
+        model="claude-opus-4",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                finish_reason="tool_calls",
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content=None,
+                    tool_calls=tool_calls,
+                ),
+            )
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        routed_inference_tier=2,
+        routed_provider="anthropic",
+    )
+
+
+def _research_allowlist(provider: str = "cl-prod") -> ChatToolAllowlist:
+    """Allowlist with one read_only research tool (search_case_law)."""
+    spec = ToolSpec(
+        function_name="search_case_law",
+        kind="research",
+        provider=provider,
+        tool="search_case_law",
+        read_only=True,
+        destructive=False,
+        requires_confirmation=False,
+        parameters={
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        },
+        description="Search case law.",
+    )
+    return ChatToolAllowlist(specs={"search_case_law": spec})
+
+
+def _get_cluster_allowlist(provider: str = "cl-prod") -> ChatToolAllowlist:
+    """Allowlist with research tools: search_case_law + get_cluster."""
+    specs = {}
+    for op in ("search_case_law", "get_cluster"):
+        specs[op] = ToolSpec(
+            function_name=op,
+            kind="research",
+            provider=provider,
+            tool=op,
+            read_only=True,
+            destructive=False,
+            requires_confirmation=False,
+            parameters={"type": "object", "properties": {}, "required": []},
+            description=op,
+        )
+    return ChatToolAllowlist(specs=specs)
+
+
+def _mcp_allowlist(
+    server: str = "my-server",
+    tool: str = "get_doc",
+    destructive: bool = False,
+    requires_confirmation: bool = False,
+) -> ChatToolAllowlist:
+    fn = f"mcp__{server}__{tool}"
+    spec = ToolSpec(
+        function_name=fn,
+        kind="mcp",
+        provider=server,
+        tool=tool,
+        read_only=True,
+        destructive=destructive,
+        requires_confirmation=requires_confirmation,
+        parameters={"type": "object", "properties": {}},
+        description="MCP tool.",
+    )
+    return ChatToolAllowlist(specs={fn: spec})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def user(db: AsyncSession) -> User:
+    u = User(
+        email=f"toolloop-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Tool Loop Tester",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(u)
+    await db.flush()
+    return u
+
+
+# ---------------------------------------------------------------------------
+# Scenario (a): immediate final answer — no tool calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_immediate_final(db: AsyncSession, user: User) -> None:
+    """When the model answers without calling any tool, LoopFinal is returned immediately."""
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    gateway = AsyncMock()
+    gateway.chat_completion.return_value = _resp_final("Here is your answer.")
+
+    al = _research_allowlist()
+    with patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=[])):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("What is the law?")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopFinal)
+    assert outcome.text == "Here is your answer."
+    assert outcome.calls_used == 0
+    # The gateway was called exactly once (no round-trip from tool execution)
+    gateway.chat_completion.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Scenario (b): one read_only research call -> execute -> LoopFinal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_executes_readonly_research_then_finalizes(db: AsyncSession, user: User) -> None:
+    """A single research tool call executes, writes an audit row, then the model finalizes."""
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    gateway = AsyncMock()
+    gateway.chat_completion.side_effect = [
+        _resp_tool_call("search_case_law", {"q": "Brown"}, call_id="c1"),
+        _resp_final("Found Brown v. Board."),
+    ]
+    al = _research_allowlist(provider="cl-prod")
+
+    with (
+        patch(
+            "app.chat.tool_loop.research_service.search_case_law",
+            new=AsyncMock(return_value={"results": [{"cluster_id": 1}]}),
+        ),
+        patch(
+            "app.chat.tool_loop.resolve_provider_tier",
+            new=AsyncMock(return_value=1),
+        ),
+        patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=[])),
+    ):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("find Brown")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopFinal)
+    assert "Brown" in outcome.text
+    assert outcome.calls_used == 1
+
+    # A tool_call_log row was written by governed_tool_invocation
+    rows = (
+        (await db.execute(select(ToolCallLog).where(ToolCallLog.origin == "chat"))).scalars().all()
+    )
+    assert len(rows) == 1
+    assert rows[0].outcome == "executed"
+
+
+# ---------------------------------------------------------------------------
+# Scenario (c): MCP read_only with token threaded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_mcp_threads_user_token(db: AsyncSession, user: User) -> None:
+    """For an oauth MCP server with a valid token, call_tool receives user_token."""
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    fn = "mcp__my-server__get_doc"
+    gateway = AsyncMock()
+    gateway.chat_completion.side_effect = [
+        _resp_tool_call(fn, {"id": "123"}, call_id="c1"),
+        _resp_final("Document retrieved."),
+    ]
+    gateway.call_tool.return_value = {"payload": {"content": "doc body"}}
+
+    al = _mcp_allowlist(server="my-server", tool="get_doc")
+
+    # Server has auth=oauth; get_valid_token returns a token
+    server_list = [{"name": "my-server", "type": "mcp", "auth": "oauth"}]
+
+    with (
+        patch(
+            "app.chat.tool_loop.list_servers",
+            new=AsyncMock(return_value=server_list),
+        ),
+        patch(
+            "app.chat.tool_loop.get_valid_token",
+            new=AsyncMock(return_value="tok-abc"),
+        ),
+        patch(
+            "app.chat.tool_loop.resolve_provider_tier",
+            new=AsyncMock(return_value=1),
+        ),
+    ):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("get document 123")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopFinal)
+    # Verify call_tool was called with the user token
+    gateway.call_tool.assert_called_once()
+    call_kwargs = gateway.call_tool.call_args
+    assert call_kwargs.kwargs.get("user_token") == "tok-abc"
+
+
+# ---------------------------------------------------------------------------
+# Scenario (d): cap reached -> final-without-tools -> LoopFinal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_cap_triggers_final_round(db: AsyncSession, user: User) -> None:
+    """After chat_tool_call_cap executions, one final round without tools is issued."""
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    # We'll use cap=2 to keep the test fast
+    # Round 1: tool call (executed, calls_used -> 1)
+    # Round 2: tool call (executed, calls_used -> 2 == cap)
+    # Final round: no tools -> LoopFinal
+    gateway = AsyncMock()
+    gateway.chat_completion.side_effect = [
+        _resp_tool_call("search_case_law", {"q": "first"}, call_id="c1"),
+        _resp_tool_call("search_case_law", {"q": "second"}, call_id="c2"),
+        _resp_final("Summarized after cap."),
+    ]
+    al = _research_allowlist(provider="cl-prod")
+
+    with (
+        patch(
+            "app.chat.tool_loop.research_service.search_case_law",
+            new=AsyncMock(return_value={"results": []}),
+        ),
+        patch(
+            "app.chat.tool_loop.resolve_provider_tier",
+            new=AsyncMock(return_value=1),
+        ),
+        patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=[])),
+        patch("app.chat.tool_loop.get_settings") as mock_settings,
+    ):
+        settings_obj = MagicMock()
+        settings_obj.chat_tool_call_cap = 2
+        mock_settings.return_value = settings_obj
+
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("research two things")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopFinal)
+    assert outcome.text == "Summarized after cap."
+    assert outcome.calls_used == 2
+
+    # Verify the final round was called without tools (third call)
+    assert gateway.chat_completion.call_count == 3
+    final_call_request: ChatCompletionRequest = gateway.chat_completion.call_args_list[2].args[0]
+    # Final round must have tool_choice="none" or no tools
+    assert final_call_request.tools is None or final_call_request.tool_choice == "none"
+
+
+# ---------------------------------------------------------------------------
+# Scenario (e): cluster cache hit — second get_cluster does NOT re-call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_cluster_cache_prevents_double_fetch(db: AsyncSession, user: User) -> None:
+    """The cluster cache prevents duplicate get_cluster calls within one turn."""
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    fn = "get_cluster"
+    gateway = AsyncMock()
+    gateway.chat_completion.side_effect = [
+        # Round 1: call get_cluster for cluster_id 42
+        _resp_tool_call(fn, {"cluster_id": 42}, call_id="c1"),
+        # Round 2: call get_cluster again for same cluster_id
+        _resp_tool_call(fn, {"cluster_id": 42}, call_id="c2"),
+        _resp_final("Cluster data used twice."),
+    ]
+    al = _get_cluster_allowlist(provider="cl-prod")
+
+    mock_get_cluster = AsyncMock(return_value={"id": 42, "case_name": "Test v. Case"})
+
+    with (
+        patch(
+            "app.chat.tool_loop.research_service.get_cluster",
+            new=mock_get_cluster,
+        ),
+        patch(
+            "app.chat.tool_loop.resolve_provider_tier",
+            new=AsyncMock(return_value=1),
+        ),
+        patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=[])),
+    ):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("get cluster 42 twice")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopFinal)
+    # The underlying service should only have been called ONCE (cache hit on 2nd)
+    mock_get_cluster.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Scenario (f): ToolTierRefused -> error tool message, loop continues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_tier_refused_continues(db: AsyncSession, user: User) -> None:
+    """ToolTierRefused appends an error tool message and the loop continues to LoopFinal."""
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    gateway = AsyncMock()
+    gateway.chat_completion.side_effect = [
+        _resp_tool_call("search_case_law", {"q": "risky"}, call_id="c1"),
+        _resp_final("Could not retrieve, here is what I know."),
+    ]
+    al = _research_allowlist(provider="cl-prod")
+
+    # governed_tool_invocation raises ToolTierRefused (written by governance before raise)
+    tier_refused = ToolTierRefused(provider="cl-prod", tool="search_case_law", tier=5, ceiling=2)
+
+    with (
+        patch(
+            "app.chat.tool_loop.governed_tool_invocation",
+            new=AsyncMock(side_effect=tier_refused),
+        ),
+        patch(
+            "app.chat.tool_loop.resolve_provider_tier",
+            new=AsyncMock(return_value=5),
+        ),
+        patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=[])),
+    ):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("search risky")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopFinal)
+    # Two gateway rounds: first with tools, second after tier-refused error message appended
+    assert gateway.chat_completion.call_count == 2
+
+    # The second round's messages should contain a tool error message
+    second_call_req: ChatCompletionRequest = gateway.chat_completion.call_args_list[1].args[0]
+    tool_messages = [m for m in second_call_req.messages if m.role == "tool"]
+    assert len(tool_messages) == 1
+
+
+# ---------------------------------------------------------------------------
+# Scenario (g): destructive tool -> LoopConfirmation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_destructive_tool_returns_confirmation(db: AsyncSession, user: User) -> None:
+    """A destructive tool call returns LoopConfirmation without executing anything."""
+    from app.chat.tool_loop import LoopConfirmation, run_chat_tool_loop
+
+    fn = "mcp__my-server__delete_doc"
+    gateway = AsyncMock()
+    gateway.chat_completion.return_value = _resp_tool_call(fn, {"id": "123"}, call_id="c1")
+
+    al = ChatToolAllowlist(
+        specs={
+            fn: ToolSpec(
+                function_name=fn,
+                kind="mcp",
+                provider="my-server",
+                tool="delete_doc",
+                read_only=False,
+                destructive=True,
+                requires_confirmation=False,
+                parameters={"type": "object", "properties": {"id": {"type": "string"}}},
+                description="Delete a document (destructive).",
+            )
+        }
+    )
+
+    server_list = [{"name": "my-server", "type": "mcp", "auth": "none"}]
+
+    with patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=server_list)):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("delete document 123")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopConfirmation)
+    assert outcome.spec.tool == "delete_doc"
+    assert outcome.args == {"id": "123"}
+    # No execution — call_tool never called
+    gateway.call_tool.assert_not_called()
+    # messages and calls_used present for Task 6/7 resume
+    assert outcome.messages is not None
+    assert outcome.calls_used == 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario (h): MCP oauth no token -> LoopMcpAuth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_mcp_oauth_no_token_returns_auth(db: AsyncSession, user: User) -> None:
+    """When get_valid_token returns None for an oauth server, LoopMcpAuth is returned."""
+    from app.chat.tool_loop import LoopMcpAuth, run_chat_tool_loop
+
+    fn = "mcp__oauth-server__read_file"
+    gateway = AsyncMock()
+    gateway.chat_completion.return_value = _resp_tool_call(
+        fn, {"path": "/docs/a.txt"}, call_id="c1"
+    )
+
+    al = ChatToolAllowlist(
+        specs={
+            fn: ToolSpec(
+                function_name=fn,
+                kind="mcp",
+                provider="oauth-server",
+                tool="read_file",
+                read_only=True,
+                destructive=False,
+                requires_confirmation=False,
+                parameters={"type": "object", "properties": {}},
+                description="Read a file.",
+            )
+        }
+    )
+
+    server_list = [{"name": "oauth-server", "type": "mcp", "auth": "oauth"}]
+
+    with (
+        patch(
+            "app.chat.tool_loop.list_servers",
+            new=AsyncMock(return_value=server_list),
+        ),
+        # get_valid_token returns None -> no token stored -> must authorize
+        patch(
+            "app.chat.tool_loop.get_valid_token",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("read file")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopMcpAuth)
+    assert outcome.server == "oauth-server"
+    # messages and calls_used present for Task 6/7 resume
+    assert outcome.messages is not None
+    assert outcome.calls_used == 0

--- a/api/tests/chat/test_tool_schemas.py
+++ b/api/tests/chat/test_tool_schemas.py
@@ -1,0 +1,102 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.chat.tool_schemas import (
+    RESEARCH_OPS,
+    assemble_allowlist,
+    mcp_function_name,
+    parse_mcp_function_name,
+)
+
+
+@pytest.mark.asyncio
+async def test_research_only_allowlist(db):
+    with (
+        patch(
+            "app.chat.tool_schemas.get_capabilities",
+            new=AsyncMock(
+                return_value={
+                    "enabled": True,
+                    "providers": [{"name": "cl-prod", "type": "courtlistener"}],
+                }
+            ),
+        ),
+        patch(
+            "app.chat.tool_schemas.research_resolve_provider", new=AsyncMock(return_value="cl-prod")
+        ),
+        patch("app.chat.tool_schemas.list_servers", new=AsyncMock(return_value=[])),
+    ):
+        al = await assemble_allowlist(db)
+    assert set(al.specs) >= RESEARCH_OPS
+    spec = al.resolve("search_case_law")
+    assert spec.kind == "research" and spec.provider == "cl-prod" and spec.read_only
+
+
+@pytest.mark.asyncio
+async def test_mcp_only_allowlist(db):
+    tools = [
+        {
+            "name": "get_doc",
+            "description": "",
+            "parameters": {"type": "object"},
+            "read_only": True,
+            "destructive": False,
+            "requires_confirmation": False,
+            "enabled": True,
+        },
+        {
+            "name": "delete_doc",
+            "description": "",
+            "parameters": {"type": "object"},
+            "read_only": False,
+            "destructive": True,
+            "requires_confirmation": True,
+            "enabled": True,
+        },
+        {
+            "name": "disabled_tool",
+            "description": "",
+            "parameters": {},
+            "read_only": True,
+            "destructive": False,
+            "requires_confirmation": False,
+            "enabled": False,
+        },
+    ]
+    with (
+        patch(
+            "app.chat.tool_schemas.get_capabilities",
+            new=AsyncMock(return_value={"enabled": False, "providers": []}),
+        ),
+        patch(
+            "app.chat.tool_schemas.list_servers",
+            new=AsyncMock(return_value=[{"name": "files", "type": "mcp"}]),
+        ),
+        patch("app.chat.tool_schemas.list_cached_tools", new=AsyncMock(return_value=tools)),
+    ):
+        al = await assemble_allowlist(db)
+    assert mcp_function_name("files", "get_doc") in al.specs
+    assert al.resolve(mcp_function_name("files", "delete_doc")).destructive is True
+    # disabled tools are NOT in the allowlist
+    assert mcp_function_name("files", "disabled_tool") not in al.specs
+
+
+@pytest.mark.asyncio
+async def test_empty_allowlist_when_nothing_enabled(db):
+    with (
+        patch(
+            "app.chat.tool_schemas.get_capabilities",
+            new=AsyncMock(return_value={"enabled": False, "providers": []}),
+        ),
+        patch("app.chat.tool_schemas.list_servers", new=AsyncMock(return_value=[])),
+    ):
+        al = await assemble_allowlist(db)
+    assert al.specs == {}
+    assert al.function_schemas() == []
+
+
+def test_mcp_name_roundtrip():
+    n = mcp_function_name("files", "get_doc")
+    assert parse_mcp_function_name(n) == ("files", "get_doc")
+    assert parse_mcp_function_name("verify_citations") is None

--- a/api/tests/integration/test_chat_tool_call_resume.py
+++ b/api/tests/integration/test_chat_tool_call_resume.py
@@ -763,3 +763,235 @@ async def test_approve_executing_audit_row_has_approved_confirmation_state(
         f"Gate row must not have outcome='executed' (it is the confirmation-request record, "
         f"not the execution record); got outcome={gate_row.outcome!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# (j) C1-fix: approve path — gateway receives valid assistant tool_calls turn
+#             before the tool result (NOT an orphaned tool message)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_approve_gateway_receives_assistant_turn_before_tool_result(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Regression: on approve, the conversation sent to run_chat_tool_loop must end with
+    an assistant message carrying a tool_calls entry, immediately followed by a role='tool'
+    message whose tool_call_id matches that assistant entry's id.
+
+    Without the C1 fix the resume path appended an orphaned role='tool' message with no
+    preceding assistant tool_calls turn, causing Anthropic/OpenAI to return 400.
+    This test asserts the conversation structure is valid — it FAILS against pre-fix code
+    (where no assistant turn is reconstructed) and PASSES after the fix.
+    """
+    chat_id, pending_id, _assistant_message_id = await _create_chat_and_pending(
+        db_session, user=db_user, client=client
+    )
+
+    spec = _make_tool_spec()
+    loop_final = LoopFinal(
+        text="Approved and done.",
+        usage_prompt=80,
+        usage_completion=30,
+        tier=2,
+        provider="anthropic-prod",
+        model="claude-sonnet-4-6",
+        applied_skills=[],
+        calls_used=1,
+    )
+    tool_result_val = ToolResult(
+        cost_usd=Decimal("0"),
+        data={"deleted": "abc123"},
+        outcome="success",
+    )
+    non_empty_allowlist = ChatToolAllowlist(specs={spec.function_name: spec})
+
+    # Capture the messages argument passed to run_chat_tool_loop.
+    captured_messages: list[list] = []
+
+    async def _capture_loop(
+        db: object,
+        *,
+        base_request: object,
+        **kwargs: object,
+    ) -> LoopFinal:
+        from app.schemas.gateway import ChatCompletionRequest as _CCR
+
+        assert isinstance(base_request, _CCR)
+        captured_messages.append(list(base_request.messages))
+        return loop_final
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        patch(
+            "app.chat.tool_loop.execute_tool",
+            new=AsyncMock(return_value=tool_result_val),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(side_effect=_capture_loop),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+            headers=_h(db_user),
+            json={"decision": "approve"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured_messages, "run_chat_tool_loop was never called — test setup issue"
+
+    msgs = captured_messages[0]
+    # Find the last assistant message with tool_calls.
+    assistant_tool_msg = None
+    for m in msgs:
+        role = m.role if hasattr(m, "role") else m.get("role")
+        tool_calls = m.tool_calls if hasattr(m, "tool_calls") else m.get("tool_calls")
+        if role == "assistant" and tool_calls:
+            assistant_tool_msg = m
+    assert assistant_tool_msg is not None, (
+        "No assistant message with tool_calls found in conversation sent to loop — "
+        "the reconstructed assistant turn is missing (pre-fix orphan bug)"
+    )
+
+    # The role='tool' message must have a tool_call_id matching the assistant turn's id.
+    tool_calls_list = (
+        assistant_tool_msg.tool_calls
+        if hasattr(assistant_tool_msg, "tool_calls")
+        else assistant_tool_msg["tool_calls"]
+    )
+    assistant_tc_id = tool_calls_list[0]["id"]
+
+    tool_msg = None
+    for m in msgs:
+        role = m.role if hasattr(m, "role") else m.get("role")
+        if role == "tool":
+            tool_call_id_val = (
+                m.tool_call_id if hasattr(m, "tool_call_id") else m.get("tool_call_id")
+            )
+            tool_msg = m
+            assert tool_call_id_val == assistant_tc_id, (
+                f"role='tool' message has tool_call_id={tool_call_id_val!r} but "
+                f"assistant turn has id={assistant_tc_id!r} — orphaned tool message!"
+            )
+            break
+
+    assert tool_msg is not None, (
+        "No role='tool' message found in conversation — tool result was not appended"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (k) C1-fix: deny path — gateway receives valid assistant tool_calls turn
+#             before the denial error message (NOT an orphaned tool message)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_deny_gateway_receives_assistant_turn_before_denial_message(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Regression: on deny, the conversation sent to run_chat_tool_loop must end with
+    an assistant message carrying a tool_calls entry, immediately followed by a role='tool'
+    denial message whose tool_call_id matches that assistant entry's id.
+
+    Without the C1 fix the deny path appended an orphaned role='tool' denial message with
+    no preceding assistant tool_calls turn, causing Anthropic/OpenAI to return 400.
+    This test FAILS against pre-fix code and PASSES after the fix.
+    """
+    chat_id, pending_id, _assistant_message_id = await _create_chat_and_pending(
+        db_session, user=db_user, client=client
+    )
+
+    spec = _make_tool_spec()
+    loop_final = LoopFinal(
+        text="The deletion was denied. No changes were made.",
+        usage_prompt=60,
+        usage_completion=25,
+        tier=2,
+        provider="anthropic-prod",
+        model="claude-sonnet-4-6",
+        applied_skills=[],
+        calls_used=0,
+    )
+    non_empty_allowlist = ChatToolAllowlist(specs={spec.function_name: spec})
+
+    captured_messages: list[list] = []
+
+    async def _capture_loop(
+        db: object,
+        *,
+        base_request: object,
+        **kwargs: object,
+    ) -> LoopFinal:
+        from app.schemas.gateway import ChatCompletionRequest as _CCR
+
+        assert isinstance(base_request, _CCR)
+        captured_messages.append(list(base_request.messages))
+        return loop_final
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(side_effect=_capture_loop),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+            headers=_h(db_user),
+            json={"decision": "deny"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured_messages, "run_chat_tool_loop was never called — test setup issue"
+
+    msgs = captured_messages[0]
+    # Find any assistant message with tool_calls.
+    assistant_tool_msg = None
+    for m in msgs:
+        role = m.role if hasattr(m, "role") else m.get("role")
+        tool_calls = m.tool_calls if hasattr(m, "tool_calls") else m.get("tool_calls")
+        if role == "assistant" and tool_calls:
+            assistant_tool_msg = m
+    assert assistant_tool_msg is not None, (
+        "No assistant message with tool_calls found in conversation sent to loop on deny — "
+        "the reconstructed assistant turn is missing (pre-fix orphan bug)"
+    )
+
+    tool_calls_list = (
+        assistant_tool_msg.tool_calls
+        if hasattr(assistant_tool_msg, "tool_calls")
+        else assistant_tool_msg["tool_calls"]
+    )
+    assistant_tc_id = tool_calls_list[0]["id"]
+
+    tool_msg = None
+    for m in msgs:
+        role = m.role if hasattr(m, "role") else m.get("role")
+        if role == "tool":
+            tool_call_id_val = (
+                m.tool_call_id if hasattr(m, "tool_call_id") else m.get("tool_call_id")
+            )
+            tool_msg = m
+            assert tool_call_id_val == assistant_tc_id, (
+                f"role='tool' denial message has tool_call_id={tool_call_id_val!r} but "
+                f"assistant turn has id={assistant_tc_id!r} — orphaned tool message on deny!"
+            )
+            break
+
+    assert tool_msg is not None, (
+        "No role='tool' denial message found in conversation — denial message was not appended"
+    )

--- a/api/tests/integration/test_chat_tool_call_resume.py
+++ b/api/tests/integration/test_chat_tool_call_resume.py
@@ -289,9 +289,7 @@ async def test_approve_executes_tool_and_streams_loop_final(
 
     # Assert pending row is resolved.
     await db_session.refresh(
-
-            await db_session.get(ChatPendingToolCall, pending_id)  # type: ignore[arg-type]
-
+        await db_session.get(ChatPendingToolCall, pending_id)  # type: ignore[arg-type]
     )
     pending_row = await db_session.get(ChatPendingToolCall, pending_id)
     assert pending_row is not None
@@ -521,3 +519,247 @@ async def test_unknown_pending_call_id_returns_404(
     body = resp.json()
     assert "detail" in body
     assert body["detail"]["code"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# (g) C1: already-resolved row returns 409 WITHOUT executing the tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_already_resolved_does_not_execute_tool(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """A replay POST on an already-resolved row must return 409 and never call execute_tool.
+
+    This verifies the atomic claim gate: once a row is resolved, a second
+    POST claiming the same row should lose the conditional UPDATE and return
+    409 without executing the destructive tool.
+    """
+    chat_id, pending_id, _ = await _create_chat_and_pending(
+        db_session,
+        user=db_user,
+        client=client,
+        status="resolved",
+    )
+
+    execute_tool_mock = AsyncMock()
+
+    # The handler imports execute_tool via `from app.chat.tool_loop import execute_tool`
+    # inside _generate(); patch at the source module so the local reference is replaced.
+    with patch("app.chat.tool_loop.execute_tool", new=execute_tool_mock):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+            headers=_h(db_user),
+            json={"decision": "approve"},
+        )
+
+    assert resp.status_code == 409, resp.text
+    # execute_tool must NEVER be called when the claim fails (the atomic gate rejected it)
+    execute_tool_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# (h) C1: claim is committed before execute_tool is called — verified via DB read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_claim_committed_before_execute_tool(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """On approve, the pending row must be status='resolved' in the DB
+    (committed, not just flushed) before execute_tool begins execution.
+
+    Strategy: intercept execute_tool at app.api.chats (the bound name from the
+    handler-level 'from app.chat.tool_loop import execute_tool') and have it
+    inspect the row's status through the SAME db session that the handler uses.
+    The handler committed before calling execute_tool, so the session should
+    see status='resolved' on a fresh get().
+    """
+    chat_id, pending_id, _assistant_message_id = await _create_chat_and_pending(
+        db_session, user=db_user, client=client
+    )
+
+    status_at_execute: list[str] = []
+
+    # We capture the db argument passed to execute_tool (the handler's session).
+    # After db.commit() the session's identity map is updated, so db.get() returns
+    # the committed state.
+    async def _capture_and_succeed(db: AsyncSession, *args: object, **kwargs: object) -> ToolResult:
+        row = await db.get(ChatPendingToolCall, pending_id)
+        if row is not None:
+            status_at_execute.append(row.status)
+        return ToolResult(cost_usd=Decimal("0"), data={"ok": True}, outcome="success")
+
+    spec = _make_tool_spec()
+    loop_final = LoopFinal(
+        text="Done.",
+        usage_prompt=10,
+        usage_completion=5,
+        tier=2,
+        provider="anthropic-prod",
+        model="claude-sonnet-4-6",
+        applied_skills=[],
+        calls_used=1,
+    )
+    non_empty_allowlist = ChatToolAllowlist(specs={spec.function_name: spec})
+
+    # Patch the name as imported by the handler module (function-level import
+    # 'from app.chat.tool_loop import execute_tool' runs at call time, so patching
+    # the source attribute covers it).
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        patch(
+            "app.chat.tool_loop.execute_tool",
+            new=AsyncMock(side_effect=_capture_and_succeed),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(return_value=loop_final),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+            headers=_h(db_user),
+            json={"decision": "approve"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    # The status observed inside execute_tool must already be 'resolved' (committed)
+    assert status_at_execute, "execute_tool was not called — test setup issue"
+    assert status_at_execute[0] == "resolved", (
+        f"Claim was not committed before execute_tool: status was {status_at_execute[0]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (i) I1: approve path writes EXECUTING tool_call_log row with confirmation_state=approved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_approve_executing_audit_row_has_approved_confirmation_state(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """On approve, the EXECUTING tool_call_log row written by governed_tool_invocation
+    must have confirmation_state='approved' and outcome='executed'.
+
+    Two-row audit model:
+    - Gate row (pending.tool_call_log_id): the confirmation-request lifecycle
+      record (pending_confirmation → approved).  confirmation_state='approved',
+      but outcome is NOT 'executed' (it is the gate record, not the execution).
+    - Execution row: written by execute_tool → governed_tool_invocation with
+      confirmation_state='approved' and outcome='executed'.
+    """
+    chat_id, pending_id, _assistant_msg_id = await _create_chat_and_pending(
+        db_session, user=db_user, client=client
+    )
+
+    # Reload the pending row to get its gate tool_call_log_id.
+    pending_row = await db_session.get(ChatPendingToolCall, pending_id)
+    assert pending_row is not None
+    gate_tcl_id = pending_row.tool_call_log_id
+    assert gate_tcl_id is not None
+
+    spec = _make_tool_spec()
+    loop_final = LoopFinal(
+        text="Executed successfully.",
+        usage_prompt=10,
+        usage_completion=5,
+        tier=2,
+        provider="anthropic-prod",
+        model="claude-sonnet-4-6",
+        applied_skills=[],
+        calls_used=1,
+    )
+    non_empty_allowlist = ChatToolAllowlist(specs={spec.function_name: spec})
+
+    # Use the real execute_tool path (but mock governed_tool_invocation to avoid
+    # actual tool dispatch) so the confirmation_state param flows through correctly.
+    from app.autonomous.guard import ToolResult as _ToolResult
+
+    execute_result = _ToolResult(cost_usd=Decimal("0"), data={"ok": True}, outcome="success")
+
+    captured_kwargs: list[dict] = []
+
+    async def _fake_gov(db: object, *args: object, **kwargs: object) -> _ToolResult:
+        captured_kwargs.append(dict(kwargs))
+        return execute_result
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(return_value=loop_final),
+        ),
+        # Patch governed_tool_invocation at the name bound in tool_loop (the
+        # from-import: 'from app.tools.governance import governed_tool_invocation').
+        patch(
+            "app.chat.tool_loop.governed_tool_invocation",
+            new=AsyncMock(side_effect=_fake_gov),
+        ),
+        # Also patch resolve_provider_tier to avoid gateway calls.
+        patch(
+            "app.chat.tool_loop.resolve_provider_tier",
+            new=AsyncMock(return_value=2),
+        ),
+        # patch estimate_tool_cost to avoid DB/gateway calls.
+        patch(
+            "app.chat.tool_loop.estimate_tool_cost",
+            new=AsyncMock(return_value=Decimal("0")),
+        ),
+        # patch list_servers to avoid gateway calls.
+        patch(
+            "app.mcp.service.list_servers",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+            headers=_h(db_user),
+            json={"decision": "approve"},
+        )
+
+    assert resp.status_code == 200, resp.text
+
+    # governed_tool_invocation must have been called with confirmation_state="approved"
+    assert captured_kwargs, "governed_tool_invocation was never called"
+    got_state = captured_kwargs[0].get("confirmation_state", "MISSING")
+    assert got_state == "approved", (
+        f"Expected confirmation_state='approved' passed to governed_tool_invocation, "
+        f"got {got_state!r}"
+    )
+
+    # The gate row must have confirmation_state="approved" but NOT outcome="executed".
+    # (The gate row is the confirmation-request lifecycle record; only the execution
+    # row — written by governed_tool_invocation — carries outcome="executed".)
+    gate_row = await db_session.get(ToolCallLog, gate_tcl_id)
+    assert gate_row is not None
+    db_session.expire(gate_row)
+    gate_row = await db_session.get(ToolCallLog, gate_tcl_id)
+    assert gate_row is not None
+    assert gate_row.confirmation_state == "approved", (
+        f"Gate row confirmation_state expected 'approved', got {gate_row.confirmation_state!r}"
+    )
+    # Gate row outcome must NOT be "executed" — it is the confirmation-request record,
+    # not the execution record.
+    assert gate_row.outcome != "executed", (
+        f"Gate row must not have outcome='executed' (it is the confirmation-request record, "
+        f"not the execution record); got outcome={gate_row.outcome!r}"
+    )

--- a/api/tests/integration/test_chat_tool_call_resume.py
+++ b/api/tests/integration/test_chat_tool_call_resume.py
@@ -1,0 +1,523 @@
+"""PR5b Task 7 — integration: resume route POST /chats/{chat_id}/tool-calls/{pending_call_id}.
+
+Covers six contract cases:
+(a) approve → executes pending tool, resumes loop, streams LoopFinal, assistant
+    Message persisted, pending status=resolved
+(b) deny → resumes loop with denial message, streams LoopFinal, pending
+    status=resolved, tool_call_log confirmation_state=denied
+(c) expired pending → 409
+(d) already-resolved (replay) → 409
+(e) non-owner → 404
+(f) unknown pending_call_id → 404
+
+Strategy: mock execute_tool and run_chat_tool_loop in app.api.chats to isolate
+from internals; use real DB for row-state assertions.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json as _json
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.guard import ToolResult
+from app.chat.tool_loop import LoopFinal
+from app.chat.tool_schemas import ChatToolAllowlist, ToolSpec
+from app.clients.gateway import GatewayClient, set_gateway_client
+from app.db.session import get_db
+from app.main import app
+from app.models.chat import Message
+from app.models.chat_pending_tool_call import ChatPendingToolCall
+from app.models.tool_call_log import ToolCallLog
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+GATEWAY_BASE = "http://test-gateway"
+GATEWAY_KEY = "test-gw-key"
+
+_DUMMY_UUID = uuid.UUID("00000000-0000-4000-8000-000000000000")
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    """In-process AsyncClient with gateway stub."""
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+
+    gw = GatewayClient(base_url=GATEWAY_BASE, gateway_key=GATEWAY_KEY)
+    set_gateway_client(gw)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    set_gateway_client(None)
+    await gw.aclose()
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def db_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"tool-resume-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Tool Resume Test User",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def other_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"other-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Other User",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+def _h(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _parse_sse_frames(body: bytes) -> list[dict]:
+    """Parse SSE body into a list of data dicts (excludes [DONE])."""
+    frames = []
+    for line in body.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :]
+        if payload == "[DONE]":
+            continue
+        with contextlib.suppress(_json.JSONDecodeError):
+            frames.append(_json.loads(payload))
+    return frames
+
+
+def _make_tool_spec(
+    *,
+    function_name: str = "mcp__files__delete_doc",
+    kind: str = "mcp",
+    provider: str = "files",
+    tool: str = "delete_doc",
+    destructive: bool = True,
+    requires_confirmation: bool = True,
+) -> ToolSpec:
+    return ToolSpec(
+        function_name=function_name,
+        kind=kind,
+        provider=provider,
+        tool=tool,
+        read_only=False,
+        destructive=destructive,
+        requires_confirmation=requires_confirmation,
+        parameters={},
+        description="delete a document",
+    )
+
+
+async def _create_chat_and_pending(
+    db_session: AsyncSession,
+    *,
+    user: User,
+    client: AsyncClient,
+    status: str = "pending",
+    expires_delta: timedelta = timedelta(minutes=15),
+) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    """Create a chat and a ChatPendingToolCall row. Returns (chat_id, pending_id, assistant_msg_id)."""
+    headers = _h(user)
+    chat_resp = await client.post("/api/v1/chats", headers=headers, json={"title": "resume-test"})
+    assert chat_resp.status_code == 201, chat_resp.text
+    chat_id = uuid.UUID(chat_resp.json()["id"])
+
+    assistant_message_id = uuid.uuid4()
+    spec = _make_tool_spec()
+
+    # Create a linked ToolCallLog row first.
+    tcl_row = ToolCallLog(
+        origin="chat",
+        provider=spec.provider,
+        tool=spec.tool,
+        tier=2,
+        intent=None,
+        confirmation_state="pending_confirmation",
+        outcome="pending",
+        cost_usd=None,
+        args_digest="deadbeef" * 8,
+        user_id=user.id,
+        chat_id=chat_id,
+        message_id=assistant_message_id,
+    )
+    db_session.add(tcl_row)
+    await db_session.flush()
+
+    pending_row = ChatPendingToolCall(
+        chat_id=chat_id,
+        user_id=user.id,
+        assistant_message_id=assistant_message_id,
+        function_name=spec.function_name,
+        kind=spec.kind,
+        provider=spec.provider,
+        tool=spec.tool,
+        destructive=spec.destructive,
+        tier=2,
+        tool_call_args={"doc_id": "abc123"},
+        resume_state={
+            "messages": [{"role": "user", "content": "delete the file"}],
+            "calls_used": 0,
+            "model": "smart",
+        },
+        status=status,
+        expires_at=datetime.now(UTC) + expires_delta,
+        tool_call_log_id=tcl_row.id,
+    )
+    db_session.add(pending_row)
+    await db_session.flush()
+    await db_session.commit()
+
+    return chat_id, pending_row.id, assistant_message_id
+
+
+# ---------------------------------------------------------------------------
+# (a) Approve path — execute_tool succeeds, LoopFinal, assistant row persisted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_approve_executes_tool_and_streams_loop_final(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Approve → execute tool, resume loop → LoopFinal; start/delta/complete/[DONE] in stream;
+    assistant Message row persisted; pending_row status=resolved.
+    """
+    chat_id, pending_id, assistant_message_id = await _create_chat_and_pending(
+        db_session, user=db_user, client=client
+    )
+
+    spec = _make_tool_spec()
+    final_text = "Done! The document was deleted."
+    loop_final = LoopFinal(
+        text=final_text,
+        usage_prompt=80,
+        usage_completion=30,
+        tier=2,
+        provider="anthropic-prod",
+        model="claude-sonnet-4-6",
+        applied_skills=[],
+        calls_used=1,
+    )
+    tool_result = ToolResult(
+        cost_usd=Decimal("0"),
+        data={"deleted": "abc123"},
+        outcome="success",
+    )
+
+    non_empty_allowlist = ChatToolAllowlist(specs={spec.function_name: spec})
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        # execute_tool is imported locally inside _generate(); patch the source module.
+        patch(
+            "app.chat.tool_loop.execute_tool",
+            new=AsyncMock(return_value=tool_result),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(return_value=loop_final),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+            headers=_h(db_user),
+            json={"decision": "approve"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert "text/event-stream" in resp.headers.get("content-type", "")
+
+    body = resp.content
+    assert b"[DONE]" in body, "No [DONE] sentinel in stream"
+
+    frames = _parse_sse_frames(body)
+    types = [f.get("type") for f in frames]
+    assert "start" in types, f"No start frame: {types}"
+    assert "delta" in types, f"No delta frame: {types}"
+    assert "complete" in types, f"No complete frame: {types}"
+
+    delta_frames = [f for f in frames if f.get("type") == "delta"]
+    assert any(final_text in f.get("delta", "") for f in delta_frames), (
+        f"Final text not in delta frames: {delta_frames}"
+    )
+
+    # Assert pending row is resolved.
+    await db_session.refresh(
+
+            await db_session.get(ChatPendingToolCall, pending_id)  # type: ignore[arg-type]
+
+    )
+    pending_row = await db_session.get(ChatPendingToolCall, pending_id)
+    assert pending_row is not None
+    assert pending_row.status == "resolved", f"Expected resolved, got {pending_row.status!r}"
+
+    # Assert assistant Message row was persisted.
+    from sqlalchemy import select
+
+    stmt = select(Message).where(
+        Message.chat_id == chat_id,
+        Message.role == "assistant",
+        Message.id == assistant_message_id,
+    )
+    rows = (await db_session.execute(stmt)).scalars().all()
+    assert rows, "No assistant Message row persisted after approve + LoopFinal"
+    assert rows[0].content == final_text
+
+
+# ---------------------------------------------------------------------------
+# (b) Deny path — denial message fed to loop, LoopFinal, pending=resolved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_deny_feeds_denial_message_and_streams_loop_final(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Deny → denial tool message fed to loop → LoopFinal; stream normal;
+    pending_row status=resolved; ToolCallLog confirmation_state=denied.
+    """
+    chat_id, pending_id, assistant_message_id = await _create_chat_and_pending(
+        db_session, user=db_user, client=client
+    )
+
+    # Reload the pending row to get its tool_call_log_id.
+    pending_row = await db_session.get(ChatPendingToolCall, pending_id)
+    assert pending_row is not None
+    tcl_id = pending_row.tool_call_log_id
+
+    spec = _make_tool_spec()
+    final_text = "The deletion was denied. No changes were made."
+    loop_final = LoopFinal(
+        text=final_text,
+        usage_prompt=60,
+        usage_completion=25,
+        tier=2,
+        provider="anthropic-prod",
+        model="claude-sonnet-4-6",
+        applied_skills=[],
+        calls_used=0,
+    )
+
+    non_empty_allowlist = ChatToolAllowlist(specs={spec.function_name: spec})
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(return_value=loop_final),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+            headers=_h(db_user),
+            json={"decision": "deny"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.content
+    assert b"[DONE]" in body
+
+    frames = _parse_sse_frames(body)
+    types = [f.get("type") for f in frames]
+    assert "start" in types
+    assert "delta" in types
+    assert "complete" in types
+
+    # Assert pending row resolved.
+    await db_session.refresh(pending_row)
+    assert pending_row.status == "resolved"
+
+    # Assert ToolCallLog confirmation_state=denied.
+    if tcl_id is not None:
+        tcl_row = await db_session.get(ToolCallLog, tcl_id)
+        assert tcl_row is not None
+        assert tcl_row.confirmation_state == "denied", (
+            f"Expected denied, got {tcl_row.confirmation_state!r}"
+        )
+        assert tcl_row.outcome == "denied"
+
+    # Assert assistant Message row persisted.
+    from sqlalchemy import select
+
+    stmt = select(Message).where(
+        Message.chat_id == chat_id,
+        Message.role == "assistant",
+        Message.id == assistant_message_id,
+    )
+    rows = (await db_session.execute(stmt)).scalars().all()
+    assert rows, "No assistant Message row persisted after deny + LoopFinal"
+
+
+# ---------------------------------------------------------------------------
+# (c) Expired pending → 409
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_expired_pending_returns_409(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """An expired pending tool-call row returns 409 Conflict."""
+    chat_id, pending_id, _ = await _create_chat_and_pending(
+        db_session,
+        user=db_user,
+        client=client,
+        expires_delta=timedelta(seconds=-1),  # already expired
+    )
+
+    resp = await client.post(
+        f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+        headers=_h(db_user),
+        json={"decision": "approve"},
+    )
+
+    assert resp.status_code == 409, resp.text
+    body = resp.json()
+    assert "detail" in body
+    assert body["detail"]["code"] == "conflict"
+
+
+# ---------------------------------------------------------------------------
+# (d) Already-resolved (replay) → 409
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_already_resolved_returns_409(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """A pending row with status='resolved' returns 409 on replay."""
+    chat_id, pending_id, _ = await _create_chat_and_pending(
+        db_session,
+        user=db_user,
+        client=client,
+        status="resolved",
+    )
+
+    resp = await client.post(
+        f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+        headers=_h(db_user),
+        json={"decision": "approve"},
+    )
+
+    assert resp.status_code == 409, resp.text
+    body = resp.json()
+    assert "detail" in body
+    assert body["detail"]["code"] == "conflict"
+
+
+# ---------------------------------------------------------------------------
+# (e) Non-owner → 404 (id-probing-safe)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_non_owner_gets_404(
+    client: AsyncClient,
+    db_user: User,
+    other_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """A different user cannot see the pending row — 404 (id-probing-safe)."""
+    chat_id, pending_id, _ = await _create_chat_and_pending(db_session, user=db_user, client=client)
+
+    # other_user tries to resume the pending call owned by db_user.
+    resp = await client.post(
+        f"/api/v1/chats/{chat_id}/tool-calls/{pending_id}",
+        headers=_h(other_user),
+        json={"decision": "approve"},
+    )
+
+    # The chat itself is owner-scoped — other_user gets 404 on the chat load.
+    assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# (f) Unknown pending_call_id → 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_unknown_pending_call_id_returns_404(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """A completely unknown pending_call_id (UUID that exists nowhere) → 404."""
+    headers = _h(db_user)
+    chat_resp = await client.post("/api/v1/chats", headers=headers, json={"title": "unknown-test"})
+    assert chat_resp.status_code == 201, chat_resp.text
+    chat_id = chat_resp.json()["id"]
+
+    unknown_id = str(uuid.uuid4())
+
+    resp = await client.post(
+        f"/api/v1/chats/{chat_id}/tool-calls/{unknown_id}",
+        headers=headers,
+        json={"decision": "approve"},
+    )
+
+    assert resp.status_code == 404, resp.text
+    body = resp.json()
+    assert "detail" in body
+    assert body["detail"]["code"] == "not_found"

--- a/api/tests/integration/test_chat_tool_loop_send.py
+++ b/api/tests/integration/test_chat_tool_loop_send.py
@@ -508,3 +508,107 @@ async def test_loop_mcp_auth_emits_gate_event_no_pending_row(
     stmt = select(ChatPendingToolCall).where(ChatPendingToolCall.chat_id == uuid.UUID(chat_id))
     rows = (await db_session.execute(stmt)).scalars().all()
     assert not rows, f"ChatPendingToolCall rows found after LoopMcpAuth — should not be: {rows}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: gate-persist failure emits an error frame, not a silent [DONE]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_gate_persist_failure_emits_error_frame(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Streaming LoopConfirmation with a simulated db.commit failure.
+
+    When the ChatPendingToolCall + ToolCallLog persist step raises, the
+    stream must:
+    - NOT emit a tool_confirmation_required frame (no partial state)
+    - Emit an error SSE frame ({"detail": {...}}) before [DONE]
+    - End with [DONE]
+    - NOT persist a ChatPendingToolCall row (the commit failed)
+    - NOT persist an assistant Message row
+    """
+    headers = _h(db_user)
+    chat_resp = await client.post(
+        "/api/v1/chats", headers=headers, json={"title": "gate-persist-fail"}
+    )
+    assert chat_resp.status_code == 201, chat_resp.text
+    chat_id = chat_resp.json()["id"]
+
+    spec = _make_tool_spec()
+    loop_outcome = LoopConfirmation(
+        spec=spec,
+        args={"doc_id": "xyz", "reason": "test persist fail"},
+        tier=2,
+        args_summary="digest-x",
+        messages=[{"role": "user", "content": "delete it"}],
+        calls_used=0,
+    )
+
+    non_empty_allowlist = _make_non_empty_allowlist()
+
+    # Monkeypatch db.commit so that early commits (user message persist) succeed
+    # but the gate-branch commit (2nd call inside the /messages endpoint) fails.
+    # The send_message endpoint commits at least once before reaching the gate branch
+    # (user message + auto-rename), so we let the first commit through and raise on
+    # the second to simulate a gate-persistence failure.
+    _original_commit = db_session.commit
+    _commit_call_count = 0
+
+    async def _fail_on_second_commit() -> None:
+        nonlocal _commit_call_count
+        _commit_call_count += 1
+        if _commit_call_count >= 2:
+            raise RuntimeError("simulated db commit failure")
+        await _original_commit()
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(return_value=loop_outcome),
+        ),
+        patch.object(db_session, "commit", side_effect=_fail_on_second_commit),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/messages",
+            headers=headers,
+            json={"content": "delete doc xyz", "stream": True},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body_text = resp.content.decode("utf-8")
+
+    # [DONE] must be present — stream must terminate cleanly.
+    assert "[DONE]" in body_text, f"No [DONE] in stream: {body_text!r}"
+
+    frames = _parse_sse_frames(resp.content)
+    types = [f.get("type") for f in frames]
+
+    # No tool_confirmation_required — persist failed before it was emitted.
+    assert "tool_confirmation_required" not in types, (
+        f"tool_confirmation_required emitted despite persist failure: {types}"
+    )
+
+    # An error frame must be present ({"detail": {...}}).
+    error_frames = [f for f in frames if "detail" in f]
+    assert error_frames, f"No error frame emitted after gate persist failure; frames: {frames}"
+    err_detail = error_frames[0]["detail"]
+    assert "code" in err_detail, f"Error detail missing 'code': {err_detail}"
+    assert err_detail["code"] == "internal_error", f"Unexpected error code: {err_detail['code']!r}"
+    # Confirm no exception internals / args leaked into the message.
+    assert "simulated" not in err_detail.get("message", ""), (
+        f"Exception internals leaked into error message: {err_detail['message']!r}"
+    )
+
+    # No assistant Message row (gate failed; resume path would write it).
+    stmt = select(Message).where(Message.chat_id == uuid.UUID(chat_id), Message.role == "assistant")
+    msg_rows = (await db_session.execute(stmt)).scalars().all()
+    assert not msg_rows, f"Unexpected assistant Message row after gate persist failure: {msg_rows}"

--- a/api/tests/integration/test_chat_tool_loop_send.py
+++ b/api/tests/integration/test_chat_tool_loop_send.py
@@ -1,0 +1,510 @@
+"""PR5b Task 6 — integration: chat tool-loop integrated into send_message.
+
+Covers the four contract cases:
+(a) Empty allowlist → byte-identical to the existing single-shot streaming path.
+    Regression guard: assemble_allowlist is mocked to return an empty allowlist;
+    the generator must use gateway.chat_completion_stream (NOT run_chat_tool_loop).
+(b) Streaming send, research allowlist, loop returns LoopFinal →
+    start / delta(final text) / complete / [DONE]; assistant Message row persisted;
+    a tool_call_log row present (written by governed_tool_invocation inside the loop
+    for the intermediate tool call, if any — or simply the LoopFinal path).
+(c) Streaming send, LoopConfirmation → terminal tool_confirmation_required event;
+    chat_pending_tool_call row status=pending; tool_call_log row
+    confirmation_state=pending_confirmation / outcome=pending; NO assistant Message;
+    stream ends.
+(d) Streaming send, LoopMcpAuth → terminal mcp_authorization_required event;
+    no pending row written; stream ends.
+
+Strategy: for (b)/(c)/(d) we mock ``run_chat_tool_loop`` to return the desired
+outcome directly — this isolates Task 6 rendering/persistence logic from the
+loop internals (covered in Task 5). For (a) we mock ``assemble_allowlist`` to
+return an empty allowlist and mock the gateway SSE path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json as _json
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.chat.tool_loop import LoopConfirmation, LoopFinal, LoopMcpAuth
+from app.chat.tool_schemas import ChatToolAllowlist, ToolSpec
+from app.clients.gateway import GatewayClient, set_gateway_client
+from app.db.session import get_db
+from app.main import app
+from app.models.chat import Message
+from app.models.chat_pending_tool_call import ChatPendingToolCall
+from app.models.tool_call_log import ToolCallLog
+from app.models.user import User
+from app.schemas.gateway import (
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
+    ChatCompletionDelta,
+)
+from app.security import create_access_token, hash_password
+from app.skills import load_registry
+from app.skills.registry import MutableSkillRegistry
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "skills"
+
+GATEWAY_BASE = "http://test-gateway"
+GATEWAY_KEY = "test-gw-key"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    """In-process AsyncClient with fixture skill registry + gateway stub."""
+
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    prior_holder = getattr(app.state, "skill_registry", None)
+    if FIXTURES_DIR.exists():
+        app.state.skill_registry = MutableSkillRegistry(load_registry(FIXTURES_DIR))
+    elif prior_holder is None:
+        app.state.skill_registry = MutableSkillRegistry(load_registry(Path("/nonexistent")))
+
+    gw = GatewayClient(base_url=GATEWAY_BASE, gateway_key=GATEWAY_KEY)
+    set_gateway_client(gw)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    set_gateway_client(None)
+    await gw.aclose()
+    if prior_holder is None:
+        if hasattr(app.state, "skill_registry"):
+            delattr(app.state, "skill_registry")
+    else:
+        app.state.skill_registry = prior_holder
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def db_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"tool-loop-send-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Tool Loop Send Test User",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+def _h(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _parse_sse_frames(body: bytes) -> list[dict]:
+    """Parse SSE body into a list of data dicts (excludes [DONE])."""
+    frames = []
+    for line in body.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :]
+        if payload == "[DONE]":
+            continue
+        with contextlib.suppress(_json.JSONDecodeError):
+            frames.append(_json.loads(payload))
+    return frames
+
+
+def _make_tool_spec(
+    *,
+    function_name: str = "mcp__files__delete_doc",
+    kind: str = "mcp",
+    provider: str = "files",
+    tool: str = "delete_doc",
+    destructive: bool = True,
+    requires_confirmation: bool = True,
+) -> ToolSpec:
+    return ToolSpec(
+        function_name=function_name,
+        kind=kind,
+        provider=provider,
+        tool=tool,
+        read_only=False,
+        destructive=destructive,
+        requires_confirmation=requires_confirmation,
+        parameters={},
+        description="delete a document",
+    )
+
+
+def _make_non_empty_allowlist() -> ChatToolAllowlist:
+    spec = _make_tool_spec()
+    return ChatToolAllowlist(specs={spec.function_name: spec})
+
+
+# ---------------------------------------------------------------------------
+# (a) Empty allowlist — byte-identical to today (no-regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_empty_allowlist_uses_single_shot_stream_path(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Empty allowlist → existing single-shot streaming path; loop NOT called.
+
+    Mocks assemble_allowlist to return an empty ChatToolAllowlist, mocks the
+    gateway's chat_completion_stream to yield one delta chunk, and asserts:
+    - The SSE stream carries start / delta / complete / [DONE]
+    - run_chat_tool_loop was never called
+    - The assistant Message row is persisted
+    """
+    headers = _h(db_user)
+    chat_resp = await client.post("/api/v1/chats", headers=headers, json={"title": "regression"})
+    assert chat_resp.status_code == 201, chat_resp.text
+    chat_id = chat_resp.json()["id"]
+
+    # Build a minimal chunk that gateway.chat_completion_stream would yield.
+    chunk = ChatCompletionChunk(
+        id="chunk-0",
+        created=0,
+        model="claude-sonnet-4-6",
+        choices=[
+            ChatCompletionChunkChoice(
+                index=0,
+                delta=ChatCompletionDelta(content="Hello from stream"),
+                finish_reason="stop",
+            )
+        ],
+        routed_inference_tier=3,
+        routed_provider="anthropic-prod",
+    )
+
+    async def _stream_gen(*_args, **_kwargs):
+        yield chunk
+
+    empty_allowlist = ChatToolAllowlist(specs={})
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=empty_allowlist),
+        ),
+        patch.object(
+            GatewayClient,
+            "chat_completion_stream",
+            new=lambda self, *a, **kw: _stream_gen(self, *a, **kw),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(),
+        ) as mock_loop,
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/messages",
+            headers=headers,
+            json={"content": "hello", "stream": True},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert "text/event-stream" in resp.headers.get("content-type", ""), resp.headers
+
+    frames = _parse_sse_frames(resp.content)
+    types = [f.get("type") for f in frames]
+    assert "start" in types, f"No start frame: {types}"
+    assert "delta" in types, f"No delta frame: {types}"
+    assert "complete" in types, f"No complete frame: {types}"
+
+    # Assert the loop was NOT invoked (empty allowlist → single-shot path).
+    mock_loop.assert_not_called()
+
+    # Assert the delta carries the text from the mock chunk.
+    delta_frames = [f for f in frames if f.get("type") == "delta"]
+    assert any("Hello from stream" in f.get("delta", "") for f in delta_frames)
+
+    # Assert the assistant Message row was persisted.
+    stmt = select(Message).where(Message.chat_id == uuid.UUID(chat_id), Message.role == "assistant")
+    rows = (await db_session.execute(stmt)).scalars().all()
+    assert rows, "No assistant Message row persisted for empty-allowlist streaming send"
+
+
+# ---------------------------------------------------------------------------
+# (b) Research allowlist, loop returns LoopFinal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_loop_final_emits_delta_complete_and_persists(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Streaming send with non-empty allowlist and LoopFinal outcome.
+
+    Asserts: start / delta(final text) / complete / [DONE] in the stream,
+    the assistant Message row is persisted with the final text.
+    """
+    headers = _h(db_user)
+    chat_resp = await client.post("/api/v1/chats", headers=headers, json={"title": "loop-final"})
+    assert chat_resp.status_code == 201, chat_resp.text
+    chat_id = chat_resp.json()["id"]
+
+    final_text = "Here is the answer from the loop."
+    loop_outcome = LoopFinal(
+        text=final_text,
+        usage_prompt=100,
+        usage_completion=50,
+        tier=3,
+        provider="anthropic-prod",
+        model="claude-sonnet-4-6",
+        applied_skills=[],
+        calls_used=1,
+    )
+
+    non_empty_allowlist = _make_non_empty_allowlist()
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(return_value=loop_outcome),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/messages",
+            headers=headers,
+            json={"content": "search for something", "stream": True},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert "text/event-stream" in resp.headers.get("content-type", ""), resp.headers
+
+    body_text = resp.content.decode("utf-8")
+    assert "[DONE]" in body_text, "No [DONE] sentinel in stream"
+
+    frames = _parse_sse_frames(resp.content)
+    types = [f.get("type") for f in frames]
+    assert "start" in types, f"No start frame: {types}"
+    assert "delta" in types, f"No delta frame: {types}"
+    assert "complete" in types, f"No complete frame: {types}"
+
+    delta_frames = [f for f in frames if f.get("type") == "delta"]
+    assert any(final_text in f.get("delta", "") for f in delta_frames), (
+        f"Final text not in delta frames: {delta_frames}"
+    )
+
+    # Assert no gate frames.
+    assert "tool_confirmation_required" not in types
+    assert "mcp_authorization_required" not in types
+
+    # Assert assistant Message row persisted with the final text.
+    stmt = select(Message).where(Message.chat_id == uuid.UUID(chat_id), Message.role == "assistant")
+    rows = (await db_session.execute(stmt)).scalars().all()
+    assert rows, "No assistant Message row persisted after LoopFinal"
+    assert rows[0].content == final_text, (
+        f"Persisted content mismatch: {rows[0].content!r} != {final_text!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) LoopConfirmation — pending rows written, terminal event emitted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_loop_confirmation_emits_gate_event_and_persists_rows(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Streaming send, LoopConfirmation → tool_confirmation_required terminal event.
+
+    Asserts:
+    - The SSE stream ends with a tool_confirmation_required frame
+    - A ChatPendingToolCall row exists with status='pending'
+    - A ToolCallLog row exists with confirmation_state='pending_confirmation' / outcome='pending'
+    - No assistant Message row was persisted (resume path handles that)
+    """
+    headers = _h(db_user)
+    chat_resp = await client.post("/api/v1/chats", headers=headers, json={"title": "loop-confirm"})
+    assert chat_resp.status_code == 201, chat_resp.text
+    chat_id = chat_resp.json()["id"]
+
+    spec = _make_tool_spec()
+    loop_outcome = LoopConfirmation(
+        spec=spec,
+        args={"doc_id": "abc123", "reason": "remove outdated"},
+        tier=2,
+        args_summary="digest-placeholder",
+        messages=[{"role": "user", "content": "delete the file"}],
+        calls_used=0,
+    )
+
+    non_empty_allowlist = _make_non_empty_allowlist()
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(return_value=loop_outcome),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/messages",
+            headers=headers,
+            json={"content": "delete doc abc123", "stream": True},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body_text = resp.content.decode("utf-8")
+    assert "[DONE]" in body_text, "No [DONE] sentinel in stream"
+
+    frames = _parse_sse_frames(resp.content)
+    gate_frames = [f for f in frames if f.get("type") == "tool_confirmation_required"]
+    assert gate_frames, (
+        f"No tool_confirmation_required frame; got: {[f.get('type') for f in frames]}"
+    )
+
+    gate = gate_frames[0]
+    assert "pending_call_id" in gate, f"pending_call_id missing from gate frame: {gate}"
+    assert gate["provider"] == spec.provider
+    assert gate["tool"] == spec.tool
+    assert gate["function_name"] == spec.function_name
+    assert gate["destructive"] is True
+    assert gate["tier"] == 2
+
+    pending_call_id = uuid.UUID(gate["pending_call_id"])
+
+    # Assert no complete frame (stream ends at gate, not complete).
+    assert not any(f.get("type") == "complete" for f in frames), (
+        "complete frame found after LoopConfirmation — should not be emitted"
+    )
+
+    # Assert ChatPendingToolCall row with status='pending'.
+    pending_row = await db_session.get(ChatPendingToolCall, pending_call_id)
+    assert pending_row is not None, "ChatPendingToolCall row not found"
+    assert pending_row.status == "pending"
+    assert pending_row.function_name == spec.function_name
+    assert pending_row.provider == spec.provider
+    assert pending_row.tool == spec.tool
+    assert pending_row.destructive is True
+
+    # Assert ToolCallLog row with pending_confirmation.
+    assert pending_row.tool_call_log_id is not None, "tool_call_log_id not linked"
+    tcl_row = await db_session.get(ToolCallLog, pending_row.tool_call_log_id)
+    assert tcl_row is not None, "ToolCallLog row not found"
+    assert tcl_row.confirmation_state == "pending_confirmation"
+    assert tcl_row.outcome == "pending"
+    assert tcl_row.origin == "chat"
+    assert tcl_row.provider == spec.provider
+    assert tcl_row.tool == spec.tool
+
+    # Assert NO finalized assistant Message row.
+    stmt = select(Message).where(Message.chat_id == uuid.UUID(chat_id), Message.role == "assistant")
+    rows = (await db_session.execute(stmt)).scalars().all()
+    assert not rows, (
+        f"Assistant Message was persisted after LoopConfirmation — should not be: {rows}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) LoopMcpAuth — terminal event, no pending row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_loop_mcp_auth_emits_gate_event_no_pending_row(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Streaming send, LoopMcpAuth → mcp_authorization_required terminal event.
+
+    Asserts:
+    - The SSE stream ends with mcp_authorization_required
+    - The authorize_url points to /api/v1/mcp/oauth/{server}/authorize
+    - No ChatPendingToolCall row was written
+    """
+    headers = _h(db_user)
+    chat_resp = await client.post("/api/v1/chats", headers=headers, json={"title": "loop-mcp-auth"})
+    assert chat_resp.status_code == 201, chat_resp.text
+    chat_id = chat_resp.json()["id"]
+
+    loop_outcome = LoopMcpAuth(
+        server="legal-research",
+        authorize_url=None,
+        messages=[{"role": "user", "content": "search"}],
+        calls_used=0,
+    )
+
+    non_empty_allowlist = _make_non_empty_allowlist()
+
+    with (
+        patch(
+            "app.api.chats.assemble_allowlist",
+            new=AsyncMock(return_value=non_empty_allowlist),
+        ),
+        patch(
+            "app.api.chats.run_chat_tool_loop",
+            new=AsyncMock(return_value=loop_outcome),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat_id}/messages",
+            headers=headers,
+            json={"content": "search legal docs", "stream": True},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body_text = resp.content.decode("utf-8")
+    assert "[DONE]" in body_text, "No [DONE] sentinel in stream"
+
+    frames = _parse_sse_frames(resp.content)
+    auth_frames = [f for f in frames if f.get("type") == "mcp_authorization_required"]
+    assert auth_frames, (
+        f"No mcp_authorization_required frame; got: {[f.get('type') for f in frames]}"
+    )
+
+    auth = auth_frames[0]
+    assert auth["server"] == "legal-research"
+    assert "/api/v1/mcp/oauth/legal-research/authorize" in auth["authorize_url"]
+
+    # Assert no complete frame.
+    assert not any(f.get("type") == "complete" for f in frames)
+
+    # Assert no ChatPendingToolCall rows were written.
+    stmt = select(ChatPendingToolCall).where(ChatPendingToolCall.chat_id == uuid.UUID(chat_id))
+    rows = (await db_session.execute(stmt)).scalars().all()
+    assert not rows, f"ChatPendingToolCall rows found after LoopMcpAuth — should not be: {rows}"

--- a/api/tests/test_chat_pending_tool_call_model.py
+++ b/api/tests/test_chat_pending_tool_call_model.py
@@ -1,0 +1,227 @@
+"""Model + migration tests for chat_pending_tool_call (PR5b / 0054).
+
+Verifies:
+
+* All spec'd columns are present on the ORM model (unit, no DB required).
+* PK is id only (UUID).
+* chat_id FK is CASCADE, user_id FK is CASCADE, tool_call_log_id FK is SET NULL.
+* Row round-trips with all fields intact, status defaults to 'pending'.
+* resume_state and tool_call_args persist as JSONB and are not logged.
+* expires_at and timestamps persist.
+
+Security: resume_state holds the conversation-so-far (same sensitivity class
+as messages.content). Tests only verify persistence; they never emit
+resume_state to logs or stdout.
+
+Tests use the session-scoped migrated DB + per-test rollback from conftest.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat
+from app.models.chat_pending_tool_call import ChatPendingToolCall
+from app.models.user import User
+from app.security.passwords import hash_password
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user() -> User:
+    """Return an unsaved User with a unique email."""
+    return User(
+        email=f"cptc-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("test-pass"),
+        is_admin=False,
+        mfa_enabled=False,
+    )
+
+
+def _make_chat(owner_id: uuid.UUID) -> Chat:
+    """Return an unsaved Chat owned by the given user."""
+    return Chat(owner_id=owner_id, title="Test chat")
+
+
+def _make_pending(
+    chat_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> ChatPendingToolCall:
+    """Return an unsaved ChatPendingToolCall row with realistic values."""
+    return ChatPendingToolCall(
+        chat_id=chat_id,
+        user_id=user_id,
+        assistant_message_id=uuid.uuid4(),
+        function_name="mcp__files__delete_doc",
+        kind="mcp",
+        provider="files",
+        tool="delete_doc",
+        destructive=True,
+        tier=2,
+        tool_call_args={"path": "/x"},
+        resume_state={"messages": [{"role": "user", "content": "hi"}], "calls_used": 1},
+        expires_at=datetime.now(UTC) + timedelta(minutes=15),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — no DB required
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_chat_pending_tool_call_columns() -> None:
+    """All spec'd columns are present on the ORM model."""
+    cols = ChatPendingToolCall.__table__.columns.keys()
+    expected = {
+        "id",
+        "chat_id",
+        "user_id",
+        "assistant_message_id",
+        "tool_call_log_id",
+        "function_name",
+        "kind",
+        "provider",
+        "tool",
+        "destructive",
+        "tier",
+        "tool_call_args",
+        "resume_state",
+        "status",
+        "expires_at",
+        "created_at",
+        "updated_at",
+    }
+    assert set(cols) >= expected
+
+
+@pytest.mark.unit
+def test_chat_pending_tool_call_pk() -> None:
+    """PK is 'id' only (single UUID column)."""
+    pk = {c.name for c in ChatPendingToolCall.__table__.primary_key.columns}
+    assert pk == {"id"}
+
+
+@pytest.mark.unit
+def test_chat_pending_tool_call_fk_chat_cascade() -> None:
+    """chat_id FK references chats.id ON DELETE CASCADE."""
+    fk_col = ChatPendingToolCall.__table__.columns["chat_id"]
+    fks = list(fk_col.foreign_keys)
+    assert len(fks) == 1
+    fk = fks[0]
+    assert fk.column.table.name == "chats"
+    assert fk.ondelete == "CASCADE"
+
+
+@pytest.mark.unit
+def test_chat_pending_tool_call_fk_user_cascade() -> None:
+    """user_id FK references users.id ON DELETE CASCADE."""
+    fk_col = ChatPendingToolCall.__table__.columns["user_id"]
+    fks = list(fk_col.foreign_keys)
+    assert len(fks) == 1
+    fk = fks[0]
+    assert fk.column.table.name == "users"
+    assert fk.ondelete == "CASCADE"
+
+
+@pytest.mark.unit
+def test_chat_pending_tool_call_fk_tool_call_log_set_null() -> None:
+    """tool_call_log_id FK references tool_call_log.id ON DELETE SET NULL."""
+    fk_col = ChatPendingToolCall.__table__.columns["tool_call_log_id"]
+    fks = list(fk_col.foreign_keys)
+    assert len(fks) == 1
+    fk = fks[0]
+    assert fk.column.table.name == "tool_call_log"
+    assert fk.ondelete == "SET NULL"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require migrated DB via conftest)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_pending_tool_call_roundtrip(db_session: AsyncSession) -> None:
+    """Row persists and reads back; status defaults to 'pending'; id is assigned."""
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    chat = _make_chat(owner_id=user.id)
+    db_session.add(chat)
+    await db_session.flush()
+
+    row = _make_pending(chat_id=chat.id, user_id=user.id)
+    db_session.add(row)
+    await db_session.flush()
+
+    assert row.status == "pending"
+    assert row.id is not None
+
+    result = await db_session.execute(
+        select(ChatPendingToolCall).where(ChatPendingToolCall.id == row.id)
+    )
+    fetched = result.scalar_one()
+    assert fetched.function_name == "mcp__files__delete_doc"
+    assert fetched.kind == "mcp"
+    assert fetched.provider == "files"
+    assert fetched.tool == "delete_doc"
+    assert fetched.destructive is True
+    assert fetched.tier == 2
+    assert fetched.tool_call_args == {"path": "/x"}
+    assert fetched.resume_state["calls_used"] == 1
+    assert fetched.expires_at is not None
+    assert fetched.created_at is not None
+    assert fetched.updated_at is not None
+
+
+@pytest.mark.integration
+async def test_pending_tool_call_status_default(db_session: AsyncSession) -> None:
+    """status server-default 'pending' is applied by the DB on insert."""
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    chat = _make_chat(owner_id=user.id)
+    db_session.add(chat)
+    await db_session.flush()
+
+    row = _make_pending(chat_id=chat.id, user_id=user.id)
+    db_session.add(row)
+    await db_session.flush()
+
+    result = await db_session.execute(
+        select(ChatPendingToolCall).where(ChatPendingToolCall.id == row.id)
+    )
+    fetched = result.scalar_one()
+    assert fetched.status == "pending"
+
+
+@pytest.mark.integration
+async def test_pending_tool_call_tool_call_log_id_nullable(db_session: AsyncSession) -> None:
+    """tool_call_log_id is nullable — row inserts fine without it."""
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    chat = _make_chat(owner_id=user.id)
+    db_session.add(chat)
+    await db_session.flush()
+
+    row = _make_pending(chat_id=chat.id, user_id=user.id)
+    assert row.tool_call_log_id is None
+    db_session.add(row)
+    await db_session.flush()
+
+    result = await db_session.execute(
+        select(ChatPendingToolCall).where(ChatPendingToolCall.id == row.id)
+    )
+    fetched = result.scalar_one()
+    assert fetched.tool_call_log_id is None

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -73,6 +73,8 @@ _PARAM_VALUES: dict[str, str] = {
     # WS2/PR4b — MCP registry admin surface
     "server": "acme-mcp",
     "tool": "read_doc",
+    # PR5b Task 7 — resume pending tool call
+    "pending_call_id": _DUMMY_UUID,
 }
 
 
@@ -325,6 +327,8 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("DELETE", "/api/v1/mcp/oauth/{server}"),
     # PR4d Ask 1 — per-user OAuth connections list
     ("GET", "/api/v1/mcp/oauth"),
+    # PR5b Task 7 — resume pending tool call
+    ("POST", "/api/v1/chats/{chat_id}/tool-calls/{pending_call_id}"),
 }
 
 

--- a/api/tests/test_gateway_call_tool.py
+++ b/api/tests/test_gateway_call_tool.py
@@ -5,6 +5,7 @@ import pytest
 import respx
 
 from app.clients.gateway import GatewayClient
+from app.schemas.gateway import ChatCompletionRequest
 
 GW = "http://gw.test"
 
@@ -63,3 +64,44 @@ async def test_call_tool_maps_gateway_4xx_envelope() -> None:
         )
         with pytest.raises(ValidationError):
             await client.call_tool("courtlistener-prod", "verify_citations", {"text": ""})
+
+
+def test_api_chat_request_carries_tools() -> None:
+    req = ChatCompletionRequest(
+        model="smart",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "x", "parameters": {}}}],
+        tool_choice="auto",
+    )
+    assert req.tools[0]["function"]["name"] == "x"  # type: ignore[index]
+    assert req.tool_choice == "auto"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_sets_user_token_header() -> None:
+    captured: dict[str, str | None] = {}
+
+    def _cap(request: httpx.Request) -> httpx.Response:
+        captured["hdr"] = request.headers.get("X-LQ-AI-User-Token")
+        return httpx.Response(200, json={"provider": "p", "tool": "t", "payload": {}, "tier": 1})
+
+    client = _client()
+    with respx.mock:
+        respx.post(f"{GW}/v1/tools/p/t").mock(side_effect=_cap)
+        await client.call_tool("p", "t", {"a": 1}, user_token="secret-tok")
+    assert captured["hdr"] == "secret-tok"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_omits_user_token_header_when_none() -> None:
+    captured: dict[str, str | None] = {}
+
+    def _cap(request: httpx.Request) -> httpx.Response:
+        captured["hdr"] = request.headers.get("X-LQ-AI-User-Token")
+        return httpx.Response(200, json={"provider": "p", "tool": "t", "payload": {}, "tier": 1})
+
+    client = _client()
+    with respx.mock:
+        respx.post(f"{GW}/v1/tools/p/t").mock(side_effect=_cap)
+        await client.call_tool("p", "t", {"a": 1})
+    assert captured["hdr"] is None

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -208,6 +208,8 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/mcp/oauth/{server}",
         # PR4d Ask 1 — per-user OAuth connections list
         "/api/v1/mcp/oauth",
+        # PR5b Task 7 — resume pending tool call
+        "/api/v1/chats/{chat_id}/tool-calls/{pending_call_id}",
     }
 )
 
@@ -318,7 +320,9 @@ async def test_openapi_paths_match_sketch() -> None:
     # /api/v1/mcp/oauth/{server}
     # PR4d Ask 1 adds one new path (131 -> 132):
     # /api/v1/mcp/oauth
-    assert len(actual) == 132
+    # PR5b Task 7 adds one new path (132 -> 133):
+    # /api/v1/chats/{chat_id}/tool-calls/{pending_call_id}
+    assert len(actual) == 133
 
 
 @pytest.mark.unit

--- a/docs/LQVern/HANDOFF-2026-06-19-pr5b-shipped-pr6-next.md
+++ b/docs/LQVern/HANDOFF-2026-06-19-pr5b-shipped-pr6-next.md
@@ -1,0 +1,62 @@
+# Handoff — 2026-06-19 · Legal-research + MCP: PR5b (governed chat tool-loop) SHIPPED to review · next = PR6/WS5 (transparency surfaces)
+
+**Repo:** `~/Code/lq-ai` (canonical; NEVER `~/Desktop`; Bash cwd resets — prefix every command `cd ~/Code/lq-ai && …`).
+**PR5b = PR #187** (`feat/pr5b-chat-tool-loop`, off main `36223de`), **awaiting Kevin's security review + merge** (security-gated: chat send path + a gateway capability). Branch pushed to origin + tucuxi. **Migration head 0054.** **`EXPECTED_PATHS` = 133.**
+**`origin/main` is a PROTECTED branch — direct pushes are REJECTED.** Everything lands via PR + GitHub merge; then sync tucuxi: `git push tucuxi <origin-main-sha>:main`. NEVER `git push origin main`.
+**ruff pinned `==0.15.17`** in both venvs.
+
+> Read these memories FIRST (durable state): `[[project-legal-research-mcp-milestone]]`, `[[project-pr6-transparency-posture-narrative]]`, `[[feedback-test-runner-venv-not-docker]]`, `[[feedback-commit-trailer-model]]`. This file is the session-specific pointer.
+
+---
+
+## What PR5b shipped (PR #187 — built subagent-driven, 8 tasks)
+
+The **governed chat tool-loop** + persist-and-resume confirmation gate. Backend-only (UI → PR6). Spec `docs/superpowers/specs/2026-06-18-pr5-governed-chat-tool-loop-design.md` §PR5b; plan `docs/superpowers/plans/2026-06-19-pr5b-chat-tool-loop.md`.
+
+**Forks Kevin approved (2026-06-19):** F1 = non-stream tool rounds, stream the final answer (so the gateway only got Anthropic **non-streaming** tool_use bridging — no streaming-delta work); F2 = `max_allowed_tier=None` for chat (mirror autonomous; gateway egress-tier policy is the authority).
+
+| Piece | Where |
+|---|---|
+| Gateway `tools`/`tool_choice` request fields + Anthropic non-streaming `tool_use`→`tool_calls` bridging (+ assistant tool_use round-trip) | `gateway/app/providers/openai_schema.py`, `anthropic.py` (OpenAI/Ollama already forwarded) |
+| api `call_tool(user_token=)` (X-LQ-AI-User-Token header) + api `ChatCompletionRequest` tools/tool_choice | `api/app/clients/gateway.py`, `api/app/schemas/gateway.py` |
+| Allowlist assembly (5 fixed research schemas + enabled MCP tools, `mcp__{server}__{tool}`) | `api/app/chat/tool_schemas.py` |
+| `chat_pending_tool_call` model + **migration 0054** (resume payloads live here, NOT on counts-only `tool_call_log`) | `api/app/models/chat_pending_tool_call.py`, `api/alembic/versions/0054_*.py` |
+| The loop (non-stream rounds, `governed_tool_invocation` reused unmodified, cluster cache, cap 8) | `api/app/chat/tool_loop.py`; `chat_tool_call_cap` in `config.py` |
+| `send_message` integration + `tool_confirmation_required` / `mcp_authorization_required` terminal SSE events | `api/app/api/chats.py` |
+| Resume route `POST /api/v1/chats/{chat_id}/tool-calls/{pending_call_id}` `{decision}` | `api/app/api/chats.py` (`EXPECTED_PATHS` 132→133) |
+
+**Gates (local):** gateway **701 pass / 3 skip**; api **2201 pass / 1 skip**; ruff + mypy (`--strict` gateway) clean both. CI on #187 running at handoff time.
+
+**Security invariants held (verified end-to-end in the whole-branch review):** no raw payloads in `tool_call_log`/logs (args → `_args_digest` only; results only in `role="tool"` conversation messages; OAuth token header-only); the confirmation gate can't be bypassed and is **single-use under concurrency** (atomic conditional `UPDATE ... WHERE status='pending' AND expires_at>=now` committed BEFORE execution); `governed_tool_invocation` reused **unmodified** (`origin="chat"`, `max_allowed_tier=None`); empty allowlist ⇒ byte-identical to the existing chat path.
+
+**Review-loop catches worth knowing (all fixed before ship):**
+- Cap now counts **governed** calls only (executed + tier-refused), with a zero-governed-round termination guard (a hallucination-only round can't loop forever).
+- Gate-persistence failure now emits a terminal **error frame**, not a silent `[DONE]`.
+- The whole-branch review caught a **Critical**: resume fed an **orphaned `role="tool"` message** with no preceding assistant `tool_calls` turn → real providers (Anthropic/OpenAI) **400**. Tests had passed only because the mock gateway didn't enforce tool_use/tool_result pairing. Fixed by reconstructing the assistant `tool_calls` turn (shared `tool_call_id`) on all resume sub-paths; locked by approve+deny pairing tests.
+
+---
+
+## After Kevin merges PR5b
+1. Sync tucuxi main: `git push tucuxi <origin-main-sha>:main`.
+2. Update `[[project-legal-research-mcp-milestone]]` with the squash SHA + "WS4 COMPLETE".
+3. Delete the feature branch on both remotes.
+
+## NEXT = PR6 / WS5 — transparency surfaces (the milestone's closing workstream)
+The backend confirmation-gate + connect-on-demand **protocol** exists (SSE events + the resume endpoint); PR6 RENDERS it and tells the posture story. Per `[[project-pr6-transparency-posture-narrative]]` (Kevin's explicit ask) the surfaces must **narrate the security posture**, not just the mechanics:
+- The **`playground`-skill "how it works" visualization** in Learn/how-it-works for the CourtListener/MCP flow (use the `playground` skill).
+- README + LQ.AI docs updates alongside it.
+- The **UI**: case-law panel, MCP provenance pills, the **destructive-confirm prompt** rendering (consumes `tool_confirmation_required` → `POST .../tool-calls/{id}`), the inline-connect prompt (consumes `mcp_authorization_required` → `/api/v1/mcp/oauth/{server}/authorize` with PR4d `return_url`).
+- **External-source citation provenance** — net-new citation "source-kind" modeling (proposal C4); PR5 feeds raw tool results into the conversation, rich provenance is PR6.
+- The **skill-frontmatter tool-usage + `minimum_inference_tier` parser** (proposal C5) — build or scope to docs.
+- **Retire the OpenWebUI MCP stub (DE-341)** — now unblocked (chat path is gateway-brokered); migrate `web/backend/open_webui/routers/configs.py` + `utils/middleware.py` off `utils/mcp/client.py`, then delete the stub.
+
+## DEs filed this PR (PRD §9)
+DE-345 (shared `_stream_loop_outcome` renderer — the send/resume rendering duplication), DE-346 (`find_in_case` result-shape unify chat vs autonomous), DE-347 (chat tool-path OTel `chat.tool_call` span — loop passes `span=None`), DE-348 (resolve expired confirmation-gate `tool_call_log` row to `expired` + a `chat_pending_tool_call` TTL pruner), DE-349 (merge consecutive `tool_result` messages into one Anthropic user message — bites multi-read-only-tool rounds against Anthropic; the single-call resume path is fine). Still open from earlier: DE-336/337/338/340/342/343/344 + DE-341 (now unblocked).
+
+## The loop (used all milestone — keep it)
+verify ask vs code → surface forks via AskUserQuestion w/ recommendation → subagent-driven (fresh implementer per task; spec + quality review; opus for the load-bearing helper/guard + the whole-branch review on security-critical work) → run gates yourself (full api suite via :15433; ruff format --check + check; mypy; evidence before claims) → ship (`git commit -s` + trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`; stage explicitly, never `git add -A`; push origin + tucuxi; PR vs main; watch CI; **Kevin merges security-gated**, then sync tucuxi). Ledger lives at `.git/sdd/progress.md`.
+
+## Hard-won facts (don't relearn)
+- **Tests via host venv, NOT docker** (`[[feedback-test-runner-venv-not-docker]]`): gateway `cd gateway && .venv/bin/pytest …`; api `cd api && DATABASE_URL='postgresql+asyncpg://lq_ai:test@127.0.0.1:15433/lq_ai' .venv/bin/pytest …` (throwaway pgvector on :15433, conftest auto-migrates to head 0054). NEVER host `alembic upgrade` against the dev DB (:15432). Never `docker compose down -v`.
+- **Subagents may spin up their own git worktree + cherry-pick back** — verify the commit landed on the feature branch and clean up the stray worktree (`git worktree remove --force …` + `git branch -D worktree-agent-…`) afterward. PR5b Task 5 did this.
+- **Collision guards** crash the whole api suite at collection: a new route → `IMPLEMENTED_ROUTES` (`test_endpoints.py`) AND `EXPECTED_PATHS` + the pinned count (`test_openapi.py`, now **133**); `backend-openapi.yaml` is hand-maintained (DE-337).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4629,6 +4629,46 @@ No code change — the runtime already returns these with the correct typed `cod
 
 **When to ship:** Before the autonomous layer (or chat) is pointed at a metered/paid third-party tool provider.
 
+#### DE-345 — Extract a shared `_stream_loop_outcome` renderer for the chat tool-loop
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** PR5b renders a tool-loop `LoopOutcome` (`LoopFinal` / `LoopConfirmation` / `LoopMcpAuth`) to SSE frames + DB persistence in two places — the initial-send streaming generator (`_stream_response`) and the resume route (`resume_tool_call`) in `api/app/api/chats.py`. The plan preferred a single shared `_stream_loop_outcome` generator, but the implementer kept the resume route's rendering inline to avoid restructuring the keystone send path mid-feature (the two have different live state: send has the live `chat`/`request`; resume reconstructs from `resume_state`). The duplication is bounded but real — a future change to the `tool_confirmation_required`/`complete` frame shapes or the gate-persistence rows must be made in both places. Surfaced in the PR5b Task 7 review (2026-06-19).
+
+**Specific scope:** Extract the outcome→frames+persistence logic into one reusable async generator both call sites drive, once both paths are stable and the no-regression risk to the send path is understood.
+
+#### DE-346 — Unify the `find_in_case` tool-result shape across chat-loop and autonomous dispatch
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** The chat tool-loop's research dispatch (`api/app/chat/tool_loop.py`) feeds the raw `find_in_case` service output (a list of match dicts) into the conversation, while the autonomous guard's dispatch wraps it as `{"matches": [...]}`. The same logical tool returns a different JSON shape to the model depending on origin (chat vs autonomous), which can confuse a skill author who relies on a stable contract. Surfaced in the PR5b Task 5 review (2026-06-19).
+
+**Specific scope:** Pick one canonical tool-result envelope for `find_in_case` (and audit the other research ops for the same divergence) and apply it in both dispatch paths.
+
+#### DE-347 — Chat tool-path OpenTelemetry span (`chat.tool_call`)
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** PR5b's chat tool-loop calls `governed_tool_invocation` with `span=None` — the helper is span-agnostic (it annotates a caller-supplied span per ADR 0015 D5 / D-a1) but the chat loop does not yet open a `chat.tool_call` domain span the way the autonomous path opens `autonomous.tool_call`. This is the chat-side slice of the standing tool-path-OTel deferred work (the inference path has `inference.dispatch`; the tool/research path has only the `tool_egress_log`/`tool_call_log` audit). Surfaced in the PR5b Task 5 review (2026-06-19).
+
+**Specific scope:** Open a `chat.tool_call` span (attributes = tool/provider/tier/outcome/cost, counts/types only) in the chat tool-loop and thread it into `governed_tool_invocation(span=...)`, mirroring `inference.dispatch` and the autonomous span. Fold into the broader tool-path-OTel follow-on.
+
+#### DE-348 — Resolve an expired confirmation-gate `tool_call_log` row to an `expired` state
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** When a chat destructive-tool confirmation expires (the `chat_pending_tool_call` row passes its TTL and a resume POST returns 409), the corresponding `tool_call_log` gate row (written at gate time with `confirmation_state="pending_confirmation"`, `outcome="pending"`) is left unchanged — it reads as perpetually pending in the audit trail even though it was never acted on. Surfaced in the PR5b Task 7 review (2026-06-19).
+
+**Specific scope:** On expiry (or via a background sweep of expired `chat_pending_tool_call` rows), flip the linked gate `tool_call_log` row to a terminal `confirmation_state="expired"` (and an `outcome` that reflects no execution) so the audit trail is honest. Pairs naturally with a TTL pruner for `chat_pending_tool_call` (the model already carries `expires_at` + an index).
+
+#### DE-349 — Merge consecutive `tool_result` messages into one Anthropic user message
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** The gateway's `_to_anthropic_request` (`gateway/app/providers/anthropic.py`) translates each incoming `role="tool"` message into its own Anthropic `user` message carrying one `tool_result` block. The PR5b chat tool-loop, when the model proposes **multiple** read-only tools in a single round, appends the assistant `tool_calls` turn followed by several `role="tool"` result messages — which become consecutive same-role `user` messages on the Anthropic hop. The Anthropic Messages API expects roles to alternate, so a multi-tool round could be rejected. PR5b's confirmation-resume path is unaffected (it reconstructs a single-call assistant turn + one tool result), and single-tool rounds are fine; this only bites multi-read-only-tool rounds against Anthropic. Surfaced in the PR5b final whole-branch review (2026-06-19).
+
+**Specific scope:** In `_to_anthropic_request`, coalesce a run of consecutive `role="tool"` messages into a single Anthropic `user` message containing multiple `tool_result` content blocks. Add a gateway adapter test feeding `assistant(tool_calls=[A,B]) → tool(A) → tool(B)` and asserting one merged user message with two `tool_result` blocks.
+
 ---
 
 ## 10. Appendices

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -3677,6 +3677,44 @@ paths:
           description: Chat not found
 
   # ============================================================
+  # PR5b Task 7 — chat tool-call resume gate
+  # ============================================================
+
+  /api/v1/chats/{chat_id}/tool-calls/{pending_call_id}:
+    post:
+      summary: Approve or deny a pending destructive chat tool-call; resumes the turn
+      tags: [chats]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: chat_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+        - name: pending_call_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToolCallDecisionRequest'
+      responses:
+        '200':
+          description: SSE stream — resumes the turn after approval or denial
+          content:
+            text/event-stream:
+              schema: { type: string }
+        '400':
+          description: Malformed request body
+        '404':
+          description: Chat or pending tool-call not found (id-probing-safe)
+        '409':
+          description: Tool-call already resolved or confirmation expired
+
+  # ============================================================
   # M3-D1 — slack-bridge persistence surface
   # ============================================================
 
@@ -8234,6 +8272,15 @@ components:
         provider_keys:
           type: array
           items: {$ref: '#/components/schemas/ProviderKeyStatus'}
+
+    ToolCallDecisionRequest:
+      type: object
+      required: [decision]
+      properties:
+        decision:
+          type: string
+          enum: [approve, deny]
+          description: Whether to approve or deny the pending tool call.
 
     Error:
       type: object

--- a/docs/superpowers/plans/2026-06-19-pr5b-chat-tool-loop.md
+++ b/docs/superpowers/plans/2026-06-19-pr5b-chat-tool-loop.md
@@ -1,0 +1,927 @@
+# PR5b — Governed chat tool-loop + confirmation gate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give interactive chat a real multi-step tool-calling loop over an operator-enabled allowlist of CourtListener + MCP tools, governed per-call through PR5a's `governed_tool_invocation`, with a persist-and-resume human confirmation gate for destructive tools.
+
+**Architecture:** The api assembles a per-turn tool allowlist (research function schemas when CourtListener is enabled + enabled MCP tools), then drives a **non-streaming** tool-decision loop against the gateway: each round the model returns either a final answer or tool-call(s); `read_only` tools execute inline through the shared governance substrate and feed results back; `destructive`/`requires_confirmation` tools persist resume state and end the turn with a terminal SSE event; a separate POST resumes. The final answer is emitted as SSE delta frames (streaming endpoint) or JSON (non-streaming). The only `gateway/**` change is adding `tools`/`tool_choice` to the request schema and bridging Anthropic's non-streaming `tool_use`.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy async, Alembic, Pydantic v2, httpx/respx, pytest. Two services: `api/` (standard mypy) and `gateway/` (mypy `--strict`).
+
+## Global Constraints
+
+- **Branch:** `feat/pr5b-chat-tool-loop` off `main` (`36223de`). Push `origin` + `tucuxi`. `origin/main` is PROTECTED — PR + GitHub merge only; sync tucuxi after. **Security-gated** (touches the chat send path + a gateway capability) → **Kevin reviews/merges**; do not self-merge.
+- **ruff pinned `==0.15.17`** in both venvs. Run BOTH `ruff format` and `ruff check` (separate CI gates) + `mypy app` (gateway is `--strict`).
+- **Tests via host venv, NOT docker.** Gateway: `cd gateway && .venv/bin/pytest tests/X -v`. API: `cd api && DATABASE_URL='postgresql+asyncpg://lq_ai:test@127.0.0.1:15433/lq_ai' .venv/bin/pytest tests/X -v` (throwaway pgvector on :15433; conftest auto-migrates). NEVER host `alembic upgrade` against the dev DB (:15432). NEVER `docker compose down -v`.
+- **Commit trailer (every commit):** `git commit -s` plus `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. Stage explicitly — never `git add -A`.
+- **Subagents have no network** — `pip install` happens in the controller before dispatch. No deps are added by this PR.
+- **Collision guards (crash the whole api suite at collection):** a new route → add to `IMPLEMENTED_ROUTES` (`api/tests/test_endpoints.py`) AND bump the pinned path count + `EXPECTED_PATHS` set (`api/tests/test_openapi.py`, currently **132 → 133**) AND update `docs/api/backend-openapi.yaml` (hand-maintained, DE-337). 204 DELETE needs `response_class=Response`. Decimal cost fields serialize as JSON **strings**.
+- **Migration head 0053 → 0054.** Verify migrations on a throwaway pgvector container (conftest), never the dev DB.
+
+## Locked decisions (from the spec + forks resolved with Kevin 2026-06-19)
+
+- **L1–L6** per `docs/superpowers/specs/2026-06-18-pr5-governed-chat-tool-loop-design.md`. PR5a is merged; reuse `app/tools/governance.py::governed_tool_invocation` **unmodified**.
+- **Fork 1 (loop streaming) = "non-stream rounds, stream final".** Tool-decision rounds call the gateway **non-streaming**; the final answer is emitted as SSE delta frame(s). Gateway needs only Anthropic **non-streaming** `tool_use` bridging — **no** streaming `tool_use` delta work. Empty allowlist ⇒ unchanged single-shot streaming.
+- **Fork 2 (tier ceiling) = `max_allowed_tier=None`.** Mirror PR5a's autonomous path; the gateway's own per-provider egress-tier policy is the enforcement authority (defense-in-depth). Document the deviation from the spec's cross-cutting note.
+- **Per-turn cap = 8**, operator-overridable via a settings field.
+- **Confirmation gate = persist-and-resume.** Resume state lives in a NEW dedicated table (`chat_pending_tool_call`), NOT on `tool_call_log` (which stays counts-only). The pending row carries the call args + the conversation-so-far (same sensitivity class as `messages.content`, stored the same way).
+- **MCP tool function-name scheme = `mcp__{server}__{tool}`** (OpenAI function-name charset `^[A-Za-z0-9_-]+$`; no dots). Research tools use bare op names.
+
+---
+
+## File Structure
+
+**New files (api):**
+- `api/app/chat/__init__.py` — package marker.
+- `api/app/chat/tool_schemas.py` — fixed research function schemas + allowlist assembly + the function-name↔ToolSpec resolver.
+- `api/app/chat/tool_loop.py` — the loop engine + typed outcomes + dispatch closures.
+- `api/app/models/chat_pending_tool_call.py` — the resume-state model.
+- `api/alembic/versions/0054_*.py` — `chat_pending_tool_call` migration.
+
+**Modified files (gateway — the only `gateway/**` surface):**
+- `gateway/app/providers/openai_schema.py` — add `tools`/`tool_choice` to `ChatCompletionRequest`.
+- `gateway/app/providers/anthropic.py` — forward request tools/tool_choice; extract non-streaming `tool_use` → `tool_calls`.
+
+**Modified files (api):**
+- `api/app/schemas/gateway.py` — add `tools`/`tool_choice` to the api `ChatCompletionRequest`.
+- `api/app/clients/gateway.py` — add `user_token` param to `call_tool`.
+- `api/app/config.py` (settings) — add `chat_tool_call_cap` (default 8).
+- `api/app/api/chats.py` — assemble allowlist in `send_message`; tool-loop stream/non-stream variants; new resume route.
+- `api/app/schemas/chats.py` (or wherever `MessagePostResponse` lives) — gate-payload response fields for the non-streaming path + resume request body schema.
+- `docs/api/backend-openapi.yaml` — the new route.
+- `api/tests/test_openapi.py`, `api/tests/test_endpoints.py` — collision guards.
+
+**New test files (api):** `api/tests/chat/test_tool_schemas.py`, `api/tests/chat/test_tool_loop.py`, `api/tests/integration/test_chat_tool_loop_send.py`, `api/tests/integration/test_chat_tool_call_resume.py`, `api/tests/test_chat_pending_tool_call_model.py`.
+**New test files (gateway):** extend `gateway/tests/providers/test_anthropic.py` (or the existing anthropic test module) + a schema test.
+
+---
+
+## Task 1 (gateway/** — security-gated): Anthropic non-streaming tool_use bridging + request `tools`/`tool_choice`
+
+**Files:**
+- Modify: `gateway/app/providers/openai_schema.py` (`ChatCompletionRequest`, ~line 144–167)
+- Modify: `gateway/app/providers/anthropic.py` (`_to_anthropic_request` ~338–409; `_from_anthropic_response` ~415–458; `STOP_REASON_MAP` ~90)
+- Test: `gateway/tests/providers/test_anthropic.py` (extend), `gateway/tests/providers/test_openai_schema.py` (extend or create)
+
+**Interfaces:**
+- Consumes: nothing from other tasks (first task).
+- Produces: a gateway `chat_completion` that, given `tools`/`tool_choice` in the request, forwards them to Anthropic and returns `response.choices[0].message.tool_calls` (OpenAI shape: `[{"id","type":"function","function":{"name","arguments"(JSON string)}}]`) with `finish_reason="tool_calls"`. OpenAI/Ollama already do this (regression-verify only).
+
+Background (verified against `main`): OpenAI/Azure forward `tools`/`tool_choice` via `model_dump()` of `extra="allow"` and pass tool_calls through; Ollama forwards them explicitly (`ollama.py:476-482`) and round-trips assistant `tool_calls`. **Anthropic does neither.** `STOP_REASON_MAP` already maps `"tool_use" → "tool_calls"`. Tool-*result* incoming messages are already translated to Anthropic `tool_result` blocks (`anthropic.py:374-389`); assistant messages carrying `tool_calls` are currently flattened to text (acceptable for v1 — the loop re-sends the full OpenAI-shaped history and Anthropic is stateless per call; **but** the assistant `tool_use` turn MUST round-trip so Anthropic accepts the following `tool_result`. See Step 5.)
+
+- [ ] **Step 1: Write failing schema test for explicit `tools`/`tool_choice` fields**
+
+In `gateway/tests/providers/test_openai_schema.py`:
+```python
+from gateway.app.providers.openai_schema import ChatCompletionRequest
+
+
+def test_chat_completion_request_accepts_tools_and_tool_choice():
+    req = ChatCompletionRequest(
+        model="smart",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "verify_citations", "parameters": {}}}],
+        tool_choice="auto",
+    )
+    assert req.tools is not None and req.tools[0]["function"]["name"] == "verify_citations"
+    assert req.tool_choice == "auto"
+    # Round-trips through model_dump (the OpenAI adapter serializes this).
+    dumped = req.model_dump(mode="json", exclude_none=True)
+    assert "tools" in dumped and "tool_choice" in dumped
+```
+
+- [ ] **Step 2: Run it; expect FAIL** — `cd gateway && .venv/bin/pytest tests/providers/test_openai_schema.py -v` → FAIL (`tools` lands in `model_extra`, attribute access via `req.tools` raises `AttributeError`).
+
+- [ ] **Step 3: Add explicit fields to `ChatCompletionRequest`** (after `n:` ~line 167):
+```python
+    # --- Function/tool calling (PR5b) ---------------------------------------
+    tools: list[dict[str, Any]] | None = None
+    """OpenAI-style tool/function declarations. Forwarded to the provider
+    so the model may emit ``tool_calls``. The backend assembles a closed
+    allowlist per turn (research + operator-enabled MCP tools); the
+    gateway's egress-tier / SSRF guards still gate the eventual call."""
+
+    tool_choice: str | dict[str, Any] | None = None
+    """OpenAI-style tool_choice (``"auto"`` / ``"none"`` / a forced
+    function). Forwarded verbatim to providers that support it."""
+```
+(`Any` is already imported in this module.)
+
+- [ ] **Step 4: Run it; expect PASS.**
+
+- [ ] **Step 5: Write failing Anthropic round-trip test**
+
+In `gateway/tests/providers/test_anthropic.py`, add (follow the module's existing respx + adapter-construction fixtures):
+```python
+@pytest.mark.asyncio
+async def test_anthropic_forwards_tools_and_surfaces_tool_calls(respx_mock):
+    captured = {}
+
+    def _capture(request):
+        import json as _j
+        captured["body"] = _j.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "content": [
+                    {"type": "text", "text": "Let me check."},
+                    {"type": "tool_use", "id": "toolu_1", "name": "verify_citations",
+                     "input": {"text": "Brown v. Board"}},
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+
+    respx_mock.post("https://api.anthropic.com/v1/messages").mock(side_effect=_capture)
+
+    adapter = _make_anthropic_adapter()  # existing helper in this module
+    req = ChatCompletionRequest(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "verify this"}],
+        tools=[{"type": "function",
+                "function": {"name": "verify_citations",
+                             "parameters": {"type": "object",
+                                            "properties": {"text": {"type": "string"}}}}}],
+        tool_choice="auto",
+    )
+    resp = await adapter.chat_completion(req, model="claude-sonnet-4-6", stream=False)
+
+    # Request side: Anthropic-shaped tools forwarded.
+    assert captured["body"]["tools"][0]["name"] == "verify_citations"
+    assert "input_schema" in captured["body"]["tools"][0]
+    assert captured["body"]["tool_choice"] == {"type": "auto"}
+    # Response side: tool_use -> OpenAI tool_calls.
+    msg = resp.choices[0].message
+    assert resp.choices[0].finish_reason == "tool_calls"
+    assert msg.tool_calls[0]["id"] == "toolu_1"
+    assert msg.tool_calls[0]["function"]["name"] == "verify_citations"
+    import json as _j
+    assert _j.loads(msg.tool_calls[0]["function"]["arguments"]) == {"text": "Brown v. Board"}
+```
+
+- [ ] **Step 6: Run it; expect FAIL** (tools not forwarded; tool_calls empty).
+
+- [ ] **Step 7: Forward `tools`/`tool_choice` in `_to_anthropic_request`**
+
+Anthropic's Messages API uses `tools: [{name, description, input_schema}]` (not the OpenAI `{type:function, function:{...}}` envelope) and `tool_choice: {"type": "auto"|"any"|"tool", "name"?}`. Before `return body` in `_to_anthropic_request` (~line 408):
+```python
+    extra = request.model_extra or {}
+    raw_tools = request.tools if request.tools is not None else extra.get("tools")
+    if raw_tools:
+        anthropic_tools: list[dict[str, Any]] = []
+        for t in raw_tools:
+            fn = t.get("function", t) if isinstance(t, dict) else {}
+            anthropic_tools.append(
+                {
+                    "name": fn.get("name", ""),
+                    "description": fn.get("description", "") or "",
+                    "input_schema": fn.get("parameters") or {"type": "object", "properties": {}},
+                }
+            )
+        body["tools"] = anthropic_tools
+
+        raw_choice = request.tool_choice if request.tool_choice is not None else extra.get("tool_choice")
+        if raw_choice is None or raw_choice == "auto":
+            body["tool_choice"] = {"type": "auto"}
+        elif raw_choice == "none":
+            # Anthropic has no "none"; omit tools to disable. Honor by dropping tools.
+            body.pop("tools", None)
+        elif raw_choice == "required":
+            body["tool_choice"] = {"type": "any"}
+        elif isinstance(raw_choice, dict):
+            fn = raw_choice.get("function", {})
+            if fn.get("name"):
+                body["tool_choice"] = {"type": "tool", "name": fn["name"]}
+```
+
+- [ ] **Step 8: Extract `tool_use` blocks in `_from_anthropic_response`**
+
+After the text-extraction loop (~line 427), and update the returned message (~line 454):
+```python
+    tool_calls: list[dict[str, Any]] = []
+    for block in blocks:
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            tool_calls.append(
+                {
+                    "id": str(block.get("id", "")),
+                    "type": "function",
+                    "function": {
+                        "name": str(block.get("name", "")),
+                        # OpenAI tool_calls carry arguments as a JSON STRING.
+                        "arguments": _json.dumps(block.get("input") or {}),
+                    },
+                }
+            )
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=text or None,
+        tool_calls=tool_calls or None,
+    )
+```
+Ensure `_json` (stdlib `json`) is imported at module top; if the module uses a different alias, match it. The `finish_reason` already derives from `STOP_REASON_MAP["tool_use"] = "tool_calls"`.
+
+- [ ] **Step 9: Round-trip the assistant tool_use turn back to Anthropic** (so a follow-up `tool_result` is accepted). In `_to_anthropic_request`, where assistant messages are built (~line 391), if `msg.role == "assistant"` and `msg.tool_calls`:
+```python
+        if msg.role == "assistant" and msg.tool_calls:
+            content_blocks: list[dict[str, Any]] = []
+            if msg.content:
+                content_blocks.append({"type": "text", "text": msg.content})
+            for tc in msg.tool_calls:
+                fn = tc.get("function", {})
+                try:
+                    parsed_input = _json.loads(fn.get("arguments") or "{}")
+                except (ValueError, TypeError):
+                    parsed_input = {}
+                content_blocks.append(
+                    {"type": "tool_use", "id": tc.get("id", ""),
+                     "name": fn.get("name", ""), "input": parsed_input}
+                )
+            chat_messages.append({"role": "assistant", "content": content_blocks})
+            continue  # skip the default text-only append below
+```
+Place this branch BEFORE the existing default `{"role": msg.role, "content": content}` append. Remove/adjust the old "tool-call assistant messages passed through as text only" DE comment.
+
+- [ ] **Step 10: Add a multi-hop round-trip test** (assistant tool_use → tool message → final answer) asserting Anthropic receives the `tool_use` block then a `user` message with a `tool_result` block, and returns `finish_reason="stop"` with text. (Mirror the Step 5 fixture; second mocked response has `stop_reason="end_turn"`, content `[{"type":"text","text":"Confirmed."}]`.)
+
+- [ ] **Step 11: Regression-verify OpenAI + Ollama still forward tools.** Add a one-liner assertion to each adapter's existing request test that `tools`/`tool_choice` appear in the upstream body when set (they already pass through; this pins it).
+
+- [ ] **Step 12: Run the full gateway suite + lint.**
+```bash
+cd gateway && .venv/bin/pytest tests/ -q && .venv/bin/ruff format --check . && .venv/bin/ruff check . && .venv/bin/mypy app
+```
+Expected: all green (`--strict` mypy).
+
+- [ ] **Step 13: Commit.**
+```bash
+git add gateway/app/providers/openai_schema.py gateway/app/providers/anthropic.py gateway/tests/providers/
+git commit -s -m "feat(gateway): forward tools/tool_choice + bridge Anthropic non-streaming tool_use
+
+PR5b dependency: the chat tool-loop drives non-streaming completions with
+function schemas. OpenAI/Ollama already forward tools and surface tool_calls;
+Anthropic now forwards request tools (OpenAI->Anthropic input_schema/tool_choice
+mapping), extracts tool_use response blocks into OpenAI-shaped tool_calls, and
+round-trips the assistant tool_use turn so a follow-up tool_result is accepted.
+No streaming tool_use delta work (loop uses non-streaming rounds; final answer
+streams as text). Refs ADR 0015.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2 (api): thread the per-user OAuth token through `GatewayClient.call_tool`
+
+**Files:**
+- Modify: `api/app/clients/gateway.py` (`call_tool` ~689)
+- Modify: `api/app/schemas/gateway.py` (`ChatCompletionRequest` — add `tools`/`tool_choice`)
+- Test: `api/tests/clients/test_gateway_call_tool.py` (extend or create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `GatewayClient.call_tool(provider, tool, args, *, max_allowed_tier=None, user_token=None, request_id=None) -> dict` — sets `X-LQ-AI-User-Token` header when `user_token` is given (the gateway route already reads it, `gateway/app/api/tools.py:110-124`). And the api `ChatCompletionRequest` carrying `tools`/`tool_choice` for the loop.
+
+- [ ] **Step 1: Failing test for the api request-schema fields.** In a schema test:
+```python
+from app.schemas.gateway import ChatCompletionRequest
+
+def test_api_chat_request_carries_tools():
+    req = ChatCompletionRequest(
+        model="smart",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "x", "parameters": {}}}],
+        tool_choice="auto",
+    )
+    assert req.tools[0]["function"]["name"] == "x"
+    assert req.tool_choice == "auto"
+```
+
+- [ ] **Step 2: Run; expect FAIL.**
+
+- [ ] **Step 3: Add fields** to `api/app/schemas/gateway.py::ChatCompletionRequest` (after `n:` ~line 114):
+```python
+    tools: list[dict[str, Any]] | None = None
+    """PR5b: per-turn closed allowlist of function schemas the backend
+    assembles (research + operator-enabled MCP tools). Forwarded to the
+    gateway, which forwards to the provider."""
+    tool_choice: str | dict[str, Any] | None = None
+```
+
+- [ ] **Step 4: Run; expect PASS.**
+
+- [ ] **Step 5: Failing test for `user_token` header on `call_tool`.**
+```python
+@pytest.mark.asyncio
+async def test_call_tool_sets_user_token_header(respx_mock):
+    captured = {}
+    def _cap(request):
+        captured["hdr"] = request.headers.get("X-LQ-AI-User-Token")
+        return httpx.Response(200, json={"provider": "p", "tool": "t", "payload": {}, "tier": 1})
+    respx_mock.post("http://gw/v1/tools/p/t").mock(side_effect=_cap)
+    client = _make_gateway_client(base_url="http://gw")  # existing helper
+    await client.call_tool("p", "t", {"a": 1}, user_token="secret-tok")
+    assert captured["hdr"] == "secret-tok"
+
+@pytest.mark.asyncio
+async def test_call_tool_omits_user_token_header_when_none(respx_mock):
+    captured = {}
+    def _cap(request):
+        captured["hdr"] = request.headers.get("X-LQ-AI-User-Token")
+        return httpx.Response(200, json={"provider": "p", "tool": "t", "payload": {}, "tier": 1})
+    respx_mock.post("http://gw/v1/tools/p/t").mock(side_effect=_cap)
+    client = _make_gateway_client(base_url="http://gw")
+    await client.call_tool("p", "t", {"a": 1})
+    assert captured["hdr"] is None
+```
+
+- [ ] **Step 6: Run; expect FAIL.**
+
+- [ ] **Step 7: Add the param.** In `call_tool` (~689) add `user_token: str | None = None` to the keyword-only params, then after `headers = self._build_headers(request_id=request_id)`:
+```python
+        if user_token is not None:
+            # Per-user OAuth token for `auth: oauth` MCP servers. Header,
+            # never query/body (PR4c discipline — keeps it out of access
+            # logs and never written to tool_egress_log).
+            headers["X-LQ-AI-User-Token"] = user_token
+```
+Update the docstring to note the new param mirrors `discover_tools`.
+
+- [ ] **Step 8: Run; expect PASS.**
+
+- [ ] **Step 9: Lint + commit.**
+```bash
+cd api && .venv/bin/ruff format api/app/clients/gateway.py api/app/schemas/gateway.py && .venv/bin/ruff check api/app/clients/gateway.py api/app/schemas/gateway.py && .venv/bin/mypy app
+git add api/app/clients/gateway.py api/app/schemas/gateway.py api/tests/
+git commit -s -m "feat(api): thread per-user OAuth token through call_tool; add tools/tool_choice to chat request
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3 (api): allowlist assembly + the function-name↔ToolSpec resolver
+
+**Files:**
+- Create: `api/app/chat/__init__.py` (empty)
+- Create: `api/app/chat/tool_schemas.py`
+- Test: `api/tests/chat/test_tool_schemas.py`
+
+**Interfaces:**
+- Consumes: `app.research.service.get_capabilities`, `app.mcp.service.list_servers`/`list_cached_tools`.
+- Produces:
+  - `@dataclass(frozen=True) class ToolSpec: function_name: str; kind: Literal["research","mcp"]; provider: str; tool: str; read_only: bool; destructive: bool; requires_confirmation: bool; parameters: dict[str, Any]`
+  - `@dataclass class ChatToolAllowlist: specs: dict[str, ToolSpec]` with `def function_schemas(self) -> list[dict[str, Any]]` (OpenAI shape) and `def resolve(self, function_name: str) -> ToolSpec | None`.
+  - `async def assemble_allowlist(db, *, request_id=None) -> ChatToolAllowlist`
+  - `MCP_NAME_PREFIX = "mcp__"`; `def mcp_function_name(server, tool) -> str`; `def parse_mcp_function_name(name) -> tuple[str, str] | None`
+  - `RESEARCH_TOOL_SCHEMAS: dict[str, dict]` — the 5 fixed schemas, and `RESEARCH_OPS: frozenset[str]`.
+
+- [ ] **Step 1: Failing tests** (`api/tests/chat/test_tool_schemas.py`) — mock `get_capabilities`, `list_servers`, `list_cached_tools`:
+```python
+import pytest
+from unittest.mock import AsyncMock, patch
+from app.chat.tool_schemas import (
+    assemble_allowlist, mcp_function_name, parse_mcp_function_name, RESEARCH_OPS,
+)
+
+@pytest.mark.asyncio
+async def test_research_only_allowlist(db):
+    with patch("app.chat.tool_schemas.get_capabilities",
+               new=AsyncMock(return_value={"enabled": True, "providers": [{"name": "cl-prod", "type": "courtlistener"}]})), \
+         patch("app.chat.tool_schemas.research_resolve_provider", new=AsyncMock(return_value="cl-prod")), \
+         patch("app.chat.tool_schemas.list_servers", new=AsyncMock(return_value=[])):
+        al = await assemble_allowlist(db)
+    assert RESEARCH_OPS <= set(al.specs)
+    spec = al.resolve("search_case_law")
+    assert spec.kind == "research" and spec.provider == "cl-prod" and spec.read_only
+
+@pytest.mark.asyncio
+async def test_mcp_only_allowlist(db):
+    tools = [
+        {"name": "get_doc", "description": "", "parameters": {"type": "object"},
+         "read_only": True, "destructive": False, "requires_confirmation": False, "enabled": True},
+        {"name": "delete_doc", "description": "", "parameters": {"type": "object"},
+         "read_only": False, "destructive": True, "requires_confirmation": True, "enabled": True},
+        {"name": "disabled_tool", "description": "", "parameters": {}, "read_only": True,
+         "destructive": False, "requires_confirmation": False, "enabled": False},
+    ]
+    with patch("app.chat.tool_schemas.get_capabilities", new=AsyncMock(return_value={"enabled": False, "providers": []})), \
+         patch("app.chat.tool_schemas.list_servers", new=AsyncMock(return_value=[{"name": "files", "type": "mcp"}])), \
+         patch("app.chat.tool_schemas.list_cached_tools", new=AsyncMock(return_value=tools)):
+        al = await assemble_allowlist(db)
+    assert mcp_function_name("files", "get_doc") in al.specs
+    assert al.resolve(mcp_function_name("files", "delete_doc")).destructive is True
+    # disabled tools are NOT in the allowlist
+    assert mcp_function_name("files", "disabled_tool") not in al.specs
+
+@pytest.mark.asyncio
+async def test_empty_allowlist_when_nothing_enabled(db):
+    with patch("app.chat.tool_schemas.get_capabilities", new=AsyncMock(return_value={"enabled": False, "providers": []})), \
+         patch("app.chat.tool_schemas.list_servers", new=AsyncMock(return_value=[])):
+        al = await assemble_allowlist(db)
+    assert al.specs == {}
+    assert al.function_schemas() == []
+
+def test_mcp_name_roundtrip():
+    n = mcp_function_name("files", "get_doc")
+    assert parse_mcp_function_name(n) == ("files", "get_doc")
+    assert parse_mcp_function_name("verify_citations") is None
+```
+Note: `db` is the existing async session fixture; `assemble_allowlist` takes it but research/MCP enumeration is what's mocked. `list_cached_tools` is `async(db, *, provider)`.
+
+- [ ] **Step 2: Run; expect FAIL** (module missing).
+
+- [ ] **Step 3: Implement `api/app/chat/tool_schemas.py`.** Full module:
+```python
+"""Per-turn chat tool allowlist (PR5b).
+
+Assembles the closed set of function schemas the chat model may call this
+turn — fixed CourtListener research ops (when enabled) + operator-enabled
+MCP tools — and resolves a model-emitted function name back to a typed
+:class:`ToolSpec`. The allowlist IS the closed set (ADR 0015, alt A): the
+model picks among allowed tools and cannot reach beyond them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp.service import list_cached_tools, list_servers
+from app.research.service import _resolve_provider as research_resolve_provider
+from app.research.service import get_capabilities
+
+MCP_NAME_PREFIX = "mcp__"
+_MCP_SEP = "__"
+
+# Fixed CourtListener research function schemas (OpenAI `parameters` shape).
+# All are read_only. `op` is the research-service op name AND the
+# tool_call_log `tool` column value.
+RESEARCH_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "verify_citations": {
+        "description": "Verify legal citations in text against CourtListener; "
+        "returns each citation's match status.",
+        "parameters": {
+            "type": "object",
+            "properties": {"text": {"type": "string", "description": "Text containing citations."}},
+            "required": ["text"],
+        },
+    },
+    "search_case_law": {
+        "description": "Search CourtListener case law. Returns matching clusters.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "q": {"type": "string", "description": "Search query."},
+                "cursor": {"type": "string", "description": "Pagination cursor (optional)."},
+            },
+            "required": ["q"],
+        },
+    },
+    "get_cluster": {
+        "description": "Fetch a CourtListener opinion cluster's metadata and opinions by cluster id.",
+        "parameters": {
+            "type": "object",
+            "properties": {"cluster_id": {"type": "integer"}},
+            "required": ["cluster_id"],
+        },
+    },
+    "read_opinion": {
+        "description": "Read the full plaintext of a fetched opinion by opinion id "
+        "(the cluster must have been fetched via get_cluster first).",
+        "parameters": {
+            "type": "object",
+            "properties": {"opinion_id": {"type": "integer"}},
+            "required": ["opinion_id"],
+        },
+    },
+    "find_in_case": {
+        "description": "Find snippets matching a query within a fetched opinion.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "opinion_id": {"type": "integer"},
+                "query": {"type": "string"},
+                "max_matches": {"type": "integer", "default": 3},
+            },
+            "required": ["opinion_id", "query"],
+        },
+    },
+}
+RESEARCH_OPS: frozenset[str] = frozenset(RESEARCH_TOOL_SCHEMAS)
+
+
+def mcp_function_name(server: str, tool: str) -> str:
+    """Model-visible function name for an MCP tool: ``mcp__{server}__{tool}``."""
+    return f"{MCP_NAME_PREFIX}{server}{_MCP_SEP}{tool}"
+
+
+def parse_mcp_function_name(name: str) -> tuple[str, str] | None:
+    """Inverse of :func:`mcp_function_name`; returns ``(server, tool)`` or None."""
+    if not name.startswith(MCP_NAME_PREFIX):
+        return None
+    rest = name[len(MCP_NAME_PREFIX) :]
+    server, sep, tool = rest.partition(_MCP_SEP)
+    if not sep or not server or not tool:
+        return None
+    return server, tool
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    function_name: str
+    kind: Literal["research", "mcp"]
+    provider: str
+    tool: str
+    read_only: bool
+    destructive: bool
+    requires_confirmation: bool
+    parameters: dict[str, Any]
+    description: str = ""
+
+
+@dataclass
+class ChatToolAllowlist:
+    specs: dict[str, ToolSpec]
+
+    def resolve(self, function_name: str) -> ToolSpec | None:
+        return self.specs.get(function_name)
+
+    def function_schemas(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": s.function_name,
+                    "description": s.description,
+                    "parameters": s.parameters,
+                },
+            }
+            for s in self.specs.values()
+        ]
+
+
+async def assemble_allowlist(db: AsyncSession, *, request_id: str | None = None) -> ChatToolAllowlist:
+    """Build the per-turn allowlist. Empty when no research/MCP is configured."""
+    specs: dict[str, ToolSpec] = {}
+
+    caps = await get_capabilities(request_id=request_id)
+    if caps.get("enabled"):
+        provider = await research_resolve_provider(request_id=request_id)
+        for op, schema in RESEARCH_TOOL_SCHEMAS.items():
+            specs[op] = ToolSpec(
+                function_name=op,
+                kind="research",
+                provider=provider,
+                tool=op,
+                read_only=True,
+                destructive=False,
+                requires_confirmation=False,
+                parameters=schema["parameters"],
+                description=schema["description"],
+            )
+
+    for server in await list_servers(request_id=request_id):
+        name = server.get("name")
+        if not name:
+            continue
+        for t in await list_cached_tools(db, provider=name):
+            if not t.get("enabled"):
+                continue
+            fn = mcp_function_name(name, t["name"])
+            specs[fn] = ToolSpec(
+                function_name=fn,
+                kind="mcp",
+                provider=name,
+                tool=t["name"],
+                read_only=bool(t.get("read_only")),
+                destructive=bool(t.get("destructive")),
+                requires_confirmation=bool(t.get("requires_confirmation")),
+                parameters=t.get("parameters") or {"type": "object", "properties": {}},
+                description=t.get("description") or "",
+            )
+
+    return ChatToolAllowlist(specs=specs)
+```
+Note: importing the underscored `research.service._resolve_provider` mirrors `guard.py:324`'s precedent (PR5a already reaches into it). `get_capabilities` returns `{"enabled": bool, "providers": [...]}` (PR3b `/research/capabilities`).
+
+- [ ] **Step 4: Run; expect PASS.** `cd api && DATABASE_URL=... .venv/bin/pytest tests/chat/test_tool_schemas.py -v`
+
+- [ ] **Step 5: Lint + commit** (`ruff format`/`check` + `mypy app`; `git add api/app/chat/ api/tests/chat/`).
+
+---
+
+## Task 4 (api): `chat_pending_tool_call` model + migration 0054
+
+**Files:**
+- Create: `api/app/models/chat_pending_tool_call.py`
+- Create: `api/alembic/versions/0054_chat_pending_tool_call.py`
+- Modify: `api/app/models/__init__.py` (export, if the package re-exports models)
+- Test: `api/tests/test_chat_pending_tool_call_model.py`
+
+**Interfaces:**
+- Produces: `ChatPendingToolCall` ORM model (`__tablename__ = "chat_pending_tool_call"`) with columns:
+  - `id: UUID` PK (server default `gen_random_uuid()`), = the route's `pending_call_id`.
+  - `chat_id: UUID` FK `chats.id` ON DELETE CASCADE, indexed.
+  - `user_id: UUID` FK `users.id` ON DELETE CASCADE.
+  - `assistant_message_id: UUID` (the in-flight assistant message id allocated up front).
+  - `tool_call_log_id: UUID | None` FK `tool_call_log.id` ON DELETE SET NULL.
+  - `function_name: str`, `kind: str` (`research`/`mcp`), `provider: str`, `tool: str`.
+  - `destructive: bool`, `tier: int`.
+  - `tool_call_args: dict` (JSONB) — args for the pending call (a payload — deliberately OFF `tool_call_log`).
+  - `resume_state: dict` (JSONB) — `{"messages": [...openai msgs incl tool results so far...], "calls_used": int}`. Same sensitivity class as `messages.content`; stored the same way; NEVER logged.
+  - `status: str` — `pending` / `resolved` (single-use), server default `pending`.
+  - `expires_at: datetime` (TTL).
+  - `created_at`/`updated_at: datetime` (app-bumped, mirror PR5a).
+
+**Security note (record in the migration docstring):** `tool_call_args` + `resume_state` hold conversation/tool payloads needed to resume. They live here — NOT on `tool_call_log` — to preserve `tool_call_log`'s counts-only invariant. Treated like `messages.content` (the existing plaintext conversation store): never emitted to logs.
+
+- [ ] **Step 1: Failing model test:**
+```python
+import uuid
+from datetime import UTC, datetime, timedelta
+import pytest
+from app.models.chat_pending_tool_call import ChatPendingToolCall
+
+@pytest.mark.asyncio
+async def test_pending_tool_call_roundtrip(db, user, chat):  # existing fixtures
+    row = ChatPendingToolCall(
+        chat_id=chat.id, user_id=user.id, assistant_message_id=uuid.uuid4(),
+        function_name="mcp__files__delete_doc", kind="mcp", provider="files", tool="delete_doc",
+        destructive=True, tier=2, tool_call_args={"path": "/x"},
+        resume_state={"messages": [{"role": "user", "content": "hi"}], "calls_used": 1},
+        expires_at=datetime.now(UTC) + timedelta(minutes=15),
+    )
+    db.add(row)
+    await db.flush()
+    assert row.status == "pending"
+    assert row.id is not None
+```
+
+- [ ] **Step 2: Run; expect FAIL.**
+
+- [ ] **Step 3: Write the model** (mirror `api/app/models/tool_call_log.py` conventions — `Mapped`/`mapped_column`, app-bumped timestamps, `gen_random_uuid()` server default).
+
+- [ ] **Step 4: Generate the migration as 0054.** Do NOT run host alembic against the dev DB. Hand-write `0054_chat_pending_tool_call.py` (down_revision `0053`) with `op.create_table(...)`, the two FKs (`ondelete="CASCADE"` / `"SET NULL"`), an index on `chat_id`, and `op.drop_table` in `downgrade`. Match column types to the model (JSONB for the two dict columns, `server_default=sa.text("'pending'")` for `status`).
+
+- [ ] **Step 5: Run the model test against throwaway pgvector** (conftest auto-migrates to head 0054). Expect PASS.
+
+- [ ] **Step 6: Lint + commit** (`git add api/app/models/chat_pending_tool_call.py api/alembic/versions/0054_*.py api/app/models/__init__.py api/tests/test_chat_pending_tool_call_model.py`). Commit message notes migration head 0053→0054.
+
+---
+
+## Task 5 (api): the loop engine `api/app/chat/tool_loop.py`
+
+**Files:**
+- Create: `api/app/chat/tool_loop.py`
+- Modify: `api/app/config.py` — add `chat_tool_call_cap: int = 8`
+- Test: `api/tests/chat/test_tool_loop.py`
+
+**Interfaces:**
+- Consumes: Task 2 (`call_tool(user_token=)`), Task 3 (`ChatToolAllowlist`, `ToolSpec`, `parse_mcp_function_name`), `app.tools.governance.governed_tool_invocation`/`resolve_provider_tier`/`ToolTierRefused` (PR5a), `app.autonomous.guard.ToolResult`/`_args_digest`, `app.autonomous.cost.estimate_tool_cost`, `app.autonomous.enums.ToolIntent`, `app.research.service`, `app.mcp.oauth.get_valid_token`/`MCPAuthorizationRequired`.
+- Produces (all consumed by Task 6/7):
+  - Outcome dataclasses: `LoopFinal(text, usage_prompt, usage_completion, tier, provider, model, applied_skills, messages)`; `LoopConfirmation(spec, args, tier, args_summary, messages, calls_used)`; `LoopMcpAuth(server, authorize_url, messages, calls_used)`; `LoopCapReached(text, ...)` (folds into `LoopFinal` — see Step note).
+  - `async def run_chat_tool_loop(db, *, user, gateway, base_request: ChatCompletionRequest, allowlist: ChatToolAllowlist, assistant_message_id, calls_used: int = 0, cluster_cache: dict | None = None, request_id=None) -> LoopOutcome`
+  - `async def execute_tool(db, *, user, gateway, spec: ToolSpec, args: dict, cluster_cache: dict, request_id=None) -> ToolResult` — runs ONE read_only/approved call through `governed_tool_invocation` (origin="chat", max_allowed_tier=None). Raises `MCPAuthorizationRequired` for oauth-no-token, `ToolTierRefused` for tier.
+  - `def tool_result_message(tool_call_id: str, result: ToolResult) -> dict` — builds the `role="tool"` message fed back.
+
+**Design notes:**
+- The loop calls `gateway.chat_completion(base_request_with_tools, request_id=...)` (NON-streaming) each round. `base_request` is rebuilt per round with the growing `messages` list and `tools=allowlist.function_schemas()`, `tool_choice="auto"`.
+- Response: `choices[0]`. If `finish_reason != "tool_calls"` (or no `message.tool_calls`) → `LoopFinal` with `message.content`.
+- If tool_calls: for EACH call, resolve `spec = allowlist.resolve(fn_name)`.
+  - `spec is None` (model hallucinated a name) → treat as a **policy refusal**: append a `role="tool"` message `{"error": "tool not permitted"}`, continue (do NOT call the gateway). (Matches PR5a D4 "unknown MCP tool → not granted".)
+  - `spec.read_only and not spec.destructive and not spec.requires_confirmation` → `execute_tool(...)`, append the result tool message. On `ToolTierRefused` → append an error tool message and continue (the model finalizes without it). On `MCPAuthorizationRequired` → return `LoopMcpAuth`.
+  - else (`destructive` or `requires_confirmation`) → return `LoopConfirmation` (Task 6/7 persists + emits the gate). Only the FIRST such call in a round triggers the gate (process one at a time; remaining proposed calls are abandoned for this turn — document this).
+- After processing all read_only calls in a round, append the assistant tool_calls message + the tool result messages to `messages`, increment `calls_used` by the number executed, and loop. Stop when `calls_used >= settings.chat_tool_call_cap` → do ONE final gateway round WITHOUT tools (`tool_choice="none"` / omit tools) so the model finalizes with what it has → `LoopFinal`.
+- **Cluster cache:** `execute_tool` for research `get_cluster`/`read_opinion` checks/fills `cluster_cache` (keys `("cluster", id)` / `("opinion", id)`) before calling the service. Cache is request-scoped (passed in, discarded at turn end).
+- **Cost:** `estimated_cost = await estimate_tool_cost(intent, args, db)` where intent = `ToolIntent.retrieve_caselaw` (research) or `ToolIntent.call_mcp_tool` (mcp). Both are `Decimal("0")` today (DE-344) — forwarded verbatim (single-estimate invariant).
+- **`governed_tool_invocation` call** (per executed tool): `origin="chat"`, `provider=spec.provider`, `tool=spec.tool`, `intent=<the ToolIntent>`, `provider_tier=await resolve_provider_tier(spec.provider)`, `max_allowed_tier=None`, `estimated_cost=...`, `dispatch=<closure>`, `confirmation_state="not_required"` (or `"approved"` when called from resume), `user_id=user.id`, `chat_id`, `message_id=assistant_message_id`, `args_digest=_args_digest(args)`, `denied_on=()`, `span=None` (OTel for the chat tool-path is a follow-on DE — note it).
+
+- [ ] **Step 1: Failing tests** (`api/tests/chat/test_tool_loop.py`), mocking `gateway.chat_completion` to return scripted responses. Cover: (a) immediate final answer (no tools); (b) one read_only research call → execute → final; (c) MCP read_only with token threaded (assert `call_tool` got `user_token`); (d) cap reached after 8 → final-without-tools; (e) cluster cache hit (second `get_cluster` does not re-call the service); (f) `ToolTierRefused` → error tool message, loop continues; (g) destructive tool → `LoopConfirmation`; (h) MCP oauth no token → `LoopMcpAuth`. Example for (b):
+```python
+@pytest.mark.asyncio
+async def test_loop_executes_readonly_research_then_finalizes(db, user, chat):
+    gateway = AsyncMock()
+    gateway.chat_completion.side_effect = [
+        _resp_tool_call("search_case_law", {"q": "Brown"}, call_id="c1"),
+        _resp_final("Found Brown v. Board."),
+    ]
+    al = _allowlist_with_research(provider="cl-prod")  # helper
+    with patch("app.chat.tool_loop.research_service.search_case_law",
+               new=AsyncMock(return_value={"results": [{"cluster_id": 1}]})), \
+         patch("app.chat.tool_loop.resolve_provider_tier", new=AsyncMock(return_value=1)):
+        outcome = await run_chat_tool_loop(
+            db, user=user, gateway=gateway, base_request=_req([_user("find Brown")]),
+            allowlist=al, assistant_message_id=uuid.uuid4(),
+        )
+    from app.chat.tool_loop import LoopFinal
+    assert isinstance(outcome, LoopFinal)
+    assert "Brown" in outcome.text
+    # a tool_call_log row was written (governed_tool_invocation)
+    rows = (await db.execute(select(ToolCallLog).where(ToolCallLog.origin == "chat"))).scalars().all()
+    assert len(rows) == 1 and rows[0].outcome == "executed"
+```
+(`_resp_tool_call`/`_resp_final`/`_allowlist_with_research`/`_req`/`_user` are small local builders returning the api `ChatCompletionResponse` / requests.)
+
+- [ ] **Step 2: Run; expect FAIL** (module missing).
+
+- [ ] **Step 3: Add the settings field.** In `api/app/config.py` add `chat_tool_call_cap: int = 8` (operator-overridable via env, follow the module's `Settings` pattern; add a docstring referencing L4).
+
+- [ ] **Step 4: Implement `tool_loop.py`.** Build the outcome dataclasses, `execute_tool`, the research/MCP dispatch closures, and `run_chat_tool_loop` per the design notes. Research dispatch maps op→service call:
+```python
+async def _dispatch_research(db, spec, args, cluster_cache, request_id):
+    op = spec.tool
+    if op == "verify_citations":
+        data = await research_service.verify_citations(args["text"], request_id=request_id)
+    elif op == "search_case_law":
+        data = await research_service.search_case_law(args, request_id=request_id)
+    elif op == "get_cluster":
+        key = ("cluster", int(args["cluster_id"]))
+        data = cluster_cache.get(key)
+        if data is None:
+            data = await research_service.get_cluster(db, cluster_id=int(args["cluster_id"]), request_id=request_id)
+            cluster_cache[key] = data
+    elif op == "read_opinion":
+        key = ("opinion", int(args["opinion_id"]))
+        data = cluster_cache.get(key)
+        if data is None:
+            data = await research_service.read_opinion(db, opinion_id=int(args["opinion_id"]))
+            cluster_cache[key] = data
+    elif op == "find_in_case":
+        data = await research_service.find_in_case(db, opinion_id=int(args["opinion_id"]),
+                                                   query=args["query"], max_matches=int(args.get("max_matches", 3)))
+    else:
+        raise ToolNotGranted(...)
+    return ToolResult(cost_usd=Decimal("0"), data=data, outcome="success")
+```
+MCP dispatch resolves the user token then calls the gateway:
+```python
+async def _dispatch_mcp(db, user, gateway, spec, args, request_id):
+    token = await get_valid_token(db, user_id=user.id, server=spec.provider)  # may raise MCPAuthorizationRequired
+    result = await gateway.call_tool(spec.provider, spec.tool, args,
+                                     max_allowed_tier=None, user_token=token, request_id=request_id)
+    return ToolResult(cost_usd=Decimal("0"), data=result.get("payload"), outcome="success")
+```
+`execute_tool` wraps the right dispatch closure in `governed_tool_invocation`. **Important:** `get_valid_token` returns `None` for connected-but-no-token AND raises `MCPAuthorizationRequired` for not-connected — verify the exact contract (`api/app/mcp/oauth.py:370`); if it returns `None`, treat `None` (for `auth=oauth` servers) as the connect-on-demand signal and raise `MCPAuthorizationRequired` yourself. Only resolve a token when the server's `auth == "oauth"` (look up via `list_servers`/server config; for `none`/`bearer` servers pass `user_token=None`).
+
+- [ ] **Step 5: Run; expect PASS.** Iterate until all 8 scenarios pass.
+
+- [ ] **Step 6: Lint + commit.**
+
+---
+
+## Task 6 (api): integrate the loop into `send_message` (stream + non-stream) + new SSE events
+
+**Files:**
+- Modify: `api/app/api/chats.py` (`send_message` ~1118; `_stream_response` ~2269; `_non_streaming_response` ~2145)
+- Modify: response schema module — add gate fields to the non-streaming response (and a `ConfirmationRequiredPayload`/`McpAuthRequiredPayload`)
+- Test: `api/tests/integration/test_chat_tool_loop_send.py`
+
+**Interfaces:**
+- Consumes: Task 3 `assemble_allowlist`, Task 5 `run_chat_tool_loop` + outcomes.
+- Produces: behavior — when the allowlist is non-empty, `send_message` drives the loop; gates surface as terminal SSE events (`tool_confirmation_required`, `mcp_authorization_required`) on the streaming path and as JSON fields on the non-streaming path. Empty allowlist ⇒ existing code path unchanged.
+
+**SSE wire shapes** (follow the existing `data: {json}\n\n`, `separators=(',',':')` convention; both are TERMINAL — emitted then `[DONE]`, stream ends):
+```json
+{"type": "tool_confirmation_required", "lq_ai_message_id": "<uuid>",
+ "pending_call_id": "<uuid>", "provider": "files", "tool": "delete_doc",
+ "function_name": "mcp__files__delete_doc", "args_summary": {...redacted-safe...},
+ "tier": 2, "destructive": true}
+{"type": "mcp_authorization_required", "lq_ai_message_id": "<uuid>",
+ "server": "files", "authorize_url": "/api/v1/mcp/oauth/files/authorize"}
+```
+`args_summary` is a shallow, size-bounded view of the args (keys + short string values; NO large payloads) — define `_safe_args_summary(args) -> dict` in chats.py.
+
+- [ ] **Step 1: Failing integration tests** (`test_chat_tool_loop_send.py`): (a) streaming send with a research allowlist + scripted gateway → `start`/`delta`(final)/`complete`/`[DONE]`, assistant message persisted, a `tool_call_log` chat row exists; (b) streaming send proposing a destructive MCP tool → `tool_confirmation_required` terminal event, a `chat_pending_tool_call` row in `status=pending` + a `tool_call_log` row `confirmation_state=pending_confirmation outcome=pending`, NO gateway tool call executed, stream ends; (c) streaming send hitting an oauth MCP server with no token → `mcp_authorization_required` terminal event; (d) **empty allowlist → byte-identical to today** (mock `assemble_allowlist` → empty; assert the existing single-shot path runs).
+
+- [ ] **Step 2: Run; expect FAIL.**
+
+- [ ] **Step 3: Assemble the allowlist in `send_message`.** After `gw_request` is built (~1500) and before the `if payload.stream:` branch (~1536):
+```python
+    allowlist = await assemble_allowlist(db, request_id=request_id)
+```
+Thread `allowlist` into `_stream_response`/`_non_streaming_response`.
+
+- [ ] **Step 4: Branch on the allowlist inside the response helpers.** In `_stream_response._generate`, after the `start` frame: if `allowlist.specs` is empty → the EXISTING `gateway.chat_completion_stream` path (unchanged). Else → run the loop:
+```python
+            cluster_cache: dict = {}
+            outcome = await run_chat_tool_loop(
+                db, user=user, gateway=gateway, base_request=request,
+                allowlist=allowlist, assistant_message_id=assistant_message_id,
+                cluster_cache=cluster_cache, request_id=request_id,
+            )
+            # render outcome -> SSE frames (see Step 5)
+```
+Wrap loop execution in the same `try/except LQAIError` the existing path uses (a gateway failure mid-loop → the existing error frame + partial persist).
+
+- [ ] **Step 5: Render outcomes to frames.**
+  - `LoopFinal` → emit the answer as one (or chunked) `delta` frame(s) using the existing `delta` shape, set `accumulated`, then persist via `_persist_assistant_message` + `_persist_message_citations` + `_audit_message_sent` (reuse the existing tail), then the existing `complete` frame + `[DONE]`.
+  - `LoopConfirmation` → persist the `chat_pending_tool_call` row (`status=pending`, `expires_at = now + CONFIRM_TTL` [define `CONFIRM_TTL = timedelta(minutes=15)`], `resume_state={"messages": outcome.messages, "calls_used": outcome.calls_used}`, `tool_call_args=outcome.args`) AND a `tool_call_log` row via `governed_tool_invocation`-style write in `confirmation_state="pending_confirmation"`/`outcome="pending"` (call the helper with a dispatch that is never run — OR write the pending `tool_call_log` row directly; simplest: have `run_chat_tool_loop` already have written nothing for the gated call, and write both rows here). Emit `tool_confirmation_required` (with `pending_call_id = row.id`), then `[DONE]`. **Do NOT** persist a final assistant Message (resume will). Commit the session so the pending row survives the turn.
+  - `LoopMcpAuth` → emit `mcp_authorization_required`, then `[DONE]`. No persistence beyond audit.
+- [ ] **Step 6: Non-streaming path** (`_non_streaming_response`): same branch — empty allowlist → existing single `gateway.chat_completion`. Else run the loop; `LoopFinal` → existing JSON `MessagePostResponse`; `LoopConfirmation`/`LoopMcpAuth` → return a 200 JSON body carrying the gate payload (add optional `pending_tool_call: ConfirmationRequiredPayload | None` and `mcp_authorization_required: McpAuthRequiredPayload | None` fields to `MessagePostResponse`, defaulting None so the existing wire shape is preserved).
+
+- [ ] **Step 7: Persist-commit boundary.** The loop uses `governed_tool_invocation`'s flush-not-commit; the chat send path already commits at the end (verify where `send_message`/helpers commit — the existing path relies on the request-scoped session commit). Ensure the pending-row write + tool_call_log rows are committed before the stream closes (the generator must `await db.commit()` for the gate case, mirroring how the existing tail persists). Add an explicit `await db.commit()` in the gate branches.
+
+- [ ] **Step 8: Run integration tests; iterate to PASS.**
+
+- [ ] **Step 9: Lint + commit.**
+
+---
+
+## Task 7 (api): resume route `POST /api/v1/chats/{chat_id}/tool-calls/{pending_call_id}` + collision guards
+
+**Files:**
+- Modify: `api/app/api/chats.py` (new route + a shared `_resume_after_decision` helper)
+- Modify: response/request schema module — `ToolCallDecisionRequest {decision: Literal["approve","deny"]}`
+- Modify: `docs/api/backend-openapi.yaml`, `api/tests/test_openapi.py` (132→133 + `EXPECTED_PATHS`), `api/tests/test_endpoints.py` (`IMPLEMENTED_ROUTES`)
+- Test: `api/tests/integration/test_chat_tool_call_resume.py`
+
+**Interfaces:**
+- Consumes: Task 4 model, Task 5 `run_chat_tool_loop`/`execute_tool`, Task 6's outcome-rendering tail (factor the streaming-render-of-`LoopOutcome` into a reusable `_stream_loop_outcome(...)` generator so both initial send and resume share it).
+- Produces: route handler `resume_tool_call(chat_id, pending_call_id, request, user, db, gateway) -> StreamingResponse`.
+
+- [ ] **Step 1: Failing integration tests** (`test_chat_tool_call_resume.py`): (a) approve → executes the pending tool via `governed_tool_invocation` (a new `executed` tool_call_log row), feeds result, resumes loop → streamed final answer + assistant message persisted; pending row `status=resolved`. (b) deny → feeds "user denied", resumes → final answer without the tool; pending `status=resolved`; tool_call_log `confirmation_state=denied`. (c) expired (`expires_at < now`) → 409/410. (d) already-resolved (replay) → 409. (e) non-owner user → 403/404 (id-probing-safe). (f) unknown `pending_call_id` → 404.
+
+- [ ] **Step 2: Run; expect FAIL** (route missing).
+
+- [ ] **Step 3: Add `ToolCallDecisionRequest` schema** (`decision: Literal["approve","deny"]`).
+
+- [ ] **Step 4: Implement the route:**
+```python
+@router.post(
+    "/{chat_id}/tool-calls/{pending_call_id}",
+    response_model=None,
+    summary="Approve or deny a pending destructive chat tool-call; resumes the turn",
+)
+async def resume_tool_call(
+    chat_id: str, pending_call_id: str, request: Request, user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    gateway: Annotated[GatewayClient, Depends(get_gateway_client)],
+) -> StreamingResponse:
+    cid = _validate_chat_id(chat_id)
+    pid = _validate_uuid(pending_call_id)  # 404 on malformed
+    chat = await _load_visible_chat(db, cid, user.id, include_archived=False)  # 404 cross-user
+    body = ToolCallDecisionRequest.model_validate(await request.json())
+
+    pending = (await db.execute(
+        select(ChatPendingToolCall).where(
+            ChatPendingToolCall.id == pid,
+            ChatPendingToolCall.chat_id == cid,
+            ChatPendingToolCall.user_id == user.id,  # owner-scoped (id-probing-safe)
+        )
+    )).scalar_one_or_none()
+    if pending is None:
+        raise NotFound("pending tool-call not found")
+    if pending.status != "pending":
+        raise Conflict("tool-call already resolved")          # 409
+    if pending.expires_at < datetime.now(UTC):
+        pending.status = "resolved"; await db.commit()
+        raise Conflict("tool-call confirmation expired")       # 409 (or Gone/410)
+    pending.status = "resolved"  # single-use: mark before doing work
+    await db.flush()
+    # ... build messages from resume_state; on approve execute_tool + append result,
+    #     on deny append a denial tool message; then resume run_chat_tool_loop and
+    #     stream the outcome via the shared _stream_loop_outcome generator.
+```
+On **approve**: reconstruct the `ChatToolAllowlist` (re-`assemble_allowlist`) to resolve the spec for the pending `function_name`; `execute_tool(...)` with `confirmation_state="approved"`; append the tool result message; resume `run_chat_tool_loop` with `messages=resume_state["messages"] + [assistant_tool_call_msg, tool_result_msg]`, `calls_used=resume_state["calls_used"]`. On **deny**: append a `role="tool"` message `{"error": "user denied this tool call"}` for the pending call id; resume so the model finalizes. Both return a `StreamingResponse` wrapping `_stream_loop_outcome`. Commit at the end (as the streaming tail does).
+
+- [ ] **Step 5: Collision guards.** Add the path to `IMPLEMENTED_ROUTES` (`test_endpoints.py`), bump the pinned count + add to `EXPECTED_PATHS` (`test_openapi.py`, 132→133), add the path to `docs/api/backend-openapi.yaml` (request body `ToolCallDecisionRequest`; response: `text/event-stream`). Run `tests/test_openapi.py` (authoritative — don't eyeball the YAML).
+
+- [ ] **Step 6: Run resume tests + the openapi/endpoints guards; iterate to PASS.**
+
+- [ ] **Step 7: Lint + commit.**
+
+---
+
+## Task 8 (api+gateway): full-suite verification, DE notes, ship
+
+**Files:** none new (verification + docs).
+
+- [ ] **Step 1: Full api suite** against :15433:
+```bash
+cd api && DATABASE_URL='postgresql+asyncpg://lq_ai:test@127.0.0.1:15433/lq_ai' .venv/bin/pytest -q
+```
+Expected: all pass (baseline was 2159 pass/1 skip after PR5a; this PR adds tests). Confirm `test_openapi.py`/`test_endpoints.py` collection-guards pass (path count 133).
+- [ ] **Step 2: Full gateway suite + both lints + mypy:**
+```bash
+cd gateway && .venv/bin/pytest -q && .venv/bin/ruff format --check . && .venv/bin/ruff check . && .venv/bin/mypy app
+cd ../api && .venv/bin/ruff format --check . && .venv/bin/ruff check . && .venv/bin/mypy app
+```
+- [ ] **Step 3: DE notes (PRD §9).** File/append: **chat tool-path OTel** (the loop passes `span=None`; the `chat.tool_call` domain span is deferred — fold into the standing tool-path-OTel DE). Note **DE-341** (retire the OpenWebUI `web/.../utils/mcp/client.py` stub) is now unblocked for PR6 (chat path is gateway-brokered). Note the **multi-call-per-round** abandonment (only the first destructive call in a round gates; siblings abandoned) and the **non-streaming-final** UX (no token streaming on tool-using turns) as accepted v1 behavior / candidate DEs. Note **per-chat cost cap** remains a DE (v1 bounds by the per-turn cap).
+- [ ] **Step 4: Update the milestone memory + write a handoff** (`docs/LQVern/HANDOFF-...-pr6-next.md`) after merge. Record: migration head 0054, `EXPECTED_PATHS` 133, the new route, the `chat_pending_tool_call` table, and PR6 = transparency surfaces (see `[[project-pr6-transparency-posture-narrative]]`).
+- [ ] **Step 5: Push both remotes, open the PR vs `main`, attach the security-review context, request Kevin's review.** Do NOT self-merge (security-gated). After Kevin merges, sync `tucuxi/main` to the squash SHA.
+
+---
+
+## Self-Review (run before dispatching execution)
+
+**Spec coverage (§PR5b):** Gateway `tools`/`tool_choice` passthrough → Task 1 ✓. Allowlist assembly (research/MCP/mixed/empty) → Task 3 ✓. The loop + per-turn cap + cluster cache → Task 5 ✓. Connect-on-demand (`mcp_authorization_required`) → Tasks 5/6 ✓. Confirmation gate persist-and-resume (SSE event + POST resume, single-use+TTL) → Tasks 4/6/7 ✓. Surface/collision guards (`EXPECTED_PATHS` +1) → Task 7 ✓. PR5b tests (happy/MCP-token/allowlist variants/cap/cache/passthrough/gate-cycle/tier-refusal/no-payload) → distributed across Tasks 1,3,5,6,7 ✓. Cross-cutting (tier ceiling, audit layering, no raw payloads) → `max_allowed_tier=None` (Fork 2, documented), `tool_call_log` counts-only + payloads only in `chat_pending_tool_call` ✓.
+
+**Open items pinned:** per-adapter forwarding (Task 1 — Anthropic is the only gap; OpenAI/Ollama verified) ✓; resume-state shape (Task 4 — `resume_state` JSONB on a dedicated table) ✓; migration number (0054) + `EXPECTED_PATHS` (132→133) ✓; gateway passthrough as PR5b's first task ✓.
+
+**Deviations to call out in the PR description:** (1) `max_allowed_tier=None` deviates from the spec's cross-cutting "compute+thread a ceiling" — gateway egress-tier policy is the authority (Fork 2, Kevin-approved). (2) Tool-using turns emit the final answer as delta frame(s), not token-streamed (Fork 1, Kevin-approved). (3) Only the first destructive call in a round triggers the gate; sibling proposed calls are abandoned that turn.

--- a/gateway/app/providers/anthropic.py
+++ b/gateway/app/providers/anthropic.py
@@ -348,19 +348,18 @@ def _to_anthropic_request(
     * ``messages[role=system]`` are pulled out and concatenated into the
       top-level ``system`` string.
     * ``messages[role=user|assistant]`` keep their order. Tool messages
-      are passed through as ``role="user"`` with content blocks shaped
-      ``{"type": "tool_result", ...}``; tool-call assistant messages are
-      currently passed through as text only (see DE note below).
+      are translated to ``role="user"`` with ``tool_result`` content blocks.
+      Assistant messages with ``tool_calls`` are translated to ``role="assistant"``
+      with ``tool_use`` content blocks so a follow-up ``tool_result`` is accepted.
+    * ``tools`` (OpenAI ``{type:function,function:{name,description,parameters}}``)
+      are translated to Anthropic ``{name,description,input_schema}`` and forwarded.
+      ``tool_choice`` is mapped: ``auto``->``{type:auto}``, ``required``->``{type:any}``,
+      ``none``->drop tools, forced function->``{type:tool,name}``.
     * ``max_tokens`` is required by Anthropic; we substitute
       :data:`DEFAULT_MAX_TOKENS` if the caller omits it.
     * ``temperature`` and ``top_p`` are forwarded if set; otherwise
       Anthropic uses its defaults.
     * ``stop`` (OpenAI) becomes ``stop_sequences`` (Anthropic, list-only).
-
-    Tool calls (DE-XXX, future): full OpenAI tool-call/tool-result bridging
-    requires translating to Anthropic's ``tool_use``/``tool_result``
-    content blocks. B3 ships text-only translation; tool-call coverage
-    arrives with the skills work in M1 Phase C.
     """
 
     system_chunks: list[str] = []
@@ -387,7 +386,29 @@ def _to_anthropic_request(
                 }
             )
             continue
-        # user / assistant
+        if msg.role == "assistant" and msg.tool_calls:
+            # Round-trip the assistant tool_use turn as Anthropic content
+            # blocks so a follow-up tool_result is accepted.
+            content_blocks: list[dict[str, Any]] = []
+            if msg.content:
+                content_blocks.append({"type": "text", "text": msg.content})
+            for tc in msg.tool_calls:
+                fn = tc.get("function", {})
+                try:
+                    parsed_input = json.loads(fn.get("arguments") or "{}")
+                except (ValueError, TypeError):
+                    parsed_input = {}
+                content_blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": tc.get("id", ""),
+                        "name": fn.get("name", ""),
+                        "input": parsed_input,
+                    }
+                )
+            chat_messages.append({"role": "assistant", "content": content_blocks})
+            continue
+        # user / assistant (no tool_calls)
         chat_messages.append({"role": msg.role, "content": content})
 
     body: dict[str, Any] = {
@@ -406,6 +427,36 @@ def _to_anthropic_request(
         body["stop_sequences"] = (
             [request.stop] if isinstance(request.stop, str) else list(request.stop)
         )
+    # PR5b: forward tools / tool_choice (OpenAI shape -> Anthropic shape).
+    extra = request.model_extra or {}
+    raw_tools = request.tools if request.tools is not None else extra.get("tools")
+    if raw_tools:
+        anthropic_tools: list[dict[str, Any]] = []
+        for t in raw_tools:
+            fn = t.get("function", t) if isinstance(t, dict) else {}
+            anthropic_tools.append(
+                {
+                    "name": fn.get("name", ""),
+                    "description": fn.get("description", "") or "",
+                    "input_schema": fn.get("parameters") or {"type": "object", "properties": {}},
+                }
+            )
+        body["tools"] = anthropic_tools
+
+        raw_choice = (
+            request.tool_choice if request.tool_choice is not None else extra.get("tool_choice")
+        )
+        if raw_choice is None or raw_choice == "auto":
+            body["tool_choice"] = {"type": "auto"}
+        elif raw_choice == "none":
+            # Anthropic has no "none"; honor by dropping tools entirely.
+            body.pop("tools", None)
+        elif raw_choice == "required":
+            body["tool_choice"] = {"type": "any"}
+        elif isinstance(raw_choice, dict):
+            fn_choice = raw_choice.get("function", {})
+            if fn_choice.get("name"):
+                body["tool_choice"] = {"type": "tool", "name": fn_choice["name"]}
     return body
 
 
@@ -426,6 +477,22 @@ def _from_anthropic_response(
             text_parts.append(str(block.get("text", "")))
     text = "".join(text_parts)
 
+    # PR5b: extract tool_use blocks into OpenAI-shaped tool_calls.
+    tool_calls: list[dict[str, Any]] = []
+    for block in blocks:
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            tool_calls.append(
+                {
+                    "id": str(block.get("id", "")),
+                    "type": "function",
+                    "function": {
+                        "name": str(block.get("name", "")),
+                        # OpenAI tool_calls carry arguments as a JSON STRING.
+                        "arguments": json.dumps(block.get("input") or {}),
+                    },
+                }
+            )
+
     stop_reason_raw = payload.get("stop_reason")
     finish_reason: FinishReason | None = None
     if isinstance(stop_reason_raw, str):
@@ -443,6 +510,11 @@ def _from_anthropic_response(
     # when present so downstream consumers see what actually ran.
     response_model = str(payload.get("model") or requested_model)
 
+    message = ChatCompletionMessage(
+        role="assistant",
+        content=text or None,
+        tool_calls=tool_calls or None,
+    )
     return ChatCompletionResponse(
         id=response_id,
         created=int(time.time()),
@@ -450,7 +522,7 @@ def _from_anthropic_response(
         choices=[
             ChatCompletionChoice(
                 index=0,
-                message=ChatCompletionMessage(role="assistant", content=text),
+                message=message,
                 finish_reason=finish_reason,
             )
         ],

--- a/gateway/app/providers/ollama.py
+++ b/gateway/app/providers/ollama.py
@@ -472,12 +472,17 @@ def _to_ollama_request(
     # Tool calls / tool choice forward through ``tools`` per Ollama's
     # 0.4+ tool-use surface. The OpenAI ``tools`` schema maps directly:
     # both use the OpenAI tool-definition shape. ``tool_choice``
-    # similarly forwards verbatim.
+    # similarly forwards verbatim.  Prefer the explicit typed field
+    # (PR5b added ``tools``/``tool_choice`` as first-class fields on
+    # ``ChatCompletionRequest``); fall back to ``model_extra`` so legacy
+    # callers that passed them as unknown extras still work.
     extra = request.model_extra or {}
-    tools = extra.get("tools")
+    tools = request.tools if request.tools is not None else extra.get("tools")
     if tools is not None:
         body["tools"] = tools
-    tool_choice = extra.get("tool_choice")
+    tool_choice = (
+        request.tool_choice if request.tool_choice is not None else extra.get("tool_choice")
+    )
     if tool_choice is not None:
         body["tool_choice"] = tool_choice
 

--- a/gateway/app/providers/openai_schema.py
+++ b/gateway/app/providers/openai_schema.py
@@ -166,6 +166,17 @@ class ChatCompletionRequest(BaseModel):
     multiplies cost without a corresponding skill use case (PRD §7).
     """
 
+    # --- Function/tool calling (PR5b) ---------------------------------------
+    tools: list[dict[str, Any]] | None = None
+    """OpenAI-style tool/function declarations. Forwarded to the provider
+    so the model may emit ``tool_calls``. The backend assembles a closed
+    allowlist per turn (research + operator-enabled MCP tools); the
+    gateway's egress-tier / SSRF guards still gate the eventual call."""
+
+    tool_choice: str | dict[str, Any] | None = None
+    """OpenAI-style tool_choice (``"auto"`` / ``"none"`` / a forced
+    function). Forwarded verbatim to providers that support it."""
+
     # --- LQ.AI extensions (per gateway-openapi.yaml) -------------------------
     minimum_inference_tier: int | None = Field(default=None, ge=1, le=5)
     """D1: per-call request override of the tier floor. The most restrictive

--- a/gateway/tests/test_anthropic_adapter.py
+++ b/gateway/tests/test_anthropic_adapter.py
@@ -562,3 +562,186 @@ def test_from_config_succeeds_with_env_set() -> None:
     )
     adapter = AnthropicAdapter.from_config(provider, env={"ANTHROPIC_API_KEY": "sk-ant-x"})
     assert adapter.name == "anthropic-test"
+
+
+# --- PR5b: tools / tool_choice forwarding + tool_use bridging ----------------
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_anthropic_forwards_tools_and_surfaces_tool_calls() -> None:
+    """PR5b Step 5/6: gateway forwards OpenAI-shaped tools to Anthropic and
+    translates the ``tool_use`` response into OpenAI ``tool_calls``."""
+
+    captured: dict[str, object] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        import json as _j
+
+        captured["body"] = _j.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "content": [
+                    {"type": "text", "text": "Let me check."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "verify_citations",
+                        "input": {"text": "Brown v. Board"},
+                    },
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(side_effect=_capture)
+
+    adapter = _make_adapter()
+    try:
+        req = ChatCompletionRequest(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "verify this"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "verify_citations",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"text": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            tool_choice="auto",
+        )
+        resp = await adapter.chat_completion(req, model="claude-sonnet-4-6", stream=False)
+    finally:
+        await adapter.aclose()
+
+    # Request side: Anthropic-shaped tools forwarded.
+    body = captured["body"]
+    assert isinstance(body, dict)
+    assert body["tools"][0]["name"] == "verify_citations"
+    assert "input_schema" in body["tools"][0]
+    assert body["tool_choice"] == {"type": "auto"}
+
+    # Response side: tool_use -> OpenAI tool_calls.
+    msg = resp.choices[0].message
+    assert resp.choices[0].finish_reason == "tool_calls"
+    assert msg.tool_calls is not None
+    assert msg.tool_calls[0]["id"] == "toolu_1"
+    assert msg.tool_calls[0]["function"]["name"] == "verify_citations"
+    import json as _j
+
+    assert _j.loads(msg.tool_calls[0]["function"]["arguments"]) == {"text": "Brown v. Board"}
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_anthropic_round_trips_assistant_tool_use_for_follow_up() -> None:
+    """PR5b Step 10: multi-hop — assistant tool_use turn round-trips back to
+    Anthropic so the follow-up tool_result is accepted, returning stop."""
+
+    call_count = 0
+
+    def _two_shot(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        body = json.loads(request.content)
+        if call_count == 1:
+            # First call: return tool_use
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg_2",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": "tool_use",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_2",
+                            "name": "verify_citations",
+                            "input": {"text": "Plessy v. Ferguson"},
+                        }
+                    ],
+                    "usage": {"input_tokens": 8, "output_tokens": 4},
+                },
+            )
+        # Second call: verify the assistant turn contains tool_use block
+        msgs = body.get("messages", [])
+        assistant_msgs = [m for m in msgs if m.get("role") == "assistant"]
+        assert any(
+            isinstance(m.get("content"), list)
+            and any(b.get("type") == "tool_use" for b in m["content"])
+            for m in assistant_msgs
+        ), "assistant tool_use block missing from second Anthropic call"
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_3",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Confirmed."}],
+                "usage": {"input_tokens": 20, "output_tokens": 3},
+            },
+        )
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(side_effect=_two_shot)
+
+    adapter = _make_adapter()
+    try:
+        # --- First turn: user asks, model returns tool_use ---
+        req1 = ChatCompletionRequest(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "verify this"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "verify_citations",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            tool_choice="auto",
+        )
+        resp1 = await adapter.chat_completion(req1, model="claude-sonnet-4-6", stream=False)
+        assert resp1.choices[0].finish_reason == "tool_calls"
+        tool_calls = resp1.choices[0].message.tool_calls
+        assert tool_calls is not None
+
+        # --- Second turn: include assistant tool_use + tool_result ---
+        req2 = ChatCompletionRequest(
+            model="claude-sonnet-4-6",
+            messages=[
+                {"role": "user", "content": "verify this"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": tool_calls,
+                },
+                {
+                    "role": "tool",
+                    "content": "Citation verified.",
+                    "tool_call_id": tool_calls[0]["id"],
+                },
+            ],
+        )
+        resp2 = await adapter.chat_completion(req2, model="claude-sonnet-4-6", stream=False)
+    finally:
+        await adapter.aclose()
+
+    assert resp2.choices[0].finish_reason == "stop"
+    assert resp2.choices[0].message.content == "Confirmed."
+    assert call_count == 2

--- a/gateway/tests/test_ollama_adapter.py
+++ b/gateway/tests/test_ollama_adapter.py
@@ -313,7 +313,11 @@ def test_to_ollama_request_stream_flag_forwarded() -> None:
 @pytest.mark.unit
 def test_to_ollama_request_forwards_tools_and_tool_choice() -> None:
     """``tools`` and ``tool_choice`` (extension fields) forward verbatim
-    to Ollama's 0.4+ tool-use surface."""
+    to Ollama's 0.4+ tool-use surface.
+
+    PR5b regression pin: tools/tool_choice must survive the explicit field
+    promotion in ``ChatCompletionRequest`` and still reach the upstream body.
+    """
 
     raw = {
         "model": "llama3.1",
@@ -333,7 +337,7 @@ def test_to_ollama_request_forwards_tools_and_tool_choice() -> None:
     req = ChatCompletionRequest.model_validate(raw)
     body = _to_ollama_request(req, model="llama3.1", stream=False)
     assert body["tools"][0]["function"]["name"] == "get_time"
-    assert body["tool_choice"] == "auto"
+    assert body["tool_choice"] == "auto"  # PR5b regression pin
 
 
 @pytest.mark.unit

--- a/gateway/tests/test_openai_adapter.py
+++ b/gateway/tests/test_openai_adapter.py
@@ -834,3 +834,63 @@ async def test_health_check_auth_rejected() -> None:
             await client.aclose()
     assert health.reachable is True
     assert "auth" in (health.error or "").lower()
+
+
+# --- PR5b regression: tools / tool_choice passthrough -----------------------
+
+
+@pytest.mark.unit
+async def test_chat_completion_forwards_tools_and_tool_choice_to_openai() -> None:
+    """PR5b regression: ``tools`` and ``tool_choice`` set on the request
+    appear verbatim in the upstream body sent to the OpenAI-compatible
+    provider.  They must not be stripped by the LQ.AI extension-key filter."""
+
+    payload = {
+        "id": "chatcmpl-t1",
+        "object": "chat.completion",
+        "created": 1715000000,
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_time", "arguments": "{}"},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    with respx.mock(base_url="https://api.openai.com/v1") as router:
+        route = router.post("/chat/completions").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        client = httpx.AsyncClient(base_url="https://api.openai.com/v1")
+        try:
+            adapter = OpenAIAdapter(
+                name="openai-prod",
+                base_url="https://api.openai.com/v1",
+                api_key="sk-test",
+                client=client,
+            )
+            request = ChatCompletionRequest(
+                model="gpt-4o",
+                messages=[ChatCompletionMessage(role="user", content="what time is it?")],
+                tools=[{"type": "function", "function": {"name": "get_time", "parameters": {}}}],
+                tool_choice="auto",
+            )
+            await adapter.chat_completion(request, model="gpt-4o", stream=False)
+        finally:
+            await client.aclose()
+    sent = json.loads(route.calls.last.request.content)
+    # Regression pin: tools/tool_choice must appear in the upstream body.
+    assert "tools" in sent and sent["tools"][0]["function"]["name"] == "get_time"
+    assert sent["tool_choice"] == "auto"

--- a/gateway/tests/test_openai_schema.py
+++ b/gateway/tests/test_openai_schema.py
@@ -1,0 +1,30 @@
+"""Unit tests for :mod:`app.providers.openai_schema`.
+
+Covers ``ChatCompletionRequest`` field acceptance, ``model_dump`` round-trips,
+and the explicit ``tools``/``tool_choice`` fields added in PR5b.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.providers.openai_schema import ChatCompletionRequest
+
+
+@pytest.mark.unit
+def test_chat_completion_request_accepts_tools_and_tool_choice() -> None:
+    """PR5b: ``tools`` and ``tool_choice`` are explicit typed fields on
+    :class:`ChatCompletionRequest`.  They must be accessible as attributes
+    (not buried in ``model_extra``) and survive a ``model_dump`` round-trip."""
+
+    req = ChatCompletionRequest(
+        model="smart",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "verify_citations", "parameters": {}}}],
+        tool_choice="auto",
+    )
+    assert req.tools is not None and req.tools[0]["function"]["name"] == "verify_citations"
+    assert req.tool_choice == "auto"
+    # Round-trips through model_dump (the OpenAI adapter serializes this).
+    dumped = req.model_dump(mode="json", exclude_none=True)
+    assert "tools" in dumped and "tool_choice" in dumped


### PR DESCRIPTION
## PR5b / WS4 — Governed chat tool-loop + persist-and-resume confirmation gate

Discharges [ADR 0015](docs/adr/0015-governed-tool-calling-model.md) (governed tool-calling) + proposal WS4. Built on merged PR1–PR5a (gateway egress boundary, CourtListener research, MCP + per-user OAuth, the PR5a governance substrate). **Backend-only** (UI = PR6). Spec: `docs/superpowers/specs/2026-06-18-pr5-governed-chat-tool-loop-design.md` (§PR5b). Plan: `docs/superpowers/plans/2026-06-19-pr5b-chat-tool-loop.md`.

Gives interactive chat a real multi-step tool-calling loop over an **operator-enabled allowlist** (the closed set, per ADR 0015 alt A) of CourtListener + MCP tools, each call governed per-call (tier → cost → audit) through PR5a's `governed_tool_invocation` **reused unmodified**, with a **human confirmation gate** for destructive tools.

### 🔒 Security review focus (this PR is security-gated)
- **`gateway/**` change (the only one):** `openai_schema.py` adds `tools`/`tool_choice`; `anthropic.py` forwards request tools (OpenAI→Anthropic `input_schema`/`tool_choice` mapping) and extracts **non-streaming** `tool_use`→`tool_calls` + round-trips the assistant tool_use turn. The streaming path is untouched (the loop uses non-streaming rounds — Fork-1). OpenAI/Ollama already forwarded tools.
- **No raw payloads, ever:** tool args reach `tool_call_log` only as `_args_digest` (a hash of key-names/types); tool **results** flow into the conversation but never into an audit row or log line; the per-user OAuth token travels only as the `X-LQ-AI-User-Token` header.
- **Confirmation gate = persist-and-resume, single-use under concurrency:** destructive/`requires_confirmation` tools never auto-execute; the gate persists a `chat_pending_tool_call` row (15-min TTL) + a counts-only `tool_call_log` row, emits a terminal `tool_confirmation_required` SSE event, and ends the turn. The resume route claims the pending row with an **atomic conditional `UPDATE ... WHERE status='pending' AND expires_at>=now` committed BEFORE any tool execution** (no double-execution under concurrent replay), owner-scoped (non-owner → 404, id-probing-safe).
- **`max_allowed_tier=None` (Fork-2):** mirrors the autonomous path; the gateway's per-provider egress-tier policy is the enforcement authority (deviation from the spec's cross-cutting note, Kevin-approved).
- **Empty allowlist ⇒ byte-for-byte the existing chat path** (deployments without research/MCP see zero change).

### What's in it
1. **Gateway** `tools`/`tool_choice` passthrough + Anthropic non-streaming tool_use bridging.
2. **Allowlist assembly** (`app/chat/tool_schemas.py`): 5 fixed research schemas (when CourtListener enabled) + enabled MCP tools (`mcp__{server}__{tool}`).
3. **The loop** (`app/chat/tool_loop.py`): non-streaming rounds; read_only tools execute inline via `governed_tool_invocation`; per-turn cap 8 (counts governed calls; terminates on a hallucination-only round); request-scoped cluster cache; connect-on-demand (`mcp_authorization_required` SSE for oauth servers with no token).
4. **Integration** into `send_message` (stream + non-stream) + the two terminal SSE events.
5. **Resume route** `POST /api/v1/chats/{chat_id}/tool-calls/{pending_call_id}` `{decision: approve|deny}`.
6. **Migration 0054** (`chat_pending_tool_call`); `EXPECTED_PATHS` 132→133.

### Gates (run locally)
- Gateway: **701 passed / 3 skipped**, ruff + mypy `--strict` clean.
- API: **2201 passed / 1 skipped**, ruff + mypy clean.

### Process
Built subagent-driven (8 tasks, per-task spec+quality review). The **opus whole-branch review caught one Critical** (resume fed an orphaned `role="tool"` message with no preceding assistant `tool_calls` turn → real providers 400; passed tests only because the mock gateway didn't enforce tool_use/tool_result pairing) — fixed by reconstructing the assistant turn with a matching `tool_call_id`, now locked by approve+deny pairing tests. Per-task reviews also fixed: cap-counting semantics + termination guard, the gate-persist error frame, and the concurrency-safe atomic claim + `confirmation_state="approved"` audit row.

### Deferred (PRD §9)
DE-345 (shared `_stream_loop_outcome` refactor), DE-346 (`find_in_case` result-shape unification), DE-347 (chat tool-path OTel span), DE-348 (expired-gate audit resolution), DE-349 (merge consecutive Anthropic `tool_result` messages for multi-read-only-tool rounds). DE-341 (retire the OpenWebUI MCP stub) is now unblocked for PR6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
