### PR TITLE
docs: DOCX-ingest mini-PRD + ADR 0014 (proposal for maintainer decision)

### DIFF
--- a/docs/adr/0014-docx-ingest-via-pandoc.md
+++ b/docs/adr/0014-docx-ingest-via-pandoc.md
@@ -1,0 +1,123 @@
+# ADR 0014 — DOCX ingest via Pandoc (canonical text) with an OOXML comment fallback
+
+**Status:** Proposed (2026-06-21) — pending maintainer decision
+**Decision-makers:** Kevin Keller (maintainer)
+**Affected components:** `api/` (`pipeline/`, `ingest`, tests), `api` + `ingest-worker` container images
+**Related:** [ADR 0006 — Document pipeline](0006-document-pipeline-architecture.md), [DE-332 — Text/markdown ingest](../PRD.md#9-deferred-enhancements-and-identified-future-work), [Mini-PRD — DOCX ingest support](../contribute/mini-prds/docx-ingest-support.md), [PRD §3 — Knowledge Bases](../PRD.md#3-capability-specifications), `api/app/citation/verification.py`
+
+---
+
+## Context
+
+The ingest pipeline is PDF-only. `api/app/pipeline/ingest.py:155` gates on `is_pdf_mime` (`api/app/pipeline/parsers.py:134`); a non-PDF upload is marked `ingestion_status='failed'` with `ingestion_error='unsupported_type'` before any parser runs. DE-332 proposes the trivial text/markdown branch; DOCX is the heavier cousin this ADR addresses.
+
+DOCX matters because it is the format legal teams *negotiate* in — the markup (tracked changes, comments, footnotes) is the signal, not noise. Three constraints shape the decision:
+
+1. **The offset-fidelity contract (ADR 0006).** Every chunk must satisfy `canonical_text[char_offset_start:char_offset_end] == chunk.content`, and `documents.normalized_content` is coupled to that canonical text at write time (`ingest.py:318`) so the Citation Engine re-reads byte-for-byte. Any DOCX reader must yield a deterministic canonical character stream.
+2. **DOCX has no fixed pagination.** The PDF "page" anchor has no DOCX analogue; anchoring must be char-offset-based.
+3. **Redline fidelity.** Insertions, deletions, comments, and footnotes must be retained — and citable — not silently flattened.
+
+Candidates considered:
+
+| Option | Reads redlines | Reads comments | Char-precise canonical | New dep | Notes |
+|---|---|---|---|---|---|
+| **A. Pandoc** (`--track-changes=all`) | ✅ ins/del + author/date | ✅ (one #9833 gap) | ✅ (flat Markdown string) | Pandoc binary (GPLv2+) | Footnotes → `[^1]`; tables grid/lossy |
+| B. python-mammoth | ❌ dropped | ❌ dropped | text only | mammoth (BSD) | lavern's path; unfit for redline review |
+| C. OOXML-direct (`zipfile`+`lxml`) | ✅ w:ins/w:del | ✅ comments.xml | ✅ | `lxml` (already transitive) | MikeOSS's approach; most code |
+| D. Docling DOCX | partial | ❌ | ❌ not char-precise | (already present) | Same offset problem PyMuPDF solved for PDF |
+| E. LibreOffice → PDF → existing pipeline | flattened | ❌ | ✅ (via PyMuPDF) | libreoffice | Loses author/date; heavy; "accept all" destroys the redline |
+
+## Decision
+
+### 1. Pandoc is the primary reader; its Markdown is the canonical text.
+
+`parse_docx()` runs **one** `pandoc -f docx -t markdown --track-changes=all --wrap=none --markdown-headings=atx --sandbox` pass. The Markdown output is the canonical character stream the existing `chunk_document` slices — the same role PyMuPDF's text plays for PDF in ADR 0006. The offset contract holds trivially because the canonical text is a deterministic string and the chunker owns the offsets.
+
+#### Why Pandoc over OOXML-direct (C)
+
+C is the most complete and is proven tractable (MikeOSS), but it means hand-writing the entire body-text walker (paragraphs, tables, lists, footnote resolution) before any of the legal-markup work begins. Pandoc gives that body text — with footnotes resolved to `[^1]` and tracked changes already parsed into spans — out of the box, mature and tested. We adopt C only for the narrow case Pandoc is documented to miss (Decision 3). This is the same "use the mature tool for the canonical stream, reconcile the gap" shape as ADR 0006 (PyMuPDF primary, not a hand-rolled extractor).
+
+#### Why Pandoc over python-mammoth (B)
+
+Mammoth drops tracked changes and comments by design — fatal for redline review (this is lavern's limitation).
+
+#### Why Pandoc over Docling-DOCX (D)
+
+Docling's output is not character-precise against the source — the exact reason ADR 0006 drives the chunker off PyMuPDF, not Docling, for PDF. The same logic rejects Docling as the DOCX canonical source.
+
+#### Why Pandoc over LibreOffice-to-PDF (E)
+
+Converting DOCX→PDF and reusing the PDF pipeline forces "accept all changes," destroying the redline and the author/date provenance that is the whole point. It also adds a far heavier dependency than a single Pandoc binary.
+
+### 2. Redline policy: retain the tracked changes and cite accordingly.
+
+From the single `--track-changes=all` pass:
+
+- **`canonical_text` / `normalized_content`** = the *changes-accepted* final text, reconstructed by keeping insertions and dropping deletions. Validated in the Phase-0 spike to be byte-identical to a separate `--track-changes=accept` pass. This is the operative text citations verify against.
+- **revision layer** → `documents.structured_content` (JSONB, reused — no migration): each insertion / deletion / comment with `text`, `author`, `date`, and a char anchor into `canonical_text`.
+- **deletions and comments are also emitted as separately-citable chunks**, provenance-tagged in `metadata_json`, so a citation can land on removed or commented text and report "deleted/flagged by X on date Y."
+
+`parser="pandoc"`, `parser_version=f"pandoc={version}"`, `page_count=1`, `was_ocrd=False` — mirroring the synthetic `ParsedDocument` at `api/app/autonomous/guard.py:588`.
+
+### 3. OOXML-direct is a fallback, not a parallel parser.
+
+Pandoc reads Word comments (validated by round-trip), but is documented to drop a comment anchored to an *unaccepted insertion* ([#9833](https://github.com/jgm/pandoc/issues/9833)) — common in live redlines. A small `api/app/pipeline/docx_ooxml.py` (`zipfile` + `lxml`, already a transitive dep) recovers **only** those comments by reading `comments.xml`. It does not re-extract body text. We borrow MikeOSS's OOXML-direct *idea*; we do not copy its code (AGPL-3.0 — incompatible with Apache-2.0).
+
+### 4. Determinism via version pinning.
+
+Pandoc output is byte-identical for a fixed input on a fixed version (spike-confirmed) but the manual makes no cross-version guarantee. We pin the exact Pandoc version in the `api`/`ingest-worker` images and record it in `parser_version` — the field exists precisely for re-ingest-on-drift decisions (`parsers.py` docstring).
+
+### 5. Untrusted-input safety.
+
+`.docx` is attacker-controlled. Pandoc runs as a **separate subprocess** with `--sandbox` (restricts IO), a wall-clock timeout, and an upload-size guard. Failures map to `parse_failed`; the worker never hangs or crashes on a malformed file.
+
+### 6. License posture: Pandoc is GPLv2+, invoked at arm's length.
+
+Pandoc is GPL-2.0-or-later. We invoke it as a **separate executable via subprocess** — never linked or imported. Under the GPL, calling an independent program at arm's length (fork/exec/pipe, like calling `grep`) is mere aggregation; the GPL does not extend to the Apache-2.0 calling code. This is **cleaner** than ADR 0006's PyMuPDF posture (PyMuPDF is AGPL and *imported as a library*, handled via the network-service boundary in PRD §7.2). Pandoc, as a separate process, raises no such linking question. The posture is documented alongside the PyMuPDF rationale in PRD §7.2.
+
+## Consequences
+
+### Positive
+
+- Offset-fidelity contract holds unchanged; the Citation Engine needs no modification.
+- Tracked changes, comments (bar #9833), and footnotes are retained with author/date — a capability the comparable OSS stacks drop.
+- One `all` pass yields canonical text + revision layer (spike-validated reconstruction).
+- No DB migration (reuses `structured_content` + `metadata_json`); no new routes.
+- Pandoc is a single mature binary invoked at arm's length — lighter and license-cleaner than the alternatives.
+
+### Negative
+
+- A new system dependency (Pandoc) in two images — the decision this ADR asks the maintainer to accept. Mitigated by in-repo precedent (`web/` ships `pypandoc`).
+- Tables with merged/nested cells degrade to grid/linearised text (a Markdown limitation).
+- The #9833 comment-on-insertion gap requires the OOXML fallback; threaded comment replies remain deferred.
+- Cross-version Pandoc drift could change output; mitigated by pinning + `parser_version`.
+
+### Neutral
+
+- Section-anchor citations ("§4.2") are deferred — anchoring stays char-offset-based, and the spike found many real contracts carry no Word heading styles, so heading-derived anchors are unreliable as a primary mechanism anyway.
+
+## Companion artifacts
+
+- `api/app/pipeline/parsers.py` — `SUPPORTED_DOCX_MIMES`, `is_docx_mime()`, `parse_docx()`.
+- `api/app/pipeline/docx_ooxml.py` — `zipfile`+`lxml` comment fallback (#9833).
+- `api/app/pipeline/ingest.py` — extended gate (155) + dispatch branch (192).
+- `api/tests/test_pipeline_parsers_docx.py`, `api/tests/test_pipeline_ingest.py` — offset-fidelity + redline/comment/footnote fixtures; the unsupported-type test flips for DOCX.
+- `api/Dockerfile` / `docker-compose*.yml` — pinned Pandoc in `api` + `ingest-worker`.
+- `docs/api/backend-openapi.yaml`, `docs/PRD.md` (§3 + a new DOCX DE in §9), `HONEST-STATE.md`, `parsers.py` docstring — doc reconciliation.
+
+## Alternatives considered
+
+### python-mammoth as the reader
+Rejected: drops tracked changes and comments by design (lavern's limitation). Unfit for redline review.
+
+### OOXML-direct (`zipfile`+`lxml`) for everything
+Rejected as the *primary* path: it means hand-writing the full body-text/footnote/table walker before any legal-markup work. Adopted only as the narrow #9833 fallback. (MikeOSS proves it tractable but is AGPL — idea borrowed, code not.)
+
+### Docling DOCX
+Rejected: not character-precise against the source — the same reason ADR 0006 drives the PDF chunker off PyMuPDF rather than Docling.
+
+### LibreOffice headless → PDF → existing pipeline
+Rejected: "accept all changes" flattens the redline and discards author/date provenance; far heavier dependency than a single Pandoc binary.
+
+### Copy MikeOSS's DOCX reader
+Rejected: AGPL-3.0, incompatible with the Apache-2.0 codebase. We reimplement the OOXML-direct idea clean.

--- a/docs/adr/0017-docx-ingest-via-pandoc.md
+++ b/docs/adr/0017-docx-ingest-via-pandoc.md
@@ -1,6 +1,6 @@
-# ADR 0014 — DOCX ingest via Pandoc (canonical text) with an OOXML comment fallback
+# ADR 0017 — DOCX ingest via Pandoc (canonical text) with an OOXML comment fallback
 
-**Status:** Proposed (2026-06-21) — pending maintainer decision
+**Status:** Accepted (2026-06-23) — maintainer approved the Pandoc dependency and the redline policy; implementation lands in a separate build PR per the [mini-PRD](../contribute/mini-prds/docx-ingest-support.md).
 **Decision-makers:** Kevin Keller (maintainer)
 **Affected components:** `api/` (`pipeline/`, `ingest`, tests), `api` + `ingest-worker` container images
 **Related:** [ADR 0006 — Document pipeline](0006-document-pipeline-architecture.md), [DE-332 — Text/markdown ingest](../PRD.md#9-deferred-enhancements-and-identified-future-work), [Mini-PRD — DOCX ingest support](../contribute/mini-prds/docx-ingest-support.md), [PRD §3 — Knowledge Bases](../PRD.md#3-capability-specifications), `api/app/citation/verification.py`

--- a/docs/contribute/mini-prds/docx-ingest-support.md
+++ b/docs/contribute/mini-prds/docx-ingest-support.md
@@ -36,7 +36,7 @@ api/tests/
 ├── test_pipeline_parsers_docx.py   # NEW — offset-fidelity + redline/comment/footnote fixtures
 └── test_pipeline_ingest.py         # flip: a .docx now SUCCEEDS (was unsupported_type)
 docs/
-├── adr/0014-docx-ingest-via-pandoc.md     # NEW — the structural decision + alternatives
+├── adr/0017-docx-ingest-via-pandoc.md     # NEW — the structural decision + alternatives
 ├── api/backend-openapi.yaml               # accepted-mime documentation for POST /files
 ├── PRD.md                                 # register DE for DOCX (§9) + §3 format note
 └── HONEST-STATE.md                        # DOCX = shipped, with honest caveats
@@ -108,4 +108,4 @@ On comments specifically — a correction worth recording so the next contributo
 
 ## Definition of "merged"
 
-The PR is merged when (a) the acceptance checklist is fully checked off; (b) the maintainer has approved **the dependency decision (Pandoc) and the redline policy** recorded in the companion ADR 0014; (c) CI is green including the DOCX offset-fidelity test and the redline/comment/footnote fixtures; and (d) the docs in the same PR (OpenAPI accepted-mimes, HONEST-STATE, PRD DE registration, the PDF-only statements that become stale) are reconciled. Because this touches `api/` (non-authz) the change is self-mergeable after CI per [§6](../coding-agent-onboarding.md) — **except** that the dependency + architectural decision must be maintainer-approved first, which is the entire purpose of this document. Commits carry DCO sign-off and the co-author trailer; the branch is pushed to both `origin` and `tucuxi` and preserved after merge.
+The PR is merged when (a) the acceptance checklist is fully checked off; (b) the maintainer has approved **the dependency decision (Pandoc) and the redline policy** recorded in the companion ADR 0017; (c) CI is green including the DOCX offset-fidelity test and the redline/comment/footnote fixtures; and (d) the docs in the same PR (OpenAPI accepted-mimes, HONEST-STATE, PRD DE registration, the PDF-only statements that become stale) are reconciled. Because this touches `api/` (non-authz) the change is self-mergeable after CI per [§6](../coding-agent-onboarding.md) — **except** that the dependency + architectural decision must be maintainer-approved first, which is the entire purpose of this document. Commits carry DCO sign-off and the co-author trailer; the branch is pushed to both `origin` and `tucuxi` and preserved after merge.

--- a/docs/contribute/mini-prds/docx-ingest-support.md
+++ b/docs/contribute/mini-prds/docx-ingest-support.md
@@ -1,0 +1,111 @@
+# Mini-PRD: DOCX ingest support (Word documents into the knowledge base)
+
+> **Status:** **Proposed — pending maintainer decision.** Unlike the other entries in this folder, this one is *not yet* "open for contribution": it carries an architectural choice (a second parser branch in the ingest cascade) and a new runtime dependency (Pandoc), both of which are explicit "stop and ask" items per [coding-agent-onboarding §8](../coding-agent-onboarding.md). This document is the artifact for that decision. If the maintainer approves the dependency and the redline policy, it becomes an open mini-PRD plus a companion ADR and a new DE.
+> **Effort:** L (vs. the M of its sibling [DE-332](../../PRD.md#9-deferred-enhancements-and-identified-future-work), because of the tracked-changes/comment layer and the new dependency)
+> **Contributor profile:** Mid-to-senior Python engineer comfortable with FastAPI, async workers, OOXML/`lxml`, and subprocess handling of untrusted input. Not a "good first issue."
+> **Mentor:** Maintainer (Kevin Keller, via PR review)
+> **Depends on / relates to:** [ADR 0006 — Document Pipeline Architecture](../../adr/0006-document-pipeline-architecture.md), [DE-332 — Text/markdown ingest-parser support](../../PRD.md#9-deferred-enhancements-and-identified-future-work)
+
+## What this is
+
+Today the ingest pipeline is PDF-only. `api/app/pipeline/ingest.py` gates every upload on `is_pdf_mime` (`api/app/pipeline/parsers.py:134`); anything else is marked `ingestion_status='failed'` with `ingestion_error='unsupported_type'` *before* a parser runs. This mini-PRD proposes a **second parser branch, `parse_docx()`**, that brings `.docx` files into the same `Document` + `DocumentChunk` + Citation-Engine path that PDFs use today — with first-class handling of the features that make Word the format legal teams actually negotiate in: **tracked changes, comments, and footnotes**.
+
+The design deliberately mirrors the existing PDF cascade (ADR 0006): a primary tool produces the canonical character stream that the chunker slices and the Citation Engine re-reads, and a richer structural representation rides alongside in `documents.structured_content`. Concretely:
+
+- **Pandoc** (`--track-changes=all`, run once) produces the Markdown the chunker treats as `canonical_text`, and carries insertions/deletions/comments inline as spans we parse out.
+- A small **OOXML pass** (`zipfile` + `lxml`) is a **fallback only** for the comments Pandoc is documented to drop (see "Prior art & the comment question" below). It is not a parallel parser.
+
+The work is well-anchored because the hard part — preserving character-offset fidelity so citations re-verify byte-for-byte — is already solved by the chunker, and the exact `ParsedDocument` shape to build already exists in the autonomous artifact handler (`api/app/autonomous/guard.py:588`, the same construction DE-332 points to).
+
+## Why it matters
+
+PDF is what contracts are *sent* as; `.docx` is what they are *negotiated* in. An in-house team's live working set — the redlined drafts, the clause a partner commented on, the footnoted carve-out — is Word, and the markup *is* the signal. A legal-AI tool that can only read the flattened PDF can tell you what the contract says; it cannot tell you **what changed, who changed it, and what they flagged**, which is most of in-house review.
+
+This is also where LQ.AI's transparency thesis pays off. The two comparable open-source legal stacks read DOCX in ways that quietly lose legal signal (see Prior art). LQ.AI's Citation Engine already verifies a quote against an exact character span (`api/app/citation/verification.py`); extending that guarantee to Word — *including a citation that lands on an inserted clause and reports "inserted by X on date Y"* — is a capability a closed SaaS presents as a black box and the other OSS tools drop on the floor.
+
+## What we'd ship
+
+No new tables (the revision/comment layer reuses the existing `documents.structured_content` JSONB; chunks reuse `metadata_json`). No new routes (upload is the existing `POST /api/v1/files`). The change is a parser branch + a fallback extractor + the gate + tests + docs:
+
+```
+api/app/pipeline/
+├── parsers.py        # + SUPPORTED_DOCX_MIMES, is_docx_mime(), parse_docx()  [NEW funcs]
+├── docx_ooxml.py     # NEW — zipfile+lxml fallback: recover comments Pandoc drops (#9833)
+└── ingest.py         # extend the gate (155) + dispatch branch (192) to call parse_docx
+api/tests/
+├── test_pipeline_parsers_docx.py   # NEW — offset-fidelity + redline/comment/footnote fixtures
+└── test_pipeline_ingest.py         # flip: a .docx now SUCCEEDS (was unsupported_type)
+docs/
+├── adr/0014-docx-ingest-via-pandoc.md     # NEW — the structural decision + alternatives
+├── api/backend-openapi.yaml               # accepted-mime documentation for POST /files
+├── PRD.md                                 # register DE for DOCX (§9) + §3 format note
+└── HONEST-STATE.md                        # DOCX = shipped, with honest caveats
+deploy/ + docker-compose*.yml + api/Dockerfile  # pin pandoc in api + ingest-worker images
+```
+
+**`parse_docx()` behaviour (the redline policy — needs maintainer sign-off):** one `pandoc --track-changes=all --wrap=none --markdown-headings=atx --sandbox -t markdown` pass, then:
+
+- **`canonical_text` / `normalized_content`** = the *final* (changes-accepted) text, reconstructed from the `all` output by keeping insertions and dropping deletions. This is the operative text citations verify against, and it is byte-identical to a separate `--track-changes=accept` pass (validated in the Phase-0 spike). The Citation Engine's re-read invariant (`chunk.content == normalized_content[char_offset_start:char_offset_end]`, coupled at write time in `ingest.py:318`) holds unchanged.
+- **revision layer** (→ `structured_content`) = the parsed insertions, deletions, and comments, each with `text`, `author`, `date`, and a character anchor into `canonical_text`. Deletions and comments are *retained*, not discarded.
+- **deletions and comments are also emitted as separately-citable chunks**, tagged with provenance in `metadata_json`, so "what was the original fee?" / "what did the reviewer flag?" are answerable and cite back to author + date. This is the concrete meaning of *retain the tracked changes and cite accordingly*.
+- `parser="pandoc"`, `parser_version=f"pandoc={<binary version>}"` (the existing field exists precisely so re-ingest decisions can be made against version drift — see `parsers.py` module docstring), `page_count=1`, `was_ocrd=False`.
+
+## How we'd know it's done
+
+- [ ] `is_docx_mime()` accepts `application/vnd.openxmlformats-officedocument.wordprocessingml.document`; the gate in `ingest.py` admits both PDF and DOCX and still rejects everything else as `unsupported_type`.
+- [ ] **Offset-fidelity test passes for DOCX** — the load-bearing contract `canonical_text[c.char_offset_start:c.char_offset_end] == c.content` holds for every chunk on at least three fixture `.docx` files of increasing complexity (mirrors `test_offset_fidelity_against_fixture_pdfs`).
+- [ ] A redlined fixture asserts: `canonical_text` equals the changes-accepted text; every insertion and deletion appears in the revision layer with correct `author` + `date`; deletions are independently citable.
+- [ ] A commented fixture asserts comments are recovered with `author` + `date` — via Pandoc where it works, via the OOXML fallback for the comment-on-insertion case Pandoc drops ([#9833](https://github.com/jgm/pandoc/issues/9833)).
+- [ ] A footnote fixture asserts footnotes survive into `canonical_text`.
+- [ ] Pandoc output is pinned and reproducible: same fixture + same pinned `pandoc` version ⇒ byte-identical (the spike confirmed determinism on a fixed version; cross-version drift is mitigated by pinning + `parser_version`).
+- [ ] Untrusted-input safety: `parse_docx` runs Pandoc with `--sandbox`, a wall-clock timeout, and a size guard; a malformed/zip-bomb `.docx` fails as `parse_failed`, not a hang or crash. A non-DOCX byte stream with a spoofed mime fails cleanly.
+- [ ] `pandoc` is pinned (exact version) in the `api` **and** `ingest-worker` images; the SBOM/justification note is in the ADR.
+- [ ] Docs are part of the change: `backend-openapi.yaml` accepted-mimes, the PDF-only statements in the file-upload docs and `parsers.py` docstring, `HONEST-STATE.md`, the new ADR, and the DOCX DE registered in PRD §9.
+- [ ] No new DB migration (reuses `structured_content` + `metadata_json`); if that turns out false, the migration is verified on a throwaway `pgvector/pgvector:pg16` container, never host alembic against the dev DB.
+
+## Where to start
+
+1. Read [ADR 0006](../../adr/0006-document-pipeline-architecture.md) — it sets the "PyMuPDF canonical + Docling structured" cascade this mirrors, and the offset-fidelity rationale.
+2. Read `api/app/pipeline/parsers.py` (the `ParsedDocument`/`PageSpan` dataclasses, `is_pdf_mime`, the `parse_pdf` cascade) and `api/app/pipeline/chunker.py` (the invariant the Citation Engine depends on).
+3. Read `api/app/pipeline/ingest.py:155-196` — the exact gate + `asyncio.to_thread(parse_pdf, …)` dispatch `parse_docx` slots beside.
+4. Read `api/app/autonomous/guard.py:588` — the synthetic single-page `ParsedDocument` construction (same shape, the one DE-332 also reuses).
+5. Read [DE-332](../../PRD.md#9-deferred-enhancements-and-identified-future-work) — the text/markdown sibling; DOCX is the heavier cousin.
+6. Reproduce the Phase-0 spike: `pandoc --track-changes=all --wrap=none --markdown-headings=atx --sandbox -t markdown <file>.docx`; confirm the insertion/deletion/comment span syntax and the accept-reconstruction on your pinned Pandoc version before writing the parser.
+
+## Scope cuts (what's out of scope for this PR)
+
+- **Legacy `.doc` (binary Word 97-2003)** — `.docx` (OOXML) only.
+- **OCR / scanned or image-only content** — unchanged from M1; `was_ocrd=False`. (No-text DOCX is out of scope, same posture as PDFs.)
+- **Lossless complex tables** — merged/nested cells degrade to grid/linearised text (a Markdown limitation, documented in the ADR). Text is captured and citable; cell-geometry fidelity is not promised.
+- **Threaded comment replies** (`commentsExtended.xml` parent/child structure) — the base anchored comment is captured; reply-thread reconstruction is deferred to its own DE.
+- **A `.docx`/PDF rendition for the document panel** — this PR is the *ingest/extraction* path (what the LLM and Citation Engine read), not a viewer. Frontend rendering is a separate concern.
+- **Section-anchor citations ("§4.2")** — anchoring stays char-offset-based. Deriving section anchors from headings is a nice-to-have deferred to a DE, *and* the spike found many real contracts carry no Word heading styles, so it is unreliable as a primary anchor.
+
+## How this strengthens the project
+
+The capability a closed SaaS demonstrates as a black box, and the two open-source legal stacks drop, LQ.AI would do **in the open and verifiably**: read a Word redline, keep every insertion/deletion/comment with its author and date, and let the existing four-stage Citation Engine prove a quote against the exact source span — including a quote that lands on an inserted clause, reported with its provenance. Every claim above re-verifies against `api/app/pipeline/` and `api/app/citation/`. The bet of the project (PRD §1.3) is that an operator who can read the code trusts the answer; extending that guarantee from "what the contract says" to "what changed and who changed it" is where in-house review actually lives.
+
+## Prior art & the comment question (why Pandoc, honestly)
+
+Two comparable OSS legal stacks were reviewed for how they read DOCX:
+
+- **lavern** (`AnttiHero/lavern`, Apache-2.0) reads via **mammoth**, which **drops tracked changes and comments by design** — collaborative redlines are invisible. Patterns are copyable (permissive), but the reader is unfit for redline review.
+- **MikeOSS** (`willchen96/mike`, **AGPL-3.0**) walks `document.xml` directly (JSZip + fast-xml-parser) and handles tracked changes with `w:id`-level precision — but its server *reading* layer uses "accepted view" (drops deletions) and explicitly leaves comments/footnotes "alone," and its **AGPL licence means we cannot copy its code** into Apache-2.0 LQ.AI. We borrow the *idea* (OOXML-direct for what convenience tools miss), reimplemented clean.
+
+On comments specifically — a correction worth recording so the next contributor doesn't repeat it: **Pandoc *does* read Word comments** with `--track-changes=all` (validated by round-trip in the spike), emitting `[body]{.comment-start id author date} … []{.comment-end id}`. An earlier claim that "Pandoc can't read real-file comments" was a measurement error (the test files had an *empty* `comments.xml`). Pandoc's real, documented limitations are narrow: it drops a comment anchored to an *unaccepted insertion* ([#9833](https://github.com/jgm/pandoc/issues/9833)), mishandles some multi-line comments ([#4270](https://github.com/jgm/pandoc/issues/4270)), and doesn't reconstruct reply threads. The `#9833` case is common in live redlines (a reviewer commenting on the very clause being inserted), which is the **sole** reason for the small `zipfile`+`lxml` comment fallback — not a full parallel parser.
+
+**The decision this PRD asks the maintainer to make:** accept **Pandoc** as a new runtime dependency in the `api`/`ingest-worker` images. It is a mature, single binary; `web/` already ships `pypandoc` (`web/pyproject.toml`), so there is in-repo precedent; the alternative (hand-rolled OOXML for everything) is materially more code for the body-text path. Per [§8](../coding-agent-onboarding.md), a new dependency is a maintainer call; this is the call.
+
+## References
+
+- [ADR 0006 — Document Pipeline Architecture](../../adr/0006-document-pipeline-architecture.md)
+- [PRD §9 — DE-332 Text/markdown ingest-parser support](../../PRD.md#9-deferred-enhancements-and-identified-future-work) (sibling)
+- `api/app/pipeline/parsers.py`, `api/app/pipeline/ingest.py`, `api/app/pipeline/chunker.py`, `api/app/autonomous/guard.py` (the construction to mirror)
+- `api/app/citation/verification.py` — the re-read invariant DOCX must preserve
+- [coding-agent-onboarding §5–§8](../coding-agent-onboarding.md) — DCO, both-remotes, merge gating, stop-and-ask
+- Pandoc: [MANUAL — track-changes](https://pandoc.org/MANUAL.html) · comment limitations [#9833](https://github.com/jgm/pandoc/issues/9833), [#4270](https://github.com/jgm/pandoc/issues/4270)
+- Prior art: `AnttiHero/lavern` (Apache-2.0, mammoth), `willchen96/mike` (AGPL-3.0, OOXML-direct)
+
+## Definition of "merged"
+
+The PR is merged when (a) the acceptance checklist is fully checked off; (b) the maintainer has approved **the dependency decision (Pandoc) and the redline policy** recorded in the companion ADR 0014; (c) CI is green including the DOCX offset-fidelity test and the redline/comment/footnote fixtures; and (d) the docs in the same PR (OpenAPI accepted-mimes, HONEST-STATE, PRD DE registration, the PDF-only statements that become stale) are reconciled. Because this touches `api/` (non-authz) the change is self-mergeable after CI per [§6](../coding-agent-onboarding.md) — **except** that the dependency + architectural decision must be maintainer-approved first, which is the entire purpose of this document. Commits carry DCO sign-off and the co-author trailer; the branch is pushed to both `origin` and `tucuxi` and preserved after merge.


### PR DESCRIPTION
## What this is

A **Proposed** mini-PRD + companion ADR to bring `.docx` files into the ingest pipeline (today PDF-only). **Docs only — no code, no migration, no new routes.** This is a **decision request, not a merge** — per [`coding-agent-onboarding` §8](docs/contribute/coding-agent-onboarding.md), it carries two maintainer "stop and ask" calls, which is the whole reason it's a Draft.

## The two decisions to approve

1. **New runtime dependency — Pandoc** in the `api` + `ingest-worker` images. A single mature binary invoked at arm's length via subprocess (GPL-via-subprocess = mere aggregation; the Apache-2.0 code is unaffected). In-repo precedent: `web/` already ships `pypandoc`.
2. **Redline policy — "retain tracked changes + cite accordingly":** canonical text = the changes-accepted final (offset-fidelity preserved, Citation Engine unchanged); insertions / deletions / comments are retained in `structured_content` and emitted as separately-citable provenance records.

## What's in here

- **Mini-PRD** — `docs/contribute/mini-prds/docx-ingest-support.md`: scope, acceptance checklist, scope cuts, where-to-start, definition of "merged".
- **ADR 0014** — `docs/adr/0014-docx-ingest-via-pandoc.md`: Pandoc primary for the canonical character stream; OOXML/`lxml` fallback only for the documented [pandoc #9833](https://github.com/jgm/pandoc/issues/9833) comment-on-insertion gap; alternatives (mammoth / OOXML-only / Docling / LibreOffice) considered with rationale; license posture mirrored on [ADR 0006](docs/adr/0006-document-pipeline-architecture.md).

## Evidence behind it

Backed by a Phase-0 spike on Pandoc 3.7: the tracked-change span syntax and comment reading were confirmed empirically, the accept-reconstruction was validated byte-identical to canonical, and determinism was confirmed on a pinned version. Prior art reviewed: `AnttiHero/lavern` (mammoth — drops redlines/comments) and `willchen96/mike` (OOXML-direct but AGPL — idea borrowed, code not).

## The ask

Approve the dependency + redline policy, or request changes, **before** any build. If approved, the build is a **separate PR** that adds `parse_docx()`, the OOXML fallback, the tests, and the pinned Pandoc — gated on the acceptance checklist in the mini-PRD.

Refs DE-332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
