### PR TITLE
feat(citation): Citation Ledger entry table + assembly (P1-A2)

### DIFF
--- a/api/alembic/versions/0058_citation_ledger_entry.py
+++ b/api/alembic/versions/0058_citation_ledger_entry.py
@@ -1,0 +1,114 @@
+"""citation_ledger_entry — the Citation Ledger (ADR 0018 D1)
+
+Revision ID: 0058
+Revises: 0057
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0058"
+down_revision: str | None = "0057"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "citation_ledger_entry",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "projects.id", ondelete="CASCADE", name="fk_citation_ledger_entry_project"
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "chat_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("chats.id", ondelete="CASCADE", name="fk_citation_ledger_entry_chat"),
+            nullable=False,
+        ),
+        sa.Column(
+            "message_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "messages.id", ondelete="CASCADE", name="fk_citation_ledger_entry_message"
+            ),
+            nullable=False,
+        ),
+        sa.Column("source_kind", sa.Text(), nullable=False),
+        sa.Column(
+            "message_citation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "message_citations.id",
+                ondelete="CASCADE",
+                name="fk_citation_ledger_entry_msg_citation",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "message_caselaw_citation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "message_caselaw_citations.id",
+                ondelete="CASCADE",
+                name="fk_citation_ledger_entry_caselaw_citation",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "message_tool_source_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "message_tool_sources.id",
+                ondelete="CASCADE",
+                name="fk_citation_ledger_entry_tool_source",
+            ),
+            nullable=True,
+        ),
+        sa.Column("verification_status", sa.Text(), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=True),
+        sa.Column("retrieved_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("treatment_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "(message_citation_id IS NOT NULL)::int "
+            "+ (message_caselaw_citation_id IS NOT NULL)::int "
+            "+ (message_tool_source_id IS NOT NULL)::int = 1",
+            name="chk_citation_ledger_entry_exactly_one_source",
+        ),
+        sa.CheckConstraint(
+            "confidence IS NULL OR (confidence >= 0 AND confidence <= 1)",
+            name="chk_citation_ledger_entry_confidence_range",
+        ),
+    )
+    op.create_index("ix_citation_ledger_entry_chat_id", "citation_ledger_entry", ["chat_id"])
+    op.create_index("ix_citation_ledger_entry_message_id", "citation_ledger_entry", ["message_id"])
+    op.create_index("ix_citation_ledger_entry_project_id", "citation_ledger_entry", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_citation_ledger_entry_project_id", table_name="citation_ledger_entry")
+    op.drop_index("ix_citation_ledger_entry_message_id", table_name="citation_ledger_entry")
+    op.drop_index("ix_citation_ledger_entry_chat_id", table_name="citation_ledger_entry")
+    op.drop_table("citation_ledger_entry")

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -85,6 +85,7 @@ from app.chat.tool_schemas import ChatToolAllowlist, assemble_allowlist
 from app.citation import extract_citations, verify
 from app.citation.caselaw import verify_and_persist_caselaw_citations
 from app.citation.cost import estimate_judge_call_cost_usd
+from app.citation.ledger import assemble_ledger_entries
 from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
 from app.config import get_settings
 from app.db.session import get_db
@@ -2884,6 +2885,10 @@ async def _non_streaming_response(
                 )
             except Exception as caselaw_exc:  # never block the turn
                 log.warning("caselaw citation verification failed: %r", caselaw_exc)
+            try:
+                await assemble_ledger_entries(db, message_id=assistant_message_id)
+            except Exception as ledger_exc:  # never block the turn
+                log.warning("citation ledger assembly failed: %r", ledger_exc)
             await _audit_message_sent(
                 db,
                 user=user,
@@ -3094,6 +3099,10 @@ async def _non_streaming_response(
         skill_registry=_skill_registry_from_request(http_request),
     )
     await _persist_message_tool_sources(db, message_id=assistant_message_id, records=[])
+    try:
+        await assemble_ledger_entries(db, message_id=assistant_message_id)
+    except Exception as ledger_exc:  # never block the turn
+        log.warning("citation ledger assembly failed: %r", ledger_exc)
 
     await _audit_message_sent(
         db,
@@ -3453,6 +3462,10 @@ async def _stream_response(
                     )
                 except Exception as caselaw_exc:  # never block the turn
                     log.warning("caselaw citation verification failed: %r", caselaw_exc)
+                try:
+                    await assemble_ledger_entries(db, message_id=assistant_message_id)
+                except Exception as ledger_exc:  # never block the turn
+                    log.warning("citation ledger assembly failed: %r", ledger_exc)
             # D3 audit row — best-effort, must not break the stream.
             try:
                 await _audit_message_sent(

--- a/api/app/citation/ledger.py
+++ b/api/app/citation/ledger.py
@@ -1,0 +1,122 @@
+"""Citation Ledger assembly (ADR 0018 D1).
+
+Reads the three per-turn citation/source artifacts for an assistant message and
+writes one ``CitationLedgerEntry`` per row — a thin referencing index. Source-kind
+agnostic over ``message_tool_sources`` (so generic-MCP rows flow in once DE-350
+lands). Holds no content; references by id.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat, Message, MessageCitation
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.message_tool_source import MessageToolSource
+
+
+def _naive(dt: datetime | None) -> datetime | None:
+    """Strip tzinfo so TIMESTAMP WITHOUT TIME ZONE columns accept the value."""
+    if dt is None:
+        return None
+    return dt.replace(tzinfo=None) if dt.tzinfo is not None else dt
+
+
+async def assemble_ledger_entries(db: AsyncSession, *, message_id: uuid.UUID) -> int:
+    """Write one ledger entry per citation/source row for ``message_id``.
+
+    Self-derives ``chat_id`` (from the message) and ``project_id`` (from the chat).
+    Returns the number of entries written. Pure DB; no egress.
+    """
+    chat_id = (
+        await db.execute(select(Message.chat_id).where(Message.id == message_id))
+    ).scalar_one_or_none()
+    if chat_id is None:
+        return 0
+    project_id = (
+        await db.execute(select(Chat.project_id).where(Chat.id == chat_id))
+    ).scalar_one_or_none()
+
+    entries: list[CitationLedgerEntry] = []
+
+    doc_citations = (
+        (await db.execute(select(MessageCitation).where(MessageCitation.message_id == message_id)))
+        .scalars()
+        .all()
+    )
+    for c in doc_citations:
+        entries.append(
+            CitationLedgerEntry(
+                project_id=project_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                source_kind="kb_document",
+                message_citation_id=c.id,
+                verification_status=c.verification_method or "verified",
+                confidence=float(c.verification_confidence)
+                if c.verification_confidence is not None
+                else None,
+                provider=None,
+                retrieved_at=None,
+            )
+        )
+
+    caselaw_citations = (
+        (
+            await db.execute(
+                select(MessageCaselawCitation).where(
+                    MessageCaselawCitation.message_id == message_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for cc in caselaw_citations:
+        entries.append(
+            CitationLedgerEntry(
+                project_id=project_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                source_kind="caselaw",
+                message_caselaw_citation_id=cc.id,
+                verification_status=cc.verification_method or "verified",
+                confidence=cc.verification_confidence,
+                provider="courtlistener",
+                retrieved_at=_naive(cc.created_at),
+            )
+        )
+
+    tool_sources = (
+        (
+            await db.execute(
+                select(MessageToolSource).where(MessageToolSource.message_id == message_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for ts in tool_sources:
+        entries.append(
+            CitationLedgerEntry(
+                project_id=project_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                source_kind=ts.source_kind,
+                message_tool_source_id=ts.id,
+                verification_status="provenance",
+                confidence=None,
+                provider=ts.provider,
+                retrieved_at=_naive(ts.created_at),
+            )
+        )
+
+    if entries:
+        db.add_all(entries)
+        await db.flush()
+    return len(entries)

--- a/api/app/citation/ledger.py
+++ b/api/app/citation/ledger.py
@@ -9,7 +9,6 @@ lands). Holds no content; references by id.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,13 +17,6 @@ from app.models.chat import Chat, Message, MessageCitation
 from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.message_tool_source import MessageToolSource
-
-
-def _naive(dt: datetime | None) -> datetime | None:
-    """Strip tzinfo so TIMESTAMP WITHOUT TIME ZONE columns accept the value."""
-    if dt is None:
-        return None
-    return dt.replace(tzinfo=None) if dt.tzinfo is not None else dt
 
 
 async def assemble_ledger_entries(db: AsyncSession, *, message_id: uuid.UUID) -> int:
@@ -88,7 +80,7 @@ async def assemble_ledger_entries(db: AsyncSession, *, message_id: uuid.UUID) ->
                 verification_status=cc.verification_method or "verified",
                 confidence=cc.verification_confidence,
                 provider="courtlistener",
-                retrieved_at=_naive(cc.created_at),
+                retrieved_at=cc.created_at,
             )
         )
 
@@ -112,7 +104,7 @@ async def assemble_ledger_entries(db: AsyncSession, *, message_id: uuid.UUID) ->
                 verification_status="provenance",
                 confidence=None,
                 provider=ts.provider,
-                retrieved_at=_naive(ts.created_at),
+                retrieved_at=ts.created_at,
             )
         )
 

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -11,6 +11,7 @@ declarative base, so Alembic's autogenerate (when used) sees them.
 from __future__ import annotations
 
 from app.models.audit import AuditLog
+from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.autonomous import (
     AutonomousMemory,
     AutonomousNotification,
@@ -49,6 +50,7 @@ from app.models.work_product import WorkProductAttribution
 
 __all__ = [
     "AuditLog",
+    "CitationLedgerEntry",
     "AutonomousMemory",
     "AutonomousNotification",
     "AutonomousSchedule",

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -11,7 +11,6 @@ declarative base, so Alembic's autogenerate (when used) sees them.
 from __future__ import annotations
 
 from app.models.audit import AuditLog
-from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.autonomous import (
     AutonomousMemory,
     AutonomousNotification,
@@ -22,6 +21,7 @@ from app.models.autonomous import (
 )
 from app.models.chat import Chat, Message
 from app.models.chat_pending_tool_call import ChatPendingToolCall
+from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.document import Document, DocumentChunk
 from app.models.enhance_prompt import EnhancePromptInteraction
 from app.models.file import File
@@ -50,7 +50,6 @@ from app.models.work_product import WorkProductAttribution
 
 __all__ = [
     "AuditLog",
-    "CitationLedgerEntry",
     "AutonomousMemory",
     "AutonomousNotification",
     "AutonomousSchedule",
@@ -58,6 +57,7 @@ __all__ = [
     "AutonomousWatch",
     "Chat",
     "ChatPendingToolCall",
+    "CitationLedgerEntry",
     "Document",
     "DocumentChunk",
     "EnhancePromptInteraction",

--- a/api/app/models/citation_ledger_entry.py
+++ b/api/app/models/citation_ledger_entry.py
@@ -1,0 +1,92 @@
+"""citation_ledger_entry — the Citation Ledger (ADR 0018 D1).
+
+One row per (assistant turn, source brought into context). A thin REFERENCING
+record: it points at exactly one of message_citations / message_caselaw_citations
+/ message_tool_sources by id (a CHECK enforces exactly-one-non-null) and mirrors
+that source's verification status as a queryable label. It holds NO content
+(source_text lives on the referenced row), so it is a metadata index and joins
+the P3 no-raw-payload tripwire. ``treatment_id`` is reserved for the WS-G derived
+treatment layer (ADR 0018 D6) and is always NULL in Phase 1.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Float, ForeignKey, Index, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class CitationLedgerEntry(Base):
+    __tablename__ = "citation_ledger_entry"
+    __table_args__ = (
+        CheckConstraint(
+            "(message_citation_id IS NOT NULL)::int "
+            "+ (message_caselaw_citation_id IS NOT NULL)::int "
+            "+ (message_tool_source_id IS NOT NULL)::int = 1",
+            name="chk_citation_ledger_entry_exactly_one_source",
+        ),
+        CheckConstraint(
+            "confidence IS NULL OR (confidence >= 0 AND confidence <= 1)",
+            name="chk_citation_ledger_entry_confidence_range",
+        ),
+        Index("ix_citation_ledger_entry_chat_id", "chat_id"),
+        Index("ix_citation_ledger_entry_message_id", "message_id"),
+        Index("ix_citation_ledger_entry_project_id", "project_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE", name="fk_citation_ledger_entry_project"),
+        nullable=True,
+    )
+    chat_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chats.id", ondelete="CASCADE", name="fk_citation_ledger_entry_chat"),
+        nullable=False,
+    )
+    message_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("messages.id", ondelete="CASCADE", name="fk_citation_ledger_entry_message"),
+        nullable=False,
+    )
+    source_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    message_citation_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "message_citations.id", ondelete="CASCADE", name="fk_citation_ledger_entry_msg_citation"
+        ),
+        nullable=True,
+    )
+    message_caselaw_citation_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "message_caselaw_citations.id",
+            ondelete="CASCADE",
+            name="fk_citation_ledger_entry_caselaw_citation",
+        ),
+        nullable=True,
+    )
+    message_tool_source_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "message_tool_sources.id",
+            ondelete="CASCADE",
+            name="fk_citation_ledger_entry_tool_source",
+        ),
+        nullable=True,
+    )
+    verification_status: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    provider: Mapped[str | None] = mapped_column(Text, nullable=True)
+    retrieved_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    treatment_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, server_default=func.now())

--- a/api/app/models/citation_ledger_entry.py
+++ b/api/app/models/citation_ledger_entry.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, Float, ForeignKey, Index, Text
+from sqlalchemy import TIMESTAMP, CheckConstraint, Float, ForeignKey, Index, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
@@ -87,6 +87,6 @@ class CitationLedgerEntry(Base):
     verification_status: Mapped[str] = mapped_column(Text, nullable=False)
     confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
     provider: Mapped[str | None] = mapped_column(Text, nullable=True)
-    retrieved_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    retrieved_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
     treatment_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(nullable=False, server_default=func.now())

--- a/api/tests/integration/test_citation_ledger.py
+++ b/api/tests/integration/test_citation_ledger.py
@@ -1,12 +1,15 @@
 import uuid
+from datetime import datetime, timezone
 
 import pytest
 import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from app.models.chat import Chat, Message
+from app.citation.ledger import assemble_ledger_entries
+from app.models.chat import Chat, Message, MessageCitation
 from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.message_tool_source import MessageToolSource
 from app.models.user import User
 
@@ -91,3 +94,56 @@ async def test_exactly_one_fk_check_rejects_zero_and_two(db_session, seeded_mess
     with pytest.raises(IntegrityError):
         await db_session.flush()
     await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_assembles_one_entry_per_source_row(db_session, seeded_message):
+    mid = seeded_message
+    # A KB-document citation (verified) — needs a real source_file_id (files row).
+    # Reuse the message_tool_sources + caselaw rows that DON'T need a file FK,
+    # plus a caselaw citation, to exercise all three source kinds without a file.
+    db_session.add(
+        MessageCaselawCitation(
+            message_id=mid, opinion_id=11, cluster_id=22,
+            source_offset_start=0, source_offset_end=5, source_text="hello",
+            verified=True, verification_method="exact_match", verification_confidence=1.0,
+        )
+    )
+    db_session.add(
+        MessageToolSource(
+            message_id=mid, source_kind="caselaw", label="Cluster 22",
+            subtitle=None, url=None, external_ref="22", provider="courtlistener", tool="get_cluster",
+        )
+    )
+    await db_session.flush()
+
+    n = await assemble_ledger_entries(db_session, message_id=mid)
+    await db_session.flush()
+
+    entries = (
+        await db_session.execute(
+            select(CitationLedgerEntry).where(CitationLedgerEntry.message_id == mid)
+        )
+    ).scalars().all()
+    assert n == 2
+    kinds = {e.source_kind for e in entries}
+    assert kinds == {"caselaw"}  # one from the caselaw citation, one from the tool source
+    by_fk = {
+        "caselaw_citation": [e for e in entries if e.message_caselaw_citation_id is not None],
+        "tool_source": [e for e in entries if e.message_tool_source_id is not None],
+    }
+    assert len(by_fk["caselaw_citation"]) == 1
+    assert by_fk["caselaw_citation"][0].verification_status == "exact_match"
+    assert by_fk["caselaw_citation"][0].confidence == 1.0
+    assert by_fk["caselaw_citation"][0].provider == "courtlistener"
+    assert len(by_fk["tool_source"]) == 1
+    assert by_fk["tool_source"][0].verification_status == "provenance"
+    assert by_fk["tool_source"][0].confidence is None
+    assert by_fk["tool_source"][0].provider == "courtlistener"
+    assert by_fk["tool_source"][0].retrieved_at is not None
+
+
+@pytest.mark.asyncio
+async def test_no_sources_yields_no_entries(db_session, seeded_message):
+    n = await assemble_ledger_entries(db_session, message_id=seeded_message)
+    assert n == 0

--- a/api/tests/integration/test_citation_ledger.py
+++ b/api/tests/integration/test_citation_ledger.py
@@ -1,0 +1,93 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.message_tool_source import MessageToolSource
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def seeded_message(db_session):
+    """Seed a user + chat + assistant message; yield the message id."""
+    user = User(
+        email=f"ledger-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        role="member",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="ledger test")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="answer")
+    db_session.add(msg)
+    await db_session.flush()
+    return msg.id
+
+
+@pytest.mark.asyncio
+async def test_ledger_entry_roundtrips(db_session, seeded_message):
+    """A single-FK entry referencing a real tool-source row persists and reads back."""
+    chat_id = (
+        await db_session.execute(select(Message.chat_id).where(Message.id == seeded_message))
+    ).scalar_one()
+    source = MessageToolSource(
+        message_id=seeded_message, source_kind="caselaw", label="Cluster 1",
+        subtitle=None, url=None, external_ref="1", provider="courtlistener", tool="get_cluster",
+    )
+    db_session.add(source)
+    await db_session.flush()
+    entry = CitationLedgerEntry(
+        chat_id=chat_id,
+        message_id=seeded_message,
+        source_kind="caselaw",
+        message_tool_source_id=source.id,
+        verification_status="provenance",
+        provider="courtlistener",
+    )
+    db_session.add(entry)
+    await db_session.flush()
+    got = (
+        await db_session.execute(
+            select(CitationLedgerEntry).where(CitationLedgerEntry.message_id == seeded_message)
+        )
+    ).scalar_one()
+    assert got.message_tool_source_id == source.id
+    assert got.message_citation_id is None
+    assert got.verification_status == "provenance"
+    assert got.treatment_id is None
+
+
+@pytest.mark.asyncio
+async def test_exactly_one_fk_check_rejects_zero_and_two(db_session, seeded_message):
+    chat_id = (
+        await db_session.execute(select(Message.chat_id).where(Message.id == seeded_message))
+    ).scalar_one()
+    # zero FKs -> CHECK violation
+    db_session.add(
+        CitationLedgerEntry(
+            chat_id=chat_id, message_id=seeded_message,
+            source_kind="kb_document", verification_status="exact_match",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+    # two FKs -> CHECK violation
+    db_session.add(
+        CitationLedgerEntry(
+            chat_id=chat_id, message_id=seeded_message,
+            source_kind="kb_document", verification_status="exact_match",
+            message_citation_id=uuid.uuid4(), message_tool_source_id=uuid.uuid4(),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()

--- a/api/tests/integration/test_citation_ledger.py
+++ b/api/tests/integration/test_citation_ledger.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import datetime, timezone
 
 import pytest
 import pytest_asyncio
@@ -7,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from app.citation.ledger import assemble_ledger_entries
-from app.models.chat import Chat, Message, MessageCitation
+from app.models.chat import Chat, Message
 from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.message_tool_source import MessageToolSource
@@ -42,8 +41,14 @@ async def test_ledger_entry_roundtrips(db_session, seeded_message):
         await db_session.execute(select(Message.chat_id).where(Message.id == seeded_message))
     ).scalar_one()
     source = MessageToolSource(
-        message_id=seeded_message, source_kind="caselaw", label="Cluster 1",
-        subtitle=None, url=None, external_ref="1", provider="courtlistener", tool="get_cluster",
+        message_id=seeded_message,
+        source_kind="caselaw",
+        label="Cluster 1",
+        subtitle=None,
+        url=None,
+        external_ref="1",
+        provider="courtlistener",
+        tool="get_cluster",
     )
     db_session.add(source)
     await db_session.flush()
@@ -76,8 +81,10 @@ async def test_exactly_one_fk_check_rejects_zero_and_two(db_session, seeded_mess
     # zero FKs -> CHECK violation
     db_session.add(
         CitationLedgerEntry(
-            chat_id=chat_id, message_id=seeded_message,
-            source_kind="kb_document", verification_status="exact_match",
+            chat_id=chat_id,
+            message_id=seeded_message,
+            source_kind="kb_document",
+            verification_status="exact_match",
         )
     )
     with pytest.raises(IntegrityError):
@@ -86,9 +93,12 @@ async def test_exactly_one_fk_check_rejects_zero_and_two(db_session, seeded_mess
     # two FKs -> CHECK violation
     db_session.add(
         CitationLedgerEntry(
-            chat_id=chat_id, message_id=seeded_message,
-            source_kind="kb_document", verification_status="exact_match",
-            message_citation_id=uuid.uuid4(), message_tool_source_id=uuid.uuid4(),
+            chat_id=chat_id,
+            message_id=seeded_message,
+            source_kind="kb_document",
+            verification_status="exact_match",
+            message_citation_id=uuid.uuid4(),
+            message_tool_source_id=uuid.uuid4(),
         )
     )
     with pytest.raises(IntegrityError):
@@ -104,15 +114,27 @@ async def test_assembles_one_entry_per_source_row(db_session, seeded_message):
     # plus a caselaw citation, to exercise all three source kinds without a file.
     db_session.add(
         MessageCaselawCitation(
-            message_id=mid, opinion_id=11, cluster_id=22,
-            source_offset_start=0, source_offset_end=5, source_text="hello",
-            verified=True, verification_method="exact_match", verification_confidence=1.0,
+            message_id=mid,
+            opinion_id=11,
+            cluster_id=22,
+            source_offset_start=0,
+            source_offset_end=5,
+            source_text="hello",
+            verified=True,
+            verification_method="exact_match",
+            verification_confidence=1.0,
         )
     )
     db_session.add(
         MessageToolSource(
-            message_id=mid, source_kind="caselaw", label="Cluster 22",
-            subtitle=None, url=None, external_ref="22", provider="courtlistener", tool="get_cluster",
+            message_id=mid,
+            source_kind="caselaw",
+            label="Cluster 22",
+            subtitle=None,
+            url=None,
+            external_ref="22",
+            provider="courtlistener",
+            tool="get_cluster",
         )
     )
     await db_session.flush()
@@ -121,10 +143,14 @@ async def test_assembles_one_entry_per_source_row(db_session, seeded_message):
     await db_session.flush()
 
     entries = (
-        await db_session.execute(
-            select(CitationLedgerEntry).where(CitationLedgerEntry.message_id == mid)
+        (
+            await db_session.execute(
+                select(CitationLedgerEntry).where(CitationLedgerEntry.message_id == mid)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert n == 2
     kinds = {e.source_kind for e in entries}
     assert kinds == {"caselaw"}  # one from the caselaw citation, one from the tool source

--- a/api/tests/test_transparency_invariants.py
+++ b/api/tests/test_transparency_invariants.py
@@ -30,6 +30,7 @@ from sqlalchemy import Table
 
 import app
 from app.models.audit import AuditLog
+from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.inference import InferenceRoutingLog
 from app.models.tool_call_log import ToolCallLog
 from app.models.tool_egress import ToolEgressLog
@@ -50,6 +51,7 @@ _AUDIT_MODELS: tuple[type, ...] = (
     AuditLog,
     ToolEgressLog,
     InferenceRoutingLog,
+    CitationLedgerEntry,
 )
 
 # Column names that, by name alone, signal raw-content storage. Matched

--- a/docs/adr/0018-citation-ledger-and-fiduciary-grade-output.md
+++ b/docs/adr/0018-citation-ledger-and-fiduciary-grade-output.md
@@ -53,6 +53,8 @@ Introduce `citation_ledger_entry` — one row per *(assistant turn, source broug
 
 *Rejected — read-model/view only:* no durable home for the reserved treatment slot, no re-run survival, and WS-G would have nowhere to write. *Rejected — denormalized snapshot:* duplicates content (P3 surface) and drifts from the source rows. The thin referencing table is the maintainer's selected option (2026-06-24).
 
+> **Reconciliation (P1-A2, 2026-06-24):** as built, the ledger references the three concrete per-turn artifacts via three nullable FKs — `message_citation_id`, `message_caselaw_citation_id`, `message_tool_source_id` (exactly one non-null). The earlier `citable_source_id` slot is realized as `message_caselaw_citation_id` (P1-A1 reused research-opinion storage + a caselaw-citation table rather than creating a standalone `citable_source`). The sketched `tier` column is deferred — `message_tool_sources` carries no tier to populate.
+
 ### D2 — External sources become quote-verifiable by **materializing** their text as a citable source
 
 To character-verify a quote drawn from an external authoritative source (a CourtListener/MCP opinion), the fetched source text is **materialized as a citable source** in the content layer — normalized text + char offsets — and **the existing cascade runs against it unchanged**. This keeps one verification path (P6): a quote from a KB document and a quote from a fetched opinion both verify by slicing stored `normalized_content[start:end]` and running exact → tolerant → paraphrase.

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -585,6 +585,76 @@ verifier.
 | Method values | `exact_match`, `tolerant_match`, `llm_judge`, `ensemble`, `failed` | `exact_match`, `tolerant_match` (P1-A1) |
 | Confidence type | `NUMERIC(3,2)` | `FLOAT` |
 
+### `citation_ledger_entry` (migration 0058, P1-A2)
+
+The Citation Ledger (ADR 0018 D1) — one thin referencing row per (turn, source), unifying KB-document citations, caselaw citations, and tool-source provenance; metadata-only (no content), in the P3 tripwire.
+
+One row per *(assistant turn, source brought into context)*, accumulated per matter (`project_id`). It **references** exactly one of `message_citations`, `message_caselaw_citations`, or `message_tool_sources` by id (a CHECK constraint enforces exactly-one-non-null) and mirrors that source's verification status as a queryable label. It holds **no content** (`source_text` and payloads live on the referenced rows); it is a metadata index.
+
+```sql
+CREATE TABLE citation_ledger_entry (
+    id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id                  UUID REFERENCES projects(id) ON DELETE CASCADE,         -- fk_citation_ledger_entry_project; nullable (chat may be matter-less)
+    chat_id                     UUID NOT NULL REFERENCES chats(id) ON DELETE CASCADE,   -- fk_citation_ledger_entry_chat
+    message_id                  UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE, -- fk_citation_ledger_entry_message
+    source_kind                 TEXT NOT NULL,    -- 'kb_document' | 'caselaw' | 'mcp' | 'kb_chunk'
+    message_citation_id         UUID REFERENCES message_citations(id) ON DELETE CASCADE,          -- fk_citation_ledger_entry_msg_citation; nullable
+    message_caselaw_citation_id UUID REFERENCES message_caselaw_citations(id) ON DELETE CASCADE,  -- fk_citation_ledger_entry_caselaw_citation; nullable
+    message_tool_source_id      UUID REFERENCES message_tool_sources(id) ON DELETE CASCADE,       -- fk_citation_ledger_entry_tool_source; nullable
+    verification_status         TEXT NOT NULL,    -- mirrored cascade label: 'exact_match' | 'tolerant_match' | 'provenance' | etc.
+    confidence                  FLOAT,            -- mirrored cascade confidence [0,1] or NULL
+    provider                    TEXT,             -- retrieval provider (e.g. 'courtlistener') or NULL for KB sources
+    retrieved_at                TIMESTAMPTZ,      -- time the external source was fetched, or NULL for KB sources
+    treatment_id                UUID,             -- reserved for WS-G derived treatment (ADR 0018 D6); always NULL in Phase 1
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT chk_citation_ledger_entry_exactly_one_source
+        CHECK (
+            (message_citation_id IS NOT NULL)::int
+            + (message_caselaw_citation_id IS NOT NULL)::int
+            + (message_tool_source_id IS NOT NULL)::int = 1
+        ),
+    CONSTRAINT chk_citation_ledger_entry_confidence_range
+        CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1))
+);
+
+CREATE INDEX ix_citation_ledger_entry_chat_id    ON citation_ledger_entry(chat_id);
+CREATE INDEX ix_citation_ledger_entry_message_id ON citation_ledger_entry(message_id);
+CREATE INDEX ix_citation_ledger_entry_project_id ON citation_ledger_entry(project_id);
+```
+
+**Columns:**
+
+| Column | Type | Nullable | Purpose |
+|---|---|---|---|
+| `id` | UUID PK | NOT NULL | Entry identity |
+| `project_id` | UUID FK → `projects.id` CASCADE | nullable | Matter scope; NULL when the chat belongs to no project |
+| `chat_id` | UUID FK → `chats.id` CASCADE | NOT NULL | Conversation scope |
+| `message_id` | UUID FK → `messages.id` CASCADE | NOT NULL | The assistant turn that brought this source into context |
+| `source_kind` | TEXT | NOT NULL | Kind label: `kb_document`, `caselaw`, `mcp`, `kb_chunk` |
+| `message_citation_id` | UUID FK → `message_citations.id` CASCADE | nullable | Set when source produced a `MessageCitation` (KB quote-verified) |
+| `message_caselaw_citation_id` | UUID FK → `message_caselaw_citations.id` CASCADE | nullable | Set when source produced a `MessageCaselawCitation` (external quote-verified) |
+| `message_tool_source_id` | UUID FK → `message_tool_sources.id` CASCADE | nullable | Set when source is retrieval-provenance only (no quote verification) |
+| `verification_status` | TEXT | NOT NULL | Mirrored cascade label (e.g. `exact_match`, `tolerant_match`, `provenance`) — a label, never payload |
+| `confidence` | FLOAT | nullable | Mirrored cascade confidence [0, 1]; NULL for provenance-only rows |
+| `provider` | TEXT | nullable | Retrieval provider (e.g. `courtlistener`); NULL for KB-document sources |
+| `retrieved_at` | TIMESTAMPTZ | nullable | When the external source was fetched; NULL for KB-document sources |
+| `treatment_id` | UUID | nullable | **Reserved** for WS-G derived treatment (ADR 0018 D6); always NULL in Phase 1 |
+| `created_at` | TIMESTAMPTZ | NOT NULL | Append time; server default `now()` |
+
+**CHECK constraints:**
+
+- `chk_citation_ledger_entry_exactly_one_source` — `(message_citation_id IS NOT NULL)::int + (message_caselaw_citation_id IS NOT NULL)::int + (message_tool_source_id IS NOT NULL)::int = 1`. Exactly one source FK must be non-null; the other two must be null. Enforces the ledger's single-source-per-row invariant.
+- `chk_citation_ledger_entry_confidence_range` — `confidence IS NULL OR (confidence >= 0 AND confidence <= 1)`. Mirrors the range constraint on the underlying citation tables.
+
+**Indexes:**
+
+- `ix_citation_ledger_entry_chat_id` on `(chat_id)` — supports the per-conversation ledger read endpoint (ADR 0018 D4).
+- `ix_citation_ledger_entry_message_id` on `(message_id)` — supports per-turn ledger queries.
+- `ix_citation_ledger_entry_project_id` on `(project_id)` — supports matter-scoped ledger queries and P9 export/delete.
+
+**P3 note:** the ledger intentionally holds **no content** (no `source_text`, no tool payloads). It is added to the `test_transparency_invariants.py` no-raw-payload tripwire scan (ADR 0018 D5) so any future content-bearing column fails CI at collection.
+
 ### `enhance_prompt_interactions` (migration 0015)
 
 One row per Enhance Prompt (⌘E) invocation. Records the raw input, the

--- a/docs/superpowers/plans/2026-06-24-p1a2-citation-ledger.md
+++ b/docs/superpowers/plans/2026-06-24-p1a2-citation-ledger.md
@@ -1,0 +1,734 @@
+# P1-A2 — Citation Ledger entry table + assembly — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `citation_ledger_entry` table that unifies a turn's KB-document citations, caselaw citations, and tool-source provenance into one matter-and-turn-scoped record, and assemble it at chat finalize.
+
+**Architecture:** A thin **referencing** table (ADR 0018 D1) with three nullable FKs (exactly one non-null per row) + a `source_kind` discriminator + mirrored verification status. A source-kind-agnostic assembler reads whatever citation/source rows exist for a message and writes one ledger entry per row, hooked (guarded) at every chat-finalize site. The entry holds no content (references only), so it joins the P3 no-raw-payload tripwire.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2 (async), Alembic, pytest (host venv + throwaway `pgvector/pgvector:pg16`), ruff, mypy.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-24-p1a2-citation-ledger-entry-design.md`. Pins [ADR 0018](../../adr/0018-citation-ledger-and-fiduciary-grade-output.md) D1/D5/D6/D7.
+- **Three nullable FKs + `source_kind`**, exactly-one-non-null CHECK; reserved `treatment_id` (nullable uuid, NO FK). No `tier` column (dropped — `message_tool_sources` can't populate it).
+- **Metadata-only:** the ledger holds NO `source_text`/content — it references content by id. It MUST be added to `api/tests/test_transparency_invariants.py`'s `_AUDIT_MODELS` and that test MUST stay green.
+- **Conservative posture:** a ledger-assembly failure logs and degrades to "no ledger this turn" — it must NEVER abort the assistant turn/stream. No new egress; pure DB.
+- **Tests:** run via host venv against the throwaway pgvector (conftest auto-migrates); NEVER host `alembic upgrade`; never use port 15432. No `-m provider` (pure DB).
+- **Migration discipline:** next revision is `0058`, `down_revision="0057"`.
+- **Gates:** `ruff format`, `ruff check`, `mypy app` (standard mode), `pytest`. Coverage no-decrease.
+- **Security review:** touches the citation/audit-adjacent surface → CODEOWNERS routes to security review.
+- **Commits:** `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Test DB env:** `cd /Users/kevinkeller/Code/lq-ai/api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest <args>`. If the throwaway container isn't running: `docker run -d --rm --name lqai-test-pg -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=lqai_test -p 55432:5432 pgvector/pgvector:pg16`, then `docker exec lqai-test-pg psql -U postgres -d lqai_test -c "CREATE EXTENSION IF NOT EXISTS vector;"`.
+
+## File Structure
+
+- `api/app/models/citation_ledger_entry.py` — **new** ORM model `CitationLedgerEntry`.
+- `api/alembic/versions/0058_citation_ledger_entry.py` — **new** migration.
+- `api/app/models/__init__.py` — **modify**: register the model.
+- `api/tests/test_transparency_invariants.py` — **modify**: add the model to `_AUDIT_MODELS`.
+- `api/app/citation/ledger.py` — **new** module: `assemble_ledger_entries`.
+- `api/app/api/chats.py` — **modify**: guarded assembler call at the three finalize branches.
+- `api/tests/integration/test_citation_ledger.py` — **new** integration tests.
+- `docs/db-schema.md` — **modify**: document the table.
+- `docs/adr/0018-citation-ledger-and-fiduciary-grade-output.md` — **modify**: D1 reconciliation note.
+
+---
+
+### Task 1: `citation_ledger_entry` model + migration + P3 tripwire
+
+**Files:**
+- Create: `api/app/models/citation_ledger_entry.py`
+- Create: `api/alembic/versions/0058_citation_ledger_entry.py`
+- Modify: `api/app/models/__init__.py`
+- Modify: `api/tests/test_transparency_invariants.py`
+- Test: `api/tests/integration/test_citation_ledger.py`
+
+**Interfaces:**
+- Produces: `CitationLedgerEntry` with columns `id, project_id, chat_id, message_id, source_kind, message_citation_id, message_caselaw_citation_id, message_tool_source_id, verification_status, confidence, provider, retrieved_at, treatment_id, created_at`.
+
+- [ ] **Step 1: Write the failing test** — `api/tests/integration/test_citation_ledger.py`
+
+```python
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.message_tool_source import MessageToolSource
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def seeded_message(db_session):
+    """Seed a user + chat + assistant message; yield the message id."""
+    user = User(
+        email=f"ledger-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        role="member",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(user_id=user.id, title="ledger test")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="answer")
+    db_session.add(msg)
+    await db_session.flush()
+    return msg.id
+
+
+@pytest.mark.asyncio
+async def test_ledger_entry_roundtrips(db_session, seeded_message):
+    """A single-FK entry referencing a real tool-source row persists and reads back."""
+    chat_id = (
+        await db_session.execute(select(Message.chat_id).where(Message.id == seeded_message))
+    ).scalar_one()
+    source = MessageToolSource(
+        message_id=seeded_message, source_kind="caselaw", label="Cluster 1",
+        subtitle=None, url=None, external_ref="1", provider="courtlistener", tool="get_cluster",
+    )
+    db_session.add(source)
+    await db_session.flush()
+    entry = CitationLedgerEntry(
+        chat_id=chat_id,
+        message_id=seeded_message,
+        source_kind="caselaw",
+        message_tool_source_id=source.id,
+        verification_status="provenance",
+        provider="courtlistener",
+    )
+    db_session.add(entry)
+    await db_session.flush()
+    got = (
+        await db_session.execute(
+            select(CitationLedgerEntry).where(CitationLedgerEntry.message_id == seeded_message)
+        )
+    ).scalar_one()
+    assert got.message_tool_source_id == source.id
+    assert got.message_citation_id is None
+    assert got.verification_status == "provenance"
+    assert got.treatment_id is None
+
+
+@pytest.mark.asyncio
+async def test_exactly_one_fk_check_rejects_zero_and_two(db_session, seeded_message):
+    chat_id = (
+        await db_session.execute(select(Message.chat_id).where(Message.id == seeded_message))
+    ).scalar_one()
+    # zero FKs -> CHECK violation
+    db_session.add(
+        CitationLedgerEntry(
+            chat_id=chat_id, message_id=seeded_message,
+            source_kind="kb_document", verification_status="exact_match",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+    # two FKs -> CHECK violation
+    db_session.add(
+        CitationLedgerEntry(
+            chat_id=chat_id, message_id=seeded_message,
+            source_kind="kb_document", verification_status="exact_match",
+            message_citation_id=uuid.uuid4(), message_tool_source_id=uuid.uuid4(),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+```
+
+> The first test is intentionally minimal (the model + a FK constraint); Task 2's tests exercise real referenced rows. If `Chat`/`Message`/`User` constructor kwargs differ on `main`, mirror the seeding in `api/tests/test_message_tool_sources.py`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_citation_ledger.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.models.citation_ledger_entry`.
+
+- [ ] **Step 3: Create the model** — `api/app/models/citation_ledger_entry.py`
+
+```python
+"""citation_ledger_entry — the Citation Ledger (ADR 0018 D1).
+
+One row per (assistant turn, source brought into context). A thin REFERENCING
+record: it points at exactly one of message_citations / message_caselaw_citations
+/ message_tool_sources by id (a CHECK enforces exactly-one-non-null) and mirrors
+that source's verification status as a queryable label. It holds NO content
+(source_text lives on the referenced row), so it is a metadata index and joins
+the P3 no-raw-payload tripwire. ``treatment_id`` is reserved for the WS-G derived
+treatment layer (ADR 0018 D6) and is always NULL in Phase 1.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Float, ForeignKey, Index, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class CitationLedgerEntry(Base):
+    __tablename__ = "citation_ledger_entry"
+    __table_args__ = (
+        CheckConstraint(
+            "(message_citation_id IS NOT NULL)::int "
+            "+ (message_caselaw_citation_id IS NOT NULL)::int "
+            "+ (message_tool_source_id IS NOT NULL)::int = 1",
+            name="chk_citation_ledger_entry_exactly_one_source",
+        ),
+        CheckConstraint(
+            "confidence IS NULL OR (confidence >= 0 AND confidence <= 1)",
+            name="chk_citation_ledger_entry_confidence_range",
+        ),
+        Index("ix_citation_ledger_entry_chat_id", "chat_id"),
+        Index("ix_citation_ledger_entry_message_id", "message_id"),
+        Index("ix_citation_ledger_entry_project_id", "project_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE", name="fk_citation_ledger_entry_project"),
+        nullable=True,
+    )
+    chat_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chats.id", ondelete="CASCADE", name="fk_citation_ledger_entry_chat"),
+        nullable=False,
+    )
+    message_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("messages.id", ondelete="CASCADE", name="fk_citation_ledger_entry_message"),
+        nullable=False,
+    )
+    source_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    message_citation_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "message_citations.id", ondelete="CASCADE", name="fk_citation_ledger_entry_msg_citation"
+        ),
+        nullable=True,
+    )
+    message_caselaw_citation_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "message_caselaw_citations.id",
+            ondelete="CASCADE",
+            name="fk_citation_ledger_entry_caselaw_citation",
+        ),
+        nullable=True,
+    )
+    message_tool_source_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "message_tool_sources.id",
+            ondelete="CASCADE",
+            name="fk_citation_ledger_entry_tool_source",
+        ),
+        nullable=True,
+    )
+    verification_status: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    provider: Mapped[str | None] = mapped_column(Text, nullable=True)
+    retrieved_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    treatment_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, server_default=func.now())
+```
+
+> Verify the projects table name is `projects` before finalizing the `project_id` FK: `grep -n '__tablename__' api/app/models/project.py`. If it differs, use the actual name. (The model uses `projects.id`; adjust if needed.)
+
+- [ ] **Step 4: Register the model** — add to `api/app/models/__init__.py`
+
+```python
+from app.models.citation_ledger_entry import CitationLedgerEntry
+```
+
+…and add `"CitationLedgerEntry"` to `__all__` if the module maintains one (follow the existing pattern/position).
+
+- [ ] **Step 5: Create the migration** — `api/alembic/versions/0058_citation_ledger_entry.py`
+
+```python
+"""citation_ledger_entry — the Citation Ledger (ADR 0018 D1)
+
+Revision ID: 0058
+Revises: 0057
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0058"
+down_revision: str | None = "0057"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "citation_ledger_entry",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE", name="fk_citation_ledger_entry_project"),
+            nullable=True,
+        ),
+        sa.Column(
+            "chat_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("chats.id", ondelete="CASCADE", name="fk_citation_ledger_entry_chat"),
+            nullable=False,
+        ),
+        sa.Column(
+            "message_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("messages.id", ondelete="CASCADE", name="fk_citation_ledger_entry_message"),
+            nullable=False,
+        ),
+        sa.Column("source_kind", sa.Text(), nullable=False),
+        sa.Column(
+            "message_citation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "message_citations.id",
+                ondelete="CASCADE",
+                name="fk_citation_ledger_entry_msg_citation",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "message_caselaw_citation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "message_caselaw_citations.id",
+                ondelete="CASCADE",
+                name="fk_citation_ledger_entry_caselaw_citation",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "message_tool_source_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "message_tool_sources.id",
+                ondelete="CASCADE",
+                name="fk_citation_ledger_entry_tool_source",
+            ),
+            nullable=True,
+        ),
+        sa.Column("verification_status", sa.Text(), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("provider", sa.Text(), nullable=True),
+        sa.Column("retrieved_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("treatment_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "(message_citation_id IS NOT NULL)::int "
+            "+ (message_caselaw_citation_id IS NOT NULL)::int "
+            "+ (message_tool_source_id IS NOT NULL)::int = 1",
+            name="chk_citation_ledger_entry_exactly_one_source",
+        ),
+        sa.CheckConstraint(
+            "confidence IS NULL OR (confidence >= 0 AND confidence <= 1)",
+            name="chk_citation_ledger_entry_confidence_range",
+        ),
+    )
+    op.create_index("ix_citation_ledger_entry_chat_id", "citation_ledger_entry", ["chat_id"])
+    op.create_index("ix_citation_ledger_entry_message_id", "citation_ledger_entry", ["message_id"])
+    op.create_index("ix_citation_ledger_entry_project_id", "citation_ledger_entry", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_citation_ledger_entry_project_id", table_name="citation_ledger_entry")
+    op.drop_index("ix_citation_ledger_entry_message_id", table_name="citation_ledger_entry")
+    op.drop_index("ix_citation_ledger_entry_chat_id", table_name="citation_ledger_entry")
+    op.drop_table("citation_ledger_entry")
+```
+
+- [ ] **Step 6: Add the model to the P3 tripwire** — `api/tests/test_transparency_invariants.py`
+
+Add the import next to the other audit-model imports (near lines 32–35):
+
+```python
+from app.models.citation_ledger_entry import CitationLedgerEntry
+```
+
+Add it to the `_AUDIT_MODELS` tuple (lines ~48–53):
+
+```python
+_AUDIT_MODELS: tuple[type, ...] = (
+    ToolCallLog,
+    AuditLog,
+    ToolEgressLog,
+    InferenceRoutingLog,
+    CitationLedgerEntry,
+)
+```
+
+> All ledger columns are metadata (`*_id`, `source_kind`, `verification_status`, `confidence`, `provider`, `retrieved_at`, `created_at`) — none is an exact denied term and none ends in a denied suffix (`message_citation_id` ends in `_id`, not `_message`), so the scan passes. This addition PROVES the ledger is metadata-only.
+
+- [ ] **Step 7: Run tests + tripwire**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_citation_ledger.py tests/test_transparency_invariants.py -v`
+Expected: PASS — round-trip + both CHECK-rejection tests + `test_audit_models_have_no_raw_payload_columns` green with the ledger included.
+
+- [ ] **Step 8: Lint + type-check**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/api && .venv/bin/ruff format app/models/citation_ledger_entry.py alembic/versions/0058_citation_ledger_entry.py && .venv/bin/ruff check app/models/citation_ledger_entry.py alembic/versions/0058_citation_ledger_entry.py tests/test_transparency_invariants.py && .venv/bin/mypy app/models/citation_ledger_entry.py`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add api/app/models/citation_ledger_entry.py api/alembic/versions/0058_citation_ledger_entry.py api/app/models/__init__.py api/tests/test_transparency_invariants.py api/tests/integration/test_citation_ledger.py
+git commit -s -m "feat(citation): citation_ledger_entry table + model + P3 tripwire (P1-A2)"
+```
+
+---
+
+### Task 2: Ledger assembly
+
+**Files:**
+- Create: `api/app/citation/ledger.py`
+- Test: `api/tests/integration/test_citation_ledger.py` (append)
+
+**Interfaces:**
+- Consumes: `CitationLedgerEntry`; `MessageCitation`, `MessageCaselawCitation`, `MessageToolSource`; `Chat`, `Message`.
+- Produces: `async def assemble_ledger_entries(db, *, message_id) -> int` — self-derives `chat_id` (from the message) and `project_id` (from the chat); writes one ledger entry per citation/source row for the message; returns the count.
+
+- [ ] **Step 1: Write the failing test** — append to `api/tests/integration/test_citation_ledger.py`
+
+```python
+from datetime import datetime, timezone
+
+from app.citation.ledger import assemble_ledger_entries
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.message_tool_source import MessageToolSource
+# MessageCitation lives in app.models.chat
+from app.models.chat import MessageCitation
+
+
+@pytest.mark.asyncio
+async def test_assembles_one_entry_per_source_row(db_session, seeded_message):
+    mid = seeded_message
+    # A KB-document citation (verified) — needs a real source_file_id (files row).
+    # Reuse the message_tool_sources + caselaw rows that DON'T need a file FK,
+    # plus a caselaw citation, to exercise all three source kinds without a file.
+    db_session.add(
+        MessageCaselawCitation(
+            message_id=mid, opinion_id=11, cluster_id=22,
+            source_offset_start=0, source_offset_end=5, source_text="hello",
+            verified=True, verification_method="exact_match", verification_confidence=1.0,
+        )
+    )
+    db_session.add(
+        MessageToolSource(
+            message_id=mid, source_kind="caselaw", label="Cluster 22",
+            subtitle=None, url=None, external_ref="22", provider="courtlistener", tool="get_cluster",
+        )
+    )
+    await db_session.flush()
+
+    n = await assemble_ledger_entries(db_session, message_id=mid)
+    await db_session.flush()
+
+    entries = (
+        await db_session.execute(
+            select(CitationLedgerEntry).where(CitationLedgerEntry.message_id == mid)
+        )
+    ).scalars().all()
+    assert n == 2
+    kinds = {e.source_kind for e in entries}
+    assert kinds == {"caselaw"}  # one from the caselaw citation, one from the tool source
+    by_fk = {
+        "caselaw_citation": [e for e in entries if e.message_caselaw_citation_id is not None],
+        "tool_source": [e for e in entries if e.message_tool_source_id is not None],
+    }
+    assert len(by_fk["caselaw_citation"]) == 1
+    assert by_fk["caselaw_citation"][0].verification_status == "exact_match"
+    assert by_fk["caselaw_citation"][0].confidence == 1.0
+    assert by_fk["caselaw_citation"][0].provider == "courtlistener"
+    assert len(by_fk["tool_source"]) == 1
+    assert by_fk["tool_source"][0].verification_status == "provenance"
+    assert by_fk["tool_source"][0].confidence is None
+    assert by_fk["tool_source"][0].provider == "courtlistener"
+    assert by_fk["tool_source"][0].retrieved_at is not None
+
+
+@pytest.mark.asyncio
+async def test_no_sources_yields_no_entries(db_session, seeded_message):
+    n = await assemble_ledger_entries(db_session, message_id=seeded_message)
+    assert n == 0
+```
+
+> The KB-document path (`MessageCitation`, which needs a real `source_file_id` → `files`) is covered indirectly by the `kb_document` mapping in the implementation; seeding a full `files`+`documents` chain is heavy, so these tests exercise the caselaw + tool-source kinds. The kb_document mapping is asserted by reading code in review; if a fuller fixture exists for files, add a kb_document case.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_citation_ledger.py -k assembles -v`
+Expected: FAIL — `ModuleNotFoundError: app.citation.ledger`.
+
+- [ ] **Step 3: Implement the assembler** — `api/app/citation/ledger.py`
+
+```python
+"""Citation Ledger assembly (ADR 0018 D1).
+
+Reads the three per-turn citation/source artifacts for an assistant message and
+writes one ``CitationLedgerEntry`` per row — a thin referencing index. Source-kind
+agnostic over ``message_tool_sources`` (so generic-MCP rows flow in once DE-350
+lands). Holds no content; references by id.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat, Message, MessageCitation
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.message_tool_source import MessageToolSource
+
+
+async def assemble_ledger_entries(db: AsyncSession, *, message_id: uuid.UUID) -> int:
+    """Write one ledger entry per citation/source row for ``message_id``.
+
+    Self-derives ``chat_id`` (from the message) and ``project_id`` (from the chat).
+    Returns the number of entries written. Pure DB; no egress.
+    """
+    chat_id = (
+        await db.execute(select(Message.chat_id).where(Message.id == message_id))
+    ).scalar_one_or_none()
+    if chat_id is None:
+        return 0
+    project_id = (
+        await db.execute(select(Chat.project_id).where(Chat.id == chat_id))
+    ).scalar_one_or_none()
+
+    entries: list[CitationLedgerEntry] = []
+
+    doc_citations = (
+        (await db.execute(select(MessageCitation).where(MessageCitation.message_id == message_id)))
+        .scalars()
+        .all()
+    )
+    for c in doc_citations:
+        entries.append(
+            CitationLedgerEntry(
+                project_id=project_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                source_kind="kb_document",
+                message_citation_id=c.id,
+                verification_status=c.verification_method or "verified",
+                confidence=float(c.verification_confidence)
+                if c.verification_confidence is not None
+                else None,
+                provider=None,
+                retrieved_at=None,
+            )
+        )
+
+    caselaw_citations = (
+        (
+            await db.execute(
+                select(MessageCaselawCitation).where(MessageCaselawCitation.message_id == message_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for cc in caselaw_citations:
+        entries.append(
+            CitationLedgerEntry(
+                project_id=project_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                source_kind="caselaw",
+                message_caselaw_citation_id=cc.id,
+                verification_status=cc.verification_method or "verified",
+                confidence=cc.verification_confidence,
+                provider="courtlistener",
+                retrieved_at=cc.created_at,
+            )
+        )
+
+    tool_sources = (
+        (
+            await db.execute(
+                select(MessageToolSource).where(MessageToolSource.message_id == message_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for ts in tool_sources:
+        entries.append(
+            CitationLedgerEntry(
+                project_id=project_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                source_kind=ts.source_kind,
+                message_tool_source_id=ts.id,
+                verification_status="provenance",
+                confidence=None,
+                provider=ts.provider,
+                retrieved_at=ts.created_at,
+            )
+        )
+
+    if entries:
+        db.add_all(entries)
+        await db.flush()
+    return len(entries)
+```
+
+> Confirm `MessageCitation` is importable from `app.models.chat` (it is defined there). If `app.models.__init__` re-exports it, importing from `app.models` is also fine — match the codebase's prevailing import style.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_citation_ledger.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 5: Lint + type-check**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/api && .venv/bin/ruff format app/citation/ledger.py && .venv/bin/ruff check app/citation/ledger.py && .venv/bin/mypy app/citation/ledger.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/app/citation/ledger.py api/tests/integration/test_citation_ledger.py
+git commit -s -m "feat(citation): citation ledger assembly (P1-A2)"
+```
+
+---
+
+### Task 3: Wire the assembler into chat finalize
+
+**Files:**
+- Modify: `api/app/api/chats.py`
+
+**Interfaces:**
+- Consumes: `assemble_ledger_entries` (Task 2).
+
+- [ ] **Step 1: Add the import** — near the other citation imports at the top of `api/app/api/chats.py` (next to `from app.citation.caselaw import verify_and_persist_caselaw_citations`)
+
+```python
+from app.citation.ledger import assemble_ledger_entries
+```
+
+- [ ] **Step 2: Wire the three finalize branches**
+
+Find the finalize sites: `grep -n "verify_and_persist_caselaw_citations\|_persist_message_tool_sources(db, message_id=assistant_message_id, records=\[\])" api/app/api/chats.py`. There are three branches that persist a turn's citations/sources:
+- **Two tool-loop branches** — each ends with `await verify_and_persist_caselaw_citations(...)` (the non-streaming `_non_streaming_response` site ~2879 and the streaming `_stream_response` site ~3446).
+- **One single-shot branch** — ends with `await _persist_message_tool_sources(db, message_id=assistant_message_id, records=[])` (~3096).
+
+After the LAST persist call in EACH of the three branches, add a guarded assembler call (use the file's existing `log` logger):
+
+```python
+            try:
+                await assemble_ledger_entries(db, message_id=assistant_message_id)
+            except Exception as ledger_exc:  # never block the turn
+                log.warning("citation ledger assembly failed: %r", ledger_exc)
+```
+
+Match the indentation of the surrounding `await _persist_*` calls at each site. Place the caselaw call (where present) BEFORE the ledger call, so all source rows exist when the ledger assembles.
+
+- [ ] **Step 3: Run the chat-path regression + ledger tests**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_chat_tool_loop_send.py tests/integration/test_chat_tool_call_resume.py tests/integration/test_citation_ledger.py -q`
+Expected: PASS, no regressions.
+
+- [ ] **Step 4: Lint + type-check**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/api && .venv/bin/ruff format app/api/chats.py && .venv/bin/ruff check app/api/chats.py && .venv/bin/mypy app/api/chats.py`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/api/chats.py
+git commit -s -m "feat(citation): assemble the ledger at chat finalize (P1-A2)"
+```
+
+---
+
+### Task 4: Docs + ADR reconciliation + full gate
+
+**Files:**
+- Modify: `docs/db-schema.md`
+- Modify: `docs/adr/0018-citation-ledger-and-fiduciary-grade-output.md`
+
+- [ ] **Step 1: Document the table** — add a `citation_ledger_entry` section to `docs/db-schema.md`
+
+Place it next to `message_citations` / `message_caselaw_citations` / `message_tool_sources`. Read `api/app/models/citation_ledger_entry.py` for the exact columns. Document: every column (type, nullability), the four FKs (`project_id`→projects, `chat_id`→chats, `message_id`→messages, and the three nullable source FKs, all ON DELETE CASCADE), both CHECK constraints (names + conditions), and the three indexes. Purpose line: "the Citation Ledger (ADR 0018 D1) — one thin referencing row per (turn, source), unifying KB-document citations, caselaw citations, and tool-source provenance; metadata-only (no content), in the P3 tripwire."
+
+- [ ] **Step 2: Reconcile ADR 0018 D1** — append a short note under decision D1 in `docs/adr/0018-citation-ledger-and-fiduciary-grade-output.md`
+
+Add (immediately after the D1 table or its trailing paragraph):
+
+```markdown
+> **Reconciliation (P1-A2, 2026-06-24):** as built, the ledger references the three concrete per-turn artifacts via three nullable FKs — `message_citation_id`, `message_caselaw_citation_id`, `message_tool_source_id` (exactly one non-null). The earlier `citable_source_id` slot is realized as `message_caselaw_citation_id` (P1-A1 reused research-opinion storage + a caselaw-citation table rather than creating a standalone `citable_source`). The sketched `tier` column is deferred — `message_tool_sources` carries no tier to populate.
+```
+
+- [ ] **Step 3: Run the full gate**
+
+Run: `cd /Users/kevinkeller/Code/lq-ai/api && .venv/bin/ruff format --check . && .venv/bin/ruff check . && .venv/bin/mypy app && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest -q`
+Expected: all green (no `-m provider`). If a failure traces to this branch, fix it; if pre-existing/unrelated, report it clearly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/db-schema.md docs/adr/0018-citation-ledger-and-fiduciary-grade-output.md
+git commit -s -m "docs: document citation_ledger_entry + reconcile ADR 0018 D1 (P1-A2)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Component 1 (table, migration 0058, exactly-one-FK CHECK, reserved treatment_id, no tier) → Task 1. ✓
+- Component 2 (source-kind-agnostic assembly, self-derived scope, per-row mapping) → Task 2. ✓
+- Component 3 (guarded hook at every finalize site incl. single-shot) → Task 3. ✓
+- Component 4 (P3 tripwire addition) → Task 1 Step 6. ✓
+- Error handling (guarded, never breaks turn; no egress) → Task 3 guard + Task 2 pure-DB. ✓
+- Testing (integration incl. CHECK rejections + per-source mapping; tripwire green) → Tasks 1–2. ✓
+- Docs + ADR D1 reconciliation → Task 4. ✓
+- Acceptance criteria 1–4 → Tasks 1–3 tests + Task 4 gate. ✓
+
+**Placeholder scan:** none — every code step is complete; commands carry expected output. Line numbers for the chats.py sites are approximate and identified by adjacent call expressions (grep), not literals.
+
+**Type consistency:** `assemble_ledger_entries(db, *, message_id) -> int` is consistent across Tasks 2–3. `verification_status` values are the citation's `verification_method` (`exact_match`/`tolerant_match`/…) or `provenance`. `confidence` is `float | None` (Decimal coerced via `float()` for KB doc; already float for caselaw; None for provenance). `CitationLedgerEntry` column names match between model (Task 1), migration (Task 1), assembler (Task 2), and tripwire (Task 1).

--- a/docs/superpowers/specs/2026-06-24-p1a2-citation-ledger-entry-design.md
+++ b/docs/superpowers/specs/2026-06-24-p1a2-citation-ledger-entry-design.md
@@ -1,0 +1,94 @@
+# P1-A2 — Citation Ledger entry table + assembly (design)
+
+**Date:** 2026-06-24
+**Milestone:** Fiduciary-grade agentic legal work — Phase 1 (WS-A)
+**Branch:** `feat/fiduciary-p1a2-citation-ledger`
+**Pins:** [ADR 0018](../../adr/0018-citation-ledger-and-fiduciary-grade-output.md) D1 (thin referencing table), D5 (no-raw-payload / tripwire), D6 (reserved treatment slot), D7 (granularity). Builds on **P1-A1** (`message_caselaw_citations`, merged in #218).
+**Security review:** required (citation/audit-adjacent surface). No new egress.
+
+## Problem
+
+P1-A1 made external caselaw quotes character-verifiable. The chat-finalize path now persists three independent per-turn artifacts: `message_citations` (KB-document quote verification), `message_caselaw_citations` (caselaw quote verification — P1-A1), and `message_tool_sources` (retrieval provenance — "sources consulted"). They are **disconnected** — there is no single, matter-and-turn-scoped record that unifies "every source the turn brought into context and the verification status of each." That unified artifact is the Citation Ledger (ADR 0018 D1), and it is what makes one-click trace (P1-A3) and the fiduciary-grade gate (P1-B1) possible. P1-A2 builds the ledger table and the assembly that populates it; it does **not** build the read API, the gate, or the UI.
+
+## Decisions (maintainer-approved 2026-06-24)
+
+- **Three nullable FKs + `source_kind`** — the entry references exactly one of `message_citations` / `message_caselaw_citations` / `message_tool_sources` (a CHECK enforces exactly-one-non-null). This **reconciles ADR 0018 D1**, whose hypothetical `citable_source_id` is replaced by the concrete `message_caselaw_citation_id` (P1-A1 reused research-opinion storage + a caselaw-citation table instead of creating a `citable_source`). A short reconciliation note is appended to ADR 0018 D1.
+- **One entry per underlying row, no dedup** — a consulted caselaw cluster (a `message_tool_sources` provenance row) and a verbatim quote from its opinion (a `message_caselaw_citations` row) are *distinct ledger facts*; both get entries (ADR D7: per-(turn, source)).
+- **Defer DE-350** from P1-A2 — assembly is source-kind-agnostic over `message_tool_sources`, so generic-MCP entries flow into the ledger automatically once [DE-350](../../PRD.md#de-350) lands. **DE-350 is sequenced as the immediate next slice after P1-A2** (maintainer directive 2026-06-24).
+- **Metadata-only entry** — the ledger holds no `source_text`; it references content by id. So it **is** added to the P3 no-raw-payload tripwire (ADR D5) — the opposite of `message_caselaw_citations`, which holds quoted text and stays out.
+
+## Design
+
+### Component 1 — `citation_ledger_entry` table (migration `0058`)
+
+| Column | Type / notes |
+|---|---|
+| `id` | uuid pk, `gen_random_uuid()` |
+| `project_id` | uuid, **nullable** (a chat may be matter-less) |
+| `chat_id` | uuid, FK → `chats.id` ON DELETE CASCADE, not null |
+| `message_id` | uuid, FK → `messages.id` ON DELETE CASCADE, not null (the assistant turn) |
+| `source_kind` | text, not null — `'kb_document'` \| `'caselaw'` \| `'mcp'` (extensible) |
+| `message_citation_id` | uuid, FK → `message_citations.id` ON DELETE CASCADE, **nullable** |
+| `message_caselaw_citation_id` | uuid, FK → `message_caselaw_citations.id` ON DELETE CASCADE, **nullable** |
+| `message_tool_source_id` | uuid, FK → `message_tool_sources.id` ON DELETE CASCADE, **nullable** |
+| `verification_status` | text, not null — the citation's `verification_method` (`'exact_match'`/`'tolerant_match'`/…), or `'provenance'` for a consulted-but-not-quoted tool source |
+| `confidence` | double precision, nullable — mirrored from the citation; null for provenance entries |
+| `provider` | text, nullable — e.g. `'courtlistener'`; null for local KB documents |
+| `retrieved_at` | timestamptz, nullable — the tool-source row's `created_at`; null for KB documents |
+| `treatment_id` | uuid, **nullable, no FK** — reserved for WS-G derived treatment (ADR D6); always null in P1-A2 |
+| `created_at` | timestamptz, not null, `now()` |
+
+CHECK constraints:
+- **exactly one source FK non-null** — `(message_citation_id IS NOT NULL)::int + (message_caselaw_citation_id IS NOT NULL)::int + (message_tool_source_id IS NOT NULL)::int = 1`.
+- `confidence IS NULL OR (confidence >= 0 AND confidence <= 1)`.
+
+Indexes: `chat_id`, `message_id`, `project_id`.
+
+ADR 0018 D1 also sketched a `tier` column; **dropped** in v1 — `message_tool_sources` does not carry a tier, so it cannot be populated honestly. A follow-on if a tier source materializes.
+
+### Component 2 — Assembly
+
+`assemble_ledger_entries(db, *, project_id, chat_id, message_id) -> int` in a new module `api/app/citation/ledger.py`:
+
+1. Query `message_citations`, `message_caselaw_citations`, and `message_tool_sources` for `message_id`.
+2. Build one `CitationLedgerEntry` per row:
+   - **`message_citations`** → `source_kind='kb_document'`, `message_citation_id` set, `verification_status = row.verification_method`, `confidence = float(row.verification_confidence)`, `provider=None`, `retrieved_at=None`.
+   - **`message_caselaw_citations`** → `source_kind='caselaw'`, `message_caselaw_citation_id` set, `verification_status = row.verification_method`, `confidence = row.verification_confidence`, `provider='courtlistener'`, `retrieved_at = row.created_at`.
+   - **`message_tool_sources`** → `source_kind = row.source_kind` (already `'caselaw'`; `'mcp'` once DE-350 lands), `message_tool_source_id` set, `verification_status='provenance'`, `confidence=None`, `provider = row.provider`, `retrieved_at = row.created_at`.
+3. `add_all` + `flush`. Returns the entry count.
+
+`message_citations.verification_confidence` is a `Decimal`; coerce to `float` for the ledger's `confidence`. Only **verified** `message_citations` / `message_caselaw_citations` rows exist (the persist steps drop unverified ones), so every citation-backed entry has a real method + confidence.
+
+### Component 3 — Hook
+
+A sibling call at chat finalize, **after** the citation/tool-source persist steps (so all rows exist), at **every** finalize site that persists citations — the streaming tool-loop site, the resume site, **and** the single-shot/non-tool site. (P1-A1 wired only the two tool-loop sites because only those produce caselaw sources; the ledger applies to KB-document chats too, so it must also cover the single-shot path where only `message_citations` rows exist.) The plan enumerates the exact sites in `api/app/api/chats.py`. Each call is guarded in `try/except` that logs and never re-raises (a ledger failure must not break the turn). The assembly reads `project_id` from the chat already in finalize scope. Because it simply maps whatever rows exist for the message, no per-site branching on source kind is needed.
+
+### Component 4 — P3 tripwire (ADR 0018 D5)
+
+Add `CitationLedgerEntry` to `api/tests/test_transparency_invariants.py`'s no-raw-payload model scan. The entry carries only ids, labels, a numeric confidence, provider, and timestamps — no content — so the scan must pass with it included, proving the ledger is a metadata index, not a content store.
+
+## Error handling (conservative posture)
+
+- Assembly is guarded at every finalize site — a failure logs and degrades to "no ledger this turn," never aborting the assistant turn/stream.
+- A row with an unexpected shape is skipped, not fatal.
+- No new egress, no gateway/LLM call — pure DB reads + writes.
+
+## Testing
+
+- **Integration (real Postgres):** a turn with (a) a `message_citations` row, (b) a `message_caselaw_citations` row, and (c) a `message_tool_sources` row → `assemble_ledger_entries` writes **three** entries with the correct `source_kind`, the correct single FK set, and the mirrored `verification_status`/`confidence`/`provider`/`retrieved_at`. Assert the exactly-one-FK CHECK rejects a 0-FK and a 2-FK insert. Assert a KB-only turn (only `message_citations`) yields one `kb_document` entry.
+- **Transparency invariant:** `test_transparency_invariants.py` stays green with `CitationLedgerEntry` added to the scanned set.
+- **No provider gating** (pure DB). Run via host venv + throwaway pgvector.
+- Gates: `ruff format` + `ruff check` + `mypy app` + full `pytest` (coverage no-decrease).
+
+## Acceptance criteria
+
+1. `citation_ledger_entry` exists (migration `0058`) with the exactly-one-FK CHECK and the three nullable source FKs.
+2. At chat finalize, every persisted `message_citations` / `message_caselaw_citations` / `message_tool_sources` row for the turn yields exactly one correctly-typed ledger entry.
+3. `CitationLedgerEntry` is in the P3 tripwire scan and the test passes (proves metadata-only).
+4. A ledger failure never breaks the turn. `ruff` + `mypy` clean; integration + invariant tests green.
+
+## Out of scope / sequencing
+
+- **DE-350** (generic-MCP provenance) — **the immediate next slice after P1-A2** (maintainer directive). Once it emits `source_kind='mcp'` rows on `message_tool_sources`, those flow into the ledger with no ledger change.
+- Ledger **read API + one-click trace** → P1-A3. **Fiduciary-grade gate** → P1-B1. **UI** → P1-C1. **Treatment population** (`treatment_id`) → WS-G.
+- ADR 0018 D1 gets a one-line reconciliation note (`citable_source_id` → `message_caselaw_citation_id`); the decision itself is unchanged.


### PR DESCRIPTION
Phase 1 WS-A, second slice of the **fiduciary-grade** Citation Ledger milestone ([ADR 0018](../blob/main/docs/adr/0018-citation-ledger-and-fiduciary-grade-output.md) D1/D5/D6/D7). Builds on P1-A1 (#218). Spec + plan in `docs/superpowers/`.

## What it does

Adds `citation_ledger_entry` — a **thin referencing** table that unifies a chat turn's three previously-disconnected per-turn artifacts into one matter-and-turn-scoped record:
- `message_citations` (KB-document quote verification)
- `message_caselaw_citations` (caselaw quote verification — P1-A1)
- `message_tool_sources` (retrieval provenance — "sources consulted")

Each entry references **exactly one** underlying row via three nullable FKs (a CHECK enforces exactly-one-non-null) + a `source_kind` discriminator, and mirrors that source's verification status as a queryable label. A reserved `treatment_id` slot awaits the WS-G validity layer. A source-kind-agnostic assembler writes one entry per row at chat finalize.

## Changes

- `api/app/models/citation_ledger_entry.py` + migration **`0058`** — the table (3 nullable source FKs + exactly-one CHECK, confidence-range CHECK, 3 indexes, reserved `treatment_id` with no FK; no `tier` — `message_tool_sources` can't populate it).
- `api/app/citation/ledger.py` — `assemble_ledger_entries(db, *, message_id)`, self-deriving chat/project scope; one entry per citation/source row.
- `api/app/api/chats.py` — guarded assembler call at all three finalize branches (incl. the single-shot non-tool path, so KB-only chats get a ledger).
- `api/tests/test_transparency_invariants.py` — `CitationLedgerEntry` added to the P3 no-raw-payload scan.
- `docs/db-schema.md` + ADR 0018 D1 reconciliation note (`citable_source_id` → `message_caselaw_citation_id`).

## Security posture

- **Metadata-only:** the entry holds NO content (`source_text` lives on the referenced row); it references by id. Verified by its inclusion in the **P3 tripwire** (`test_audit_models_have_no_raw_payload_columns` green; denylist/allowlist unchanged).
- **No new egress** — pure DB reads + writes.
- **Conservative posture** — every finalize hook is guarded; a ledger-assembly failure logs and degrades to "no ledger this turn," never aborting the assistant turn/stream.

This touches the citation/audit-adjacent surface → **security review per CODEOWNERS**.

## Sequencing note

The assembler is **source-kind-agnostic** over `message_tool_sources`, so generic-MCP entries flow into the ledger automatically once **DE-350** lands — which is sequenced as the immediate next slice.

## Verification

Built via TDD with per-task spec+quality review and an Opus whole-branch review (**Ready to merge**, no Critical/Important). The final review independently probed the exactly-one CHECK (Postgres evaluates CHECK before FK lookups → the 2-FK rejection test genuinely exercises it). One mid-stream fix: aligned `retrieved_at` to `TIMESTAMPTZ` to match the migration and removed a tzinfo-stripping shim. Gates: `ruff` + `mypy` clean; full api suite **2266 passed, 1 pre-existing skip** (no `-m provider`).

Practicing-attorney attestation: **N/A** (pure code; no legal-substance skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)