### PR TITLE
fix(ingest): mark file failed on parse timeout instead of stuck in processing (DE-351)

### DIFF
--- a/api/app/pipeline/ingest.py
+++ b/api/app/pipeline/ingest.py
@@ -187,12 +187,43 @@ async def ingest_file(
         )
         raise
 
-    # ---- Run parsers in a thread (sync libraries).
+    # ---- Run parsers in a thread (sync libraries), bounded by an in-job
+    # soft timeout. A slow first-run docling model download (~hundreds of MB
+    # on first use) can otherwise blow past arq's hard ``job_timeout``, which
+    # kills the worker mid-parse and leaves the row stuck in ``processing``
+    # with an empty ``ingestion_error`` — a UI polling for ``ready`` then
+    # spins forever (DE-351). The arq job_timeout is set strictly higher
+    # (see ``WorkerSettings`` in ``app.workers.document_pipeline``) so this
+    # soft path wins the race and can persist a terminal ``failed`` row.
+    # The orphaned worker thread finishes its download in the background, so
+    # a retry once the models are cached succeeds.
     try:
-        parsed = await asyncio.to_thread(
-            parse_pdf,
-            pdf_bytes,
-            run_docling=settings.lq_ai_docling_enabled,
+        parsed = await asyncio.wait_for(
+            asyncio.to_thread(
+                parse_pdf,
+                pdf_bytes,
+                run_docling=settings.lq_ai_docling_enabled,
+            ),
+            timeout=settings.lq_ai_docling_timeout_seconds,
+        )
+    except TimeoutError:
+        await _mark_failed(
+            db,
+            row,
+            error="ingestion_timeout",
+            reason=(
+                f"parse exceeded {settings.lq_ai_docling_timeout_seconds}s "
+                "(a first-run docling model download can exceed the budget; "
+                "retry once models are cached — DE-351)"
+            ),
+        )
+        return IngestResult(
+            file_id=file_id,
+            status="failed",
+            document_id=None,
+            chunk_count=0,
+            parser=None,
+            error="ingestion_timeout",
         )
     except ParserUnsupported as exc:
         await _mark_failed(db, row, error="unsupported_content", reason=str(exc))

--- a/api/app/workers/document_pipeline.py
+++ b/api/app/workers/document_pipeline.py
@@ -50,6 +50,13 @@ from app.workers.user_export import export_gc_job, export_user_data_job
 
 log = logging.getLogger(__name__)
 
+# DE-351: arq's hard ``job_timeout`` is set strictly ABOVE the in-job docling
+# soft timeout (``app.pipeline.ingest`` wraps the parse in ``asyncio.wait_for``
+# at ``lq_ai_docling_timeout_seconds``). The buffer guarantees the soft path
+# fires first and can persist a terminal ``failed`` row, rather than arq
+# killing the worker mid-parse and leaving the file stuck in ``processing``.
+_ARQ_JOB_TIMEOUT_BUFFER_SECONDS = 60
+
 
 # ---------------------------------------------------------------------------
 # Job functions
@@ -266,7 +273,9 @@ class WorkerSettings:
             "on_shutdown": cls.on_shutdown,
             "redis_settings": _build_redis_settings(),
             "max_jobs": settings.lq_ai_ingest_worker_concurrency,
-            "job_timeout": settings.lq_ai_docling_timeout_seconds,
+            "job_timeout": (
+                settings.lq_ai_docling_timeout_seconds + _ARQ_JOB_TIMEOUT_BUFFER_SECONDS
+            ),
             # arq's queue-name default is "arq:queue"; we override
             # only if a future config wants to namespace.
         }
@@ -288,7 +297,9 @@ def _populate_class_attrs() -> None:
         WorkerSettings.cron_jobs = _build_cron_jobs()  # type: ignore[attr-defined]
         settings = get_settings()
         WorkerSettings.max_jobs = settings.lq_ai_ingest_worker_concurrency  # type: ignore[attr-defined]
