### PR TITLE
feat(citation): caselaw paraphrase/content judge — SUPPORTED tier (P1-B1b)

### DIFF
--- a/api/alembic/versions/0060_caselaw_method_paraphrase.py
+++ b/api/alembic/versions/0060_caselaw_method_paraphrase.py
@@ -1,0 +1,38 @@
+"""relax message_caselaw_citations method CHECK to allow paraphrase_judge (P1-B1b)
+
+Revision ID: 0060
+Revises: 0059
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0060"
+down_revision: str | None = "0059"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NAME = "chk_message_caselaw_citations_method_values"
+_TABLE = "message_caselaw_citations"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_NAME, _TABLE, type_="check")
+    op.create_check_constraint(
+        _NAME,
+        _TABLE,
+        "verification_method IS NULL OR verification_method IN "
+        "('exact_match', 'tolerant_match', 'paraphrase_judge')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_NAME, _TABLE, type_="check")
+    op.create_check_constraint(
+        _NAME,
+        _TABLE,
+        "verification_method IS NULL OR verification_method IN ('exact_match', 'tolerant_match')",
+    )

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -2922,6 +2922,7 @@ async def _non_streaming_response(
                     message_id=assistant_message_id,
                     assistant_text=outcome.text,
                     tool_sources=outcome.tool_sources,
+                    gateway=gateway,
                 )
             except Exception as caselaw_exc:  # never block the turn
                 log.warning("caselaw citation verification failed: %r", caselaw_exc)
@@ -3507,6 +3508,7 @@ async def _stream_response(
                         tool_sources=loop_outcome.tool_sources
                         if isinstance(loop_outcome, LoopFinal)
                         else [],
+                        gateway=gateway,
                     )
                 except Exception as caselaw_exc:  # never block the turn
                     log.warning("caselaw citation verification failed: %r", caselaw_exc)

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -2916,6 +2916,9 @@ async def _non_streaming_response(
             await _persist_message_tool_sources(
                 db, message_id=assistant_message_id, records=outcome.tool_sources
             )
+            _caselaw_judge_model = "fast"
+            if gateway is not None:
+                _caselaw_judge_model = await gateway.get_citation_engine_judge_model()
             try:
                 await verify_and_persist_caselaw_citations(
                     db,
@@ -2923,6 +2926,7 @@ async def _non_streaming_response(
                     assistant_text=outcome.text,
                     tool_sources=outcome.tool_sources,
                     gateway=gateway,
+                    judge_model=_caselaw_judge_model,
                 )
             except Exception as caselaw_exc:  # never block the turn
                 log.warning("caselaw citation verification failed: %r", caselaw_exc)
@@ -3500,6 +3504,9 @@ async def _stream_response(
                             "error": str(cite_exc),
                         },
                     )
+                _caselaw_judge_model = "fast"
+                if gateway is not None:
+                    _caselaw_judge_model = await gateway.get_citation_engine_judge_model()
                 try:
                     await verify_and_persist_caselaw_citations(
                         db,
@@ -3509,6 +3516,7 @@ async def _stream_response(
                         if isinstance(loop_outcome, LoopFinal)
                         else [],
                         gateway=gateway,
+                        judge_model=_caselaw_judge_model,
                     )
                 except Exception as caselaw_exc:  # never block the turn
                     log.warning("caselaw citation verification failed: %r", caselaw_exc)

--- a/api/app/citation/case_content_judge.py
+++ b/api/app/citation/case_content_judge.py
@@ -1,0 +1,163 @@
+"""Whole-opinion caselaw content judge (DE-280, P1-B1b).
+
+For a caselaw blockquote that did not match any consulted opinion verbatim,
+ask an LLM judge whether the passage is faithfully supported by the *whole*
+opinion text (10-50pp) — the SUPPORTED tier. Reuses the cascade's judge
+surface (``_JudgeGatewayProtocol``) and response parser; conservative bias
+(a false-positive verification is worse than a false-negative). Cost-bounded
+by a per-message budget enforced in the caselaw orchestrator.
+
+Unlike Stage 3 (``verify_paraphrase``), which feeds a ±200-char window
+around the cited span, this judge feeds the *entire* opinion text so the
+LLM can locate support anywhere in the document. That is appropriate for
+caselaw paraphrase checks: a holding may be stated once, elaborated
+elsewhere, and the blockquote may conflate both — a narrow window would miss
+the elaboration. The cost estimate accounts for the longer context.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.cost import estimate_judge_call_cost_usd
+from app.citation.judge_prompts import build_judge_prompt
+from app.citation.verification import (
+    _MISS,
+    VerificationResult,
+    _JudgeGatewayProtocol,
+    _parse_judge_response,
+)
+from app.schemas.gateway import ChatCompletionRequest
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants.
+# ---------------------------------------------------------------------------
+
+CHARS_PER_TOKEN: int = 4
+"""Approximate characters per token used for opinion-length cost scaling.
+Conservative (real-world is ~3.8 for English legal prose) so the estimate
+errs toward over-budgeting rather than under-budgeting."""
+
+TYPICAL_PARAPHRASE_TOKENS: int = 1500
+"""Stage-3 baseline: the rolling-average judge-call cost in ``cost.py``
+was calibrated against calls that include a ±200-char context window and
+a short claim, totalling roughly 1 500 input tokens. We use this as the
+denominator when scaling from a per-call average up to a whole-opinion
+cost estimate."""
+
+CASE_CONTENT_JUDGE_BUDGET_USD: Decimal = Decimal("0.25")
+"""Per-assistant-turn hard cap. The orchestrator (Task 3) refuses to run
+the whole-opinion judge if the pre-flight estimate exceeds this value.
+Intentionally conservative — a 50-page opinion with a high-cost model
+can approach $0.05; $0.25 gives 5x headroom while still blocking runaway
+spend."""
+
+_PURPOSE = "judge_case_content"
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder.
+# ---------------------------------------------------------------------------
+
+
+def _build_prompt(passage: str, opinion_text: str, *, judge_model: str) -> ChatCompletionRequest:
+    """Build the ChatCompletionRequest for the whole-opinion content judge.
+
+    Reuses ``build_judge_prompt`` from ``judge_prompts`` (same system
+    prompt, same conservative-bias calibration) but passes the *full*
+    opinion text as the single source chunk rather than a ±200-char window.
+
+    The ``lq_ai_purpose`` tag is set to ``'judge_case_content'`` so the
+    routing log segregates these calls from Stage-3 paraphrase calls in
+    the cost-calibration query.
+    """
+    messages = build_judge_prompt(claim_text=passage, chunks=[opinion_text])
+    return ChatCompletionRequest(
+        model=judge_model,
+        messages=messages,
+        # Cap output — the judge returns a short JSON object; ~400 tokens
+        # is ample for {"verdict": ..., "confidence": ..., "justification": "..."}.
+        max_tokens=400,
+        # Deterministic — no creative paraphrasing of the verdict.
+        temperature=0.0,
+        # The judge must see real content to verify it; anonymization would
+        # destroy the semantics it is checking against.
+        anonymize=False,
+        # Tag the routing-log row for segregated cost calibration.
+        lq_ai_purpose=_PURPOSE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public interface.
+# ---------------------------------------------------------------------------
+
+
+async def judge_case_content(
+    *,
+    passage: str,
+    opinion_text: str,
+    gateway: _JudgeGatewayProtocol,
+    judge_model: str,
+) -> VerificationResult:
+    """Ask the LLM judge whether ``passage`` is faithfully supported by ``opinion_text``.
+
+    Dispatches one structured-JSON judge call through the gateway (reusing
+    the cascade's prompt and parser) and returns:
+
+    * ``VerificationResult(verified=True, method='paraphrase_judge', ...)``
+      when the judge returns ``yes`` or ``partial``.
+    * :data:`app.citation.verification._MISS` (``verified=False``) when
+      the judge returns ``no``, produces malformed JSON, or the gateway
+      call fails.
+
+    No exception is ever raised — all failure modes are swallowed and
+    surfaced as MISS. The caselaw orchestrator (Task 3) treats MISS as
+    "could not confirm support" and routes the citation accordingly.
+    """
+    try:
+        request = _build_prompt(passage, opinion_text, judge_model=judge_model)
+        response = await gateway.chat_completion(request)
+    except Exception as exc:
+        log.warning(
+            "case-content judge call failed: %r",
+            exc,
+            extra={
+                "event": "caselaw_content_judge_error",
+                "error_type": type(exc).__name__,
+            },
+        )
+        return _MISS
+
+    return _parse_judge_response(response)
+
+
+async def estimate_case_content_cost_usd(
+    db: AsyncSession | None,
+    *,
+    judge_model: str,
+    opinion_text: str,
+) -> Decimal:
+    """Estimate the USD cost of one whole-opinion judge call.
+
+    Scales the per-call rolling average from the routing log (filtered to
+    ``purpose='judge_case_content'`` rows) by the ratio of the opinion's
+    token count to the Stage-3 baseline (:data:`TYPICAL_PARAPHRASE_TOKENS`).
+    The scale factor is floored at 1 so short opinions (under the baseline
+    length) use the per-call average as-is.
+
+    ``db=None`` → no DB query; returns the conservative
+    :data:`app.citation.cost.DEFAULT_PER_JUDGE_USD` scaled by the opinion
+    length. This path is used in tests and cold-start pre-flights.
+    """
+    per_call = await estimate_judge_call_cost_usd(db, judge_model=judge_model, purpose=_PURPOSE)
+    opinion_tokens = max(1, len(opinion_text) // CHARS_PER_TOKEN)
+    scale = Decimal(opinion_tokens) / Decimal(TYPICAL_PARAPHRASE_TOKENS)
+    if scale < Decimal(1):
+        scale = Decimal(1)
+    return per_call * scale

--- a/api/app/citation/case_content_judge.py
+++ b/api/app/citation/case_content_judge.py
@@ -22,7 +22,7 @@ from decimal import Decimal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.citation.cost import estimate_judge_call_cost_usd
+from app.citation.cost import DEFAULT_PER_JUDGE_USD, estimate_judge_call_cost_usd
 from app.citation.judge_prompts import build_judge_prompt
 from app.citation.verification import (
     _MISS,
@@ -160,4 +160,4 @@ async def estimate_case_content_cost_usd(
     scale = Decimal(opinion_tokens) / Decimal(TYPICAL_PARAPHRASE_TOKENS)
     if scale < Decimal(1):
         scale = Decimal(1)
-    return per_call * scale
+    return max(per_call * scale, DEFAULT_PER_JUDGE_USD)

--- a/api/app/citation/caselaw.py
+++ b/api/app/citation/caselaw.py
@@ -1,8 +1,14 @@
-"""Caselaw quote verification (P1-A1).
+"""Caselaw quote verification (P1-A1, P1-B1b).
 
 Extracts blockquote passages from an assistant answer, locates each verbatim in
 a consulted CourtListener opinion's stored plaintext, runs the existing citation
 cascade (deterministic stages 1-2), and persists verified rows.
+
+P1-B1b adds a SUPPORTED judge pass: passages that did not match verbatim are
+judged against the whole opinion text (cost-gated). A judge-accepted passage
+persists a paraphrase_judge row (gate -> supported_only). Additive-only: no
+FAIL/unverified rows are ever written here.
+
 See docs/superpowers/specs/2026-06-24-p1a1-external-caselaw-quote-verification-design.md.
 """
 
@@ -12,13 +18,19 @@ import logging
 import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.chat.tool_loop import ToolSourceRecord
-from app.citation.verification import verify
+from app.citation.case_content_judge import (
+    CASE_CONTENT_JUDGE_BUDGET_USD,
+    estimate_case_content_cost_usd,
+    judge_case_content,
+)
+from app.citation.verification import _JudgeGatewayProtocol, verify
 from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.research import ResearchOpinionMetadata
 from app.research.service import read_opinion
@@ -117,12 +129,21 @@ async def verify_and_persist_caselaw_citations(
     assistant_text: str,
     tool_sources: Sequence[ToolSourceRecord],
     load_opinion_text: _LoadOpinionText = _default_load_opinion_text,
+    gateway: _JudgeGatewayProtocol | None = None,
+    judge_model: str = "fast",
 ) -> int:
-    """Verify verbatim caselaw quotes in ``assistant_text`` and persist verified rows.
+    """Verify caselaw quotes in ``assistant_text`` and persist verified rows.
 
-    Deterministic stages 1-2 only (``gateway=None``). Returns the row count.
-    Never raises on a per-opinion failure (conservative posture): a load miss is
-    logged and skipped, and the turn proceeds with whatever verified.
+    Stage 1: verbatim locate + deterministic cascade (stages 1-2). Stage 2
+    (P1-B1b, SUPPORTED): passages that produced no verbatim row are judged
+    against the whole opinion text (cost-gated, additive-only).
+
+    ``gateway=None`` (default) runs the verbatim path only — behaviour is
+    byte-for-byte identical to the pre-P1-B1b implementation.
+
+    Returns the total row count. Never raises on a per-opinion failure
+    (conservative posture): a load miss is logged and skipped, and the turn
+    proceeds with whatever verified.
     """
     cluster_ids = {
         int(r.external_ref)
@@ -157,6 +178,10 @@ async def verify_and_persist_caselaw_citations(
             log.warning("caselaw verify: could not load opinion %s: %r", op.opinion_id, exc)
 
     rows: list[MessageCaselawCitation] = []
+
+    # --- Verbatim loop (stages 1-2) ----------------------------------------
+    # Track which passages were resolved verbatim so the judge pass can skip them.
+    verbatim_matched: set[str] = set()
     for passage in passages:
         for op, text in texts:
             loc = locate_passage(passage, text)
@@ -187,8 +212,66 @@ async def verify_and_persist_caselaw_citations(
                     partial=result.partial,
                 )
             )
+            verbatim_matched.add(passage)
             break  # one verified row per passage (first matching opinion wins)
 
+    # --- SUPPORTED judge pass (P1-B1b, additive-only) -----------------------
+    # Only runs when a gateway is supplied. Passages that got a verbatim row
+    # are skipped. Per-turn budget stops the whole pass when exceeded.
+    if gateway is not None:
+        spent: Decimal = Decimal("0")
+        budget_exhausted = False
+        for passage in passages:
+            if budget_exhausted:
+                break
+            if passage in verbatim_matched:
+                continue  # already have a verbatim row — skip
+            for op, text in texts:
+                est = await estimate_case_content_cost_usd(
+                    db, judge_model=judge_model, opinion_text=text
+                )
+                if spent + est > CASE_CONTENT_JUDGE_BUDGET_USD:
+                    log.info(
+                        "case-content judge: per-turn budget reached; stopping judge pass",
+                        extra={"event": "caselaw_judge_budget_reached"},
+                    )
+                    budget_exhausted = True
+                    break  # stop the whole judge pass for this turn
+                spent += est
+                try:
+                    result = await judge_case_content(
+                        passage=passage,
+                        opinion_text=text,
+                        gateway=gateway,
+                        judge_model=judge_model,
+                    )
+                except Exception as exc:
+                    log.warning(
+                        "case-content judge error on opinion %s: %r",
+                        op.opinion_id,
+                        exc,
+                    )
+                    continue  # per-opinion error — try next opinion
+                if not result.verified:
+                    continue  # this opinion's judge rejected — try next opinion
+                # Judge accepted — write one SUPPORTED row and move to next passage.
+                rows.append(
+                    MessageCaselawCitation(
+                        message_id=message_id,
+                        opinion_id=op.opinion_id,
+                        cluster_id=op.cluster_id,
+                        source_offset_start=0,
+                        source_offset_end=len(text),
+                        source_text=passage,
+                        verified=True,
+                        verification_method="paraphrase_judge",
+                        verification_confidence=result.confidence,
+                        partial=True,
+                    )
+                )
+                break  # one SUPPORTED row per passage; first accepting opinion wins
+
+    # --- Persist (single add_all / flush) -----------------------------------
     if rows:
         db.add_all(rows)
         await db.flush()

--- a/api/app/citation/caselaw.py
+++ b/api/app/citation/caselaw.py
@@ -238,6 +238,9 @@ async def verify_and_persist_caselaw_citations(
                     budget_exhausted = True
                     break  # stop the whole judge pass for this turn
                 spent += est
+                # Defense-in-depth: judge_case_content is contractually non-raising
+                # (all errors resolve to _MISS), but the guard protects against a
+                # future refactor that inadvertently breaks that contract.
                 try:
                     result = await judge_case_content(
                         passage=passage,

--- a/api/app/citation/cost.py
+++ b/api/app/citation/cost.py
@@ -107,12 +107,13 @@ async def estimate_judge_call_cost_usd(
     db: AsyncSession | None,
     *,
     judge_model: str,
+    purpose: str = "judge_paraphrase",
 ) -> Decimal:
     """Return the estimated USD cost of one judge call to ``judge_model``.
 
     Computes the rolling average ``cost_estimate`` across the last
     :data:`_WINDOW_SAMPLES` ``inference_routing_log`` rows where
-    ``routed_model = judge_model`` AND ``purpose = 'judge_paraphrase'``.
+    ``routed_model = judge_model`` AND ``purpose = purpose``.
     Returns :data:`DEFAULT_PER_JUDGE_USD` if fewer than
     :data:`_MIN_SAMPLES` such rows exist.
 
@@ -120,6 +121,11 @@ async def estimate_judge_call_cost_usd(
     Honored by tests that exercise the activation-resolver logic without
     caring about cost calibration; production callers always pass a real
     session.
+
+    ``purpose`` selects which routing-log rows to average. The default
+    (``'judge_paraphrase'``) preserves all existing callers. Pass
+    ``'judge_case_content'`` (or any other tag) to calibrate against a
+    different inference purpose — e.g., the whole-opinion caselaw judge.
 
     Cached in-process per :data:`_CACHE_TTL_SECONDS`. Tests can use
     :func:`invalidate_cache` to reset between assertions.
@@ -129,7 +135,8 @@ async def estimate_judge_call_cost_usd(
         return DEFAULT_PER_JUDGE_USD
 
     now = time.monotonic()
-    cached = _cache.get(judge_model)
+    cache_key = f"{judge_model}:{purpose}"
+    cached = _cache.get(cache_key)
     if cached is not None:
         cached_at, cached_value = cached
         if now - cached_at < _CACHE_TTL_SECONDS:
@@ -140,7 +147,7 @@ async def estimate_judge_call_cost_usd(
         select(InferenceRoutingLog.cost_estimate)
         .where(
             InferenceRoutingLog.routed_model == judge_model,
-            InferenceRoutingLog.purpose == "judge_paraphrase",
+            InferenceRoutingLog.purpose == purpose,
             InferenceRoutingLog.cost_estimate.is_not(None),
             InferenceRoutingLog.timestamp >= cutoff,
         )
@@ -177,11 +184,11 @@ async def estimate_judge_call_cost_usd(
         # deployments don't query repeatedly. Caching the fallback
         # also limits DB load if a misconfigured model name is asked
         # about hundreds of times per minute.
-        _cache[judge_model] = (now, DEFAULT_PER_JUDGE_USD)
+        _cache[cache_key] = (now, DEFAULT_PER_JUDGE_USD)
         return DEFAULT_PER_JUDGE_USD
 
     estimate = Decimal(str(avg_raw))
-    _cache[judge_model] = (now, estimate)
+    _cache[cache_key] = (now, estimate)
     return estimate
 
 
@@ -191,9 +198,18 @@ def invalidate_cache(judge_model: str | None = None) -> None:
     Tests call this between assertions. Operators can call it via an
     admin endpoint (not currently exposed) when they know prices have
     shifted out of band. ``judge_model=None`` clears all entries.
+
+    Since the cache key is ``"<model>:<purpose>"``, passing a
+    ``judge_model`` clears *all* purposes for that model (i.e., every
+    key that starts with ``judge_model + ":"``) — the common case in
+    tests is "reset everything for this model". Pass ``None`` to clear
+    the whole cache.
     """
 
     if judge_model is None:
         _cache.clear()
     else:
-        _cache.pop(judge_model, None)
+        prefix = judge_model + ":"
+        keys_to_delete = [k for k in _cache if k.startswith(prefix)]
+        for k in keys_to_delete:
+            del _cache[k]

--- a/api/app/models/message_caselaw_citation.py
+++ b/api/app/models/message_caselaw_citation.py
@@ -33,7 +33,7 @@ class MessageCaselawCitation(Base):
         ),
         CheckConstraint(
             "verification_method IS NULL OR verification_method IN "
-            "('exact_match', 'tolerant_match')",
+            "('exact_match', 'tolerant_match', 'paraphrase_judge')",
             name="chk_message_caselaw_citations_method_values",
         ),
         CheckConstraint(

--- a/api/tests/integration/test_caselaw_paraphrase_judge.py
+++ b/api/tests/integration/test_caselaw_paraphrase_judge.py
@@ -1,0 +1,347 @@
+"""Integration tests for the caselaw paraphrase-judge SUPPORTED pass (P1-B1b).
+
+These tests cover the four invariants in the task brief:
+
+1. Paraphrased quote (not verbatim) + accepting judge -> one paraphrase_judge
+   row -> ledger + gate -> gate_status == 'supported_only'.
+2. Mocked judge rejects all consulted opinions -> NO row written (additive-only).
+3. Budget set to zero (monkeypatch CASE_CONTENT_JUDGE_BUDGET_USD) -> judge mock
+   is NEVER called and no row is written.
+4. gateway=None -> unchanged today (verbatim path only; no judge, no rows).
+
+Refs ADR 0018 D2/D3, DE-280, P1-B1b.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.chat.tool_loop import ToolSourceRecord
+from app.citation.caselaw import verify_and_persist_caselaw_citations
+from app.citation.gate import compute_and_record_gate
+from app.citation.ledger import assemble_ledger_entries
+from app.models.chat import Chat, Message
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.research import ResearchOpinionMetadata
+from app.models.user import User
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Opinion text — deliberately NOT verbatim; passage is a paraphrase.
+# ---------------------------------------------------------------------------
+
+_OPINION_TEXT = (
+    "The Supreme Court addressed the good faith doctrine at length. "
+    "The justices unanimously agreed that every commercial contract "
+    "carries an implied duty of honest dealing between parties. "
+    "This principle has been recognised since at least 1890. "
+    "It applies regardless of whether the parties are sophisticated. "
+    "The holding was clear: good-faith performance is mandatory."
+)
+
+# This passage paraphrases the opinion but is NOT a verbatim substring.
+_PARAPHRASED_PASSAGE = "the court held that an implied duty of good faith applies to all contracts"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _caselaw_source(cluster_id: int) -> ToolSourceRecord:
+    return ToolSourceRecord(
+        source_kind="caselaw",
+        label=f"Cluster {cluster_id}",
+        subtitle=None,
+        url=None,
+        external_ref=str(cluster_id),
+        provider="courtlistener",
+        tool="get_cluster",
+    )
+
+
+def _judge_completion(verdict_json: str) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        id="chatcmpl-pj-test",
+        created=0,
+        model="fast",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=verdict_json),
+                finish_reason="stop",
+            )
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=50, completion_tokens=20, total_tokens=70),
+    )
+
+
+class _FakeGateway:
+    """Minimal gateway stub that records calls and returns a canned verdict."""
+
+    def __init__(self, verdict_json: str) -> None:
+        self._verdict = verdict_json
+        self.calls = 0
+        self.last_request: ChatCompletionRequest | None = None
+
+    async def chat_completion(
+        self,
+        request: ChatCompletionRequest,
+        *,
+        request_id: str | None = None,
+    ) -> ChatCompletionResponse:
+        self.calls += 1
+        self.last_request = request
+        return _judge_completion(self._verdict)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seeded_msg(db_session: AsyncSession):
+    """Seed a user + chat + assistant message and a consulted opinion.
+
+    Returns (message_id, opinion_id, cluster_id).
+    """
+    user = User(
+        email=f"pj-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        role="member",
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    chat = Chat(owner_id=user.id, title="pj-chat")
+    db_session.add(chat)
+    await db_session.flush()
+
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="passage")
+    db_session.add(msg)
+    await db_session.flush()
+
+    opinion_id = 8001
+    cluster_id = 701
+    db_session.add(
+        ResearchOpinionMetadata(
+            opinion_id=opinion_id,
+            cluster_id=cluster_id,
+            text_field_used="plain_text",
+            storage_path=f"courtlistener/opinions/by-cluster/{cluster_id}/{opinion_id}",
+            char_length=len(_OPINION_TEXT),
+        )
+    )
+    await db_session.flush()
+
+    return msg.id, chat.id, opinion_id, cluster_id
+
+
+async def _fake_loader(db: AsyncSession, opinion_id: int) -> str:
+    return _OPINION_TEXT
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — accept -> paraphrase_judge row -> supported_only gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accepting_judge_writes_paraphrase_judge_row_and_gate(
+    db_session: AsyncSession,
+    seeded_msg,
+) -> None:
+    """Paraphrased quote + accepting judge -> one paraphrase_judge row.
+
+    After assemble_ledger_entries + compute_and_record_gate the gate must be
+    'supported_only' because paraphrase_judge maps to SUPPORTED_STATUSES.
+    """
+    message_id, _chat_id, opinion_id, cluster_id = seeded_msg
+
+    assistant_text = f"> {_PARAPHRASED_PASSAGE}\n"
+    gw = _FakeGateway(json.dumps({"verdict": "yes", "confidence": "high"}))
+
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=assistant_text,
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_fake_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+
+    # One row written.
+    assert n == 1, f"Expected 1 row, got {n}"
+
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCaselawCitation).where(
+                    MessageCaselawCitation.message_id == message_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.verified is True
+    assert row.verification_method == "paraphrase_judge"
+    assert row.opinion_id == opinion_id
+    assert row.partial is True
+    assert row.source_offset_start == 0
+    assert row.source_offset_end == len(_OPINION_TEXT)
+
+    # Ledger + gate.
+    await assemble_ledger_entries(db_session, message_id=message_id)
+    await compute_and_record_gate(db_session, message_id=message_id)
+
+    gate = (
+        await db_session.execute(
+            select(WorkProductFiduciaryGate).where(
+                WorkProductFiduciaryGate.message_id == message_id
+            )
+        )
+    ).scalar_one()
+    assert gate.gate_status == "supported_only"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — rejecting judge -> no row (additive-only invariant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rejecting_judge_writes_no_row(
+    db_session: AsyncSession,
+    seeded_msg,
+) -> None:
+    """Judge rejects all consulted opinions -> no row written, additive-only."""
+    message_id, _chat_id, _opinion_id, cluster_id = seeded_msg
+
+    assistant_text = f"> {_PARAPHRASED_PASSAGE}\n"
+    gw = _FakeGateway(json.dumps({"verdict": "no"}))
+
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=assistant_text,
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_fake_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+
+    assert n == 0, f"Expected 0 rows, got {n}"
+
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCaselawCitation).where(
+                    MessageCaselawCitation.message_id == message_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 0
+    # Judge was called (there was a passage to judge and budget was available).
+    assert gw.calls >= 1
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — budget=0 -> judge never called, no row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_zero_budget_prevents_judge_call(
+    db_session: AsyncSession,
+    seeded_msg,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Budget monkeypatched to Decimal('0') -> judge mock never called, no row."""
+    import app.citation.caselaw as caselaw_mod
+
+    monkeypatch.setattr(caselaw_mod, "CASE_CONTENT_JUDGE_BUDGET_USD", Decimal("0"))
+
+    message_id, _chat_id, _opinion_id, cluster_id = seeded_msg
+
+    assistant_text = f"> {_PARAPHRASED_PASSAGE}\n"
+    gw = _FakeGateway(json.dumps({"verdict": "yes", "confidence": "high"}))
+
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=assistant_text,
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_fake_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+
+    assert n == 0, f"Expected 0 rows, got {n}"
+    assert gw.calls == 0, f"Judge should not be called with budget=0; got {gw.calls} calls"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — gateway=None -> verbatim-only path unchanged, no judge, no rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gateway_none_is_verbatim_only(
+    db_session: AsyncSession,
+    seeded_msg,
+) -> None:
+    """gateway=None -> behaves exactly as today: no judge, no paraphrase_judge rows."""
+    message_id, _chat_id, _opinion_id, cluster_id = seeded_msg
+
+    # The passage is paraphrased, so the verbatim path produces nothing.
+    assistant_text = f"> {_PARAPHRASED_PASSAGE}\n"
+
+    # No gateway kwarg -> defaults to None.
+    n_paraphrase = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=assistant_text,
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_fake_loader,
+        # gateway omitted — defaults to None
+    )
+    assert n_paraphrase == 0, (
+        f"gateway=None must not produce rows for paraphrased quote; got {n_paraphrase}"
+    )
+
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCaselawCitation).where(
+                    MessageCaselawCitation.message_id == message_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 0

--- a/api/tests/integration/test_caselaw_paraphrase_method.py
+++ b/api/tests/integration/test_caselaw_paraphrase_method.py
@@ -1,0 +1,64 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.exc import IntegrityError
+
+from app.models.chat import Chat, Message
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def msg(db_session):
+    u = User(email=f"cm-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(u)
+    await db_session.flush()
+    c = Chat(owner_id=u.id, title="t")
+    db_session.add(c)
+    await db_session.flush()
+    m = Message(chat_id=c.id, role="assistant", kind="ai", content="a")
+    db_session.add(m)
+    await db_session.flush()
+    return m.id
+
+
+@pytest.mark.asyncio
+async def test_paraphrase_judge_method_accepted(db_session, msg):
+    db_session.add(
+        MessageCaselawCitation(
+            message_id=msg,
+            opinion_id=1,
+            cluster_id=1,
+            source_offset_start=0,
+            source_offset_end=10,
+            source_text="held that",
+            verified=True,
+            verification_method="paraphrase_judge",
+            verification_confidence=0.7,
+            partial=True,
+        )
+    )
+    await db_session.flush()  # must NOT raise
+
+
+@pytest.mark.asyncio
+async def test_bogus_method_rejected(db_session, msg):
+    db_session.add(
+        MessageCaselawCitation(
+            message_id=msg,
+            opinion_id=1,
+            cluster_id=1,
+            source_offset_start=0,
+            source_offset_end=10,
+            source_text="x",
+            verified=True,
+            verification_method="made_up",
+            verification_confidence=0.5,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()

--- a/api/tests/test_case_content_judge.py
+++ b/api/tests/test_case_content_judge.py
@@ -1,0 +1,246 @@
+"""Whole-opinion caselaw content judge tests (DE-280, P1-B1b).
+
+``judge_case_content(*, passage, opinion_text, gateway, judge_model)``
+feeds the full opinion text to an LLM judge and returns a
+VerificationResult.  These tests cover:
+
+* accept (yes/partial) → verified=True, method='paraphrase_judge'.
+* reject (no) → MISS (verified=False, method=None).
+* malformed / non-JSON output → MISS.
+* prompt content: opinion_text AND passage both appear in the request.
+* cost estimate scales with opinion length.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+
+import pytest
+
+from app.citation.case_content_judge import (
+    CHARS_PER_TOKEN,
+    estimate_case_content_cost_usd,
+    judge_case_content,
+)
+from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mirror the shape used in citation/test_paraphrase_judge.py.
+# ---------------------------------------------------------------------------
+
+
+def _judge_completion(verdict_json: str) -> ChatCompletionResponse:
+    """Build a canned ChatCompletionResponse with the given content string."""
+    return ChatCompletionResponse(
+        id="chatcmpl-ccjudge",
+        created=0,
+        model="fast",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=verdict_json),
+                finish_reason="stop",
+            )
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+    )
+
+
+def _serialize_messages(request: ChatCompletionRequest) -> str:
+    """Concatenate all message content fields for assertion convenience."""
+    parts = []
+    for msg in request.messages:
+        if msg.content:
+            parts.append(msg.content)
+    return "\n".join(parts)
+
+
+class _FakeGateway:
+    """Minimal gateway stub — records the request and returns a canned response."""
+
+    def __init__(self, verdict_json: str) -> None:
+        self._verdict = verdict_json
+        self.calls = 0
+        self.last_request: ChatCompletionRequest | None = None
+
+    async def chat_completion(
+        self,
+        request: ChatCompletionRequest,
+        *,
+        request_id: str | None = None,
+    ) -> ChatCompletionResponse:
+        self.calls += 1
+        self.last_request = request
+        return _judge_completion(self._verdict)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accept_yields_paraphrase_judge() -> None:
+    """yes verdict → verified=True, method='paraphrase_judge'."""
+    gw = _FakeGateway(json.dumps({"verdict": "yes", "confidence": "high"}))
+    r = await judge_case_content(
+        passage="The court held X.",
+        opinion_text="...full opinion...",
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert r.verified is True
+    assert r.method == "paraphrase_judge"
+    assert gw.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_partial_verdict_accepted() -> None:
+    """partial verdict → verified=True, partial=True."""
+    gw = _FakeGateway(json.dumps({"verdict": "partial", "confidence": "medium"}))
+    r = await judge_case_content(
+        passage="The court held X.",
+        opinion_text="...full opinion...",
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert r.verified is True
+    assert r.partial is True
+    assert r.method == "paraphrase_judge"
+
+
+@pytest.mark.asyncio
+async def test_reject_yields_miss() -> None:
+    """no verdict → verified=False, method=None."""
+    gw = _FakeGateway(json.dumps({"verdict": "no"}))
+    r = await judge_case_content(
+        passage="Fabricated holding.",
+        opinion_text="...",
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert r.verified is False
+    assert r.method is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_output_is_miss() -> None:
+    """Non-JSON judge output → MISS, does not raise."""
+    gw = _FakeGateway("not json at all")
+    r = await judge_case_content(
+        passage="x",
+        opinion_text="...",
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert r.verified is False
+
+
+@pytest.mark.asyncio
+async def test_gateway_error_returns_miss() -> None:
+    """Gateway transport error → MISS, does not raise."""
+
+    class _ErrorGW:
+        async def chat_completion(
+            self,
+            request: ChatCompletionRequest,
+            *,
+            request_id: str | None = None,
+        ) -> ChatCompletionResponse:
+            raise RuntimeError("gateway down")
+
+    r = await judge_case_content(
+        passage="x",
+        opinion_text="...",
+        gateway=_ErrorGW(),
+        judge_model="fast",
+    )
+    assert r.verified is False
+
+
+# ---------------------------------------------------------------------------
+# Prompt content — opinion + passage must appear in the request.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prompt_includes_opinion_and_passage() -> None:
+    """The full opinion_text and the passage both appear in the gateway request."""
+    captured: dict[str, ChatCompletionRequest] = {}
+
+    class _CapGW:
+        async def chat_completion(
+            self,
+            request: ChatCompletionRequest,
+            *,
+            request_id: str | None = None,
+        ) -> ChatCompletionResponse:
+            captured["request"] = request
+            return _judge_completion(json.dumps({"verdict": "yes", "confidence": "medium"}))
+
+    await judge_case_content(
+        passage="UNIQUE_PASSAGE",
+        opinion_text="UNIQUE_OPINION_BODY",
+        gateway=_CapGW(),
+        judge_model="fast",
+    )
+    assert "request" in captured
+    text = _serialize_messages(captured["request"])
+    assert "UNIQUE_PASSAGE" in text
+    assert "UNIQUE_OPINION_BODY" in text
+
+
+@pytest.mark.asyncio
+async def test_request_purpose_is_judge_case_content() -> None:
+    """The gateway request is tagged with lq_ai_purpose='judge_case_content'."""
+    captured: dict[str, ChatCompletionRequest] = {}
+
+    class _CapGW:
+        async def chat_completion(
+            self,
+            request: ChatCompletionRequest,
+            *,
+            request_id: str | None = None,
+        ) -> ChatCompletionResponse:
+            captured["request"] = request
+            return _judge_completion(json.dumps({"verdict": "yes", "confidence": "high"}))
+
+    await judge_case_content(
+        passage="some passage",
+        opinion_text="some opinion",
+        gateway=_CapGW(),
+        judge_model="fast",
+    )
+    assert captured["request"].lq_ai_purpose == "judge_case_content"
+
+
+# ---------------------------------------------------------------------------
+# Cost estimate — scales with opinion length.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cost_estimate_scales_with_opinion_length() -> None:
+    """A longer opinion yields a higher cost estimate than a short one."""
+    short = await estimate_case_content_cost_usd(None, judge_model="fast", opinion_text="x" * 1000)
+    long = await estimate_case_content_cost_usd(
+        None, judge_model="fast", opinion_text="x" * (1000 * CHARS_PER_TOKEN * 50)
+    )
+    assert long > short
+
+
+@pytest.mark.asyncio
+async def test_cost_estimate_minimum_scale_is_one() -> None:
+    """A very short opinion (under one typical chunk) still returns a positive cost."""
+    cost = await estimate_case_content_cost_usd(None, judge_model="fast", opinion_text="x")
+    assert cost > Decimal("0")

--- a/docs/superpowers/plans/2026-06-25-p1b1b-caselaw-paraphrase-judge.md
+++ b/docs/superpowers/plans/2026-06-25-p1b1b-caselaw-paraphrase-judge.md
@@ -1,0 +1,468 @@
+# P1-B1b — Caselaw paraphrase/content judge (SUPPORTED-only) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give a non-verbatim caselaw blockquote that a whole-opinion judge finds faithfully supported a `paraphrase_judge` row (gate → `supported_only`), cost-bounded, **additive-only** (no FAIL/unverified rows).
+
+**Architecture:** A new `case_content_judge.py` runs a whole-opinion fidelity judge over the already-stored opinion text via the existing `_JudgeGatewayProtocol`, reusing the cascade's judge-response parser. A per-message cost pre-flight bounds egress. `caselaw.py` gains a `gateway` param: after the verbatim loop, dropped passages are judged (cost-gated) and a SUPPORTED row is written on accept. A migration relaxes the caselaw method CHECK. No change to the gate or the ledger assembler.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 async, Alembic (migration 0060), pytest with a **mocked gateway** (no live egress), throwaway pgvector.
+
+## Global Constraints
+
+- **Additive-only (load-bearing invariant).** B1b writes **only** `verified=True, verification_method='paraphrase_judge'` rows. It never writes a FAIL/unverified caselaw row and never flips a turn that is `fiduciary_grade`/`supported_only` today into `flagged`. Caselaw FAIL is P1-B1c. A passage no consulted opinion's judge accepts stays **dropped** (unchanged from today).
+- **Whole-opinion judge.** Feed the judge the full opinion text + the candidate passage (a dropped passage has no located span, so the cascade's ±200-char window doesn't apply). Same `_JudgeGatewayProtocol` surface (`chat_completion`) as stage-3.
+- **Per-message cost budget bounds spend.** Estimate each judge call's cost; accumulate per turn against a configured cap (`CASE_CONTENT_JUDGE_BUDGET_USD`). When the next call would exceed it, **stop judging this turn** (remaining passages drop) — no special row.
+- **Conservative parse.** Malformed judge output → `_MISS` (no row). A per-opinion gateway error → "no verdict" for that opinion (logged), never fatal.
+- **`gateway=None` is unchanged behaviour.** Verbatim-only, deterministic, no egress, no cost — preserves every existing caller/test.
+- **No gate / ledger change.** The gate already buckets `paraphrase_judge`→SUPPORTED; `assemble_ledger_entries` already maps the method. Do not touch `gate.py` or `ledger.py`.
+- **P5:** persistence flushes (the existing `verify_and_persist_caselaw_citations` already flushes; do not add a commit).
+- **Migration:** new revision `0060`, `down_revision="0059"`. NEVER host `alembic upgrade` the dev DB; the conftest auto-migrates the throwaway pgvector. Register nothing new (no new model — only a CHECK change).
+- **Offsets for a paraphrase row:** a paraphrase has no exact span; store the **whole-opinion span** `source_offset_start=0, source_offset_end=len(opinion_text)`, `partial=True` (satisfies the `offset_end > offset_start` CHECK; the trace reads "supported by this opinion," not a false exact locus).
+- **Security review (CODEOWNERS):** `api/app/citation/**` + `chats.py` + new egress — do not self-merge.
+- **Tests:** host venv + throwaway pgvector (`DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test`); mocked gateway → no `-m provider`. `ruff format` + `ruff check` + `mypy app` + `pytest`. **Next migration = 0060.**
+- **Commits:** `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `case_content_judge.py` — whole-opinion judge + cost pre-flight
+
+**Files:**
+- Create: `api/app/citation/case_content_judge.py`
+- Modify: `api/app/citation/cost.py` (generalize `estimate_judge_call_cost_usd` with a `purpose` param)
+- Test: `api/tests/test_case_content_judge.py` (unit, mocked gateway)
+
+**Interfaces:**
+- Consumes: `verify` internals from `verification.py` — `VerificationResult`, `_MISS`, `_parse_judge_response`, `_JudgeGatewayProtocol`, and the `ChatCompletionRequest` shape used by `verify_paraphrase`; `estimate_judge_call_cost_usd` from `cost.py`.
+- Produces: `async def judge_case_content(*, passage: str, opinion_text: str, gateway, judge_model: str) -> VerificationResult`; `async def estimate_case_content_cost_usd(db, *, judge_model: str, opinion_text: str) -> Decimal`; constants `CHARS_PER_TOKEN`, `TYPICAL_PARAPHRASE_TOKENS`, `CASE_CONTENT_JUDGE_BUDGET_USD`. Consumed by Task 3.
+
+- [ ] **Step 1: Generalize the cost estimator.** In `api/app/citation/cost.py`, change `estimate_judge_call_cost_usd` to accept `purpose` (default preserves today's behaviour):
+
+```python
+async def estimate_judge_call_cost_usd(
+    db: AsyncSession | None,
+    *,
+    judge_model: str,
+    purpose: str = "judge_paraphrase",
+) -> Decimal:
+    ...
+    # in the WHERE clause, replace the literal with the param:
+    #   InferenceRoutingLog.purpose == purpose,
+```
+
+Existing callers pass no `purpose` → unchanged. (Confirm the one query predicate at ~line 143 now uses the `purpose` variable.)
+
+- [ ] **Step 2: Write the failing judge test** `api/tests/test_case_content_judge.py` (mock the gateway — a fake with `async def chat_completion(...)` returning a canned judge response; mirror how `verification.py`'s paraphrase tests mock the judge — read an existing `verify_paraphrase` test for the exact fake-gateway shape and the judge-response JSON the parser expects):
+
+```python
+import pytest
+from decimal import Decimal
+from app.citation.case_content_judge import (
+    judge_case_content, estimate_case_content_cost_usd, CHARS_PER_TOKEN,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeGateway:
+    def __init__(self, verdict_json: str):
+        self._verdict = verdict_json
+        self.calls = 0
+    async def chat_completion(self, request, *, request_id=None):
+        self.calls += 1
+        # shape this to match what _parse_judge_response reads (see verify_paraphrase tests)
+        return _judge_completion(self._verdict)
+
+
+@pytest.mark.asyncio
+async def test_accept_yields_paraphrase_judge():
+    gw = _FakeGateway(verdict='{"verdict":"yes","confidence":"high"}')
+    r = await judge_case_content(passage="The court held X.", opinion_text="...full opinion...", gateway=gw, judge_model="fast")
+    assert r.verified is True
+    assert r.method == "paraphrase_judge"
+    assert gw.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_reject_yields_miss():
+    gw = _FakeGateway(verdict='{"verdict":"no"}')
+    r = await judge_case_content(passage="Fabricated holding.", opinion_text="...", gateway=gw, judge_model="fast")
+    assert r.verified is False
+    assert r.method is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_output_is_miss():
+    gw = _FakeGateway(verdict="not json at all")
+    r = await judge_case_content(passage="x", opinion_text="...", gateway=gw, judge_model="fast")
+    assert r.verified is False
+
+
+@pytest.mark.asyncio
+async def test_prompt_includes_opinion_and_passage(monkeypatch):
+    captured = {}
+    class _CapGW:
+        async def chat_completion(self, request, *, request_id=None):
+            captured["request"] = request
+            return _judge_completion('{"verdict":"yes","confidence":"medium"}')
+    await judge_case_content(passage="UNIQUE_PASSAGE", opinion_text="UNIQUE_OPINION_BODY", gateway=_CapGW(), judge_model="fast")
+    text = _serialize_messages(captured["request"])  # helper: concat message contents
+    assert "UNIQUE_PASSAGE" in text and "UNIQUE_OPINION_BODY" in text
+
+
+@pytest.mark.asyncio
+async def test_cost_estimate_scales_with_opinion_length():
+    short = await estimate_case_content_cost_usd(None, judge_model="fast", opinion_text="x" * 1000)
+    long = await estimate_case_content_cost_usd(None, judge_model="fast", opinion_text="x" * (1000 * CHARS_PER_TOKEN * 50))
+    assert long > short
+```
+
+(The `_judge_completion` / `_serialize_messages` helpers + the exact judge-response JSON shape come from the existing paraphrase-judge tests — read `api/tests/` for the cascade's judge test to reuse them verbatim.)
+
+- [ ] **Step 3: Run it (fails)** — `cd api && DATABASE_URL=... .venv/bin/pytest tests/test_case_content_judge.py -v` → FAIL (module missing).
+
+- [ ] **Step 4: Implement** `api/app/citation/case_content_judge.py`:
+
+```python
+"""Whole-opinion caselaw content judge (DE-280, P1-B1b).
+
+For a caselaw blockquote that did not match any consulted opinion verbatim,
+ask an LLM judge whether the passage is faithfully supported by the *whole*
+opinion text (10-50pp) — the SUPPORTED tier. Reuses the cascade's judge
+surface (``_JudgeGatewayProtocol``) and response parser; conservative bias
+(a false-positive verification is worse than a false-negative). Cost-bounded
+by a per-message budget enforced in the caselaw orchestrator.
+"""
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.cost import estimate_judge_call_cost_usd
+from app.citation.verification import (
+    VerificationResult,
+    _MISS,
+    _parse_judge_response,
+    _JudgeGatewayProtocol,
+)
+# reuse the ChatCompletionRequest construction pattern from verify_paraphrase.
+
+log = logging.getLogger(__name__)
+
+CHARS_PER_TOKEN = 4
+TYPICAL_PARAPHRASE_TOKENS = 1500  # stage-3 chunk+window baseline the calibration reflects
+CASE_CONTENT_JUDGE_BUDGET_USD = Decimal("0.25")  # per assistant turn; config constant in v1
+_PURPOSE = "judge_case_content"
+
+
+def _build_prompt(passage: str, opinion_text: str): ...
+    # Build the same ChatCompletionRequest shape verify_paraphrase uses, but:
+    #  - system/user content asks: "Is the PASSAGE faithfully supported by the
+    #    OPINION (same holding/quote, not a distortion)? Answer the judge schema."
+    #  - include the WHOLE opinion_text (not a ±200-char window) + the passage.
+    #  - carry purpose=_PURPOSE so the inference is logged as judge_case_content
+    #    (follow how verify_paraphrase tags purpose on its request).
+
+
+async def judge_case_content(
+    *, passage: str, opinion_text: str, gateway: _JudgeGatewayProtocol, judge_model: str
+) -> VerificationResult:
+    try:
+        request = _build_prompt(passage, opinion_text)
+        response = await gateway.chat_completion(request)
+    except Exception as exc:  # gateway/transport error -> no verdict
+        log.warning("case-content judge call failed: %r", exc)
+        return _MISS
+    result = _parse_judge_response(response)  # -> VerificationResult(method="paraphrase_judge"...) or _MISS
+    return result
+
+
+async def estimate_case_content_cost_usd(
+    db: AsyncSession | None, *, judge_model: str, opinion_text: str
+) -> Decimal:
+    per_call = await estimate_judge_call_cost_usd(db, judge_model=judge_model, purpose=_PURPOSE)
+    opinion_tokens = max(1, len(opinion_text) // CHARS_PER_TOKEN)
+    scale = Decimal(opinion_tokens) / Decimal(TYPICAL_PARAPHRASE_TOKENS)
+    if scale < 1:
+        scale = Decimal(1)
+    return per_call * scale
+```
+
+> **Implementer:** `_parse_judge_response` must return `method="paraphrase_judge"` for this judge too (it is method-agnostic — it parses the verdict; confirm by reading it). If it hard-codes a method, pass/override the method to `"paraphrase_judge"`. Read `verify_paraphrase` for the exact `ChatCompletionRequest` construction + how `purpose`/`judge_model` are threaded, and reuse it in `_build_prompt`.
+
+- [ ] **Step 5: Run the tests (pass)** — `cd api && DATABASE_URL=... .venv/bin/pytest tests/test_case_content_judge.py -v` → all PASS.
+
+- [ ] **Step 6: Lint + type, commit**
+
+```bash
+cd api && .venv/bin/ruff format app/citation/case_content_judge.py app/citation/cost.py tests/test_case_content_judge.py && .venv/bin/ruff check app/citation tests/test_case_content_judge.py && .venv/bin/mypy app/citation/case_content_judge.py app/citation/cost.py
+```
+```bash
+git add api/app/citation/case_content_judge.py api/app/citation/cost.py api/tests/test_case_content_judge.py
+git commit -s -m "feat(citation): whole-opinion caselaw content judge + cost estimate (P1-B1b)
+
+judge_case_content runs an LLM fidelity judge over the full opinion text
+(DE-280) reusing the cascade judge surface + parser; accept ->
+paraphrase_judge, reject/malformed -> MISS. estimate_case_content_cost_usd
+scales the per-judge cost by opinion length; estimate_judge_call_cost_usd
+gains a purpose param (judge_case_content) for segregated calibration.
+
+Refs ADR 0018 D2, DE-280.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Migration 0060 — relax the caselaw method CHECK
+
+**Files:**
+- Create: `api/alembic/versions/0060_caselaw_method_paraphrase.py`
+- Modify: `api/app/models/message_caselaw_citation.py` (CHECK string)
+- Test: `api/tests/integration/test_caselaw_paraphrase_method.py`
+
+**Interfaces:** none new — schema only.
+
+- [ ] **Step 1: Write the failing test** `api/tests/integration/test_caselaw_paraphrase_method.py`:
+
+```python
+import uuid
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from app.models.chat import Chat, Message
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def msg(db_session):
+    u = User(email=f"cm-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(u); await db_session.flush()
+    c = Chat(owner_id=u.id, title="t"); db_session.add(c); await db_session.flush()
+    m = Message(chat_id=c.id, role="assistant", kind="ai", content="a"); db_session.add(m); await db_session.flush()
+    return m.id
+
+
+@pytest.mark.asyncio
+async def test_paraphrase_judge_method_accepted(db_session, msg):
+    db_session.add(MessageCaselawCitation(
+        message_id=msg, opinion_id=1, cluster_id=1, source_offset_start=0, source_offset_end=10,
+        source_text="held that", verified=True, verification_method="paraphrase_judge",
+        verification_confidence=0.7, partial=True))
+    await db_session.flush()  # must NOT raise
+
+
+@pytest.mark.asyncio
+async def test_bogus_method_rejected(db_session, msg):
+    db_session.add(MessageCaselawCitation(
+        message_id=msg, opinion_id=1, cluster_id=1, source_offset_start=0, source_offset_end=10,
+        source_text="x", verified=True, verification_method="made_up", verification_confidence=0.5))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+```
+
+- [ ] **Step 2: Run it (fails)** — the `paraphrase_judge` insert raises `IntegrityError` against the current CHECK. `cd api && DATABASE_URL=... .venv/bin/pytest tests/integration/test_caselaw_paraphrase_method.py -v` → first test FAILs.
+
+- [ ] **Step 3: Update the model** `api/app/models/message_caselaw_citation.py` CHECK:
+
+```python
+        CheckConstraint(
+            "verification_method IS NULL OR verification_method IN "
+            "('exact_match', 'tolerant_match', 'paraphrase_judge')",
+            name="chk_message_caselaw_citations_method_values",
+        ),
+```
+
+- [ ] **Step 4: Create migration** `api/alembic/versions/0060_caselaw_method_paraphrase.py`:
+
+```python
+"""relax message_caselaw_citations method CHECK to allow paraphrase_judge (P1-B1b)
+
+Revision ID: 0060
+Revises: 0059
+"""
+from __future__ import annotations
+from collections.abc import Sequence
+from alembic import op
+
+revision: str = "0060"
+down_revision: str | None = "0059"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NAME = "chk_message_caselaw_citations_method_values"
+_TABLE = "message_caselaw_citations"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_NAME, _TABLE, type_="check")
+    op.create_check_constraint(
+        _NAME, _TABLE,
+        "verification_method IS NULL OR verification_method IN "
+        "('exact_match', 'tolerant_match', 'paraphrase_judge')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_NAME, _TABLE, type_="check")
+    op.create_check_constraint(
+        _NAME, _TABLE,
+        "verification_method IS NULL OR verification_method IN ('exact_match', 'tolerant_match')",
+    )
+```
+
+- [ ] **Step 5: Run the tests (pass)** — `cd api && DATABASE_URL=... .venv/bin/pytest tests/integration/test_caselaw_paraphrase_method.py -v` → both PASS (conftest auto-applies 0060).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd api && .venv/bin/ruff format app/models/message_caselaw_citation.py alembic/versions/0060_caselaw_method_paraphrase.py tests/integration/test_caselaw_paraphrase_method.py && .venv/bin/ruff check app/models alembic/versions/0060_caselaw_method_paraphrase.py tests/integration/test_caselaw_paraphrase_method.py
+```
+```bash
+git add api/app/models/message_caselaw_citation.py api/alembic/versions/0060_caselaw_method_paraphrase.py api/tests/integration/test_caselaw_paraphrase_method.py
+git commit -s -m "feat(citation): migration 0060 — allow paraphrase_judge on caselaw citations (P1-B1b)
+
+Refs ADR 0018 D2.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `caselaw.py` orchestration + thread the gateway at finalize
+
+**Files:**
+- Modify: `api/app/citation/caselaw.py` (gateway param + SUPPORTED judge pass)
+- Modify: `api/app/api/chats.py` (pass `gateway=gateway` at the two caselaw finalize sites — ~lines 2920, 3503)
+- Test: `api/tests/integration/test_caselaw_paraphrase_judge.py`
+
+**Interfaces:**
+- Consumes: `judge_case_content`, `estimate_case_content_cost_usd`, `CASE_CONTENT_JUDGE_BUDGET_USD` (Task 1).
+
+- [ ] **Step 1: Write the failing integration tests** `api/tests/integration/test_caselaw_paraphrase_judge.py` (real Postgres, mocked judge; reuse P1-A1's `test_caselaw_citations.py` seeding of `ResearchOpinionMetadata` + the `load_opinion_text` injection point — read it for the exact fixture shape):
+
+```python
+# Cover (using the existing caselaw test fixtures + an injected load_opinion_text):
+# 1. A paraphrased blockquote (not verbatim) + a mocked judge that ACCEPTS ->
+#    exactly one MessageCaselawCitation with verification_method='paraphrase_judge',
+#    verified=True, offsets (0, len(opinion)), partial=True. assemble_ledger_entries
+#    + compute_and_record_gate -> gate_status == 'supported_only'.
+# 2. A mocked judge that REJECTS all consulted opinions -> NO row written (drop),
+#    gate unaffected (additive-only invariant).
+# 3. Budget set below one call's estimate (monkeypatch CASE_CONTENT_JUDGE_BUDGET_USD
+#    to Decimal('0')) -> the judge mock is NEVER called and NO row is written.
+# 4. gateway=None -> behaves exactly as today (verbatim path only; no judge, no rows).
+```
+
+(Write these out fully against the real `verify_and_persist_caselaw_citations` signature + a `_FakeGateway` whose `chat_completion` returns accept/reject, plus a `load_opinion_text` stub returning a known opinion body. Assert the mock's call count for cases 3–4.)
+
+- [ ] **Step 2: Run (fails)** — judge pass not implemented → no `paraphrase_judge` rows. `cd api && DATABASE_URL=... .venv/bin/pytest tests/integration/test_caselaw_paraphrase_judge.py -v` → FAIL.
+
+- [ ] **Step 3: Implement the orchestration** in `api/app/citation/caselaw.py`. Add params and, after the existing verbatim loop, a SUPPORTED judge pass over passages that produced no row. Keep the verbatim loop unchanged; track which passages remain unverified.
+
+```python
+async def verify_and_persist_caselaw_citations(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    assistant_text: str,
+    tool_sources: Sequence[ToolSourceRecord],
+    load_opinion_text: _LoadOpinionText = _default_load_opinion_text,
+    gateway: _JudgeGatewayProtocol | None = None,
+    judge_model: str = "fast",
+) -> int:
+    ...
+    # (existing verbatim loop builds `rows`; track passages that matched verbatim)
+    matched = {id(p) for p in passages if _passage_has_row(p, rows)}  # or track inline
+    # --- SUPPORTED judge pass (additive; only with a gateway) ---
+    if gateway is not None:
+        spent = Decimal("0")
+        for passage in passages:
+            if _already_verbatim(passage):   # skip passages that got a verbatim row
+                continue
+            for op, text in texts:
+                est = await estimate_case_content_cost_usd(db, judge_model=judge_model, opinion_text=text)
+                if spent + est > CASE_CONTENT_JUDGE_BUDGET_USD:
+                    log.info("case-content judge: per-turn budget reached; stopping")
+                    break  # stop judging this turn
+                spent += est
+                try:
+                    result = await judge_case_content(passage=passage, opinion_text=text, gateway=gateway, judge_model=judge_model)
+                except Exception as exc:
+                    log.warning("case-content judge error on opinion %s: %r", op.opinion_id, exc)
+                    continue
+                if not result.verified:
+                    continue  # this opinion's judge rejected; try next
+                rows.append(MessageCaselawCitation(
+                    message_id=message_id, opinion_id=op.opinion_id, cluster_id=op.cluster_id,
+                    source_offset_start=0, source_offset_end=len(text),
+                    source_text=passage, verified=True, verification_method="paraphrase_judge",
+                    verification_confidence=result.confidence, partial=True))
+                break  # one SUPPORTED row per passage, first accepting opinion wins
+            else:
+                continue
+            # (inner break already advanced to next passage)
+    if rows:
+        db.add_all(rows)  # NOTE: keep a single add_all/flush; see below
+        await db.flush()
+    return len(rows)
+```
+
+> **Implementer:** the existing function already builds `rows` from the verbatim loop and does one `add_all` + `flush` at the end — fold the judge-pass rows into the **same** `rows` list and the existing single `add_all`/`flush` (don't add a second flush). Track "which passages got a verbatim row" cleanly (e.g. collect verbatim-matched passage strings into a set during the first loop, then `if passage in verbatim_matched: continue` in the judge pass). The budget `break` must stop the whole judge pass for the turn (not just the inner opinion loop) — restructure with a flag or early-return so the per-turn cap is honored.
+
+Add the imports: `from decimal import Decimal`, `from app.citation.case_content_judge import judge_case_content, estimate_case_content_cost_usd, CASE_CONTENT_JUDGE_BUDGET_USD`, and the `_JudgeGatewayProtocol` type.
+
+- [ ] **Step 4: Thread the gateway at the two finalize sites** in `api/app/api/chats.py` (~2920 and ~3503): add `gateway=gateway` to both `verify_and_persist_caselaw_citations(...)` calls (the `GatewayClient` is already in scope at both — confirm the local variable name and pass it).
+
+- [ ] **Step 5: Run the integration tests (pass)** — `cd api && DATABASE_URL=... .venv/bin/pytest tests/integration/test_caselaw_paraphrase_judge.py -v` → all PASS (accept→supported_only; reject→drop; budget=0→no call/no row; gateway=None→unchanged).
+
+- [ ] **Step 6: Full gate**
+
+```bash
+cd api && .venv/bin/ruff format app tests && .venv/bin/ruff check app tests && .venv/bin/mypy app && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/pytest -q
+```
+Expected: ruff + mypy clean; full suite green (no decrease). In particular the **existing** caselaw tests (`gateway=None` default) must be unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/app/citation/caselaw.py api/app/api/chats.py api/tests/integration/test_caselaw_paraphrase_judge.py
+git commit -s -m "feat(citation): caselaw paraphrase judge SUPPORTED pass + wire gateway (P1-B1b)
+
+After the verbatim loop, dropped caselaw passages are judged against the
+consulted opinions (cost-gated, per-turn budget); a judge-accepted
+passage persists a paraphrase_judge row (gate -> supported_only).
+Additive-only: no FAIL/unverified rows; gateway=None is unchanged.
+Gateway threaded at the two caselaw finalize sites.
+
+Refs ADR 0018 D2/D3, DE-280.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Whole-opinion judge (DE-280) over stored text → Task 1 (`judge_case_content`). ✓
+- Per-message cost budget + stop-when-exceeded → Task 1 (`estimate_case_content_cost_usd`) + Task 3 (the `spent`/budget loop). ✓
+- SUPPORTED `paraphrase_judge` row on accept; drop on reject (additive-only) → Task 3. ✓
+- Migration 0060 relaxes the caselaw method CHECK → Task 2. ✓
+- Thread gateway at the two finalize sites → Task 3 Step 4. ✓
+- `gateway=None` unchanged; no gate/ledger change → Global Constraints + Task 3 (default param; tests assert it). ✓
+- Whole-opinion offsets `(0, len)` + `partial=True` → Task 3 + Global Constraints. ✓
+- Caselaw FAIL explicitly NOT here (B1c) → no FAIL row anywhere in the plan. ✓
+
+**Placeholder scan:** The `_build_prompt` body and `judge_case_content` reuse points carry "read `verify_paraphrase` for the exact `ChatCompletionRequest`/`purpose` threading" instructions with the named source symbol — precise reuse, not a TODO. The Task-1 test helpers (`_judge_completion`/`_serialize_messages`) are sourced from the existing cascade judge tests by name. Task-3 Step-1 enumerates the four required tests with exact expected outcomes + assertions (call-count for budget/None cases). No "TBD"/"implement later". ✓
+
+**Type consistency:** `judge_case_content(*, passage, opinion_text, gateway, judge_model) -> VerificationResult` and `estimate_case_content_cost_usd(db, *, judge_model, opinion_text) -> Decimal` are defined in Task 1 and consumed identically in Task 3. `verification_method="paraphrase_judge"` matches the CHECK relaxed in Task 2 and the gate's SUPPORTED set. The `gateway`/`judge_model` params added to `verify_and_persist_caselaw_citations` match the call-site threading in Task 3 Step 4. ✓
+
+**Note for executor:** Before Task 1, read `verify_paraphrase` + `_parse_judge_response` + an existing paraphrase-judge test in `api/tests/` to copy the `ChatCompletionRequest` construction, the `purpose` tagging, the fake-gateway shape, and the judge-response JSON. Before Task 3, read P1-A1's `verify_and_persist_caselaw_citations` end-to-end and `test_caselaw_citations.py` to fold the judge pass into the existing `rows`/`add_all`/`flush` without a second flush and to reuse the opinion-seeding fixtures. Confirm the `GatewayClient` variable name at chats.py:2920 / 3503.

--- a/docs/superpowers/specs/2026-06-25-p1b1b-caselaw-paraphrase-judge-design.md
+++ b/docs/superpowers/specs/2026-06-25-p1b1b-caselaw-paraphrase-judge-design.md
@@ -1,0 +1,100 @@
+# P1-B1b — Caselaw paraphrase/content judge (SUPPORTED tier) (design)
+
+**Date:** 2026-06-25
+**Milestone:** Fiduciary-grade agentic legal work — Phase 1 (WS-B)
+**Branch:** `feat/fiduciary-p1b1b-caselaw-paraphrase-judge`
+**Pins:** [ADR 0018](../../adr/0018-citation-ledger-and-fiduciary-grade-output.md) D2 (verify external quotes against the materialized opinion text), D3 (fiduciary-grade gate). Realizes the [DE-280](../../PRD.md#de-280) case-content-accuracy judge as the SUPPORTED tier. Builds on **P1-A1** (caselaw verbatim verification, #218) and **P1-B1** (the gate, #225).
+**Security review:** **required** (citation surface + **new gateway egress** + cost accounting; `api/app/citation/**`, `chats.py`).
+
+## Problem
+
+P1-A1 verifies caselaw quotes **verbatim** (cascade stages 1–2, `gateway=None`); a quote that doesn't locate verbatim in any consulted opinion is **silently dropped**. So a paraphrased-but-faithful caselaw quote never reaches a verified tier — the lawyer sees no signal that the quote is *supported* by the cited case even though it is. P1-B1b adds that tier: a **whole-opinion content judge** runs over the dropped passages (cost-bounded) and, when it judges a passage **faithfully supported** by a consulted opinion, persists a `paraphrase_judge` row. The gate (already shipped) reads that as SUPPORTED, so the turn renders `supported_only` (amber in P1-C1) instead of hiding the quote.
+
+**Explicitly out of scope (→ P1-B1c):** persisting caselaw **FAIL** rows for fabricated/misquoted quotes. Safe FAIL requires reliable passage→opinion attribution (parsing each blockquote's `### Case Name` H3 header and matching it to a consulted opinion); without it, judging a dropped passage against *all* consulted opinions would false-positive on legitimate non-caselaw blockquotes (a statute, a KB quote) — wrongly flagging a good draft, the worst failure for a fiduciary tool. B1b ships the false-positive-free SUPPORTED tier; B1c builds the attribution parser + FAIL (pairs with the deferred [DE-279](../../PRD.md#de-279) case-cite resolution). **B1b is purely additive — it only ever writes new SUPPORTED rows; it never writes a FAIL/unverified row and never changes a turn that is fiduciary-grade today into flagged.**
+
+## Why a whole-opinion judge (not the cascade's stage-3)
+
+The cascade's `verify_paraphrase` (stage 3) windows ±200 chars around a **located** span. A dropped caselaw passage has **no located span**, so there is nothing to window. DE-280's design is the right one: feed the judge the **whole opinion** (10–50pp) + the candidate passage and ask "is this passage faithfully supported by this opinion?" Same `_JudgeGatewayProtocol` surface (`chat_completion`), longer context, fidelity-focused prompt — a different verification surface than stage-3 (PRD DE-280).
+
+## Decisions (maintainer-approved 2026-06-25)
+
+- **SUPPORTED-only.** B1b persists a `paraphrase_judge` row when the judge accepts; it does **not** persist FAIL/unverified rows. A passage no consulted opinion's judge accepts stays **dropped** (unchanged from today). Caselaw FAIL + the attribution parser are **P1-B1c**.
+- **Per-message cost budget bounds spend.** Before each judge call, estimate cost (`estimate_judge_call_cost_usd` scaled by the opinion's token size) and accumulate per turn against a configured cap. When the next call would exceed the cap, **stop judging this turn** (remaining passages drop, as today). Because B1b writes no FAIL/unverified rows, exhausting the budget simply means "fewer SUPPORTED rows," never a flagged turn — so the over-budget case needs no special row, just a logged stop.
+- **Whole-opinion judge over stored text.** The opinion plaintext is already stored locally (`read_opinion` / `ResearchOpinionMetadata`) — no live CourtListener fetch at verification time.
+- **DE-360 stays deferred.** B1b runs the judge on a single configured longer-context tier; the cheap→capable escalation router ([DE-360](../../PRD.md#de-360)) ships later. The per-message budget bounds spend until then.
+- **No gate / ledger change.** The gate already buckets `paraphrase_judge` → SUPPORTED; `assemble_ledger_entries` already maps the method onto the ledger status. B1b only produces richer rows.
+
+## Design
+
+### Component 1 — `api/app/citation/case_content_judge.py`
+
+```python
+async def judge_case_content(
+    *, passage: str, opinion_text: str, gateway: _JudgeGatewayProtocol, judge_model: str,
+) -> VerificationResult:
+```
+
+Builds a fidelity prompt (the full opinion text + the candidate passage; "is the passage faithfully supported — same holding/quote, not a distortion?"), calls `gateway.chat_completion`, and parses to `VerificationResult(verified=True, method="paraphrase_judge", confidence, partial)` on accept or `_MISS` on reject — reusing the cascade's judge-response parser (`_parse_judge_response`) and the `judge_prompts.py` conservative-bias convention (a false-positive verification is worse than a false-negative; malformed output → `_MISS`). Inference logged with `purpose='judge_case_content'` (a new `InferenceRoutingLog.purpose` string — no schema change) so cost calibration stays segregated from stage-3's `judge_paraphrase`.
+
+### Component 2 — Cost pre-flight
+
+```python
+async def estimate_case_content_cost_usd(db, *, judge_model: str, opinion_text: str) -> Decimal:
+```
+
+`estimate_judge_call_cost_usd(db, judge_model=...)` (rolling average, `0.005` cold-start) scaled by an opinion-token estimate (`len(opinion_text) / CHARS_PER_TOKEN`). The orchestrator (Component 3) keeps a per-turn running total against a configured `CASE_CONTENT_JUDGE_BUDGET_USD` cap (a module/config constant in v1; operator-tunable later, not this slice). When the next call would exceed the cap, the orchestrator stops judging and logs the stop.
+
+### Component 3 — `caselaw.py` orchestration
+
+`verify_and_persist_caselaw_citations` gains `gateway: _JudgeGatewayProtocol | None = None` and a `judge_model` (default a configured longer-context tier). The existing verbatim loop is unchanged. **After** it (for passages that produced no verbatim row), **and only if `gateway` is provided**:
+
+1. For each still-unverified passage, iterate the already-loaded consulted opinion texts:
+   - **Cost pre-flight** for `(judge_model, opinion_text)`; if the turn budget would be exceeded → **stop** (break out; remaining passages drop). Log the stop.
+   - Else `judge_case_content(passage, opinion_text, gateway, judge_model)`. On **accept** → append a `MessageCaselawCitation(verified=True, verification_method="paraphrase_judge", verification_confidence=…, partial=…, opinion_id=op.opinion_id, cluster_id=op.cluster_id, source_offset_start/end=…)` and **break** (one SUPPORTED row per passage, first accepting opinion wins).
+2. A passage no opinion accepts → **dropped** (no row), exactly as today.
+3. A per-opinion judge/gateway error is caught and treated as "no verdict" for that opinion (logged, never fatal).
+4. `gateway=None` → the function behaves exactly as today (verbatim-only; deterministic; no egress, no cost).
+
+> **Offsets for a paraphrase row.** A paraphrase has no exact span in the opinion. v1 stores the **judge-identified supporting span** when the judge returns one, else a sentinel (e.g. `0,0` is rejected by the `offset_end > offset_start` CHECK) — so the judge prompt must return a best-effort supporting char range, or B1b stores the **whole-opinion span** (`0, len(opinion_text)`) as the "passage read" with `partial=True`. **Pin in the plan (task 1):** the simplest honest choice is the whole-opinion span (the trace shows "supported by this opinion" rather than a false exact locus); confirm the `MessageCaselawCitation` offset CHECK accepts it.
+
+### Component 4 — Migration `0060` (relax the caselaw method CHECK)
+
+`chk_message_caselaw_citations_method_values` currently admits `('exact_match','tolerant_match')`. Add `'paraphrase_judge'`. Update the model's `CheckConstraint` to match. (`down_revision="0059"`; next migration after the gate table.)
+
+### Component 5 — Thread the gateway at the finalize sites
+
+The two caselaw finalize sites in `chats.py` already have a live `GatewayClient` in scope. Pass it: `verify_and_persist_caselaw_citations(db, …, gateway=gateway)`.
+
+### Ledger + gate (no change)
+
+`assemble_ledger_entries` maps `message_caselaw_citations.verification_method` → the ledger entry status; the gate buckets `paraphrase_judge` → SUPPORTED. A B1b SUPPORTED row makes the turn `supported_only`. **No** change to `ledger.py` / `gate.py`. P1-C1 renders it amber.
+
+## Error handling (conservative posture)
+
+- Gateway/judge error on an opinion → "no verdict" for that opinion (logged), never fatal; the turn proceeds.
+- Malformed judge output → `_MISS` (conservative; no row).
+- Budget exhausted → stop judging (remaining passages drop); no special row, no flag.
+- `gateway=None` → unchanged verbatim-only behaviour (no egress, no cost).
+- B1b never writes a row that could flip a turn to `flagged` (additive-only invariant).
+
+## Testing
+
+- **Unit (mocked gateway — no live egress):** `judge_case_content` accept → `paraphrase_judge` result; reject → `_MISS`; the prompt includes the full opinion text + passage; malformed output → `_MISS`. `estimate_case_content_cost_usd` scales with opinion length.
+- **Integration (real Postgres, mocked gateway):** a turn with a paraphrased caselaw quote → one `paraphrase_judge` `MessageCaselawCitation`; `assemble_ledger_entries` + the gate → `supported_only`. A budget set below one call's estimate → **no** judge call made (assert the mock was not called) and **no** row (passage drops); the turn's gate is whatever the verbatim rows say (not flipped to flagged). `gateway=None` → identical to today (no rows beyond verbatim, no egress). A judge that rejects all consulted opinions → passage drops (no row, additive-only invariant holds).
+- **Migration:** `0060` applies (conftest auto-migrate); a `paraphrase_judge` row inserts; the CHECK still rejects a bogus method.
+- Gates: `ruff format` + `ruff check` + `mypy app` + full `pytest`. Mocked gateway → no `-m provider`. Host venv + throwaway pgvector; **next migration = 0060**.
+
+## Acceptance criteria
+
+1. A faithful but non-verbatim caselaw quote, against a consulted opinion, persists a `paraphrase_judge` `MessageCaselawCitation` and moves the turn's gate to `supported_only` (rendered amber by C1).
+2. **Additive-only:** B1b never writes a FAIL/unverified caselaw row; a turn that is `fiduciary_grade` or `supported_only` today is never flipped to `flagged` by B1b. A passage no opinion accepts stays dropped.
+3. The per-message cost budget bounds spend: once the cap is reached, no further judge calls are made for the turn (asserted with a call-count on the mock).
+4. `gateway=None` preserves today's verbatim-only behaviour exactly (no egress); migration `0060` adds `paraphrase_judge` to the caselaw CHECK.
+5. No change to `ledger.py` or `gate.py`. `ruff` + `mypy` clean; unit + integration + migration tests green; security review passes the egress/cost surface.
+
+## Out of scope / sequencing
+
+- **P1-B1c — caselaw FAIL + attribution** (NEW): a passage→opinion attribution parser (blockquote → nearest `### Case` H3 → matched consulted opinion) so a judge-rejected quote against its *attributed* opinion persists a FAIL row (gate → `flagged`) without false-positives on non-caselaw blockquotes. Pairs with DE-279. **To be added to the proposal's Phase-1 PR decomposition + PRD as its own (security-gated) slice.**
+- **DE-360** escalation routing — deferred; B1b uses one configured judge tier.
+- **Operator-tunable** budget cap / PASS set — deferred (config constant in v1).
+- **C1 UI** ships **first** and renders the new `supported_only` amber state automatically once B1b lands.


### PR DESCRIPTION
## P1-B1b — Caselaw paraphrase/content judge (SUPPORTED-only)

Gives a non-verbatim caselaw blockquote that a **whole-opinion** LLM judge finds faithfully supported a `paraphrase_judge` row — so the already-shipped gate renders the turn `supported_only` (amber in the P1-C1 ledger UI) instead of silently dropping the quote. Realizes the [DE-280](../PRD.md#de-280) content-accuracy judge as the SUPPORTED tier. Milestone: fiduciary-grade agentic legal work, Phase 1 (WS-B).

### What's here
- **`api/app/citation/case_content_judge.py`** — `judge_case_content` runs an LLM fidelity judge over the **full** stored opinion text (a dropped passage has no located span, so the cascade's ±200-char window doesn't apply), reusing the cascade's `_JudgeGatewayProtocol` + `_parse_judge_response`. Accept → `paraphrase_judge`; reject / malformed / gateway-error → MISS (never raises). Plus `estimate_case_content_cost_usd` (per-call cost × opinion-length, floored). Inference tagged `purpose='judge_case_content'`; `estimate_judge_call_cost_usd` generalized with a `purpose` param (cache key `<model>:<purpose>` — backward-compatible).
- **Migration `0060`** — relaxes the `message_caselaw_citations` method CHECK to allow `paraphrase_judge`.
- **`caselaw.py` orchestration** — after the verbatim loop, a **cost-gated** judge pass over dropped passages writes SUPPORTED rows (whole-opinion span, `partial=True`, first accepting opinion wins). Gateway + the operator-configured judge model threaded at the two caselaw finalize sites.

### Load-bearing invariants
- **Additive-only.** Writes ONLY `verified=True, method='paraphrase_judge'` rows — never a FAIL/unverified row, never flips a turn to `flagged`. A passage no judge accepts stays dropped. (Caselaw fabrication-flagging is the separate **P1-B1c** slice, which needs passage→opinion attribution.)
- **`gateway=None` is byte-identical** to today (verbatim-only; no egress; no cost) — every existing caller/test uses the default and is unaffected.
- **Per-turn cost budget** stops the *whole* judge pass when exceeded (pre-flight, so an over-budget call is never made); the estimate is floored so a zero estimate can't defeat the bound (DoS-safe fan-out cap).
- **No gate / ledger change** — the gate already buckets `paraphrase_judge`→SUPPORTED; B1b only produces richer rows.

### Testing
- Unit (mocked gateway): accept→`paraphrase_judge`, reject/malformed/gateway-error→MISS, prompt includes whole opinion + passage, purpose tag, cost scaling.
- Integration (real Postgres, mocked gateway): paraphrased quote → `paraphrase_judge` row → gate `supported_only`; reject-all → drop (additive-only); budget=0 → judge never called + no row; `gateway=None` → unchanged.
- Migration 0060 chains from 0059. Full api gate: ruff + mypy clean; full suite green.

### Review
Built via brainstorm → spec → plan → subagent-driven-development (per-task spec+quality reviews + an Opus whole-branch review). The Opus review caught that the caselaw judge ignored the operator-configured judge model (used hardcoded `fast`, diverging from the document-citation path) and a theoretical zero-cost-estimate budget hole — both fixed.

> **Security review (CODEOWNERS):** new gateway egress + cost accounting + citation surface (`api/app/citation/**`, `chats.py`) — please review/merge; I have not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Spec: `docs/superpowers/specs/2026-06-25-p1b1b-caselaw-paraphrase-judge-design.md` · Plan: `docs/superpowers/plans/2026-06-25-p1b1b-caselaw-paraphrase-judge.md` · Refs ADR 0018 D2/D3, DE-280.
