### PR TITLE
feat(chat): opt-in sticky-skills toggle (#207 finding 4)

### DIFF
--- a/api/alembic/versions/0056_chat_sticky_skills.py
+++ b/api/alembic/versions/0056_chat_sticky_skills.py
@@ -1,0 +1,44 @@
+"""chat_sticky_skills — per-chat sticky-skill set for the opt-in sticky toggle
+
+Adds ``chats.sticky_skills text[] NOT NULL DEFAULT '{}'``. The array IS the
+state: empty means the sticky toggle is OFF (fail-restrictive default — a new
+chat never inherits stickiness, issue #207 finding 4). A non-empty set is the
+snapshot of skills the user made sticky; the chat send path unions it into each
+turn's effective skills so a follow-up turn keeps applying them without the
+client re-sending. Toggling off clears the set.
+
+No raw payloads here — it holds skill *slugs* (identifiers), same sensitivity
+class as ``messages.applied_skills``.
+
+Revision ID: 0056
+Revises: 0055
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0056"
+down_revision: str | None = "0055"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chats",
+        sa.Column(
+            "sticky_skills",
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chats", "sticky_skills")

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -512,6 +512,7 @@ async def _serialize_chat(
         created_at=chat.created_at,
         updated_at=chat.updated_at,
         message_count=message_count,
+        sticky_skills=list(chat.sticky_skills or []),
     )
 
 
@@ -1312,6 +1313,25 @@ async def send_message(
             attached_skill_provenance.append(
                 {"name": resolved_slug, "source": "slash", "kind": "slug"}
             )
+
+    # Sticky skills (issue #207 finding 4) — opt-in, per-chat. ``chat.sticky_skills``
+    # is the persisted set (empty = toggle OFF, fail-restrictive). While active it
+    # is unioned into this turn's skills so a follow-up turn keeps applying them
+    # without the client re-sending; per-turn explicit skills are kept too (union).
+    # ``set_sticky`` is the toggle: True snapshots the current set, False clears it,
+    # None leaves it unchanged.
+    if payload.set_sticky is False:
+        # Toggle off: clear the set; this turn applies only explicitly-chosen skills.
+        chat.sticky_skills = []
+    else:
+        for slug in chat.sticky_skills or []:
+            if slug not in effective_skills:
+                effective_skills.append(slug)
+            if slug not in {e["name"] for e in attached_skill_provenance}:
+                attached_skill_provenance.append({"name": slug, "source": "sticky", "kind": "slug"})
+        if payload.set_sticky is True:
+            # Snapshot everything applied this turn as the chat's sticky set.
+            chat.sticky_skills = list(effective_skills)
 
     # Persist the user message FIRST. This is unconditionally written,
     # even if the gateway call ultimately fails — the user did say

--- a/api/app/models/chat.py
+++ b/api/app/models/chat.py
@@ -93,6 +93,15 @@ class Chat(Base):
         server_default=text("'New chat'"),
     )
     archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Opt-in "sticky skills" set (issue #207 finding 4). Empty = toggle OFF
+    # (fail-restrictive; a new chat never inherits stickiness). When non-empty,
+    # the chat send path unions these skill slugs into each turn's effective
+    # skills so follow-up turns keep applying them without the client re-sending.
+    sticky_skills: Mapped[list[str]] = mapped_column(
+        ARRAY(Text),
+        nullable=False,
+        server_default=text("'{}'::text[]"),
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/api/app/schemas/chats.py
+++ b/api/app/schemas/chats.py
@@ -387,6 +387,13 @@ class MessageCreateRequest(BaseModel):
     to bound workload multiplication (I1 — a single message attaching
     thousands of inline refs x 32 KB each is a DoS vector)."""
 
+    set_sticky: bool | None = Field(default=None)
+    """Issue #207 finding 4 — opt-in per-chat "sticky skills" toggle. ``True``
+    snapshots this turn's applied skills as the chat's sticky set (carried into
+    later turns without the client re-sending); ``False`` clears the set;
+    ``None``/omitted leaves it unchanged. Off by default — a new chat never
+    inherits stickiness (fail-restrictive)."""
+
     skill_inputs: dict[str, dict[str, Any]] = Field(default_factory=dict)
     """C2: per-skill input bindings, keyed by skill name. Forwarded as
     ``lq_ai_skill_inputs``. Per-attachment ``inputs`` on
@@ -447,6 +454,9 @@ class ChatResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     message_count: int = 0
+    sticky_skills: list[str] = Field(default_factory=list)
+    """Issue #207 finding 4 — the chat's active sticky-skill set (empty = the
+    sticky toggle is off). Lets the client reflect the toggle state on load."""
 
 
 class MessageResponse(BaseModel):

--- a/api/tests/test_chats_skills_forwarding.py
+++ b/api/tests/test_chats_skills_forwarding.py
@@ -816,3 +816,129 @@ async def test_attached_file_writes_audit_row(
     assert row.details["file_ids"] == [str(f.id)]
     assert row.details["attached_count"] == 1
     assert row.details["injected_count"] == 1
+
+
+# --- Sticky skills (issue #207 finding 4) -----------------------------------
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_set_sticky_true_snapshots_applied_skills(
+    client: AsyncClient, db_user: User, db_chat: Chat, db_session: AsyncSession
+) -> None:
+    """``set_sticky=True`` snapshots this turn's applied skills as the chat set."""
+
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(applied_skills=["nda-review"]))
+    )
+    token = _bearer_for(db_user)
+    resp = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "review", "model": "smart", "skills": ["nda-review"], "set_sticky": True},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert _json.loads(route.calls[0].request.read())["lq_ai_skills"] == ["nda-review"]
+    await db_session.refresh(db_chat)
+    assert db_chat.sticky_skills == ["nda-review"]
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_sticky_set_carries_into_follow_up_turn(
+    client: AsyncClient, db_user: User, db_chat: Chat, db_session: AsyncSession
+) -> None:
+    """With a sticky set, a follow-up turn that sends NO skills still applies them."""
+
+    db_chat.sticky_skills = ["nda-review"]
+    await db_session.flush()
+
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(applied_skills=["nda-review"]))
+    )
+    token = _bearer_for(db_user)
+    resp = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "and the indemnity clause?", "model": "smart"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert _json.loads(route.calls[0].request.read())["lq_ai_skills"] == ["nda-review"]
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_explicit_skill_unions_with_sticky_set_unchanged(
+    client: AsyncClient, db_user: User, db_chat: Chat, db_session: AsyncSession
+) -> None:
+    """An explicit skill on a turn unions with the sticky set; the set is unchanged."""
+
+    db_chat.sticky_skills = ["nda-review"]
+    await db_session.flush()
+
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    resp = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "also apply US overlay", "model": "smart", "skills": ["us-overlay"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    # Union for this turn: explicit first, then the sticky slug.
+    assert _json.loads(route.calls[0].request.read())["lq_ai_skills"] == [
+        "us-overlay",
+        "nda-review",
+    ]
+    await db_session.refresh(db_chat)
+    assert db_chat.sticky_skills == ["nda-review"]  # set NOT changed by a one-off skill
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_set_sticky_false_clears_and_does_not_apply(
+    client: AsyncClient, db_user: User, db_chat: Chat, db_session: AsyncSession
+) -> None:
+    """``set_sticky=False`` clears the set; that turn applies only explicit skills."""
+
+    db_chat.sticky_skills = ["nda-review"]
+    await db_session.flush()
+
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload())
+    )
+    token = _bearer_for(db_user)
+    resp = await client.post(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}/messages",
+        json={"content": "stop applying it", "model": "smart", "set_sticky": False},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert _json.loads(route.calls[0].request.read()).get("lq_ai_skills", []) == []
+    await db_session.refresh(db_chat)
+    assert db_chat.sticky_skills == []
+
+
+@pytest.mark.integration
+@respx.mock
+async def test_get_chat_exposes_sticky_skills(
+    client: AsyncClient, db_user: User, db_chat: Chat, db_session: AsyncSession
+) -> None:
+    """GET /chats/{id} surfaces ``sticky_skills`` so the client reflects the toggle."""
+
+    db_chat.sticky_skills = ["nda-review"]
+    await db_session.flush()
+
+    token = _bearer_for(db_user)
+    resp = await client.get(
+        f"/api/v1/chats/{_DUMMY_CHAT_ID}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["sticky_skills"] == ["nda-review"]

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -7095,6 +7095,15 @@ components:
         message_count:
           type: integer
           description: "Count of persisted messages in this chat."
+        sticky_skills:
+          type: array
+          items: {type: string}
+          description: |
+            Opt-in per-chat "sticky skills" set (issue #207 finding 4).
+            Empty means the sticky toggle is off (a new chat never inherits
+            stickiness). When non-empty, these skill slugs are auto-applied
+            (unioned) to every turn in this chat until cleared. Set via
+            `MessageCreate.set_sticky`.
         created_at: {type: string, format: date-time}
         updated_at: {type: string, format: date-time}
 
@@ -7191,6 +7200,16 @@ components:
             C2: skill names to attach. The backend forwards these as
             `lq_ai_skills` to the gateway, which fetches each from the
             backend's internal-skills endpoint and assembles the prompt.
+        set_sticky:
+          type: boolean
+          nullable: true
+          default: null
+          description: |
+            Issue #207 finding 4 — opt-in per-chat "sticky skills" toggle.
+            `true` snapshots this turn's applied skills as the chat's sticky
+            set (auto-applied to later turns without re-sending); `false`
+            clears it; omitted/null leaves it unchanged. Off by default — a
+            new chat never inherits stickiness (fail-restrictive).
         skill_inputs:
           type: object
           additionalProperties:

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -317,6 +317,11 @@ CREATE TABLE chats (
     title       TEXT NOT NULL DEFAULT 'New chat'
                   CHECK (char_length(title) > 0 AND char_length(title) <= 200),
     archived_at TIMESTAMPTZ,
+    -- Opt-in per-chat "sticky skills" set (issue #207 finding 4, migration 0056).
+    -- Empty = sticky toggle OFF (fail-restrictive; a new chat never inherits it).
+    -- When non-empty, these skill slugs are unioned into every turn's effective
+    -- skills until cleared. Set via MessageCreate.set_sticky.
+    sticky_skills TEXT[] NOT NULL DEFAULT '{}',
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/web/src/lib/lq-ai/components/ChatPanel.svelte
+++ b/web/src/lib/lq-ai/components/ChatPanel.svelte
@@ -19,9 +19,7 @@
 	 *   - Empty query is allowed (`/` alone opens the popover with the
 	 *     "no-query" empty state per SlashPopover.emptyStateKind()).
 	 */
-	export type SlashDetection =
-		| { open: false }
-		| { open: true; query: string; slashIndex: number };
+	export type SlashDetection = { open: false } | { open: true; query: string; slashIndex: number };
 
 	export function isAtLineStart(text: string, pos: number): boolean {
 		if (pos === 0) return true;
@@ -84,17 +82,9 @@
 		projectsStore,
 		skillsStore
 	} from '$lib/lq-ai/stores';
-	import {
-		consumeMessageStream
-	} from '$lib/lq-ai/sse/parser';
+	import { consumeMessageStream } from '$lib/lq-ai/sse/parser';
 	import { buildAuthorizeUrl, type PendingGate } from '$lib/lq-ai/chat/toolGate';
-	import type {
-		Chat,
-		FileMeta,
-		Message,
-		Project,
-		Skill
-	} from '$lib/lq-ai/types';
+	import type { Chat, FileMeta, Message, Project, Skill } from '$lib/lq-ai/types';
 
 	import ChatSidebar from '$lib/lq-ai/components/ChatSidebar.svelte';
 	import AttachedFilesPanel from '$lib/lq-ai/components/AttachedFilesPanel.svelte';
@@ -137,6 +127,22 @@
 	// `attachedSkillNames` whenever the chat changes. Plain Record
 	// (not Map) so Svelte 4 reactivity tracks the assignment.
 	let attachmentSources: Record<string, string> = {};
+
+	// Issue #207 finding 4 — opt-in "sticky skills" toggle. `stickyEnabled`
+	// mirrors the chat's persisted sticky set (on when non-empty). `stickyDirty`
+	// marks that the user flipped the toggle since the last send, so we send
+	// `set_sticky` ONLY on a real change — otherwise the backend leaves the set
+	// unchanged and just carries it forward (we must not re-snapshot every turn).
+	// `stickyInitChatId` tracks which chat we initialized from so a chat switch
+	// re-syncs the toggle without clobbering an in-progress toggle mid-chat.
+	let stickyEnabled = false;
+	let stickyDirty = false;
+	let stickyInitChatId: string | null = null;
+
+	function toggleSticky(): void {
+		stickyEnabled = !stickyEnabled;
+		stickyDirty = true;
+	}
 
 	// Wave D.1 T20 follow-on (deferral A + B) — Enhance Prompt tracking.
 	// `pendingEnhancement` holds the most recent "Use enhanced" outcome
@@ -279,9 +285,7 @@
 		// the assistant rendering path takes over for that slot.
 		const replacing = overrideMessage;
 		if (replacing) {
-			messagesStore.update(($m) =>
-				$m.map((m) => (m.id === replacing.id ? newAiMessage : m))
-			);
+			messagesStore.update(($m) => $m.map((m) => (m.id === replacing.id ? newAiMessage : m)));
 		}
 		closeOverrideModal();
 	}
@@ -474,9 +478,7 @@
 				const newId = frame.lq_ai_message_id;
 				if (newId !== assistantId) {
 					const prev = assistantId;
-					messagesStore.update(($m) =>
-						$m.map((m) => (m.id === prev ? { ...m, id: newId } : m))
-					);
+					messagesStore.update(($m) => $m.map((m) => (m.id === prev ? { ...m, id: newId } : m)));
 					assistantId = newId;
 				}
 				streamingMessageId = assistantId;
@@ -492,7 +494,7 @@
 									content: (m.content ?? '') + frame.delta,
 									routed_inference_tier: frame.routed_inference_tier ?? m.routed_inference_tier,
 									applied_skills: frame.applied_skills ?? m.applied_skills
-							  }
+								}
 							: m
 					)
 				);
