### PR TITLE
feat(citation): deterministic fiduciary-grade gate (P1-B1)

### DIFF
--- a/api/alembic/versions/0059_work_product_fiduciary_gate.py
+++ b/api/alembic/versions/0059_work_product_fiduciary_gate.py
@@ -1,0 +1,96 @@
+"""work_product_fiduciary_gate — fiduciary-grade verdict (ADR 0018 D3)
+
+Revision ID: 0059
+Revises: 0058
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0059"
+down_revision: str | None = "0058"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "work_product_fiduciary_gate",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "message_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "messages.id",
+                ondelete="CASCADE",
+                name="fk_work_product_fiduciary_gate_message",
+            ),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column(
+            "chat_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "chats.id", ondelete="CASCADE", name="fk_work_product_fiduciary_gate_chat"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "projects.id",
+                ondelete="SET NULL",
+                name="fk_work_product_fiduciary_gate_project",
+            ),
+            nullable=True,
+        ),
+        sa.Column("gate_status", sa.Text(), nullable=False),
+        sa.Column("pass_count", sa.Integer(), nullable=False),
+        sa.Column("supported_count", sa.Integer(), nullable=False),
+        sa.Column("fail_count", sa.Integer(), nullable=False),
+        sa.Column("total_assertions", sa.Integer(), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "gate_status IN ('fiduciary_grade', 'supported_only', 'flagged')",
+            name="chk_work_product_fiduciary_gate_status_values",
+        ),
+        sa.CheckConstraint(
+            "confidence IS NULL OR (confidence >= 0 AND confidence <= 1)",
+            name="chk_work_product_fiduciary_gate_confidence_range",
+        ),
+        sa.CheckConstraint(
+            "pass_count >= 0 AND supported_count >= 0 AND fail_count >= 0 "
+            "AND total_assertions >= 0",
+            name="chk_work_product_fiduciary_gate_counts_nonneg",
+        ),
+    )
+    op.create_index(
+        "ix_work_product_fiduciary_gate_chat_id",
+        "work_product_fiduciary_gate",
+        ["chat_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_work_product_fiduciary_gate_chat_id", table_name="work_product_fiduciary_gate"
+    )
+    op.drop_table("work_product_fiduciary_gate")

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -85,6 +85,7 @@ from app.chat.tool_schemas import ChatToolAllowlist, assemble_allowlist
 from app.citation import extract_citations, verify
 from app.citation.caselaw import verify_and_persist_caselaw_citations
 from app.citation.cost import estimate_judge_call_cost_usd
+from app.citation.gate import compute_and_record_gate, resolve_gates
 from app.citation.ledger import assemble_ledger_entries, resolve_ledger_entries
 from app.clients.gateway import EnsembleConfig, GatewayClient, get_gateway_client
 from app.config import get_settings
@@ -1815,7 +1816,8 @@ async def get_chat_ledger(
             raise NotFound(f"Message {mid} not found.", details={"message_id": str(mid)})
 
     entries = await resolve_ledger_entries(db, chat_id=cid, message_id=mid)
-    return {"chat_id": str(cid), "entries": entries}
+    gates = await resolve_gates(db, chat_id=cid, message_id=mid)
+    return {"chat_id": str(cid), "entries": entries, "gates": gates}
 
 
 # ---------------------------------------------------------------------------
@@ -2927,6 +2929,10 @@ async def _non_streaming_response(
                 await assemble_ledger_entries(db, message_id=assistant_message_id)
             except Exception as ledger_exc:  # never block the turn
                 log.warning("citation ledger assembly failed: %r", ledger_exc)
+            try:
+                await compute_and_record_gate(db, message_id=assistant_message_id)
+            except Exception as gate_exc:  # never break the turn (conservative posture)
+                log.warning("fiduciary gate computation failed: %r", gate_exc)
             await _audit_message_sent(
                 db,
                 user=user,
@@ -3141,6 +3147,10 @@ async def _non_streaming_response(
         await assemble_ledger_entries(db, message_id=assistant_message_id)
     except Exception as ledger_exc:  # never block the turn
         log.warning("citation ledger assembly failed: %r", ledger_exc)
+    try:
+        await compute_and_record_gate(db, message_id=assistant_message_id)
+    except Exception as gate_exc:  # never break the turn (conservative posture)
+        log.warning("fiduciary gate computation failed: %r", gate_exc)
 
     await _audit_message_sent(
         db,
@@ -3504,6 +3514,10 @@ async def _stream_response(
                     await assemble_ledger_entries(db, message_id=assistant_message_id)
                 except Exception as ledger_exc:  # never block the turn
                     log.warning("citation ledger assembly failed: %r", ledger_exc)
+                try:
+                    await compute_and_record_gate(db, message_id=assistant_message_id)
+                except Exception as gate_exc:  # never break the turn (conservative posture)
+                    log.warning("fiduciary gate computation failed: %r", gate_exc)
             # D3 audit row — best-effort, must not break the stream.
             try:
                 await _audit_message_sent(

--- a/api/app/citation/gate.py
+++ b/api/app/citation/gate.py
@@ -1,0 +1,132 @@
+"""Fiduciary-grade gate computation (ADR 0018 D3).
+
+Deterministically buckets a turn's ``citation_ledger_entry`` rows into PASS /
+SUPPORTED / FAIL by their mirrored ``verification_status`` and records one
+``work_product_fiduciary_gate`` verdict per assistant message. Pure DB; no egress.
+Provenance-only entries (tool sources, no quote) are not assertions and are
+excluded from the counts.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+
+log = logging.getLogger(__name__)
+
+PASS_STATUSES: frozenset[str] = frozenset({"exact_match", "tolerant_match"})
+SUPPORTED_STATUSES: frozenset[str] = frozenset(
+    {"paraphrase_judge", "ensemble_strict", "ensemble_majority"}
+)
+FAIL_STATUSES: frozenset[str] = frozenset({"unverified", "failed"})
+_PROVENANCE = "provenance"
+
+
+async def compute_and_record_gate(
+    db: AsyncSession, *, message_id: uuid.UUID
+) -> WorkProductFiduciaryGate | None:
+    """Compute the fiduciary-grade verdict for ``message_id`` and upsert it.
+
+    Returns the recorded row, or ``None`` if the message has no chat (should not
+    happen at finalize). Flushes, never commits (rides the caller's transaction).
+    """
+    chat_id = (
+        await db.execute(select(Message.chat_id).where(Message.id == message_id))
+    ).scalar_one_or_none()
+    if chat_id is None:
+        return None
+    project_id = (
+        await db.execute(select(Chat.project_id).where(Chat.id == chat_id))
+    ).scalar_one_or_none()
+
+    entries = (
+        (
+            await db.execute(
+                select(CitationLedgerEntry).where(CitationLedgerEntry.message_id == message_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    pass_count = supported_count = fail_count = 0
+    confidences: list[float] = []
+    for e in entries:
+        status = e.verification_status
+        if status == _PROVENANCE:
+            continue
+        if status in PASS_STATUSES:
+            pass_count += 1
+        elif status in SUPPORTED_STATUSES:
+            supported_count += 1
+        elif status in FAIL_STATUSES:
+            fail_count += 1
+        else:
+            log.warning(
+                "fiduciary gate: unrecognized verification_status %r on entry %s; excluded",
+                status,
+                e.id,
+            )
+            continue
+        if e.confidence is not None:
+            confidences.append(e.confidence)
+
+    total = pass_count + supported_count + fail_count
+    if fail_count > 0:
+        gate_status = "flagged"
+    elif supported_count > 0:
+        gate_status = "supported_only"
+    else:
+        gate_status = "fiduciary_grade"
+    confidence = sum(confidences) / len(confidences) if confidences else None
+
+    # Upsert: a re-finalize replaces the current verdict (the ledger is the history).
+    await db.execute(
+        delete(WorkProductFiduciaryGate).where(WorkProductFiduciaryGate.message_id == message_id)
+    )
+    row = WorkProductFiduciaryGate(
+        message_id=message_id,
+        chat_id=chat_id,
+        project_id=project_id,
+        gate_status=gate_status,
+        pass_count=pass_count,
+        supported_count=supported_count,
+        fail_count=fail_count,
+        total_assertions=total,
+        confidence=confidence,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def resolve_gates(
+    db: AsyncSession, *, chat_id: uuid.UUID, message_id: uuid.UUID | None = None
+) -> list[dict[str, Any]]:
+    """Return the fiduciary-grade verdict(s) for a chat (optionally one turn)."""
+    stmt = select(WorkProductFiduciaryGate).where(WorkProductFiduciaryGate.chat_id == chat_id)
+    if message_id is not None:
+        stmt = stmt.where(WorkProductFiduciaryGate.message_id == message_id)
+    stmt = stmt.order_by(WorkProductFiduciaryGate.created_at, WorkProductFiduciaryGate.id)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "message_id": str(g.message_id),
+            "gate_status": g.gate_status,
+            "pass_count": g.pass_count,
+            "supported_count": g.supported_count,
+            "fail_count": g.fail_count,
+            "total_assertions": g.total_assertions,
+            "confidence": g.confidence,
+            "created_at": g.created_at.isoformat(),
+        }
+        for g in rows
+    ]

--- a/api/app/citation/ledger.py
+++ b/api/app/citation/ledger.py
@@ -53,10 +53,12 @@ async def assemble_ledger_entries(db: AsyncSession, *, message_id: uuid.UUID) ->
                 message_id=message_id,
                 source_kind="kb_document",
                 message_citation_id=c.id,
-                verification_status=c.verification_method or "verified",
-                confidence=float(c.verification_confidence)
-                if c.verification_confidence is not None
-                else None,
+                verification_status=c.verification_method if c.verified else "unverified",
+                confidence=(
+                    float(c.verification_confidence)
+                    if (c.verified and c.verification_confidence is not None)
+                    else None
+                ),
                 provider=None,
                 retrieved_at=None,
             )
@@ -81,8 +83,8 @@ async def assemble_ledger_entries(db: AsyncSession, *, message_id: uuid.UUID) ->
                 message_id=message_id,
                 source_kind="caselaw",
                 message_caselaw_citation_id=cc.id,
-                verification_status=cc.verification_method or "verified",
-                confidence=cc.verification_confidence,
+                verification_status=cc.verification_method if cc.verified else "unverified",
+                confidence=cc.verification_confidence if cc.verified else None,
                 provider="courtlistener",
                 retrieved_at=cc.created_at,
             )

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -47,6 +47,7 @@ from app.models.user import User, UserSession
 from app.models.user_export import UserExportJob
 from app.models.user_skill import UserSkill
 from app.models.work_product import WorkProductAttribution
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
 
 __all__ = [
     "AuditLog",
@@ -95,4 +96,5 @@ __all__ = [
     "UserSession",
     "UserSkill",
     "WorkProductAttribution",
+    "WorkProductFiduciaryGate",
 ]

--- a/api/app/models/work_product_fiduciary_gate.py
+++ b/api/app/models/work_product_fiduciary_gate.py
@@ -1,0 +1,73 @@
+"""work_product_fiduciary_gate — the per-turn fiduciary-grade verdict (ADR 0018 D3).
+
+One row per assistant turn (UNIQUE on message_id): the computed gate verdict
+(``fiduciary_grade`` | ``supported_only`` | ``flagged``) plus per-tier counts and
+an aggregate confidence, derived deterministically from the turn's
+``citation_ledger_entry`` rows. Metadata-only — a status label, integer counts,
+and a numeric confidence; it holds NO content, so it joins the P3 no-raw-payload
+tripwire. The history-preserving record is the ledger; this verdict is upserted
+(current-verdict) on re-finalize.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Float, ForeignKey, Index, Integer, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class WorkProductFiduciaryGate(Base):
+    __tablename__ = "work_product_fiduciary_gate"
+    __table_args__ = (
+        CheckConstraint(
+            "gate_status IN ('fiduciary_grade', 'supported_only', 'flagged')",
+            name="chk_work_product_fiduciary_gate_status_values",
+        ),
+        CheckConstraint(
+            "confidence IS NULL OR (confidence >= 0 AND confidence <= 1)",
+            name="chk_work_product_fiduciary_gate_confidence_range",
+        ),
+        CheckConstraint(
+            "pass_count >= 0 AND supported_count >= 0 AND fail_count >= 0 "
+            "AND total_assertions >= 0",
+            name="chk_work_product_fiduciary_gate_counts_nonneg",
+        ),
+        Index("ix_work_product_fiduciary_gate_chat_id", "chat_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    message_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "messages.id", ondelete="CASCADE", name="fk_work_product_fiduciary_gate_message"
+        ),
+        nullable=False,
+        unique=True,
+    )
+    chat_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chats.id", ondelete="CASCADE", name="fk_work_product_fiduciary_gate_chat"),
+        nullable=False,
+    )
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "projects.id", ondelete="SET NULL", name="fk_work_product_fiduciary_gate_project"
+        ),
+        nullable=True,
+    )
+    gate_status: Mapped[str] = mapped_column(Text, nullable=False)
+    pass_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    supported_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    fail_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    total_assertions: Mapped[int] = mapped_column(Integer, nullable=False)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, server_default=func.now())

--- a/api/tests/integration/test_fiduciary_gate.py
+++ b/api/tests/integration/test_fiduciary_gate.py
@@ -1,0 +1,340 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.citation.gate import compute_and_record_gate, resolve_gates
+from app.citation.ledger import assemble_ledger_entries
+from app.models.chat import Chat, Message, MessageCitation
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.file import File as FileModel
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.message_tool_source import MessageToolSource
+from app.models.user import User
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def seeded(db_session):
+    user = User(email=f"g-{uuid.uuid4().hex[:8]}@example.com", hashed_password="x", role="member")
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="gate")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="a")
+    db_session.add(msg)
+    await db_session.flush()
+    return user, chat, msg
+
+
+async def _seed_entry(db_session, chat, msg, status, conf, *, opinion_id):
+    """Create an FK-valid caselaw-citation-backed ledger entry whose
+    verification_status is overridden to ``status`` (the entry's status is what
+    the gate reads — it need not equal the citation's real method)."""
+    cc = MessageCaselawCitation(
+        message_id=msg.id,
+        opinion_id=opinion_id,
+        cluster_id=opinion_id,
+        source_offset_start=0,
+        source_offset_end=3,
+        source_text="abc",
+        verified=True,
+        verification_method="exact_match",
+        verification_confidence=1.0,
+    )
+    db_session.add(cc)
+    await db_session.flush()
+    db_session.add(
+        CitationLedgerEntry(
+            chat_id=chat.id,
+            message_id=msg.id,
+            source_kind="caselaw",
+            message_caselaw_citation_id=cc.id,
+            verification_status=status,
+            confidence=conf,
+        )
+    )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_all_pass_is_fiduciary_grade(db_session, seeded):
+    _user, chat, msg = seeded
+    # Seed ledger entries directly via real caselaw-citation rows so FKs resolve.
+    for status, conf in [("exact_match", 1.0), ("tolerant_match", 0.95)]:
+        cc = MessageCaselawCitation(
+            message_id=msg.id,
+            opinion_id=1,
+            cluster_id=1,
+            source_offset_start=0,
+            source_offset_end=3,
+            source_text="abc",
+            verified=True,
+            verification_method=status,
+            verification_confidence=conf,
+        )
+        db_session.add(cc)
+        await db_session.flush()
+        db_session.add(
+            CitationLedgerEntry(
+                chat_id=chat.id,
+                message_id=msg.id,
+                source_kind="caselaw",
+                message_caselaw_citation_id=cc.id,
+                verification_status=status,
+                confidence=conf,
+            )
+        )
+    await db_session.flush()
+
+    gate = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate is not None
+    assert gate.gate_status == "fiduciary_grade"
+    assert gate.pass_count == 2
+    assert gate.supported_count == 0
+    assert gate.fail_count == 0
+    assert gate.total_assertions == 2
+    assert abs(gate.confidence - 0.975) < 1e-6
+
+
+@pytest.mark.asyncio
+async def test_supported_only_when_paraphrase_no_fail(db_session, seeded):
+    _user, chat, msg = seeded
+    # one PASS (tolerant_match) + one SUPPORTED (paraphrase_judge), no FAIL
+    await _seed_entry(db_session, chat, msg, "tolerant_match", 0.95, opinion_id=101)
+    await _seed_entry(db_session, chat, msg, "paraphrase_judge", 0.8, opinion_id=102)
+
+    gate = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate is not None
+    assert gate.gate_status == "supported_only"
+    assert gate.pass_count == 1
+    assert gate.supported_count == 1
+    assert gate.fail_count == 0
+    assert gate.total_assertions == 2
+
+
+@pytest.mark.asyncio
+async def test_any_fail_is_flagged(db_session, seeded):
+    _user, chat, msg = seeded
+    # one PASS (exact_match, conf=1.0) + one FAIL (unverified, conf=None)
+    await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=201)
+    await _seed_entry(db_session, chat, msg, "unverified", None, opinion_id=202)
+
+    gate = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate is not None
+    assert gate.gate_status == "flagged"
+    assert gate.pass_count == 1
+    assert gate.supported_count == 0
+    assert gate.fail_count == 1
+    assert gate.total_assertions == 2
+    # confidence = mean of non-null only: 1.0
+    assert gate.confidence == 1.0
+
+
+@pytest.mark.asyncio
+async def test_provenance_excluded(db_session, seeded):
+    _user, chat, msg = seeded
+    # one PASS entry + one provenance entry (via a real MessageToolSource)
+    await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=301)
+
+    ts = MessageToolSource(
+        message_id=msg.id,
+        source_kind="caselaw",
+        label="Cluster 301",
+        subtitle=None,
+        url=None,
+        external_ref="301",
+        provider="courtlistener",
+        tool="get_cluster",
+    )
+    db_session.add(ts)
+    await db_session.flush()
+    db_session.add(
+        CitationLedgerEntry(
+            chat_id=chat.id,
+            message_id=msg.id,
+            source_kind="caselaw",
+            message_tool_source_id=ts.id,
+            verification_status="provenance",
+            confidence=None,
+        )
+    )
+    await db_session.flush()
+
+    gate = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate is not None
+    assert gate.total_assertions == 1
+    assert gate.pass_count == 1
+    assert gate.gate_status == "fiduciary_grade"
+
+
+@pytest.mark.asyncio
+async def test_zero_assertions_is_fiduciary_grade(db_session, seeded):
+    _user, chat, msg = seeded
+    # only a provenance entry — no assertion entries
+    ts = MessageToolSource(
+        message_id=msg.id,
+        source_kind="caselaw",
+        label="Cluster 401",
+        subtitle=None,
+        url=None,
+        external_ref="401",
+        provider="courtlistener",
+        tool="get_cluster",
+    )
+    db_session.add(ts)
+    await db_session.flush()
+    db_session.add(
+        CitationLedgerEntry(
+            chat_id=chat.id,
+            message_id=msg.id,
+            source_kind="caselaw",
+            message_tool_source_id=ts.id,
+            verification_status="provenance",
+            confidence=None,
+        )
+    )
+    await db_session.flush()
+
+    gate = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate is not None
+    assert gate.gate_status == "fiduciary_grade"
+    assert gate.total_assertions == 0
+    assert gate.confidence is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_status_excluded(db_session, seeded):
+    _user, chat, msg = seeded
+    # one valid PASS + one entry with unknown status "weird"
+    await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=501)
+    await _seed_entry(db_session, chat, msg, "weird", 0.5, opinion_id=502)
+
+    gate = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate is not None
+    # unknown is excluded; only the valid PASS counts
+    assert gate.total_assertions == 1
+    assert gate.pass_count == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_replaces(db_session, seeded):
+    _user, chat, msg = seeded
+    # First call: one exact_match (PASS) → fiduciary_grade
+    await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=601)
+    gate1 = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate1 is not None
+    assert gate1.gate_status == "fiduciary_grade"
+
+    # Add a FAIL entry and call again — second verdict should win
+    await _seed_entry(db_session, chat, msg, "unverified", None, opinion_id=602)
+    gate2 = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate2 is not None
+    assert gate2.gate_status == "flagged"
+
+    # Exactly one row remains for this message
+    count = len(
+        (
+            await db_session.execute(
+                select(WorkProductFiduciaryGate).where(
+                    WorkProductFiduciaryGate.message_id == msg.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_gates_shapes(db_session, seeded):
+    _user, chat, msg = seeded
+    await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=701)
+    await compute_and_record_gate(db_session, message_id=msg.id)
+
+    # all turns in the chat
+    results = await resolve_gates(db_session, chat_id=chat.id)
+    assert len(results) == 1
+    r = results[0]
+    for key in (
+        "message_id",
+        "gate_status",
+        "pass_count",
+        "supported_count",
+        "fail_count",
+        "total_assertions",
+        "confidence",
+        "created_at",
+    ):
+        assert key in r, f"missing key: {key}"
+    assert r["message_id"] == str(msg.id)
+
+    # filtered by message_id
+    filtered = await resolve_gates(db_session, chat_id=chat.id, message_id=msg.id)
+    assert len(filtered) == 1
+
+    # wrong message_id → empty
+    empty = await resolve_gates(db_session, chat_id=chat.id, message_id=uuid.uuid4())
+    assert empty == []
+
+
+@pytest.mark.asyncio
+async def test_assembler_marks_unverified_kb_citation(db_session, seeded):
+    """Regression: an unverified KB citation must land as 'unverified', not 'verified'."""
+    user, _chat, msg = seeded
+
+    # Need a real File row for source_file_id FK
+    f = FileModel(
+        owner_id=user.id,
+        filename="doc.pdf",
+        mime_type="application/pdf",
+        size_bytes=10,
+        hash_sha256="a" * 64,
+        storage_path=f"k/{uuid.uuid4().hex}",
+    )
+    db_session.add(f)
+    await db_session.flush()
+
+    # An unverified KB citation (verified=False, verification_method=None)
+    doc_cite = MessageCitation(
+        message_id=msg.id,
+        source_file_id=f.id,
+        source_offset_start=0,
+        source_offset_end=5,
+        source_page=1,
+        source_text="hello",
+        verified=False,
+        verification_method=None,
+        verification_confidence=None,
+    )
+    db_session.add(doc_cite)
+    await db_session.flush()
+
+    await assemble_ledger_entries(db_session, message_id=msg.id)
+    await db_session.flush()
+
+    entries = (
+        (
+            await db_session.execute(
+                select(CitationLedgerEntry).where(CitationLedgerEntry.message_id == msg.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(entries) == 1
+    e = entries[0]
+    # The mislabel fix: must be "unverified", not "verified"
+    assert e.verification_status == "unverified"
+    assert e.confidence is None
+
+    # And compute_and_record_gate should detect the FAIL
+    gate = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate is not None
+    assert gate.fail_count == 1
+    assert gate.gate_status == "flagged"

--- a/api/tests/integration/test_ledger_endpoint.py
+++ b/api/tests/integration/test_ledger_endpoint.py
@@ -8,6 +8,7 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+from app.citation.gate import compute_and_record_gate
 from app.citation.ledger import assemble_ledger_entries
 from app.db.session import get_db
 from app.main import app
@@ -130,3 +131,20 @@ async def test_ledger_non_uuid_400(client, seeded):
     user, _, _ = seeded
     r = await client.get("/api/v1/chats/not-a-uuid/ledger", headers=_auth(user))
     assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_ledger_includes_gate(client, db_session, seeded):
+    user, chat, msg = seeded
+    await compute_and_record_gate(db_session, message_id=msg.id)
+    await db_session.flush()
+    r = await client.get(f"/api/v1/chats/{chat.id}/ledger", headers=_auth(user))
+    assert r.status_code == 200
+    body = r.json()
+    assert "gates" in body
+    assert len(body["gates"]) == 1
+    g = body["gates"][0]
+    assert g["message_id"] == str(msg.id)
+    # the seeded turn has one exact_match KB citation -> fiduciary_grade
+    assert g["gate_status"] == "fiduciary_grade"
+    assert g["pass_count"] == 1

--- a/api/tests/integration/test_work_product_fiduciary_gate.py
+++ b/api/tests/integration/test_work_product_fiduciary_gate.py
@@ -1,0 +1,97 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.models.chat import Chat, Message
+from app.models.user import User
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def seeded_message(db_session):
+    user = User(
+        email=f"gate-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        role="member",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="gate test")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="answer")
+    db_session.add(msg)
+    await db_session.flush()
+    return chat.id, msg.id
+
+
+@pytest.mark.asyncio
+async def test_gate_row_roundtrips(db_session, seeded_message):
+    chat_id, mid = seeded_message
+    db_session.add(
+        WorkProductFiduciaryGate(
+            message_id=mid,
+            chat_id=chat_id,
+            gate_status="fiduciary_grade",
+            pass_count=2,
+            supported_count=0,
+            fail_count=0,
+            total_assertions=2,
+            confidence=0.97,
+        )
+    )
+    await db_session.flush()
+    got = (
+        await db_session.execute(
+            select(WorkProductFiduciaryGate).where(WorkProductFiduciaryGate.message_id == mid)
+        )
+    ).scalar_one()
+    assert got.gate_status == "fiduciary_grade"
+    assert got.total_assertions == 2
+    assert got.confidence == 0.97
+
+
+@pytest.mark.asyncio
+async def test_message_id_unique(db_session, seeded_message):
+    chat_id, mid = seeded_message
+    for _ in range(2):
+        db_session.add(
+            WorkProductFiduciaryGate(
+                message_id=mid,
+                chat_id=chat_id,
+                gate_status="flagged",
+                pass_count=0,
+                supported_count=0,
+                fail_count=1,
+                total_assertions=1,
+                confidence=None,
+            )
+        )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_confidence_range_check(db_session, seeded_message):
+    chat_id, mid = seeded_message
+    db_session.add(
+        WorkProductFiduciaryGate(
+            message_id=mid,
+            chat_id=chat_id,
+            gate_status="fiduciary_grade",
+            pass_count=1,
+            supported_count=0,
+            fail_count=0,
+            total_assertions=1,
+            confidence=1.5,  # out of [0,1]
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()

--- a/api/tests/test_transparency_invariants.py
+++ b/api/tests/test_transparency_invariants.py
@@ -34,6 +34,7 @@ from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.inference import InferenceRoutingLog
 from app.models.tool_call_log import ToolCallLog
 from app.models.tool_egress import ToolEgressLog
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
 from app.tools.governance import _MAX_TIER
 
 # Root of the importable ``app`` package (``api/app``).
@@ -52,6 +53,7 @@ _AUDIT_MODELS: tuple[type, ...] = (
     ToolEgressLog,
     InferenceRoutingLog,
     CitationLedgerEntry,
+    WorkProductFiduciaryGate,
 )
 
 # Column names that, by name alone, signal raw-content storage. Matched

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -1098,6 +1098,20 @@ paths:
                   entries:
                     type: array
                     items: {$ref: '#/components/schemas/LedgerEntry'}
+                  gates:
+                    type: array
+                    description: Per-turn fiduciary-grade verdicts (ADR 0018 D3).
+                    items:
+                      type: object
+                      properties:
+                        message_id: {type: string, format: uuid}
+                        gate_status: {type: string, enum: [fiduciary_grade, supported_only, flagged]}
+                        pass_count: {type: integer}
+                        supported_count: {type: integer}
+                        fail_count: {type: integer}
+                        total_assertions: {type: integer}
+                        confidence: {type: number, nullable: true}
+                        created_at: {type: string, format: date-time}
         '404':
           description: Chat (or filtered message) does not exist
           content:

--- a/docs/superpowers/plans/2026-06-25-p1b1-fiduciary-grade-gate.md
+++ b/docs/superpowers/plans/2026-06-25-p1b1-fiduciary-grade-gate.md
@@ -1,0 +1,861 @@
+# P1-B1 — Deterministic fiduciary-grade gate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compute a per-turn fiduciary-grade verdict (ADR 0018 D3) deterministically over the turn's citation-ledger entries — PASS `{exact_match, tolerant_match}` / SUPPORTED `{paraphrase_judge, ensemble_*}` / FAIL `{unverified, failed}` — record it on a new 1:1 `work_product_fiduciary_gate` table, hook it at finalize, and surface it in the A3 `/ledger` endpoint.
+
+**Architecture:** A new metadata-only table + model; a pure-DB gate module (`app/citation/gate.py`) that buckets ledger entries by `verification_status` and upserts a verdict; a one-line assembler mislabel fix so unverified KB citations are honest; the gate hooked at the three finalize sites alongside `assemble_ledger_entries`; and a `gates` key added to the merged A3 `/ledger` response. No egress; deterministic.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 async, Alembic (migration 0059), pytest (`integration` marker) against a throwaway pgvector.
+
+## Global Constraints
+
+- **No new egress** — pure DB reads + writes; no gateway/LLM call. The DE-280 paraphrase judge is P1-B1b, out of scope here.
+- **Gate row is metadata-only** — status label + integer counts + a numeric confidence + ids + timestamp; **no content**. It joins the `test_transparency_invariants.py` P3 tripwire (`_AUDIT_MODELS`).
+- **Status sets (exact strings):** PASS = `{"exact_match", "tolerant_match"}`; SUPPORTED = `{"paraphrase_judge", "ensemble_strict", "ensemble_majority"}`; FAIL = `{"unverified", "failed"}`. `"provenance"` entries (tool sources, no quote) are **not** assertions — excluded from all counts.
+- **`gate_status` derivation:** `flagged` if `fail_count > 0`; else `supported_only` if `supported_count > 0`; else `fiduciary_grade` (zero-assertion turn → `fiduciary_grade`, `total_assertions=0`, vacuously true).
+- **`confidence`** = mean of counted entries' non-null `confidence` values; `None` if none.
+- **1:1 per assistant message** — `work_product_fiduciary_gate.message_id` is `UNIQUE`; re-finalize **upserts** (delete-then-insert) the verdict (current-verdict, not history; the ledger entries are the history-preserving record per ADR D7).
+- **Conservative posture** — the gate hook is guarded at every finalize site (`try/except … log`, never re-raise); an unrecognized `verification_status` is excluded from buckets and logged, never silently counted as PASS.
+- **Assembler mislabel fix** — `assemble_ledger_entries` currently writes `verification_status = c.verification_method or "verified"` for KB `message_citations`; an unverified row (`verified=False`, `verification_method=None`) is thus mislabeled `"verified"`. Fix to `c.verification_method if c.verified else "unverified"` (confidence `None` when unverified). Same defensive correction on the caselaw branch.
+- **Migration discipline:** new revision `0059`, `down_revision="0058"`. NEVER run host `alembic upgrade` against the dev DB; the conftest auto-migrates the throwaway pgvector to `head`. Register the new model in `app/models/__init__.py` (else alembic/metadata won't see it).
+- **P5 (atomic audit):** the gate helper **flushes, never commits** — it rides the caller's transaction.
+- **Tests:** host venv + throwaway pgvector (`DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test`). Run `ruff format` + `ruff check` + `mypy app` + `pytest` (coverage no-decrease). No `-m provider`.
+- **Security review (CODEOWNERS):** citation/audit surface — do not self-merge.
+- **Commits:** `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `work_product_fiduciary_gate` table + model + migration 0059 + P3 tripwire
+
+**Files:**
+- Create: `api/app/models/work_product_fiduciary_gate.py`
+- Modify: `api/app/models/__init__.py` (register the model)
+- Create: `api/alembic/versions/0059_work_product_fiduciary_gate.py`
+- Modify: `api/tests/test_transparency_invariants.py` (add to `_AUDIT_MODELS`)
+- Test: `api/tests/integration/test_work_product_fiduciary_gate.py` (new)
+
+**Interfaces:**
+- Produces: `WorkProductFiduciaryGate` ORM model — columns `id, message_id (unique), chat_id, project_id, gate_status, pass_count, supported_count, fail_count, total_assertions, confidence, created_at`. Used by Task 2's gate module.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/tests/integration/test_work_product_fiduciary_gate.py`:
+
+```python
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.models.chat import Chat, Message
+from app.models.user import User
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def seeded_message(db_session):
+    user = User(
+        email=f"gate-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        role="member",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="gate test")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="answer")
+    db_session.add(msg)
+    await db_session.flush()
+    return chat.id, msg.id
+
+
+@pytest.mark.asyncio
+async def test_gate_row_roundtrips(db_session, seeded_message):
+    chat_id, mid = seeded_message
+    db_session.add(
+        WorkProductFiduciaryGate(
+            message_id=mid,
+            chat_id=chat_id,
+            gate_status="fiduciary_grade",
+            pass_count=2,
+            supported_count=0,
+            fail_count=0,
+            total_assertions=2,
+            confidence=0.97,
+        )
+    )
+    await db_session.flush()
+    got = (
+        await db_session.execute(
+            select(WorkProductFiduciaryGate).where(WorkProductFiduciaryGate.message_id == mid)
+        )
+    ).scalar_one()
+    assert got.gate_status == "fiduciary_grade"
+    assert got.total_assertions == 2
+    assert got.confidence == 0.97
+
+
+@pytest.mark.asyncio
+async def test_message_id_unique(db_session, seeded_message):
+    chat_id, mid = seeded_message
+    for _ in range(2):
+        db_session.add(
+            WorkProductFiduciaryGate(
+                message_id=mid,
+                chat_id=chat_id,
+                gate_status="flagged",
+                pass_count=0,
+                supported_count=0,
+                fail_count=1,
+                total_assertions=1,
+                confidence=None,
+            )
+        )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_confidence_range_check(db_session, seeded_message):
+    chat_id, mid = seeded_message
+    db_session.add(
+        WorkProductFiduciaryGate(
+            message_id=mid,
+            chat_id=chat_id,
+            gate_status="fiduciary_grade",
+            pass_count=1,
+            supported_count=0,
+            fail_count=0,
+            total_assertions=1,
+            confidence=1.5,  # out of [0,1]
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_work_product_fiduciary_gate.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.models.work_product_fiduciary_gate` (and the conftest migration won't have the table until the migration exists).
+
+- [ ] **Step 3: Create the model**
+
+Create `api/app/models/work_product_fiduciary_gate.py`:
+
+```python
+"""work_product_fiduciary_gate — the per-turn fiduciary-grade verdict (ADR 0018 D3).
+
+One row per assistant turn (UNIQUE on message_id): the computed gate verdict
+(``fiduciary_grade`` | ``supported_only`` | ``flagged``) plus per-tier counts and
+an aggregate confidence, derived deterministically from the turn's
+``citation_ledger_entry`` rows. Metadata-only — a status label, integer counts,
+and a numeric confidence; it holds NO content, so it joins the P3 no-raw-payload
+tripwire. The history-preserving record is the ledger; this verdict is upserted
+(current-verdict) on re-finalize.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Float, ForeignKey, Index, Integer, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class WorkProductFiduciaryGate(Base):
+    __tablename__ = "work_product_fiduciary_gate"
+    __table_args__ = (
+        CheckConstraint(
+            "gate_status IN ('fiduciary_grade', 'supported_only', 'flagged')",
+            name="chk_work_product_fiduciary_gate_status_values",
+        ),
+        CheckConstraint(
+            "confidence IS NULL OR (confidence >= 0 AND confidence <= 1)",
+            name="chk_work_product_fiduciary_gate_confidence_range",
+        ),
+        CheckConstraint(
+            "pass_count >= 0 AND supported_count >= 0 AND fail_count >= 0 "
+            "AND total_assertions >= 0",
+            name="chk_work_product_fiduciary_gate_counts_nonneg",
+        ),
+        Index("ix_work_product_fiduciary_gate_chat_id", "chat_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    message_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "messages.id", ondelete="CASCADE", name="fk_work_product_fiduciary_gate_message"
+        ),
+        nullable=False,
+        unique=True,
+    )
+    chat_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chats.id", ondelete="CASCADE", name="fk_work_product_fiduciary_gate_chat"),
+        nullable=False,
+    )
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "projects.id", ondelete="SET NULL", name="fk_work_product_fiduciary_gate_project"
+        ),
+        nullable=True,
+    )
+    gate_status: Mapped[str] = mapped_column(Text, nullable=False)
+    pass_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    supported_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    fail_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    total_assertions: Mapped[int] = mapped_column(Integer, nullable=False)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, server_default=func.now())
+```
+
+Add to `api/app/models/__init__.py` (next to the `work_product` import, line ~49):
+
+```python
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+```
+
+If `__init__.py` has an `__all__`, add `"WorkProductFiduciaryGate"` to it.
+
+- [ ] **Step 4: Create the migration**
+
+Create `api/alembic/versions/0059_work_product_fiduciary_gate.py` (mirror `0058`'s style):
+
+```python
+"""work_product_fiduciary_gate — fiduciary-grade verdict (ADR 0018 D3)
+
+Revision ID: 0059
+Revises: 0058
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0059"
+down_revision: str | None = "0058"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "work_product_fiduciary_gate",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "message_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "messages.id",
+                ondelete="CASCADE",
+                name="fk_work_product_fiduciary_gate_message",
+            ),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column(
+            "chat_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "chats.id", ondelete="CASCADE", name="fk_work_product_fiduciary_gate_chat"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "projects.id",
+                ondelete="SET NULL",
+                name="fk_work_product_fiduciary_gate_project",
+            ),
+            nullable=True,
+        ),
+        sa.Column("gate_status", sa.Text(), nullable=False),
+        sa.Column("pass_count", sa.Integer(), nullable=False),
+        sa.Column("supported_count", sa.Integer(), nullable=False),
+        sa.Column("fail_count", sa.Integer(), nullable=False),
+        sa.Column("total_assertions", sa.Integer(), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "gate_status IN ('fiduciary_grade', 'supported_only', 'flagged')",
+            name="chk_work_product_fiduciary_gate_status_values",
+        ),
+        sa.CheckConstraint(
+            "confidence IS NULL OR (confidence >= 0 AND confidence <= 1)",
+            name="chk_work_product_fiduciary_gate_confidence_range",
+        ),
+        sa.CheckConstraint(
+            "pass_count >= 0 AND supported_count >= 0 AND fail_count >= 0 "
+            "AND total_assertions >= 0",
+            name="chk_work_product_fiduciary_gate_counts_nonneg",
+        ),
+    )
+    op.create_index(
+        "ix_work_product_fiduciary_gate_chat_id",
+        "work_product_fiduciary_gate",
+        ["chat_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_work_product_fiduciary_gate_chat_id", table_name="work_product_fiduciary_gate"
+    )
+    op.drop_table("work_product_fiduciary_gate")
+```
+
+- [ ] **Step 5: Add to the P3 tripwire**
+
+In `api/tests/test_transparency_invariants.py`, add the import and the model to `_AUDIT_MODELS`:
+
+```python
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+```
+
+```python
+_AUDIT_MODELS: tuple[type, ...] = (
+    ToolCallLog,
+    AuditLog,
+    ToolEgressLog,
+    InferenceRoutingLog,
+    CitationLedgerEntry,
+    WorkProductFiduciaryGate,
+)
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_work_product_fiduciary_gate.py tests/test_transparency_invariants.py -v`
+Expected: all PASS (roundtrip, unique, confidence-range; tripwire green with the new model — its column names `gate_status`/`*_count`/`total_assertions`/`confidence` do not trip `_implies_raw_content`).
+
+- [ ] **Step 7: Lint + type-check, then commit**
+
+```bash
+cd api && .venv/bin/ruff format app/models/work_product_fiduciary_gate.py alembic/versions/0059_work_product_fiduciary_gate.py tests/integration/test_work_product_fiduciary_gate.py && .venv/bin/ruff check app/models tests/integration/test_work_product_fiduciary_gate.py && .venv/bin/mypy app/models/work_product_fiduciary_gate.py
+```
+
+```bash
+git add api/app/models/work_product_fiduciary_gate.py api/app/models/__init__.py api/alembic/versions/0059_work_product_fiduciary_gate.py api/tests/test_transparency_invariants.py api/tests/integration/test_work_product_fiduciary_gate.py
+git commit -s -m "feat(citation): work_product_fiduciary_gate table (P1-B1)
+
+The per-turn fiduciary-grade verdict (ADR 0018 D3): 1:1-per-message,
+metadata-only (status label + per-tier counts + aggregate confidence),
+migration 0059. Joins the P3 no-raw-payload tripwire.
+
+Refs ADR 0018 D3/D5.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Gate computation `compute_and_record_gate` + assembler mislabel fix
+
+**Files:**
+- Create: `api/app/citation/gate.py`
+- Modify: `api/app/citation/ledger.py` (assembler mislabel fix in `assemble_ledger_entries`)
+- Test: `api/tests/integration/test_fiduciary_gate.py` (new)
+
+**Interfaces:**
+- Consumes: `WorkProductFiduciaryGate` (Task 1); `CitationLedgerEntry`, `Chat`, `Message` models.
+- Produces: `async def compute_and_record_gate(db: AsyncSession, *, message_id: uuid.UUID) -> WorkProductFiduciaryGate | None` and module constants `PASS_STATUSES`, `SUPPORTED_STATUSES`, `FAIL_STATUSES` — used by Task 3's hook. Also `async def resolve_gates(db: AsyncSession, *, chat_id: uuid.UUID, message_id: uuid.UUID | None = None) -> list[dict[str, Any]]` for Task 3's endpoint wiring.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `api/tests/integration/test_fiduciary_gate.py`:
+
+```python
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.citation.gate import compute_and_record_gate, resolve_gates
+from app.citation.ledger import assemble_ledger_entries
+from app.models.chat import Chat, Message, MessageCitation
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.file import File as FileModel
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def seeded(db_session):
+    user = User(
+        email=f"g-{uuid.uuid4().hex[:8]}@example.com", hashed_password="x", role="member"
+    )
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="gate")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="a")
+    db_session.add(msg)
+    await db_session.flush()
+    return user, chat, msg
+
+
+async def _seed_entry(db_session, chat, msg, status, conf, *, opinion_id):
+    """Create an FK-valid caselaw-citation-backed ledger entry whose
+    verification_status is overridden to ``status`` (the entry's status is what
+    the gate reads — it need not equal the citation's real method)."""
+    cc = MessageCaselawCitation(
+        message_id=msg.id,
+        opinion_id=opinion_id,
+        cluster_id=opinion_id,
+        source_offset_start=0,
+        source_offset_end=3,
+        source_text="abc",
+        verified=True,
+        verification_method="exact_match",
+        verification_confidence=1.0,
+    )
+    db_session.add(cc)
+    await db_session.flush()
+    db_session.add(
+        CitationLedgerEntry(
+            chat_id=chat.id,
+            message_id=msg.id,
+            source_kind="caselaw",
+            message_caselaw_citation_id=cc.id,
+            verification_status=status,
+            confidence=conf,
+        )
+    )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_all_pass_is_fiduciary_grade(db_session, seeded):
+    user, chat, msg = seeded
+    # Seed ledger entries directly via real caselaw-citation rows so FKs resolve.
+    for status, conf in [("exact_match", 1.0), ("tolerant_match", 0.95)]:
+        cc = MessageCaselawCitation(
+            message_id=msg.id,
+            opinion_id=1,
+            cluster_id=1,
+            source_offset_start=0,
+            source_offset_end=3,
+            source_text="abc",
+            verified=True,
+            verification_method=status,
+            verification_confidence=conf,
+        )
+        db_session.add(cc)
+        await db_session.flush()
+        db_session.add(
+            CitationLedgerEntry(
+                chat_id=chat.id,
+                message_id=msg.id,
+                source_kind="caselaw",
+                message_caselaw_citation_id=cc.id,
+                verification_status=status,
+                confidence=conf,
+            )
+        )
+    await db_session.flush()
+
+    gate = await compute_and_record_gate(db_session, message_id=msg.id)
+    assert gate is not None
+    assert gate.gate_status == "fiduciary_grade"
+    assert gate.pass_count == 2
+    assert gate.supported_count == 0
+    assert gate.fail_count == 0
+    assert gate.total_assertions == 2
+    assert abs(gate.confidence - 0.975) < 1e-6
+```
+
+> **Implementer note:** the `CitationLedgerEntry` exactly-one-FK CHECK means every fabricated entry needs a real backing row, so use the `_seed_entry` helper above (a `MessageCaselawCitation` + a ledger entry referencing it with an overridden `verification_status`) for every status case — vary `opinion_id` per call to keep rows distinct. `test_all_pass_is_fiduciary_grade` above shows the inline pattern; the remaining tests can call `_seed_entry` directly. For the `provenance` case create a real `MessageToolSource` + an entry referencing it via `message_tool_source_id` (see `tests/integration/test_citation_ledger.py` for that shape).
+
+The full test set the implementer must produce (using `_seed_entry` / the provenance shape):
+- `test_all_pass_is_fiduciary_grade` — two PASS entries → `fiduciary_grade`, counts (2,0,0,2), confidence ≈ 0.975.
+- `test_supported_only_when_paraphrase_no_fail` — one `tolerant_match` + one `paraphrase_judge`, no FAIL → `supported_only`, counts (1,1,0,2).
+- `test_any_fail_is_flagged` — one `exact_match` + one `unverified` → `flagged`, counts (1,0,1,2), confidence = mean of non-null (the `unverified` entry has confidence `None`, so confidence = 1.0).
+- `test_provenance_excluded` — one `exact_match` (PASS) + one `provenance` entry (via a real `MessageToolSource`) → `total_assertions == 1`, `pass_count == 1`, provenance not counted.
+- `test_zero_assertions_is_fiduciary_grade` — only a `provenance` entry (or none) → `fiduciary_grade`, `total_assertions == 0`, confidence `None`.
+- `test_unknown_status_excluded` — an entry with `verification_status="weird"` + one `exact_match` → counted total is 1, the unknown is excluded (assert `total_assertions == 1`).
+- `test_upsert_replaces` — call `compute_and_record_gate` twice; assert exactly one row for the message and the second call's verdict wins (change the entries between calls).
+- `test_resolve_gates_shapes` — after recording, `resolve_gates(db, chat_id=chat.id)` returns a list with one dict carrying `message_id, gate_status, pass_count, supported_count, fail_count, total_assertions, confidence, created_at`; `message_id` filter narrows.
+- `test_assembler_marks_unverified_kb_citation` — seed a `message_citations` row with `verified=False, verification_method=None` (needs a real `File` row: kwargs `owner_id, filename, mime_type, size_bytes, hash_sha256, storage_path`), run `assemble_ledger_entries`, assert the resulting ledger entry has `verification_status == "unverified"` and `confidence is None` (regression-locks the mislabel fix), then `compute_and_record_gate` → `fail_count == 1`, `gate_status == "flagged"`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_fiduciary_gate.py -v`
+Expected: FAIL — `ImportError: cannot import name 'compute_and_record_gate'` / `resolve_gates`.
+
+- [ ] **Step 3: Implement the assembler mislabel fix**
+
+In `api/app/citation/ledger.py`, in `assemble_ledger_entries`, replace the KB `message_citations` branch's status/confidence:
+
+```python
+    for c in doc_citations:
+        entries.append(
+            CitationLedgerEntry(
+                project_id=project_id,
+                chat_id=chat_id,
+                message_id=message_id,
+                source_kind="kb_document",
+                message_citation_id=c.id,
+                verification_status=c.verification_method if c.verified else "unverified",
+                confidence=(
+                    float(c.verification_confidence)
+                    if (c.verified and c.verification_confidence is not None)
+                    else None
+                ),
+                provider=None,
+                retrieved_at=None,
+            )
+        )
+```
+
+And the caselaw branch (defensive symmetry — today only verified rows reach it):
+
+```python
+            verification_status=cc.verification_method if cc.verified else "unverified",
+            confidence=cc.verification_confidence if cc.verified else None,
+```
+
+- [ ] **Step 4: Implement the gate module**
+
+Create `api/app/citation/gate.py`:
+
+```python
+"""Fiduciary-grade gate computation (ADR 0018 D3).
+
+Deterministically buckets a turn's ``citation_ledger_entry`` rows into PASS /
+SUPPORTED / FAIL by their mirrored ``verification_status`` and records one
+``work_product_fiduciary_gate`` verdict per assistant message. Pure DB; no egress.
+Provenance-only entries (tool sources, no quote) are not assertions and are
+excluded from the counts.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+
+log = logging.getLogger(__name__)
+
+PASS_STATUSES: frozenset[str] = frozenset({"exact_match", "tolerant_match"})
+SUPPORTED_STATUSES: frozenset[str] = frozenset(
+    {"paraphrase_judge", "ensemble_strict", "ensemble_majority"}
+)
+FAIL_STATUSES: frozenset[str] = frozenset({"unverified", "failed"})
+_PROVENANCE = "provenance"
+
+
+async def compute_and_record_gate(
+    db: AsyncSession, *, message_id: uuid.UUID
+) -> WorkProductFiduciaryGate | None:
+    """Compute the fiduciary-grade verdict for ``message_id`` and upsert it.
+
+    Returns the recorded row, or ``None`` if the message has no chat (should not
+    happen at finalize). Flushes, never commits (rides the caller's transaction).
+    """
+    chat_id = (
+        await db.execute(select(Message.chat_id).where(Message.id == message_id))
+    ).scalar_one_or_none()
+    if chat_id is None:
+        return None
+    project_id = (
+        await db.execute(select(Chat.project_id).where(Chat.id == chat_id))
+    ).scalar_one_or_none()
+
+    entries = (
+        (
+            await db.execute(
+                select(CitationLedgerEntry).where(CitationLedgerEntry.message_id == message_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    pass_count = supported_count = fail_count = 0
+    confidences: list[float] = []
+    for e in entries:
+        status = e.verification_status
+        if status == _PROVENANCE:
+            continue
+        if status in PASS_STATUSES:
+            pass_count += 1
+        elif status in SUPPORTED_STATUSES:
+            supported_count += 1
+        elif status in FAIL_STATUSES:
+            fail_count += 1
+        else:
+            log.warning(
+                "fiduciary gate: unrecognized verification_status %r on entry %s; excluded",
+                status,
+                e.id,
+            )
+            continue
+        if e.confidence is not None:
+            confidences.append(e.confidence)
+
+    total = pass_count + supported_count + fail_count
+    if fail_count > 0:
+        gate_status = "flagged"
+    elif supported_count > 0:
+        gate_status = "supported_only"
+    else:
+        gate_status = "fiduciary_grade"
+    confidence = sum(confidences) / len(confidences) if confidences else None
+
+    # Upsert: a re-finalize replaces the current verdict (the ledger is the history).
+    await db.execute(
+        delete(WorkProductFiduciaryGate).where(
+            WorkProductFiduciaryGate.message_id == message_id
+        )
+    )
+    row = WorkProductFiduciaryGate(
+        message_id=message_id,
+        chat_id=chat_id,
+        project_id=project_id,
+        gate_status=gate_status,
+        pass_count=pass_count,
+        supported_count=supported_count,
+        fail_count=fail_count,
+        total_assertions=total,
+        confidence=confidence,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def resolve_gates(
+    db: AsyncSession, *, chat_id: uuid.UUID, message_id: uuid.UUID | None = None
+) -> list[dict[str, Any]]:
+    """Return the fiduciary-grade verdict(s) for a chat (optionally one turn)."""
+    stmt = select(WorkProductFiduciaryGate).where(WorkProductFiduciaryGate.chat_id == chat_id)
+    if message_id is not None:
+        stmt = stmt.where(WorkProductFiduciaryGate.message_id == message_id)
+    stmt = stmt.order_by(WorkProductFiduciaryGate.created_at, WorkProductFiduciaryGate.id)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "message_id": str(g.message_id),
+            "gate_status": g.gate_status,
+            "pass_count": g.pass_count,
+            "supported_count": g.supported_count,
+            "fail_count": g.fail_count,
+            "total_assertions": g.total_assertions,
+            "confidence": g.confidence,
+            "created_at": g.created_at.isoformat(),
+        }
+        for g in rows
+    ]
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_fiduciary_gate.py -v`
+Expected: all PASS (every classification case, the upsert, `resolve_gates`, and the assembler-mislabel regression).
+
+- [ ] **Step 6: Lint + type-check, then commit**
+
+```bash
+cd api && .venv/bin/ruff format app/citation/gate.py app/citation/ledger.py tests/integration/test_fiduciary_gate.py && .venv/bin/ruff check app/citation tests/integration/test_fiduciary_gate.py && .venv/bin/mypy app/citation/gate.py app/citation/ledger.py
+```
+
+```bash
+git add api/app/citation/gate.py api/app/citation/ledger.py api/tests/integration/test_fiduciary_gate.py
+git commit -s -m "feat(citation): deterministic fiduciary-grade gate computation (P1-B1)
+
+compute_and_record_gate buckets a turn's ledger entries into
+PASS/SUPPORTED/FAIL and upserts the verdict + per-tier counts +
+aggregate confidence (ADR 0018 D3). Provenance entries excluded.
+Fixes the assemble_ledger_entries mislabel so unverified KB citations
+land as 'unverified' (were 'verified'), making FAIL honest. Pure DB.
+
+Refs ADR 0018 D3.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Hook at the three finalize sites + wire `gates` into the `/ledger` endpoint
+
+**Files:**
+- Modify: `api/app/api/chats.py` (3 finalize hooks + endpoint `gates` key + import)
+- Modify: `docs/api/backend-openapi.yaml` (add `gates` to the ledger 200 response)
+- Test: `api/tests/integration/test_ledger_endpoint.py` (extend — gate appears in response) and `api/tests/integration/test_fiduciary_gate.py` (the hook is exercised end-to-end via an existing chat-send test if cheap, else a focused finalize test)
+
+**Interfaces:**
+- Consumes: `compute_and_record_gate`, `resolve_gates` (Task 2).
+- Produces: the `/ledger` endpoint response gains a top-level `gates` key.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `api/tests/integration/test_ledger_endpoint.py` — in the existing `seeded` fixture the turn already has a `message_citations` row and assembled ledger entries; after `assemble_ledger_entries`, also call the gate, then assert the endpoint surfaces it. Add:
+
+```python
+from app.citation.gate import compute_and_record_gate  # add to imports
+
+
+@pytest.mark.asyncio
+async def test_ledger_includes_gate(client, db_session, seeded):
+    user, chat, msg = seeded
+    await compute_and_record_gate(db_session, message_id=msg.id)
+    await db_session.flush()
+    r = await client.get(f"/api/v1/chats/{chat.id}/ledger", headers=_auth(user))
+    assert r.status_code == 200
+    body = r.json()
+    assert "gates" in body
+    assert len(body["gates"]) == 1
+    g = body["gates"][0]
+    assert g["message_id"] == str(msg.id)
+    # the seeded turn has one exact_match KB citation -> fiduciary_grade
+    assert g["gate_status"] == "fiduciary_grade"
+    assert g["pass_count"] == 1
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_ledger_endpoint.py::test_ledger_includes_gate -v`
+Expected: FAIL — `KeyError: 'gates'` / `assert "gates" in body`.
+
+- [ ] **Step 3: Wire `gates` into the endpoint**
+
+In `api/app/api/chats.py`, extend the gate import (add to the existing `app.citation.ledger` import line or a new line):
+
+```python
+from app.citation.gate import compute_and_record_gate, resolve_gates
+```
+
+In `get_chat_ledger`, change the return to include `gates`:
+
+```python
+    entries = await resolve_ledger_entries(db, chat_id=cid, message_id=mid)
+    gates = await resolve_gates(db, chat_id=cid, message_id=mid)
+    return {"chat_id": str(cid), "entries": entries, "gates": gates}
+```
+
+- [ ] **Step 4: Add the finalize hooks**
+
+At **each** of the three sites where `assemble_ledger_entries(db, message_id=assistant_message_id)` is called (in `_send_message`'s non-streaming tool-loop path ~line 2927, the non-tool path ~line 3141, and the streaming path ~line 3504), add the gate call **immediately after** the assembler's `try/except`, in its own guard. Pattern (apply at all three, matching each site's existing indentation and the variable name used for the assistant message id at that site):
+
+```python
+                try:
+                    await compute_and_record_gate(db, message_id=assistant_message_id)
+                except Exception as gate_exc:  # never break the turn (conservative posture)
+                    log.warning("fiduciary gate computation failed: %r", gate_exc)
+```
+
+> **Implementer note:** confirm the assistant-message-id variable name at each site (the assembler call shows it — reuse the same identifier). Do not change the assembler call; add the gate call as a sibling guard right after it.
+
+- [ ] **Step 5: Update the OpenAPI sketch**
+
+In `docs/api/backend-openapi.yaml`, in the `/api/v1/chats/{chat_id}/ledger` `200` response schema (added in P1-A3), add a `gates` property next to `entries`:
+
+```yaml
+                  gates:
+                    type: array
+                    description: Per-turn fiduciary-grade verdicts (ADR 0018 D3).
+                    items:
+                      type: object
+                      properties:
+                        message_id: {type: string, format: uuid}
+                        gate_status: {type: string, enum: [fiduciary_grade, supported_only, flagged]}
+                        pass_count: {type: integer}
+                        supported_count: {type: integer}
+                        fail_count: {type: integer}
+                        total_assertions: {type: integer}
+                        confidence: {type: number, nullable: true}
+                        created_at: {type: string, format: date-time}
+```
+
+(No path-count change — the `/ledger` path already exists; this only extends its response body. `test_openapi.py` count stays 135.)
+
+- [ ] **Step 6: Run the endpoint + gate tests**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest tests/integration/test_ledger_endpoint.py tests/integration/test_fiduciary_gate.py tests/test_openapi.py -v`
+Expected: all PASS (the new `gates` assertion; count still 135).
+
+- [ ] **Step 7: Full gate**
+
+Run: `cd api && .venv/bin/ruff format app tests && .venv/bin/ruff check app tests && .venv/bin/mypy app && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest -q`
+Expected: ruff + mypy clean; full suite green (no decrease).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/app/api/chats.py docs/api/backend-openapi.yaml api/tests/integration/test_ledger_endpoint.py api/tests/integration/test_fiduciary_gate.py
+git commit -s -m "feat(citation): hook fiduciary gate at finalize + surface in /ledger (P1-B1)
+
+compute_and_record_gate runs at all three chat-finalize sites
+(guarded, never breaks the turn); GET /chats/{id}/ledger now returns
+a gates[] array of per-turn verdicts alongside entries (additive, the
+A3 response object reserved for this). OpenAPI sketch extended.
+
+Refs ADR 0018 D3/D4.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- D3 gate computation (PASS/SUPPORTED/FAIL, derivation, confidence-as-mean, zero-assertion case) → Task 2 `compute_and_record_gate` + tests. ✓
+- New 1:1 metadata table + migration 0059 + P3 tripwire → Task 1. ✓
+- Assembler mislabel fix (unverified KB → `"unverified"`) + regression test → Task 2. ✓
+- Hook at 3 finalize sites, guarded → Task 3. ✓
+- `gates` surfaced in the merged A3 `/ledger` response → Task 3 (`resolve_gates`). ✓
+- No egress; flush-not-commit (P5) → Task 2 (`db.flush()` only). ✓
+- Caselaw-FAIL persistence + paraphrase tier explicitly **out of scope** (B1b) → not in any task. ✓
+
+**Placeholder scan:** Task 2 Step 1 gives one fully-worked FK-valid test (`test_all_pass_is_fiduciary_grade`) plus an `_seed_entry` helper and an enumerated list of the remaining tests with exact expected values (counts, statuses, confidence) — guided construction over a real helper, not a silent TODO. All other steps carry complete code. No "TBD"/"implement later". ✓
+
+**Type consistency:** `compute_and_record_gate(db, *, message_id) -> WorkProductFiduciaryGate | None` and `resolve_gates(db, *, chat_id, message_id=None) -> list[dict]` are defined in Task 2 and consumed identically in Task 3. `WorkProductFiduciaryGate` columns defined in Task 1 match the model fields set in Task 2 and read in `resolve_gates`. Status strings (`exact_match`, `tolerant_match`, `paraphrase_judge`, `ensemble_strict`, `ensemble_majority`, `unverified`, `failed`, `provenance`) are consistent with the cascade's `method` values and the ledger assembler. ✓
+
+**Note for executor:** the cascade's real method strings are `exact_match`, `tolerant_match`, `paraphrase_judge`, `ensemble_strict`, `ensemble_majority` (`api/app/citation/verification.py`). If any differ at implementation time, align the `*_STATUSES` frozensets to the actual values and say so — the gate is only honest if its buckets match what the cascade writes.

--- a/docs/superpowers/specs/2026-06-25-p1b1-fiduciary-grade-gate-design.md
+++ b/docs/superpowers/specs/2026-06-25-p1b1-fiduciary-grade-gate-design.md
@@ -1,0 +1,110 @@
+# P1-B1 — Deterministic fiduciary-grade gate (design)
+
+**Date:** 2026-06-25
+**Milestone:** Fiduciary-grade agentic legal work — Phase 1 (WS-B)
+**Branch:** `feat/fiduciary-p1b1-fiduciary-gate`
+**Pins:** [ADR 0018](../../adr/0018-citation-ledger-and-fiduciary-grade-output.md) D3 (fiduciary-grade is a computed gate), D5 (no-raw-payload / tripwire). Builds on **P1-A2** (`citation_ledger_entry` + assembly, #219) and **P1-A1** (#218).
+**Security review:** required (citation/audit-adjacent surface; new metadata record on work product). **No new egress** — deterministic over already-persisted statuses.
+
+## Problem
+
+ADR 0018 D3 defines "fiduciary-grade" as a **computed gate**, not a label: a turn is fiduciary-grade iff every cited assertion resolves to a ledger entry whose `verification_status` is in the PASS set, with no FAIL entry left un-surfaced. The ledger exists (P1-A2) but nothing computes or records this verdict. P1-B1 computes the gate **deterministically over the per-turn ledger entries** and records it.
+
+**Scope split (maintainer-approved 2026-06-25):** the DE-280 paraphrase judge over stored opinion text — which would let a caselaw quote that misses verbatim reach the SUPPORTED tier — adds gateway egress, R4 cost accounting, and a cost pre-flight. That is split out as **P1-B1b**. P1-B1 is **gate-only**: deterministic, no egress, no cost.
+
+## Decisions (maintainer-approved 2026-06-25)
+
+- **Split, gate-only.** P1-B1 classifies existing ledger statuses and records the verdict. The paraphrase judge + cost pre-flight → P1-B1b.
+- **New `work_product_fiduciary_gate` table** (migration `0059`), 1:1-per-assistant-message — not new columns on `work_product_attribution` (which holds routing/attribution metadata, not verification). Matches the codebase's focused-per-artifact-table pattern; keeps the verdict + per-tier counts together.
+- **Metadata-only → joins the P3 tripwire** (ADR D5). The gate row holds a status label, integer counts, and a numeric confidence — no content — so it is added to `test_transparency_invariants.py`'s scanned set, like `citation_ledger_entry`.
+
+## The FAIL-detection reality (load-bearing — read before implementing)
+
+ADR D3's FAIL set is `{unverified, failed}`, but the two quote pipelines persist failures **asymmetrically** today, and the P1-A2 assembler has a latent mislabel:
+
+- **KB documents** (`message_citations`): a quote that fails every cascade stage **is persisted** with `verified=False, verification_method=None` (`app/citation/__init__.py`). So KB failures already reach the ledger — **but** the P1-A2 assembler writes `verification_status = c.verification_method or "verified"`, which mislabels an unverified KB citation as `"verified"`. **P1-B1 fixes this:** map `verified=False` → `verification_status="unverified"` (and `confidence=None`). Without the fix the gate would count a failed KB quote as PASS — the exact conservative-posture violation D3 forbids.
+- **Caselaw** (`message_caselaw_citations`): `verify_and_persist_caselaw_citations` **drops** non-verified passages (`if not result.verified: continue`). So caselaw failures are invisible to the ledger today. Persisting caselaw FAIL attempts is **deferred to P1-B1b**, where the paraphrase judge runs and a "located but not verbatim, and not paraphrase-supported" passage becomes a genuine FAIL row. P1-B1 documents this as a known, scoped gap rather than over-flagging every unmatched blockquote (a blockquote may not be a caselaw quote at all).
+
+**Net for P1-B1:** the gate flags FAIL for KB-document quotes (the dominant case) honestly once the assembler mislabel is fixed; caselaw-FAIL surfacing lands with the paraphrase work in B1b. This is stated plainly in the gate's docstring and the PR description — no overclaiming.
+
+## Design
+
+### Component 1 — Assembler mislabel fix (`api/app/citation/ledger.py`)
+
+In `assemble_ledger_entries`, replace the `c.verification_method or "verified"` fallback for KB `message_citations` with: `verification_status = c.verification_method if c.verified else "unverified"`, and set `confidence = float(c.verification_confidence)` only when verified (else `None`). Same correction for the `message_caselaw_citations` branch for symmetry (today only verified rows reach it, so this is defensive). This makes the ledger's status field honest, which the gate and P1-A3's trace both depend on.
+
+### Component 2 — `work_product_fiduciary_gate` table (migration `0059`)
+
+| Column | Type / notes |
+|---|---|
+| `id` | uuid pk, `gen_random_uuid()` |
+| `message_id` | uuid, FK → `messages.id` ON DELETE CASCADE, **not null, UNIQUE** (1:1 per assistant turn) |
+| `chat_id` | uuid, FK → `chats.id` ON DELETE CASCADE, not null |
+| `project_id` | uuid, FK → `projects.id` ON DELETE SET NULL, **nullable** (matter-less chats) |
+| `gate_status` | text, not null — `'fiduciary_grade'` \| `'supported_only'` \| `'flagged'` |
+| `pass_count` | integer, not null — entries in PASS `{exact_match, tolerant_match}` |
+| `supported_count` | integer, not null — entries in SUPPORTED `{paraphrase_judge, ensemble_strict, ensemble_majority}` |
+| `fail_count` | integer, not null — entries in FAIL `{unverified, failed}` |
+| `total_assertions` | integer, not null — `pass + supported + fail` (provenance entries excluded) |
+| `confidence` | double precision, nullable — aggregate over counted entries (see Component 3) |
+| `created_at` | timestamptz, not null, `now()` |
+
+CHECK: `confidence IS NULL OR (confidence >= 0 AND confidence <= 1)`; `pass_count >= 0` etc. Index on `chat_id`. Model `app/models/work_product_fiduciary_gate.py` (`WorkProductFiduciaryGate`).
+
+`gate_status` derivation:
+- `flagged` if `fail_count > 0` (a FAIL entry exists → not fiduciary-grade; D3 conservative posture).
+- else `supported_only` if `supported_count > 0` (no FAIL, but some assertions are paraphrase/ensemble-supported, not verbatim).
+- else `fiduciary_grade` (every counted assertion is verbatim PASS). A turn with **zero counted assertions** (e.g. a chit-chat turn with only provenance or nothing) → `fiduciary_grade` with `total_assertions=0` (vacuously true; the UI can render "no cited assertions" distinctly from "all verified").
+
+### Component 3 — Gate computation (`api/app/citation/gate.py`)
+
+```python
+PASS_STATUSES = frozenset({"exact_match", "tolerant_match"})
+SUPPORTED_STATUSES = frozenset({"paraphrase_judge", "ensemble_strict", "ensemble_majority"})
+FAIL_STATUSES = frozenset({"unverified", "failed"})
+# 'provenance' entries (tool sources, no quote) are NOT assertions — excluded.
+
+async def compute_and_record_gate(db: AsyncSession, *, message_id: uuid.UUID) -> WorkProductFiduciaryGate | None:
+```
+
+1. Self-derive `chat_id` (from the message) and `project_id` (from the chat), mirroring `assemble_ledger_entries`. If the message has no chat (shouldn't happen at finalize), return `None`.
+2. Load `CitationLedgerEntry` rows for `message_id`. Bucket each by `verification_status` into PASS / SUPPORTED / FAIL; ignore `provenance` and any unrecognized status (logged once — defends against a future status string slipping the gate).
+3. `confidence` = the mean of the counted entries' non-null `confidence` values (PASS entries from exact match carry `1.0`; tolerant/paraphrase carry the cascade confidence). `None` when no counted entry has a confidence. (Mean, not min — the gate's confidence is a summary signal, not a worst-case bound; the per-entry detail is in P1-A3. Documented in the docstring.)
+4. Derive `gate_status` (Component 2 rules), build the row, **upsert** on `message_id` (a re-finalize of the same turn replaces its gate — the gate is a current-verdict, not history; the ledger entries are the history-preserving record per ADR D7). Implement as delete-existing-then-insert or `ON CONFLICT (message_id) DO UPDATE`.
+5. `add` + `flush` (never commit — rides the caller's transaction, P5). Return the row.
+
+### Component 4 — Hook (`api/app/api/chats.py`)
+
+Call `compute_and_record_gate(db, message_id=assistant_message_id)` at the **same three finalize sites** as `assemble_ledger_entries`, immediately **after** it (the gate reads the entries the assembler just wrote): the non-streaming tool-loop site (~2880), the non-streaming non-tool site (~3091/3103), and the streaming site (~3455). Each guarded in `try/except` that logs and never re-raises — a gate failure must not break the turn (conservative posture, matching the ledger hook).
+
+### Component 5 — P3 tripwire (ADR 0018 D5)
+
+Add `WorkProductFiduciaryGate` to `_AUDIT_MODELS` in `api/tests/test_transparency_invariants.py`. Its columns (`gate_status`, the `_count` integers, `confidence`, ids, timestamp) carry no content and do not trip `_implies_raw_content`, so the scan stays green — proving the gate is a metadata verdict, not a content store.
+
+## Error handling (conservative posture)
+
+- The gate hook is guarded at every finalize site — a failure logs and degrades to "no gate this turn," never aborting the turn/stream.
+- An unrecognized `verification_status` is excluded from all buckets and logged (does not silently count as PASS).
+- No egress, no gateway/LLM call — pure DB reads + a single upsert.
+
+## Testing
+
+- **Unit (classification, `gate.py`):** all-PASS turn → `fiduciary_grade`, counts correct, `confidence≈1.0`; mixed PASS+SUPPORTED, no FAIL → `supported_only`; any FAIL (an `unverified` entry) → `flagged`; `provenance` entries excluded from `total_assertions`; zero-assertion turn → `fiduciary_grade`, `total=0`; unknown status excluded + logged.
+- **Integration (real Postgres, host venv + throwaway pgvector):** seed a turn's ledger entries across statuses → `compute_and_record_gate` writes one correctly-derived row; re-running upserts (no duplicate, `UNIQUE(message_id)` holds); the assembler fix is exercised — an unverified `message_citations` row produces an `unverified` ledger entry → `fail_count=1` → `flagged` (regression-locks the mislabel fix).
+- **Transparency invariant:** `test_transparency_invariants.py` green with `WorkProductFiduciaryGate` in the scanned set.
+- Gates: `ruff format` + `ruff check` + `mypy app` + full `pytest` (coverage no-decrease).
+
+## Acceptance criteria
+
+1. `work_product_fiduciary_gate` exists (migration `0059`), 1:1-unique on `message_id`, metadata-only.
+2. At finalize, every assistant turn gets exactly one gate row whose `gate_status` follows D3 (`flagged` on any FAIL; `supported_only` when SUPPORTED-but-no-FAIL; `fiduciary_grade` otherwise), with correct per-tier counts and aggregate confidence; provenance entries are excluded from assertions.
+3. The P1-A2 assembler mislabel is fixed — an unverified KB `message_citations` row lands as `verification_status="unverified"`, so the gate flags it (regression test locks this).
+4. `WorkProductFiduciaryGate` is in the P3 tripwire scan and the test passes (proves metadata-only).
+5. A gate failure never breaks the turn; no new egress. `ruff` + `mypy` clean; unit + integration + invariant tests green.
+
+## Out of scope / sequencing
+
+- **DE-280 paraphrase judge + cost pre-flight + caselaw-FAIL persistence** → **P1-B1b** (the SUPPORTED tier for caselaw, new egress, R4 cost, heavier security review). Filed in PRD §9.
+- **Surfacing the gate in the read API** — P1-A3 ships its response as an object so B1 adds a `gates` key additively (whichever merges second wires it); the gate read shape is otherwise out of scope here.
+- **UI** (P1-C1) renders the badge + verbatim-vs-supported distinction.
+- **Operator tuning of the PASS set** — deferred per ADR D3 (not v1).


### PR DESCRIPTION
## P1-B1 — Deterministic fiduciary-grade gate

Computes the **fiduciary-grade verdict** (ADR 0018 D3) for each assistant turn, deterministically over the turn's citation-ledger entries, and records it. The transparency posture becomes a hard, computed gate — not a label. Milestone: fiduciary-grade agentic legal work, Phase 1 (WS-B). Builds on P1-A2 (ledger) and the merged P1-A3 (read API).

### What's here
- **`work_product_fiduciary_gate`** table (migration `0059`) — 1:1-per-assistant-message, **metadata-only**: `gate_status` (`fiduciary_grade`/`supported_only`/`flagged`) + per-tier counts + aggregate `confidence`. Joins the P3 no-raw-payload tripwire.
- **`compute_and_record_gate`** (`api/app/citation/gate.py`) — buckets each ledger entry by `verification_status`: PASS `{exact_match, tolerant_match}` / SUPPORTED `{paraphrase_judge, ensemble_strict, ensemble_majority}` / FAIL `{unverified, failed}`; `provenance` entries are not assertions (excluded). Verdict: `flagged` on any FAIL; else `supported_only` if any SUPPORTED; else `fiduciary_grade` (zero-assertion turn → `fiduciary_grade`, vacuously). Confidence = mean of counted non-null confidences. **Upserts** the verdict (the ledger is the history-preserving record). Flushes, never commits (P5).
- **Assembler honesty fix** — `assemble_ledger_entries` mislabeled unverified KB `message_citations` (`verified=False`) as `"verified"`; now `"unverified"`. This is what makes **FAIL detection honest** for KB quotes — without it the gate would count a failed quote as PASS. Regression-locked.
- **Finalize hooks** — `compute_and_record_gate` runs at all three chat-finalize sites (each guarded; a gate failure never breaks the turn/stream).
- **Read** — `GET /chats/{chat_id}/ledger` now returns a `gates[]` array of per-turn verdicts alongside `entries` (additive — the A3 response object reserved this). OpenAPI extended; no path-count change.

### Scope boundary (honest)
**Gate-only / deterministic — no new egress.** The DE-280 opinion-scale **paraphrase judge** (the SUPPORTED tier for caselaw), **caselaw-FAIL persistence**, and the long-opinion **cost pre-flight** are deferred to **P1-B1b** (new egress + R4 cost). So today: KB-document FAIL is detected and flagged; caselaw failures are *dropped at persistence* (not miscounted — the gate cannot read a dropped failure as PASS), and surface honestly once B1b lands.

### Invariants
- **P3:** gate row holds only labels/counts/confidence/ids — no content; in the tripwire scan.
- **P5:** the helper flushes, never commits — rides the finalize transaction (verdict atomic with the audit row).
- **Conservative posture:** unrecognized status is excluded + logged, never silently counted as PASS; any FAIL → `flagged`, never silently emitted.
- Migration `0059` chains from `0058`.

### Testing
- Gate classification (all-PASS, mixed SUPPORTED, any-FAIL, provenance-excluded, zero-assertion, unknown-status-excluded), upsert, `resolve_gates`, the assembler-mislabel regression (genuine `verified=False` → `unverified` → `flagged` path), the endpoint `gates[]` integration.
- Full api gate: `ruff format` + `ruff check` + `mypy app` clean; full suite green.

### Review
Built via brainstorm → spec → plan → subagent-driven-development (per-task spec+quality reviews + an Opus whole-branch review: *Ready to merge*; P3 + P5 + conservative posture independently verified). Final review surfaced one **forward-consistency follow-up** (filed as a DE): `llm_judge` is a legal `verification_method` value not yet routed into a gate bucket — latent (the cascade doesn't emit it today), excluded-not-miscounted if it ever appears.

> **Security review (CODEOWNERS):** citation/audit surface — please review/merge; I have not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Spec: `docs/superpowers/specs/2026-06-25-p1b1-fiduciary-grade-gate-design.md` · Plan: `docs/superpowers/plans/2026-06-25-p1b1-fiduciary-grade-gate.md` · Refs ADR 0018 D3/D5.
