### PR TITLE
fix(chat): write a final answer when the tool-loop hits the call cap

### DIFF
--- a/api/app/chat/tool_loop.py
+++ b/api/app/chat/tool_loop.py
@@ -513,10 +513,7 @@ async def run_chat_tool_loop(
         # destructive call that pushed us to the limit), fire the final round
         # immediately without tools.
         if calls_used >= settings.chat_tool_call_cap:
-            final_resp = await gateway.chat_completion(
-                _build_request(base_request, messages, tools=None, tool_choice="none"),
-                request_id=request_id,
-            )
+            final_resp = await _final_synthesis_round(gateway, base_request, messages, request_id)
             return _build_loop_final(final_resp, messages, calls_used, collected_sources)
 
         # ── Build this round's request with tools ──────────────────────────
@@ -646,24 +643,52 @@ async def run_chat_tool_loop(
         # forever.  Break out immediately to the final no-tools round so the
         # model synthesises from whatever it has gathered so far.
         if governed_count == 0:
-            final_resp = await gateway.chat_completion(
-                _build_request(base_request, messages, tools=None, tool_choice="none"),
-                request_id=request_id,
-            )
+            final_resp = await _final_synthesis_round(gateway, base_request, messages, request_id)
             return _build_loop_final(final_resp, messages, calls_used, collected_sources)
 
         # ── Cap check AFTER incrementing ─────────────────────────────────
         if calls_used >= settings.chat_tool_call_cap:
-            final_resp = await gateway.chat_completion(
-                _build_request(base_request, messages, tools=None, tool_choice="none"),
-                request_id=request_id,
-            )
+            final_resp = await _final_synthesis_round(gateway, base_request, messages, request_id)
             return _build_loop_final(final_resp, messages, calls_used, collected_sources)
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+_SYNTHESIS_DIRECTIVE = (
+    "Tool access is now disabled for this turn (the per-turn tool-call limit "
+    "was reached). Do not request any further tools. Using only the "
+    "information already gathered in the tool results above, write your "
+    "complete final answer to the user's request now. If some information is "
+    "missing, answer with what you have and note the gap explicitly."
+)
+
+
+async def _final_synthesis_round(
+    gateway: Any,
+    base_request: ChatCompletionRequest,
+    messages: list[dict[str, Any]],
+    request_id: str | None,
+) -> Any:
+    """Issue the final no-tools round with an explicit synthesis directive.
+
+    Flipping tools off and re-sending the message list verbatim leaves the
+    model mid-research with no instruction to stop and write — empirically it
+    then returns empty content (the cap-hit "blank answer" bug: a turn that
+    exhausts the tool-call cap mid-research persisted a zero-length assistant
+    message). Appending an explicit synthesis directive makes the model
+    compose its answer from what it has already gathered.
+
+    The directive is appended to a COPY of ``messages`` so it is sent to the
+    model for this round only and never leaks into the persisted turn history.
+    """
+    synth_messages = [*messages, {"role": "user", "content": _SYNTHESIS_DIRECTIVE}]
+    return await gateway.chat_completion(
+        _build_request(base_request, synth_messages, tools=None, tool_choice="none"),
+        request_id=request_id,
+    )
 
 
 def _build_request(

--- a/api/tests/chat/test_tool_loop.py
+++ b/api/tests/chat/test_tool_loop.py
@@ -750,3 +750,72 @@ async def test_loop_hallucination_only_round_terminates_finitely(
     assert outcome.calls_used == 0
     # Exactly two gateway calls consumed — no extras that would signal infinite loop
     assert gateway.chat_completion.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Scenario (j): cap-triggered final round injects an explicit synthesis directive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_cap_final_round_injects_synthesis_directive(
+    db: AsyncSession, user: User
+) -> None:
+    """Regression: the cap-triggered final no-tools round must carry an explicit
+    synthesis directive so the model writes its answer instead of returning empty.
+
+    Bug: a research turn that exhausts the tool-call cap mid-research issued a
+    plain ``tool_choice="none"`` round (tools off, identical message list). With
+    no instruction to stop researching and write, the model returned empty
+    content and the turn persisted a zero-length assistant message. The final
+    round must append a user directive instructing synthesis from what was
+    already gathered — and that directive must NOT leak into the persisted turn.
+    """
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    gateway = AsyncMock()
+    gateway.chat_completion.side_effect = [
+        _resp_tool_call("search_case_law", {"q": "x"}, call_id="c1"),
+        _resp_final("Here is the synthesized answer."),
+    ]
+    al = _research_allowlist(provider="cl-prod")
+
+    with (
+        patch(
+            "app.chat.tool_loop.research_service.search_case_law",
+            new=AsyncMock(return_value={"results": []}),
+        ),
+        patch("app.chat.tool_loop.resolve_provider_tier", new=AsyncMock(return_value=1)),
+        patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=[])),
+        patch("app.chat.tool_loop.get_settings") as mock_settings,
+    ):
+        settings_obj = MagicMock()
+        settings_obj.chat_tool_call_cap = 1  # trip the cap after one executed call
+        mock_settings.return_value = settings_obj
+
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("research it")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+        )
+
+    assert isinstance(outcome, LoopFinal)
+    assert outcome.text == "Here is the synthesized answer."
+
+    # Final (2nd) round: tools disabled AND a synthesis directive appended last.
+    assert gateway.chat_completion.call_count == 2
+    final_req: ChatCompletionRequest = gateway.chat_completion.call_args_list[1].args[0]
+    assert final_req.tools is None
+    last_msg = final_req.messages[-1]
+    assert last_msg.role == "user"
+    assert "final answer" in (last_msg.content or "").lower()
+
+    # The directive must NOT leak into the persisted turn messages.
+    assert all(
+        "final answer" not in (m.get("content") or "").lower()
+        for m in outcome.messages
+        if isinstance(m, dict)
+    )


### PR DESCRIPTION
## What this PR does

Fixes the chat tool-loop so it writes a real final answer when a turn exhausts `chat_tool_call_cap`, instead of persisting an empty assistant message.

## Why

Closes #207.

The forced final round disabled tools (`tool_choice="none"`) but re-sent the message list verbatim, with no instruction to stop calling tools and synthesize. A research turn that hit the cap mid-research therefore returned ~empty content and persisted a zero-length assistant message (observed live: 25 tool calls, 121 sources collected, final round `tokens_out=9`, `length(content)=0`).

This adds `_final_synthesis_round()`, which appends an explicit synthesis directive to a **copy** of the message list before the no-tools round, so the model composes its answer from what it already gathered. Appending to a copy keeps the directive out of the persisted turn history. It is wired into all three forced-synthesis exit points (cap-before-loop, all-hallucination guard, cap-after-increment).

## What this PR does *not* do

Deliberately scoped to the empty-answer bug. Out of scope (noted as follow-ups in #207):
- Raising the default cap (`8`) for multi-call-per-case skills.
- The `config.py` docstring naming the override `LQ_AI_CHAT_TOOL_CALL_CAP` (real var: `CHAT_TOOL_CALL_CAP`).
- `tool_call_log.chat_id` landing NULL (`execute_tool` called without `chat_id=`).
- `applied_skills` emptying on follow-up turns.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit test added (`test_loop_cap_final_round_injects_synthesis_directive`): asserts the cap-triggered final round disables tools, appends a `role="user"` synthesis directive as the last message, and that the directive does **not** leak into the persisted turn.
- [x] Manually tested against a real deployment: a cap-hit (25-call) `case-law-research` turn went from a **0-character** answer to a full **8,305-character** report.

> ⚠️ **Reviewer note (transparency):** I could not run the test suite or linters locally — the api image is runtime-only (no pytest/ruff, no `tests/` baked in) and I didn't have a dev env handy. CI will be the first real run of the new test. Please give it a look there.

## DCO sign-off

- [x] All commits are signed off per the DCO.

## Related issues

Closes #207

## Reviewer notes

Two design choices I'd specifically welcome your call on:
- The wording of the synthesis directive (`_SYNTHESIS_DIRECTIVE`).
- Whether the directive should be a `role="user"` turn (current approach) vs. a system message — `user` was the most reliable steer in testing, but you know the gateway/Anthropic bridge better than I do.