@@ -510,7 +512,7 @@
 										frame.routed_inference_tier ?? frame.message.routed_inference_tier,
 									routed_provider: frame.routed_provider ?? frame.message.routed_provider,
 									citations: frame.citations ?? frame.message.citations ?? []
-							  }
+								}
 							: m
 					)
 				);
@@ -631,17 +633,21 @@
 				{
 					content: composerText,
 					model: currentModelId ?? undefined,
-					attached_skills:
-						attachedSkillsPayload.length > 0 ? attachedSkillsPayload : undefined,
+					attached_skills: attachedSkillsPayload.length > 0 ? attachedSkillsPayload : undefined,
 					skill_inputs:
 						Object.keys(skillInputs).length > 0
 							? (skillInputs as Record<string, Record<string, unknown>>)
 							: undefined,
+					// Issue #207 finding 4 — only send set_sticky on a real toggle
+					// change; otherwise leave the chat's sticky set unchanged.
+					set_sticky: stickyDirty ? stickyEnabled : undefined,
 					stream: true
 				},
 				streamAbort.signal
 			);
 			composerText = '';
+			// The toggle change has now been applied server-side for this turn.
+			stickyDirty = false;
 			// Clear the pending-enhancement marker now that the send is in
 			// flight. The enhancementOriginals map keeps the captured
 			// original keyed by content so the pill's tap-to-diff still
