### PR TITLE
Add transparency & governance invariants (ADR 0016) with CI gates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,6 +50,24 @@ non-goals prevents reviewer scope creep and makes follow-up PRs cleaner. -->
 - [ ] Compliance documentation updated (if compliance posture changes)
 - [ ] OpenAPI schema regenerated (if API endpoints change)
 
+## Transparency & governance invariants
+
+<!-- The posture that *is* the product (ADR 0016). Check each box or mark it
+n/a. If you can't, stop and either fix the change or surface the decision to a
+maintainer. The cheap-to-check ones are enforced by
+api/tests/test_transparency_invariants.py — but the judgment ones are on you. -->
+
+- [ ] **Egress (P1):** any outbound third-party call goes through the gateway only — no direct egress from `api/`.
+- [ ] **Closed set (P2):** any new model/autonomous-invokable capability is a bounded, operator-controlled allowlist entry, not an open hook.
+- [ ] **No raw payloads (P3):** no row or log line I add carries raw content (message bodies, tool args/results, fetched text, keys) — counts, types, ids, digests, outcomes only.
+- [ ] **Fail restrictive (P4):** missing/broken config fails closed, and I tested that path, not just the happy path.
+- [ ] **Atomic audit (P5):** state changes get an audit row committed in the same transaction (helpers flush, the handler commits).
+- [ ] **One governance path (P6):** I reused the shared governance/audit helpers rather than re-deriving tier/cost/audit logic.
+- [ ] **Human gate (P7):** anything destructive/irreversible is behind the confirmation gate and excluded from unattended/autonomous execution.
+- [ ] **Operator control (P8):** any new capability has an operator enable/disable and appears on an admin surface.
+- [ ] **User owns data (P9):** outbound matter context is anonymized; the change respects export/delete and data-residency guarantees.
+- [ ] **Contract is truth (P10):** OpenAPI sketch / DB schema doc / relevant ADR updated in this PR; any architectural/authz decision is recorded or surfaced, not made silently.
+
 ## DCO sign-off
 
 - [ ] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

