### PR TITLE
feat: WS-G PR1 — citation-graph treatment signal (Phase 2)

### DIFF
--- a/api/alembic/versions/0061_citation_treatment.py
+++ b/api/alembic/versions/0061_citation_treatment.py
@@ -1,0 +1,62 @@
+"""create citation_treatment (WS-G PR1 citation-graph signal)
+
+Revision ID: 0061
+Revises: 0060
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0061"
+down_revision: str | None = "0060"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "citation_treatment",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("cluster_id", sa.BigInteger(), nullable=False),
+        sa.Column("opinion_id", sa.BigInteger(), nullable=True),
+        sa.Column("cited_by_count", sa.Integer(), nullable=False),
+        sa.Column("citing_opinions", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("derived_method", sa.Text(), nullable=False),
+        sa.Column(
+            "as_of", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_citation_treatment"),
+        sa.UniqueConstraint("cluster_id", name="uq_citation_treatment_cluster_id"),
+        sa.CheckConstraint("cited_by_count >= 0", name="chk_citation_treatment_count_nonneg"),
+        sa.CheckConstraint(
+            "derived_method IN ('citation_graph')", name="chk_citation_treatment_method_values"
+        ),
+    )
+    op.create_index("ix_citation_treatment_cluster_id", "citation_treatment", ["cluster_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_citation_treatment_cluster_id", table_name="citation_treatment")
+    op.drop_table("citation_treatment")

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -128,6 +128,7 @@ from app.schemas.gateway import (
     InlineSkillRef,
 )
 from app.skills.registry import MutableSkillRegistry, SkillRegistry
+from app.workers.queue import enqueue_treatment_derivation_job
 
 router = APIRouter(prefix="/chats", tags=["chats"])
 log = logging.getLogger(__name__)
@@ -2951,6 +2952,10 @@ async def _non_streaming_response(
                 request=http_request,
                 attached_skill_provenance=attached_skill_provenance,
             )
+            try:
+                await enqueue_treatment_derivation_job(assistant_message_id)
+            except Exception as treatment_exc:  # never block the turn response
+                log.warning("treatment derivation enqueue failed: %r", treatment_exc)
             body = MessagePostResponse(
                 message=message_to_response(persisted),
                 citations=[],
@@ -3170,6 +3175,10 @@ async def _non_streaming_response(
         request=http_request,
         attached_skill_provenance=attached_skill_provenance,
     )
+    try:
+        await enqueue_treatment_derivation_job(assistant_message_id)
+    except Exception as treatment_exc:  # never block the turn response
+        log.warning("treatment derivation enqueue failed: %r", treatment_exc)
 
     body = MessagePostResponse(
         message=message_to_response(persisted),
@@ -3554,6 +3563,10 @@ async def _stream_response(
                         "error": str(audit_exc),
                     },
                 )
+            try:
+                await enqueue_treatment_derivation_job(assistant_message_id)
+            except Exception as treatment_exc:  # never block the turn response
+                log.warning("treatment derivation enqueue failed: %r", treatment_exc)
         except Exception as persist_exc:
             # Persisting the audit row must not break the stream; the
             # operator sees this in logs and the client gets the same

--- a/api/app/citation/ledger.py
+++ b/api/app/citation/ledger.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.chat import Chat, Message, MessageCitation
 from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
 from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.message_tool_source import MessageToolSource
 
@@ -232,6 +233,20 @@ async def resolve_ledger_entries(
             .all()
         }
 
+    treatment_ids = {e.treatment_id for e in entries if e.treatment_id is not None}
+    treatments: dict[uuid.UUID, CitationTreatment] = {}
+    if treatment_ids:
+        treatments = {
+            t.id: t
+            for t in (
+                await db.execute(
+                    select(CitationTreatment).where(CitationTreatment.id.in_(treatment_ids))
+                )
+            )
+            .scalars()
+            .all()
+        }
+
     out: list[dict[str, Any]] = []
     for e in entries:
         source = _resolve_source(e, docs, caselaw, tools)
@@ -248,6 +263,16 @@ async def resolve_ledger_entries(
                 "provider": e.provider,
                 "retrieved_at": e.retrieved_at.isoformat() if e.retrieved_at else None,
                 "treatment_id": str(e.treatment_id) if e.treatment_id else None,
+                "treatment": (
+                    {
+                        "cited_by_count": treatments[e.treatment_id].cited_by_count,
+                        "as_of": treatments[e.treatment_id].as_of.isoformat(),
+                        "derived_method": treatments[e.treatment_id].derived_method,
+                        "citing": treatments[e.treatment_id].citing_opinions,
+                    }
+                    if e.treatment_id is not None and e.treatment_id in treatments
+                    else None
+                ),
                 "created_at": e.created_at.isoformat(),
                 "source": source,
             }

--- a/api/app/citation/treatment.py
+++ b/api/app/citation/treatment.py
@@ -123,8 +123,13 @@ async def derive_treatment_for_message(
     )
     linked = 0
     for e in entries:
-        cluster_id = cc_id_to_cluster.get(e.message_caselaw_citation_id)
-        treatment_id = cluster_to_treatment.get(cluster_id) if cluster_id is not None else None
+        cc_id = e.message_caselaw_citation_id
+        if cc_id is None:
+            continue
+        entry_cluster_id = cc_id_to_cluster.get(cc_id)
+        if entry_cluster_id is None:
+            continue
+        treatment_id = cluster_to_treatment.get(entry_cluster_id)
         if treatment_id is not None:
             e.treatment_id = treatment_id
             linked += 1

--- a/api/app/citation/treatment.py
+++ b/api/app/citation/treatment.py
@@ -47,6 +47,8 @@ async def derive_treatment_for_message(
     Returns the number of caselaw ledger entries linked to a treatment row.
     Never raises on a per-case failure (logged and skipped).
     """