-        WorkerSettings.job_timeout = settings.lq_ai_docling_timeout_seconds  # type: ignore[attr-defined]
+        WorkerSettings.job_timeout = (  # type: ignore[attr-defined]
+            settings.lq_ai_docling_timeout_seconds + _ARQ_JOB_TIMEOUT_BUFFER_SECONDS
+        )
     except ImportError:  # pragma: no cover - arq missing in some envs
         pass
 

--- a/api/tests/test_pipeline_ingest.py
+++ b/api/tests/test_pipeline_ingest.py
@@ -396,6 +396,53 @@ async def test_ingest_corrupt_pdf_marks_failed(
 
 
 @pytest.mark.integration
+async def test_ingest_parse_timeout_marks_failed(
+    db_session: AsyncSession,
+    db_user: User,
+    fake_s3: FakeS3Client,
+    patched_storage: FakeS3Client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parse that exceeds the docling soft timeout flips the row to
+    ``failed`` with ``ingestion_timeout`` — never left stuck in
+    ``processing`` (DE-351 regression)."""
+
+    import time
+
+    from app.config import get_settings
+
+    settings = get_settings()
+    # Tiny soft timeout so the test is fast; the fake parser blocks past it.
+    monkeypatch.setattr(settings, "lq_ai_docling_timeout_seconds", 1)
+
+    def _slow_parse(*args: object, **kwargs: object) -> object:
+        # Blocks the worker thread well past the 1s soft timeout, standing
+        # in for a slow first-run docling model download.
+        time.sleep(3)
+        return None
+
+    monkeypatch.setattr("app.pipeline.ingest.parse_pdf", _slow_parse)
+
+    storage_key = f"{uuid.uuid4()}"
+    _put_in_fake_s3(fake_s3, storage_key, b"%PDF-1.4 fake")
+
+    file_row = await _create_file_row(
+        db_session,
+        db_user,
+        storage_path=storage_key,
+        pdf_bytes=b"%PDF-1.4 fake",
+    )
+
+    result = await ingest_file(db_session, file_row.id)
+    assert result.status == "failed"
+    assert result.error == "ingestion_timeout"
+
+    await db_session.refresh(file_row)
+    assert file_row.ingestion_status == "failed"
+    assert file_row.ingestion_error == "ingestion_timeout"
+
+
+@pytest.mark.integration
 async def test_ingest_soft_deleted_row_skipped(
     db_session: AsyncSession,
     db_user: User,


### PR DESCRIPTION
## DE-351 — first-run document ingestion left files stuck in `processing`

Found during the **v0.5.0 release-readiness fresh-clone verification**.

**Symptom:** on a fresh deployment the *first* PDF upload fails — docling downloads ~696 MB of HuggingFace layout/OCR models on first use, which exceeds the arq `job_timeout` (`lq_ai_docling_timeout_seconds`, default 300 s). arq hard-kills the worker mid-parse (`CancelledError`), which bypasses the `except ParserError` handlers in `ingest_file`, so the file is left stuck in `processing` with an empty `ingestion_error`. A UI polling for `ready` then spins forever. (A second upload, models now cached, ingests in <6 s — the pipeline itself is sound.)

**Fix (the stuck-state half of DE-351):**
- Wrap the `parse_pdf` thread call in an in-job `asyncio.wait_for` soft timeout (`lq_ai_docling_timeout_seconds`). On `TimeoutError`, mark the file `failed` with `ingestion_error='ingestion_timeout'` and return a failed `IngestResult` — a terminal, visible state.
- Bump arq's hard `job_timeout` to `soft + 60 s` so the soft path wins the race and can persist the row before arq kills the worker.
- The orphaned worker thread finishes its download in the background, so a retry once models are cached succeeds.

**Regression test:** `test_ingest_parse_timeout_marks_failed` — a parse that blocks past a tiny soft timeout flips the row to `failed`/`ingestion_timeout` (not stuck in `processing`).

**Out of scope (deferred, the larger half of DE-351):** pre-warming / baking docling models into the `ingest-worker` image so the first PDF doesn't time out at all. Tracked in PRD §9 DE-351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)