### PR TITLE
chore(release): bump api + gateway __version__ 0.4.2 → 0.5.0

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI backend API service."""
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"

--- a/gateway/app/__init__.py
+++ b/gateway/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI Inference Gateway."""
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"


### PR DESCRIPTION
Release version bump for **v0.5.0** — the gateway-brokered legal-research + connectors (MCP) milestone (#158–#193) plus the release-readiness verification pass (#195 docs reconciliation, #196 DE-351 fix).

Tag `v0.5.0` on this commit once merged → `release.yml` builds/pushes the multi-arch GHCR images; `desktop-v0.5.0` → `desktop-release.yml` cuts the signed/notarized launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)