### PR TITLE
feat(ingest): accept text/markdown uploads (DE-332)

### DIFF
--- a/api/app/pipeline/__init__.py
+++ b/api/app/pipeline/__init__.py
@@ -21,16 +21,20 @@ architectural decisions behind this layout.
 from app.pipeline.chunker import Chunk, chunk_document
 from app.pipeline.parsers import (
     ParsedDocument,
+    ParserDecodeError,
     ParserError,
     ParserUnsupported,
     parse_pdf,
+    parse_text,
 )
 
 __all__ = [
     "Chunk",
     "ParsedDocument",
+    "ParserDecodeError",
     "ParserError",
     "ParserUnsupported",
     "chunk_document",
     "parse_pdf",
+    "parse_text",
 ]

--- a/api/app/pipeline/ingest.py
+++ b/api/app/pipeline/ingest.py
@@ -16,13 +16,14 @@ This module is the entry point invoked by the ``arq`` worker. Given a
 
 Failure paths:
 
-* **Unsupported file type** (non-PDF MIME): row goes to
-  ``ingestion_status='failed'`` with
-  ``ingestion_error='unsupported_type'``. C4 leaves project_id and
-  other metadata intact.
-* **Parser failure** (corrupt PDF, encrypted, image-only PDF that
-  PyMuPDF can't handle): same — ``failed`` + descriptive
-  ``ingestion_error``.
+* **Unsupported file type** (neither PDF nor text/Markdown — by MIME
+  or filename extension): row goes to ``ingestion_status='failed'``
+  with ``ingestion_error='unsupported_type'``. C4 leaves project_id
+  and other metadata intact.
+* **Parser failure**: ``failed`` + descriptive ``ingestion_error`` —
+  ``parse_failed`` (corrupt PDF), ``unsupported_content`` (encrypted /
+  image-only PDF), or ``decode_error`` (a text/Markdown upload that is
+  not valid UTF-8, or contains a NUL byte).
 * **Storage failure** (MinIO unreachable): the worker raises and
   ``arq`` retries per its visibility-timeout policy. The row stays
   at ``processing`` until a successful run flips it.
@@ -52,10 +53,14 @@ from app.pipeline.chunker import (
 )
 from app.pipeline.parsers import (
     ParsedDocument,
+    ParserDecodeError,
     ParserError,
     ParserUnsupported,
     is_pdf_mime,
+    is_text_filename,
+    is_text_mime,
     parse_pdf,
+    parse_text,
 )
 from app.storage import stream_download
 
@@ -151,8 +156,19 @@ async def ingest_file(
             error="soft_deleted",
         )
 
-    # ---- Reject unsupported types early.
-    if not is_pdf_mime(row.mime_type):
+    # ---- Resolve the parser route. PDF and plain-text/Markdown ride
+    # different branches. The browser-supplied MIME is unreliable for
+    # .md/.txt (often application/octet-stream or empty), so fall back to the
+    # filename extension when the MIME isn't already a text type. parse_text
+    # still validates the bytes (UTF-8, no NUL), so a binary file with a text
+    # name fails cleanly as decode_error rather than being trusted.
+    route_pdf = is_pdf_mime(row.mime_type)
+    route_text = is_text_mime(row.mime_type) or (not route_pdf and is_text_filename(row.filename))
+
+    # ---- Reject unsupported types early. Log the MIME only — never the
+    # filename (P3: counts/types/outcomes in logs, never user content; a
+    # legal filename can itself be sensitive).
+    if not (route_pdf or route_text):
         await _mark_failed(db, row, error="unsupported_type", reason=f"mime={row.mime_type!r}")
         return IngestResult(
             file_id=file_id,
@@ -172,7 +188,7 @@ async def ingest_file(
 
     # ---- Pull bytes from MinIO.
     try:
-        pdf_bytes = await _read_all_bytes(row.storage_path)
+        raw_bytes = await _read_all_bytes(row.storage_path)
     except Exception as exc:
         # Storage failures: log and re-raise so arq retries. Don't flip
         # status to failed — operator-side fixes (MinIO restart) should
@@ -198,14 +214,20 @@ async def ingest_file(
     # The orphaned worker thread finishes its download in the background, so
     # a retry once the models are cached succeeds.
     try:
-        parsed = await asyncio.wait_for(
-            asyncio.to_thread(
-                parse_pdf,
-                pdf_bytes,
-                run_docling=settings.lq_ai_docling_enabled,
-            ),
-            timeout=settings.lq_ai_docling_timeout_seconds,
-        )
+        if route_text:
+            # Plain text / Markdown needs no parsing library and no network:
+            # the decoded bytes are the canonical stream. Pure and fast, so
+            # it skips the Docling thread/timeout machinery entirely.
+            parsed = parse_text(raw_bytes)
+        else:
+            parsed = await asyncio.wait_for(
+                asyncio.to_thread(
+                    parse_pdf,
+                    raw_bytes,
+                    run_docling=settings.lq_ai_docling_enabled,
+                ),
+                timeout=settings.lq_ai_docling_timeout_seconds,
+            )
     except TimeoutError:
         await _mark_failed(
             db,
@@ -224,6 +246,18 @@ async def ingest_file(
             chunk_count=0,
             parser=None,
             error="ingestion_timeout",
+        )
+    except ParserDecodeError as exc:
+        # A supported text type whose bytes are not valid UTF-8. Honest,
+        # distinct from ``unsupported_type`` (the type IS supported).
+        await _mark_failed(db, row, error="decode_error", reason=str(exc))
+        return IngestResult(
+            file_id=file_id,
+            status="failed",
+            document_id=None,
+            chunk_count=0,
+            parser=None,
+            error="decode_error",
         )
     except ParserUnsupported as exc:
         await _mark_failed(db, row, error="unsupported_content", reason=str(exc))

--- a/api/app/pipeline/parsers.py
+++ b/api/app/pipeline/parsers.py
@@ -1,6 +1,8 @@
-"""PDF parser adapters — PyMuPDF (canonical) and Docling (structure).
+"""Document parser adapters — PyMuPDF/Docling for PDF, a stdlib decode for text.
 
-Per ADR 0006:
+Plain text and Markdown (:func:`parse_text`) need no parsing library: the
+decoded bytes are themselves the canonical character stream, stored verbatim
+so citations resolve byte-for-byte. PDF needs real extraction, per ADR 0006:
 
 * **PyMuPDF** is the source of truth for the canonical character
   stream. Every chunk's ``content`` slices the PyMuPDF output by
@@ -56,8 +58,19 @@ class ParserError(Exception):
 class ParserUnsupported(ParserError):
     """The file type or content is not supported by any installed parser.
 
-    Currently raised for non-PDF MIME types (DOCX, RTF, TXT — M2)
-    and for encrypted PDFs (the M1 pipeline does not unlock them).
+    Currently raised for non-PDF MIME types (DOCX, RTF — M2) and for
+    encrypted PDFs (the M1 pipeline does not unlock them).
+    """
+
+
+class ParserDecodeError(ParserError):
+    """A text/markdown upload could not be decoded as UTF-8.
+
+    Distinct from :class:`ParserUnsupported`: the MIME *is* a supported
+    text type, but the bytes are not valid UTF-8. We fail loud rather
+    than guess an encoding — a silent mis-decode would corrupt the
+    canonical text a citation later verifies against. The orchestrator
+    maps this to ``ingestion_error='decode_error'``.
     """
 
 
@@ -116,9 +129,9 @@ class ParsedDocument:
 # Public entry point
 # ---------------------------------------------------------------------------
 
-# Sentinel MIME types we accept for M1 PDFs. C5 is PDF-only; DOCX/RTF/TXT
-# stay at ``ingestion_status='failed'`` with ``unsupported_type`` per the
-# C5 brief.
+# Sentinel MIME types we accept for PDFs. DOCX/RTF still stay at
+# ``ingestion_status='failed'`` with ``unsupported_type``; plain
+# text / Markdown are handled by the :func:`parse_text` branch below.
 SUPPORTED_PDF_MIMES = frozenset(
     {
         "application/pdf",
@@ -127,6 +140,18 @@ SUPPORTED_PDF_MIMES = frozenset(
         "applications/vnd.pdf",
         "text/pdf",
         "text/x-pdf",
+    }
+)
+
+# Plain-text and Markdown uploads. These need no parsing library — the
+# decoded bytes are themselves the canonical character stream — so they
+# take the :func:`parse_text` branch rather than the PyMuPDF/Docling
+# cascade.
+SUPPORTED_TEXT_MIMES = frozenset(
+    {
+        "text/plain",
+        "text/markdown",
+        "text/x-markdown",
     }
 )
 
@@ -139,6 +164,93 @@ def is_pdf_mime(mime_type: str) -> bool:
     """
 
     return mime_type.lower() in SUPPORTED_PDF_MIMES
+
+
+def is_text_mime(mime_type: str) -> bool:
+    """Return True if the MIME indicates plain text or Markdown.
+
+    Text uploads commonly carry a charset parameter
+    (``text/plain; charset=utf-8``), so we match on the bare type and
+    ignore parameters. The charset is *not* honoured for decoding —
+    :func:`parse_text` always decodes strict UTF-8 (see its docstring).
+    """
+
+    base = mime_type.split(";", 1)[0].strip().lower()
+    return base in SUPPORTED_TEXT_MIMES
+
+
+# Filename extensions treated as text when the browser-supplied MIME is
+# unreliable. Browsers and operating systems disagree on the MIME for ``.md``
+# (frequently ``application/octet-stream`` or empty), so the extension is the
+# dependable signal. This only *routes* the upload to :func:`parse_text`, which
+# still validates the bytes (strict UTF-8, no NUL) — so a binary file with a
+# ``.md`` name fails cleanly as ``decode_error`` rather than being trusted.
+TEXT_EXTENSIONS = (".md", ".markdown", ".txt")
+
+
+def is_text_filename(filename: str) -> bool:
+    """Return True if the filename has a known text/Markdown extension.
+
+    The fallback for generic-MIME uploads (e.g. ``application/octet-stream``),
+    which is what many browsers send for ``.md``.
+    """
+
+    return filename.lower().endswith(TEXT_EXTENSIONS)
+
+
+def parse_text(raw_bytes: bytes) -> ParsedDocument:
+    """Build a canonical :class:`ParsedDocument` from a text/Markdown upload.
+
+    Unlike PDF, plain text needs no parsing library: the decoded bytes
+    *are* the canonical character stream. Storing them verbatim makes the
+    offset-fidelity contract
+    (``canonical_text[char_offset_start:char_offset_end] == chunk.content``)
+    hold exactly, so the Citation Engine re-reads byte-for-byte and the
+    strongest (exact-match) citation tier resolves for every text document.
+
+    Markdown is stored **verbatim, never rendered** — a citation must
+    resolve against the source the user uploaded, not a derived rendering,
+    and rendering would also add a non-deterministic dependency.
+
+    Decoding is strict UTF-8 (``utf-8-sig`` transparently drops an optional
+    BOM). A non-UTF-8 byte stream raises :class:`ParserDecodeError` rather
+    than guessing an encoding — a silent mis-decode would corrupt the text a
+    citation later verifies against. This is a pure, deterministic function:
+    same bytes in, same canonical text out, with no model, OCR, or network.
+
+    A NUL byte (``0x00``) is also rejected: it decodes as valid Unicode but
+    PostgreSQL ``text`` columns cannot store it, so ``normalized_content``
+    would fail to persist downstream. A NUL almost always means the upload is
+    binary (or UTF-16) mislabeled as text — failing loud here is correct, and
+    keeps the failure a clean ``decode_error`` rather than a DB exception that
+    strands the row mid-ingest.
+    """
+
+    try:
+        text = raw_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise ParserDecodeError(
+            f"upload is not valid UTF-8 text (offset {exc.start}): {exc.reason}. "
+            "Save the file as UTF-8 (not UTF-16 / ANSI / Latin-1) and retry."
+        ) from exc
+
+    if "\x00" in text:
+        raise ParserDecodeError(
+            "upload contains a NUL byte (0x00); this is not a valid text "
+            "document (likely a binary or UTF-16 file mislabeled as text)."
+        )
+
+    # Single synthetic page over the whole stream — text has no pagination;
+    # this mirrors the autonomous-artifact construction in
+    # ``app.autonomous.guard`` and keeps the chunker's page lookup happy.
+    return ParsedDocument(
+        canonical_text=text,
+        pages=[PageSpan(page_number=1, char_start=0, char_end=len(text))],
+        page_count=1,
+        parser="plain-text",
+        parser_version="1",
+        structured_content=None,
+    )
 
 
 def parse_pdf(pdf_bytes: bytes, *, run_docling: bool = True) -> ParsedDocument:

--- a/api/tests/test_pipeline_ingest.py
+++ b/api/tests/test_pipeline_ingest.py
@@ -226,6 +226,160 @@ async def test_ingest_happy_path_marks_ready_with_chunks(
 
 
 @pytest.mark.integration
+async def test_ingest_markdown_happy_path_stores_verbatim(
+    db_session: AsyncSession,
+    db_user: User,
+    fake_s3: FakeS3Client,
+    patched_storage: FakeS3Client,
+) -> None:
+    """A Markdown upload ingests to ``ready`` with verbatim canonical text.
+
+    Plain text needs no PyMuPDF/Docling, so this path is deterministic and
+    offline. The key assertion is that ``normalized_content`` (what the
+    Citation Engine re-reads) equals the uploaded text byte-for-byte — so
+    exact-match citations resolve against the source the user uploaded.
+    """
+
+    source = (
+        "# Master Services Agreement\n\n"
+        "1. **Term.** Three (3) years from the Effective Date.\n\n"
+        "2. **Fees.** Customer shall pay within thirty (30) days of invoice.\n\n"
+        "Cláusula 3 — Límite de responsabilidad — 第4条.\n"
+    ) * 20
+    body = source.encode("utf-8")
+    storage_key = f"{uuid.uuid4()}"
+    _put_in_fake_s3(fake_s3, storage_key, body)
+
+    file_row = await _create_file_row(
+        db_session,
+        db_user,
+        storage_path=storage_key,
+        pdf_bytes=body,
+        mime="text/markdown",
+        filename="msa.md",
+    )
+
+    result = await ingest_file(db_session, file_row.id)
+
+    assert result.status == "ready"
+    assert result.error is None
+    assert result.chunk_count > 0
+
+    await db_session.refresh(file_row)
+    assert file_row.ingestion_status == "ready"
+    assert file_row.ingestion_error is None
+
+    doc = (
+        await db_session.execute(select(Document).where(Document.file_id == file_row.id))
+    ).scalar_one()
+    assert doc.parser == "plain-text"
+    assert doc.page_count == 1
+    assert doc.was_ocrd is False
+    # Verbatim: the re-read source equals the uploaded text exactly.
+    assert doc.normalized_content == source
+
+    chunks = (
+        (
+            await db_session.execute(
+                select(DocumentChunk)
+                .where(DocumentChunk.document_id == doc.id)
+                .order_by(DocumentChunk.chunk_index)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(chunks) > 0
+    for chunk in chunks:
+        slice_ = doc.normalized_content[chunk.char_offset_start : chunk.char_offset_end]
+        assert slice_ == chunk.content, (
+            f"chunk {chunk.chunk_index} fidelity broken: "
+            f"len(slice)={len(slice_)}, len(content)={len(chunk.content)}"
+        )
+        assert chunk.page_start == 1 and chunk.page_end == 1
+
+
+@pytest.mark.integration
+async def test_ingest_non_utf8_text_fails_decode_error(
+    db_session: AsyncSession,
+    db_user: User,
+    fake_s3: FakeS3Client,
+    patched_storage: FakeS3Client,
+) -> None:
+    """A supported text MIME whose bytes are not UTF-8 fails as ``decode_error``.
+
+    Distinct from ``unsupported_type`` (the type IS supported) — and we fail
+    loud rather than guess an encoding, since a silent mis-decode would
+    corrupt the text a citation later verifies against.
+    """
+
+    body = b"valid ascii then non-utf8: \xff\xfe and a lone \x80 byte"
+    storage_key = f"{uuid.uuid4()}"
+    _put_in_fake_s3(fake_s3, storage_key, body)
+
+    file_row = await _create_file_row(
+        db_session,
+        db_user,
+        storage_path=storage_key,
+        pdf_bytes=body,
+        mime="text/plain",
+        filename="latin1-notes.txt",
+    )
+
+    result = await ingest_file(db_session, file_row.id)
+
+    assert result.status == "failed"
+    assert result.error == "decode_error"
+
+    await db_session.refresh(file_row)
+    assert file_row.ingestion_status == "failed"
+    assert file_row.ingestion_error == "decode_error"
+
+    # No Document persisted for a failed decode.
+    doc = (
+        await db_session.execute(select(Document).where(Document.file_id == file_row.id))
+    ).scalar_one_or_none()
+    assert doc is None
+
+
+@pytest.mark.integration
+async def test_ingest_markdown_as_octet_stream_routes_by_extension(
+    db_session: AsyncSession,
+    db_user: User,
+    fake_s3: FakeS3Client,
+    patched_storage: FakeS3Client,
+) -> None:
+    """Many browsers send `.md` as application/octet-stream (or empty). The gate
+    must fall back to the filename extension, or the headline use case (upload a
+    Markdown file) silently fails as unsupported_type before the parser runs."""
+
+    source = "# Notes\n\nThe party shall deliver within 30 days.\n" * 10
+    body = source.encode("utf-8")
+    storage_key = f"{uuid.uuid4()}"
+    _put_in_fake_s3(fake_s3, storage_key, body)
+
+    file_row = await _create_file_row(
+        db_session,
+        db_user,
+        storage_path=storage_key,
+        pdf_bytes=body,
+        mime="application/octet-stream",  # the browser did not recognize .md
+        filename="notes.md",
+    )
+
+    result = await ingest_file(db_session, file_row.id)
+
+    assert result.status == "ready", f"expected ready, got {result.status}/{result.error}"
+    assert result.chunk_count > 0
+
+    doc = (
+        await db_session.execute(select(Document).where(Document.file_id == file_row.id))
+    ).scalar_one()
+    assert doc.parser == "plain-text"
+    assert doc.normalized_content == source
+
+
+@pytest.mark.integration
 async def test_ingest_multipage_records_per_chunk_pages(
     db_session: AsyncSession,
     db_user: User,

--- a/api/tests/test_pipeline_ingest.py
+++ b/api/tests/test_pipeline_ingest.py
@@ -493,7 +493,9 @@ async def test_ingest_unsupported_mime_marks_failed(
     fake_s3: FakeS3Client,
     patched_storage: FakeS3Client,
 ) -> None:
-    """A non-PDF MIME flips the row to failed with unsupported_type."""
+    """A MIME that is neither PDF nor text/Markdown flips the row to failed
+    with unsupported_type. (text/plain is now supported — see DE-332 — so this
+    uses an image, which is still unsupported.)"""
 
     storage_key = f"{uuid.uuid4()}"
     _put_in_fake_s3(fake_s3, storage_key, b"hello world")
@@ -503,8 +505,8 @@ async def test_ingest_unsupported_mime_marks_failed(
         db_user,
         storage_path=storage_key,
         pdf_bytes=b"hello world",
-        mime="text/plain",
-        filename="x.txt",
+        mime="image/png",
+        filename="x.png",
     )
 
     result = await ingest_file(db_session, file_row.id)

--- a/api/tests/test_pipeline_parsers_text.py
+++ b/api/tests/test_pipeline_parsers_text.py
@@ -1,0 +1,242 @@
+"""Unit tests for the plain-text / Markdown parser (``parse_text``).
+
+Deliberately **independent of PyMuPDF** — unlike ``test_pipeline_parsers.py``
+there is no ``importorskip("fitz")`` here, because the whole point of the
+text branch is that it needs no parsing library. These tests run on a bare
+Python + pytest install.
+
+The load-bearing test is :func:`test_offset_fidelity_text`: it runs the full
+``parse_text → chunk_document`` path and slices every chunk back against the
+canonical text byte-for-byte. That invariant is the Citation Engine's
+precondition — for text it holds *exactly*, because the canonical text is the
+verbatim decoded upload.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.pipeline.chunker import chunk_document
+from app.pipeline.parsers import (
+    PageSpan,
+    ParsedDocument,
+    ParserDecodeError,
+    ParserError,
+    is_text_filename,
+    is_text_mime,
+    parse_text,
+)
+
+# ---------------------------------------------------------------------------
+# is_text_mime
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_is_text_mime_accepts_text_and_markdown() -> None:
+    assert is_text_mime("text/plain") is True
+    assert is_text_mime("text/markdown") is True
+    assert is_text_mime("text/x-markdown") is True
+    # Charset parameters are common on text uploads; the bare type matches.
+    assert is_text_mime("text/plain; charset=utf-8") is True
+    assert is_text_mime("TEXT/MARKDOWN; charset=UTF-8") is True
+
+
+@pytest.mark.unit
+def test_is_text_mime_rejects_non_text() -> None:
+    assert is_text_mime("application/pdf") is False
+    assert is_text_mime("application/octet-stream") is False
+    assert (
+        is_text_mime("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+        is False
+    )
+    assert is_text_mime("") is False
+
+
+@pytest.mark.unit
+def test_is_text_filename_extension_fallback() -> None:
+    """Browsers/OSes often send .md as application/octet-stream or empty, so the
+    extension is the dependable routing signal (parse_text still validates bytes)."""
+    assert is_text_filename("notes.md") is True
+    assert is_text_filename("NOTES.MD") is True
+    assert is_text_filename("spec.markdown") is True
+    assert is_text_filename("memo.txt") is True
+    assert is_text_filename("/path/to/a.MD") is True
+    # Not text extensions:
+    assert is_text_filename("contract.pdf") is False
+    assert is_text_filename("brief.docx") is False
+    assert is_text_filename("archive") is False
+    assert is_text_filename("image.md.png") is False
+
+
+# ---------------------------------------------------------------------------
+# parse_text — happy path + verbatim store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw, label",
+    [
+        (b"Plain text. " * 200, "plain"),
+        (
+            (
+                b"# Heading\n\n"
+                b"Clause 1. The party **shall** pay within 30 days.\n\n"
+                b"| term | value |\n|---|---|\n| fee | 100 |\n"
+            )
+            * 30,
+            "markdown",
+        ),
+    ],
+)
+def test_parse_text_stores_verbatim_single_page(raw: bytes, label: str) -> None:
+    parsed = parse_text(raw)
+
+    assert isinstance(parsed, ParsedDocument)
+    # Verbatim: the canonical text is exactly the decoded upload — no
+    # rendering, no normalization. This is what makes exact-match citations
+    # resolve against the source the user uploaded.
+    assert parsed.canonical_text == raw.decode("utf-8"), f"[{label}] not verbatim"
+    assert parsed.parser == "plain-text"
+    assert parsed.parser_version == "1"
+    assert parsed.structured_content is None
+    # Text has no pagination — a single synthetic page over the whole stream.
+    assert parsed.page_count == 1
+    assert parsed.pages == [
+        PageSpan(page_number=1, char_start=0, char_end=len(parsed.canonical_text))
+    ]
+
+
+@pytest.mark.unit
+def test_parse_text_drops_utf8_bom() -> None:
+    """A leading UTF-8 BOM is an encoding artifact, not content — drop it."""
+
+    parsed = parse_text("﻿hello".encode())
+    assert parsed.canonical_text == "hello"
+    assert parsed.pages[0].char_end == len("hello")
+
+
+@pytest.mark.unit
+def test_parse_text_unicode_byte_fidelity() -> None:
+    """Non-ASCII content round-trips exactly, and the page span covers it."""
+
+    source = "Cláusula — 第4.2条 — café ☕ §4.2"
+    parsed = parse_text(source.encode("utf-8"))
+
+    assert parsed.canonical_text == source
+    span = parsed.pages[0]
+    assert parsed.canonical_text[span.char_start : span.char_end] == source
+
+
+@pytest.mark.unit
+def test_parse_text_empty_yields_no_chunks() -> None:
+    """An empty file is honestly empty: ready, zero chunks."""
+
+    parsed = parse_text(b"")
+    assert parsed.canonical_text == ""
+    assert parsed.page_count == 1
+    assert chunk_document(parsed) == []
+
+
+# ---------------------------------------------------------------------------
+# parse_text — failure path: fail loud on non-UTF-8 (never silently mis-decode)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_text_rejects_non_utf8() -> None:
+    """A non-UTF-8 byte stream raises rather than guessing an encoding.
+
+    A silent mis-decode (e.g. latin-1 fallback) would corrupt the canonical
+    text a citation later verifies against — the worst possible failure for a
+    verification-critical path. ``ParserDecodeError`` is a ``ParserError``, so
+    the ingest orchestrator maps it to a terminal ``failed`` row.
+    """
+
+    bad = b"valid ascii then a lone continuation byte: \xff\xfe and \x80"
+    with pytest.raises(ParserDecodeError):
+        parse_text(bad)
+    # Subclass relationship the orchestrator relies on.
+    assert issubclass(ParserDecodeError, ParserError)
+
+
+@pytest.mark.unit
+def test_parse_text_rejects_nul_byte() -> None:
+    """A NUL byte decodes as valid Unicode but PostgreSQL ``text`` cannot store
+    it. Reject at parse time so it surfaces as a clean ``decode_error`` rather
+    than a DB exception that strands the row mid-ingest. (A NUL almost always
+    means a binary/UTF-16 file mislabeled as text.)"""
+
+    with pytest.raises(ParserDecodeError):
+        parse_text(b"clause one\x00clause two")
+
+
+# ---------------------------------------------------------------------------
+# THE LOAD-BEARING TEST — offset fidelity through parse_text → chunk_document.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("target, overlap", [(200, 20), (1200, 100)])
+def test_offset_fidelity_text(target: int, overlap: int) -> None:
+    """Every chunk slices back to its content byte-for-byte (Citation Engine
+    precondition). For text this holds exactly: canonical_text is verbatim."""
+
+    source = (
+        "# Master Services Agreement\n\n"
+        "1. Term. This Agreement commences on the Effective Date and "
+        "continues for three (3) years.\n\n"
+        "2. Fees. Customer shall pay the fees set out in Exhibit A within "
+        "thirty (30) days of invoice.\n\n"
+        "Cláusula 3 — Límite de responsabilidad — 第4条.\n\n"
+    ) * 25
+    parsed = parse_text(source.encode("utf-8"))
+    chunks = chunk_document(parsed, target_chars=target, overlap_chars=overlap)
+
+    assert chunks, "chunker produced no chunks for non-empty text"
+    for chunk in chunks:
+        canonical_slice = parsed.canonical_text[chunk.char_offset_start : chunk.char_offset_end]
+        assert canonical_slice == chunk.content, (
+            f"chunk {chunk.chunk_index} fidelity broken: "
+            f"offsets=[{chunk.char_offset_start}, {chunk.char_offset_end})"
+        )
+        # Every text chunk lands on the single synthetic page.
+        assert chunk.page_start == 1
+        assert chunk.page_end == 1
+
+
+# ---------------------------------------------------------------------------
+# ADVERSARIAL INPUT — a .txt/.md is attacker-controlled content that flows
+# into the chunker. These lock in that pathological text cannot hang a worker
+# (no ReDoS, guaranteed loop advance) and still satisfies offset-fidelity.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw, label",
+    [
+        (b"A" * 300_000, "one-giant-line-no-whitespace"),
+        (b".!?" * 100_000, "all-sentence-punctuation-no-spaces"),
+        (b"\n" * 200_000, "all-newlines"),
+        (b" " * 200_000, "all-whitespace"),
+        ("一".encode() * 100_000, "dense-cjk-no-boundaries"),
+    ],
+)
+def test_parse_text_pathological_input_terminates_with_fidelity(raw: bytes, label: str) -> None:
+    """Pathological text terminates in linear time and keeps offset-fidelity.
+
+    The chunker's regexes (`[.!?]\\s`, `\\n\\s*\\n`) are backtracking-free and the
+    chunk loop is guaranteed to advance, so none of these inputs can hang a
+    worker — and every chunk still slices back to its source bytes exactly.
+    """
+
+    parsed = parse_text(raw)
+    chunks = chunk_document(parsed, target_chars=2000, overlap_chars=200)
+    # Whitespace-only inputs are non-empty text but may yield no chunks — both
+    # are acceptable; what matters is termination and fidelity where chunks exist.
+    for chunk in chunks:
+        assert (
+            parsed.canonical_text[chunk.char_offset_start : chunk.char_offset_end] == chunk.content
+        ), f"[{label}] offset fidelity broken at chunk {chunk.chunk_index}"

--- a/docs/HONEST-STATE.md
+++ b/docs/HONEST-STATE.md
@@ -49,6 +49,7 @@ The surface in-house counsel touches every day. Every row is wired end-to-end in
 | Skill capture / wizard authoring / fork / versions tab | M1 | `web/cypress/e2e/wave-d2-skill-creator.cy.ts` Tests 1–6 |
 | Saved Prompts library with one-click "Use in chat" | M1 | `api/app/api/saved_prompts.py`; `web/cypress/e2e/wave-m1-final-surfaces.cy.ts` Test 1 |
 | Knowledge bases — create, attach documents, ingest to `ready` (hybrid BM25 + vector retrieval) | M1 | `api/app/api/knowledge_bases.py`; `api/app/workers/document_pipeline.py` |
+| Ingest formats — **PDF** (PyMuPDF/Docling) and **plain text / Markdown** (`parse_text`, verbatim canonical text → exact-match citations; non-UTF-8 → `decode_error`). DOCX is roadmap. | M1 (PDF); post-v0.5.0 (text/md, DE-332) | `api/app/pipeline/parsers.py`; `api/app/pipeline/ingest.py` |
 | Receipts drawer with per-event provenance | M1 | `api/app/api/chat_receipts.py`; `web/cypress/e2e/wave-m1-final-surfaces.cy.ts` Test 3 |
 | Enhance Prompt (⌘E) | M1 | `api/app/api/enhance_prompt.py` |
 | Audit log of all sensitive actions | M1 | `api/app/audit.py`; admin reads at `/lq-ai/admin/audit-log` |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4500,7 +4500,9 @@ Two bulk operations as originally written in the M3-C4 spec:
 
 ---
 
-#### DE-332 — Text/markdown ingest-parser support (today the ingest pipeline is PDF-only)
+#### DE-332 — Text/markdown ingest-parser support
+
+**Status: Shipped (post-v0.5.0).** `parse_text` (`api/app/pipeline/parsers.py`) accepts `text/plain` / `text/markdown`, stores the verbatim decoded bytes as canonical text so exact-match citations resolve against the source, and fails a non-UTF-8 upload as `decode_error` rather than guessing an encoding. Markdown is stored verbatim, never rendered. Tests: `api/tests/test_pipeline_parsers_text.py` (unit, no PyMuPDF) + `api/tests/test_pipeline_ingest.py` (ingest happy-path + decode_error). DOCX remains roadmap.
 
 **Priority:** P3 · **Effort:** M · **Good first issue** (community-suitable)
 

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -7698,14 +7698,17 @@ components:
             Lifecycle: `pending` (just uploaded; C4 sets this on insert)
             → `processing` (C5 worker has picked it up) → `ready`
             (parsed, chunks persisted) OR `failed` (with `ingestion_error`
-            set; e.g., `unsupported_type` for non-PDF MIMEs in M1, or
-            `parse_failed` for corrupt PDFs).
+            set; e.g., `unsupported_type` for unsupported MIMEs (anything
+            that is neither PDF nor text/Markdown), `decode_error` for a
+            non-UTF-8 text upload, or `parse_failed` for corrupt PDFs).
         ingestion_error:
           type: string
           nullable: true
           description: |
-            Set when `ingestion_status='failed'`. M1 values include
-            `unsupported_type`, `unsupported_content`, `parse_failed`.
+            Set when `ingestion_status='failed'`. Values include
+            `unsupported_type`, `unsupported_content`, `parse_failed`,
+            and `decode_error` (a `text/plain` or `text/markdown` upload
+            whose bytes are not valid UTF-8).
         page_count:
           type: integer
           nullable: true
@@ -7719,8 +7722,9 @@ components:
           description: |
             Populated by the C5 document pipeline once
             `ingestion_status='ready'`; counts characters of the
-            canonical PyMuPDF-extracted text, not of the original
-            PDF byte stream.
+            canonical extracted text (PyMuPDF for PDF; the verbatim
+            decoded bytes for text/Markdown), not the original byte
+            stream.
         document_id:
           type: string
           format: uuid

--- a/web/src/routes/lq-ai/knowledge/[id]/+page.svelte
+++ b/web/src/routes/lq-ai/knowledge/[id]/+page.svelte
@@ -371,7 +371,7 @@
 					</button>
 					<input
 						type="file"
-						accept="application/pdf,.pdf"
+						accept="application/pdf,.pdf,text/plain,text/markdown,.md,.markdown,.txt"
 						bind:this={fileInput}
 						on:change={handleFileSelected}
 						class="lq-file-input"


### PR DESCRIPTION
<!-- Paste into the PR body (their PULL_REQUEST_TEMPLATE.md). Fill #NN with the claim-issue number. -->

## What this PR does

Adds a plain-text / Markdown ingest path. `.md` and `.txt` uploads now ingest into a knowledge base through the same chunk → embed → cite pipeline that PDFs use, via a new `parse_text` branch alongside `parse_pdf`. The decoded bytes are stored **verbatim** as the canonical character stream.

## Why

**Refs DE-332.** The pipeline was PDF-only — every non-PDF was rejected as `unsupported_type` before a parser ran, so a user couldn't add plain text or Markdown (including the project's own skill files and autonomous-layer memos) to a KB.

The design choice that matters: storing the text verbatim means `documents.normalized_content` equals the uploaded bytes exactly, so the Citation Engine's **exact-match tier resolves byte-for-byte** — the direct defense against quote-misattribution (a quote that *looks* sourced but was silently altered). For text this is *higher* fidelity than the PDF path, which can introduce extraction artifacts. `parse_text` is pure stdlib: no model, no OCR, no network — deterministic, and runs identically air-gapped.

This is the **trivial, dependency-free sibling of the DOCX work in #198**; the `is_X_mime`/`parse_X` dispatch composes with a future `parse_docx`.

## What this PR does *not* do

- **No DOCX** (separate, heavier effort — #198 / its ADR).
- **No in-app text preview** — `.md`/`.txt` is downloadable but the viewer is PDF-only (a raw-text viewer is a follow-up; if added it must show Markdown *raw*, never render to HTML).
- **No structure-aware Markdown chunking** — a long table can split across chunks, identical to the PDF path (follow-up DE).
- **No charset guessing** — UTF-16 / Latin-1 / Word exports are rejected as `decode_error` with a "save as UTF-8" message (deliberate: guessing risks silent mis-decode → wrong citations).
- **No new dependency, no DB migration, no `gateway`/authz/secrets/CI/infra changes.** The PDF path is byte-identical (the gate is *widened*, not rerouted; zero deletions). Per `docs/security/external-contribution-vetting.md` this should be a "normal read," not the supply-chain playbook.

## Type of change

- [x] New feature (non-breaking change that adds capability)
- [x] Documentation update
- [ ] Bug fix / Breaking change / Skill / Refactor

## Testing

- [x] Unit tests added — `api/tests/test_pipeline_parsers_text.py` (fitz-free; verbatim store, BOM, unicode byte-fidelity, empty→0 chunks, **non-UTF-8 → `decode_error`**, **NUL-byte → `decode_error`**, the offset-fidelity invariant, the `.md`/`.txt` extension fallback, and **adversarial-input regression** locking in that pathological text can't hang the chunker).
- [x] Integration tests added — `api/tests/test_pipeline_ingest.py`: Markdown happy-path (`normalized_content == source` verbatim, chunks slice back, `parser="plain-text"`, `page_count=1`, `was_ocrd=False`); non-UTF-8 → `failed`/`decode_error` with no Document persisted; **`.md` sent as `application/octet-stream` routes by extension** (the common browser case).
- [ ] Manually tested against a real deployment — *not yet; flagging honestly. Happy to run a live smoke if useful.*

<details><summary>Robustness notes (what I checked beyond the happy path)</summary>

- **NUL byte:** valid Unicode but unstorable in a Postgres `text` column — would strand the row mid-ingest. Rejected up front as `decode_error`.
- **`.md` MIME variance:** browsers/OSes frequently send `application/octet-stream` (or empty) for `.md`; routing falls back to the filename extension, with `parse_text`'s UTF-8/NUL validation as the safety net (a binary renamed `.md` fails cleanly).
- **DoS / ReDoS:** a `.txt` is attacker-controlled content flowing into the chunker. Both chunker regexes are backtracking-free and the chunk loop is guaranteed to advance — a 100MB pathological file processes in linear time (~0.01s). Regression-tested.
- **No migration:** writes only existing columns (`normalized_content`/`was_ocrd`, etc.). **Re-ingest** is the existing atomic delete-then-insert — format-agnostic, no duplication.
- **Known pre-existing limitation (not changed here):** embedding runs as a separate post-ingest job, so a doc can be `ready` (keyword-searchable) before semantic embeddings complete — format-agnostic, surfaced in KB-detail.
</details>

## Documentation

- [x] PRD updated (DE-332 marked shipped)
- [x] OpenAPI accepted-types / error descriptions (+`decode_error`)
- [x] HONEST-STATE updated (ingest-formats row)
- [x] `parsers.py` / `ingest.py` module docstrings reconciled (no longer "PDF-only")
- [ ] README / deployment / compliance — n/a

## DCO sign-off

- [x] All commits signed off per the DCO.

## Principles self-check (per the Part-2 contributor prompt)

1. **Egress** — n/a: no outbound call; `parse_text` is pure stdlib decode.
2. **Closed set** — n/a: adds no model-/autonomous-invokable capability or hook (the accepted types are a closed, code-defined set).
3. **Payloads in logs** — yes: log lines/rows carry MIME + outcome only; **never the filename or document content**.
4. **Fail restrictive** — yes, and the failure paths are tested: unknown type → `unsupported_type`; bad encoding / NUL → `decode_error`; a binary renamed `.md` is validated then rejected.
5. **Atomicity** — n/a: reuses the existing persist/commit boundary unchanged.
6. **Reuse the governance path** — n/a: no tier/cost/audit logic added.
7. **Irreversibility** — n/a: ingest is reversible; nothing destructive.
8. **Operator control** — n/a: file-format support is core ingest, not a toggleable capability (neither is PDF).
9. **User data** — yes: verbatim inbound text *because citation grounding requires it* (P9); export/delete are format-agnostic.
10. **Contract & docs** — yes: OpenAPI + HONEST-STATE + PRD updated in this PR. The one behavior choice beyond the DE's literal "by MIME" — routing `.md`/`.txt` by filename extension when the MIME is generic (browsers send `.md` inconsistently) — is surfaced here for you to ratify or ask me to drop.
11. **Tests as part of the change** — yes: the offset-fidelity test is a security-relevant invariant that *fails* if violated; plus adversarial-input regression (a `.txt` is attacker-controlled content into the chunker).
12. **No black box** — yes: a citation resolves against the verbatim source at exact offsets, and the parser is open and inspectable.

## Related issues

Refs **DE-332** (PRD §9) · sibling of #198 (DOCX ingest) — happy to sequence behind/ahead of the DOCX work as you prefer.

## Reviewer notes

Scope is deliberately minimal and additive; the verification-critical guarantee (verbatim canonical text → exact-match citations) is encoded as the offset-fidelity test, not asserted in prose. Files touched: `api/app/pipeline/{parsers,ingest,__init__}.py`, the two test files, `web/.../knowledge/[id]/+page.svelte` (one `accept` attribute), and docs. No `gateway`/authz/secrets. Glad to split the `web/` accept-attribute change out if you'd prefer it separate.
