### PR TITLE
feat(web): Citation Ledger UI — fiduciary badge + one-click trace (P1-C1)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-p1c1-ledger-ui.md
+++ b/docs/superpowers/plans/2026-06-25-p1c1-ledger-ui.md
@@ -1,0 +1,513 @@
+# P1-C1 — Citation Ledger UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A per-assistant-turn fiduciary badge that opens a one-click-trace panel listing every source the turn used — resolved to the passage read and its verification state — consuming the merged `GET /api/v1/chats/{chat_id}/ledger` (`{entries, gates}`).
+
+**Architecture:** All testable logic lives in pure TypeScript (API client + status→state + gate→badge helpers), unit-tested via Vitest with a `fetch` mock — matching this codebase's testing posture. The `.svelte` files are thin presentational components driven by those helpers, verified by `svelte-check` (the repo has **no** Svelte component-test harness; do not add one). Additive — `M2Citations`/`ToolSourcesPanel` are untouched.
+
+**Tech Stack:** SvelteKit, TypeScript, Vitest (`fetch`-mock unit tests), `svelte-check`, Prettier/ESLint. Reuses `apiRequest` (`api/client.ts`), `CitationRenderState` (`citations/state.ts`), `TrustPill`, the `TierDetailsPanel` modal pattern.
+
+## Global Constraints
+
+- **No new dependencies.** No `@testing-library/svelte` or other test libs — pure-TS unit tests + `svelte-check` only. New UI reuses existing primitives (`TrustPill`, `InfoTip`, the `TierDetailsPanel` modal shape).
+- **Reuse the 5-state map, don't fork it.** Ledger entry states map onto the existing `CitationRenderState` union (`verified-exact` | `verified-tolerant` | `verified-paraphrase` | `unverified`) from `web/src/lib/lq-ai/citations/state.ts`. No new visual states.
+- **Gate→tone mapping (exact):** `fiduciary_grade` → `sage`; `supported_only` → `amber`; `flagged` → `red` (the `TrustPill` `TrustTone` values).
+- **Additive only.** Do not modify `M2Citations.svelte`, `ToolSourcesPanel.svelte`, or their wiring. The ledger badge/panel are new, rendered alongside.
+- **Degrade silently.** 404 / network error → no ledger badge (exactly how `loadCitations`/`loadSources` degrade to `[]` today). Never throw on unknown `source_kind`/`verification_status`.
+- **Canonical API surface:** all calls go through `apiRequest` from `web/src/lib/lq-ai/api/client.ts` (handles `Authorization`, 401-refresh, typed errors). Path is relative to `/api/v1`.
+- **Commands:** `cd web && npm run format && npm run check:lq-ai && npm run test:frontend`. The `web` container serves a prebuilt bundle (no HMR) — rebuild it before manual verification.
+- **Commits:** `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Types + API client + pure state/badge helpers (fully unit-tested)
+
+**Files:**
+- Modify: `web/src/lib/lq-ai/types.ts` (add ledger types)
+- Create: `web/src/lib/lq-ai/api/ledger.ts`
+- Modify: `web/src/lib/lq-ai/api/index.ts` (export `ledgerApi`)
+- Create: `web/src/lib/lq-ai/citations/ledger-state.ts`
+- Test: `web/src/lib/lq-ai/api/__tests__/ledger.test.ts`
+- Test: `web/src/lib/lq-ai/citations/__tests__/ledger-state.test.ts`
+
+**Interfaces:**
+- Produces: `getChatLedger(chatId: string, messageId?: string): Promise<ChatLedger>`; `ledgerEntryState(status: string): CitationRenderState`; `gateBadge(gate: LedgerGate | undefined): GateBadge | null`. Types `ChatLedger`, `LedgerEntry`, `LedgerGate`, `LedgerSource`, `LedgerPassage`, `GateBadge`. Consumed by Tasks 2–3.
+
+- [ ] **Step 1: Add types** to `web/src/lib/lq-ai/types.ts` (append near the other citation types):
+
+```ts
+export interface LedgerPassage {
+	text: string;
+	offset_start: number;
+	offset_end: number;
+	page?: number | null;
+}
+export interface LedgerSource {
+	kind: string; // kb_document | caselaw | mcp | ...
+	source_file_id?: string;
+	opinion_id?: number;
+	cluster_id?: number;
+	label?: string | null;
+	subtitle?: string | null;
+	url?: string | null;
+	external_ref?: string | null;
+	tool?: string | null;
+	passages?: LedgerPassage[];
+}
+export interface LedgerEntry {
+	id: string;
+	message_id: string;
+	source_kind: string;
+	verification_status: string;
+	confidence: number | null;
+	provider: string | null;
+	retrieved_at: string | null;
+	treatment_id: string | null;
+	created_at: string;
+	source: LedgerSource;
+}
+export type GateStatus = 'fiduciary_grade' | 'supported_only' | 'flagged';
+export interface LedgerGate {
+	message_id: string;
+	gate_status: GateStatus;
+	pass_count: number;
+	supported_count: number;
+	fail_count: number;
+	total_assertions: number;
+	confidence: number | null;
+	created_at: string;
+}
+export interface ChatLedger {
+	chat_id: string;
+	entries: LedgerEntry[];
+	gates: LedgerGate[];
+}
+```
+
+- [ ] **Step 2: Write the failing API-client test** `web/src/lib/lq-ai/api/__tests__/ledger.test.ts` (mirror `tabular.test.ts`'s `fetch`-mock shape):
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getChatLedger } from '../ledger';
+
+function jsonResponseLike(status: number, body: unknown) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		headers: { get: (n: string) => (n.toLowerCase() === 'content-type' ? 'application/json' : null) },
+		json: async () => body
+	};
+}
+
+describe('ledger API client', () => {
+	const fetchMock = vi.fn();
+	let originalFetch: typeof globalThis.fetch;
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+		fetchMock.mockReset();
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it('GETs /chats/{id}/ledger with no message filter', async () => {
+		fetchMock.mockResolvedValue(jsonResponseLike(200, { chat_id: 'c1', entries: [], gates: [] }));
+		const out = await getChatLedger('c1');
+		expect(out.chat_id).toBe('c1');
+		const url = fetchMock.mock.calls[0][0] as string;
+		expect(url).toContain('/chats/c1/ledger');
+		expect(url).not.toContain('message_id');
+	});
+
+	it('appends ?message_id when given (encoded)', async () => {
+		fetchMock.mockResolvedValue(jsonResponseLike(200, { chat_id: 'c1', entries: [], gates: [] }));
+		await getChatLedger('c1', 'm 1');
+		const url = fetchMock.mock.calls[0][0] as string;
+		expect(url).toContain('/chats/c1/ledger?message_id=m%201');
+	});
+});
+```
+
+- [ ] **Step 3: Run it (fails)** — `cd web && npm run test:frontend -- ledger.test` → FAIL (`Cannot find module '../ledger'`).
+
+- [ ] **Step 4: Implement** `web/src/lib/lq-ai/api/ledger.ts`:
+
+```ts
+/**
+ * /api/v1/chats/{chat_id}/ledger — Citation Ledger read surface (P1-A3/B1).
+ *
+ * Returns the turn/chat ledger resolved to source identity + passage(s) read
+ * + verification status + provenance, plus per-turn fiduciary-grade verdicts
+ * (`gates`). Lazy-fetched per assistant message, like citations/sources.
+ */
+import { apiRequest } from './client';
+import type { ChatLedger } from '../types';
+
+/** GET /api/v1/chats/{chat_id}/ledger[?message_id=…] */
+export async function getChatLedger(chatId: string, messageId?: string): Promise<ChatLedger> {
+	const q = messageId ? `?message_id=${encodeURIComponent(messageId)}` : '';
+	return apiRequest<ChatLedger>(`/chats/${encodeURIComponent(chatId)}/ledger${q}`);
+}
+```
+
+Add to `web/src/lib/lq-ai/api/index.ts` (next to `citationsApi`):
+
+```ts
+export * as ledgerApi from './ledger';
+```
+
+- [ ] **Step 5: Write the failing helper test** `web/src/lib/lq-ai/citations/__tests__/ledger-state.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { ledgerEntryState, gateBadge } from '../ledger-state';
+import type { LedgerGate } from '../../types';
+
+describe('ledgerEntryState', () => {
+	it('maps verbatim methods to green states', () => {
+		expect(ledgerEntryState('exact_match')).toBe('verified-exact');
+		expect(ledgerEntryState('tolerant_match')).toBe('verified-tolerant');
+	});
+	it('maps judge/ensemble methods to paraphrase (amber)', () => {
+		for (const s of ['paraphrase_judge', 'ensemble_strict', 'ensemble_majority']) {
+			expect(ledgerEntryState(s)).toBe('verified-paraphrase');
+		}
+	});
+	it('maps unverified/failed/provenance/unknown to unverified', () => {
+		for (const s of ['unverified', 'failed', 'provenance', 'something_new']) {
+			expect(ledgerEntryState(s)).toBe('unverified');
+		}
+	});
+});
+
+describe('gateBadge', () => {
+	const base: Omit<LedgerGate, 'gate_status'> = {
+		message_id: 'm1', pass_count: 2, supported_count: 1, fail_count: 1,
+		total_assertions: 4, confidence: 0.9, created_at: 't'
+	};
+	it('returns null for undefined', () => {
+		expect(gateBadge(undefined)).toBeNull();
+	});
+	it('maps each verdict to a tone + label', () => {
+		expect(gateBadge({ ...base, gate_status: 'fiduciary_grade' })?.tone).toBe('sage');
+		expect(gateBadge({ ...base, gate_status: 'supported_only' })?.tone).toBe('amber');
+		expect(gateBadge({ ...base, gate_status: 'flagged' })?.tone).toBe('red');
+		expect(gateBadge({ ...base, gate_status: 'flagged' })?.label).toBeTruthy();
+	});
+});
+```
+
+- [ ] **Step 6: Run it (fails)** — `cd web && npm run test:frontend -- ledger-state` → FAIL (module missing).
+
+- [ ] **Step 7: Implement** `web/src/lib/lq-ai/citations/ledger-state.ts`:
+
+```ts
+/**
+ * Ledger entry status → CitationRenderState, and gate verdict → badge.
+ *
+ * Reuses the M2-C2 5-state palette (state.ts) so ledger entry chips pick up
+ * the existing colors/labels/tooltips. Operates on the ledger's
+ * `verification_status` string directly (the ledger mirrors the cascade
+ * method onto the entry), so no Citation row is needed.
+ */
+import type { CitationRenderState } from './state';
+import type { LedgerGate } from '../types';
+import type { TrustTone } from '../components/TrustPill.svelte';
+
+export function ledgerEntryState(status: string): CitationRenderState {
+	switch (status) {
+		case 'exact_match':
+			return 'verified-exact';
+		case 'tolerant_match':
+			return 'verified-tolerant';
+		case 'paraphrase_judge':
+		case 'llm_judge':
+		case 'ensemble_strict':
+		case 'ensemble_majority':
+			return 'verified-paraphrase';
+		default:
+			// unverified | failed | provenance | unknown — conservative gray.
+			return 'unverified';
+	}
+}
+
+export interface GateBadge {
+	tone: TrustTone;
+	label: string;
+	tip: string;
+}
+
+export function gateBadge(gate: LedgerGate | undefined): GateBadge | null {
+	if (!gate) return null;
+	switch (gate.gate_status) {
+		case 'fiduciary_grade':
+			return {
+				tone: 'sage',
+				label: 'Fiduciary-grade',
+				tip: `Every cited assertion (${gate.pass_count}) is verified verbatim against its source.`
+			};
+		case 'supported_only':
+			return {
+				tone: 'amber',
+				label: 'Supported — not all verbatim',
+				tip: `${gate.supported_count} assertion(s) are supported (paraphrase), not verbatim; none failed.`
+			};
+		case 'flagged':
+			return {
+				tone: 'red',
+				label: 'Unverified claims flagged',
+				tip: `${gate.fail_count} cited assertion(s) could not be verified.`
+			};
+	}
+}
+```
+
+> If importing `TrustTone` from a `.svelte` module is awkward for `svelte-check`, define `type TrustTone = 'sage' | 'amber' | 'red' | 'slate' | 'neutral'` locally in `ledger-state.ts` and keep `GateBadge.tone` to that union — the three values used here are a subset. Pin in implementation.
+
+- [ ] **Step 8: Run both test files (pass)** — `cd web && npm run test:frontend -- ledger` → all PASS.
+
+- [ ] **Step 9: check + format, then commit**
+
+```bash
+cd web && npm run format && npm run check:lq-ai && npm run test:frontend -- ledger
+```
+
+```bash
+git add web/src/lib/lq-ai/types.ts web/src/lib/lq-ai/api/ledger.ts web/src/lib/lq-ai/api/index.ts web/src/lib/lq-ai/citations/ledger-state.ts web/src/lib/lq-ai/api/__tests__/ledger.test.ts web/src/lib/lq-ai/citations/__tests__/ledger-state.test.ts
+git commit -s -m "feat(web): ledger API client + state/badge helpers (P1-C1)
+
+getChatLedger + ledgerEntryState (reuses the M2-C2 5-state palette) +
+gateBadge (gate verdict -> TrustPill tone). Pure TS, unit-tested via
+fetch mock.
+
+Refs ADR 0018 D4.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Presentational components — `LedgerEntryRow` + `CitationLedgerPanel`
+
+**Files:**
+- Create: `web/src/lib/lq-ai/components/LedgerEntryRow.svelte`
+- Create: `web/src/lib/lq-ai/components/CitationLedgerPanel.svelte`
+
+**Interfaces:**
+- Consumes: `LedgerEntry`, `LedgerGate`, `ledgerEntryState`, `gateBadge`, `InfoTip`, `TrustPill` (Task 1 + existing).
+- Produces: `CitationLedgerPanel` (props `entries: LedgerEntry[]`, `gate: LedgerGate | undefined`, `open: boolean`, `onClose: () => void`); `LedgerEntryRow` (prop `entry: LedgerEntry`). Consumed by Task 3.
+
+No unit tests (no Svelte component harness in-repo). Verified by `svelte-check` + reuse of the Task-1 tested helpers. Keep components thin — all branching logic comes from the tested helpers.
+
+- [ ] **Step 1: `LedgerEntryRow.svelte`** — one row per entry: a state chip (class from `ledgerEntryState(entry.verification_status)` → reuse the M2 chip classes, e.g. `lq-cite-inline-{state}` or the chip class `M2Citations` uses; inspect `M2Citations.svelte` for the exact class names and mirror them), the source identity, and the passage(s).
+
+```svelte
+<script lang="ts">
+	import type { LedgerEntry } from '../types';
+	import { ledgerEntryState } from '../citations/ledger-state';
+	export let entry: LedgerEntry;
+	$: state = ledgerEntryState(entry.verification_status);
+	$: src = entry.source;
+	function identity(): string {
+		if (src.kind === 'kb_document') return 'Document';
+		if (src.kind === 'caselaw') return `Opinion ${src.opinion_id ?? ''} · cluster ${src.cluster_id ?? ''}`.trim();
+		return src.label ?? src.tool ?? src.kind;
+	}
+</script>
+
+<li class="lq-ledger-row">
+	<span class="lq-ledger-chip lq-cite-inline-{state}">{entry.verification_status}</span>
+	<span class="lq-ledger-identity">{identity()}</span>
+	{#if src.url}<a class="lq-ledger-url" href={src.url} target="_blank" rel="noopener noreferrer">source ↗</a>{/if}
+	{#if src.passages && src.passages.length > 0}
+		{#each src.passages as p}
+			<blockquote class="lq-ledger-passage">{p.text}<span class="lq-ledger-offset">chars {p.offset_start}–{p.offset_end}</span></blockquote>
+		{/each}
+	{:else}
+		<span class="lq-ledger-consulted">consulted</span>
+	{/if}
+</li>
+```
+
+(Match the existing chip class names — read `M2Citations.svelte` to reuse the same `verified-exact` / `verified-paraphrase` / `unverified` class treatment rather than inventing `lq-ledger-chip`. Style with the `practice.css` tokens.)
+
+- [ ] **Step 2: `CitationLedgerPanel.svelte`** — the `TierDetailsPanel` modal shape (`fixed inset-0 z-50` backdrop, focus-trap, Esc-to-close; read `TierDetailsPanel.svelte` and mirror its structure/classes):
+
+```svelte
+<script lang="ts">
+	import type { LedgerEntry, LedgerGate } from '../types';
+	import { gateBadge } from '../citations/ledger-state';
+	import TrustPill from './TrustPill.svelte';
+	import InfoTip from './InfoTip.svelte';
+	import LedgerEntryRow from './LedgerEntryRow.svelte';
+	export let entries: LedgerEntry[] = [];
+	export let gate: LedgerGate | undefined = undefined;
+	export let open = false;
+	export let onClose: () => void;
+	$: badge = gateBadge(gate);
+	function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose(); }
+</script>
+
+{#if open}
+	<div class="lq-ledger-backdrop" on:click={onClose} on:keydown={onKey} role="presentation">
+		<div class="lq-ledger-panel" role="dialog" aria-modal="true" aria-label="Citation ledger" on:click|stopPropagation>
+			<header class="lq-ledger-header">
+				{#if badge}
+					<TrustPill variant="audit" tone={badge.tone} label={badge.label} />
+					<InfoTip content={badge.tip} />
+				{/if}
+				{#if gate}
+					<span class="lq-ledger-counts">{gate.pass_count} verbatim · {gate.supported_count} supported · {gate.fail_count} unverified</span>
+				{/if}
+			</header>
+			{#if entries.length > 0}
+				<ul class="lq-ledger-list">
+					{#each entries as e (e.id)}<LedgerEntryRow entry={e} />{/each}
+				</ul>
+			{:else}
+				<p class="lq-ledger-empty">No sources were brought into context for this turn.</p>
+			{/if}
+		</div>
+	</div>
+{/if}
+```
+
+- [ ] **Step 3: check + format**
+
+```bash
+cd web && npm run format && npm run check:lq-ai
+```
+Expected: `svelte-check` clean (0 errors). Fix any prop/type mismatches against the Task-1 types.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/lib/lq-ai/components/LedgerEntryRow.svelte web/src/lib/lq-ai/components/CitationLedgerPanel.svelte
+git commit -s -m "feat(web): CitationLedgerPanel + LedgerEntryRow (P1-C1)
+
+Trace panel (TierDetailsPanel modal shape) listing each ledger entry
+resolved to source + passage(s) + a verification-state chip (reusing
+the M2-C2 5-state palette), headed by the fiduciary-grade badge +
+per-tier counts. Thin presentational components driven by the tested
+Task-1 helpers.
+
+Refs ADR 0018 D3/D4.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `MessageBubble` wiring — lazy-fetch + fiduciary badge + panel
+
+**Files:**
+- Modify: `web/src/lib/lq-ai/components/MessageBubble.svelte`
+
+**Interfaces:**
+- Consumes: `ledgerApi.getChatLedger`, `gateBadge`, `TrustPill`, `CitationLedgerPanel` (Tasks 1–2).
+
+- [ ] **Step 1: Add the lazy-fetch block** (mirror the existing `loadSources` block ~lines 133–161). Imports: `import { citationsApi, sourcesApi, ledgerApi, LQAIApiError } from '$lib/lq-ai/api';` (add `ledgerApi`), `import CitationLedgerPanel from './CitationLedgerPanel.svelte';`, `import TrustPill from './TrustPill.svelte';`, `import { gateBadge } from '$lib/lq-ai/citations/ledger-state';`, and the `ChatLedger`/`LedgerGate` types.
+
+```ts
+let fetchedLedger: import('$lib/lq-ai/types').ChatLedger | null = null;
+let ledgerFetchInflight = false;
+let ledgerPanelOpen = false;
+
+async function loadLedger(chatId: string, messageId: string): Promise<void> {
+	ledgerFetchInflight = true;
+	try {
+		fetchedLedger = await ledgerApi.getChatLedger(chatId, messageId);
+	} catch (e) {
+		if (!(e instanceof LQAIApiError)) console.error(e);
+		fetchedLedger = { chat_id: chatId, entries: [], gates: [] };
+	} finally {
+		ledgerFetchInflight = false;
+	}
+}
+
+$: if (
+	message?.role === 'assistant' &&
+	message.chat_id &&
+	message.id &&
+	!isStreaming &&
+	fetchedLedger === null &&
+	!ledgerFetchInflight
+) {
+	void loadLedger(message.chat_id, message.id);
+}
+
+$: ledgerGate = fetchedLedger?.gates?.[0];
+$: ledgerBadge = gateBadge(ledgerGate);
+```
+
+(Match the exact reactive-guard predicate the existing `loadSources` block uses — copy its `message?.role === 'assistant'` / `!isStreaming` conditions verbatim so the fetch fires at the same lifecycle point.)
+
+- [ ] **Step 2: Render the badge** in the pill row (next to the existing `ProvenancePill kind="caselaw"` ~line 262). The badge shows when there's a gate **or** any entries:
+
+```svelte
+{#if ledgerBadge && (fetchedLedger?.entries.length || ledgerGate)}
+	<TrustPill
+		variant="audit"
+		tone={ledgerBadge.tone}
+		label={ledgerBadge.label}
+		onClick={() => (ledgerPanelOpen = true)}
+	/>
+{/if}
+```
+
+- [ ] **Step 3: Render the panel** near the other panels (~line 338, by `ToolSourcesPanel`):
+
+```svelte
+{#if fetchedLedger}
+	<CitationLedgerPanel
+		entries={fetchedLedger.entries}
+		gate={ledgerGate}
+		open={ledgerPanelOpen}
+		onClose={() => (ledgerPanelOpen = false)}
+	/>
+{/if}
+```
+
+- [ ] **Step 4: check + format + the full frontend test run**
+
+```bash
+cd web && npm run format && npm run check:lq-ai && npm run test:frontend
+```
+Expected: `svelte-check` clean; Vitest green (Task-1 tests + the existing suite, `--passWithNoTests` tolerant).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/lq-ai/components/MessageBubble.svelte
+git commit -s -m "feat(web): wire Citation Ledger badge + trace panel into MessageBubble (P1-C1)
+
+Lazy-fetch getChatLedger per assistant turn (mirrors loadSources);
+render the fiduciary-grade badge (TrustPill, sage/amber/red) in the
+pill row and open CitationLedgerPanel on click. Additive — M2Citations
+and ToolSourcesPanel unchanged. Degrades silently on 404.
+
+Refs ADR 0018 D3/D4.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- API client `getChatLedger(chatId, messageId?)` → Task 1. ✓
+- `verification_status`→state + gate→badge mapping reusing the 5-state palette → Task 1 (`ledger-state.ts`). ✓
+- `LedgerEntryRow` (source identity + passage + offsets + state chip; "consulted" for provenance) → Task 2. ✓
+- `CitationLedgerPanel` (badge + counts + list + empty state, modal pattern) → Task 2. ✓
+- `MessageBubble` lazy-fetch + badge + panel, additive, silent degrade → Task 3. ✓
+- All three gate verdicts → sage/amber/red → Task 1 `gateBadge` + Task 3 badge. ✓
+- No new test dependency; pure-TS unit tests + svelte-check → Global Constraints + task structure. ✓
+
+**Placeholder scan:** Two "inspect/mirror the existing component" notes (chip class names in `M2Citations`; modal structure in `TierDetailsPanel`) are precise reuse instructions with a named source file, not TODOs. The `TrustTone` import fallback is a stated either/or with a concrete default. No "TBD"/"implement later". ✓
+
+**Type consistency:** `getChatLedger`, `ledgerEntryState`, `gateBadge`, and the `ChatLedger`/`LedgerEntry`/`LedgerGate`/`GateBadge` types are defined in Task 1 and consumed with the same names/shapes in Tasks 2–3. `gateBadge.tone` ∈ `TrustTone` matches `TrustPill`'s `tone` prop. ✓
+
+**Note for executor:** confirm the exact reactive-guard condition and the `message` prop shape in `MessageBubble.svelte` (the `loadCitations`/`loadSources` blocks at ~lines 100–161 are the template — copy their guard verbatim). Confirm the chip class names by reading `M2Citations.svelte` before writing `LedgerEntryRow`'s chip. `web` serves a prebuilt bundle — rebuild before manual verification.

--- a/docs/superpowers/specs/2026-06-25-p1c1-ledger-ui-design.md
+++ b/docs/superpowers/specs/2026-06-25-p1c1-ledger-ui-design.md
@@ -1,0 +1,141 @@
+# P1-C1 — Matter/chat-scoped Citation Ledger UI (design)
+
+**Date:** 2026-06-25
+**Milestone:** Fiduciary-grade agentic legal work — Phase 1 (WS-C)
+**Branch:** `feat/fiduciary-p1c1-ledger-ui`
+**Pins:** [ADR 0018](../../adr/0018-citation-ledger-and-fiduciary-grade-output.md) D3 (fiduciary-grade gate), D4 (one-click trace). Consumes the merged **P1-A3** (`GET /api/v1/chats/{chat_id}/ledger`, #223) + **P1-B1** (`gates[]` in that response, #225).
+**Security review:** not required (frontend `web/` only; no gateway, no auth/authz/crypto change).
+
+## Problem
+
+The Citation Ledger is populated and readable (`GET /chats/{chat_id}/ledger` → `{chat_id, entries[], gates[]}`), but nothing renders it. The milestone's whole point — *transparency you can demonstrate, not assert* (ADR 0018 D4: one click from a cited assertion to the exact source and passage read, with verification status visible) — is invisible until there's UI. P1-C1 builds that surface. It does **not** add backend behavior; it consumes what A3/B1 already return.
+
+## Decisions (maintainer-approved 2026-06-25)
+
+- **Per-message inline pill + panel** (not a chat-level drawer). A fiduciary badge on each assistant turn opens a panel showing that turn's ledger entries + verdict. This reuses the established `MessageBubble` lazy-fetch pattern (`loadCitations`/`loadSources`) and the existing 5-state citation rendering, and is turn-scoped to match the `?message_id` filter. A chat-level rollup drawer is deferred (a later DE if wanted).
+- **Additive, not a replacement.** The existing `M2Citations` (inline citation chips) and `ToolSourcesPanel` ("sources consulted") stay. The ledger is the *unified one-click-trace* view alongside them; v1 does not rip out working components.
+- **Reuse the 5-state map.** Ledger entry `verification_status` maps onto the existing `CitationRenderState` (`web/src/lib/lq-ai/citations/state.ts`): `exact_match`/`tolerant_match` → `verified-exact`/`verified-tolerant` (green, "verbatim"); `paraphrase_judge`/`ensemble_strict`/`ensemble_majority` → `verified-paraphrase` (amber, "supported"); `unverified`/`failed`/`provenance` → `unverified`-style (gray). No new states.
+- **Fiduciary badge = `TrustPill`.** The three gate verdicts map to `TrustPill` tones: `fiduciary_grade` → sage; `supported_only` → amber; `flagged` → red. Each carries an `InfoTip`.
+
+## Design
+
+### Component 1 — API client (`web/src/lib/lq-ai/api/ledger.ts`)
+
+Mirrors `citations.ts` (the `apiRequest` wrapper handles auth + 401-refresh + typed errors):
+
+```ts
+import { apiRequest } from './client';
+import type { ChatLedger } from '../types';
+
+export async function getChatLedger(chatId: string, messageId?: string): Promise<ChatLedger> {
+  const q = messageId ? `?message_id=${encodeURIComponent(messageId)}` : '';
+  return apiRequest<ChatLedger>(`/chats/${encodeURIComponent(chatId)}/ledger${q}`);
+}
+```
+
+Re-exported as `ledgerApi` from `web/src/lib/lq-ai/api/index.ts`. Types in `web/src/lib/lq-ai/types` (or a `types.ts` sibling):
+
+```ts
+export interface LedgerPassage { text: string; offset_start: number; offset_end: number; page?: number | null; }
+export interface LedgerSource {
+  kind: string; // kb_document | caselaw | mcp ...
+  source_file_id?: string; opinion_id?: number; cluster_id?: number;
+  label?: string | null; subtitle?: string | null; url?: string | null;
+  external_ref?: string | null; tool?: string | null;
+  passages?: LedgerPassage[];
+}
+export interface LedgerEntry {
+  id: string; message_id: string; source_kind: string;
+  verification_status: string; confidence: number | null;
+  provider: string | null; retrieved_at: string | null;
+  treatment_id: string | null; created_at: string; source: LedgerSource;
+}
+export interface LedgerGate {
+  message_id: string; gate_status: 'fiduciary_grade' | 'supported_only' | 'flagged';
+  pass_count: number; supported_count: number; fail_count: number;
+  total_assertions: number; confidence: number | null; created_at: string;
+}
+export interface ChatLedger { chat_id: string; entries: LedgerEntry[]; gates: LedgerGate[]; }
+```
+
+### Component 2 — Gate→badge + status→state mapping (`web/src/lib/lq-ai/citations/ledger-state.ts`)
+
+Two pure functions (unit-testable, no DOM):
+
+```ts
+import type { CitationRenderState } from './state';
+
+export function ledgerEntryState(status: string): CitationRenderState {
+  switch (status) {
+    case 'exact_match': return 'verified-exact';
+    case 'tolerant_match': return 'verified-tolerant';
+    case 'paraphrase_judge':
+    case 'ensemble_strict':
+    case 'ensemble_majority': return 'verified-paraphrase';
+    default: return 'unverified'; // unverified | failed | provenance | unknown
+  }
+}
+
+export interface GateBadge { tone: 'sage' | 'amber' | 'red'; label: string; tip: string; }
+export function gateBadge(gate: LedgerGate | undefined): GateBadge | null {
+  if (!gate) return null;
+  switch (gate.gate_status) {
+    case 'fiduciary_grade':
+      return { tone: 'sage', label: 'Fiduciary-grade',
+        tip: `Every cited assertion (${gate.pass_count}) is verified verbatim against its source.` };
+    case 'supported_only':
+      return { tone: 'amber', label: 'Supported — not all verbatim',
+        tip: `${gate.supported_count} assertion(s) are supported (paraphrase), not verbatim; none failed.` };
+    case 'flagged':
+      return { tone: 'red', label: 'Unverified claims flagged',
+        tip: `${gate.fail_count} cited assertion(s) could not be verified.` };
+  }
+}
+```
+
+Reusing `CitationRenderState` means the entry chips pick up the existing colors/labels/tooltips for free.
+
+### Component 3 — `LedgerEntryRow.svelte`
+
+One row per `LedgerEntry`: a state chip (color from `ledgerEntryState` → the existing palette), the source identity (file name for `kb_document`, "Cluster N / opinion N" for `caselaw`, label/url for `mcp`), and — when present — the passage(s) read shown as quoted text with a char-offset caption (`chars 1240–1310`). The passage text *is* the one-click trace (the chat owner is entitled to it). Provenance-only entries (no `passages`) render identity + a "consulted" tag, no quote.
+
+### Component 4 — `CitationLedgerPanel.svelte`
+
+Follows the `TierDetailsPanel` modal pattern (`fixed inset-0 z-50` backdrop, focus-trap, Esc-to-close). Header: the gate verdict badge + a one-line count summary (`2 verbatim · 1 supported · 0 unverified`). Body: the list of `LedgerEntryRow`. Footer/empty: "No sources were brought into context for this turn" when `entries` is empty.
+
+### Component 5 — `MessageBubble.svelte` wiring
+
+A new lazy-fetch block alongside `loadCitations`/`loadSources`, fired once per assistant message after streaming completes (`!isStreaming && message.id && message.chat_id && fetchedLedger === null && !ledgerFetchInflight`):
+
+```ts
+fetchedLedger = await ledgerApi.getChatLedger(chatId, messageId); // {entries, gates}
+```
+
+404/empty → `fetchedLedger = { chat_id, entries: [], gates: [] }` (degrade silently, no pill). When `entries.length > 0` **or** a gate exists, render the **fiduciary badge** (`TrustPill` with `gateBadge(gates[0])`) in the message's pill row; `onClick` opens `CitationLedgerPanel`. The badge is the entry point; the panel is the trace.
+
+## Error handling
+
+- 404 / network error → no ledger pill (matches how citations/sources degrade today); never blocks the bubble.
+- A turn with a gate but zero entries (e.g. a chit-chat `fiduciary_grade`/`total_assertions=0`) → render the badge, panel shows the empty-state line (the verdict is still meaningful: "no cited assertions").
+- Unknown `source_kind` / `verification_status` → entry renders with the `unverified` fallback state and its raw identity; never throws.
+
+## Testing
+
+- **Vitest (unit):** `getChatLedger` builds the right path (with/without `messageId`); `ledgerEntryState` maps every status (incl. unknown → `unverified`); `gateBadge` returns the right tone/label for all three verdicts + `null` for undefined.
+- **Component (Vitest + Testing Library or Svelte harness):** `CitationLedgerPanel` renders the correct badge + counts per verdict; `LedgerEntryRow` shows passage + offsets for quote kinds and the "consulted" tag for provenance; empty-entries shows the empty line.
+- **Playwright (optional, e2e):** a seeded chat whose assistant turn has a ledger → the fiduciary badge appears; clicking opens the panel with the entries; the verbatim vs supported chips are visually distinct.
+- Gates: `npm run lint` (ESLint/Prettier) + `svelte-check` + Vitest. **Rebuild the `web` container** before manual verification (it serves a prebuilt static bundle — no HMR).
+
+## Acceptance criteria
+
+1. Each assistant turn with a ledger shows a fiduciary badge reflecting its gate verdict (sage/amber/red); clicking opens a panel listing the turn's entries, each resolved to source identity + passage(s) read + a verification-state chip.
+2. The verbatim (green) vs supported (amber) vs unverified (gray/red) distinction is visible and reuses the existing 5-state rendering — no new state machine.
+3. A turn with no ledger renders no badge; a turn with a gate but no entries renders the badge + an empty-state panel; nothing ever throws on unknown kinds/statuses.
+4. The existing `M2Citations` / `ToolSourcesPanel` are unchanged (additive).
+5. `svelte-check` + lint clean; Vitest unit + component tests green.
+
+## Out of scope / sequencing
+
+- **Chat-level / matter-level ledger rollup drawer** — deferred (file a DE if wanted); v1 is per-turn.
+- **Derived treatment** (`treatment_id`) rendering — WS-G; null today, ignored by the row.
+- **The richer caselaw SUPPORTED/FAIL data** the amber/red chips will show for caselaw arrives with **P1-B1b**; C1 renders whatever statuses the ledger contains, so it works today (KB verbatim + provenance) and gets richer automatically once B1b lands.

--- a/web/src/lib/lq-ai/api/__tests__/ledger.test.ts
+++ b/web/src/lib/lq-ai/api/__tests__/ledger.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getChatLedger } from '../ledger';
+
+function jsonResponseLike(status: number, body: unknown) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		headers: {
+			get: (n: string) => (n.toLowerCase() === 'content-type' ? 'application/json' : null)
+		},
+		json: async () => body
+	};
+}
+
+describe('ledger API client', () => {
+	const fetchMock = vi.fn();
+	let originalFetch: typeof globalThis.fetch;
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+		fetchMock.mockReset();
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it('GETs /chats/{id}/ledger with no message filter', async () => {
+		fetchMock.mockResolvedValue(jsonResponseLike(200, { chat_id: 'c1', entries: [], gates: [] }));
+		const out = await getChatLedger('c1');
+		expect(out.chat_id).toBe('c1');
+		const url = fetchMock.mock.calls[0][0] as string;
+		expect(url).toContain('/chats/c1/ledger');
+		expect(url).not.toContain('message_id');
+	});
+
+	it('appends ?message_id when given (encoded)', async () => {
+		fetchMock.mockResolvedValue(jsonResponseLike(200, { chat_id: 'c1', entries: [], gates: [] }));
+		await getChatLedger('c1', 'm 1');
+		const url = fetchMock.mock.calls[0][0] as string;
+		expect(url).toContain('/chats/c1/ledger?message_id=m%201');
+	});
+});

--- a/web/src/lib/lq-ai/api/index.ts
+++ b/web/src/lib/lq-ai/api/index.ts
@@ -27,3 +27,4 @@ export * as preferencesApi from './preferences';
 export * as usersApi from './users';
 export * as enhancePromptApi from './enhancePrompt';
 export * as autonomousApi from './autonomous';
+export * as ledgerApi from './ledger';

--- a/web/src/lib/lq-ai/api/ledger.ts
+++ b/web/src/lib/lq-ai/api/ledger.ts
@@ -1,0 +1,15 @@
+/**
+ * /api/v1/chats/{chat_id}/ledger — Citation Ledger read surface (P1-A3/B1).
+ *
+ * Returns the turn/chat ledger resolved to source identity + passage(s) read
+ * + verification status + provenance, plus per-turn fiduciary-grade verdicts
+ * (`gates`). Lazy-fetched per assistant message, like citations/sources.
+ */
+import { apiRequest } from './client';
+import type { ChatLedger } from '../types';
+
+/** GET /api/v1/chats/{chat_id}/ledger[?message_id=…] */
+export async function getChatLedger(chatId: string, messageId?: string): Promise<ChatLedger> {
+	const q = messageId ? `?message_id=${encodeURIComponent(messageId)}` : '';
+	return apiRequest<ChatLedger>(`/chats/${encodeURIComponent(chatId)}/ledger${q}`);
+}

--- a/web/src/lib/lq-ai/citations/__tests__/ledger-state.test.ts
+++ b/web/src/lib/lq-ai/citations/__tests__/ledger-state.test.ts
@@ -8,7 +8,7 @@ describe('ledgerEntryState', () => {
 		expect(ledgerEntryState('tolerant_match')).toBe('verified-tolerant');
 	});
 	it('maps judge/ensemble methods to paraphrase (amber)', () => {
-		for (const s of ['paraphrase_judge', 'ensemble_strict', 'ensemble_majority']) {
+		for (const s of ['paraphrase_judge', 'llm_judge', 'ensemble_strict', 'ensemble_majority']) {
 			expect(ledgerEntryState(s)).toBe('verified-paraphrase');
 		}
 	});
@@ -31,6 +31,9 @@ describe('gateBadge', () => {
 	};
 	it('returns null for undefined', () => {
 		expect(gateBadge(undefined)).toBeNull();
+	});
+	it('returns null for an unrecognized gate_status', () => {
+		expect(gateBadge({ ...base, gate_status: 'bogus' as any })).toBeNull();
 	});
 	it('maps each verdict to a tone + label', () => {
 		expect(gateBadge({ ...base, gate_status: 'fiduciary_grade' })?.tone).toBe('sage');

--- a/web/src/lib/lq-ai/citations/__tests__/ledger-state.test.ts
+++ b/web/src/lib/lq-ai/citations/__tests__/ledger-state.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { ledgerEntryState, gateBadge } from '../ledger-state';
+import type { LedgerGate } from '../../types';
+
+describe('ledgerEntryState', () => {
+	it('maps verbatim methods to green states', () => {
+		expect(ledgerEntryState('exact_match')).toBe('verified-exact');
+		expect(ledgerEntryState('tolerant_match')).toBe('verified-tolerant');
+	});
+	it('maps judge/ensemble methods to paraphrase (amber)', () => {
+		for (const s of ['paraphrase_judge', 'ensemble_strict', 'ensemble_majority']) {
+			expect(ledgerEntryState(s)).toBe('verified-paraphrase');
+		}
+	});
+	it('maps unverified/failed/provenance/unknown to unverified', () => {
+		for (const s of ['unverified', 'failed', 'provenance', 'something_new']) {
+			expect(ledgerEntryState(s)).toBe('unverified');
+		}
+	});
+});
+
+describe('gateBadge', () => {
+	const base: Omit<LedgerGate, 'gate_status'> = {
+		message_id: 'm1',
+		pass_count: 2,
+		supported_count: 1,
+		fail_count: 1,
+		total_assertions: 4,
+		confidence: 0.9,
+		created_at: 't'
+	};
+	it('returns null for undefined', () => {
+		expect(gateBadge(undefined)).toBeNull();
+	});
+	it('maps each verdict to a tone + label', () => {
+		expect(gateBadge({ ...base, gate_status: 'fiduciary_grade' })?.tone).toBe('sage');
+		expect(gateBadge({ ...base, gate_status: 'supported_only' })?.tone).toBe('amber');
+		expect(gateBadge({ ...base, gate_status: 'flagged' })?.tone).toBe('red');
+		expect(gateBadge({ ...base, gate_status: 'flagged' })?.label).toBeTruthy();
+	});
+});

--- a/web/src/lib/lq-ai/citations/ledger-state.ts
+++ b/web/src/lib/lq-ai/citations/ledger-state.ts
@@ -60,5 +60,7 @@ export function gateBadge(gate: LedgerGate | undefined): GateBadge | null {
 				label: 'Unverified claims flagged',
 				tip: `${gate.fail_count} cited assertion(s) could not be verified.`
 			};
+		default:
+			return null;
 	}
 }

--- a/web/src/lib/lq-ai/citations/ledger-state.ts
+++ b/web/src/lib/lq-ai/citations/ledger-state.ts
@@ -1,0 +1,64 @@
+/**
+ * Ledger entry status → CitationRenderState, and gate verdict → badge.
+ *
+ * Reuses the M2-C2 5-state palette (state.ts) so ledger entry chips pick up
+ * the existing colors/labels/tooltips. Operates on the ledger's
+ * `verification_status` string directly (the ledger mirrors the cascade
+ * method onto the entry), so no Citation row is needed.
+ *
+ * TrustTone is defined locally (subset of TrustPill.svelte's union) to keep
+ * `npm run check:lq-ai` clean — importing types from a `.svelte` module
+ * context="module" block is awkward in pure TS files.
+ */
+import type { CitationRenderState } from './state';
+import type { LedgerGate } from '../types';
+
+// Local subset — matches TrustPill.svelte's TrustTone union exactly.
+type TrustTone = 'sage' | 'slate' | 'amber' | 'red' | 'neutral';
+
+export function ledgerEntryState(status: string): CitationRenderState {
+	switch (status) {
+		case 'exact_match':
+			return 'verified-exact';
+		case 'tolerant_match':
+			return 'verified-tolerant';
+		case 'paraphrase_judge':
+		case 'llm_judge':
+		case 'ensemble_strict':
+		case 'ensemble_majority':
+			return 'verified-paraphrase';
+		default:
+			// unverified | failed | provenance | unknown — conservative gray.
+			return 'unverified';
+	}
+}
+
+export interface GateBadge {
+	tone: TrustTone;
+	label: string;
+	tip: string;
+}
+
+export function gateBadge(gate: LedgerGate | undefined): GateBadge | null {
+	if (!gate) return null;
+	switch (gate.gate_status) {
+		case 'fiduciary_grade':
+			return {
+				tone: 'sage',
+				label: 'Fiduciary-grade',
+				tip: `Every cited assertion (${gate.pass_count}) is verified verbatim against its source.`
+			};
+		case 'supported_only':
+			return {
+				tone: 'amber',
+				label: 'Supported — not all verbatim',
+				tip: `${gate.supported_count} assertion(s) are supported (paraphrase), not verbatim; none failed.`
+			};
+		case 'flagged':
+			return {
+				tone: 'red',
+				label: 'Unverified claims flagged',
+				tip: `${gate.fail_count} cited assertion(s) could not be verified.`
+			};
+	}
+}

--- a/web/src/lib/lq-ai/components/CitationLedgerPanel.svelte
+++ b/web/src/lib/lq-ai/components/CitationLedgerPanel.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+	/**
+	 * CitationLedgerPanel — fiduciary-grade citation trace modal (P1-C1).
+	 *
+	 * Modal structure mirrors TierDetailsPanel.svelte (fixed inset-0 z-50,
+	 * backdrop click and Esc-to-close via onMount document listener, role="dialog"
+	 * aria-modal). Header carries the gateBadge TrustPill + InfoTip + per-tier
+	 * counts. Body is a list of LedgerEntryRow components.
+	 *
+	 * Props:
+	 *   entries  — ledger entries for this message turn.
+	 *   gate     — gate verdict row (undefined when no gate was computed).
+	 *   open     — whether the panel is visible.
+	 *   onClose  — callback invoked on Esc or backdrop click.
+	 *
+	 * Refs ADR 0018 D4.
+	 */
+	import { onMount } from 'svelte';
+	import type { LedgerEntry, LedgerGate } from '../types';
+	import { gateBadge } from '../citations/ledger-state';
+	import TrustPill from './TrustPill.svelte';
+	import InfoTip from './InfoTip.svelte';
+	import LedgerEntryRow from './LedgerEntryRow.svelte';
+
+	export let entries: LedgerEntry[] = [];
+	export let gate: LedgerGate | undefined = undefined;
+	export let open = false;
+	export let onClose: () => void;
+
+	$: badge = gateBadge(gate);
+
+	function handleKeydown(event: KeyboardEvent): void {
+		if (event.key === 'Escape') onClose();
+	}
+
+	function handleBackdropClick(event: MouseEvent): void {
+		if (event.target === event.currentTarget) onClose();
+	}
+
+	onMount(() => {
+		document.addEventListener('keydown', handleKeydown);
+		return () => document.removeEventListener('keydown', handleKeydown);
+	});
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+		on:click={handleBackdropClick}
+		on:keydown={handleKeydown}
+		role="dialog"
+		aria-modal="true"
+		aria-label="Citation ledger"
+		tabindex="-1"
+		data-testid="lq-ledger-backdrop"
+	>
+		<!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
+		<div
+			class="bg-white dark:bg-gray-900 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-lg w-full lq-ledger-panel"
+			on:click|stopPropagation
+			data-testid="lq-ledger-panel"
+		>
+			<header class="lq-ledger-header">
+				<div class="lq-ledger-header-top">
+					{#if badge}
+						<TrustPill variant="audit" tone={badge.tone} label={badge.label} />
+						<InfoTip content={badge.tip} />
+					{:else}
+						<span class="lq-ledger-no-gate">No gate verdict</span>
+					{/if}
+					<button
+						type="button"
+						class="lq-ledger-close"
+						on:click={onClose}
+						aria-label="Close citation ledger"
+						data-testid="lq-ledger-close"
+					>
+						&times;
+					</button>
+				</div>
+				{#if gate}
+					<p class="lq-ledger-counts">
+						{gate.pass_count} verbatim · {gate.supported_count} supported · {gate.fail_count} unverified
+					</p>
+				{/if}
+			</header>
+
+			<div class="lq-ledger-body">
+				{#if entries.length > 0}
+					<ul class="lq-ledger-list">
+						{#each entries as e (e.id)}
+							<LedgerEntryRow entry={e} />
+						{/each}
+					</ul>
+				{:else}
+					<p class="lq-ledger-empty">No sources were brought into context for this turn.</p>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.lq-ledger-panel {
+		max-height: 80vh;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	.lq-ledger-header {
+		padding: var(--lq-space-4);
+		border-bottom: 1px solid var(--lq-border);
+		flex-shrink: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-2);
+	}
+
+	.lq-ledger-header-top {
+		display: flex;
+		align-items: center;
+		gap: var(--lq-space-2);
+	}
+
+	.lq-ledger-no-gate {
+		font-size: 13px;
+		color: var(--lq-text-tertiary);
+		font-style: italic;
+	}
+
+	.lq-ledger-close {
+		margin-left: auto;
+		background: transparent;
+		border: none;
+		font-size: 1.25rem;
+		line-height: 1;
+		color: var(--lq-text-secondary);
+		cursor: pointer;
+		padding: 0 2px;
+		border-radius: var(--lq-radius-sm);
+	}
+	.lq-ledger-close:hover {
+		color: var(--lq-text);
+	}
+	.lq-ledger-close:focus-visible {
+		outline: 2px solid var(--lq-accent);
+		outline-offset: 2px;
+	}
+
+	.lq-ledger-counts {
+		font-size: 12px;
+		color: var(--lq-text-secondary);
+		margin: 0;
+	}
+
+	.lq-ledger-body {
+		overflow-y: auto;
+		padding: 0 var(--lq-space-4);
+		flex: 1 1 auto;
+	}
+
+	.lq-ledger-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.lq-ledger-empty {
+		padding: var(--lq-space-6) 0;
+		font-size: 13px;
+		color: var(--lq-text-tertiary);
+		font-style: italic;
+		text-align: center;
+		margin: 0;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/CitationLedgerPanel.svelte
+++ b/web/src/lib/lq-ai/components/CitationLedgerPanel.svelte
@@ -37,10 +37,12 @@
 		if (event.target === event.currentTarget) onClose();
 	}
 
-	onMount(() => {
-		document.addEventListener('keydown', handleKeydown);
-		return () => document.removeEventListener('keydown', handleKeydown);
-	});
+	$: if (typeof document !== 'undefined') {
+		if (open) document.addEventListener('keydown', handleKeydown);
+		else document.removeEventListener('keydown', handleKeydown);
+	}
+
+	onMount(() => () => document.removeEventListener('keydown', handleKeydown));
 </script>
 
 {#if open}

--- a/web/src/lib/lq-ai/components/LedgerEntryRow.svelte
+++ b/web/src/lib/lq-ai/components/LedgerEntryRow.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+	/**
+	 * LedgerEntryRow — one row in the Citation Ledger panel (P1-C1).
+	 *
+	 * Renders the verification-state chip (reusing M2Citations' `lq-m2-cite-chip`
+	 * + `state-*` classes), source identity, optional URL, and passage blockquotes.
+	 * All state logic is delegated to the Task-1 helper `ledgerEntryState`.
+	 *
+	 * Refs ADR 0018 D3.
+	 */
+	import type { LedgerEntry } from '../types';
+	import { ledgerEntryState } from '../citations/ledger-state';
+
+	export let entry: LedgerEntry;
+
+	$: state = ledgerEntryState(entry.verification_status);
+	$: src = entry.source;
+
+	function identity(): string {
+		if (src.kind === 'kb_document') return 'Document';
+		if (src.kind === 'caselaw')
+			return `Opinion ${src.opinion_id ?? ''} · cluster ${src.cluster_id ?? ''}`.trim();
+		return src.label ?? src.tool ?? src.kind;
+	}
+</script>
+
+<li class="lq-ledger-row">
+	<div class="lq-ledger-row-header">
+		<!-- Reuse the M2Citations chip class + the state-* class directives from M2Citations.svelte. -->
+		<span
+			class="lq-m2-cite-chip lq-ledger-chip"
+			class:state-verified-exact={state === 'verified-exact'}
+			class:state-verified-tolerant={state === 'verified-tolerant'}
+			class:state-verified-paraphrase={state === 'verified-paraphrase'}
+			class:state-unverified={state === 'unverified'}
+			data-state={state}
+		>
+			{entry.verification_status}
+		</span>
+		<span class="lq-ledger-identity">{identity()}</span>
+		{#if src.url}
+			<a class="lq-ledger-url" href={src.url} target="_blank" rel="noopener noreferrer">source ↗</a>
+		{/if}
+	</div>
+
+	{#if src.passages && src.passages.length > 0}
+		{#each src.passages as p}
+			<blockquote class="lq-ledger-passage">
+				<span class="lq-ledger-passage-text">{p.text}</span>
+				<cite class="lq-ledger-offset">chars {p.offset_start}–{p.offset_end}</cite>
+			</blockquote>
+		{/each}
+	{:else}
+		<span class="lq-ledger-consulted">consulted</span>
+	{/if}
+</li>
+
+<style>
+	.lq-ledger-row {
+		list-style: none;
+		padding: var(--lq-space-3) 0;
+		border-bottom: 1px solid var(--lq-border);
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-2);
+	}
+	.lq-ledger-row:last-child {
+		border-bottom: none;
+	}
+
+	.lq-ledger-row-header {
+		display: flex;
+		align-items: center;
+		gap: var(--lq-space-2);
+		flex-wrap: wrap;
+	}
+
+	/* Override the button cursor — this chip is display-only in the ledger. */
+	.lq-ledger-chip {
+		cursor: default;
+		font-size: 11px;
+		padding: 1px 7px;
+		/* Inherit the state color from M2Citations' state-* rules. */
+	}
+
+	.lq-ledger-identity {
+		font-size: 13px;
+		font-weight: 500;
+		color: var(--lq-text);
+	}
+
+	.lq-ledger-url {
+		font-size: 12px;
+		color: var(--lq-accent);
+		text-decoration: none;
+		margin-left: auto;
+	}
+	.lq-ledger-url:hover {
+		text-decoration: underline;
+	}
+
+	.lq-ledger-passage {
+		margin: 0;
+		padding: var(--lq-space-2) var(--lq-space-3);
+		border-left: 3px solid var(--lq-border-strong);
+		background: var(--lq-inset);
+		border-radius: 0 var(--lq-radius-sm) var(--lq-radius-sm) 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-1);
+	}
+
+	.lq-ledger-passage-text {
+		font-size: 12px;
+		line-height: 1.5;
+		color: var(--lq-text);
+	}
+
+	.lq-ledger-offset {
+		font-size: 10px;
+		color: var(--lq-text-tertiary);
+		font-style: normal;
+	}
+
+	.lq-ledger-consulted {
+		font-size: 11px;
+		color: var(--lq-text-tertiary);
+		font-style: italic;
+		padding-left: var(--lq-space-1);
+	}
+</style>

--- a/web/src/lib/lq-ai/components/LedgerEntryRow.svelte
+++ b/web/src/lib/lq-ai/components/LedgerEntryRow.svelte
@@ -75,12 +75,66 @@
 		flex-wrap: wrap;
 	}
 
-	/* Override the button cursor — this chip is display-only in the ledger. */
-	.lq-ledger-chip {
+	/* Chip shape — reproduced locally because Svelte scopes <style> to its
+	   own component; M2Citations' .lq-m2-cite-chip rules never apply here. */
+	.lq-m2-cite-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 8px;
+		border-radius: 9999px;
+		border: 1px solid transparent;
+		background: transparent;
+		font: inherit;
 		cursor: default;
+		max-width: 360px;
+		transition:
+			background-color 0.15s ease,
+			border-color 0.15s ease;
+	}
+
+	/* Override padding/font-size for the ledger context. */
+	.lq-ledger-chip {
 		font-size: 11px;
 		padding: 1px 7px;
-		/* Inherit the state color from M2Citations' state-* rules. */
+	}
+
+	/* verified-exact + verified-tolerant: emerald (same tokens as M2Citations) */
+	.state-verified-exact,
+	.state-verified-tolerant {
+		color: #047857; /* emerald-700 */
+		background-color: rgba(16, 185, 129, 0.08);
+		border-color: rgba(16, 185, 129, 0.32);
+	}
+	:global(.dark) .state-verified-exact,
+	:global(.dark) .state-verified-tolerant {
+		color: #6ee7b7; /* emerald-300 */
+		background-color: rgba(16, 185, 129, 0.12);
+		border-color: rgba(16, 185, 129, 0.36);
+	}
+
+	/* verified-paraphrase: amber */
+	.state-verified-paraphrase {
+		color: #b45309; /* amber-700 */
+		background-color: rgba(245, 158, 11, 0.08);
+		border-color: rgba(245, 158, 11, 0.32);
+	}
+	:global(.dark) .state-verified-paraphrase {
+		color: #fcd34d; /* amber-300 */
+		background-color: rgba(245, 158, 11, 0.12);
+		border-color: rgba(245, 158, 11, 0.36);
+	}
+
+	/* unverified: gray */
+	.state-unverified {
+		color: #6b7280; /* gray-500 */
+		background-color: rgba(107, 114, 128, 0.08);
+		border-color: rgba(107, 114, 128, 0.32);
+	}
+	:global(.dark) .state-unverified {
+		color: #9ca3af; /* gray-400 */
+		background-color: rgba(107, 114, 128, 0.16);
+		border-color: rgba(107, 114, 128, 0.36);
 	}
 
 	.lq-ledger-identity {

--- a/web/src/lib/lq-ai/components/MessageBubble.svelte
+++ b/web/src/lib/lq-ai/components/MessageBubble.svelte
@@ -18,10 +18,11 @@
 	import { marked } from 'marked';
 
 	import { captureAffordanceInline } from '$lib/lq-ai/preferences/capture-affordance';
-	import { citationsApi, sourcesApi, LQAIApiError } from '$lib/lq-ai/api';
+	import { citationsApi, sourcesApi, ledgerApi, LQAIApiError } from '$lib/lq-ai/api';
 	import { decorateCitationsInline } from '$lib/lq-ai/citations/decorate-inline';
+	import { gateBadge } from '$lib/lq-ai/citations/ledger-state';
 
-	import type { Citation, Message, ToolSource } from '../types';
+	import type { Citation, Message, ToolSource, ChatLedger, LedgerGate } from '../types';
 	import AppliedSkillsChip from './AppliedSkillsChip.svelte';
 	import CaptureSkillModal from './CaptureSkillModal.svelte';
 	import EnhancedDiffModal from './EnhancedDiffModal.svelte';
@@ -33,6 +34,8 @@
 	import TierDetailsPanel from './TierDetailsPanel.svelte';
 	import ToolGatePrompt from './ToolGatePrompt.svelte';
 	import ToolSourcesPanel, { sourcesPillLabel } from './ToolSourcesPanel.svelte';
+	import CitationLedgerPanel from './CitationLedgerPanel.svelte';
+	import TrustPill from './TrustPill.svelte';
 	import type { PendingGate } from '../chat/toolGate';
 
 	export let message: Message;
@@ -161,12 +164,47 @@
 		void loadSources(message.chat_id, message.id);
 	}
 
+	// P1-C1 — Citation Ledger. Lazy-fetch per-message ledger from
+	// `GET /chats/{chat_id}/ledger?message_id={id}` once the assistant
+	// message has finished streaming (mirrors loadSources above).
+	// `fetchedLedger === null` means "not yet fetched"; `{ entries: [], gates: [] }`
+	// means "fetched, no rows". Degrades silently on error.
+	let fetchedLedger: ChatLedger | null = null;
+	let ledgerFetchInflight = false;
+	let ledgerPanelOpen = false;
+
+	async function loadLedger(chatId: string, messageId: string): Promise<void> {
+		ledgerFetchInflight = true;
+		try {
+			fetchedLedger = await ledgerApi.getChatLedger(chatId, messageId);
+		} catch (e) {
+			if (!(e instanceof LQAIApiError)) console.error(e);
+			fetchedLedger = { chat_id: chatId, entries: [], gates: [] };
+		} finally {
+			ledgerFetchInflight = false;
+		}
+	}
+
+	$: if (
+		message.role === 'assistant' &&
+		message.id &&
+		message.chat_id &&
+		!isStreaming &&
+		fetchedLedger === null &&
+		!ledgerFetchInflight
+	) {
+		void loadLedger(message.chat_id, message.id);
+	}
+
+	$: ledgerGate = fetchedLedger?.gates?.[0] as LedgerGate | undefined;
+	$: ledgerBadge = gateBadge(ledgerGate);
+
 	$: bubbleClasses =
 		message.role === 'user'
 			? 'bg-indigo-600 text-white self-end'
 			: message.role === 'assistant'
-			? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700 self-start'
-			: 'bg-gray-100 text-gray-700 self-center text-sm';
+				? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700 self-start'
+				: 'bg-gray-100 text-gray-700 self-center text-sm';
 
 	$: rendered =
 		message.role === 'assistant'
@@ -175,10 +213,7 @@
 </script>
 
 {#if message.kind === 'refusal'}
-	<div
-		class="flex flex-col max-w-3xl items-start mb-3"
-		data-testid={`lq-ai-message-${message.id}`}
-	>
+	<div class="flex flex-col max-w-3xl items-start mb-3" data-testid={`lq-ai-message-${message.id}`}>
 		<RefusalMessageBubble
 			{message}
 			{currentUserRole}
@@ -188,136 +223,144 @@
 		/>
 	</div>
 {:else}
-<div class="flex flex-col max-w-3xl {message.role === 'user' ? 'items-end' : 'items-start'} mb-3" data-testid={`lq-ai-message-${message.id}`}>
-	<div class="rounded-lg px-3 py-2 {bubbleClasses} max-w-full">
-		{#if message.role === 'assistant'}
-			<div
-				class="prose prose-sm dark:prose-invert max-w-none"
-				data-testid="lq-ai-message-content"
-				use:decorateCitationsInline={{
-					citations: fetchedCitations ?? [],
-					enabled: !isStreaming
-				}}
-			>
-				{@html rendered}
-			</div>
-			{#if isStreaming}
-				<div class="mt-1 text-xs text-gray-500 italic">Streaming…</div>
+	<div
+		class="flex flex-col max-w-3xl {message.role === 'user' ? 'items-end' : 'items-start'} mb-3"
+		data-testid={`lq-ai-message-${message.id}`}
+	>
+		<div class="rounded-lg px-3 py-2 {bubbleClasses} max-w-full">
+			{#if message.role === 'assistant'}
+				<div
+					class="prose prose-sm dark:prose-invert max-w-none"
+					data-testid="lq-ai-message-content"
+					use:decorateCitationsInline={{
+						citations: fetchedCitations ?? [],
+						enabled: !isStreaming
+					}}
+				>
+					{@html rendered}
+				</div>
+				{#if isStreaming}
+					<div class="mt-1 text-xs text-gray-500 italic">Streaming…</div>
+				{/if}
+			{:else}
+				<div class="whitespace-pre-wrap text-sm" data-testid="lq-ai-message-content">
+					{message.content}
+				</div>
 			{/if}
-		{:else}
-			<div class="whitespace-pre-wrap text-sm" data-testid="lq-ai-message-content">
-				{message.content}
-			</div>
-		{/if}
-	</div>
-
-	{#if gateForMessage}
-		<div class="mt-2 w-full max-w-full" data-testid="lq-ai-tool-gate">
-			<ToolGatePrompt
-				variant={gateForMessage.kind}
-				confirm={gateForMessage.kind === 'confirm' ? gateForMessage.frame : null}
-				connect={gateForMessage.kind === 'connect' ? gateForMessage.frame : null}
-				busy={gateBusy}
-				onApprove={onGateApprove}
-				onDeny={onGateDeny}
-				onConnect={onGateConnect}
-			/>
 		</div>
-	{/if}
 
-	{#if message.role === 'user' && message.is_enhanced}
-		<div
-			class="mt-1 flex items-center gap-2 flex-wrap justify-end"
-			data-testid="provenance-pill-enhanced"
-		>
-			<ProvenancePill
-				kind="enhanced"
-				summary="enhanced"
-				onTap={() => (enhancedDiffOpen = true)}
-			/>
-		</div>
-		{#if enhancedDiffOpen}
-			<EnhancedDiffModal
-				original={originalEnhancedPrompt}
-				enhanced={message.content}
-				on:close={() => (enhancedDiffOpen = false)}
-			/>
-		{/if}
-	{/if}
-
-	{#if message.role === 'assistant'}
-		<div class="mt-1 flex items-center gap-2 flex-wrap justify-start w-full">
-			<div class="flex items-center gap-2 flex-wrap">
-				{#if message.routed_inference_tier}
-					<TierBadge
-						tier={message.routed_inference_tier}
-						provider={message.routed_provider ?? null}
-						on:open={() => (tierDetailsOpen = true)}
-					/>
-				{/if}
-				<AppliedSkillsChip
-					appliedSkills={message.applied_skills ?? []}
-					onSkillClicked={onAppliedSkillClicked}
-				/>
-				{#if fetchedSources && fetchedSources.length > 0}
-					<ProvenancePill kind="caselaw" summary={sourcesPillLabel(fetchedSources.length)} />
-				{/if}
-			</div>
-			<div class="flex items-center gap-1">
-				{#if $captureAffordanceInline}
-					<button
-						type="button"
-						class="text-base leading-none px-2 py-1 rounded text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
-						aria-label={isStreaming
-							? 'Capture as skill (available when streaming completes)'
-							: 'Capture as skill'}
-						title={isStreaming
-							? 'Capture as skill (available when streaming completes)'
-							: 'Capture as skill'}
-						disabled={isStreaming}
-						data-testid="lq-ai-message-capture-inline"
-						on:click={() => (captureOpen = true)}
-					>📝</button>
-				{/if}
-				<MessageOverflowMenu
-					captureInOverflow={!$captureAffordanceInline}
-					captureDisabled={isStreaming}
-					onCapture={() => (captureOpen = true)}
+		{#if gateForMessage}
+			<div class="mt-2 w-full max-w-full" data-testid="lq-ai-tool-gate">
+				<ToolGatePrompt
+					variant={gateForMessage.kind}
+					confirm={gateForMessage.kind === 'confirm' ? gateForMessage.frame : null}
+					connect={gateForMessage.kind === 'connect' ? gateForMessage.frame : null}
+					busy={gateBusy}
+					onApprove={onGateApprove}
+					onDeny={onGateDeny}
+					onConnect={onGateConnect}
 				/>
 			</div>
-		</div>
-
-		{#if captureOpen}
-			<CaptureSkillModal
-				sourceMessage={message}
-				onClose={() => (captureOpen = false)}
-			/>
 		{/if}
 
-		{#if tierDetailsOpen}
-			<TierDetailsPanel
-				tier={message.routed_inference_tier ?? null}
-				provider={message.routed_provider ?? null}
-				model={message.routed_model ?? null}
-				requestedModel={message.requested_model ?? null}
-				promptTokens={message.prompt_tokens ?? null}
-				completionTokens={message.completion_tokens ?? null}
-				costEstimate={message.cost_estimate ?? null}
-				on:close={() => (tierDetailsOpen = false)}
-			/>
-		{/if}
-
-		{#if message.error_code}
+		{#if message.role === 'user' && message.is_enhanced}
 			<div
-				class="mt-2 px-2 py-1 rounded border border-rose-300 bg-rose-50 text-rose-800 text-xs max-w-full"
-				data-testid="lq-ai-message-error"
+				class="mt-1 flex items-center gap-2 flex-wrap justify-end"
+				data-testid="provenance-pill-enhanced"
 			>
-				Error: <strong>{message.error_code}</strong>. The assistant message was persisted with the
-				partial content above for audit.
+				<ProvenancePill
+					kind="enhanced"
+					summary="enhanced"
+					onTap={() => (enhancedDiffOpen = true)}
+				/>
 			</div>
+			{#if enhancedDiffOpen}
+				<EnhancedDiffModal
+					original={originalEnhancedPrompt}
+					enhanced={message.content}
+					on:close={() => (enhancedDiffOpen = false)}
+				/>
+			{/if}
 		{/if}
 
-		<!--
+		{#if message.role === 'assistant'}
+			<div class="mt-1 flex items-center gap-2 flex-wrap justify-start w-full">
+				<div class="flex items-center gap-2 flex-wrap">
+					{#if message.routed_inference_tier}
+						<TierBadge
+							tier={message.routed_inference_tier}
+							provider={message.routed_provider ?? null}
+							on:open={() => (tierDetailsOpen = true)}
+						/>
+					{/if}
+					<AppliedSkillsChip
+						appliedSkills={message.applied_skills ?? []}
+						onSkillClicked={onAppliedSkillClicked}
+					/>
+					{#if fetchedSources && fetchedSources.length > 0}
+						<ProvenancePill kind="caselaw" summary={sourcesPillLabel(fetchedSources.length)} />
+					{/if}
+					{#if ledgerBadge && (fetchedLedger?.entries.length || ledgerGate)}
+						<TrustPill
+							variant="audit"
+							tone={ledgerBadge.tone}
+							label={ledgerBadge.label}
+							onClick={() => (ledgerPanelOpen = true)}
+						/>
+					{/if}
+				</div>
+				<div class="flex items-center gap-1">
+					{#if $captureAffordanceInline}
+						<button
+							type="button"
+							class="text-base leading-none px-2 py-1 rounded text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+							aria-label={isStreaming
+								? 'Capture as skill (available when streaming completes)'
+								: 'Capture as skill'}
+							title={isStreaming
+								? 'Capture as skill (available when streaming completes)'
+								: 'Capture as skill'}
+							disabled={isStreaming}
+							data-testid="lq-ai-message-capture-inline"
+							on:click={() => (captureOpen = true)}>📝</button
+						>
+					{/if}
+					<MessageOverflowMenu
+						captureInOverflow={!$captureAffordanceInline}
+						captureDisabled={isStreaming}
+						onCapture={() => (captureOpen = true)}
+					/>
+				</div>
+			</div>
+
+			{#if captureOpen}
+				<CaptureSkillModal sourceMessage={message} onClose={() => (captureOpen = false)} />
+			{/if}
+
+			{#if tierDetailsOpen}
+				<TierDetailsPanel
+					tier={message.routed_inference_tier ?? null}
+					provider={message.routed_provider ?? null}
+					model={message.routed_model ?? null}
+					requestedModel={message.requested_model ?? null}
+					promptTokens={message.prompt_tokens ?? null}
+					completionTokens={message.completion_tokens ?? null}
+					costEstimate={message.cost_estimate ?? null}
+					on:close={() => (tierDetailsOpen = false)}
+				/>
+			{/if}
+
+			{#if message.error_code}
+				<div
+					class="mt-2 px-2 py-1 rounded border border-rose-300 bg-rose-50 text-rose-800 text-xs max-w-full"
+					data-testid="lq-ai-message-error"
+				>
+					Error: <strong>{message.error_code}</strong>. The assistant message was persisted with the
+					partial content above for audit.
+				</div>
+			{/if}
+
+			<!--
 			M2-C2 — Citation Engine sidecar chip list. Renders one chip per
 			`"<quote>" (Source: [N])` marker the assistant emitted, joined
 			to its persisted MessageCitation row. Markers without a row are
@@ -326,18 +369,24 @@
 			message has no citation markers — older skills + non-RAG turns
 			stay visually unchanged.
 		-->
-		{#if fetchedCitations !== null}
-			<div data-testid="lq-ai-message-citations">
-				<M2Citations
-					citations={fetchedCitations}
-					messageContent={message.content}
-				/>
-			</div>
-		{/if}
+			{#if fetchedCitations !== null}
+				<div data-testid="lq-ai-message-citations">
+					<M2Citations citations={fetchedCitations} messageContent={message.content} />
+				</div>
+			{/if}
 
-		{#if fetchedSources && fetchedSources.length > 0}
-			<ToolSourcesPanel sources={fetchedSources} />
+			{#if fetchedSources && fetchedSources.length > 0}
+				<ToolSourcesPanel sources={fetchedSources} />
+			{/if}
+
+			{#if fetchedLedger}
+				<CitationLedgerPanel
+					entries={fetchedLedger.entries}
+					gate={ledgerGate}
+					open={ledgerPanelOpen}
+					onClose={() => (ledgerPanelOpen = false)}
+				/>
+			{/if}
 		{/if}
-	{/if}
-</div>
+	</div>
 {/if}

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -1260,3 +1260,52 @@ export interface TabularPreviewCostResponse {
 	estimated_cost_usd: string;
 	per_tier_breakdown: Record<string, number>;
 }
+
+// ----- Citation Ledger (P1-A3 / P1-C1) -----
+
+export interface LedgerPassage {
+	text: string;
+	offset_start: number;
+	offset_end: number;
+	page?: number | null;
+}
+export interface LedgerSource {
+	kind: string; // kb_document | caselaw | mcp | ...
+	source_file_id?: string;
+	opinion_id?: number;
+	cluster_id?: number;
+	label?: string | null;
+	subtitle?: string | null;
+	url?: string | null;
+	external_ref?: string | null;
+	tool?: string | null;
+	passages?: LedgerPassage[];
+}
+export interface LedgerEntry {
+	id: string;
+	message_id: string;
+	source_kind: string;
+	verification_status: string;
+	confidence: number | null;
+	provider: string | null;
+	retrieved_at: string | null;
+	treatment_id: string | null;
+	created_at: string;
+	source: LedgerSource;
+}
+export type GateStatus = 'fiduciary_grade' | 'supported_only' | 'flagged';
+export interface LedgerGate {
+	message_id: string;
+	gate_status: GateStatus;
+	pass_count: number;
+	supported_count: number;
+	fail_count: number;
+	total_assertions: number;
+	confidence: number | null;
+	created_at: string;
+}
+export interface ChatLedger {
+	chat_id: string;
+	entries: LedgerEntry[];
+	gates: LedgerGate[];
+}


### PR DESCRIPTION
## P1-C1 — Citation Ledger UI

The transparency payoff made visible: a per-assistant-turn **fiduciary badge** that opens a **one-click-trace panel** listing every source the turn brought into context — resolved to the passage read and its verification state. Consumes the merged `GET /api/v1/chats/{chat_id}/ledger` (`{entries, gates}`). Frontend-only (`web/`), **not security-gated**. Milestone: fiduciary-grade agentic legal work, Phase 1 (WS-C).

### What's here
- **`api/ledger.ts`** — `getChatLedger(chatId, messageId?)` via the canonical `apiRequest` wrapper.
- **`citations/ledger-state.ts`** — pure, unit-tested helpers: `ledgerEntryState(status)` reuses the existing M2-C2 5-state palette (verbatim→green, supported→amber, unverified→gray); `gateBadge(gate)` maps the verdict to a `TrustPill` tone (`fiduciary_grade`→sage, `supported_only`→amber, `flagged`→red).
- **`CitationLedgerPanel.svelte` + `LedgerEntryRow.svelte`** — a `TierDetailsPanel`-style trace modal: gate badge + per-tier counts header, one row per entry (source identity + the passage(s) read with char offsets + a verification-state chip), empty-state line.
- **`MessageBubble.svelte`** — lazy-fetch per assistant turn (mirrors `loadSources`), render the badge in the pill row, open the panel on click. **Additive** — `M2Citations`/`ToolSourcesPanel` untouched; degrades silently on 404.

### Posture
- **No new dependencies / no component-test harness.** All branching logic lives in pure, unit-tested helpers; the `.svelte` files are thin and verified by `svelte-check` — matching the codebase's testing convention.
- **No XSS surface** — all ledger text renders via Svelte's auto-escaped `{...}`; no `{@html}`; the source URL link carries `rel="noopener noreferrer"`.
- The richer **caselaw SUPPORTED** (amber) state arrives with **P1-B1b**; C1 renders whatever statuses the ledger contains, so it works today (KB verbatim + provenance) and gets richer automatically.

### Review
Built via brainstorm → spec → plan → subagent-driven-development (per-task spec+quality reviews + an Opus whole-branch review). The Opus review caught a Svelte CSS-scoping bug — the entry chip reused M2Citations' component-scoped `.state-*` classes, which silently no-op'd the verification colors (the feature's core distinction); fixed by defining the chip + 4 state colors (incl. dark mode) locally. `svelte-check` 0 errors; ledger unit tests + the existing 728-test suite green.

> **Manual visual QA recommended at merge:** CSS class resolution isn't covered by any automated gate — worth opening the panel once to confirm the chips render colored (the fix makes this correct by construction, but a glance confirms it). The `web` container serves a prebuilt bundle — rebuild before checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Spec: `docs/superpowers/specs/2026-06-25-p1c1-ledger-ui-design.md` · Plan: `docs/superpowers/plans/2026-06-25-p1c1-ledger-ui.md` · Refs ADR 0018 D3/D4.