@@ -866,8 +872,17 @@
 			: groups;
 	$: activeChat = $activeChatStore;
 	$: messages = $messagesStore;
+	// Issue #207 finding 4 — re-sync the sticky toggle from the chat's persisted
+	// set whenever the active chat changes (initial load + switches). Fires only
+	// on an id change so it never clobbers an in-progress toggle within a chat;
+	// a brand-new chat has an empty set → toggle off (fail-restrictive).
+	$: if (activeChat && activeChat.id !== stickyInitChatId) {
+		stickyInitChatId = activeChat.id;
+		stickyEnabled = (activeChat.sticky_skills?.length ?? 0) > 0;
+		stickyDirty = false;
+	}
 	$: projectAttachedSkills = activeChat?.project_id
-		? $projectsStore.find((p) => p.id === activeChat?.project_id)?.attached_skill_names ?? []
+		? ($projectsStore.find((p) => p.id === activeChat?.project_id)?.attached_skill_names ?? [])
 		: [];
 
 	// T12 — derive the project id + attached-KB ids the AttachKBModal needs.
@@ -876,7 +891,7 @@
 	// modal's "currently attached" badge without a manual refresh.
 	$: composerProjectId = activeChat?.project_id ?? null;
 	$: composerAttachedKbIds = composerProjectId