--- a/api/tests/test_transparency_invariants.py
+++ b/api/tests/test_transparency_invariants.py
@@ -1,0 +1,252 @@
+"""Transparency & governance invariants — structural CI gates (ADR 0016).
+
+These tests do not exercise behaviour; they pin the *posture* invariants
+that ADR 0016 makes binding, so a future change that quietly violates one
+fails CI at collection rather than slipping past review. Each test is
+designed to be green on current ``main`` and to trip only on a genuine
+violation, with an explicit, documented escape hatch (an allowlist a
+contributor must consciously extend) rather than a blunt grep.
+
+Mapped invariants:
+
+* **P1 — one audited egress boundary:** the backend makes no direct
+  third-party HTTP calls (``test_backend_makes_no_direct_third_party_egress``).
+* **P3 — counts/types, never payloads:** no audit/log model carries a
+  raw-content column (``test_audit_models_have_no_raw_payload_columns``).
+* **P4 — fail restrictive:** the tier fail-safe is the most-restrictive
+  tier (``test_fail_safe_tier_is_most_restrictive``).
+* **P5 — atomic audit:** the audit/governance helpers flush, never commit
+  (``test_governance_and_audit_helpers_do_not_commit``).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Table
+
+import app
+from app.models.audit import AuditLog
+from app.models.inference import InferenceRoutingLog
+from app.models.tool_call_log import ToolCallLog
+from app.models.tool_egress import ToolEgressLog
+from app.tools.governance import _MAX_TIER
+
+# Root of the importable ``app`` package (``api/app``).
+_APP_DIR = Path(app.__file__).resolve().parent
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# P3 — counts/types, never payloads
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Every model whose entire purpose is an audit/log row. If a column name on
+# one of these implies it holds raw content, that is a P3 violation.
+_AUDIT_MODELS: tuple[type, ...] = (
+    ToolCallLog,
+    AuditLog,
+    ToolEgressLog,
+    InferenceRoutingLog,
+)
+
+# Column names that, by name alone, signal raw-content storage. Matched
+# case-insensitively as an exact name, a suffix, or a prefix — chosen so the
+# legitimate columns on the audit models today (e.g. ``args_digest``,
+# ``details``, ``refusal_reason``, ``user_agent``) do NOT trip.
+_DENIED_EXACT: frozenset[str] = frozenset(
+    {
+        "body",
+        "content",
+        "payload",
+        "plaintext",
+        "raw",
+        "args",
+        "arguments",
+        "result",
+        "results",
+        "response",
+        "prompt",
+        "completion",
+        "message",
+        "text",
+        "query",
+        "input",
+        "output",
+    }
+)
+_DENIED_SUFFIX: tuple[str, ...] = (
+    "_body",
+    "_payload",
+    "_content",
+    "_plaintext",
+    "_text",
+    "_raw",
+    "_args",
+    "_arguments",
+    "_result",
+    "_results",
+    "_response",
+    "_prompt",
+    "_completion",
+    "_message",
+)
+_DENIED_PREFIX: tuple[str, ...] = ("raw_", "plaintext_")
+
+# Intentional, reviewed exceptions, keyed by (table_name, column_name). Empty
+# today: a contributor who genuinely needs a content-bearing column on an audit
+# model must add it here in the same PR, which forces the decision into review.
+_ALLOWED_CONTENT_COLUMNS: frozenset[tuple[str, str]] = frozenset()
+
+
+def _implies_raw_content(column_name: str) -> bool:
+    name = column_name.lower()
+    return name in _DENIED_EXACT or name.endswith(_DENIED_SUFFIX) or name.startswith(_DENIED_PREFIX)
+
+
+@pytest.mark.unit
+def test_audit_models_have_no_raw_payload_columns() -> None:
+    """P3: audit/log rows record counts and types, never raw payloads.
+
+    Adding a content-bearing column to an audit model is the most likely
+    way to silently turn an auditable surface into a black box, so the
+    column names themselves are the tripwire.
+    """
+    offenders: list[str] = []
+    for model in _AUDIT_MODELS:
+        table: Table = model.__table__  # type: ignore[attr-defined]
+        for column in table.columns:
+            if (table.name, column.name) in _ALLOWED_CONTENT_COLUMNS:
+                continue
+            if _implies_raw_content(column.name):
+                offenders.append(f"{table.name}.{column.name}")
+
+    assert not offenders, (
+        "Audit/log models must store counts and types only, never raw payloads "
+        f"(ADR 0016 P3). Columns whose names imply raw content: {offenders}. "
+        "If a column genuinely needs a content-style name, justify it in review "
+        "and add it to _ALLOWED_CONTENT_COLUMNS in this file."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# P5 — atomic audit: the helpers flush, never commit
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Helpers that MUST ride the caller's transaction (flush-not-commit) so an
+# audit row and the state change it describes are committed together.
+_FLUSH_ONLY_MODULES: tuple[Path, ...] = (
+    _APP_DIR / "audit.py",
+    _APP_DIR / "tools" / "governance.py",
+)
+
+
+def _calls_commit(source: str) -> bool:
+    """True if *source* contains a ``<expr>.commit(...)`` call.
+
+    AST-based so that docstring / comment mentions of ``commit`` (e.g. the
+    ``audit.py`` docstring that documents the caller's commit) do not match.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "commit"
+        ):
+            return True
+    return False
+
+
+@pytest.mark.unit
+def test_governance_and_audit_helpers_do_not_commit() -> None:
+    """P5: the audit/governance helpers flush, never commit.
+
+    Committing inside a helper would let an audit row land in its own
+    transaction, decoupling it from the state change it is supposed to
+    describe (the audit-without-state-change / state-change-without-audit
+    failure modes ADR 0016 P5 forbids).
+    """
+    offenders: list[str] = []
+    for module_path in _FLUSH_ONLY_MODULES:
+        assert module_path.exists(), f"expected helper module missing: {module_path}"
+        if _calls_commit(module_path.read_text(encoding="utf-8")):
+            offenders.append(str(module_path.relative_to(_APP_DIR.parent)))
+
+    assert not offenders, (
+        "Audit/governance helpers must flush, not commit, so audit rows ride "
+        f"the caller's transaction (ADR 0016 P5). Offending modules: {offenders}."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# P1 — one audited egress boundary
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Only this module may construct an outbound HTTP client: it is the backend's
+# single door to the gateway, which is itself the only egress boundary (ADR
+# 0014). Paths are relative to the ``app`` package root.
+_EGRESS_ALLOWLIST: frozenset[str] = frozenset({"clients/gateway.py"})
+
+# Import forms that pull in a general-purpose outbound HTTP client. Targeted at
+# import statements (not prose) to avoid false positives on words like
+# "requests" in comments.
+_HTTP_CLIENT_IMPORTS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\s*import\s+httpx\b", re.MULTILINE),
+    re.compile(r"^\s*from\s+httpx\b", re.MULTILINE),
+    re.compile(r"^\s*import\s+requests\b", re.MULTILINE),
+    re.compile(r"^\s*from\s+requests\b", re.MULTILINE),
+    re.compile(r"^\s*import\s+aiohttp\b", re.MULTILINE),
+    re.compile(r"^\s*from\s+aiohttp\b", re.MULTILINE),
+    re.compile(r"^\s*import\s+urllib\.request\b", re.MULTILINE),
+    re.compile(r"^\s*from\s+urllib\.request\b", re.MULTILINE),
+)
+
+
+@pytest.mark.unit
+def test_backend_makes_no_direct_third_party_egress() -> None:
+    """P1: the backend egresses only through the gateway.
+
+    The backend holds no third-party credentials and makes no third-party
+    calls (ADR 0014 D1). The single door is the gateway client; any other
+    module importing a general-purpose HTTP client is a new, un-audited
+    egress path.
+    """
+    offenders: list[str] = []
+    for path in _APP_DIR.rglob("*.py"):
+        rel = path.relative_to(_APP_DIR).as_posix()
+        if rel in _EGRESS_ALLOWLIST:
+            continue
+        source = path.read_text(encoding="utf-8")
+        if any(pattern.search(source) for pattern in _HTTP_CLIENT_IMPORTS):
+            offenders.append(rel)
+
+    assert not offenders, (
+        "All third-party egress must go through the gateway (ADR 0016 P1 / ADR "
+        f"0014). Modules importing an outbound HTTP client directly: {offenders}. "
+        "Route the call through app.clients.gateway, or — if this is genuinely a "
+        "new audited boundary — record the decision and extend _EGRESS_ALLOWLIST."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# P4 — fail restrictive
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_fail_safe_tier_is_most_restrictive() -> None:
+    """P4: the tier fail-safe is the most-restrictive egress tier.
+
+    ``resolve_provider_tier`` returns ``_MAX_TIER`` when the gateway config
+    is absent or a provider is unknown. Egress tiers run 0 (least
+    sensitive) … 5 (most restrictive); the fail-safe must be 5 so a missing
+    config fails closed, never open.
+    """
+    most_restrictive_egress_tier = 5
+    assert most_restrictive_egress_tier == _MAX_TIER, (
+        "The tier fail-safe must be the most-restrictive tier so missing config "
+        f"fails closed (ADR 0016 P4); got _MAX_TIER={_MAX_TIER}."
+    )

--- a/docs/adr/0016-transparency-and-governance-invariants.md
+++ b/docs/adr/0016-transparency-and-governance-invariants.md
@@ -1,0 +1,201 @@
+# ADR 0016 — Transparency and governance invariants (the engineering posture, made enforceable)
+
+**Status:** Proposed
+**Date:** 2026-06-20
+**Owner:** Maintainer team (transparency-posture hardening)
+
+## Context
+
+LQ.AI's reason for existing is **transparency**: every artifact that shapes the
+user experience is visible, auditable work product, and the operator/admin keep
+complete visibility and control over their data ([PRD §1.3](../PRD.md#13-transparency-as-a-founding-principle),
+[§1.8](../PRD.md#18-security-posture)). That posture is real in the code today —
+the single audited egress boundary (ADR [0014](0014-gateway-egress-boundary-for-tool-providers.md)),
+the closed-set governed tool-calling model (ADR [0015](0015-governed-tool-calling-model.md)),
+the counts-and-types-only audit logs ([audit-logging.md](../security/audit-logging.md)),
+and the fail-restrictive governance substrate (`api/app/tools/governance.py`).
+
+But it is enforced almost entirely by **review culture** (CLAUDE.md, the ADRs,
+[CODEOWNERS](../../.github/CODEOWNERS)) rather than by **gates**. CI runs ruff +
+mypy + pytest + the OpenAPI/route collision guards — none of which fail when a
+change quietly violates the posture: nothing stops a contributor from adding a
+raw-payload column to an audit table, making the backend call a third-party
+endpoint directly, or committing an audit row outside its state-change
+transaction.
+
+This ADR does two things. It **names the invariants** that, taken together, *are*
+the product — so they have the same decision-record status as the architecture
+they protect — and it **makes the cheap-to-check ones enforceable in CI** so the
+posture survives contributors and coding agents who have not internalised the
+culture. Each invariant restates an existing decision; this ADR is a
+consolidation and a hardening, not a new direction.
+
+## Decision drivers
+
+1. **An invariant the reviewer must remember is an invariant that eventually
+   slips.** The recurring-pitfalls history in CLAUDE.md (the 204-DELETE
+   assertion, the route-count collision guards) shows the pattern: a rule that
+   lives only in prose or code comments re-breaks. The fix that holds is a test
+   that fails at collection.
+2. **Transparency is a property of the *whole* codebase, not just `gateway/`.**
+   Security review is routed to `gateway/**` and `docs/security/**`, but the
+   backend now holds half the governance surface (`api/app/tools/`,
+   `api/app/autonomous/guard.py`). The invariants must bind there too.
+3. **A gate with false positives gets disabled.** Every enforced check here is
+   designed to be green on current `main` and to trip only on a genuine
+   violation, with an explicit, documented escape hatch (an allowlist a
+   contributor must consciously extend) rather than a blunt grep.
+4. **Contributors and agents need one place to check themselves.** The
+   pre-flight checklist (the PR template) and these invariants are the same list,
+   stated once.
+
+## Decision
+
+The following ten invariants are binding for every change to this codebase. Each
+cites the prior decision it restates and the enforcement that backs it.
+"Enforced" = a CI-failing test exists; "reviewed" = checked by humans/CODEOWNERS
+and the PR-template checklist (no automated gate yet — candidate for a follow-up).
+
+### P1 — One audited egress boundary
+
+All outbound calls to anything outside the operator's own infrastructure go
+through the Inference Gateway. The backend (`api/`) holds no third-party
+credentials and makes no third-party calls — including OAuth token exchange,
+which is gateway-passthrough (ADR-0014-pure). *Restates ADR 0014 D1; rejects the
+backend-direct-egress shape.*
+**Enforced:** `api/tests/test_transparency_invariants.py::test_backend_makes_no_direct_third_party_egress`
+— scans `api/app/` for outbound HTTP clients (`httpx`/`requests`/`aiohttp`/
+`urllib.request`) and fails unless the only user is the gateway client
+(`app/clients/gateway.py`, the documented allowlist).
+
+### P2 — Closed set, operator-configured — never an open surface
+
+The model and the autonomous layer choose *among* an operator-enabled allowlist;
+they can never reach beyond it. A new model-invokable capability is a new
+bounded, declared entry on an operator-controlled list, not a general-purpose
+hook. *Restates ADR 0015 alternative A / D1; rejects open function-calling.*
+**Reviewed.**
+
+### P3 — Counts and types, never payloads
+
+Audit and log rows record *that* something happened, its shape, and its
+outcome — never the content. No raw arguments, tool results, message bodies,
+fetched text, or cryptographic material lands in any row or log line; only ids,
+counts, tiers, digests, and outcome labels. *Restates ADR 0014 D3, ADR 0015 D2,
+[audit-logging.md](../security/audit-logging.md) "What is NOT logged".*
+**Enforced:** `test_audit_models_have_no_raw_payload_columns` — introspects the
+audit/log ORM models (`ToolCallLog`, `AuditLog`, `ToolEgressLog`,
+`InferenceRoutingLog`) and fails if a column name implies content (`*_body`,
+`*_payload`, `*_content`, `raw_*`, `args`, `result`, …). The OTel span-hygiene
+case is already covered by
+`api/tests/test_tool_governance.py::test_tier_refusal_annotates_span`.
+
+### P4 — Fail restrictive, never open
+
+Missing config, an unknown provider, or a failed lookup resolves to the
+*most-restrictive* outcome, not a permissive fallback. A guard that fails open is
+a bug even when every happy-path test passes. *Restates the `governance.py`
+`_MAX_TIER` fail-safe (ADR 0015 D-a2).*
+**Enforced:** `test_fail_safe_tier_is_most_restrictive` (the most-restrictive
+tier is the ceiling 5) plus the existing
+`test_tool_governance.py::test_resolve_provider_tier_fail_safe_*`.
+
+### P5 — Atomic audit: no state change without its audit row, and vice-versa
+
+Audit/governance writes `flush()` inside the caller's transaction; the handler
+commits the state change and the audit row in one boundary. There is no
+"did-it-but-didn't-log-it" and no "logged-it-but-didn't-do-it" failure mode.
+*Restates `app/audit.py` and `governed_tool_invocation` flush-not-commit.*
+**Enforced:** `test_governance_and_audit_helpers_do_not_commit` — AST-parses
+`app/audit.py` and `app/tools/governance.py` and fails if either calls
+`.commit()` (AST, so docstring/comment mentions of commit don't false-positive).
+
+### P6 — One governance path, not two
+
+Chat and the autonomous layer share a single substrate
+(`governed_tool_invocation`; `guarded_tool_call` delegates to it). A new caller
+reuses the helper; it does not re-derive tier/cost/audit logic. *Restates ADR
+0015 L6.* **Reviewed** (CODEOWNERS should route `api/app/tools/` +
+`api/app/autonomous/guard.py` to security — see "Follow-ups").
+
+### P7 — A human gate for every irreversible action
+
+Anything `destructive` / `requires_confirmation` cannot fire unattended: it is
+gated behind explicit human approval in chat and excluded from autonomous grants
+entirely in v1. *Restates ADR 0015 D4.*
+**Enforced:** the destructive-exclusion behaviour is covered by
+`api/tests/autonomous/test_guard_external_tool_intents.py`.
+
+### P8 — Operator visibility and control over every capability
+
+Every tool / provider / data source has an explicit operator-owned enable/disable
+and appears on an admin surface. A capability the operator cannot see or turn off
+does not ship. *Restates the `mcp_tools.enabled` + `/admin/mcp` +
+`gateway.yaml` `tool_providers:` design.* **Reviewed.**
+
+### P9 — The user owns their data
+
+Outbound matter context is anonymized by default; public inbound text stays
+verbatim only because citation grounding requires it. Users can export and delete
+their own data; deletion anonymizes the actor but preserves the audit trail.
+*Restates ADR 0014 D5 and the user-export/deletion behaviour in
+[audit-logging.md](../security/audit-logging.md).* **Reviewed.**
+
+### P10 — The contract is the source of truth; surface forks, don't decide silently
+
+The OpenAPI sketches, the DB schema doc, and the relevant ADR are updated in the
+*same* PR as the code. A change that hides an architectural / authz / scope
+decision stops and puts options to a maintainer rather than choosing
+unilaterally. *Restates CLAUDE.md decision-routing.*
+**Enforced (partial):** the OpenAPI/route collision guards
+(`test_openapi.py`, `test_endpoints.py`) already pin the API contract;
+documentation/ADR currency is **reviewed** via the PR-template checklist.
+
+## Enforcement summary
+
+| Invariant | Status | Backing |
+|---|---|---|
+| P1 one egress boundary | Enforced | `test_backend_makes_no_direct_third_party_egress` |
+| P2 closed set | Reviewed | CODEOWNERS + PR template |
+| P3 no raw payloads | Enforced | `test_audit_models_have_no_raw_payload_columns` + span-hygiene test |
+| P4 fail restrictive | Enforced | `test_fail_safe_tier_is_most_restrictive` + governance fail-safe tests |
+| P5 atomic audit | Enforced | `test_governance_and_audit_helpers_do_not_commit` |
+| P6 one governance path | Reviewed | CODEOWNERS (follow-up) + PR template |
+| P7 human gate | Enforced | `test_guard_external_tool_intents` |
+| P8 operator control | Reviewed | PR template |
+| P9 user owns data | Reviewed | PR template |
+| P10 contract is truth | Enforced (partial) | OpenAPI/route guards + PR template |
+
+## Follow-ups (out of scope for this ADR; tracked for a maintainer-buy-in PR)
+
+These are higher-value but heavier or touch the security-gated
+`.github/workflows/**` surface, so they ship separately:
+
+- **CODEOWNERS** — route `api/app/tools/` and `api/app/autonomous/guard.py` to
+  `@legalquants/security` so the backend half of the governance surface gets the
+  same review as `gateway/**` (P6).
+- **Audit-coverage gate** — assert every state-changing (non-GET) route emits an
+  `audit_action` (allowlist of `action=` literals) or is explicitly annotated
+  no-audit (P5/P10).
+- **Capability enable/disable gate** — assert every registered tool provider
+  exposes an `enabled` flag and appears on the admin surface (P8).
+- **CI infrastructure** (`.github/workflows/**`, security-gated): secret
+  scanning (gitleaks/trufflehog), dependency audit (`pip-audit`), and coverage
+  no-decrease — none exist in `ci.yml` today.
+- **mypy --strict** for `api/app/tools/` even while the rest of `api/` stays
+  standard mode (P6).
+
+## Cross-references
+
+- ADR [0013](0013-autonomous-layer-design-influences.md) (closed `ToolIntent`,
+  `PHASE_GRANTS`, R5→R6→R4, audit/OTel counts-only),
+  [0014](0014-gateway-egress-boundary-for-tool-providers.md) (egress boundary),
+  [0015](0015-governed-tool-calling-model.md) (governed tool-calling).
+- PRD [§1.3](../PRD.md#13-transparency-as-a-founding-principle),
+  [§1.8](../PRD.md#18-security-posture), [§5.3](../PRD.md) (audit requirement).
+- [docs/security/audit-logging.md](../security/audit-logging.md),
+  [docs/security/threat-model.md](../security/threat-model.md).
+- [CLAUDE.md](../../CLAUDE.md) (decision routing, the build loop, common
+  pitfalls), [.github/CODEOWNERS](../../.github/CODEOWNERS).
+- Enforcement: `api/tests/test_transparency_invariants.py`;
+  `.github/PULL_REQUEST_TEMPLATE.md` (the contributor pre-flight checklist).


### PR DESCRIPTION
## What this PR does

Names the ten invariants that constitute LQ.AI's transparency/auditability
posture (P1–P10) as a binding decision record (ADR 0016), and makes the
cheap-to-check ones enforceable in CI instead of relying on review culture
alone. Adds four structural gate tests and a transparency pre-flight
checklist to the PR template.

## Why

The posture that *is* the product — one audited egress boundary, closed-set
tool calling, counts/types-not-payloads audit, fail-restrictive defaults,
atomic audit — is currently enforced almost entirely by review culture
(CLAUDE.md, the ADRs, CODEOWNERS). Nothing in CI fails when a change quietly
violates it: a contributor (or a coding agent) could add a raw-payload column
to an audit table, make the backend call a third-party endpoint directly, or
commit an audit row outside its state-change transaction, and every existing
gate would stay green. This PR closes that gap for the invariants that are
cheap and unambiguous to check, and records the rest as binding-but-reviewed
with a follow-up list. Each invariant restates an existing decision (ADRs
0013/0014/0015 + the audit-logging contract) — this is a consolidation and a
hardening, not a new direction.

## What this PR does *not* do

- Does **not** change any runtime behaviour — no endpoints, models, or
  migrations.
- Does **not** add the heavier/security-gated gates (CODEOWNERS routing of the
  backend governance surface, audit-coverage gate, secret scanning, pip-audit,
  coverage no-decrease, mypy --strict for `api/app/tools/`). Those touch
  `.github/workflows/**` or need maintainer buy-in and are recorded as
  follow-ups in ADR 0016 §Follow-ups.

## Type of change

- [x] Documentation update
- [x] Test / CI / tooling

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] Manually tested against a real deployment (describe scenario below)
- [ ] Acceptance test plan updated (if changing skill behavior)

<details>
<summary>Manual testing notes</summary>

Ran the new gates under the CI-pinned toolchain (Python 3.12, ruff 0.15.17):

- `pytest tests/test_transparency_invariants.py` → 4 passed.
- `ruff format --check` + `ruff check` on the new file → clean.
- Confirmed each detector fires on a real violation (a `request_body` column,
  an in-helper `.commit()`, a non-allowlisted `import httpx`) and does not
  false-positive on the legitimate columns/imports present today
  (`args_digest`, `details`, the gateway client).

</details>

## Documentation

- [ ] PRD updated (if user-facing behavior changes) — n/a, no user-facing change
- [ ] README updated (if quickstart or capability list changes) — n/a
- [ ] Skill-authoring guide updated — n/a
- [ ] Deployment cookbook updated — n/a
- [ ] Compliance documentation updated — n/a (candidate to map P1–P10 into the
      Compliance Pack later)
- [ ] OpenAPI schema regenerated — n/a, no endpoints changed

ADR 0016 is the documentation deliverable of this PR.

## Transparency & governance invariants

<!-- This PR adds the invariants; it does not exercise the runtime surfaces
they govern, so most are n/a here. -->

- [ ] **Egress (P1):** n/a — adds the enforcing test, no new egress.
- [ ] **Closed set (P2):** n/a.
- [ ] **No raw payloads (P3):** n/a — adds the enforcing test, no new rows/logs.
- [ ] **Fail restrictive (P4):** n/a.
- [ ] **Atomic audit (P5):** n/a — adds the enforcing test, no new writes.
- [ ] **One governance path (P6):** n/a.
- [ ] **Human gate (P7):** n/a.
- [ ] **Operator control (P8):** n/a.
- [ ] **User owns data (P9):** n/a.
- [x] **Contract is truth (P10):** the relevant ADR (0016) is added in this PR;
      OpenAPI/DB schema unchanged.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO

## Related issues

<!-- Link any tracking issue if one exists. -->

## Reviewer notes

- The two structural scanners are deliberately conservative to avoid the
  "gate with false positives gets disabled" failure mode: the egress check
  targets *import statements* (not the word "requests" in prose), and the
  payload-column check matches column-name patterns with an explicit
  `_ALLOWED_CONTENT_COLUMNS` escape hatch. Both are green on current `main`.
- The commit detector is AST-based on purpose — `app/audit.py`'s docstring
  documents the caller's `db.commit()`, which a grep would false-positive on.
- ADR status is **Proposed**; I'd value a maintainer call on whether to move it
  to **Accepted** in this PR or a follow-up, and on the §Follow-ups items
  (especially the CODEOWNERS routing of `api/app/tools/` +
  `api/app/autonomous/guard.py` to `@legalquants/security`).