+    if now.tzinfo is None:
+        raise ValueError("derive_treatment_for_message requires a timezone-aware 'now'")
     citations = (
         (
             await db.execute(

--- a/api/app/citation/treatment.py
+++ b/api/app/citation/treatment.py
@@ -1,0 +1,131 @@
+"""Derive the citation-graph treatment signal for a turn's cited cases (WS-G PR1).
+
+Graph-only: for each case a turn cited, reuse a fresh ``citation_treatment`` row
+or fetch the citing graph via the gateway and upsert one, then link the turn's
+caselaw ledger entries to it. No LLM-judge (that is PR2). Per-case non-fatal
+(conservative posture). ADR 0019 D2.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
+from app.models.message_caselaw_citation import MessageCaselawCitation
+
+log = logging.getLogger(__name__)
+
+TREATMENT_TTL_DAYS = 30
+
+_FetchCiting = Callable[[int], Awaitable[dict[str, Any]]]
+
+
+async def _default_fetch_citing(opinion_id: int) -> dict[str, Any]:
+    from app.research import service as research_service
+
+    return await research_service.get_citing_opinions(opinion_id)
+
+
+async def derive_treatment_for_message(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    now: datetime,
+    ttl_days: int = TREATMENT_TTL_DAYS,
+    fetch_citing: _FetchCiting = _default_fetch_citing,
+) -> int:
+    """Derive/refresh graph treatment for each case this turn cited; link entries.
+
+    Returns the number of caselaw ledger entries linked to a treatment row.
+    Never raises on a per-case failure (logged and skipped).
+    """
+    citations = (
+        (
+            await db.execute(
+                select(MessageCaselawCitation).where(
+                    MessageCaselawCitation.message_id == message_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not citations:
+        return 0
+
+    # One derivation per distinct cited cluster; remember a representative opinion_id.
+    by_cluster: dict[int, int] = {}
+    for c in citations:
+        by_cluster.setdefault(c.cluster_id, c.opinion_id)
+
+    cluster_to_treatment: dict[int, uuid.UUID] = {}
+    stale_before = now - timedelta(days=ttl_days)
+    for cluster_id, opinion_id in by_cluster.items():
+        try:
+            existing = (
+                await db.execute(
+                    select(CitationTreatment).where(CitationTreatment.cluster_id == cluster_id)
+                )
+            ).scalar_one_or_none()
+            if existing is not None and existing.as_of >= stale_before:
+                cluster_to_treatment[cluster_id] = existing.id
+                continue
+            payload = await fetch_citing(opinion_id)
+            if existing is None:
+                row = CitationTreatment(
+                    cluster_id=cluster_id,
+                    opinion_id=opinion_id,
+                    cited_by_count=int(payload.get("cited_by_count") or 0),
+                    citing_opinions=list(payload.get("citing") or []),
+                    derived_method="citation_graph",
+                    as_of=now,
+                )
+                db.add(row)
+                await db.flush()
+                cluster_to_treatment[cluster_id] = row.id
+            else:
+                existing.cited_by_count = int(payload.get("cited_by_count") or 0)
+                existing.citing_opinions = list(payload.get("citing") or [])
+                existing.derived_method = "citation_graph"
+                existing.opinion_id = opinion_id
+                existing.as_of = now
+                await db.flush()
+                cluster_to_treatment[cluster_id] = existing.id
+        except Exception as exc:  # per-case non-fatal (conservative posture)
+            log.warning("treatment derivation failed for cluster %s: %r", cluster_id, exc)
+
+    if not cluster_to_treatment:
+        return 0
+
+    # Link this turn's caselaw ledger entries to their cluster's treatment row.
+    cc_id_to_cluster = {c.id: c.cluster_id for c in citations}
+    entries = (
+        (
+            await db.execute(
+                select(CitationLedgerEntry).where(
+                    CitationLedgerEntry.message_id == message_id,
+                    CitationLedgerEntry.source_kind == "caselaw",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    linked = 0
+    for e in entries:
+        cluster_id = cc_id_to_cluster.get(e.message_caselaw_citation_id)
+        treatment_id = cluster_to_treatment.get(cluster_id) if cluster_id is not None else None
+        if treatment_id is not None:
+            e.treatment_id = treatment_id
+            linked += 1
+    if linked:
+        await db.flush()
+    return linked

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.autonomous import (
 from app.models.chat import Chat, Message
 from app.models.chat_pending_tool_call import ChatPendingToolCall
 from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
 from app.models.document import Document, DocumentChunk
 from app.models.enhance_prompt import EnhancePromptInteraction
 from app.models.file import File
@@ -59,6 +60,7 @@ __all__ = [
     "Chat",
     "ChatPendingToolCall",
     "CitationLedgerEntry",
+    "CitationTreatment",
     "Document",
     "DocumentChunk",
     "EnhancePromptInteraction",

--- a/api/app/models/citation_treatment.py
+++ b/api/app/models/citation_treatment.py
@@ -1,0 +1,51 @@
+"""citation_treatment — derived validity/treatment signal per cited case (WS-G).
+
+One row per cited case (``cluster_id``), holding the citation-graph signal:
+the total cited-by count + a capped list of recent citing-opinion *references*
+(ids + case_name + court + date — never opinion text, P3). ADR 0019 D2/D7.
+PR1 (this) is graph-only (``derived_method='citation_graph'``); PR2 extends the
+row with judge-classified treatment. Reference-only → joins the P3 tripwire.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import BigInteger, CheckConstraint, DateTime, Integer, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class CitationTreatment(Base):
+    __tablename__ = "citation_treatment"
+    __table_args__ = (
+        UniqueConstraint("cluster_id", name="uq_citation_treatment_cluster_id"),
+        CheckConstraint("cited_by_count >= 0", name="chk_citation_treatment_count_nonneg"),
+        CheckConstraint(
+            "derived_method IN ('citation_graph')",
+            name="chk_citation_treatment_method_values",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    cluster_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    opinion_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    cited_by_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    citing_opinions: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
+    derived_method: Mapped[str] = mapped_column(Text, nullable=False)
+    as_of: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )

--- a/api/app/research/service.py
+++ b/api/app/research/service.py
@@ -89,6 +89,14 @@ async def search_case_law(args: dict[str, Any], *, request_id: str | None = None
     return result["payload"]
 
 
+async def get_citing_opinions(opinion_id: int, *, request_id: str | None = None) -> dict[str, Any]:
+    provider = await _resolve_provider(request_id=request_id)
+    result = await get_gateway_client().call_tool(
+        provider, "get_citing_opinions", {"opinion_id": opinion_id}, request_id=request_id
+    )
+    return result["payload"]
+
+
 def _opinion_storage_path(cluster_id: int, opinion_id: int) -> str:
     return f"courtlistener/opinions/by-cluster/{cluster_id}/{opinion_id}"
 

--- a/api/app/workers/document_pipeline.py
+++ b/api/app/workers/document_pipeline.py
@@ -45,6 +45,7 @@ from typing import Any, ClassVar
 from app.config import get_settings
 from app.db.session import dispose_engine, get_session_factory
 from app.pipeline.ingest import find_orphaned_files, ingest_file
+from app.workers.treatment_worker import treatment_derivation_job
 from app.workers.user_deletion import hard_delete_due_users_job
 from app.workers.user_export import export_gc_job, export_user_data_job
 
@@ -254,6 +255,7 @@ class WorkerSettings:
         ingest_file_job,
         embed_chunks_for_file_job,
         export_user_data_job,
+        treatment_derivation_job,
     ]
     on_startup = on_startup
     on_shutdown = on_shutdown

--- a/api/app/workers/queue.py
+++ b/api/app/workers/queue.py
@@ -51,6 +51,11 @@ playbook worker (see :mod:`app.workers.arq_setup`) consumes from the
 shared playbook queue, walks the document corpus, and writes the
 assembled draft playbook back to the ``easy_playbook_generations`` row."""
 
+TREATMENT_DERIVATION_JOB_NAME = "treatment_derivation_job"
+"""WS-G PR1 — citation-graph treatment derivation job. Enqueued best-effort
+after each assistant turn finalizes; the ingest worker consumes it and derives
+the citation-graph treatment signal for all caselaw citations in the turn."""
+
 AUTONOMOUS_SESSION_JOB_NAME = "autonomous_session_job"
 """M4-A2 / M4-B3 — Autonomous Session execution pipeline. Enqueued by the
 B3 schedule dispatcher (and future watch/manual triggers) onto the shared
@@ -339,6 +344,37 @@ async def enqueue_user_export_job(job_id: uuid.UUID) -> bool:
             extra={
                 "event": "user_export_enqueue_failed",
                 "job_id": str(job_id),
+                "error": str(exc),
+            },
+        )
+        return False
+
+
+async def enqueue_treatment_derivation_job(message_id: uuid.UUID) -> bool:
+    """Enqueue a citation-graph treatment-derivation job (WS-G PR1).
+
+    Best-effort: failures are logged at WARNING and return False. The
+    caller (turn-finalize path in ``app.api.chats``) never blocks on this;
+    a missed derivation is silent — no retry sweep (treatment is
+    re-derived on demand when the Ledger UI queries the signal).
+    """
+    try:
+        pool = await _get_pool()
+        await pool.enqueue_job(TREATMENT_DERIVATION_JOB_NAME, str(message_id))
+        log.info(
+            "enqueue_treatment_derivation_job: enqueued",
+            extra={
+                "event": "treatment_derivation_enqueue",
+                "message_id": str(message_id),
+            },
+        )
+        return True
+    except Exception as exc:
+        log.warning(
+            "enqueue_treatment_derivation_job: failed",
+            extra={
+                "event": "treatment_derivation_enqueue_failed",
+                "message_id": str(message_id),
                 "error": str(exc),
             },
         )

--- a/api/app/workers/treatment_worker.py
+++ b/api/app/workers/treatment_worker.py
@@ -1,0 +1,71 @@
+"""arq job — derive citation-graph treatment for an assistant turn (WS-G PR1).
+
+Runs OFF the turn's critical path: enqueued best-effort after each assistant
+turn finalizes (see ``app.api.chats``), consumed by the ingest worker.
+Mirrors the ``ingest_file_job`` session-factory pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.treatment import _default_fetch_citing, _FetchCiting, derive_treatment_for_message
+from app.db.session import get_session_factory
+
+log = logging.getLogger(__name__)
+
+
+async def run_treatment_derivation(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    fetch_citing: _FetchCiting = _default_fetch_citing,
+) -> int:
+    """Session-injected core (testable without arq/Redis).
+
+    Calls ``derive_treatment_for_message`` with a UTC-aware *now*, then
+    commits the session. Returns the number of ledger entries linked.
+    """
+    linked = await derive_treatment_for_message(
+        db,
+        message_id=message_id,
+        now=datetime.now(UTC),
+        fetch_citing=fetch_citing,
+    )
+    await db.commit()
+    return linked
+
+
+async def treatment_derivation_job(ctx: dict[str, Any], message_id_str: str) -> dict[str, Any]:
+    """arq entrypoint — opens a session, runs derivation, commits.
+
+    The outer try/except is the backstop for session-level and flush
+    failures; it ensures the worker never crashes on a single bad turn.
+    """
+    message_id = uuid.UUID(message_id_str)
+    try:
+        factory = get_session_factory()
+        async with factory() as db:
+            linked = await run_treatment_derivation(db, message_id=message_id)
+    except Exception as exc:  # outer guard: session-level/flush failures
+        log.warning(
+            "treatment_derivation_job failed for %s: %r",
+            message_id,
+            exc,
+            extra={"event": "treatment_derivation_failed", "message_id": message_id_str},
+        )
+        return {"message_id": message_id_str, "linked": 0, "ok": False}
+    log.info(
+        "treatment_derivation_job complete",
+        extra={
+            "event": "treatment_derivation_complete",
+            "message_id": message_id_str,
+            "linked": linked,
+        },
+    )
+    return {"message_id": message_id_str, "linked": linked, "ok": True}

--- a/api/tests/citation/test_treatment_derivation.py
+++ b/api/tests/citation/test_treatment_derivation.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.treatment import TREATMENT_TTL_DAYS, derive_treatment_for_message
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+_NOW = datetime(2026, 6, 26, tzinfo=UTC)
+
+
+def _citing(n: int) -> dict:
+    return {
+        "cited_by_count": 412,
+        "citing": [
+            {
+                "cluster_id": 1000 + i,
+                "opinion_id": 9000 + i,
+                "case_name": f"C{i}",
+                "court": "ca9",
+                "date_filed": "2021-01-01",
+            }
+            for i in range(n)
+        ],
+    }
+
+
+@pytest.fixture
+async def seeded(db_session: AsyncSession):
+    user = User(email=f"t-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="t")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
+    db_session.add(msg)
+    await db_session.flush()
+    cc = MessageCaselawCitation(
+        message_id=msg.id,
+        opinion_id=2812209,
+        cluster_id=2812209,
+        source_offset_start=0,
+        source_offset_end=5,
+        source_text="quote",
+        verified=True,
+        verification_method="exact_match",
+    )
+    db_session.add(cc)
+    await db_session.flush()
+    entry = CitationLedgerEntry(
+        chat_id=chat.id,
+        message_id=msg.id,
+        source_kind="caselaw",
+        message_caselaw_citation_id=cc.id,
+        verification_status="exact_match",
+    )
+    db_session.add(entry)
+    await db_session.flush()
+    return msg.id, chat.id, cc, entry
+
+
+@pytest.mark.asyncio
+async def test_derives_fetches_and_links(db_session, seeded):
+    message_id, _chat, _cc, entry = seeded
+    calls = []
+
+    async def fake_fetch(opinion_id: int) -> dict:
+        calls.append(opinion_id)
+        return _citing(32)
+
+    n = await derive_treatment_for_message(
+        db_session, message_id=message_id, now=_NOW, fetch_citing=fake_fetch
+    )
+    assert n == 1
+    assert calls == [2812209]
+    row = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == 2812209)
+        )
+    ).scalar_one()
+    assert row.cited_by_count == 412
+    assert (
+        len(row.citing_opinions) == 32
+    )  # service stores what the op returns (op already capped at 30; service does not re-cap)
+    assert row.derived_method == "citation_graph"
+    await db_session.refresh(entry)
+    assert entry.treatment_id == row.id
+
+
+@pytest.mark.asyncio
+async def test_reuses_fresh_cache_without_fetch(db_session, seeded):
+    message_id, _chat, _cc, entry = seeded
+    db_session.add(
+        CitationTreatment(
+            cluster_id=2812209,
+            opinion_id=2812209,
+            cited_by_count=10,
+            citing_opinions=[],
+            derived_method="citation_graph",
+            as_of=_NOW - timedelta(days=5),
+        )
+    )
+    await db_session.flush()
+    calls = []
+
+    async def fake_fetch(opinion_id: int) -> dict:
+        calls.append(opinion_id)
+        return _citing(1)
+
+    n = await derive_treatment_for_message(
+        db_session, message_id=message_id, now=_NOW, fetch_citing=fake_fetch
+    )
+    assert n == 1
+    assert calls == []  # fresh cache reused, no fetch
+    await db_session.refresh(entry)
+    assert entry.treatment_id is not None
+
+
+@pytest.mark.asyncio
+async def test_refetches_when_stale(db_session, seeded):
+    message_id, *_ = seeded
+    db_session.add(
+        CitationTreatment(
+            cluster_id=2812209,
+            opinion_id=2812209,
+            cited_by_count=10,
+            citing_opinions=[],
+            derived_method="citation_graph",
+            as_of=_NOW - timedelta(days=TREATMENT_TTL_DAYS + 1),
+        )
+    )
+    await db_session.flush()
+    calls = []
+
+    async def fake_fetch(opinion_id: int) -> dict:
+        calls.append(opinion_id)
+        return _citing(3)
+
+    await derive_treatment_for_message(
+        db_session, message_id=message_id, now=_NOW, fetch_citing=fake_fetch
+    )
+    assert calls == [2812209]  # stale → refetch
+    row = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == 2812209)
+        )
+    ).scalar_one()
+    assert row.cited_by_count == 412  # upserted
+
+
+@pytest.mark.asyncio
+async def test_per_case_fetch_error_is_non_fatal(db_session, seeded):
+    message_id, *_ = seeded
+
+    async def boom(opinion_id: int) -> dict:
+        raise RuntimeError("upstream down")
+
+    n = await derive_treatment_for_message(
+        db_session, message_id=message_id, now=_NOW, fetch_citing=boom
+    )
+    assert n == 0  # nothing linked, but no raise
+    rows = (await db_session.execute(select(CitationTreatment))).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_no_caselaw_citations_is_noop(db_session):
+    # a message with no caselaw citations
+    user = User(email=f"t-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="t")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
+    db_session.add(msg)
+    await db_session.flush()
+    called = []
+
+    async def fake_fetch(opinion_id: int) -> dict:
+        called.append(opinion_id)
+        return _citing(1)
+
+    n = await derive_treatment_for_message(
+        db_session, message_id=msg.id, now=_NOW, fetch_citing=fake_fetch
+    )
+    assert n == 0
+    assert called == []

--- a/api/tests/integration/test_ledger_treatment_exposure.py
+++ b/api/tests/integration/test_ledger_treatment_exposure.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.ledger import resolve_ledger_entries
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_ledger_entry_carries_resolved_treatment(db_session: AsyncSession):
+    user = User(email=f"l-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="l")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
+    db_session.add(msg)
+    await db_session.flush()
+    cc = MessageCaselawCitation(
+        message_id=msg.id,
+        opinion_id=2812209,
+        cluster_id=2812209,
+        source_offset_start=0,
+        source_offset_end=5,
+        source_text="q",
+        verified=True,
+        verification_method="exact_match",
+    )
+    db_session.add(cc)
+    await db_session.flush()
+    treatment = CitationTreatment(
+        cluster_id=2812209,
+        opinion_id=2812209,
+        cited_by_count=412,
+        citing_opinions=[
+            {
+                "cluster_id": 1,
+                "opinion_id": 2,
+                "case_name": "A",
+                "court": "ca9",
+                "date_filed": "2021-01-01",
+            }
+        ],
+        derived_method="citation_graph",
+    )
+    db_session.add(treatment)
+    await db_session.flush()
+    linked = CitationLedgerEntry(
+        chat_id=chat.id,
+        message_id=msg.id,
+        source_kind="caselaw",
+        message_caselaw_citation_id=cc.id,
+        verification_status="exact_match",
+        treatment_id=treatment.id,
+    )
+    unlinked = CitationLedgerEntry(
+        chat_id=chat.id,
+        message_id=msg.id,
+        source_kind="caselaw",
+        message_caselaw_citation_id=cc.id,
+        verification_status="exact_match",
+    )
+    db_session.add_all([linked, unlinked])
+    await db_session.flush()
+
+    entries = await resolve_ledger_entries(db_session, chat_id=chat.id, message_id=msg.id)
+    by_treatment = {bool(e.get("treatment")): e for e in entries}
+    assert by_treatment[True]["treatment"]["cited_by_count"] == 412
+    assert by_treatment[True]["treatment"]["derived_method"] == "citation_graph"
+    assert by_treatment[True]["treatment"]["citing"][0]["case_name"] == "A"
+    assert by_treatment[False]["treatment"] is None

--- a/api/tests/integration/test_treatment_job.py
+++ b/api/tests/integration/test_treatment_job.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_run_treatment_derivation_writes_row_and_links(db_session: AsyncSession, monkeypatch):
+    # Seed a turn with a caselaw citation + ledger entry (as in Task 3's fixture).
+    user = User(email=f"j-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="j")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
+    db_session.add(msg)
+    await db_session.flush()
+    cc = MessageCaselawCitation(
+        message_id=msg.id,
+        opinion_id=2812209,
+        cluster_id=2812209,
+        source_offset_start=0,
+        source_offset_end=5,
+        source_text="q",
+        verified=True,
+        verification_method="exact_match",
+    )
+    db_session.add(cc)
+    await db_session.flush()
+    entry = CitationLedgerEntry(
+        chat_id=chat.id,
+        message_id=msg.id,
+        source_kind="caselaw",
+        message_caselaw_citation_id=cc.id,
+        verification_status="exact_match",
+    )
+    db_session.add(entry)
+    await db_session.flush()
+
+    # The job's _run helper takes an injected session + fetch so we can test it without Redis/arq.
+    from app.workers.treatment_worker import run_treatment_derivation
+
+    async def fake_fetch(opinion_id: int) -> dict:
+        return {
+            "cited_by_count": 7,
+            "citing": [
+                {
+                    "cluster_id": 1,
+                    "opinion_id": 2,
+                    "case_name": "A",
+                    "court": "ca9",
+                    "date_filed": "2022-01-01",
+                }
+            ],
+        }
+
+    linked = await run_treatment_derivation(db_session, message_id=msg.id, fetch_citing=fake_fetch)
+    assert linked == 1
+    row = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == 2812209)
+        )
+    ).scalar_one()
+    assert row.cited_by_count == 7
+    await db_session.refresh(entry)
+    assert entry.treatment_id == row.id

--- a/api/tests/test_citation_treatment_model.py
+++ b/api/tests/test_citation_treatment_model.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.citation_treatment import CitationTreatment
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_citation_treatment_roundtrip(db_session: AsyncSession) -> None:
+    row = CitationTreatment(
+        cluster_id=2812209,
+        opinion_id=2812209,
+        cited_by_count=412,
+        citing_opinions=[
+            {
+                "cluster_id": 1001,
+                "opinion_id": 9001,
+                "case_name": "X v. Y",
+                "court": "ca9",
+                "date_filed": "2021-01-01",
+            }
+        ],
+        derived_method="citation_graph",
+    )
+    db_session.add(row)
+    await db_session.flush()
+    got = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == 2812209)
+        )
+    ).scalar_one()
+    assert got.cited_by_count == 412
+    assert got.citing_opinions[0]["case_name"] == "X v. Y"
+    assert got.derived_method == "citation_graph"
+    assert got.as_of is not None  # server_default now()

--- a/api/tests/test_transparency_invariants.py
+++ b/api/tests/test_transparency_invariants.py
@@ -31,6 +31,7 @@ from sqlalchemy import Table
 import app
 from app.models.audit import AuditLog
 from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
 from app.models.inference import InferenceRoutingLog
 from app.models.tool_call_log import ToolCallLog
 from app.models.tool_egress import ToolEgressLog
@@ -53,6 +54,7 @@ _AUDIT_MODELS: tuple[type, ...] = (
     ToolEgressLog,
     InferenceRoutingLog,
     CitationLedgerEntry,
+    CitationTreatment,
     WorkProductFiduciaryGate,
 )
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4827,6 +4827,18 @@ So the single longest phase (image pull) has neither a stream nor a poll. The re
 
 ---
 
+#### DE-364 — Per-cluster SAVEPOINT isolation in treatment derivation (concurrency)
+
+**Priority:** P2 · **Effort:** S · **Status: OPEN (land before Phase 2 closes)**
+
+**Context:** Surfaced by the WS-G PR1 Opus whole-branch review. `derive_treatment_for_message` (`api/app/citation/treatment.py`) processes each cited cluster in a per-cluster `try/except` so that one case's failure does not sink the others (the conservative per-case non-fatal guarantee). That guarantee holds for the **common** failure — a `fetch_citing` network error happens before any DB mutation, so the session stays clean and other clusters proceed (this is what the tests exercise). It does **not** fully hold for a `db.flush()` failure: if two concurrent turns cite the **same not-yet-cached case**, both miss the cache, both attempt to INSERT a `citation_treatment` row, and the second hits the `uq_citation_treatment_cluster_id` unique constraint → `IntegrityError`. That poisons the `AsyncSession` (pending-rollback), so the *remaining* clusters on a **multi-cluster** turn then fail with `PendingRollbackError` and the whole turn's derivation is lost. The worker's outer `try/except` catches it and returns `{"ok": False}` — **no crash**, and the underived state is honestly re-derivable by [DE-363](#de-363)'s lazy fallback — but the per-cluster non-fatal invariant is narrower than the code claims for multi-cluster turns under concurrent same-case citation. Single-cluster turns (the overwhelming common case) degrade to exactly the intended "this one case failed, underived" outcome.
+
+**Specific scope:** Wrap each cluster's mutate+flush in a SAVEPOINT (`async with db.begin_nested():`) so an `IntegrityError` rolls back only that cluster and leaves the session usable for the rest, OR catch the unique-violation specifically and re-read + reuse the row the concurrent turn inserted (the more correct outcome — the case *is* now cached). Add a concurrency regression test that forces a mid-loop flush failure on one cluster of a multi-cluster turn and asserts the others still derive + link.
+
+**When to ship:** Within WS-G (Phase 2), before the milestone closes — alongside DE-363 or PR2. Filed (not fixed) in PR1 to keep the security-gated slice scoped; the degradation is non-crashing and DE-363-recoverable in the interim.
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4815,6 +4815,18 @@ So the single longest phase (image pull) has neither a stream nor a poll. The re
 
 ---
 
+#### DE-363 — WS-G lazy-on-trace-open treatment fallback
+
+**Priority:** P2 · **Effort:** S · **Status: OPEN (committed to land within Phase 2 / WS-G)**
+
+**Context:** [ADR 0019](adr/0019-transparent-validity-treatment-layer.md) D2 specifies a **lazy-on-first-trace-open** fallback for deriving a cited case's treatment when the async derivation job has not yet populated it (worker backlog, a failed/dropped enqueue, or a row that expired its staleness TTL between turns). WS-G PR1 (the citation-graph signal) ships **async-only** to keep the ledger read path fast and egress-free; an entry whose treatment is not yet derived renders nothing / "pending." That is an honest interim state, not a silent gap — but the ADR's fallback is part of the intended design, and the maintainer approved deferring it (2026-06-26) **on the condition that it lands by the end of Phase 2.**
+
+**Specific scope:** When `GET /chats/{chat_id}/ledger` resolves a caselaw entry whose `treatment_id` is null (or whose `citation_treatment.as_of` is stale beyond the TTL), trigger a best-effort derivation — most likely by **enqueuing the existing `treatment_derivation_job`** for that turn (keeping egress off the synchronous read path) and returning `treatment: null` / "deriving" for that read, rather than blocking the response on a live CourtListener fetch. Decide in the implementing PR whether the fallback ever derives **synchronously** on read (latency + egress cost) or strictly re-enqueues; the re-enqueue path is the conservative default.
+
+**When to ship:** Within WS-G (Phase 2) — alongside or immediately after PR2, before the milestone closes. Not optional; tracked here so the PR1 async-only simplification cannot silently become permanent.
+
+---
+
 ## 10. Appendices
 
 ### Appendix A — Glossary

--- a/docs/superpowers/plans/2026-06-26-wsg-pr1-citation-graph-treatment.md
+++ b/docs/superpowers/plans/2026-06-26-wsg-pr1-citation-graph-treatment.md
@@ -1,0 +1,967 @@
+# WS-G PR1 — Citation-graph treatment signal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Derive a cited case's citation-graph signal ("cited by N later opinions; here are the most recent N") off the turn's critical path, cache it per case, and populate the ledger's reserved `treatment_id` slot — no LLM-judge (that is PR2).
+
+**Architecture:** A new `get_citing_opinions` CourtListener gateway op (Search API `cites:` filter) → a thin `research.service` wrapper → a `derive_treatment_for_message` service that upserts a `citation_treatment` row per cited case and links the turn's caselaw ledger entries → an arq job enqueued after turn finalize → `resolve_ledger_entries` exposes the signal on the `/ledger` read. Strictly additive; treatment never gates the turn.
+
+**Tech Stack:** Python 3.12, async SQLAlchemy + Alembic, FastAPI, arq (Redis), pytest/pytest-asyncio. Gateway is `mypy --strict`. No new dependency.
+
+## Global Constraints
+
+- **Security-gated** (`gateway/**` + `api/app/citation/**`): **do not self-merge**; Kevin/security merges; mirror `origin/main → tucuxi` after.
+- **No judge in PR1.** No LLM call anywhere in this PR. The signal is graph-only (`derived_method="citation_graph"`).
+- **Graph signal:** `cited_by_count` (the upstream total) + a capped list of **N=30** citing-opinion refs, ordered **most-recent-first** (`order_by=dateFiled desc`). *(The spec's "highest-court-then-recent" is not server-orderable on CourtListener's Search API; court-rank re-ranking of the materialized subset is PR2. v1 = most-recent-first. `cited_by_count` is the upstream `count`, NEVER the truncated list length.)*
+- **P3:** `citation_treatment.citing_opinions` holds **structured refs only** (`cluster_id`, `opinion_id`, `case_name`, `court`, `date_filed`) — never opinion text. The model joins the P3 tripwire (`_AUDIT_MODELS`). No column name may match the tripwire denylist (`text`, `content`, `body`, `payload`, `*_opinions` is fine — not on the list).
+- **Treatment never gates the turn.** The fiduciary-grade gate (ADR 0018 D3) is untouched; derivation runs async after `_audit_message_sent`; absent treatment → `treatment: null` on the read.
+- **`cites:` keys on opinion id.** `message_caselaw_citations` carries both `opinion_id` and `cluster_id`; derivation cites-searches the `opinion_id` and caches keyed by `cluster_id`.
+- **Tests:** host venv + throwaway pgvector (`lqai-test-pg` :55432, `DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test`, conftest auto-migrates). Gateway tests mock `_request`; api tests mock the citing fetch — **no `-m provider`**, no live CourtListener. Run `ruff format` AND `ruff check` on touched files; gateway is `mypy --strict`.
+- **Commits:** `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. Next migration = `0061`.
+
+---
+
+### Task 1: Gateway op `get_citing_opinions` (CourtListener Search `cites:` filter)
+
+**Files:**
+- Modify: `gateway/app/providers/tool/courtlistener.py` (`list_tools` add a `ToolSpec`; `invoke_tool` add a branch; add `_get_citing_opinions` + a `_CITING_TOP_N` const)
+- Test: `gateway/tests/providers/tool/test_courtlistener.py` (extend; if absent, create — locate the existing CL provider test first)
+
+**Interfaces:**
+- Consumes: the provider's `self._request(method, path, params=...)`, `self._result(tool, payload, *, sent, received)`, `_cursor_from`, and the existing `_search_case_law` result-mapping shape.
+- Produces: tool `get_citing_opinions`, input `{"opinion_id": int}`, payload `{"cited_by_count": int, "citing": [{"cluster_id", "opinion_id", "case_name", "court", "date_filed"}]}` (≤30, most-recent-first).
+
+- [ ] **Step 1: Write the failing test**
+
+Locate the existing CL provider test (`grep -rl "class.*CourtListener\|_search_case_law\|get_cases" gateway/tests`). Mirror its HTTP-mock style (it stubs `_request`/httpx). Add:
+
+```python
+@pytest.mark.asyncio
+async def test_get_citing_opinions_shapes_count_and_capped_list(monkeypatch) -> None:
+    provider = _make_provider()  # mirror the existing helper in this test module
+    # 32 citing results upstream; count=412 total.
+    results = [
+        {"cluster_id": 1000 + i, "caseName": f"Citing Case {i}", "court": "ca9",
+         "dateFiled": f"2020-01-{(i % 28) + 1:02d}", "citation": [], "absolute_url": "/x"}
+        for i in range(32)
+    ]
+    captured = {}
+
+    async def fake_request(method, path, *, params=None, json_body=None):
+        captured["method"], captured["path"], captured["params"] = method, path, params
+        return _FakeResp({"count": 412, "results": results, "next": None})
+
+    monkeypatch.setattr(provider, "_request", fake_request)
+    result = await provider.invoke_tool("get_citing_opinions", {"opinion_id": 2812209}, request_id="r")
+    payload = result.payload  # adapt to how ToolResult exposes payload in this test module
+
+    assert captured["method"] == "GET"
+    assert captured["path"] == "/search/"
+    assert captured["params"]["q"] == "cites:(2812209)"
+    assert captured["params"]["type"] == "o"
+    assert captured["params"]["order_by"] == "dateFiled desc"
+    assert payload["cited_by_count"] == 412          # upstream total, NOT 30
+    assert len(payload["citing"]) == 30              # capped at N
+    assert payload["citing"][0]["case_name"] == "Citing Case 0"
+    assert payload["citing"][0]["court"] == "ca9"
+    assert set(payload["citing"][0]) == {"cluster_id", "opinion_id", "case_name", "court", "date_filed"}
+
+
+@pytest.mark.asyncio
+async def test_get_citing_opinions_requires_integer_opinion_id() -> None:
+    provider = _make_provider()
+    with pytest.raises(ToolProviderInvalidRequestError):
+        await provider.invoke_tool("get_citing_opinions", {"opinion_id": "x"}, request_id="r")
+```
+
+*(Adapt `_make_provider`, `_FakeResp`, and `result.payload` access to the existing test module's conventions — read it first.)*
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd gateway && .venv/bin/python -m pytest tests/providers/tool/test_courtlistener.py -k citing -v` (adjust path)
+Expected: FAIL — `unknown tool 'get_citing_opinions'`.
+
+- [ ] **Step 3: Implement the op**
+
+In `gateway/app/providers/tool/courtlistener.py`, add near the top (module constant):
+
+```python
+_CITING_TOP_N = 30
+```
+
+Add to the `list_tools` list (after the `get_cases` ToolSpec):
+
+```python
+ToolSpec(
+    name="get_citing_opinions",
+    description="List later opinions that CITE a given opinion id (the "
+    "'cited by' direction), via the CourtListener Search API. Returns the "
+    "total cited-by count + the most recent citing opinions (capped).",
+    parameters={
+        "type": "object",
+        "properties": {"opinion_id": {"type": "integer"}},
+        "required": ["opinion_id"],
+    },
+    read_only=True,
+),
+```
+
+Add to `invoke_tool` (before the final `raise`):
+
+```python
+if tool == "get_citing_opinions":
+    return await self._get_citing_opinions(args)
+```
+
+Add the method (mirrors `_search_case_law`):
+
+```python
+async def _get_citing_opinions(self, args: dict[str, Any]) -> ToolResult:
+    opinion_id = args.get("opinion_id")
+    if not isinstance(opinion_id, int) or isinstance(opinion_id, bool):
+        raise ToolProviderInvalidRequestError(
+            "get_citing_opinions requires integer 'opinion_id'", upstream_status=400
+        )
+    params = {"q": f"cites:({opinion_id})", "type": "o", "order_by": "dateFiled desc"}
+    resp = await self._request("GET", "/search/", params=params)
+    data = resp.json()
+    citing = [
+        {
+            "cluster_id": r.get("cluster_id"),
+            "opinion_id": (r.get("opinions") or [{}])[0].get("id"),
+            "case_name": r.get("caseName"),
+            "court": r.get("court"),
+            "date_filed": r.get("dateFiled"),
+        }
+        for r in (data.get("results") or [])[:_CITING_TOP_N]
+    ]
+    payload = {"cited_by_count": data.get("count"), "citing": citing}
+    return self._result("get_citing_opinions", payload, sent=params, received=data)
+```
+
+*(The Search `type=o` result nests the opinion id under `opinions[0].id`; `opinion_id` is best-effort and may be `None` for a result without a nested opinion — acceptable for PR1, the cluster_id is the load-bearing ref.)*
+
+- [ ] **Step 4: Run to verify pass + mypy strict**
+
+Run: `cd gateway && .venv/bin/python -m pytest tests/providers/tool/test_courtlistener.py -k citing -v && ruff format app/providers/tool/courtlistener.py && ruff check app/providers/tool/courtlistener.py && mypy app/providers/tool/courtlistener.py`
+Expected: tests PASS; ruff clean; mypy `Success`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gateway/app/providers/tool/courtlistener.py gateway/tests/providers/tool/test_courtlistener.py
+git commit -s -m "feat(gateway): get_citing_opinions CourtListener op (WS-G PR1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `citation_treatment` model + migration 0061 + P3 tripwire
+
+**Files:**
+- Create: `api/app/models/citation_treatment.py`
+- Create: `api/alembic/versions/0061_citation_treatment.py`
+- Modify: `api/app/models/__init__.py` (export `CitationTreatment`), `api/tests/test_transparency_invariants.py` (add to `_AUDIT_MODELS`)
+- Test: `api/tests/test_citation_treatment_model.py` (create)
+
+**Interfaces:**
+- Produces: `CitationTreatment` ORM model (table `citation_treatment`); columns `id, cluster_id (unique), opinion_id, cited_by_count, citing_opinions (JSONB), derived_method, as_of, created_at, updated_at`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/tests/test_citation_treatment_model.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.citation_treatment import CitationTreatment
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_citation_treatment_roundtrip(db_session: AsyncSession) -> None:
+    row = CitationTreatment(
+        cluster_id=2812209,
+        opinion_id=2812209,
+        cited_by_count=412,
+        citing_opinions=[
+            {"cluster_id": 1001, "opinion_id": 9001, "case_name": "X v. Y", "court": "ca9", "date_filed": "2021-01-01"}
+        ],
+        derived_method="citation_graph",
+    )
+    db_session.add(row)
+    await db_session.flush()
+    got = (
+        await db_session.execute(select(CitationTreatment).where(CitationTreatment.cluster_id == 2812209))
+    ).scalar_one()
+    assert got.cited_by_count == 412
+    assert got.citing_opinions[0]["case_name"] == "X v. Y"
+    assert got.derived_method == "citation_graph"
+    assert got.as_of is not None  # server_default now()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/test_citation_treatment_model.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.models.citation_treatment`.
+
+- [ ] **Step 3: Create the model**
+
+`api/app/models/citation_treatment.py` (mirror `message_caselaw_citation.py` conventions):
+
+```python
+"""citation_treatment — derived validity/treatment signal per cited case (WS-G).
+
+One row per cited case (``cluster_id``), holding the citation-graph signal:
+the total cited-by count + a capped list of recent citing-opinion *references*
+(ids + case_name + court + date — never opinion text, P3). ADR 0019 D2/D7.
+PR1 (this) is graph-only (``derived_method='citation_graph'``); PR2 extends the
+row with judge-classified treatment. Reference-only → joins the P3 tripwire.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import BigInteger, CheckConstraint, DateTime, Integer, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class CitationTreatment(Base):
+    __tablename__ = "citation_treatment"
+    __table_args__ = (
+        UniqueConstraint("cluster_id", name="uq_citation_treatment_cluster_id"),
+        CheckConstraint("cited_by_count >= 0", name="chk_citation_treatment_count_nonneg"),
+        CheckConstraint(
+            "derived_method IN ('citation_graph')",
+            name="chk_citation_treatment_method_values",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    cluster_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    opinion_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    cited_by_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    citing_opinions: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
+    derived_method: Mapped[str] = mapped_column(Text, nullable=False)
+    as_of: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+```
+
+Export it in `api/app/models/__init__.py` (add `from app.models.citation_treatment import CitationTreatment` and add `"CitationTreatment"` to `__all__` — keep both alphabetically sorted to satisfy ruff I001/RUF022).
+
+- [ ] **Step 4: Create migration 0061**
+
+`api/alembic/versions/0061_citation_treatment.py` (mirror 0060's header; this one is `create_table`):
+
+```python
+"""create citation_treatment (WS-G PR1 citation-graph signal)
+
+Revision ID: 0061
+Revises: 0060
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0061"
+down_revision: str | None = "0060"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "citation_treatment",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("cluster_id", sa.BigInteger(), nullable=False),
+        sa.Column("opinion_id", sa.BigInteger(), nullable=True),
+        sa.Column("cited_by_count", sa.Integer(), nullable=False),
+        sa.Column("citing_opinions", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("derived_method", sa.Text(), nullable=False),
+        sa.Column("as_of", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_citation_treatment"),
+        sa.UniqueConstraint("cluster_id", name="uq_citation_treatment_cluster_id"),
+        sa.CheckConstraint("cited_by_count >= 0", name="chk_citation_treatment_count_nonneg"),
+        sa.CheckConstraint("derived_method IN ('citation_graph')", name="chk_citation_treatment_method_values"),
+    )
+    op.create_index("ix_citation_treatment_cluster_id", "citation_treatment", ["cluster_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_citation_treatment_cluster_id", table_name="citation_treatment")
+    op.drop_table("citation_treatment")
+```
+
+- [ ] **Step 5: Add to the P3 tripwire**
+
+In `api/tests/test_transparency_invariants.py`: add `from app.models.citation_treatment import CitationTreatment` (with the other model imports) and add `CitationTreatment,` to the `_AUDIT_MODELS` tuple. *(All `citation_treatment` column names are tripwire-safe: none match `_DENIED_EXACT`/`_DENIED_SUFFIX`/`_DENIED_PREFIX` — `citing_opinions` is not on any list.)*
+
+- [ ] **Step 6: Run model + migration + tripwire**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/test_citation_treatment_model.py tests/test_transparency_invariants.py -v`
+Expected: PASS (conftest auto-migrates 0061; tripwire green with the new model).
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd api && ruff format app/models/citation_treatment.py app/models/__init__.py alembic/versions/0061_citation_treatment.py tests/test_citation_treatment_model.py tests/test_transparency_invariants.py && ruff check app/models/citation_treatment.py app/models/__init__.py alembic/versions/0061_citation_treatment.py tests/test_citation_treatment_model.py tests/test_transparency_invariants.py
+git add api/app/models/citation_treatment.py api/app/models/__init__.py api/alembic/versions/0061_citation_treatment.py api/tests/test_citation_treatment_model.py api/tests/test_transparency_invariants.py
+git commit -s -m "feat(api): citation_treatment table + migration 0061 (WS-G PR1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `research.service` wrapper + `derive_treatment_for_message` service
+
+**Files:**
+- Modify: `api/app/research/service.py` (add `get_citing_opinions` wrapper)
+- Create: `api/app/citation/treatment.py`
+- Test: `api/tests/citation/test_treatment_derivation.py` (create)
+
+**Interfaces:**
+- Consumes: `app.research.service.get_citing_opinions` (Task 3a), `MessageCaselawCitation` (opinion_id/cluster_id), `CitationTreatment` (Task 2), `CitationLedgerEntry` (`treatment_id`, `message_caselaw_citation_id`).
+- Produces:
+  ```python
+  TREATMENT_TTL_DAYS = 30
+  async def derive_treatment_for_message(
+      db, *, message_id: uuid.UUID, now: datetime,
+      ttl_days: int = TREATMENT_TTL_DAYS,
+      fetch_citing: _FetchCiting = _default_fetch_citing,
+  ) -> int   # number of ledger entries linked
+  ```
+  where `_FetchCiting = Callable[[int], Awaitable[dict[str, Any]]]` taking an opinion_id, returning `{"cited_by_count": int, "citing": [...]}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `api/tests/citation/test_treatment_derivation.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.treatment import TREATMENT_TTL_DAYS, derive_treatment_for_message
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+_NOW = datetime(2026, 6, 26, tzinfo=timezone.utc)
+
+
+def _citing(n: int) -> dict:
+    return {"cited_by_count": 412, "citing": [
+        {"cluster_id": 1000 + i, "opinion_id": 9000 + i, "case_name": f"C{i}", "court": "ca9", "date_filed": "2021-01-01"}
+        for i in range(n)
+    ]}
+
+
+@pytest.fixture
+async def seeded(db_session: AsyncSession):
+    user = User(email=f"t-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user); await db_session.flush()
+    chat = Chat(owner_id=user.id, title="t"); db_session.add(chat); await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
+    db_session.add(msg); await db_session.flush()
+    cc = MessageCaselawCitation(
+        message_id=msg.id, opinion_id=2812209, cluster_id=2812209,
+        source_offset_start=0, source_offset_end=5, source_text="quote",
+        verified=True, verification_method="exact_match",
+    )
+    db_session.add(cc); await db_session.flush()
+    entry = CitationLedgerEntry(
+        chat_id=chat.id, message_id=msg.id, source_kind="caselaw",
+        message_caselaw_citation_id=cc.id, verification_status="exact_match",
+    )
+    db_session.add(entry); await db_session.flush()
+    return msg.id, chat.id, cc, entry
+
+
+@pytest.mark.asyncio
+async def test_derives_fetches_and_links(db_session, seeded):
+    message_id, _chat, _cc, entry = seeded
+    calls = []
+    async def fake_fetch(opinion_id: int) -> dict:
+        calls.append(opinion_id); return _citing(32)
+    n = await derive_treatment_for_message(db_session, message_id=message_id, now=_NOW, fetch_citing=fake_fetch)
+    assert n == 1
+    assert calls == [2812209]
+    row = (await db_session.execute(select(CitationTreatment).where(CitationTreatment.cluster_id == 2812209))).scalar_one()
+    assert row.cited_by_count == 412
+    assert len(row.citing_opinions) == 32  # service stores what the op returns (op already capped at 30; service does not re-cap)
+    assert row.derived_method == "citation_graph"
+    await db_session.refresh(entry)
+    assert entry.treatment_id == row.id
+
+
+@pytest.mark.asyncio
+async def test_reuses_fresh_cache_without_fetch(db_session, seeded):
+    message_id, _chat, _cc, entry = seeded
+    db_session.add(CitationTreatment(
+        cluster_id=2812209, opinion_id=2812209, cited_by_count=10,
+        citing_opinions=[], derived_method="citation_graph", as_of=_NOW - timedelta(days=5),
+    ))
+    await db_session.flush()
+    calls = []
+    async def fake_fetch(opinion_id: int) -> dict:
+        calls.append(opinion_id); return _citing(1)
+    n = await derive_treatment_for_message(db_session, message_id=message_id, now=_NOW, fetch_citing=fake_fetch)
+    assert n == 1
+    assert calls == []  # fresh cache reused, no fetch
+    await db_session.refresh(entry)
+    assert entry.treatment_id is not None
+
+
+@pytest.mark.asyncio
+async def test_refetches_when_stale(db_session, seeded):
+    message_id, *_ = seeded
+    db_session.add(CitationTreatment(
+        cluster_id=2812209, opinion_id=2812209, cited_by_count=10,
+        citing_opinions=[], derived_method="citation_graph",
+        as_of=_NOW - timedelta(days=TREATMENT_TTL_DAYS + 1),
+    ))
+    await db_session.flush()
+    calls = []
+    async def fake_fetch(opinion_id: int) -> dict:
+        calls.append(opinion_id); return _citing(3)
+    await derive_treatment_for_message(db_session, message_id=message_id, now=_NOW, fetch_citing=fake_fetch)
+    assert calls == [2812209]  # stale → refetch
+    row = (await db_session.execute(select(CitationTreatment).where(CitationTreatment.cluster_id == 2812209))).scalar_one()
+    assert row.cited_by_count == 412  # upserted
+
+
+@pytest.mark.asyncio
+async def test_per_case_fetch_error_is_non_fatal(db_session, seeded):
+    message_id, *_ = seeded
+    async def boom(opinion_id: int) -> dict:
+        raise RuntimeError("upstream down")
+    n = await derive_treatment_for_message(db_session, message_id=message_id, now=_NOW, fetch_citing=boom)
+    assert n == 0  # nothing linked, but no raise
+    rows = (await db_session.execute(select(CitationTreatment))).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_no_caselaw_citations_is_noop(db_session):
+    # a message with no caselaw citations
+    user = User(email=f"t-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user); await db_session.flush()
+    chat = Chat(owner_id=user.id, title="t"); db_session.add(chat); await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x"); db_session.add(msg); await db_session.flush()
+    called = []
+    async def fake_fetch(opinion_id: int) -> dict:
+        called.append(opinion_id); return _citing(1)
+    n = await derive_treatment_for_message(db_session, message_id=msg.id, now=_NOW, fetch_citing=fake_fetch)
+    assert n == 0
+    assert called == []
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/citation/test_treatment_derivation.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.citation.treatment`.
+
+- [ ] **Step 3a: Add the `research.service` wrapper**
+
+In `api/app/research/service.py`, add (mirrors `search_case_law`):
+
+```python
+async def get_citing_opinions(opinion_id: int, *, request_id: str | None = None) -> dict[str, Any]:
+    provider = await _resolve_provider(request_id=request_id)
+    result = await get_gateway_client().call_tool(
+        provider, "get_citing_opinions", {"opinion_id": opinion_id}, request_id=request_id
+    )
+    return result["payload"]
+```
+
+- [ ] **Step 3b: Implement the derivation service**
+
+Create `api/app/citation/treatment.py`:
+
+```python
+"""Derive the citation-graph treatment signal for a turn's cited cases (WS-G PR1).
+
+Graph-only: for each case a turn cited, reuse a fresh ``citation_treatment`` row
+or fetch the citing graph via the gateway and upsert one, then link the turn's
+caselaw ledger entries to it. No LLM-judge (that is PR2). Per-case non-fatal
+(conservative posture). ADR 0019 D2.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
+from app.models.message_caselaw_citation import MessageCaselawCitation
+
+log = logging.getLogger(__name__)
+
+TREATMENT_TTL_DAYS = 30
+
+_FetchCiting = Callable[[int], Awaitable[dict[str, Any]]]
+
+
+async def _default_fetch_citing(opinion_id: int) -> dict[str, Any]:
+    from app.research import service as research_service
+
+    return await research_service.get_citing_opinions(opinion_id)
+
+
+async def derive_treatment_for_message(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    now: datetime,
+    ttl_days: int = TREATMENT_TTL_DAYS,
+    fetch_citing: _FetchCiting = _default_fetch_citing,
+) -> int:
+    """Derive/refresh graph treatment for each case this turn cited; link entries.
+
+    Returns the number of caselaw ledger entries linked to a treatment row.
+    Never raises on a per-case failure (logged and skipped).
+    """
+    citations = (
+        (
+            await db.execute(
+                select(MessageCaselawCitation).where(
+                    MessageCaselawCitation.message_id == message_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not citations:
+        return 0
+
+    # One derivation per distinct cited cluster; remember a representative opinion_id.
+    by_cluster: dict[int, int] = {}
+    for c in citations:
+        by_cluster.setdefault(c.cluster_id, c.opinion_id)
+
+    cluster_to_treatment: dict[int, uuid.UUID] = {}
+    stale_before = now - timedelta(days=ttl_days)
+    for cluster_id, opinion_id in by_cluster.items():
+        try:
+            existing = (
+                await db.execute(
+                    select(CitationTreatment).where(CitationTreatment.cluster_id == cluster_id)
+                )
+            ).scalar_one_or_none()
+            if existing is not None and existing.as_of >= stale_before:
+                cluster_to_treatment[cluster_id] = existing.id
+                continue
+            payload = await fetch_citing(opinion_id)
+            if existing is None:
+                row = CitationTreatment(
+                    cluster_id=cluster_id,
+                    opinion_id=opinion_id,
+                    cited_by_count=int(payload.get("cited_by_count") or 0),
+                    citing_opinions=list(payload.get("citing") or []),
+                    derived_method="citation_graph",
+                    as_of=now,
+                )
+                db.add(row)
+                await db.flush()
+                cluster_to_treatment[cluster_id] = row.id
+            else:
+                existing.cited_by_count = int(payload.get("cited_by_count") or 0)
+                existing.citing_opinions = list(payload.get("citing") or [])
+                existing.derived_method = "citation_graph"
+                existing.opinion_id = opinion_id
+                existing.as_of = now
+                await db.flush()
+                cluster_to_treatment[cluster_id] = existing.id
+        except Exception as exc:  # per-case non-fatal (conservative posture)
+            log.warning("treatment derivation failed for cluster %s: %r", cluster_id, exc)
+
+    if not cluster_to_treatment:
+        return 0
+
+    # Link this turn's caselaw ledger entries to their cluster's treatment row.
+    cc_id_to_cluster = {c.id: c.cluster_id for c in citations}
+    entries = (
+        (
+            await db.execute(
+                select(CitationLedgerEntry).where(
+                    CitationLedgerEntry.message_id == message_id,
+                    CitationLedgerEntry.source_kind == "caselaw",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    linked = 0
+    for e in entries:
+        cluster_id = cc_id_to_cluster.get(e.message_caselaw_citation_id)
+        treatment_id = cluster_to_treatment.get(cluster_id) if cluster_id is not None else None
+        if treatment_id is not None:
+            e.treatment_id = treatment_id
+            linked += 1
+    if linked:
+        await db.flush()
+    return linked
+```
+
+*(Confirm `CitationLedgerEntry.message_caselaw_citation_id` is the column name during implementation — it is the caselaw FK from P1-A2.)*
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/citation/test_treatment_derivation.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd api && ruff format app/research/service.py app/citation/treatment.py tests/citation/test_treatment_derivation.py && ruff check app/research/service.py app/citation/treatment.py tests/citation/test_treatment_derivation.py
+git add api/app/research/service.py api/app/citation/treatment.py api/tests/citation/test_treatment_derivation.py
+git commit -s -m "feat(api): citation-graph treatment derivation service (WS-G PR1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Async job + enqueue at the two turn-finalize sites
+
+**Files:**
+- Create: `api/app/workers/treatment_worker.py` (the job)
+- Modify: `api/app/workers/queue.py` (an `enqueue_treatment_derivation_job` helper), `api/app/workers/document_pipeline.py` (register the job in the ingest `WorkerSettings.functions`), `api/app/api/chats.py` (enqueue at both finalize sites)
+- Test: `api/tests/integration/test_treatment_job.py` (create)
+
+**Interfaces:**
+- Consumes: `derive_treatment_for_message` (Task 3); the existing `_get_pool()` enqueue pattern in `queue.py`; the `db_session`/session-factory pattern an existing ingest job uses.
+- Produces: `treatment_derivation_job(ctx, message_id_str) -> dict`; `enqueue_treatment_derivation_job(message_id: uuid.UUID) -> bool`.
+
+- [ ] **Step 1: Write the failing test** (exercise the job body against a real DB; mock the citing fetch)
+
+Create `api/tests/integration/test_treatment_job.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_run_treatment_derivation_writes_row_and_links(db_session: AsyncSession, monkeypatch):
+    # Seed a turn with a caselaw citation + ledger entry (as in Task 3's fixture).
+    user = User(email=f"j-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user); await db_session.flush()
+    chat = Chat(owner_id=user.id, title="j"); db_session.add(chat); await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x"); db_session.add(msg); await db_session.flush()
+    cc = MessageCaselawCitation(message_id=msg.id, opinion_id=2812209, cluster_id=2812209,
+        source_offset_start=0, source_offset_end=5, source_text="q", verified=True, verification_method="exact_match")
+    db_session.add(cc); await db_session.flush()
+    entry = CitationLedgerEntry(chat_id=chat.id, message_id=msg.id, source_kind="caselaw",
+        message_caselaw_citation_id=cc.id, verification_status="exact_match")
+    db_session.add(entry); await db_session.flush()
+
+    # The job's _run helper takes an injected session + fetch so we can test it without Redis/arq.
+    from app.workers.treatment_worker import run_treatment_derivation
+
+    async def fake_fetch(opinion_id: int) -> dict:
+        return {"cited_by_count": 7, "citing": [{"cluster_id": 1, "opinion_id": 2, "case_name": "A", "court": "ca9", "date_filed": "2022-01-01"}]}
+
+    linked = await run_treatment_derivation(db_session, message_id=msg.id, fetch_citing=fake_fetch)
+    assert linked == 1
+    row = (await db_session.execute(select(CitationTreatment).where(CitationTreatment.cluster_id == 2812209))).scalar_one()
+    assert row.cited_by_count == 7
+    await db_session.refresh(entry)
+    assert entry.treatment_id == row.id
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/integration/test_treatment_job.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.workers.treatment_worker`.
+
+- [ ] **Step 3: Implement the worker job**
+
+Create `api/app/workers/treatment_worker.py`. Read an existing ingest job (`api/app/workers/document_pipeline.py` or `easy_playbook_worker.py`) for the exact session-factory + `now`/UTC + ctx conventions, then:
+
+```python
+"""arq job — derive citation-graph treatment for an assistant turn (WS-G PR1)."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.treatment import _FetchCiting, _default_fetch_citing, derive_treatment_for_message
+
+log = logging.getLogger(__name__)
+
+
+async def run_treatment_derivation(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    fetch_citing: _FetchCiting = _default_fetch_citing,
+) -> int:
+    """Session-injected core (testable without arq/Redis)."""
+    linked = await derive_treatment_for_message(
+        db, message_id=message_id, now=datetime.now(timezone.utc), fetch_citing=fetch_citing
+    )
+    await db.commit()
+    return linked
+
+
+async def treatment_derivation_job(ctx: dict[str, Any], message_id_str: str) -> dict[str, Any]:
+    """arq entrypoint. Opens a session, runs derivation, commits."""
+    message_id = uuid.UUID(message_id_str)
+    # Use the same async-session factory the other ingest jobs use (read one for the exact import).
+    from app.db.session import async_session_factory  # confirm the actual factory path
+
+    async with async_session_factory() as db:
+        try:
+            linked = await run_treatment_derivation(db, message_id=message_id)
+        except Exception as exc:  # never crash the worker on one turn
+            log.warning("treatment_derivation_job failed for %s: %r", message_id, exc)
+            return {"message_id": message_id_str, "linked": 0, "ok": False}
+    return {"message_id": message_id_str, "linked": linked, "ok": True}
+```
+
+*(Pin the real `async_session_factory`/session-context import from a sibling ingest job during implementation — do not invent it.)*
+
+Add the enqueue helper to `api/app/workers/queue.py` (mirror `enqueue_easy_playbook_generation_job`, but use the **ingest** `_get_pool()`):
+
+```python
+async def enqueue_treatment_derivation_job(message_id: uuid.UUID) -> bool:
+    try:
+        pool = await _get_pool()
+        await pool.enqueue_job("treatment_derivation_job", str(message_id))
+        return True
+    except Exception as exc:
+        logger.warning("failed to enqueue treatment_derivation_job for %s: %r", message_id, exc)
+        return False
+```
+
+Register the job: add `treatment_derivation_job` to the ingest `WorkerSettings.functions` in `api/app/workers/document_pipeline.py` (import it at top).
+
+- [ ] **Step 4: Enqueue at both finalize sites**
+
+In `api/app/api/chats.py`, immediately **after** the `await _audit_message_sent(...)` call at **both** finalize sites (~line 2941–2953 and ~3533–3545 — locate by the `_audit_message_sent` call), add a best-effort enqueue (import `enqueue_treatment_derivation_job` at top):
+
+```python
+try:
+    await enqueue_treatment_derivation_job(assistant_message_id)
+except Exception as treatment_exc:  # never block the turn response
+    log.warning("treatment derivation enqueue failed: %r", treatment_exc)
+```
+
+*(The enqueue helper already swallows its own errors; the extra guard is defense-in-depth and matches the surrounding best-effort posture. Confirm the message-id variable name at each site — `assistant_message_id`.)*
+
+- [ ] **Step 5: Run the job test + a focused chats import smoke**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/integration/test_treatment_job.py -v`
+Expected: PASS. Then confirm chats.py still imports/collects: `.venv/bin/python -m pytest tests/test_endpoints.py -q` (collection must not break).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd api && ruff format app/workers/treatment_worker.py app/workers/queue.py app/workers/document_pipeline.py app/api/chats.py tests/integration/test_treatment_job.py && ruff check app/workers/treatment_worker.py app/workers/queue.py app/workers/document_pipeline.py app/api/chats.py tests/integration/test_treatment_job.py
+git add api/app/workers/treatment_worker.py api/app/workers/queue.py api/app/workers/document_pipeline.py api/app/api/chats.py api/tests/integration/test_treatment_job.py
+git commit -s -m "feat(api): async treatment-derivation job enqueued at turn finalize (WS-G PR1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Expose the treatment signal on the `/ledger` read
+
+**Files:**
+- Modify: `api/app/citation/ledger.py` (`resolve_ledger_entries` — resolve `treatment_id` → a `treatment` object)
+- Test: `api/tests/integration/test_ledger_treatment_exposure.py` (create)
+
+**Interfaces:**
+- Consumes: `CitationTreatment` (Task 2); the existing `resolve_ledger_entries` batch-load + per-entry dict shape (`treatment_id` already present).
+- Produces: each resolved entry gains `"treatment": {...} | None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/tests/integration/test_ledger_treatment_exposure.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.ledger import resolve_ledger_entries
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.citation_treatment import CitationTreatment
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_ledger_entry_carries_resolved_treatment(db_session: AsyncSession):
+    user = User(email=f"l-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user); await db_session.flush()
+    chat = Chat(owner_id=user.id, title="l"); db_session.add(chat); await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x"); db_session.add(msg); await db_session.flush()
+    cc = MessageCaselawCitation(message_id=msg.id, opinion_id=2812209, cluster_id=2812209,
+        source_offset_start=0, source_offset_end=5, source_text="q", verified=True, verification_method="exact_match")
+    db_session.add(cc); await db_session.flush()
+    treatment = CitationTreatment(cluster_id=2812209, opinion_id=2812209, cited_by_count=412,
+        citing_opinions=[{"cluster_id": 1, "opinion_id": 2, "case_name": "A", "court": "ca9", "date_filed": "2021-01-01"}],
+        derived_method="citation_graph")
+    db_session.add(treatment); await db_session.flush()
+    linked = CitationLedgerEntry(chat_id=chat.id, message_id=msg.id, source_kind="caselaw",
+        message_caselaw_citation_id=cc.id, verification_status="exact_match", treatment_id=treatment.id)
+    unlinked = CitationLedgerEntry(chat_id=chat.id, message_id=msg.id, source_kind="caselaw",
+        message_caselaw_citation_id=cc.id, verification_status="exact_match")
+    db_session.add_all([linked, unlinked]); await db_session.flush()
+
+    entries = await resolve_ledger_entries(db_session, chat_id=chat.id, message_id=msg.id)
+    by_treatment = {bool(e.get("treatment")): e for e in entries}
+    assert by_treatment[True]["treatment"]["cited_by_count"] == 412
+    assert by_treatment[True]["treatment"]["derived_method"] == "citation_graph"
+    assert by_treatment[True]["treatment"]["citing"][0]["case_name"] == "A"
+    assert by_treatment[False]["treatment"] is None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/integration/test_ledger_treatment_exposure.py -v`
+Expected: FAIL — entries carry no `treatment` key (KeyError / None).
+
+- [ ] **Step 3: Resolve treatment in `resolve_ledger_entries`**
+
+In `api/app/citation/ledger.py`, in `resolve_ledger_entries`: after the entry rows are loaded and before building the per-entry dicts, **batch-load** the referenced treatments:
+
+```python
+treatment_ids = {e.treatment_id for e in entries if e.treatment_id is not None}
+treatments: dict[uuid.UUID, CitationTreatment] = {}
+if treatment_ids:
+    treatments = {
+        t.id: t
+        for t in (
+            await db.execute(select(CitationTreatment).where(CitationTreatment.id.in_(treatment_ids)))
+        ).scalars().all()
+    }
+```
+
+(Add `from app.models.citation_treatment import CitationTreatment` at top.) Then in the per-entry dict, add a `treatment` key:
+
+```python
+"treatment": (
+    {
+        "cited_by_count": treatments[e.treatment_id].cited_by_count,
+        "as_of": treatments[e.treatment_id].as_of.isoformat(),
+        "derived_method": treatments[e.treatment_id].derived_method,
+        "citing": treatments[e.treatment_id].citing_opinions,
+    }
+    if e.treatment_id is not None and e.treatment_id in treatments
+    else None
+),
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/integration/test_ledger_treatment_exposure.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd api && ruff format app/citation/ledger.py tests/integration/test_ledger_treatment_exposure.py && ruff check app/citation/ledger.py tests/integration/test_ledger_treatment_exposure.py
+git add api/app/citation/ledger.py api/tests/integration/test_ledger_treatment_exposure.py
+git commit -s -m "feat(api): expose citation-graph treatment on the ledger read (WS-G PR1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full gates
+
+**Files:** none (verification + any lint/collision fixes surfaced).
+
+- [ ] **Step 1: Full api suite** — `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest -q`. Expected: PASS, no collection errors. (No new route → `test_endpoints.py`/`test_openapi.py` path counts unchanged.)
+- [ ] **Step 2: Gateway suite** — `cd gateway && .venv/bin/python -m pytest -q && mypy app`. Expected: PASS; mypy `Success`.
+- [ ] **Step 3:** If either gate surfaces a lint/collision issue, fix in the owning task's files and re-run. Commit any fix with a clear message.
+
+---
+
+## Final review (after Task 6)
+
+- [ ] **Opus whole-branch review** vs `main`. Focus: treatment never affects the fiduciary gate (gate independence); the derivation is genuinely non-fatal per case (one bad case never sinks the turn or the others); the `cited_by_count` vs capped-list distinction; the enqueue is best-effort at BOTH finalize sites; P3 tripwire covers `citation_treatment`; no LLM call sneaks in; gateway `mypy --strict` holds.
+- [ ] **Push both remotes** (`origin` + `tucuxi`).
+- [ ] **Open the PR** (origin). **Security-gated — do NOT self-merge.** Kevin/security merges; then mirror `origin/main → tucuxi main` and confirm `origin == tucuxi`.
+
+## Self-review against the spec
+
+- **Spec coverage:** Component 1 (gateway op) → Task 1; Component 2 (model+migration+P3) → Task 2; Component 3 (derivation service + research wrapper) → Task 3; Component 4 (async job + enqueue) → Task 4; Component 5 (read exposure) → Task 5; "no judge / additive / gate-independent" → Global Constraints + Tasks 3–5 tests; P3 tripwire → Task 2; DE-363 (lazy fallback) correctly **out of scope** (filed in the spec).
+- **Spec deviation (recorded):** ordering is **most-recent-first** (`dateFiled desc`), not "highest-court-then-recent" — CourtListener's Search API has no server-side court-rank sort; court-rank re-ranking of the materialized subset is PR2. The capped list still pre-stages PR2's subset.
+- **Placeholder scan:** the "confirm during implementation" notes (the CL test module's helpers, the `async_session_factory` import, the `message_caselaw_citation_id` column name, the exact finalize-site line numbers) are real-anchor confirmations, not vague placeholders — each names exactly what to verify and where.
+- **Type consistency:** `derive_treatment_for_message(db, *, message_id, now, ttl_days, fetch_citing) -> int`, `_FetchCiting = Callable[[int], Awaitable[dict]]`, `run_treatment_derivation(db, *, message_id, fetch_citing) -> int`, `treatment_derivation_job(ctx, message_id_str) -> dict`, `enqueue_treatment_derivation_job(message_id) -> bool`, payload `{cited_by_count, citing[]}`, entry `treatment` `{cited_by_count, as_of, derived_method, citing}` — consistent across Tasks 1–5.

--- a/docs/superpowers/specs/2026-06-26-wsg-pr1-citation-graph-treatment-design.md
+++ b/docs/superpowers/specs/2026-06-26-wsg-pr1-citation-graph-treatment-design.md
@@ -1,0 +1,122 @@
+# WS-G PR1 — Citation-graph treatment signal (design)
+
+**Date:** 2026-06-26
+**Milestone:** Fiduciary-grade agentic legal work — Phase 2 (WS-G)
+**Branch:** `feat/wsg-pr1-citation-graph-treatment`
+**Pins:** [ADR 0019](../../adr/0019-transparent-validity-treatment-layer.md) (transparent validity/treatment layer) — realizes **D2** (per-cited-case, cached, off the critical path), **D3** (the new `get_citing_opinions` gateway egress op), **D4 PR1** (graph-first, no judge), **D7** (P3-preserving reference storage), **D8** (staleness/as-of), **D10** (DE-344 cost estimate so R4 can see the op). Builds on [ADR 0018](../../adr/0018-citation-ledger-and-fiduciary-grade-output.md) D6 (fills the reserved `citation_ledger_entry.treatment_id` slot) and [ADR 0014](../../adr/0014-gateway-egress-boundary-for-tool-providers.md) (where the new egress op lives).
+**Security review:** **required** (new gateway egress operation `gateway/**`; citation/derivation surface `api/app/citation/**`; new audit-adjacent table). **Do not self-merge** — Kevin/security merges; mirror `origin/main → tucuxi` after.
+
+## Problem
+
+The Phase-1 citation engine verifies a citation **exists** and is **accurately quoted**; it says nothing about whether a later court has **followed, distinguished, criticized, questioned, overruled, or superseded** the cited case — the validity/treatment gap (the KeyCite/Shepard's parity axis). ADR 0019 answers it **LQ.AI's way — derive the signal transparently, never assert an editorial verdict** — and phases the build: **PR1 ships the citation graph as a derived provenance signal** ("cited by N later opinions; here are the most significant"), **with no judge fan-out**; PR2 adds the treatment-classifying judge.
+
+PR1 stands up the whole spine — the new egress operation, the `citation_treatment` table, the per-cited-case cached derivation, the async trigger, and the read-API exposure — at the **cheapest, deterministic** tier. It delivers immediate value (a lawyer sees and can inspect the citing set) and pre-stages the exact ranked subset PR2's judge will run over.
+
+## Decisions (ADR-0019-derived + maintainer-approved 2026-06-26)
+
+- **Backend vertical only.** PR1 is the security-gated backend: the gateway op + `citation_treatment` table + derivation service + async trigger + read-API exposure. The web trace rendering is a **separate, non-gated PR1-UI** follow-on (mirrors P1's split of the gate backend #225 from the C1 UI #228).
+- **Graph-only signal (no judge).** `citation_treatment` stores `cited_by_count` + a **capped, ordered top-N** (N=30, highest-court-then-most-recent) of citing-opinion refs `{cluster_id, opinion_id, case_name, court, date_filed}`. No LLM-judge runs in PR1 (that is PR2). The capped list **pre-stages PR2's judge subset** — PR2 ranks/judges over the same selection.
+- **Per-cited-case, cached, async.** Treatment is keyed by the cited **`cluster_id`** (one cached row per case), derived **off the turn's critical path** by an arq job enqueued after `_audit_message_sent`, reused within a **30-day TTL** (D8), and re-fetched when stale. The fiduciary-grade gate stays **independent** of treatment (ADR 0018 D3 / 0019 D2) — treatment enriches the ledger entry; it never gates the turn.
+- **P3-preserving storage.** `citing_opinions` holds **structured refs only** (ids + case_name + court + date), never opinion **text**; the opinion body is read from the content layer at trace time, as the ledger does (ADR 0018 D5). `citation_treatment` is metadata-only and is **added to the P3 no-raw-payload tripwire** in this PR.
+- **Extensible row.** The table is designed so **PR2 extends it** (nullable judge-classification + rollup fields, or a per-citing-opinion treatment slot), never rewrites it. `derived_method` discriminates (`"citation_graph"` in PR1).
+- **Lazy-on-trace-open fallback deferred (tracked, must land in Phase 2).** ADR 0019 D2 names a lazy fallback for entries the async job hasn't populated yet. PR1 ships **async-only**; an entry with no treatment yet renders nothing/"pending." The lazy fallback is filed as **DE-363** and is committed to land within WS-G (by end of these phases) — not dropped.
+- **R4: estimate only, no enforcement yet.** PR1 adds a real `estimate_tool_cost` for `get_citing_opinions` (DE-344) so the R4 brake can *see* the op; real per-case budget **enforcement** is PR2 (where the judge fan-out is the actual cost).
+
+## Design
+
+### Component 1 — Gateway op `get_citing_opinions` (`gateway/app/providers/tool/courtlistener.py`)
+
+A fourth read operation, following the `get_cases` pattern (`ToolSpec` in `list_tools` + a branch in `invoke_tool` + a `_get_citing_opinions` method building a `ToolResult` via `self._result`). 
+
+- **Input:** `{ "cluster_id": int }` (required). `read_only=True`. BYO-key-gated exactly like the existing CL ops (operator `user_token`).
+- **Upstream:** CourtListener's citing-relationships surface. **Pin in the plan (task 1) via a CourtListener v4 docs check:** the candidate is the search API `GET /search/?q=cites:(<opinion_ids>)&type=o&order_by=dateFiled desc` (returns later opinions citing the given opinion(s), already date-orderable) vs. the `/opinions-cited/?cited_opinion=<id>` relation endpoint. The op resolves the cluster's opinion id(s) (reuse the `get_cases`/cluster path) then queries citing opinions.
+- **Output:** `{ "cited_by_count": int, "citing": [ {cluster_id, opinion_id, case_name, court, date_filed}, ... ] }` — `citing` is the **ordered top-N** (N=30): **highest-court-first, then most-recent** (the ordering PR2's judge prioritization reuses). `cited_by_count` is the *total* (from the upstream `count`), not the truncated list length.
+- **Cost:** add `get_citing_opinions` to the provider's `estimate_tool_cost` with a small real estimate (per-call API cost; no inference) so R4/DE-344 can read it. (Confirm the exact `estimate_tool_cost` location in the plan.)
+- **Errors:** invalid/missing `cluster_id` → `ToolProviderInvalidRequestError`; upstream failure → the provider's existing error mapping. Never returns opinion text.
+
+### Component 2 — Model `citation_treatment` + migration `0061` (`api/app/models/citation_treatment.py`)
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid pk | `server_default gen_random_uuid()` |
+| `cluster_id` | bigint, **unique** | the cited case; the cache key (one treatment per case) |
+| `opinion_id` | bigint, nullable | the specific cited opinion, when known |
+| `cited_by_count` | int, not null | total citing count (upstream `count`) |
+| `citing_opinions` | JSONB, not null | the capped top-N refs `[{cluster_id, opinion_id, case_name, court, date_filed}]` — **refs only, no opinion text** (P3) |
+| `derived_method` | text, not null | `"citation_graph"` (PR1); PR2 adds judge methods. CHECK constrains the allowed set |
+| `as_of` | timestamptz, not null | when this row was derived (D8 staleness anchor) |
+| `created_at` / `updated_at` | timestamptz | standard |
+
+- Unique constraint on `cluster_id` (upsert key). Index on `cluster_id`.
+- **P3:** add `citation_treatment` to the no-raw-payload tripwire test (`test_audit_models_have_no_raw_payload_columns` or its WS-G equivalent) — assert it carries no `payload`/`raw`/`body`/`response`/text-content column. `citing_opinions` is structured refs, not a raw upstream-response dump.
+- **PR2 extension note (non-binding):** PR2 will add nullable treatment-classification + rollup columns (or a child table) and additional `derived_method` values; the migration/CHECK is written to make that additive.
+
+### Component 3 — Derivation service (`api/app/citation/treatment.py`, new module)
+
+```python
+async def derive_treatment_for_message(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    gateway: _CitingGraphGatewayProtocol,
+    now: datetime,
+    ttl_days: int = TREATMENT_TTL_DAYS,   # 30
+) -> int:
+    """Derive/refresh graph-level treatment for each case this turn cited, and
+    link the turn's caselaw ledger entries to it. Returns rows linked. Non-fatal
+    per case (conservative posture); never raises on a per-case failure."""
+```
+
+Flow:
+1. Load the turn's `message_caselaw_citations` → the distinct cited `cluster_id`s (and `opinion_id`s) the turn actually relied on. (None → return 0.)
+2. For each cited cluster:
+   - **Reuse** an existing `citation_treatment` row whose `as_of` is within `ttl_days` → link.
+   - Else **fetch** `get_citing_opinions(cluster_id)` via the gateway, **upsert** the `citation_treatment` row (`as_of=now`, `derived_method="citation_graph"`, the capped list), → link.
+   - A per-case gateway/storage failure is logged and skipped (never fatal).
+3. **Link:** set `citation_ledger_entry.treatment_id` for this message's caselaw entries (those whose `cluster_id` matches) to the treatment row's id.
+
+`_CitingGraphGatewayProtocol` is a narrow Protocol (one method, mirroring the citation judge's `_JudgeGatewayProtocol` convention) so the service is unit-testable with a fake gateway. No judge, no cost budget enforcement in PR1.
+
+### Component 4 — Async trigger (`api/app/workers/` + `api/app/api/chats.py`)
+
+- New arq job `treatment_derivation_job(ctx, message_id_str) -> dict` (mirrors `easy_playbook_generation_job`): opens a DB session + a gateway client from `ctx`, calls `derive_treatment_for_message`, returns a small result dict. Registered in the **ingest** `WorkerSettings.functions` (the `_get_pool()` queue, **not** the m3a6 playbook queue) — confirm the exact `WorkerSettings`/queue in the plan.
+- **Enqueue** `treatment_derivation_job(str(assistant_message_id))` **after `_audit_message_sent`** at **both** finalize sites (chats.py ~2953 and ~3545), via an `enqueue_treatment_derivation_job` helper that mirrors the existing best-effort enqueue helpers (catch + log on failure; **never block the turn response**).
+- The job constructs its own gateway client (the worker context has no request-scoped gateway) — confirm the worker's gateway-client construction pattern in the plan.
+
+### Component 5 — Read-API exposure (`api/app/citation/ledger.py` `resolve_ledger_entries`)
+
+`resolve_ledger_entries` already returns `treatment_id`. PR1 resolves it: batch-load the referenced `citation_treatment` rows and attach a `treatment` object to each caselaw entry:
+
+```json
+"treatment": { "cited_by_count": 412, "as_of": "2026-06-26T...", "derived_method": "citation_graph",
+               "citing": [ {"cluster_id":..., "opinion_id":..., "case_name":"...", "court":"...", "date_filed":"..."}, ... ] }
+```
+
+Entries with no `treatment_id` (job pending/failed) carry `"treatment": null`. No N+1 (batch-load by id set, as A3 does for the ref tables). The `/chats/{id}/ledger` response shape gains `treatment` on caselaw entries; this is additive (the UI PR consumes it).
+
+## Testing
+
+Gateway (provider unit, mocked HTTP — no live CL):
+- `get_citing_opinions` shapes `{cited_by_count, citing[]}`; the list is capped at N=30 and ordered highest-court-then-most-recent; `cited_by_count` is the upstream total, not the truncated length; invalid `cluster_id` → invalid-request; upstream error → mapped error; never returns opinion text.
+
+API unit (mocked gateway op — no `-m provider`):
+- Derivation service: cache **reuse** within TTL (no fetch); **refetch** when `as_of` is stale; upsert is idempotent on `cluster_id`; top-N cap/order preserved into the row; per-case failure is non-fatal (one bad case doesn't sink the others); `treatment_id` linked on the right caselaw entries only.
+
+Integration (throwaway pgvector; conftest auto-migrates):
+- enqueue path: calling the derivation directly (job body) on a seeded turn writes a `citation_treatment` row and populates the caselaw entries' `treatment_id`; the `/ledger` read returns the `treatment` object; an entry with no treatment → `treatment: null`.
+- **P3 tripwire** includes `citation_treatment` (no raw-payload column).
+- **Additive guarantee:** a turn with no caselaw citations writes no treatment row and changes nothing; the fiduciary gate verdict is unchanged by treatment derivation (gate independence).
+
+## Out of scope (PR1) / Deferred
+
+- **Treatment-classifying judge + rollup + per-case cost budget** — **WS-G PR2**.
+- **Web trace rendering** of the treatment signal — **PR1-UI** (separate, non-gated).
+- **Lazy-on-trace-open fallback** — **DE-363** (filed this PR; committed to land within WS-G/Phase 2 per maintainer 2026-06-26).
+- **R4 budget enforcement** for the op — PR2 (PR1 adds the estimate only).
+- **Editorial-connector treatment coexistence** (ADR 0019 D9) — later, when a licensed connector ships.
+
+## Pointers
+
+- ADR: [`0019-transparent-validity-treatment-layer.md`](../../adr/0019-transparent-validity-treatment-layer.md) (D2/D3/D4/D7/D8/D10)
+- Reused: `gateway/app/providers/tool/courtlistener.py` (op pattern: `_get_cases`), `api/app/workers/` (arq enqueue pattern: `easy_playbook_*`), `api/app/citation/ledger.py` (`resolve_ledger_entries`), `api/app/models/citation_ledger_entry.py` (`treatment_id` slot), `api/app/research/service.py` (`read_opinion`, cluster/opinion ids).
+- Next migration = `0061`. Next DE after this = DE-364 (DE-363 = the lazy-fallback, filed here).

--- a/gateway/app/providers/tool/courtlistener.py
+++ b/gateway/app/providers/tool/courtlistener.py
@@ -31,6 +31,8 @@ from app.secrets import ProviderKeyResolver
 
 DEFAULT_TIMEOUT_SECONDS = 30.0
 
+_CITING_TOP_N = 30
+
 _OPINION_TEXT_FIELDS = (
     "html_with_citations",
     "html_columbia",
@@ -183,6 +185,18 @@ class CourtListenerToolAdapter(ToolProviderAdapter):
                 },
                 read_only=True,
             ),
+            ToolSpec(
+                name="get_citing_opinions",
+                description="List later opinions that CITE a given opinion id (the "
+                "'cited by' direction), via the CourtListener Search API. Returns the "
+                "total cited-by count + the most recent citing opinions (capped).",
+                parameters={
+                    "type": "object",
+                    "properties": {"opinion_id": {"type": "integer"}},
+                    "required": ["opinion_id"],
+                },
+                read_only=True,
+            ),
         ]
 
     async def invoke_tool(
@@ -194,6 +208,8 @@ class CourtListenerToolAdapter(ToolProviderAdapter):
             return await self._search_case_law(args)
         if tool == "get_cases":
             return await self._get_cases(args)
+        if tool == "get_citing_opinions":
+            return await self._get_citing_opinions(args)
         raise ToolProviderError(f"unknown tool {tool!r} for courtlistener provider")
 
     async def _verify_citations(self, args: dict[str, Any]) -> ToolResult:
@@ -286,6 +302,32 @@ class CourtListenerToolAdapter(ToolProviderAdapter):
             "opinions": opinions,
         }
         return self._result("get_cases", payload, sent={"cluster_id": cluster_id}, received=cluster)
+
+    async def _get_citing_opinions(self, args: dict[str, Any]) -> ToolResult:
+        opinion_id = args.get("opinion_id")
+        if not isinstance(opinion_id, int) or isinstance(opinion_id, bool):
+            raise ToolProviderInvalidRequestError(
+                "get_citing_opinions requires integer 'opinion_id'", upstream_status=400
+            )
+        params: dict[str, Any] = {
+            "q": f"cites:({opinion_id})",
+            "type": "o",
+            "order_by": "dateFiled desc",
+        }
+        resp = await self._request("GET", "/search/", params=params)
+        data = resp.json()
+        citing = [
+            {
+                "cluster_id": r.get("cluster_id"),
+                "opinion_id": (r.get("opinions") or [{}])[0].get("id"),
+                "case_name": r.get("caseName"),
+                "court": r.get("court"),
+                "date_filed": r.get("dateFiled"),
+            }
+            for r in (data.get("results") or [])[:_CITING_TOP_N]
+        ]
+        payload = {"cited_by_count": data.get("count"), "citing": citing}
+        return self._result("get_citing_opinions", payload, sent=params, received=data)
 
     def _result(self, tool: str, payload: Any, *, sent: Any, received: Any) -> ToolResult:
         """Build a ToolResult with byte counts; mark public data verbatim."""

--- a/gateway/tests/test_courtlistener_adapter.py
+++ b/gateway/tests/test_courtlistener_adapter.py
@@ -330,11 +330,17 @@ async def test_get_citing_opinions_shapes_count_and_capped_list(monkeypatch) -> 
     assert params["type"] == "o"
     assert params["order_by"] == "dateFiled desc"
     payload = result.payload
-    assert payload["cited_by_count"] == 412          # upstream total, NOT 30
-    assert len(payload["citing"]) == 30              # capped at _CITING_TOP_N
+    assert payload["cited_by_count"] == 412  # upstream total, NOT 30
+    assert len(payload["citing"]) == 30  # capped at _CITING_TOP_N
     assert payload["citing"][0]["case_name"] == "Citing Case 0"
     assert payload["citing"][0]["court"] == "ca9"
-    assert set(payload["citing"][0]) == {"cluster_id", "opinion_id", "case_name", "court", "date_filed"}
+    assert set(payload["citing"][0]) == {
+        "cluster_id",
+        "opinion_id",
+        "case_name",
+        "court",
+        "date_filed",
+    }
 
 
 @pytest.mark.unit

--- a/gateway/tests/test_courtlistener_adapter.py
+++ b/gateway/tests/test_courtlistener_adapter.py
@@ -36,7 +36,7 @@ async def test_lists_three_read_tools(monkeypatch) -> None:
     adapter = _adapter(monkeypatch)
     try:
         names = {t.name for t in await adapter.list_tools()}
-        assert names == {"verify_citations", "search_case_law", "get_cases"}
+        assert names == {"verify_citations", "search_case_law", "get_cases", "get_citing_opinions"}
         assert all(t.read_only for t in await adapter.list_tools())
     finally:
         await adapter.aclose()
@@ -295,3 +295,53 @@ async def test_courtlistener_through_router_writes_audit(monkeypatch) -> None:
     assert res.payload["count"] == 0
     assert writer.rows[-1].refused is False
     assert writer.rows[-1].bytes_in is not None
+
+
+@pytest.mark.unit
+async def test_get_citing_opinions_shapes_count_and_capped_list(monkeypatch) -> None:
+    adapter = _adapter(monkeypatch)
+    # 32 results upstream; upstream total count is 412 — capped to 30 in payload
+    results = [
+        {
+            "cluster_id": 1000 + i,
+            "caseName": f"Citing Case {i}",
+            "court": "ca9",
+            "dateFiled": f"2020-01-{(i % 28) + 1:02d}",
+            "citation": [],
+            "absolute_url": "/x",
+            "opinions": [{"id": 5000 + i}],
+        }
+        for i in range(32)
+    ]
+    with respx.mock:
+        route = respx.get(f"{BASE}/search/").mock(
+            return_value=httpx.Response(200, json={"count": 412, "results": results, "next": None})
+        )
+        try:
+            result = await adapter.invoke_tool(
+                "get_citing_opinions", {"opinion_id": 2812209}, request_id="r"
+            )
+        finally:
+            await adapter.aclose()
+
+    assert route.called
+    params = route.calls.last.request.url.params
+    assert params["q"] == "cites:(2812209)"
+    assert params["type"] == "o"
+    assert params["order_by"] == "dateFiled desc"
+    payload = result.payload
+    assert payload["cited_by_count"] == 412          # upstream total, NOT 30
+    assert len(payload["citing"]) == 30              # capped at _CITING_TOP_N
+    assert payload["citing"][0]["case_name"] == "Citing Case 0"
+    assert payload["citing"][0]["court"] == "ca9"
+    assert set(payload["citing"][0]) == {"cluster_id", "opinion_id", "case_name", "court", "date_filed"}
+
+
+@pytest.mark.unit
+async def test_get_citing_opinions_requires_integer_opinion_id(monkeypatch) -> None:
+    adapter = _adapter(monkeypatch)
+    try:
+        with pytest.raises(ToolProviderInvalidRequestError):
+            await adapter.invoke_tool("get_citing_opinions", {"opinion_id": "x"}, request_id="r")
+    finally:
+        await adapter.aclose()


### PR DESCRIPTION
## WS-G PR1 — Citation-graph treatment signal

First slice of the **validity/treatment layer** (ADR 0019) — the KeyCite/Shepard's analog, done LQ.AI's way: **derive the signal transparently, never assert an editorial verdict.** For each case an assistant turn cites, this derives a citation-graph signal ("cited by N later opinions; here are the most recent ≤30") **off the turn's critical path** and populates the Citation Ledger's reserved `treatment_id` slot. **Graph-only — no LLM-judge** (that's PR2, per ADR 0019 D4).

### Pipeline
`get_citing_opinions` CourtListener gateway op (Search `cites:(opinion_id)` filter) → `research.service` wrapper → `derive_treatment_for_message` (per-cited-case cache-reuse-or-fetch, upsert `citation_treatment`, link ledger entries) → arq `treatment_derivation_job` enqueued **best-effort after `_audit_message_sent`** at all **3** turn-finalize sites → `resolve_ledger_entries` exposes a `treatment` object on the `/chats/{id}/ledger` read.

### Load-bearing properties (verified by the Opus whole-branch review)
- **Gate independence** — derivation is async; the enqueue fires *after* the message+citations+ledger commit, is best-effort (never blocks/raises into the turn), and the fiduciary-grade gate verdict/latency never depends on treatment (ADR 0018 D3 / 0019 D2).
- **No LLM** anywhere in PR1 — graph-only.
- **P3** — `citation_treatment.citing_opinions` holds **refs only** (cluster/opinion ids + case_name/court/date, never opinion text); the model joins the `_AUDIT_MODELS` no-raw-payload tripwire; the ledger read batch-loads treatments (no N+1).
- **Per-case non-fatal** + **cache/TTL** (30-day reuse, in-place upsert), **`flush` not `commit`** (worker commits once), **`cited_by_count` = upstream total** (not the capped list length).
- **Security** — new egress is `read_only`, BYO-key-gated like the other CL ops; `cites:(<int>)` built from an int-validated value (no injection); no new agent-exposed surface.

### Migration
`0061` creates `citation_treatment` (chains 0060). No change to the ledger/gate tables.

### ⚠️ For the security reviewer — two tracked follow-ups (both committed to land before Phase 2 closes)
- **DE-363** — the ADR-0019-D2 **lazy-on-trace-open fallback** is deferred; PR1 ships async-only (an undurived entry renders `treatment: null` — honest, not a silent gap).
- **DE-364** — the Opus review found a concurrency edge: a `db.flush()` IntegrityError (two concurrent turns citing the **same uncached case** → `uq_citation_treatment_cluster_id` collision) poisons the session, so a **multi-cluster** turn loses its remaining derivations. **Non-crashing** (worker returns `ok:False`), single-cluster turns unaffected, DE-363-recoverable. Fix = per-cluster `begin_nested()` SAVEPOINT; filed (not fixed) to keep this slice scoped.

### Spec deviation (recorded)
Ordering is **most-recent-first** (`dateFiled desc`) — CourtListener's Search API has no server-side court-rank sort; court-rank re-ranking of the materialized subset is PR2. The capped list still pre-stages PR2's judge subset.

### Tests
8 new tests (gateway provider op; model+migration+P3 tripwire; derivation service cache/stale/non-fatal/link; async job; ledger exposure). **Full api suite: 2339 passed, 1 skipped, 0 failures.** Gateway: 703 passed, **mypy --strict** clean. `ruff format`+`check` clean.

### Review
Subagent-driven: per-task spec+quality reviews + an **Opus whole-branch review** (Ready-to-merge: Yes, no Critical). The Task-3 review's tz-awareness finding was folded forward into Task 4 as a guard; the implementer correctly discovered the **third** finalize site the plan missed.

**Attestation:** N/A — citation-engine infrastructure, no skill legal-substance change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs ADR 0019 (D2/D3/D4/D7/D8), ADR 0018 D6, ADR 0014. Builds on Phase 1 (Citation Ledger + fiduciary gate).