-		? $projectsStore.find((p) => p.id === composerProjectId)?.attached_knowledge_base_ids ?? []
+		? ($projectsStore.find((p) => p.id === composerProjectId)?.attached_knowledge_base_ids ?? [])
 		: [];
 
 	// Wave D.1 T19 — Restore receipts drawer open-state when the active
@@ -890,9 +905,7 @@
 	// picker's default (``smart`` if available, else the first row) when
 	// the user hasn't picked yet for this chat.
 	$: currentModelId = activeChat
-		? modelByChat[activeChat.id] ??
-		  defaultSelection(groupModels(availableModels))?.id ??
-		  null
+		? (modelByChat[activeChat.id] ?? defaultSelection(groupModels(availableModels))?.id ?? null)
 		: null;
 
 	// Wave D.1 T15 — role for the refusal-bubble override-button gate.
@@ -1006,6 +1019,27 @@
 						selectedId={currentModelId}
 						onSelect={selectModel}
 					/>
+					<!-- Issue #207 finding 4 — opt-in "sticky skills" toggle. Off by
+					     default; when on, the skills applied here stay applied to
+					     follow-up messages in this chat (resets for a new chat). -->
+					<button
+						type="button"
+						role="switch"
+						aria-checked={stickyEnabled}
+						on:click={toggleSticky}
+						data-testid="lq-ai-sticky-toggle"
+						title="Keep the skills applied here active for follow-up messages in this chat. Off by default; a new chat starts fresh."
+						class="flex items-center gap-2 text-xs font-medium px-2 py-1 rounded-md border transition-colors {stickyEnabled
+							? 'border-emerald-500 text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-950/40'
+							: 'border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400'}"
+					>
+						<span
+							class="inline-block w-2 h-2 rounded-full {stickyEnabled
+								? 'bg-emerald-500'
+								: 'bg-gray-300 dark:bg-gray-600'}"
+						></span>
+						Keep skills on
+					</button>
 				</div>
 
 				<SkillPicker
