### PR TITLE
fix(chat): correct cap env-var alias + thread chat_id into tool-call audit (#207)

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -2045,6 +2045,7 @@ async def resume_tool_call(
                 base_request=base_request,
                 allowlist=resume_allowlist,
                 assistant_message_id=assistant_message_id,
+                chat_id=cid,
                 calls_used=calls_used,
                 cluster_cache={},
                 request_id=request_id,
@@ -2804,6 +2805,7 @@ async def _non_streaming_response(
                 base_request=request,
                 allowlist=allowlist,
                 assistant_message_id=assistant_message_id,
+                chat_id=chat.id,
                 cluster_cache={},
                 request_id=request_id,
             )
@@ -3157,6 +3159,7 @@ async def _stream_response(
                     base_request=request,
                     allowlist=allowlist,
                     assistant_message_id=assistant_message_id,
+                    chat_id=chat.id,
                     cluster_cache={},
                     request_id=request_id,
                 )

--- a/api/app/chat/tool_loop.py
+++ b/api/app/chat/tool_loop.py
@@ -437,6 +437,7 @@ async def run_chat_tool_loop(
     base_request: ChatCompletionRequest,
     allowlist: ChatToolAllowlist,
     assistant_message_id: UUID,
+    chat_id: UUID | None = None,
     calls_used: int = 0,
     cluster_cache: dict[Any, Any] | None = None,
     request_id: str | None = None,
@@ -595,6 +596,7 @@ async def run_chat_tool_loop(
                     cluster_cache=cluster_cache,
                     server_auth_map=server_auth_map,
                     assistant_message_id=assistant_message_id,
+                    chat_id=chat_id,
                     request_id=request_id,
                 )
                 tool_result_msgs.append(tool_result_message(tc_id, result))

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -384,6 +384,11 @@ class Settings(BaseSettings):
             "single turn before issuing a final no-tools round (PRD §L4). "
             "Default: 8. Operator-overridable via LQ_AI_CHAT_TOOL_CALL_CAP."
         ),
+        # Settings has no env_prefix, so the field name alone would bind to the
+        # bare CHAT_TOOL_CALL_CAP. Accept the documented LQ_AI_-prefixed name
+        # (matching the autonomous settings convention) while keeping the bare
+        # name working for any existing deployment that set it.
+        validation_alias=AliasChoices("LQ_AI_CHAT_TOOL_CALL_CAP", "CHAT_TOOL_CALL_CAP"),
     )
 
     # ----- Operational -----

--- a/api/tests/chat/test_tool_loop.py
+++ b/api/tests/chat/test_tool_loop.py
@@ -819,3 +819,52 @@ async def test_loop_cap_final_round_injects_synthesis_directive(
         for m in outcome.messages
         if isinstance(m, dict)
     )
+
+
+# ---------------------------------------------------------------------------
+# Scenario (k): the tool-call audit row is chat-scoped (chat_id threaded through)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_threads_chat_id_into_tool_call_audit(db: AsyncSession, user: User) -> None:
+    """Regression (issue #207, finding 3): ``run_chat_tool_loop`` must pass
+    ``chat_id`` through to ``execute_tool`` so the ``tool_call_log`` audit row is
+    chat-scoped. It was previously omitted, leaving ``chat_id`` NULL and making
+    chat-scoped audit queries miss the rows.
+    """
+    from app.chat.tool_loop import LoopFinal, run_chat_tool_loop
+
+    chat_id = uuid.uuid4()
+    gateway = AsyncMock()
+    gateway.chat_completion.side_effect = [
+        _resp_tool_call("search_case_law", {"q": "Brown"}, call_id="c1"),
+        _resp_final("Found Brown v. Board."),
+    ]
+    al = _research_allowlist(provider="cl-prod")
+
+    with (
+        patch(
+            "app.chat.tool_loop.research_service.search_case_law",
+            new=AsyncMock(return_value={"results": [{"cluster_id": 1}]}),
+        ),
+        patch("app.chat.tool_loop.resolve_provider_tier", new=AsyncMock(return_value=1)),
+        patch("app.chat.tool_loop.list_servers", new=AsyncMock(return_value=[])),
+    ):
+        outcome = await run_chat_tool_loop(
+            db,
+            user=user,
+            gateway=gateway,
+            base_request=_req([_user_msg("find Brown")]),
+            allowlist=al,
+            assistant_message_id=uuid.uuid4(),
+            chat_id=chat_id,
+        )
+
+    assert isinstance(outcome, LoopFinal)
+
+    rows = (
+        (await db.execute(select(ToolCallLog).where(ToolCallLog.origin == "chat"))).scalars().all()
+    )
+    assert len(rows) == 1
+    assert rows[0].chat_id == chat_id

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -89,6 +89,22 @@ def test_overrides_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.unit
+def test_chat_tool_call_cap_env_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression (issue #207, finding 2): the cap honors the documented
+    ``LQ_AI_CHAT_TOOL_CALL_CAP`` var, and still accepts the bare
+    ``CHAT_TOOL_CALL_CAP`` so existing deployments don't break."""
+    # The documented, LQ_AI_-prefixed var now works (it silently did not before).
+    monkeypatch.delenv("CHAT_TOOL_CALL_CAP", raising=False)
+    monkeypatch.setenv("LQ_AI_CHAT_TOOL_CALL_CAP", "3")
+    assert Settings(_env_file=None).chat_tool_call_cap == 3  # type: ignore[call-arg]
+
+    # The bare name still binds (back-compat for anyone relying on the accident).
+    monkeypatch.delenv("LQ_AI_CHAT_TOOL_CALL_CAP", raising=False)
+    monkeypatch.setenv("CHAT_TOOL_CALL_CAP", "5")
+    assert Settings(_env_file=None).chat_tool_call_cap == 5  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
 def test_get_settings_is_cached() -> None:
     """`get_settings()` returns the same instance until the cache is cleared."""
     a = get_settings()


### PR DESCRIPTION
Addresses two of the lower-priority follow-up findings from #207 (the empty-answer fix landed separately in #208). Both are correctness fixes with no runtime behaviour change beyond the audit row and the now-honored env var.

## (2) Cap env-var alias
`Settings.chat_tool_call_cap` is documented as overridable via `LQ_AI_CHAT_TOOL_CALL_CAP`, but `Settings` has no `env_prefix`, so only the bare `CHAT_TOOL_CALL_CAP` actually bound — the documented var silently did nothing. Adds a `validation_alias=AliasChoices("LQ_AI_CHAT_TOOL_CALL_CAP", "CHAT_TOOL_CALL_CAP")` (matching the autonomous-settings convention) so the documented name works, keeping the bare name for back-compat.

## (3) chat_id in the tool-call audit
`run_chat_tool_loop` never passed `chat_id` to `execute_tool`, so `tool_call_log.chat_id` was always NULL and chat-scoped audit queries missed the rows. `execute_tool` already accepts `chat_id`; this just threads it through the loop signature and all three call sites in `chats.py` (resume / non-streaming / streaming).

## Testing
- `test_config.py`: the documented `LQ_AI_` var is honored, and the bare name still binds.
- `test_tool_loop.py` (scenario k): the chat tool-call audit row is chat-scoped end to end.
- Local gates (Python 3.12.13, ruff 0.15.17): ruff format/check clean, mypy clean, 4 config + 12 tool-loop tests pass.

## Not in this PR
- Finding (1) (default cap of 8 is low for multi-call skills) — config/docs tuning, follow-up.
- Finding (4) (skills drop on follow-up turns) — being designed as an explicit, off-by-default per-chat "sticky skill" toggle (transparency/operator-control posture); separate PR.

Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)