### PR TITLE
fix(launcher): make the macOS first-run work for a stranger (DE-353 + DE-354)

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -79,6 +79,14 @@ ipcMain.handle('wizard:complete', async (_e, input: WizardInput) => {
 		// failed first run re-shows the wizard instead of stranding a half-configured install.
 		writeEnvFile(cfg)
 		const b = base()
+		// A prior failed first-run attempt can leave an orphaned postgres volume
+		// initialized with a now-discarded password (we regenerate secrets each
+		// wizard run, and POSTGRES only honors the password on first init of an
+		// empty volume). Without this, the second attempt's fresh secrets meet
+		// the old volume → api "password authentication failed" crash-loop. Since
+		// the wizard only runs on first-run (no persisted config), wiping volumes
+		// here is safe and guarantees fresh secrets meet a fresh postgres init.
+		await resetStack(b)
 		await startStack(b, process.env)
 		await waitHealthy(b)
 		const admin = await runAdminFixture(b, input.adminEmail, input.adminPassword)

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -286,6 +286,13 @@ services:
       WEBUI_AUTH: ${WEBUI_AUTH:-false}
       WEBUI_NAME: ${WEBUI_NAME:-LQ.AI}
       WEBUI_URL: ${WEBUI_URL:-http://localhost:3000}
+      # DE-353: LQ.AI does its own embeddings/citations in api+gateway; OpenWebUI's
+      # local RAG is unused. A non-empty engine makes get_ef() return None instead
+      # of constructing a local SentenceTransformer at import — which skips the
+      # boot-time "Fetching 30 files" HuggingFace download that otherwise blocks
+      # web from binding :8080 (HF-rate-limited; can stall for many minutes →
+      # web never goes healthy → the macOS launcher reports "Stack failed to start").
+      RAG_EMBEDDING_ENGINE: ${RAG_EMBEDDING_ENGINE:-openai}
     # No host ports: web is INTERNAL-ONLY now. The proxy below owns the
     # user-facing WEB_HOST_PORT and routes everything-but-/lq to web:8080 on
     # the compose network (including /api/config and OpenWebUI's own /api/v1/*).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -389,6 +389,11 @@ services:
       WEBUI_AUTH: ${WEBUI_AUTH:-false}
       WEBUI_NAME: ${WEBUI_NAME:-LQ.AI}
       WEBUI_URL: ${WEBUI_URL:-http://localhost:3000}
+      # DE-353: LQ.AI does its own embeddings/citations in api+gateway; OpenWebUI's
+      # local RAG is unused. A non-empty engine makes get_ef() return None instead
+      # of building a local SentenceTransformer at import, skipping the boot-time
+      # "Fetching 30 files" HuggingFace download that otherwise delays web health.
+      RAG_EMBEDDING_ENGINE: ${RAG_EMBEDDING_ENGINE:-openai}
       # OpenWebUI's full env-var surface (DATABASE_URL, OLLAMA_BASE_URL,
       # ENABLE_*, etc.) lands when Task A1.d imports the fork and we know
       # the exact set to override vs. default.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4691,6 +4691,18 @@ No code change — the runtime already returns these with the correct typed `cod
 
 **Context:** Found during the v0.5.0 release-readiness verification. Ingestion is PDF-only today (DOCX/RTF/TXT are M2), but the upload endpoint accepts a TXT/DOCX file (HTTP 2xx) and only marks it `failed` with `unsupported_type` after the worker picks it up — so a user learns the format is unsupported only after upload + a poll cycle. Add a pre-upload MIME/extension guard that rejects unsupported types synchronously with a clear error (or a documented "PDF only for now" note on the upload surface) until the M2 format expansion lands.
 
+#### DE-353 — `web` (OpenWebUI) container blocked first-boot on an unnecessary HuggingFace model fetch — **RESOLVED**
+
+**Priority:** P2 · **Effort:** S · **Status: RESOLVED** in the v0.5.0 launcher-readiness pass.
+
+**Context:** Found during the v0.5.0 release-readiness verification (isolated boot of the published images + the macOS launcher first-run). At import, `web/backend/open_webui/main.py` calls `get_ef(RAG_EMBEDDING_ENGINE, …)` **before** uvicorn binds `:8080`; with the default empty engine it builds a local SentenceTransformer → `snapshot_download` → the "Fetching 30 files" HuggingFace download. Under HF rate-limiting this stalled near 0% for many minutes, so the `web` healthcheck failed → `web` went `unhealthy` after its 20s start_period → the dependent user-facing `proxy` never started, and the macOS launcher (which fails the moment any service is `unhealthy`) reported "Stack failed to start." LQ.AI does its **own** embeddings/citations (api/gateway via OpenAI `text-embedding-3-*`) and does not use OpenWebUI's local RAG, so the fetch was pure waste. **Fix:** set `RAG_EMBEDDING_ENGINE=openai` (a non-empty sentinel) on the `web` service in `docker-compose.yml` and `docker-compose.release.yml` — `get_ef()` then returns `None` and the local-model construction/download is skipped. Empirically verified on `lq-ai-web:v0.5.0`: `/health` → 200 in **~11s** (vs never/183s+ baseline), no "Fetching" line, UI shell intact. Compose-only — no image re-cut required.
+
+#### DE-354 — macOS launcher regenerated secrets on a retried first-run without `down -v` → stale-volume auth crash-loop — **RESOLVED**
+
+**Priority:** P1 · **Effort:** S · **Status: RESOLVED** in the v0.5.0 launcher-readiness pass.
+
+**Context:** Found during the v0.5.0 launcher first-run test. `wizard:complete` (`desktop/src/main/index.ts`) calls `generateSecrets()` every run and only `saveConfig()`s on success, and `down -v` was wired only to the Reset button. So a first start that failed for any reason (e.g. [DE-353](#de-353--web-openwebui-container-blocked-first-boot-on-an-unnecessary-huggingface-model-fetch--resolved)) left an orphaned postgres volume initialized with the first attempt's password; the next start generated fresh secrets, but POSTGRES only honors the password on first init of an empty volume, so the api hit `password authentication failed` and crash-looped — unrecoverable without a manual Reset. **Fix:** `wizard:complete` now calls `resetStack()` (`down -v`) before `startStack()`, guaranteeing fresh secrets always meet a fresh postgres init (safe because the wizard only runs on first-run, when there is no real data yet). With DE-353 fixed, the first start succeeds outright; DE-354 makes any future failed attempt cleanly recoverable.
+
 ---
 
 ## 10. Appendices


### PR DESCRIPTION
The v0.5.0 launcher (`.dmg`) first-run failed with **"Stack failed to start"** → api `password authentication failed` crash-loop. Root-caused to two compounding bugs (the published **images are fine** — Arm B + isolated-boot passed).

### DE-353 — web blocked boot on an unnecessary HF model fetch (RESOLVED)
`web/backend/open_webui/main.py` builds a **local** SentenceTransformer at import (default empty `RAG_EMBEDDING_ENGINE`) → "Fetching 30 files" from HF **before** binding `:8080`. Under HF rate-limiting this stalls for minutes → `web` goes `unhealthy` after its 20s start_period → the launcher (which fails on any `unhealthy` service) gives up. LQ.AI uses its **own** embeddings, so the fetch is waste.
**Fix:** `RAG_EMBEDDING_ENGINE=openai` (non-empty sentinel) on the `web` service in both compose files → `get_ef()` returns `None`, no local model. **Empirically verified** on `lq-ai-web:v0.5.0`: `/health` → 200 in **~11s** (vs never/183s+). Compose-only; **no image re-cut** (the `.dmg` bundles `docker-compose.release.yml` at build).

### DE-354 — launcher regenerated secrets on retry without `down -v` (RESOLVED)
`wizard:complete` (`desktop/src/main/index.ts`) calls `generateSecrets()` each run, only `saveConfig`s on success, and `down -v` was wired only to Reset. So a failed first attempt orphaned a postgres volume with password A; the retry used password B → Postgres (init'd with A, no re-init on existing volume) → auth crash-loop, unrecoverable without manual Reset.
**Fix:** `resetStack()` (`down -v`) before `startStack()` in the first-run wizard — fresh secrets always meet a fresh postgres init (safe; no real data on first-run).

### Validation
Desktop gates pass locally: `tsc --noEmit` clean, `vitest` 47/47. Main CI here covers api/gateway/web (unaffected). After merge: re-cut the launcher (`desktop-v0.5.1`) to pick up the bundled compose + launcher fix, then re-verify the `.dmg` first-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)