@@ -1021,9 +1055,7 @@
 
 				<SavedPromptsPanel
 					onInsert={(text) => {
-						composerText = composerText.trim()
-							? `${composerText.trimEnd()}\n\n${text}`
-							: text;
+						composerText = composerText.trim() ? `${composerText.trimEnd()}\n\n${text}` : text;
 					}}
 				/>
 

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -168,6 +168,12 @@ export interface Chat {
 	message_count?: number;
 	created_at: string;
 	updated_at: string;
+	/**
+	 * Issue #207 finding 4 — the chat's active "sticky skills" set. Empty (or
+	 * absent) means the sticky toggle is off; a new chat never inherits it.
+	 * When non-empty, these skills are auto-applied to every turn until cleared.
+	 */
+	sticky_skills?: string[];
 }
 
 export interface ChatCreate {
@@ -358,6 +364,12 @@ export interface MessageCreate {
 		source?: string;
 		inputs?: Record<string, unknown>;
 	}>;
+	/**
+	 * Issue #207 finding 4 — opt-in "sticky skills" toggle. `true` makes this
+	 * turn's applied skills sticky for the chat (auto-applied to later turns);
+	 * `false` clears the set; omitted leaves it unchanged. Off by default.
+	 */
+	set_sticky?: boolean | null;
 }
 
 export interface MessagePostResponse {
@@ -1074,12 +1086,7 @@ export interface EasyPlaybookGeneration {
  * execution surface does NOT have — tabular runs can be hours long, so
  * cancellation matters.
  */
-export type TabularExecutionStatus =
-	| 'pending'
-	| 'running'
-	| 'completed'
-	| 'failed'
-	| 'cancelled';
+export type TabularExecutionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
 
 /**
  * Per-cell confidence from the Citation Engine cascade. `failed` is


### PR DESCRIPTION
Implements the opt-in **sticky skills** mechanism from #207 finding 4: a skill applied in a chat can persist to follow-up turns instead of dropping when the client stops re-sending it — but only when the user explicitly turns it on.

Designed to fit the transparency posture: **off by default (P4 fail-restrictive)**, **explicit user control (P8)**, per-chat scope that **resets for a new chat**, and every turn still records its own `applied_skills` so the audit trail stays honest.

## Behavior (per maintainer decisions)
- **Off by default**; a new chat never inherits stickiness.
- Toggle **on** snapshots *all skills currently applied* on that turn as the chat's sticky set.
- While on, the set is **unioned into every turn** (carried forward without re-sending).
- An explicit per-turn skill **unions for that turn only**; the sticky set is left unchanged (no silent re-snapshot).
- Toggle **off** clears the set.

## Backend (`api/`) — commit 1
- Migration **0056**: `chats.sticky_skills text[] NOT NULL DEFAULT '{}'` (empty = off).
- `Chat`/`ChatResponse` expose `sticky_skills`; `MessageCreateRequest.set_sticky` (true=snapshot, false=clear, null=unchanged).
- `send_message` unions the sticky set into the turn's effective skills (forwarded as `lq_ai_skills` + recorded on the user message).
- Docs: `backend-openapi.yaml` (both fields) + `db-schema.md` (the column) — P10 contract-is-truth.
- Tests: snapshot-on-toggle, carry-to-follow-up, union-with-set-unchanged, toggle-off-clears, GET exposes the set.

## Frontend (`web/`) — commit 2
- A **"Keep skills on"** toggle in the composer toolbar; mirrors the chat's persisted set, re-syncs on chat switch (id-tracked so it never clobbers an in-progress toggle), sends `set_sticky` only on a real change.
- `Chat.sticky_skills` + `MessageCreate.set_sticky` types.

## Testing
Local gates (Python 3.12.13 / ruff 0.15.17; throwaway pgvector): ruff + mypy clean, **74 api tests pass** (incl. 5 new), migration 0056 round-trips; **svelte-check 0 errors**, prettier/eslint clean on changed files. Migration does not touch the running launcher stack (released images); never ran host alembic on a live DB.

Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)