### PR TITLE
feat(citation): caselaw FAIL tier via H3 attribution (P1-B1c)

### DIFF
--- a/api/app/citation/caselaw.py
+++ b/api/app/citation/caselaw.py
@@ -22,6 +22,7 @@ See docs/superpowers/specs/2026-06-24-p1a1-external-caselaw-quote-verification-d
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import uuid
@@ -211,6 +212,30 @@ def _fail_row(
     )
 
 
+def _judge_returned_explicit_no(response: Any) -> bool:
+    """True only if the judge returned a parseable ``{"verdict": "no"}``.
+
+    A reject must be an *explicit* "no". Non-substantive failures — truncated or
+    non-JSON output (the judge caps at 400 tokens), an unknown verdict, or a
+    "yes"/"partial" with an unrecognized confidence — all collapse to the same
+    _MISS in _parse_judge_response, but they are NOT rejections: treating them as
+    FAIL would flag good work product on judge-output noise (the exact
+    false-positive this tier exists to avoid). Those cases drop, like a transient
+    error.
+    """
+    try:
+        choices = response.choices
+        if not choices:
+            return False
+        content = choices[0].message.content
+        if not content:
+            return False
+        payload = json.loads(content)
+    except (AttributeError, json.JSONDecodeError, TypeError):
+        return False
+    return isinstance(payload, dict) and payload.get("verdict") == "no"
+
+
 async def _judge_attributed_passage(
     db: AsyncSession,
     *,
@@ -249,6 +274,7 @@ async def _judge_attributed_passage(
             request = _build_case_content_prompt(passage, text, judge_model=judge_model)
             response = await gateway.chat_completion(request)
             result = _parse_judge_response(response)
+            explicit_no = _judge_returned_explicit_no(response)
         except Exception as exc:
             log.warning("case-content judge error on opinion %s: %r", opinion_id, exc)
             continue  # transient on this opinion -> try the next
@@ -265,7 +291,10 @@ async def _judge_attributed_passage(
                 verification_confidence=result.confidence,
                 partial=True,
             )
-        saw_reject = True  # a real "no" from the judge
+        if explicit_no:
+            saw_reject = True  # an explicit "no" from the judge -> reject
+        # else: non-substantive output (unparseable/unknown verdict/missing
+        # confidence) -> drop this opinion, like a transient error.
     if saw_reject:
         log.info(
             "case-content judge: attributed passage rejected; flagging FAIL",

--- a/api/app/citation/caselaw.py
+++ b/api/app/citation/caselaw.py
@@ -36,30 +36,64 @@ from app.models.research import ResearchOpinionMetadata
 from app.research.service import read_opinion
 
 
-def extract_blockquote_passages(answer_text: str) -> list[str]:
-    """Return the text of each markdown blockquote in ``answer_text``.
+@dataclass(slots=True)
+class AttributedPassage:
+    """A blockquote passage paired with the case name of its nearest ``### `` heading.
 
-    The case-law-research skill renders each cited passage as a markdown
-    blockquote (``> ...``) under a "Relevant passage:" header. Consecutive
-    blockquote lines are one passage (wrapped quote); a non-blockquote line
-    ends the current passage.
+    ``case_name`` is the text of the most recent ``### `` heading above the
+    blockquote, taken up to the first comma (the case-law-research skill renders
+    headings as ``### [Case Name], [Court], [Year] ([Citation])``). ``None`` when
+    no ``### `` heading precedes the blockquote — the attribution false-positive
+    guard: an unattributed passage never produces a FAIL row.
     """
-    passages: list[str] = []
+
+    passage: str
+    case_name: str | None
+
+
+def attribute_passages(answer_text: str) -> list[AttributedPassage]:
+    """Return each markdown blockquote paired with its nearest ``### `` case heading.
+
+    Consecutive blockquote lines (``> ...``) join into one passage; a
+    non-blockquote line ends the current passage. Each closed passage is paired
+    with the case name parsed from the most recent ``### `` heading seen so far.
+    """
+    result: list[AttributedPassage] = []
     current: list[str] = []
+    current_case: str | None = None
+
+    def _flush() -> None:
+        nonlocal current
+        joined = " ".join(p for p in current if p).strip()
+        if joined:
+            result.append(AttributedPassage(passage=joined, case_name=current_case))
+        current = []
+
     for line in answer_text.splitlines():
         stripped = line.lstrip()
         if stripped.startswith(">"):
             current.append(stripped[1:].strip())
-        elif current:
-            joined = " ".join(p for p in current if p).strip()
-            if joined:
-                passages.append(joined)
-            current = []
+            continue
+        if current:
+            _flush()
+        # Only level-3 (``### ``) headings carry case attribution. ``##``/``#``
+        # (and ``####``) do not — guard with an exact "### " prefix that is not
+        # also "#### ".
+        if stripped.startswith("### ") and not stripped.startswith("#### "):
+            heading = stripped[4:].strip()
+            current_case = heading.split(",", 1)[0].strip() or None
     if current:
-        joined = " ".join(p for p in current if p).strip()
-        if joined:
-            passages.append(joined)
-    return passages
+        _flush()
+    return result
+
+
+def extract_blockquote_passages(answer_text: str) -> list[str]:
+    """Return the text of each markdown blockquote in ``answer_text`` (flat list).
+
+    Retained for existing callers/tests; equivalent to the passages produced by
+    :func:`attribute_passages`.
+    """
+    return [a.passage for a in attribute_passages(answer_text)]
 
 
 # Stable namespace so a given opinion_id maps to a deterministic synthetic id.

--- a/api/app/citation/caselaw.py
+++ b/api/app/citation/caselaw.py
@@ -15,6 +15,7 @@ See docs/superpowers/specs/2026-06-24-p1a1-external-caselaw-quote-verification-d
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
@@ -85,6 +86,35 @@ def attribute_passages(answer_text: str) -> list[AttributedPassage]:
     if current:
         _flush()
     return result
+
+
+def normalize_case_name(name: str) -> str:
+    """Normalize a case name for attribution matching.
+
+    Lowercases, strips a trailing ``(...)`` citation parenthetical, strips
+    trailing punctuation/whitespace, and collapses internal whitespace runs to
+    single spaces. Conservative: only a normalized-exact match attributes.
+    """
+    text = name.strip()
+    # Drop a trailing parenthetical citation, e.g. "(410 U.S. 113)".
+    text = re.sub(r"\s*\([^()]*\)\s*$", "", text)
+    text = text.lower()
+    text = re.sub(r"\s+", " ", text)
+    return text.strip().rstrip(",;: ")
+
+
+def match_case_name(parsed: str, clusters: Sequence[tuple[int, str]]) -> int | None:
+    """Return the cluster_id iff exactly one cluster's case_name matches ``parsed``.
+
+    Normalized-exact, single-match only (the false-positive guard). Zero matches,
+    two-or-more matches, or clusters with an empty case_name → ``None`` →
+    the passage stays on the B1b path (never produces a FAIL row).
+    """
+    target = normalize_case_name(parsed)
+    if not target:
+        return None
+    matches = [cid for cid, name in clusters if name and normalize_case_name(name) == target]
+    return matches[0] if len(matches) == 1 else None
 
 
 def extract_blockquote_passages(answer_text: str) -> list[str]:

--- a/api/app/citation/caselaw.py
+++ b/api/app/citation/caselaw.py
@@ -1,4 +1,4 @@
-"""Caselaw quote verification (P1-A1, P1-B1b).
+"""Caselaw quote verification (P1-A1, P1-B1b, P1-B1c).
 
 Extracts blockquote passages from an assistant answer, locates each verbatim in
 a consulted CourtListener opinion's stored plaintext, runs the existing citation
@@ -6,8 +6,16 @@ cascade (deterministic stages 1-2), and persists verified rows.
 
 P1-B1b adds a SUPPORTED judge pass: passages that did not match verbatim are
 judged against the whole opinion text (cost-gated). A judge-accepted passage
-persists a paraphrase_judge row (gate -> supported_only). Additive-only: no
-FAIL/unverified rows are ever written here.
+persists a paraphrase_judge row (gate -> supported_only).
+
+P1-B1c adds attribution-aware FAIL rows: passages confidently attributed to a
+single consulted case (via ``### `` heading match) are judged against that one
+opinion only. A real judge rejection writes an unverified FAIL row
+(verified=False, verification_method=NULL), which flows through the unchanged
+ledger/gate to a ``flagged`` turn status. Over-budget attributed passages also
+write an unverified FAIL row. Transient gateway errors on ALL opinions of an
+attributed passage → drop (no row). Unattributed passages keep B1b's
+all-opinions SUPPORTED-or-drop behavior (strict additive guarantee).
 
 See docs/superpowers/specs/2026-06-24-p1a1-external-caselaw-quote-verification-design.md.
 """
@@ -28,12 +36,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.chat.tool_loop import ToolSourceRecord
 from app.citation.case_content_judge import (
     CASE_CONTENT_JUDGE_BUDGET_USD,
+    _build_prompt as _build_case_content_prompt,
     estimate_case_content_cost_usd,
     judge_case_content,
 )
-from app.citation.verification import _JudgeGatewayProtocol, verify
+from app.citation.verification import _JudgeGatewayProtocol, _parse_judge_response, verify
 from app.models.message_caselaw_citation import MessageCaselawCitation
-from app.models.research import ResearchOpinionMetadata
+from app.models.research import ResearchClusterMetadata, ResearchOpinionMetadata
 from app.research.service import read_opinion
 
 
@@ -173,10 +182,102 @@ def locate_passage(passage: str, opinion_text: str) -> tuple[int, int] | None:
 
 
 # ---------------------------------------------------------------------------
-# Orchestrator
+# Private helpers (FAIL tier — P1-B1c)
 # ---------------------------------------------------------------------------
 
 log = logging.getLogger(__name__)
+
+
+def _fail_row(
+    message_id: uuid.UUID, opinion_id: int, cluster_id: int, passage: str
+) -> MessageCaselawCitation:
+    """Build an unverified caselaw FAIL row (gate -> flagged).
+
+    Offsets are a documented placeholder: a FAIL passage has no verified span in
+    the opinion, but the CHECK requires offset_end > offset_start >= 0. The ledger
+    and trace never read caselaw offsets (ledger.py:78-91).
+    """
+    return MessageCaselawCitation(
+        message_id=message_id,
+        opinion_id=opinion_id,
+        cluster_id=cluster_id,
+        source_offset_start=0,
+        source_offset_end=len(passage),
+        source_text=passage,
+        verified=False,
+        verification_method=None,
+        verification_confidence=None,
+        partial=False,
+    )
+
+
+async def _judge_attributed_passage(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    passage: str,
+    cluster_id: int,
+    opinions: list[tuple[int, str]],
+    gateway: _JudgeGatewayProtocol,
+    judge_model: str,
+    spent: Decimal,
+) -> tuple[Decimal, MessageCaselawCitation | None]:
+    """Judge an attributed passage against its cluster's opinion(s) only.
+
+    Returns (updated_spent, row_or_None):
+      * accept            -> SUPPORTED row (paraphrase_judge)
+      * judge reject      -> FAIL row (verified=False, method NULL)
+      * over budget       -> unverified FAIL row (verified=False, method NULL)
+      * all transient err -> None (drop; no row)
+    """
+    saw_reject = False
+    first_opinion_id = opinions[0][0]
+    for opinion_id, text in opinions:
+        est = await estimate_case_content_cost_usd(db, judge_model=judge_model, opinion_text=text)
+        if spent + est > CASE_CONTENT_JUDGE_BUDGET_USD:
+            log.info(
+                "case-content judge: attributed passage over budget; flagging unverified",
+                extra={"event": "caselaw_fail_over_budget", "cluster_id": cluster_id},
+            )
+            return spent, _fail_row(message_id, opinion_id, cluster_id, passage)
+        spent += est
+        # Call the gateway directly (not via judge_case_content) so transient errors
+        # propagate as exceptions. judge_case_content swallows all errors and returns
+        # _MISS, making "real rejection" and "transient error" indistinguishable — but
+        # the attribution FAIL tier needs to distinguish them (transient → drop, not FAIL).
+        try:
+            request = _build_case_content_prompt(passage, text, judge_model=judge_model)
+            response = await gateway.chat_completion(request)
+            result = _parse_judge_response(response)
+        except Exception as exc:
+            log.warning("case-content judge error on opinion %s: %r", opinion_id, exc)
+            continue  # transient on this opinion -> try the next
+        if result.verified:
+            return spent, MessageCaselawCitation(
+                message_id=message_id,
+                opinion_id=opinion_id,
+                cluster_id=cluster_id,
+                source_offset_start=0,
+                source_offset_end=len(text),
+                source_text=passage,
+                verified=True,
+                verification_method="paraphrase_judge",
+                verification_confidence=result.confidence,
+                partial=True,
+            )
+        saw_reject = True  # a real "no" from the judge
+    if saw_reject:
+        log.info(
+            "case-content judge: attributed passage rejected; flagging FAIL",
+            extra={"event": "caselaw_fail_judge_rejected", "cluster_id": cluster_id},
+        )
+        return spent, _fail_row(message_id, first_opinion_id, cluster_id, passage)
+    return spent, None  # every opinion errored transiently -> drop
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
 
 _LoadOpinionText = Callable[[AsyncSession, int], Awaitable[str]]
 
@@ -279,49 +380,85 @@ async def verify_and_persist_caselaw_citations(
             verbatim_matched.add(passage)
             break  # one verified row per passage (first matching opinion wins)
 
-    # --- SUPPORTED judge pass (P1-B1b, additive-only) -----------------------
-    # Only runs when a gateway is supplied. Passages that got a verbatim row
-    # are skipped. Per-turn budget stops the whole pass when exceeded.
+    # --- Attribution-aware judge pass (P1-B1c) --------------------------------
+    # Confidently-attributed passages are judged against their one opinion:
+    #   reject -> FAIL row; over-budget -> unverified FAIL row; transient error
+    #   -> drop. Unattributed passages keep B1b's all-opinions SUPPORTED-or-drop
+    #   behavior. FAIL is strictly additive: only attributed passages can FAIL.
     if gateway is not None:
+        # Case names for the consulted clusters (for H3 attribution).
+        cluster_metas = (
+            (
+                await db.execute(
+                    select(ResearchClusterMetadata).where(
+                        ResearchClusterMetadata.cluster_id.in_(cluster_ids)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        clusters: list[tuple[int, str]] = [
+            (c.cluster_id, c.case_name) for c in cluster_metas if c.case_name
+        ]
+        # cluster_id -> [(opinion_id, text)] from the already-loaded opinion texts.
+        cluster_texts: dict[int, list[tuple[int, str]]] = {}
+        for op, text in texts:
+            cluster_texts.setdefault(op.cluster_id, []).append((op.opinion_id, text))
+
+        # Resolve attribution per still-unverified passage; judge attributed
+        # passages FIRST so the per-turn budget is spent on FAIL-bearing checks.
+        pending = [
+            a for a in attribute_passages(assistant_text) if a.passage not in verbatim_matched
+        ]
+
+        def _attributed_cluster(a: AttributedPassage) -> int | None:
+            if a.case_name is None:
+                return None
+            cid = match_case_name(a.case_name, clusters)
+            if cid is None or cid not in cluster_texts:
+                return None  # no confident match, or named-but-not-fetched
+            return cid
+
+        annotated = [(a, _attributed_cluster(a)) for a in pending]
+        annotated.sort(key=lambda t: t[1] is None)  # attributed (cid not None) first
+
         spent: Decimal = Decimal("0")
-        budget_exhausted = False
-        for passage in passages:
-            if budget_exhausted:
-                break
-            if passage in verbatim_matched:
-                continue  # already have a verbatim row — skip
+        for a, cid in annotated:
+            if cid is not None:
+                spent, row = await _judge_attributed_passage(
+                    db,
+                    message_id=message_id,
+                    passage=a.passage,
+                    cluster_id=cid,
+                    opinions=cluster_texts[cid],
+                    gateway=gateway,
+                    judge_model=judge_model,
+                    spent=spent,
+                )
+                if row is not None:
+                    rows.append(row)
+                continue
+            # --- Unattributed: B1b all-opinions SUPPORTED-or-drop ------------
             for op, text in texts:
                 est = await estimate_case_content_cost_usd(
                     db, judge_model=judge_model, opinion_text=text
                 )
                 if spent + est > CASE_CONTENT_JUDGE_BUDGET_USD:
-                    log.info(
-                        "case-content judge: per-turn budget reached; stopping judge pass",
-                        extra={"event": "caselaw_judge_budget_reached"},
-                    )
-                    budget_exhausted = True
-                    break  # stop the whole judge pass for this turn
+                    break  # budget reached -> drop remaining unattributed work
                 spent += est
-                # Defense-in-depth: judge_case_content is contractually non-raising
-                # (all errors resolve to _MISS), but the guard protects against a
-                # future refactor that inadvertently breaks that contract.
                 try:
                     result = await judge_case_content(
-                        passage=passage,
+                        passage=a.passage,
                         opinion_text=text,
                         gateway=gateway,
                         judge_model=judge_model,
                     )
                 except Exception as exc:
-                    log.warning(
-                        "case-content judge error on opinion %s: %r",
-                        op.opinion_id,
-                        exc,
-                    )
-                    continue  # per-opinion error — try next opinion
+                    log.warning("case-content judge error on opinion %s: %r", op.opinion_id, exc)
+                    continue
                 if not result.verified:
-                    continue  # this opinion's judge rejected — try next opinion
-                # Judge accepted — write one SUPPORTED row and move to next passage.
+                    continue
                 rows.append(
                     MessageCaselawCitation(
                         message_id=message_id,
@@ -329,14 +466,14 @@ async def verify_and_persist_caselaw_citations(
                         cluster_id=op.cluster_id,
                         source_offset_start=0,
                         source_offset_end=len(text),
-                        source_text=passage,
+                        source_text=a.passage,
                         verified=True,
                         verification_method="paraphrase_judge",
                         verification_confidence=result.confidence,
                         partial=True,
                     )
                 )
-                break  # one SUPPORTED row per passage; first accepting opinion wins
+                break
 
     # --- Persist (single add_all / flush) -----------------------------------
     if rows:

--- a/api/tests/citation/test_caselaw_extraction.py
+++ b/api/tests/citation/test_caselaw_extraction.py
@@ -1,4 +1,4 @@
-from app.citation.caselaw import extract_blockquote_passages
+from app.citation.caselaw import AttributedPassage, attribute_passages, extract_blockquote_passages
 
 
 def test_extracts_single_blockquote() -> None:
@@ -29,3 +29,69 @@ def test_no_blockquotes_returns_empty() -> None:
 def test_strips_marker_and_extra_spaces() -> None:
     answer = ">   padded passage   \n"
     assert extract_blockquote_passages(answer) == ["padded passage"]
+
+
+def test_attributes_blockquote_to_nearest_h3_case() -> None:
+    answer = (
+        "### Brown v. Board of Education, U.S. Supreme Court, 1954 (347 U.S. 483)\n"
+        "\n**Relevant passage:**\n"
+        "> Separate educational facilities are inherently unequal.\n"
+    )
+    assert attribute_passages(answer) == [
+        AttributedPassage(
+            passage="Separate educational facilities are inherently unequal.",
+            case_name="Brown v. Board of Education",
+        )
+    ]
+
+
+def test_blockquote_with_no_preceding_h3_has_none_case_name() -> None:
+    answer = "> some emphasis quote with no case heading above it\n"
+    assert attribute_passages(answer) == [
+        AttributedPassage(
+            passage="some emphasis quote with no case heading above it", case_name=None
+        )
+    ]
+
+
+def test_uses_nearest_preceding_h3_when_prose_separates() -> None:
+    answer = (
+        "### Palsgraf v. Long Island R.R., N.Y., 1928\n"
+        "What was retrieved: the opinion discusses proximate cause.\n"
+        "How this bears: relevant to foreseeability.\n"
+        "> The risk reasonably to be perceived defines the duty to be obeyed.\n"
+    )
+    result = attribute_passages(answer)
+    assert result == [
+        AttributedPassage(
+            passage="The risk reasonably to be perceived defines the duty to be obeyed.",
+            case_name="Palsgraf v. Long Island R.R.",
+        )
+    ]
+
+
+def test_case_name_is_text_before_first_comma() -> None:
+    # The skill format is "### [Case Name], [Court], [Year] ([Citation])".
+    answer = "### Roe v. Wade, U.S., 1973 (410 U.S. 113)\n> a passage\n"
+    assert attribute_passages(answer)[0].case_name == "Roe v. Wade"
+
+
+def test_non_h3_headings_do_not_attribute() -> None:
+    # A "## Gaps and caveats" section (level-2) must not attribute its content.
+    answer = "## Gaps and caveats\n> not a case passage\n"
+    assert attribute_passages(answer) == [
+        AttributedPassage(passage="not a case passage", case_name=None)
+    ]
+
+
+def test_later_h3_resets_attribution_for_subsequent_blockquote() -> None:
+    answer = "### Case A, Court, 1990\n> passage one\n### Case B, Court, 1991\n> passage two\n"
+    assert attribute_passages(answer) == [
+        AttributedPassage(passage="passage one", case_name="Case A"),
+        AttributedPassage(passage="passage two", case_name="Case B"),
+    ]
+
+
+def test_extract_blockquote_passages_still_returns_flat_list() -> None:
+    answer = "### Case A, Court, 1990\n> alpha\n\nprose\n\n> beta\n"
+    assert extract_blockquote_passages(answer) == ["alpha", "beta"]

--- a/api/tests/citation/test_caselaw_matching.py
+++ b/api/tests/citation/test_caselaw_matching.py
@@ -1,0 +1,39 @@
+from app.citation.caselaw import match_case_name, normalize_case_name
+
+
+def test_normalize_lowercases_and_collapses_whitespace() -> None:
+    assert normalize_case_name("Brown   v.  Board") == "brown v. board"
+
+
+def test_normalize_strips_trailing_citation_parenthetical() -> None:
+    assert normalize_case_name("Roe v. Wade (410 U.S. 113)") == "roe v. wade"
+
+
+def test_normalize_strips_trailing_punctuation() -> None:
+    assert normalize_case_name("Palsgraf v. Long Island R.R.,") == "palsgraf v. long island r.r."
+
+
+def test_match_returns_cluster_on_single_exact_match() -> None:
+    clusters = [(701, "Brown v. Board of Education"), (702, "Roe v. Wade")]
+    assert match_case_name("Brown v. Board of Education", clusters) == 701
+
+
+def test_match_is_case_and_whitespace_insensitive() -> None:
+    clusters = [(701, "Brown v. Board of Education")]
+    assert match_case_name("brown   v.   board of education", clusters) == 701
+
+
+def test_match_returns_none_on_zero_matches() -> None:
+    clusters = [(701, "Brown v. Board of Education")]
+    assert match_case_name("Marbury v. Madison", clusters) is None
+
+
+def test_match_returns_none_on_two_matches() -> None:
+    # Two consulted clusters share a normalized name -> ambiguous -> no attribution.
+    clusters = [(701, "Smith v. Jones"), (702, "smith v. jones")]
+    assert match_case_name("Smith v. Jones", clusters) is None
+
+
+def test_match_skips_clusters_with_empty_case_name() -> None:
+    clusters = [(701, ""), (702, "Roe v. Wade")]
+    assert match_case_name("Roe v. Wade", clusters) == 702

--- a/api/tests/integration/test_caselaw_fail_attribution.py
+++ b/api/tests/integration/test_caselaw_fail_attribution.py
@@ -270,3 +270,49 @@ async def test_attributed_transient_error_drops(db_session: AsyncSession, seeded
     assert n == 0
     assert await _rows(db_session, message_id) == []
     assert gw.calls >= 1
+
+
+@pytest.mark.asyncio
+async def test_attributed_yes_without_confidence_drops(db_session: AsyncSession, seeded) -> None:
+    """A 'yes' verdict without a confidence field is non-substantive -> drop, no row.
+
+    _parse_judge_response returns _MISS for {"verdict": "yes"} with no confidence.
+    That MISS must NOT set saw_reject=True; only an explicit "no" may do that.
+    """
+    message_id, _opinion_id, cluster_id = seeded
+    # verdict "yes" but no confidence field -> _parse_judge_response -> _MISS
+    gw = _FakeGateway(json.dumps({"verdict": "yes"}))
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 0, "a yes-without-confidence should drop, not write a FAIL row"
+    assert await _rows(db_session, message_id) == []
+
+
+@pytest.mark.asyncio
+async def test_attributed_nonjson_output_drops(db_session: AsyncSession, seeded) -> None:
+    """Truncated / non-JSON judge output is non-substantive -> drop, no row.
+
+    The judge caps at max_tokens=400; a verbose justification can truncate the
+    JSON. That non-JSON body must NOT set saw_reject=True.
+    """
+    message_id, _opinion_id, cluster_id = seeded
+    # plain prose, not JSON -> _parse_judge_response -> _MISS
+    gw = _FakeGateway("the opinion does support this, frankly")
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 0, "non-JSON judge output should drop, not write a FAIL row"
+    assert await _rows(db_session, message_id) == []

--- a/api/tests/integration/test_caselaw_fail_attribution.py
+++ b/api/tests/integration/test_caselaw_fail_attribution.py
@@ -1,0 +1,272 @@
+"""Integration tests for the caselaw FAIL tier via H3 attribution (P1-B1c).
+
+Invariants:
+1. Attributed + judge REJECT -> one FAIL row (verified=False, method NULL)
+   -> ledger 'unverified' -> gate 'flagged'.
+2. Attributed + judge ACCEPT -> SUPPORTED row (paraphrase_judge) [B1b preserved].
+3. UNATTRIBUTED (H3 matches no consulted case) + would-reject -> drop, NO FAIL
+   (the false-positive guard).
+4. Attributed + over-budget -> unverified FAIL row.
+5. Attributed + transient judge error -> drop, no row.
+
+Refs ADR 0018 D2/D3, P1-B1c.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.chat.tool_loop import ToolSourceRecord
+from app.citation.caselaw import verify_and_persist_caselaw_citations
+from app.citation.gate import compute_and_record_gate
+from app.citation.ledger import assemble_ledger_entries
+from app.models.chat import Chat, Message
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.research import ResearchClusterMetadata, ResearchOpinionMetadata
+from app.models.user import User
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+
+pytestmark = pytest.mark.integration
+
+_OPINION_TEXT = (
+    "The court considered the duty of good faith. It held that every contract "
+    "carries an implied covenant of good faith and fair dealing between parties."
+)
+# Paraphrase (not verbatim) so the verbatim loop produces nothing.
+_PASSAGE = "the court recognized an implied covenant of good faith in all contracts"
+_CASE_NAME = "Smith v. Acme Corp."
+
+
+def _caselaw_source(cluster_id: int) -> ToolSourceRecord:
+    return ToolSourceRecord(
+        source_kind="caselaw",
+        label=_CASE_NAME,
+        subtitle=None,
+        url=None,
+        external_ref=str(cluster_id),
+        provider="courtlistener",
+        tool="get_cluster",
+    )
+
+
+def _attributed_answer() -> str:
+    return f"### {_CASE_NAME}, N.Y., 2001 (1 N.Y. 1)\n\n**Relevant passage:**\n> {_PASSAGE}\n"
+
+
+def _judge_completion(verdict_json: str) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        id="chatcmpl-fail-test",
+        created=0,
+        model="fast",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=verdict_json),
+                finish_reason="stop",
+            )
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=50, completion_tokens=20, total_tokens=70),
+    )
+
+
+class _FakeGateway:
+    def __init__(self, verdict_json: str) -> None:
+        self._verdict = verdict_json
+        self.calls = 0
+
+    async def chat_completion(
+        self, request: ChatCompletionRequest, *, request_id: str | None = None
+    ) -> ChatCompletionResponse:
+        self.calls += 1
+        return _judge_completion(self._verdict)
+
+
+class _ErroringGateway:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def chat_completion(
+        self, request: ChatCompletionRequest, *, request_id: str | None = None
+    ) -> ChatCompletionResponse:
+        self.calls += 1
+        raise RuntimeError("transient gateway failure")
+
+
+@pytest_asyncio.fixture
+async def seeded(db_session: AsyncSession):
+    user = User(
+        email=f"fail-{uuid.uuid4().hex[:8]}@example.com", hashed_password="x", role="member"
+    )
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="fail-chat")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="passage")
+    db_session.add(msg)
+    await db_session.flush()
+    opinion_id, cluster_id = 9001, 901
+    db_session.add(
+        ResearchOpinionMetadata(
+            opinion_id=opinion_id,
+            cluster_id=cluster_id,
+            text_field_used="plain_text",
+            storage_path=f"courtlistener/opinions/by-cluster/{cluster_id}/{opinion_id}",
+            char_length=len(_OPINION_TEXT),
+        )
+    )
+    db_session.add(
+        ResearchClusterMetadata(
+            cluster_id=cluster_id, case_name=_CASE_NAME, court="N.Y.", date_filed="2001-01-01"
+        )
+    )
+    await db_session.flush()
+    return msg.id, opinion_id, cluster_id
+
+
+async def _loader(db: AsyncSession, opinion_id: int) -> str:
+    return _OPINION_TEXT
+
+
+async def _rows(db_session: AsyncSession, message_id: uuid.UUID) -> list[MessageCaselawCitation]:
+    return list(
+        (
+            await db_session.execute(
+                select(MessageCaselawCitation).where(
+                    MessageCaselawCitation.message_id == message_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+@pytest.mark.asyncio
+async def test_attributed_reject_writes_fail_row_and_flags(
+    db_session: AsyncSession, seeded
+) -> None:
+    message_id, opinion_id, cluster_id = seeded
+    gw = _FakeGateway(json.dumps({"verdict": "no"}))
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 1
+    rows = await _rows(db_session, message_id)
+    assert len(rows) == 1
+    assert rows[0].verified is False
+    assert rows[0].verification_method is None
+    assert rows[0].opinion_id == opinion_id
+    assert rows[0].source_offset_end == len(_PASSAGE)
+    await assemble_ledger_entries(db_session, message_id=message_id)
+    await compute_and_record_gate(db_session, message_id=message_id)
+    gate = (
+        await db_session.execute(
+            select(WorkProductFiduciaryGate).where(
+                WorkProductFiduciaryGate.message_id == message_id
+            )
+        )
+    ).scalar_one()
+    assert gate.gate_status == "flagged"
+
+
+@pytest.mark.asyncio
+async def test_attributed_accept_writes_supported_row(db_session: AsyncSession, seeded) -> None:
+    message_id, _opinion_id, cluster_id = seeded
+    gw = _FakeGateway(json.dumps({"verdict": "yes", "confidence": "high"}))
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 1
+    rows = await _rows(db_session, message_id)
+    assert rows[0].verified is True
+    assert rows[0].verification_method == "paraphrase_judge"
+
+
+@pytest.mark.asyncio
+async def test_unattributed_reject_drops_no_fail(db_session: AsyncSession, seeded) -> None:
+    message_id, _opinion_id, cluster_id = seeded
+    # H3 names a DIFFERENT case than the consulted cluster -> no attribution.
+    answer = "### Totally Different Case, N.Y., 1999\n\n**Relevant passage:**\n> " + _PASSAGE + "\n"
+    gw = _FakeGateway(json.dumps({"verdict": "no"}))
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=answer,
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 0
+    assert await _rows(db_session, message_id) == []
+
+
+@pytest.mark.asyncio
+async def test_attributed_over_budget_writes_unverified_fail(
+    db_session: AsyncSession, seeded, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.citation.caselaw as caselaw_mod
+
+    monkeypatch.setattr(caselaw_mod, "CASE_CONTENT_JUDGE_BUDGET_USD", Decimal("0"))
+    message_id, opinion_id, cluster_id = seeded
+    gw = _FakeGateway(json.dumps({"verdict": "yes", "confidence": "high"}))
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 1
+    rows = await _rows(db_session, message_id)
+    assert rows[0].verified is False
+    assert rows[0].verification_method is None
+    assert rows[0].opinion_id == opinion_id
+    assert gw.calls == 0  # over-budget -> never judged
+
+
+@pytest.mark.asyncio
+async def test_attributed_transient_error_drops(db_session: AsyncSession, seeded) -> None:
+    message_id, _opinion_id, cluster_id = seeded
+    gw = _ErroringGateway()
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 0
+    assert await _rows(db_session, message_id) == []
+    assert gw.calls >= 1

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4803,6 +4803,18 @@ So the single longest phase (image pull) has neither a stream nor a poll. The re
 
 ---
 
+#### DE-362 — Caselaw FAIL severity split in the Citation Ledger trace UI
+
+**Priority:** P3 · **Effort:** S · **Status: OPEN**
+
+**Context:** Surfaced by P1-B1c (the caselaw FAIL tier). P1-B1c writes a `message_caselaw_citations` FAIL row (`verified=False`, `verification_method=NULL`) in two distinct situations: (a) the whole-opinion judge **explicitly rejected** an attributed quote (the quote is likely fabricated or materially misquoted), and (b) the quote was **confidently attributed but could not be judged** because the per-turn cost budget was exhausted ("claims case X, not checked"). Both collapse to the same ledger `verification_status="unverified"` → gate `flagged`, and the C1 trace panel renders them identically. The distinction lives only in structured log events (`caselaw_fail_judge_rejected` vs `caselaw_fail_over_budget`). For a fiduciary tool the severity gap matters: "we checked and the cited case does not support this" is materially different from "we could not afford to check."
+
+**Specific scope:** Carry the FAIL reason from `_judge_attributed_passage` (`api/app/citation/caselaw.py`) through to the ledger/trace so the C1 panel can distinguish "judge-rejected" from "unverified — not checked." Likely needs a discriminating field on `message_caselaw_citations` (a nullable `fail_reason` enum) and a small ledger/UI change; weigh against simply surfacing the existing log distinction. Pairs with DE-279 (format-independent case-citation attribution), which would also let the same surface explain *why* a quote could not be attributed.
+
+**When to ship:** When the C1 trace UI is next iterated, or sooner if operators report confusion between the two FAIL kinds. Until then both honestly read "unverified" / flagged — conservative and correct, just coarse.
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary

--- a/docs/superpowers/plans/2026-06-26-p1b1c-caselaw-fail-attribution.md
+++ b/docs/superpowers/plans/2026-06-26-p1b1c-caselaw-fail-attribution.md
@@ -1,0 +1,870 @@
+# P1-B1c — Caselaw FAIL tier via H3 attribution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Flag a fabricated/misquoted caselaw quote by attributing each blockquote to its nearest `### Case` H3 heading, matching that case to one consulted opinion, judging the passage against that opinion only, and persisting a FAIL row on reject — without false-positives on legitimate non-caselaw blockquotes.
+
+**Architecture:** Two new pure helpers in `api/app/citation/caselaw.py` (`attribute_passages`, `match_case_name`/`normalize_case_name`) parse and match the attribution signal. The orchestrator `verify_and_persist_caselaw_citations` gains an attribution-aware judge pass: confidently-attributed passages are judged against their one opinion (reject → FAIL row; over-budget → unverified FAIL row; transient error → drop), while unattributed passages keep B1b's all-opinions SUPPORTED-or-drop behavior exactly. FAIL is strictly additive on top of B1b.
+
+**Tech Stack:** Python 3.12, async SQLAlchemy, FastAPI, pytest/pytest-asyncio. Reuses B1b's `judge_case_content` + per-turn cost budget. No new dependency.
+
+## Global Constraints
+
+- **No migration.** FAIL rows are `verified=False, verification_method=NULL`; they already satisfy every `message_caselaw_citations` CHECK (`chk_message_caselaw_citations_verified_has_method` requires a method only when `verified=True`). Do not add or alter a migration. Next migration number stays `0061` for the next slice.
+- **No gate / ledger / UI / call-site-signature change.** `assemble_ledger_entries` already maps `verified=False → "unverified"` (`ledger.py:86`), the gate already maps `"unverified" → flagged`, and the ledger never reads caselaw offsets. Touch only `api/app/citation/caselaw.py` (+ its tests).
+- **Additive guarantee.** A passage that is NOT confidently attributed (normalized-exact single-match to one consulted cluster with loaded opinion text) must behave **byte-for-byte as on `main` today**. Verbatim loop unchanged; `gateway=None` path unchanged.
+- **Conservative bias.** A false FAIL (flagging a good draft) is worse than a missed FAIL. When in doubt, drop.
+- **Offsets for a FAIL row:** `source_offset_start=0, source_offset_end=len(passage)` (passage is non-empty by construction). Documented placeholder; never surfaced (ledger/trace ignore caselaw offsets — confirmed `ledger.py:78-91`).
+- **Tests:** host venv + throwaway pgvector (`lqai-test-pg` on `:55432`, conftest auto-migrates). Mocked gateway → **no `-m provider`**. Run `ruff format` AND `ruff check` on touched files before each commit.
+- **Commits:** `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Security-gated** (`api/app/citation/**`): **do not self-merge**; Kevin/security merges; mirror `origin/main → tucuxi` after.
+
+---
+
+### Task 1: `attribute_passages` — pair each blockquote with its nearest `### Case` heading
+
+**Files:**
+- Modify: `api/app/citation/caselaw.py` (add `AttributedPassage` dataclass + `attribute_passages`; re-express `extract_blockquote_passages` in terms of it)
+- Test: `api/tests/citation/test_caselaw_extraction.py` (extend — existing tests must stay green)
+
+**Interfaces:**
+- Consumes: nothing (pure function over `str`).
+- Produces:
+  ```python
+  @dataclass(slots=True)
+  class AttributedPassage:
+      passage: str
+      case_name: str | None
+  def attribute_passages(answer_text: str) -> list[AttributedPassage]
+  def extract_blockquote_passages(answer_text: str) -> list[str]  # == [a.passage for a in attribute_passages(text)]
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `api/tests/citation/test_caselaw_extraction.py`:
+
+```python
+from app.citation.caselaw import AttributedPassage, attribute_passages
+
+
+def test_attributes_blockquote_to_nearest_h3_case() -> None:
+    answer = (
+        "### Brown v. Board of Education, U.S. Supreme Court, 1954 (347 U.S. 483)\n"
+        "\n**Relevant passage:**\n"
+        "> Separate educational facilities are inherently unequal.\n"
+    )
+    assert attribute_passages(answer) == [
+        AttributedPassage(
+            passage="Separate educational facilities are inherently unequal.",
+            case_name="Brown v. Board of Education",
+        )
+    ]
+
+
+def test_blockquote_with_no_preceding_h3_has_none_case_name() -> None:
+    answer = "> some emphasis quote with no case heading above it\n"
+    assert attribute_passages(answer) == [
+        AttributedPassage(passage="some emphasis quote with no case heading above it", case_name=None)
+    ]
+
+
+def test_uses_nearest_preceding_h3_when_prose_separates() -> None:
+    answer = (
+        "### Palsgraf v. Long Island R.R., N.Y., 1928\n"
+        "What was retrieved: the opinion discusses proximate cause.\n"
+        "How this bears: relevant to foreseeability.\n"
+        "> The risk reasonably to be perceived defines the duty to be obeyed.\n"
+    )
+    result = attribute_passages(answer)
+    assert result == [
+        AttributedPassage(
+            passage="The risk reasonably to be perceived defines the duty to be obeyed.",
+            case_name="Palsgraf v. Long Island R.R.",
+        )
+    ]
+
+
+def test_case_name_is_text_before_first_comma() -> None:
+    # The skill format is "### [Case Name], [Court], [Year] ([Citation])".
+    answer = "### Roe v. Wade, U.S., 1973 (410 U.S. 113)\n> a passage\n"
+    assert attribute_passages(answer)[0].case_name == "Roe v. Wade"
+
+
+def test_non_h3_headings_do_not_attribute() -> None:
+    # A "## Gaps and caveats" section (level-2) must not attribute its content.
+    answer = "## Gaps and caveats\n> not a case passage\n"
+    assert attribute_passages(answer) == [
+        AttributedPassage(passage="not a case passage", case_name=None)
+    ]
+
+
+def test_later_h3_resets_attribution_for_subsequent_blockquote() -> None:
+    answer = (
+        "### Case A, Court, 1990\n> passage one\n"
+        "### Case B, Court, 1991\n> passage two\n"
+    )
+    assert attribute_passages(answer) == [
+        AttributedPassage(passage="passage one", case_name="Case A"),
+        AttributedPassage(passage="passage two", case_name="Case B"),
+    ]
+
+
+def test_extract_blockquote_passages_still_returns_flat_list() -> None:
+    answer = "### Case A, Court, 1990\n> alpha\n\nprose\n\n> beta\n"
+    assert extract_blockquote_passages(answer) == ["alpha", "beta"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd api && pytest tests/citation/test_caselaw_extraction.py -v`
+Expected: FAIL — `ImportError: cannot import name 'AttributedPassage'`.
+
+- [ ] **Step 3: Implement `AttributedPassage` + `attribute_passages`; re-express `extract_blockquote_passages`**
+
+In `api/app/citation/caselaw.py`, replace the existing `extract_blockquote_passages` function (lines ~39-62) with:
+
+```python
+@dataclass(slots=True)
+class AttributedPassage:
+    """A blockquote passage paired with the case name of its nearest ``### `` heading.
+
+    ``case_name`` is the text of the most recent ``### `` heading above the
+    blockquote, taken up to the first comma (the case-law-research skill renders
+    headings as ``### [Case Name], [Court], [Year] ([Citation])``). ``None`` when
+    no ``### `` heading precedes the blockquote — the attribution false-positive
+    guard: an unattributed passage never produces a FAIL row.
+    """
+
+    passage: str
+    case_name: str | None
+
+
+def attribute_passages(answer_text: str) -> list[AttributedPassage]:
+    """Return each markdown blockquote paired with its nearest ``### `` case heading.
+
+    Consecutive blockquote lines (``> ...``) join into one passage; a
+    non-blockquote line ends the current passage. Each closed passage is paired
+    with the case name parsed from the most recent ``### `` heading seen so far.
+    """
+    result: list[AttributedPassage] = []
+    current: list[str] = []
+    current_case: str | None = None
+
+    def _flush() -> None:
+        nonlocal current
+        joined = " ".join(p for p in current if p).strip()
+        if joined:
+            result.append(AttributedPassage(passage=joined, case_name=current_case))
+        current = []
+
+    for line in answer_text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith(">"):
+            current.append(stripped[1:].strip())
+            continue
+        if current:
+            _flush()
+        # Only level-3 (``### ``) headings carry case attribution. ``##``/``#``
+        # (and ``####``) do not — guard with an exact "### " prefix that is not
+        # also "#### ".
+        if stripped.startswith("### ") and not stripped.startswith("#### "):
+            heading = stripped[4:].strip()
+            current_case = heading.split(",", 1)[0].strip() or None
+    if current:
+        _flush()
+    return result
+
+
+def extract_blockquote_passages(answer_text: str) -> list[str]:
+    """Return the text of each markdown blockquote in ``answer_text`` (flat list).
+
+    Retained for existing callers/tests; equivalent to the passages produced by
+    :func:`attribute_passages`.
+    """
+    return [a.passage for a in attribute_passages(answer_text)]
+```
+
+(`dataclass` is already imported at the top of `caselaw.py` — `from dataclasses import dataclass`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd api && pytest tests/citation/test_caselaw_extraction.py -v`
+Expected: PASS (all new + the 5 pre-existing tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd api && ruff format app/citation/caselaw.py tests/citation/test_caselaw_extraction.py \
+  && ruff check app/citation/caselaw.py tests/citation/test_caselaw_extraction.py
+git add api/app/citation/caselaw.py api/tests/citation/test_caselaw_extraction.py
+git commit -s -m "feat(citation): attribute caselaw blockquotes to nearest ### Case heading (P1-B1c)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `normalize_case_name` + `match_case_name` — normalized-exact, single-match attribution
+
+**Files:**
+- Modify: `api/app/citation/caselaw.py` (add both functions)
+- Test: `api/tests/citation/test_caselaw_matching.py` (create)
+
+**Interfaces:**
+- Consumes: nothing (pure functions).
+- Produces:
+  ```python
+  def normalize_case_name(name: str) -> str
+  def match_case_name(parsed: str, clusters: Sequence[tuple[int, str]]) -> int | None
+  ```
+  `match_case_name` returns the `cluster_id` iff exactly one cluster's `case_name` normalizes equal to `parsed`; else `None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `api/tests/citation/test_caselaw_matching.py`:
+
+```python
+from app.citation.caselaw import match_case_name, normalize_case_name
+
+
+def test_normalize_lowercases_and_collapses_whitespace() -> None:
+    assert normalize_case_name("Brown   v.  Board") == "brown v. board"
+
+
+def test_normalize_strips_trailing_citation_parenthetical() -> None:
+    assert normalize_case_name("Roe v. Wade (410 U.S. 113)") == "roe v. wade"
+
+
+def test_normalize_strips_trailing_punctuation() -> None:
+    assert normalize_case_name("Palsgraf v. Long Island R.R.,") == "palsgraf v. long island r.r."
+
+
+def test_match_returns_cluster_on_single_exact_match() -> None:
+    clusters = [(701, "Brown v. Board of Education"), (702, "Roe v. Wade")]
+    assert match_case_name("Brown v. Board of Education", clusters) == 701
+
+
+def test_match_is_case_and_whitespace_insensitive() -> None:
+    clusters = [(701, "Brown v. Board of Education")]
+    assert match_case_name("brown   v.   board of education", clusters) == 701
+
+
+def test_match_returns_none_on_zero_matches() -> None:
+    clusters = [(701, "Brown v. Board of Education")]
+    assert match_case_name("Marbury v. Madison", clusters) is None
+
+
+def test_match_returns_none_on_two_matches() -> None:
+    # Two consulted clusters share a normalized name -> ambiguous -> no attribution.
+    clusters = [(701, "Smith v. Jones"), (702, "smith v. jones")]
+    assert match_case_name("Smith v. Jones", clusters) is None
+
+
+def test_match_skips_clusters_with_empty_case_name() -> None:
+    clusters = [(701, ""), (702, "Roe v. Wade")]
+    assert match_case_name("Roe v. Wade", clusters) == 702
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd api && pytest tests/citation/test_caselaw_matching.py -v`
+Expected: FAIL — `ImportError: cannot import name 'match_case_name'`.
+
+- [ ] **Step 3: Implement both functions**
+
+Add to `api/app/citation/caselaw.py` (after `attribute_passages`). `re` import at top of file if not present (`import re`):
+
+```python
+def normalize_case_name(name: str) -> str:
+    """Normalize a case name for attribution matching.
+
+    Lowercases, strips a trailing ``(...)`` citation parenthetical, strips
+    trailing punctuation/whitespace, and collapses internal whitespace runs to
+    single spaces. Conservative: only a normalized-exact match attributes.
+    """
+    text = name.strip()
+    # Drop a trailing parenthetical citation, e.g. "(410 U.S. 113)".
+    text = re.sub(r"\s*\([^()]*\)\s*$", "", text)
+    text = text.lower()
+    text = re.sub(r"\s+", " ", text)
+    return text.strip().rstrip(",.;: ")
+
+
+def match_case_name(parsed: str, clusters: Sequence[tuple[int, str]]) -> int | None:
+    """Return the cluster_id iff exactly one cluster's case_name matches ``parsed``.
+
+    Normalized-exact, single-match only (the false-positive guard). Zero matches,
+    two-or-more matches, or clusters with an empty case_name → ``None`` →
+    the passage stays on the B1b path (never produces a FAIL row).
+    """
+    target = normalize_case_name(parsed)
+    if not target:
+        return None
+    matches = [cid for cid, name in clusters if name and normalize_case_name(name) == target]
+    return matches[0] if len(matches) == 1 else None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd api && pytest tests/citation/test_caselaw_matching.py -v`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd api && ruff format app/citation/caselaw.py tests/citation/test_caselaw_matching.py \
+  && ruff check app/citation/caselaw.py tests/citation/test_caselaw_matching.py
+git add api/app/citation/caselaw.py api/tests/citation/test_caselaw_matching.py
+git commit -s -m "feat(citation): normalized-exact single-match case-name matcher (P1-B1c)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Attribution-aware judge pass — FAIL on reject, unverified-FAIL on over-budget, drop on transient error
+
+**Files:**
+- Modify: `api/app/citation/caselaw.py` (`verify_and_persist_caselaw_citations` — load `ResearchClusterMetadata`; replace the B1b judge pass with the attribution-aware pass)
+- Test: `api/tests/integration/test_caselaw_fail_attribution.py` (create)
+
+**Interfaces:**
+- Consumes: `attribute_passages`, `match_case_name` (Tasks 1-2); `judge_case_content`, `estimate_case_content_cost_usd`, `CASE_CONTENT_JUDGE_BUDGET_USD` (B1b); `ResearchClusterMetadata`, `ResearchOpinionMetadata`.
+- Produces: same `verify_and_persist_caselaw_citations` signature (unchanged). New private helper `_judge_attributed_passage`.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Create `api/tests/integration/test_caselaw_fail_attribution.py`:
+
+```python
+"""Integration tests for the caselaw FAIL tier via H3 attribution (P1-B1c).
+
+Invariants:
+1. Attributed + judge REJECT -> one FAIL row (verified=False, method NULL)
+   -> ledger 'unverified' -> gate 'flagged'.
+2. Attributed + judge ACCEPT -> SUPPORTED row (paraphrase_judge) [B1b preserved].
+3. UNATTRIBUTED (H3 matches no consulted case) + would-reject -> drop, NO FAIL
+   (the false-positive guard).
+4. Attributed + over-budget -> unverified FAIL row.
+5. Attributed + transient judge error -> drop, no row.
+
+Refs ADR 0018 D2/D3, P1-B1c.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.chat.tool_loop import ToolSourceRecord
+from app.citation.caselaw import verify_and_persist_caselaw_citations
+from app.citation.gate import compute_and_record_gate
+from app.citation.ledger import assemble_ledger_entries
+from app.models.chat import Chat, Message
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.research import ResearchClusterMetadata, ResearchOpinionMetadata
+from app.models.user import User
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+from app.schemas.gateway import (
+    ChatCompletionChoice,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+)
+
+pytestmark = pytest.mark.integration
+
+_OPINION_TEXT = (
+    "The court considered the duty of good faith. It held that every contract "
+    "carries an implied covenant of good faith and fair dealing between parties."
+)
+# Paraphrase (not verbatim) so the verbatim loop produces nothing.
+_PASSAGE = "the court recognized an implied covenant of good faith in all contracts"
+_CASE_NAME = "Smith v. Acme Corp."
+
+
+def _caselaw_source(cluster_id: int) -> ToolSourceRecord:
+    return ToolSourceRecord(
+        source_kind="caselaw",
+        label=_CASE_NAME,
+        subtitle=None,
+        url=None,
+        external_ref=str(cluster_id),
+        provider="courtlistener",
+        tool="get_cluster",
+    )
+
+
+def _attributed_answer() -> str:
+    return f"### {_CASE_NAME}, N.Y., 2001 (1 N.Y. 1)\n\n**Relevant passage:**\n> {_PASSAGE}\n"
+
+
+def _judge_completion(verdict_json: str) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        id="chatcmpl-fail-test",
+        created=0,
+        model="fast",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=verdict_json),
+                finish_reason="stop",
+            )
+        ],
+        usage=ChatCompletionUsage(prompt_tokens=50, completion_tokens=20, total_tokens=70),
+    )
+
+
+class _FakeGateway:
+    def __init__(self, verdict_json: str) -> None:
+        self._verdict = verdict_json
+        self.calls = 0
+
+    async def chat_completion(
+        self, request: ChatCompletionRequest, *, request_id: str | None = None
+    ) -> ChatCompletionResponse:
+        self.calls += 1
+        return _judge_completion(self._verdict)
+
+
+class _ErroringGateway:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def chat_completion(
+        self, request: ChatCompletionRequest, *, request_id: str | None = None
+    ) -> ChatCompletionResponse:
+        self.calls += 1
+        raise RuntimeError("transient gateway failure")
+
+
+@pytest_asyncio.fixture
+async def seeded(db_session: AsyncSession):
+    user = User(email=f"fail-{uuid.uuid4().hex[:8]}@example.com", hashed_password="x", role="member")
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="fail-chat")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="passage")
+    db_session.add(msg)
+    await db_session.flush()
+    opinion_id, cluster_id = 9001, 901
+    db_session.add(
+        ResearchOpinionMetadata(
+            opinion_id=opinion_id,
+            cluster_id=cluster_id,
+            text_field_used="plain_text",
+            storage_path=f"courtlistener/opinions/by-cluster/{cluster_id}/{opinion_id}",
+            char_length=len(_OPINION_TEXT),
+        )
+    )
+    db_session.add(
+        ResearchClusterMetadata(cluster_id=cluster_id, case_name=_CASE_NAME, court="N.Y.", date_filed="2001-01-01")
+    )
+    await db_session.flush()
+    return msg.id, opinion_id, cluster_id
+
+
+async def _loader(db: AsyncSession, opinion_id: int) -> str:
+    return _OPINION_TEXT
+
+
+async def _rows(db_session: AsyncSession, message_id: uuid.UUID) -> list[MessageCaselawCitation]:
+    return list(
+        (
+            await db_session.execute(
+                select(MessageCaselawCitation).where(MessageCaselawCitation.message_id == message_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+@pytest.mark.asyncio
+async def test_attributed_reject_writes_fail_row_and_flags(db_session: AsyncSession, seeded) -> None:
+    message_id, opinion_id, cluster_id = seeded
+    gw = _FakeGateway(json.dumps({"verdict": "no"}))
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 1
+    rows = await _rows(db_session, message_id)
+    assert len(rows) == 1
+    assert rows[0].verified is False
+    assert rows[0].verification_method is None
+    assert rows[0].opinion_id == opinion_id
+    assert rows[0].source_offset_end == len(_PASSAGE)
+    await assemble_ledger_entries(db_session, message_id=message_id)
+    await compute_and_record_gate(db_session, message_id=message_id)
+    gate = (
+        await db_session.execute(
+            select(WorkProductFiduciaryGate).where(WorkProductFiduciaryGate.message_id == message_id)
+        )
+    ).scalar_one()
+    assert gate.gate_status == "flagged"
+
+
+@pytest.mark.asyncio
+async def test_attributed_accept_writes_supported_row(db_session: AsyncSession, seeded) -> None:
+    message_id, _opinion_id, cluster_id = seeded
+    gw = _FakeGateway(json.dumps({"verdict": "yes", "confidence": "high"}))
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 1
+    rows = await _rows(db_session, message_id)
+    assert rows[0].verified is True
+    assert rows[0].verification_method == "paraphrase_judge"
+
+
+@pytest.mark.asyncio
+async def test_unattributed_reject_drops_no_fail(db_session: AsyncSession, seeded) -> None:
+    message_id, _opinion_id, cluster_id = seeded
+    # H3 names a DIFFERENT case than the consulted cluster -> no attribution.
+    answer = "### Totally Different Case, N.Y., 1999\n\n**Relevant passage:**\n> " + _PASSAGE + "\n"
+    gw = _FakeGateway(json.dumps({"verdict": "no"}))
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=answer,
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 0
+    assert await _rows(db_session, message_id) == []
+
+
+@pytest.mark.asyncio
+async def test_attributed_over_budget_writes_unverified_fail(
+    db_session: AsyncSession, seeded, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.citation.caselaw as caselaw_mod
+
+    monkeypatch.setattr(caselaw_mod, "CASE_CONTENT_JUDGE_BUDGET_USD", Decimal("0"))
+    message_id, opinion_id, cluster_id = seeded
+    gw = _FakeGateway(json.dumps({"verdict": "yes", "confidence": "high"}))
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 1
+    rows = await _rows(db_session, message_id)
+    assert rows[0].verified is False
+    assert rows[0].verification_method is None
+    assert rows[0].opinion_id == opinion_id
+    assert gw.calls == 0  # over-budget -> never judged
+
+
+@pytest.mark.asyncio
+async def test_attributed_transient_error_drops(db_session: AsyncSession, seeded) -> None:
+    message_id, _opinion_id, cluster_id = seeded
+    gw = _ErroringGateway()
+    n = await verify_and_persist_caselaw_citations(
+        db_session,
+        message_id=message_id,
+        assistant_text=_attributed_answer(),
+        tool_sources=[_caselaw_source(cluster_id)],
+        load_opinion_text=_loader,
+        gateway=gw,
+        judge_model="fast",
+    )
+    assert n == 0
+    assert await _rows(db_session, message_id) == []
+    assert gw.calls >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test pytest tests/integration/test_caselaw_fail_attribution.py -v`
+Expected: FAIL — `test_attributed_reject_writes_fail_row_and_flags` and `test_attributed_over_budget...` fail (today the reject/over-budget passage drops → `n == 0`, no FAIL row). `ImportError` for `ResearchClusterMetadata` will NOT occur (it exists). The accept/unattributed/transient tests may already pass under B1b — that's fine.
+
+- [ ] **Step 3: Implement the attribution-aware judge pass**
+
+In `api/app/citation/caselaw.py`, add the import for `ResearchClusterMetadata` (the file already imports `ResearchOpinionMetadata` from `app.models.research`):
+
+```python
+from app.models.research import ResearchClusterMetadata, ResearchOpinionMetadata
+```
+
+Add a `VerificationResult` import for the helper's type if needed — `judge_case_content` returns one; we only inspect `.verified`/`.confidence`. No new import required.
+
+Replace the entire `# --- SUPPORTED judge pass (P1-B1b, additive-only) ---` block (current lines ~218-275, the `if gateway is not None:` block) with the attribution-aware pass below. The verbatim loop above it and the persist block below it are unchanged.
+
+```python
+    # --- Attribution-aware judge pass (P1-B1c) ------------------------------
+    # Confidently-attributed passages are judged against their one opinion:
+    #   reject -> FAIL row; over-budget -> unverified FAIL row; transient error
+    #   -> drop. Unattributed passages keep B1b's all-opinions SUPPORTED-or-drop
+    #   behavior. FAIL is strictly additive: only attributed passages can FAIL.
+    if gateway is not None:
+        # Case names for the consulted clusters (for H3 attribution).
+        cluster_metas = (
+            (
+                await db.execute(
+                    select(ResearchClusterMetadata).where(
+                        ResearchClusterMetadata.cluster_id.in_(cluster_ids)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        clusters: list[tuple[int, str]] = [
+            (c.cluster_id, c.case_name) for c in cluster_metas if c.case_name
+        ]
+        # cluster_id -> [(opinion_id, text)] from the already-loaded opinion texts.
+        cluster_texts: dict[int, list[tuple[int, str]]] = {}
+        for op, text in texts:
+            cluster_texts.setdefault(op.cluster_id, []).append((op.opinion_id, text))
+
+        # Resolve attribution per still-unverified passage; judge attributed
+        # passages FIRST so the per-turn budget is spent on FAIL-bearing checks.
+        pending = [a for a in attribute_passages(assistant_text) if a.passage not in verbatim_matched]
+
+        def _attributed_cluster(a: AttributedPassage) -> int | None:
+            if a.case_name is None:
+                return None
+            cid = match_case_name(a.case_name, clusters)
+            if cid is None or cid not in cluster_texts:
+                return None  # no confident match, or named-but-not-fetched
+            return cid
+
+        annotated = [(a, _attributed_cluster(a)) for a in pending]
+        annotated.sort(key=lambda t: t[1] is None)  # attributed (cid not None) first
+
+        spent: Decimal = Decimal("0")
+        for a, cid in annotated:
+            if cid is not None:
+                spent, row = await _judge_attributed_passage(
+                    db,
+                    message_id=message_id,
+                    passage=a.passage,
+                    cluster_id=cid,
+                    opinions=cluster_texts[cid],
+                    gateway=gateway,
+                    judge_model=judge_model,
+                    spent=spent,
+                )
+                if row is not None:
+                    rows.append(row)
+                continue
+            # --- Unattributed: B1b all-opinions SUPPORTED-or-drop ------------
+            for op, text in texts:
+                est = await estimate_case_content_cost_usd(
+                    db, judge_model=judge_model, opinion_text=text
+                )
+                if spent + est > CASE_CONTENT_JUDGE_BUDGET_USD:
+                    break  # budget reached -> drop remaining unattributed work
+                spent += est
+                try:
+                    result = await judge_case_content(
+                        passage=a.passage, opinion_text=text, gateway=gateway, judge_model=judge_model
+                    )
+                except Exception as exc:
+                    log.warning("case-content judge error on opinion %s: %r", op.opinion_id, exc)
+                    continue
+                if not result.verified:
+                    continue
+                rows.append(
+                    MessageCaselawCitation(
+                        message_id=message_id,
+                        opinion_id=op.opinion_id,
+                        cluster_id=op.cluster_id,
+                        source_offset_start=0,
+                        source_offset_end=len(text),
+                        source_text=a.passage,
+                        verified=True,
+                        verification_method="paraphrase_judge",
+                        verification_confidence=result.confidence,
+                        partial=True,
+                    )
+                )
+                break
+```
+
+Add the private helper above `verify_and_persist_caselaw_citations` (after `locate_passage`):
+
+```python
+async def _judge_attributed_passage(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    passage: str,
+    cluster_id: int,
+    opinions: list[tuple[int, str]],
+    gateway: _JudgeGatewayProtocol,
+    judge_model: str,
+    spent: Decimal,
+) -> tuple[Decimal, MessageCaselawCitation | None]:
+    """Judge an attributed passage against its cluster's opinion(s) only.
+
+    Returns (updated_spent, row_or_None):
+      * accept            -> SUPPORTED row (paraphrase_judge)
+      * judge reject      -> FAIL row (verified=False, method NULL)
+      * over budget       -> unverified FAIL row (verified=False, method NULL)
+      * all transient err -> None (drop; no row)
+    """
+    saw_reject = False
+    first_opinion_id = opinions[0][0]
+    for opinion_id, text in opinions:
+        est = await estimate_case_content_cost_usd(db, judge_model=judge_model, opinion_text=text)
+        if spent + est > CASE_CONTENT_JUDGE_BUDGET_USD:
+            log.info(
+                "case-content judge: attributed passage over budget; flagging unverified",
+                extra={"event": "caselaw_fail_over_budget", "cluster_id": cluster_id},
+            )
+            return spent, _fail_row(message_id, opinion_id, cluster_id, passage)
+        spent += est
+        try:
+            result = await judge_case_content(
+                passage=passage, opinion_text=text, gateway=gateway, judge_model=judge_model
+            )
+        except Exception as exc:
+            log.warning("case-content judge error on opinion %s: %r", opinion_id, exc)
+            continue  # transient on this opinion -> try the next
+        if result.verified:
+            return spent, MessageCaselawCitation(
+                message_id=message_id,
+                opinion_id=opinion_id,
+                cluster_id=cluster_id,
+                source_offset_start=0,
+                source_offset_end=len(text),
+                source_text=passage,
+                verified=True,
+                verification_method="paraphrase_judge",
+                verification_confidence=result.confidence,
+                partial=True,
+            )
+        saw_reject = True  # a real "no" from the judge
+    if saw_reject:
+        log.info(
+            "case-content judge: attributed passage rejected; flagging FAIL",
+            extra={"event": "caselaw_fail_judge_rejected", "cluster_id": cluster_id},
+        )
+        return spent, _fail_row(message_id, first_opinion_id, cluster_id, passage)
+    return spent, None  # every opinion errored transiently -> drop
+
+
+def _fail_row(
+    message_id: uuid.UUID, opinion_id: int, cluster_id: int, passage: str
+) -> MessageCaselawCitation:
+    """Build an unverified caselaw FAIL row (gate -> flagged).
+
+    Offsets are a documented placeholder: a FAIL passage has no verified span in
+    the opinion, but the CHECK requires offset_end > offset_start >= 0. The ledger
+    and trace never read caselaw offsets (ledger.py:78-91).
+    """
+    return MessageCaselawCitation(
+        message_id=message_id,
+        opinion_id=opinion_id,
+        cluster_id=cluster_id,
+        source_offset_start=0,
+        source_offset_end=len(passage),
+        source_text=passage,
+        verified=False,
+        verification_method=None,
+        verification_confidence=None,
+        partial=False,
+    )
+```
+
+Also update the module docstring (lines ~8-10) to note B1c writes FAIL rows for attributed passages.
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test pytest tests/integration/test_caselaw_fail_attribution.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run the B1b regression suite (additive guarantee)**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test pytest tests/integration/test_caselaw_paraphrase_judge.py tests/integration/test_caselaw_citations.py tests/citation/ tests/test_case_content_judge.py -v`
+Expected: PASS — B1b SUPPORTED behavior and verbatim behavior unchanged. (The B1b tests use answers with no `### Case` heading → unattributed → identical behavior.)
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd api && ruff format app/citation/caselaw.py tests/integration/test_caselaw_fail_attribution.py \
+  && ruff check app/citation/caselaw.py tests/integration/test_caselaw_fail_attribution.py
+git add api/app/citation/caselaw.py api/tests/integration/test_caselaw_fail_attribution.py
+git commit -s -m "feat(citation): caselaw FAIL tier via H3 attribution (P1-B1c)
+
+Attributed passages judged against their one opinion: reject -> FAIL row,
+over-budget -> unverified FAIL, transient error -> drop. Unattributed
+passages keep B1b's all-opinions SUPPORTED-or-drop behavior. FAIL is
+strictly additive; no migration / gate / ledger / UI change.
+
+Refs ADR 0018 D2/D3. Builds on P1-A1 (#218), P1-B1 (#225), P1-B1b (#229).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: File the deferred FAIL-severity-split DE + run the full api gate
+
+**Files:**
+- Modify: `docs/PRD.md` (§9 Deferred Enhancements — add the DE)
+
+**Interfaces:** none (docs + verification).
+
+- [ ] **Step 1: File the DE**
+
+In `docs/PRD.md` §9, add a new DE entry (use the next free DE number — grep `DE-3` to find the highest; B1b/this session referenced up to DE-361, so the next is likely `DE-362` — confirm). Text:
+
+> **DE-XXX — Caselaw FAIL severity split in the trace UI.** P1-B1c surfaces both a judge-rejected caselaw quote (likely fabricated/misquoted) and an over-budget-but-attributed quote (claims case X, not checked) identically as `"unverified"` / `flagged`; the distinction lives only in structured logs (`caselaw_fail_judge_rejected` vs `caselaw_fail_over_budget`). Surface the severity distinction in the C1 trace panel so a reviewer can tell "we checked and it's unsupported" from "we couldn't afford to check." Pairs with DE-279 (format-independent attribution).
+
+- [ ] **Step 2: Run the full api unit + integration suite (collision-guard check)**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test pytest -q`
+Expected: PASS, no collection errors. (No new route → `test_endpoints.py`/`test_openapi.py` unchanged; this run confirms nothing collided.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/PRD.md
+git commit -s -m "docs: file DE-XXX (caselaw FAIL severity split in trace UI) (P1-B1c)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final review (after Task 4)
+
+- [ ] **Opus whole-branch review** — dispatch an Opus reviewer over the full branch diff vs `main`. Focus: the additive guarantee (no `fiduciary_grade`→`flagged` regression for unattributed passages), the reject-vs-transient-error distinction in `_judge_attributed_passage` (a real "no" must FAIL; an all-errored passage must drop), budget accounting across attributed→unattributed ordering, and the offset/CHECK placeholder. This pattern has repeatedly caught gate-passing defects.
+- [ ] **Push both remotes** — `git push origin feat/p1b1c-caselaw-fail-attribution` and `git push tucuxi feat/p1b1c-caselaw-fail-attribution`.
+- [ ] **Open the PR** (origin), attestation N/A (no skill legal substance change). **Security-gated — do NOT self-merge.** Kevin/security merges; then mirror `origin/main → tucuxi main` and confirm `origin == tucuxi`.
+
+## Self-review against the spec
+
+- **Spec coverage:** Component 1 → Task 1; Component 2 → Task 2; Component 3 (orchestration, budget, offsets) → Task 3; "no migration / gate / ledger / UI change" → Global Constraints + Task 3 (no migration touched); decisions #1 (normalized-exact single-match) → Task 2; decision #2 (over-budget→unverified-FAIL, transient→drop) → Task 3 `_judge_attributed_passage` + tests 4-5; FAIL-severity-split DE → Task 4; all 6 spec test cases → Task 3 tests + Task 1/2 unit tests.
+- **Placeholder scan:** the only `DE-XXX` is the to-be-numbered DE (Task 4 step 1 says to confirm the number) — acceptable. No TODO/TBD in code.
+- **Type consistency:** `AttributedPassage(passage, case_name)`, `attribute_passages -> list[AttributedPassage]`, `match_case_name(parsed, clusters) -> int | None`, `_judge_attributed_passage(...) -> tuple[Decimal, MessageCaselawCitation | None]`, `_fail_row(...) -> MessageCaselawCitation` — used consistently across Tasks 1-3.

--- a/docs/superpowers/specs/2026-06-26-p1b1c-caselaw-fail-attribution-design.md
+++ b/docs/superpowers/specs/2026-06-26-p1b1c-caselaw-fail-attribution-design.md
@@ -1,0 +1,105 @@
+# P1-B1c — Caselaw FAIL tier via H3 attribution (design)
+
+**Date:** 2026-06-26
+**Milestone:** Fiduciary-grade agentic legal work — Phase 1 (WS-B)
+**Branch:** `feat/p1b1c-caselaw-fail-attribution`
+**Pins:** [ADR 0018](../../adr/0018-citation-ledger-and-fiduciary-grade-output.md) D2 (verify external quotes against the materialized opinion text), D3 (the fiduciary-grade gate). Builds on **P1-A1** (caselaw verbatim verification, #218), **P1-B1** (the gate, #225), and **P1-B1b** (the SUPPORTED tier, #229). Lighter, skill-format-coupled cousin of the deferred [DE-279](../../PRD.md#de-279) case-cite resolution.
+**Security review:** **required** (citation surface + the gateway egress reused from B1b + the audit/ledger surface; `api/app/citation/**`, `chats.py`). **Do not self-merge** — Kevin/security merges; mirror `origin/main → tucuxi` after.
+
+## Problem
+
+P1-A1 verifies caselaw quotes **verbatim**; P1-B1b adds a **SUPPORTED** tier (paraphrased-but-faithful quotes → `paraphrase_judge` rows). Both are **additive-only**: a caselaw quote that matches no consulted opinion — verbatim *or* by the judge — is still **silently dropped**. So a **fabricated or materially misquoted** caselaw quote leaves no trace, and the gate cannot flag it. This is the last honesty gap in Phase 1: today the fiduciary gate can mark a turn `fiduciary_grade` even though it contains a quote attributed to a real consulted case that the case's own opinion text does not support.
+
+P1-B1c closes that gap: when a blockquote is **confidently attributed** to exactly one consulted opinion and the whole-opinion judge **rejects** it against that opinion, persist a **FAIL** row (`verified=False`). The gate already maps `verified=False → "unverified" → flagged`, and the P1-C1 UI already renders the red flagged badge — so a B1c FAIL row flows end-to-end with **no gate / ledger / UI change**.
+
+## Why FAIL needs attribution (the load-bearing reason it was split from B1b)
+
+B1b's judge pass tries a dropped passage against **every** consulted opinion and accepts if **any** supports it — safe for SUPPORTED (a false *accept* only fails to flag a fabrication; it never flags a good draft). FAIL is the opposite risk: judging a passage against an opinion it was never meant to be checked against, and **rejecting**, would write a wrong FAIL and turn a fiduciary-grade draft `flagged` — **the worst failure mode for a fiduciary tool**. A legitimate **non-caselaw** blockquote (a statute, a KB quote, an emphasis quote) judged against caselaw opinions would reject against all of them → a wrong flag.
+
+So FAIL requires **per-passage → opinion attribution**, which does not exist today: `extract_blockquote_passages` returns a flat `list[str]` with no case association. The signal to attribute on **does** exist but is unparsed: the case-law-research skill ([`skills/case-law-research/SKILL.md`](../../../skills/case-law-research/SKILL.md) §Output) mandates each cited passage render as a markdown blockquote **directly under a `### [Case Name], [Court], [Year] ([Citation])` H3 heading**. The parseable signal is therefore *"the nearest `###` heading above the blockquote."* B1c parses it, matches the case name to one consulted opinion, judges the passage against **that opinion only**, and writes a FAIL row on reject.
+
+## Decisions (maintainer-approved 2026-06-26)
+
+- **Matcher: normalized-exact, single-match only.** Normalize both sides (lowercase, collapse internal whitespace, strip a trailing parenthetical citation and trailing punctuation). Attribute a passage **only** when exactly one consulted cluster's `case_name` normalized-matches the parsed H3 case name. Zero matches, multiple matches, or any near-miss → **no attribution** → the passage stays on the B1b path (drop on reject; never FAIL). The match-gate **is** the false-positive guard. (`ResearchClusterMetadata` stores `case_name`/`court`/`date_filed` but **not** citation, so citation-matching is unavailable; case-name match only.)
+- **Can't-judge an attributed passage: flag over-budget as unverified; drop on transient error.** A passage confidently attributed to one consulted opinion, but where the per-turn cost pre-flight is exhausted (deterministic) → write an **unverified FAIL row** ("claims case X, not verified"). A passage where the gateway judge call **errors** (transient) → **drop** (don't flag a good draft on a flaky call).
+- **FAIL is strictly additive on top of B1b.** B1c only ever adds FAIL rows for passages that are (a) confidently attributed and (b) judge-rejected or over-budget against the attributed opinion. **Every passage that is *not* confidently attributed behaves exactly as it does on `main` today** (verbatim loop unchanged; unattributed passages take the B1b all-opinions SUPPORTED path and drop on reject). No turn that is `fiduciary_grade` today becomes `flagged` *unless* it contains a quote attributed to a consulted case that that case's opinion does not support — which is precisely the intended behavior.
+- **No schema distinction between "judge-rejected" and "over-budget" FAIL.** Both are `verified=False, verification_method=NULL` → ledger `"unverified"` → gate `flagged`. That is the honest framing: a judge reject is *non-support*, not proof of fabrication; both rows are genuinely "not verified." The *why* is captured in **distinct structured log events** for audit (`caselaw_fail_judge_rejected` vs `caselaw_fail_over_budget`). A user-facing severity split is a follow-on **DE** (filed in this PR's §Deferred).
+- **Minimal skill-coupled parser now; DE-279 supersedes later.** B1c builds a lightweight parser coupled to the skill's `### Case` convention. The coupling is a **noted risk** (a skill that drops the format silently loses attribution → passages drop, never mis-FAIL — conservative). [DE-279](../../PRD.md#de-279) (Bluebook cite → opinion resolution, a `message_case_citations` table) can later replace the matcher with a format-independent resolver.
+- **No migration.** FAIL rows (`verified=False, verification_method=NULL`) already satisfy every `message_caselaw_citations` CHECK — `chk_message_caselaw_citations_verified_has_method` only requires a method when `verified=True`. No gate / ledger / UI / call-site-signature change. Only `ResearchClusterMetadata` gets loaded alongside the existing `ResearchOpinionMetadata`.
+
+## Design
+
+### Component 1 — `attribute_passages` (pure, unit-tested helper, `caselaw.py`)
+
+```python
+@dataclass(slots=True)
+class AttributedPassage:
+    passage: str
+    case_name: str | None   # nearest preceding "### " heading's case name, or None
+
+def attribute_passages(answer_text: str) -> list[AttributedPassage]: ...
+```
+
+Single pass over `answer_text.splitlines()`, tracking the **most recent `### ` heading** seen. Blockquote-passage assembly is identical to today's `extract_blockquote_passages` (consecutive `>` lines join into one passage; a non-blockquote line ends it). When a passage closes, pair it with the current heading's **case name** — the heading text after stripping the leading `### `, taken **up to the first comma** (the skill format is `### [Case Name], [Court], [Year] ([Citation])`). No preceding `### ` heading → `case_name=None`.
+
+`extract_blockquote_passages` is **kept** (re-expressed as `[a.passage for a in attribute_passages(text)]`) so its existing call sites and tests are untouched.
+
+> **Heading-comma edge case:** a case name itself can contain a comma (rare; e.g. *"In re Marriage of X, Y"*). v1 takes text-before-first-comma — a conservative truncation that, on a comma-containing name, simply *fails to match* the full stored `case_name` → no attribution → drop. It never **mis**-attributes. Note as a parser-fidelity follow-on.
+
+### Component 2 — `match_case_name` (pure, unit-tested helper, `caselaw.py`)
+
+```python
+def normalize_case_name(name: str) -> str: ...
+def match_case_name(parsed: str, clusters: Sequence[tuple[int, str]]) -> int | None: ...
+```
+
+`normalize_case_name`: lowercase; strip a trailing ` (…)` parenthetical (citation); strip trailing punctuation/whitespace; collapse internal whitespace runs to single spaces. `match_case_name`: normalize `parsed` and each cluster's `case_name`; return the `cluster_id` **iff exactly one** cluster normalizes-equal to `parsed`. Zero or ≥2 → `None`. Clusters with a null/empty `case_name` are skipped. Pure and total — no DB, no I/O.
+
+### Component 3 — `caselaw.py` orchestration (attribution-aware judge pass)
+
+`verify_and_persist_caselaw_citations` keeps its signature (the call site already passes `assistant_text` + `tool_sources`). Changes:
+
+1. **Load cluster names.** Alongside the existing `ResearchOpinionMetadata` query, load `ResearchClusterMetadata` for the same `cluster_ids` → build `clusters: list[(cluster_id, case_name)]` and a `cluster_id → opinion text(s)` lookup from the already-loaded `texts`.
+2. **Verbatim loop — unchanged.** (Tries all opinions; a verbatim match anywhere = legitimately quoted = SUPPORTED.)
+3. **Attribution-aware judge pass** (only when `gateway is not None`). Build `AttributedPassage`s once. **Process attributed passages first, then unattributed** (budget priority — the FAIL-bearing checks get first claim on the per-turn budget). For each still-unverified passage:
+   - **Attributed** (`match_case_name` → a cluster `C` that has loaded opinion text):
+     - **Cost pre-flight** against `C`'s opinion. If the per-turn budget would be exceeded → write an **unverified FAIL row** for this passage (`verified=False`, `verification_method=NULL`, `opinion_id`/`cluster_id` = `C`'s), log `caselaw_fail_over_budget`, and **continue** (do not spend; later attributed passages also over-budget → each gets its own unverified FAIL row).
+     - Else `judge_case_content(passage, C_opinion, gateway, judge_model)`:
+       - **accept** → SUPPORTED row (`paraphrase_judge`), exactly as B1b.
+       - **reject** → **FAIL row** (`verified=False`, `verification_method=NULL`), log `caselaw_fail_judge_rejected`.
+       - If `C` has multiple opinions: judge each until one accepts (SUPPORTED) or all reject (one FAIL row, attributed to `C`'s first opinion).
+     - A **transient gateway error** (caught) → **drop** this passage (logged, never fatal). *No FAIL row.*
+   - **Unattributed** (`case_name is None`, or no single match, or matched cluster has no loaded opinion text) → the **existing B1b all-opinions path**: judge against each consulted opinion, first accept → SUPPORTED, all reject → **drop**. Never FAIL.
+4. `gateway=None` → behaves exactly as today (verbatim-only; deterministic; no egress, no FAIL).
+
+> **Offsets for a FAIL row.** A FAIL passage has no verified span in any opinion. The `message_caselaw_citations` CHECK requires `offset_end > offset_start >= 0`. v1 stores a documented placeholder `source_offset_start=0, source_offset_end=len(passage)` (passage length, always ≥ 1 for a non-empty blockquote — guard empties out before row creation). The trace renders `source_text` (the quote) for display, not the offsets, for caselaw rows. Confirm in the plan (task 1) that C1's trace panel does not key off caselaw offsets.
+
+### Budgeting
+
+Reuses B1b's `CASE_CONTENT_JUDGE_BUDGET_USD` per-turn cap and `estimate_case_content_cost_usd` pre-flight verbatim. The only change is **what happens at the cap for an attributed passage**: B1b stops the whole pass and drops the rest; B1c, for an **attributed** passage, writes an unverified FAIL instead of dropping (decision #2). Unattributed passages at the cap still drop (B1b). Because attributed passages are judged **first**, the budget is spent on FAIL-bearing checks before SUPPORTED-only checks.
+
+## Testing
+
+Unit (pure helpers — the bulk of the value; no DB, no gateway):
+- `attribute_passages`: blockquote under a `### Case` H3 → `(passage, "Case Name")`; blockquote with no preceding H3 → `case_name=None`; multi-line wrapped blockquote joins; a `### Case` heading followed by prose then a *later* blockquote still attributes to the nearest preceding H3; comma-in-case-name truncates conservatively; the `## Gaps and caveats` section's non-`###` content never attributes.
+- `normalize_case_name` / `match_case_name`: exact match; case/whitespace/trailing-citation-insensitive match; **zero match → None**; **two clusters match → None** (the single-match guard); null `case_name` cluster skipped.
+
+Integration (mocked gateway — **no `-m provider`**; throwaway pgvector, conftest auto-migrates):
+- Attributed + judge-**reject** → one FAIL row (`verified=False`, method `NULL`); `assemble_ledger_entries` → `"unverified"`; `compute_and_record_gate` → `flagged`.
+- Attributed + judge-**accept** → SUPPORTED row (regression: B1b behavior preserved on the attributed path).
+- **Unattributed** (a statute blockquote whose H3 matches no consulted case) + judge would-reject → **drop, no FAIL** (the false-positive guard).
+- Attributed + **over-budget** → unverified FAIL row + `caselaw_fail_over_budget` event.
+- Attributed + **transient judge error** → drop, no row.
+- `gateway=None` → byte-for-byte the pre-B1c verbatim behavior (no FAIL rows).
+
+## Out of scope / Deferred (file as DE-XXX in this PR)
+
+- **DE — FAIL severity split in the trace UI.** Distinguish "judge-rejected (likely fabricated/misquoted)" from "unverified (claims case X, not checked — budget)" in the C1 trace. v1 surfaces both as `"unverified"`/`flagged`; the distinction lives only in structured logs.
+- **DE-279** — Bluebook cite → opinion resolution; a format-independent attribution layer that supersedes B1c's skill-coupled `### Case` parser.
+- A whitespace/format-tolerant or fuzzy case-name matcher (decision #1 chose normalized-exact-single-match; fuzzy is a later option if drift-misses prove common in practice).
+
+## Pointers
+
+- Strategy: [`docs/proposals/fiduciary-grade-agentic-legal-work.md`](../../proposals/fiduciary-grade-agentic-legal-work.md) (P1-B1c slice)
+- Prior slice spec: [`2026-06-25-p1b1b-caselaw-paraphrase-judge-design.md`](2026-06-25-p1b1b-caselaw-paraphrase-judge-design.md) (§"Explicitly out of scope → P1-B1c")
+- Reused judge: `api/app/citation/case_content_judge.py`; orchestrator: `api/app/citation/caselaw.py`; FAIL-row model: `api/app/models/message_caselaw_citation.py`; case-name source: `api/app/models/research.py` (`ResearchClusterMetadata`); skill contract: `skills/case-law-research/SKILL.md` §Output; gate/ledger (no change): `api/app/citation/{gate,ledger}.py`.


### PR DESCRIPTION
## P1-B1c — Caselaw FAIL tier via H3 attribution

Closes the last Phase-1 honesty gap in the fiduciary-grade chain: a **fabricated or materially misquoted** caselaw quote is no longer silently dropped — it is now flagged.

Before this PR, a caselaw quote that matched no consulted opinion (verbatim *or* via P1-B1b's SUPPORTED judge) was dropped → invisible → the fiduciary gate could not flag it. P1-B1c attributes each blockquote to its `### [Case Name], [Court], [Year] ([Citation])` H3 heading, matches the case name to **exactly one** consulted opinion, judges the passage against **that opinion only**, and writes a FAIL row on reject — which flows through the **unchanged** ledger + gate to a `flagged` turn.

### Design (maintainer-approved decisions)
- **Matcher: normalized-exact, single-match only.** A passage is attributed only when exactly one consulted cluster's `case_name` normalizes-equal to the parsed H3 case name. Zero/multiple matches, or no H3, → the passage stays on B1b's all-opinions SUPPORTED-or-drop path. **This match-gate is the false-positive guard** — a statute/KB/emphasis blockquote never matches a consulted case, so it can never produce a FAIL row.
- **Can't-judge an attributed passage:** over-budget → unverified FAIL row ("claims case X, not verified"); transient gateway error → drop (don't flag a good draft on a flaky call).
- **Strictly additive on P1-B1b.** Only confidently-attributed passages can FAIL; everything else behaves byte-for-byte as on `main` today. `gateway=None` stays verbatim-only.

### ⚠️ One intended behavior change (for the security reviewer)
A quote confidently attributed to case X, not verbatim, that **case X's own opinion rejects** now FAILs — *even if* some other consulted opinion would have SUPPORTED it (B1b's all-opinions path would have tagged it SUPPORTED). This is **intentional**: it is precisely the honesty gap this slice closes (a quote attributed to a case whose text does not support it is unverified, regardless of other cases on the docket).

### No schema / gate / ledger / UI change
FAIL rows are `verified=False, verification_method=NULL` — already permitted by `chk_message_caselaw_citations_verified_has_method`. `ledger.py` already maps `verified=False → "unverified"`; the gate already maps that to `flagged`; C1 already renders the red badge. **No migration.** Only `ResearchClusterMetadata` is newly loaded (for case names). FAIL-reason severity split (judge-rejected vs over-budget) deferred as **DE-362**.

### Two pure, unit-tested helpers
- `attribute_passages` — blockquote → nearest `### ` H3 → case name (text before first comma)
- `normalize_case_name` / `match_case_name` — normalized-exact single-match guard

### Tests
- 7 new B1c tests (2 unit files + 1 integration file): reject→FAIL→`flagged`; accept→SUPPORTED (B1b preserved); **unattributed→drop, no FAIL** (false-positive guard); over-budget→unverified FAIL; transient-error→drop; missing-confidence/non-JSON judge output→drop (no false FAIL).
- 167-test B1b + verbatim + unit regression: green (additive guarantee).
- **Full api suite: 2331 passed, 1 skipped, 0 failures.** `ruff format` + `ruff check` + `mypy` clean.

### Review
Subagent-driven development: per-task spec + quality reviews, plus an **Opus whole-branch review** (Ready-to-merge: Yes — no Critical/Important; verified the additive guarantee, airtight reject-vs-drop, no new egress/injection). The Opus task-review caught a real fiduciary-critical defect mid-build — `_parse_judge_response` collapses an explicit `"no"`, truncated JSON, an unknown verdict, and a missing-confidence `"yes"` all to the same miss — which would have written a **false FAIL** on judge-output noise; fixed so only a parseable `{"verdict":"no"}` flags a FAIL.

**Attestation:** N/A — no skill legal-substance change (citation-engine infrastructure only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs ADR 0018 D2/D3. Builds on P1-A1 (#218), P1-B1 (#225), P1-B1b (#229).
