### PR TITLE
feat: WS-G PR2 — treatment-classifying judge (Phase 2)

### DIFF
--- a/api/alembic/versions/0062_citation_treatment_signal.py
+++ b/api/alembic/versions/0062_citation_treatment_signal.py
@@ -24,48 +24,71 @@ _NEGATIVE = "'overruled','superseded','criticized','questioned','distinguished'"
 def upgrade() -> None:
     op.create_table(
         "citation_treatment_signal",
-        sa.Column("id", postgresql.UUID(as_uuid=True),
-                  server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
         sa.Column("treatment_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("citing_opinion_id", sa.BigInteger(), nullable=False),
         sa.Column("classification", sa.Text(), nullable=False),
         sa.Column("confidence", sa.Float(), nullable=False),
         sa.Column("justification", sa.Text(), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True),
-                  server_default=sa.text("now()"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
         sa.ForeignKeyConstraint(["treatment_id"], ["citation_treatment.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("treatment_id", "citing_opinion_id",
-                            name="uq_treatment_signal_treatment_citing"),
-        sa.CheckConstraint(f"classification IN ({_CLASSES})",
-                           name="chk_treatment_signal_classification"),
+        sa.UniqueConstraint(
+            "treatment_id", "citing_opinion_id", name="uq_treatment_signal_treatment_citing"
+        ),
+        sa.CheckConstraint(
+            f"classification IN ({_CLASSES})", name="chk_treatment_signal_classification"
+        ),
     )
-    op.create_index("ix_citation_treatment_signal_treatment_id", "citation_treatment_signal", ["treatment_id"])
+    op.create_index(
+        "ix_citation_treatment_signal_treatment_id", "citation_treatment_signal", ["treatment_id"]
+    )
 
-    op.add_column("citation_treatment", sa.Column("strongest_negative_class", sa.Text(), nullable=True))
+    op.add_column(
+        "citation_treatment", sa.Column("strongest_negative_class", sa.Text(), nullable=True)
+    )
     op.add_column("citation_treatment", sa.Column("judged_count", sa.Integer(), nullable=True))
-    op.add_column("citation_treatment", sa.Column("judge_as_of", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "citation_treatment", sa.Column("judge_as_of", sa.DateTime(timezone=True), nullable=True)
+    )
 
     op.drop_constraint("chk_citation_treatment_method_values", "citation_treatment", type_="check")
     op.create_check_constraint(
-        "chk_citation_treatment_method_values", "citation_treatment",
+        "chk_citation_treatment_method_values",
+        "citation_treatment",
         "derived_method IN ('citation_graph', 'citation_graph+judge')",
     )
     op.create_check_constraint(
-        "chk_citation_treatment_strongest_negative", "citation_treatment",
+        "chk_citation_treatment_strongest_negative",
+        "citation_treatment",
         f"strongest_negative_class IS NULL OR strongest_negative_class IN ({_NEGATIVE})",
     )
 
 
 def downgrade() -> None:
-    op.drop_constraint("chk_citation_treatment_strongest_negative", "citation_treatment", type_="check")
+    op.drop_constraint(
+        "chk_citation_treatment_strongest_negative", "citation_treatment", type_="check"
+    )
     op.drop_constraint("chk_citation_treatment_method_values", "citation_treatment", type_="check")
     op.create_check_constraint(
-        "chk_citation_treatment_method_values", "citation_treatment",
+        "chk_citation_treatment_method_values",
+        "citation_treatment",
         "derived_method IN ('citation_graph')",
     )
     op.drop_column("citation_treatment", "judge_as_of")
     op.drop_column("citation_treatment", "judged_count")
     op.drop_column("citation_treatment", "strongest_negative_class")
-    op.drop_index("ix_citation_treatment_signal_treatment_id", table_name="citation_treatment_signal")
+    op.drop_index(
+        "ix_citation_treatment_signal_treatment_id", table_name="citation_treatment_signal"
+    )
     op.drop_table("citation_treatment_signal")

--- a/api/alembic/versions/0062_citation_treatment_signal.py
+++ b/api/alembic/versions/0062_citation_treatment_signal.py
@@ -1,0 +1,71 @@
+"""citation_treatment_signal + parent rollup columns (WS-G PR2 treatment judge)
+
+Revision ID: 0062
+Revises: 0061
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0062"
+down_revision: str | None = "0061"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CLASSES = "'followed','distinguished','criticized','questioned','overruled','superseded','neutral'"
+_NEGATIVE = "'overruled','superseded','criticized','questioned','distinguished'"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "citation_treatment_signal",
+        sa.Column("id", postgresql.UUID(as_uuid=True),
+                  server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("treatment_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("citing_opinion_id", sa.BigInteger(), nullable=False),
+        sa.Column("classification", sa.Text(), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("justification", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["treatment_id"], ["citation_treatment.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("treatment_id", "citing_opinion_id",
+                            name="uq_treatment_signal_treatment_citing"),
+        sa.CheckConstraint(f"classification IN ({_CLASSES})",
+                           name="chk_treatment_signal_classification"),
+    )
+    op.create_index("ix_treatment_signal_treatment_id", "citation_treatment_signal", ["treatment_id"])
+
+    op.add_column("citation_treatment", sa.Column("strongest_negative_class", sa.Text(), nullable=True))
+    op.add_column("citation_treatment", sa.Column("judged_count", sa.Integer(), nullable=True))
+    op.add_column("citation_treatment", sa.Column("judge_as_of", sa.DateTime(timezone=True), nullable=True))
+
+    op.drop_constraint("chk_citation_treatment_method_values", "citation_treatment", type_="check")
+    op.create_check_constraint(
+        "chk_citation_treatment_method_values", "citation_treatment",
+        "derived_method IN ('citation_graph', 'citation_graph+judge')",
+    )
+    op.create_check_constraint(
+        "chk_citation_treatment_strongest_negative", "citation_treatment",
+        f"strongest_negative_class IS NULL OR strongest_negative_class IN ({_NEGATIVE})",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("chk_citation_treatment_strongest_negative", "citation_treatment", type_="check")
+    op.drop_constraint("chk_citation_treatment_method_values", "citation_treatment", type_="check")
+    op.create_check_constraint(
+        "chk_citation_treatment_method_values", "citation_treatment",
+        "derived_method IN ('citation_graph')",
+    )
+    op.drop_column("citation_treatment", "judge_as_of")
+    op.drop_column("citation_treatment", "judged_count")
+    op.drop_column("citation_treatment", "strongest_negative_class")
+    op.drop_index("ix_treatment_signal_treatment_id", table_name="citation_treatment_signal")
+    op.drop_table("citation_treatment_signal")

--- a/api/alembic/versions/0062_citation_treatment_signal.py
+++ b/api/alembic/versions/0062_citation_treatment_signal.py
@@ -40,7 +40,7 @@ def upgrade() -> None:
         sa.CheckConstraint(f"classification IN ({_CLASSES})",
                            name="chk_treatment_signal_classification"),
     )
-    op.create_index("ix_treatment_signal_treatment_id", "citation_treatment_signal", ["treatment_id"])
+    op.create_index("ix_citation_treatment_signal_treatment_id", "citation_treatment_signal", ["treatment_id"])
 
     op.add_column("citation_treatment", sa.Column("strongest_negative_class", sa.Text(), nullable=True))
     op.add_column("citation_treatment", sa.Column("judged_count", sa.Integer(), nullable=True))
@@ -67,5 +67,5 @@ def downgrade() -> None:
     op.drop_column("citation_treatment", "judge_as_of")
     op.drop_column("citation_treatment", "judged_count")
     op.drop_column("citation_treatment", "strongest_negative_class")
-    op.drop_index("ix_treatment_signal_treatment_id", table_name="citation_treatment_signal")
+    op.drop_index("ix_citation_treatment_signal_treatment_id", table_name="citation_treatment_signal")
     op.drop_table("citation_treatment_signal")

--- a/api/app/citation/ledger.py
+++ b/api/app/citation/ledger.py
@@ -15,9 +15,12 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.citation.treatment_judge import TreatmentJudgment
+from app.citation.treatment_rollup import roll_up
 from app.models.chat import Chat, Message, MessageCitation
 from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.citation_treatment import CitationTreatment
+from app.models.citation_treatment_signal import CitationTreatmentSignal
 from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.message_tool_source import MessageToolSource
 
@@ -175,6 +178,52 @@ def _resolve_source(
     return None
 
 
+def _build_treatment_dict(
+    treatment: CitationTreatment,
+    sigs: list[CitationTreatmentSignal],
+) -> dict[str, Any]:
+    """Build the resolved treatment object for one ledger entry.
+
+    Combines the four PR1 graph keys with the PR2 rollup columns and per-passage
+    signal list. ``sigs`` is pre-fetched (no N+1); empty list for graph-only rows.
+    ``roll_up([])`` returns per_class_counts={}, case_confidence=None.
+    """
+    rollup = roll_up(
+        [
+            TreatmentJudgment(
+                classification=s.classification,
+                confidence=s.confidence,
+                justification=s.justification,
+            )
+            for s in sigs
+        ]
+    )
+    return {
+        # PR1 graph keys (unchanged).
+        "cited_by_count": treatment.cited_by_count,
+        "as_of": treatment.as_of.isoformat(),
+        "derived_method": treatment.derived_method,
+        "citing": treatment.citing_opinions,
+        # PR2 rollup columns from CitationTreatment (None when graph-only).
+        "strongest_negative_class": treatment.strongest_negative_class,
+        "judged_count": treatment.judged_count,
+        "judge_as_of": treatment.judge_as_of.isoformat() if treatment.judge_as_of else None,
+        # Computed via roll_up (empty/None when no signals).
+        "per_class_counts": rollup.per_class_counts,
+        "case_confidence": rollup.case_confidence,
+        # Per-passage signals — no snippet (ADR 0016 P3 / ADR 0019 D7).
+        "signals": [
+            {
+                "citing_opinion_id": s.citing_opinion_id,
+                "classification": s.classification,
+                "confidence": s.confidence,
+                "justification": s.justification,
+            }
+            for s in sigs
+        ],
+    }
+
+
 async def resolve_ledger_entries(
     db: AsyncSession, *, chat_id: uuid.UUID, message_id: uuid.UUID | None = None
 ) -> list[dict[str, Any]]:
@@ -247,6 +296,22 @@ async def resolve_ledger_entries(
             .all()
         }
 
+    signals_by_treatment: dict[uuid.UUID, list[CitationTreatmentSignal]] = {}
+    if treatment_ids:
+        signal_rows = (
+            (
+                await db.execute(
+                    select(CitationTreatmentSignal).where(
+                        CitationTreatmentSignal.treatment_id.in_(treatment_ids)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for s in signal_rows:
+            signals_by_treatment.setdefault(s.treatment_id, []).append(s)
+
     out: list[dict[str, Any]] = []
     for e in entries:
         source = _resolve_source(e, docs, caselaw, tools)
@@ -264,12 +329,10 @@ async def resolve_ledger_entries(
                 "retrieved_at": e.retrieved_at.isoformat() if e.retrieved_at else None,
                 "treatment_id": str(e.treatment_id) if e.treatment_id else None,
                 "treatment": (
-                    {
-                        "cited_by_count": treatments[e.treatment_id].cited_by_count,
-                        "as_of": treatments[e.treatment_id].as_of.isoformat(),
-                        "derived_method": treatments[e.treatment_id].derived_method,
-                        "citing": treatments[e.treatment_id].citing_opinions,
-                    }
+                    _build_treatment_dict(
+                        treatments[e.treatment_id],
+                        signals_by_treatment.get(e.treatment_id, []),
+                    )
                     if e.treatment_id is not None and e.treatment_id in treatments
                     else None
                 ),

--- a/api/app/citation/treatment.py
+++ b/api/app/citation/treatment.py
@@ -137,6 +137,14 @@ async def derive_treatment_for_message(
                 existing.judge_as_of = None
                 existing.opinion_id = opinion_id
                 existing.as_of = now
+                # Clear child signals unconditionally on every stale refresh, regardless
+                # of whether a judge pass will follow. Prevents stale "overruled"/etc.
+                # signals from resurfacing on a graph-only row (FIX 1, WS-G PR2 review).
+                await db.execute(
+                    delete(CitationTreatmentSignal).where(
+                        CitationTreatmentSignal.treatment_id == existing.id
+                    )
+                )
                 await db.flush()
                 cluster_to_treatment[cluster_id] = existing.id
                 treatment_row = existing
@@ -227,12 +235,17 @@ async def _run_judge_pass(
     per_call = await estimate_treatment_cost_usd(db, judge_model=judge_model)
     spent = Decimal("0")
     judgments = []
+    seen: set[int] = set()
     # raw_citing is already recency-sorted by the upstream service; take the cap.
     for ref in raw_citing[:n_judged_cap]:
         snippet = ref.get("snippet")
         citing_opinion_id = ref.get("opinion_id")
         if not snippet or citing_opinion_id is None:
             continue
+        # Dedup: two refs sharing an opinion_id would violate the unique constraint.
+        if int(citing_opinion_id) in seen:
+            continue
+        seen.add(int(citing_opinion_id))
         if spent + per_call > judge_budget_usd:
             break  # budget exhausted — keep what was judged so far
         spent += per_call

--- a/api/app/citation/treatment.py
+++ b/api/app/citation/treatment.py
@@ -1,9 +1,14 @@
-"""Derive the citation-graph treatment signal for a turn's cited cases (WS-G PR1).
+"""Derive the citation-graph treatment signal for a turn's cited cases (WS-G PR1/PR2).
 
-Graph-only: for each case a turn cited, reuse a fresh ``citation_treatment`` row
+Graph-only (PR1): for each case a turn cited, reuse a fresh ``citation_treatment`` row
 or fetch the citing graph via the gateway and upsert one, then link the turn's
-caselaw ledger entries to it. No LLM-judge (that is PR2). Per-case non-fatal
-(conservative posture). ADR 0019 D2.
+caselaw ledger entries to it.
+
+Judge pass (PR2): when a gateway is supplied, after the graph upsert, judge the
+top-N citing snippets per cluster, write CitationTreatmentSignal child rows, and
+set the rollup on the parent row (``derived_method='citation_graph+judge'``).
+Snippets are transient judge input — NEVER stored (P3). Per-case non-fatal
+(conservative posture). ADR 0019 D2/D5.
 """
 
 from __future__ import annotations
@@ -12,20 +17,37 @@ import logging
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
+from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.citation.treatment_judge import (
+    _TREATMENT_PURPOSE,  # noqa: F401 — imported for callers / tests
+    estimate_treatment_cost_usd,
+    judge_treatment,
+)
+from app.citation.treatment_rollup import roll_up
+from app.citation.verification import _JudgeGatewayProtocol
 from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.citation_treatment import CitationTreatment
+from app.models.citation_treatment_signal import CitationTreatmentSignal
 from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.research import ResearchClusterMetadata
 
 log = logging.getLogger(__name__)
 
 TREATMENT_TTL_DAYS = 30
+N_JUDGED_CAP = 10
+TREATMENT_JUDGE_BUDGET_USD = Decimal("0.25")
 
 _FetchCiting = Callable[[int], Awaitable[dict[str, Any]]]
+
+
+def _strip_snippet(citing: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Persist refs only — the snippet is transient judge input (P3)."""
+    return [{k: v for k, v in ref.items() if k != "snippet"} for ref in citing]
 
 
 async def _default_fetch_citing(opinion_id: int) -> dict[str, Any]:
@@ -41,8 +63,17 @@ async def derive_treatment_for_message(
     now: datetime,
     ttl_days: int = TREATMENT_TTL_DAYS,
     fetch_citing: _FetchCiting = _default_fetch_citing,
+    gateway: _JudgeGatewayProtocol | None = None,
+    judge_model: str = "fast",
+    judge_budget_usd: Decimal = TREATMENT_JUDGE_BUDGET_USD,
+    n_judged_cap: int = N_JUDGED_CAP,
 ) -> int:
     """Derive/refresh graph treatment for each case this turn cited; link entries.
+
+    When ``gateway`` is supplied and the cited case name can be resolved from
+    ``ResearchClusterMetadata``, also runs the treatment judge over the top-N
+    citing snippets and writes ``CitationTreatmentSignal`` child rows + rollup.
+    Snippets are transient — never stored (P3).
 
     Returns the number of caselaw ledger entries linked to a treatment row.
     Never raises on a per-case failure (logged and skipped).
@@ -78,29 +109,63 @@ async def derive_treatment_for_message(
                 )
             ).scalar_one_or_none()
             if existing is not None and existing.as_of >= stale_before:
+                # Fresh cache — reuse without fetch or re-judging.
                 cluster_to_treatment[cluster_id] = existing.id
                 continue
             payload = await fetch_citing(opinion_id)
+            raw_citing = list(payload.get("citing") or [])
+            persisted_citing = _strip_snippet(raw_citing)
+            treatment_row: CitationTreatment
             if existing is None:
                 row = CitationTreatment(
                     cluster_id=cluster_id,
                     opinion_id=opinion_id,
                     cited_by_count=int(payload.get("cited_by_count") or 0),
-                    citing_opinions=list(payload.get("citing") or []),
+                    citing_opinions=persisted_citing,
                     derived_method="citation_graph",
                     as_of=now,
                 )
                 db.add(row)
                 await db.flush()
                 cluster_to_treatment[cluster_id] = row.id
+                treatment_row = row
             else:
                 existing.cited_by_count = int(payload.get("cited_by_count") or 0)
-                existing.citing_opinions = list(payload.get("citing") or [])
+                existing.citing_opinions = persisted_citing
                 existing.derived_method = "citation_graph"
                 existing.opinion_id = opinion_id
                 existing.as_of = now
                 await db.flush()
                 cluster_to_treatment[cluster_id] = existing.id
+                treatment_row = existing
+
+            # Judge pass (PR2): only when a gateway is supplied.
+            if gateway is not None:
+                meta = (
+                    await db.execute(
+                        select(ResearchClusterMetadata).where(
+                            ResearchClusterMetadata.cluster_id == cluster_id
+                        )
+                    )
+                ).scalar_one_or_none()
+                case_name = meta.case_name if meta is not None else None
+                if case_name:
+                    await _run_judge_pass(
+                        db,
+                        treatment_row=treatment_row,
+                        cited_case_name=case_name,
+                        raw_citing=raw_citing,
+                        now=now,
+                        gateway=gateway,
+                        judge_model=judge_model,
+                        judge_budget_usd=judge_budget_usd,
+                        n_judged_cap=n_judged_cap,
+                    )
+                else:
+                    log.debug(
+                        "treatment judge skipped for cluster %s: case_name unavailable",
+                        cluster_id,
+                    )
         except Exception as exc:  # per-case non-fatal (conservative posture)
             log.warning("treatment derivation failed for cluster %s: %r", cluster_id, exc)
 
@@ -136,3 +201,67 @@ async def derive_treatment_for_message(
     if linked:
         await db.flush()
     return linked
+
+
+async def _run_judge_pass(
+    db: AsyncSession,
+    *,
+    treatment_row: CitationTreatment,
+    cited_case_name: str,
+    raw_citing: list[dict[str, Any]],
+    now: datetime,
+    gateway: _JudgeGatewayProtocol,
+    judge_model: str,
+    judge_budget_usd: Decimal,
+    n_judged_cap: int,
+) -> None:
+    """Judge top-N citing snippets, write child signals + rollup. Non-fatal per passage."""
+    # Idempotent refresh: clear this row's prior signals before writing new ones.
+    await db.execute(
+        delete(CitationTreatmentSignal).where(
+            CitationTreatmentSignal.treatment_id == treatment_row.id
+        )
+    )
+    per_call = await estimate_treatment_cost_usd(db, judge_model=judge_model)
+    spent = Decimal("0")
+    judgments = []
+    # raw_citing is already recency-sorted by the upstream service; take the cap.
+    for ref in raw_citing[:n_judged_cap]:
+        snippet = ref.get("snippet")
+        citing_opinion_id = ref.get("opinion_id")
+        if not snippet or citing_opinion_id is None:
+            continue
+        if spent + per_call > judge_budget_usd:
+            break  # budget exhausted — keep what was judged so far
+        spent += per_call
+        try:
+            judgment = await judge_treatment(
+                cited_case_name=cited_case_name,
+                snippet=snippet,
+                gateway=gateway,
+                judge_model=judge_model,
+            )
+        except Exception as exc:  # defense in depth; judge_treatment already swallows
+            log.warning("treatment judge raised for opinion %s: %r", citing_opinion_id, exc)
+            continue
+        if judgment is None:
+            continue
+        db.add(
+            CitationTreatmentSignal(
+                treatment_id=treatment_row.id,
+                citing_opinion_id=int(citing_opinion_id),
+                classification=judgment.classification,
+                confidence=judgment.confidence,
+                justification=judgment.justification,
+            )
+        )
+        judgments.append(judgment)
+    if not judgments:
+        # Nothing classified — leave graph-only; signals already cleared above.
+        return
+    rollup = roll_up(judgments)
+    treatment_row.strongest_negative_class = rollup.strongest_negative_class
+    treatment_row.judged_count = rollup.judged_count
+    treatment_row.judge_as_of = now
+    treatment_row.derived_method = "citation_graph+judge"
+    await db.flush()

--- a/api/app/citation/treatment.py
+++ b/api/app/citation/treatment.py
@@ -24,7 +24,6 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.treatment_judge import (
-    _TREATMENT_PURPOSE,  # noqa: F401 — imported for callers / tests
     estimate_treatment_cost_usd,
     judge_treatment,
 )
@@ -133,6 +132,9 @@ async def derive_treatment_for_message(
                 existing.cited_by_count = int(payload.get("cited_by_count") or 0)
                 existing.citing_opinions = persisted_citing
                 existing.derived_method = "citation_graph"
+                existing.strongest_negative_class = None
+                existing.judged_count = None
+                existing.judge_as_of = None
                 existing.opinion_id = opinion_id
                 existing.as_of = now
                 await db.flush()

--- a/api/app/citation/treatment_judge.py
+++ b/api/app/citation/treatment_judge.py
@@ -1,0 +1,157 @@
+"""Treatment-classifying judge over a citing snippet (WS-G PR2).
+
+A NEW judge prompt + verdict schema (the cascade judge speaks yes/partial/no;
+this speaks the 7-class treatment taxonomy). Reuses the judge RAILS only:
+the gateway protocol, the cost estimator, the _CONFIDENCE_MAP scale, and the
+parse-or-skip discipline. The snippet is transient input — never persisted (P3).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.cost import estimate_judge_call_cost_usd
+from app.citation.verification import _CONFIDENCE_MAP, _JudgeGatewayProtocol
+from app.schemas.gateway import ChatCompletionMessage, ChatCompletionRequest
+
+log = logging.getLogger(__name__)
+
+TREATMENT_CLASSES = (
+    "followed",
+    "distinguished",
+    "criticized",
+    "questioned",
+    "overruled",
+    "superseded",
+    "neutral",
+)
+_TREATMENT_PURPOSE = "judge_treatment"
+
+_SYSTEM_PROMPT = """\
+You are a Legal Treatment Classifier for a legal AI assistant.
+
+You are given the NAME of a CITED case and a SNIPPET from a LATER opinion
+that cites it. Classify how the later opinion TREATS the cited case, using
+EXACTLY ONE of these labels:
+
+* "overruled"    — the later court overrules/abrogates the cited case.
+* "superseded"   — the cited case is superseded (e.g., by statute/rule).
+* "criticized"   — the later court criticizes the cited case's reasoning.
+* "questioned"   — the later court doubts/questions the cited case.
+* "distinguished"— the later court distinguishes the cited case on its facts.
+* "followed"     — the later court follows/applies the cited case favorably.
+* "neutral"      — a bare citation with no discernible treatment signal.
+
+Respond with STRICTLY VALID JSON in this exact shape:
+
+  {"treatment": "<one label above>",
+   "confidence": "high" | "medium" | "low",
+   "justification": "<one or two sentences; DESCRIBE the treatment in your
+                      own words — do NOT quote the opinion text>"}
+
+CALIBRATION — IMPORTANT. When uncertain between a negative label
+(overruled/superseded/criticized/questioned/distinguished) and "neutral",
+choose "neutral". A false negative-treatment flag is worse than a missed
+one. Only assert a negative label when the snippet clearly supports it.
+
+Output ONLY the JSON object. No preamble, no markdown fencing."""
+
+
+@dataclass(slots=True)
+class TreatmentJudgment:
+    classification: str
+    confidence: float
+    justification: str
+
+
+def build_treatment_judge_prompt(
+    *, cited_case_name: str, snippet: str
+) -> list[ChatCompletionMessage]:
+    user = (
+        f'CITED CASE:\n"""\n{cited_case_name}\n"""\n\n'
+        f'SNIPPET FROM THE LATER (CITING) OPINION:\n"""\n{snippet}\n"""\n\n'
+        "How does the later opinion treat the CITED CASE? Respond with the JSON object only."
+    )
+    return [
+        ChatCompletionMessage(role="system", content=_SYSTEM_PROMPT),
+        ChatCompletionMessage(role="user", content=user),
+    ]
+
+
+def parse_treatment_response(response: Any) -> TreatmentJudgment | None:
+    try:
+        choices = response.choices
+        if not choices:
+            return None
+        content = choices[0].message.content
+    except AttributeError:
+        return None
+    if not content:
+        return None
+    try:
+        payload = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        log.info("treatment judge produced non-JSON", extra={"event": "treatment_judge_malformed"})
+        return None
+    if not isinstance(payload, dict):
+        return None
+    treatment = payload.get("treatment")
+    confidence_label = payload.get("confidence")
+    justification = payload.get("justification")
+    if treatment not in TREATMENT_CLASSES:
+        log.info(
+            "treatment judge unknown class %r",
+            treatment,
+            extra={"event": "treatment_judge_unknown_class"},
+        )
+        return None
+    if confidence_label not in _CONFIDENCE_MAP:
+        return None
+    if not isinstance(justification, str) or not justification.strip():
+        return None
+    return TreatmentJudgment(
+        classification=treatment,
+        confidence=_CONFIDENCE_MAP[confidence_label],
+        justification=justification.strip(),
+    )
+
+
+async def judge_treatment(
+    *,
+    cited_case_name: str,
+    snippet: str,
+    gateway: _JudgeGatewayProtocol,
+    judge_model: str,
+) -> TreatmentJudgment | None:
+    request = ChatCompletionRequest(
+        model=judge_model,
+        messages=build_treatment_judge_prompt(cited_case_name=cited_case_name, snippet=snippet),
+        max_tokens=400,
+        temperature=0.0,
+        anonymize=False,
+        lq_ai_purpose=_TREATMENT_PURPOSE,
+    )
+    try:
+        response = await gateway.chat_completion(request)
+    except Exception as exc:
+        log.warning(
+            "treatment judge gateway call failed: %r",
+            exc,
+            extra={"event": "treatment_judge_error", "error_type": type(exc).__name__},
+        )
+        return None
+    return parse_treatment_response(response)
+
+
+async def estimate_treatment_cost_usd(db: AsyncSession | None, *, judge_model: str) -> Decimal:
+    """Per-call estimate. The snippet is short + bounded, so (unlike the
+    whole-opinion judge) no opinion-length scaling is applied."""
+    return await estimate_judge_call_cost_usd(
+        db, judge_model=judge_model, purpose=_TREATMENT_PURPOSE
+    )

--- a/api/app/citation/treatment_rollup.py
+++ b/api/app/citation/treatment_rollup.py
@@ -1,0 +1,48 @@
+"""Roll per-passage treatment judgments up to a case-level signal (WS-G PR2).
+
+Strongest-negative posture (ADR 0019 D5): the case-level signal is the most
+SEVERE negative class present; confidence (D6) is that class's strongest
+contributor confidence plus a small corroboration bump per additional
+agreeing passage, capped. Absence of any negative class → None (surfaced as
+"no negative treatment found as of <date>", never "good law"). Pure + total.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from app.citation.treatment_judge import TreatmentJudgment
+
+# Strongest first.
+NEGATIVE_SEVERITY: tuple[str, ...] = (
+    "overruled",
+    "superseded",
+    "criticized",
+    "questioned",
+    "distinguished",
+)
+_CORROBORATION_BUMP = 0.05
+_CONFIDENCE_CAP = 0.95
+
+
+@dataclass(slots=True)
+class Rollup:
+    strongest_negative_class: str | None
+    per_class_counts: dict[str, int]
+    case_confidence: float | None
+    judged_count: int
+
+
+def roll_up(signals: Sequence[TreatmentJudgment]) -> Rollup:
+    counts = Counter(s.classification for s in signals)
+    per_class = dict(counts)
+    strongest: str | None = next((c for c in NEGATIVE_SEVERITY if counts.get(c)), None)
+    if strongest is None:
+        return Rollup(None, per_class, None, len(signals))
+    agreeing = [s.confidence for s in signals if s.classification == strongest]
+    base = max(agreeing)
+    bumped = base + _CORROBORATION_BUMP * (len(agreeing) - 1)
+    confidence = min(bumped, _CONFIDENCE_CAP)
+    return Rollup(strongest, per_class, confidence, len(signals))

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -23,6 +23,7 @@ from app.models.chat import Chat, Message
 from app.models.chat_pending_tool_call import ChatPendingToolCall
 from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.citation_treatment import CitationTreatment
+from app.models.citation_treatment_signal import CitationTreatmentSignal
 from app.models.document import Document, DocumentChunk
 from app.models.enhance_prompt import EnhancePromptInteraction
 from app.models.file import File
@@ -61,6 +62,7 @@ __all__ = [
     "ChatPendingToolCall",
     "CitationLedgerEntry",
     "CitationTreatment",
+    "CitationTreatmentSignal",
     "Document",
     "DocumentChunk",
     "EnhancePromptInteraction",

--- a/api/app/models/citation_treatment.py
+++ b/api/app/models/citation_treatment.py
@@ -27,8 +27,13 @@ class CitationTreatment(Base):
         UniqueConstraint("cluster_id", name="uq_citation_treatment_cluster_id"),
         CheckConstraint("cited_by_count >= 0", name="chk_citation_treatment_count_nonneg"),
         CheckConstraint(
-            "derived_method IN ('citation_graph')",
+            "derived_method IN ('citation_graph', 'citation_graph+judge')",
             name="chk_citation_treatment_method_values",
+        ),
+        CheckConstraint(
+            "strongest_negative_class IS NULL OR strongest_negative_class IN "
+            "('overruled','superseded','criticized','questioned','distinguished')",
+            name="chk_citation_treatment_strongest_negative",
         ),
     )
 
@@ -40,6 +45,9 @@ class CitationTreatment(Base):
     cited_by_count: Mapped[int] = mapped_column(Integer, nullable=False)
     citing_opinions: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
     derived_method: Mapped[str] = mapped_column(Text, nullable=False)
+    strongest_negative_class: Mapped[str | None] = mapped_column(Text, nullable=True)
+    judged_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    judge_as_of: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     as_of: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/api/app/models/citation_treatment_signal.py
+++ b/api/app/models/citation_treatment_signal.py
@@ -1,0 +1,63 @@
+"""citation_treatment_signal — one judged citing passage's treatment (WS-G PR2).
+
+One row per citing opinion the treatment judge classified for a cited case.
+Stores the DERIVED classification + confidence + the judge's short
+justification (our reasoning) + the citing opinion ref — NEVER the raw
+snippet or opinion text (ADR 0016 P3 / ADR 0019 D7). Joins the P3 tripwire.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+_CLASS_LIST = (
+    "'followed','distinguished','criticized','questioned','overruled','superseded','neutral'"
+)
+
+
+class CitationTreatmentSignal(Base):
+    __tablename__ = "citation_treatment_signal"
+    __table_args__ = (
+        UniqueConstraint(
+            "treatment_id",
+            "citing_opinion_id",
+            name="uq_treatment_signal_treatment_citing",
+        ),
+        CheckConstraint(
+            f"classification IN ({_CLASS_LIST})",
+            name="chk_treatment_signal_classification",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    treatment_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("citation_treatment.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    citing_opinion_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    classification: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    justification: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/api/app/workers/treatment_worker.py
+++ b/api/app/workers/treatment_worker.py
@@ -1,4 +1,4 @@
-"""arq job — derive citation-graph treatment for an assistant turn (WS-G PR1).
+"""arq job — derive citation-graph treatment for an assistant turn (WS-G PR1/PR2).
 
 Runs OFF the turn's critical path: enqueued best-effort after each assistant
 turn finalizes (see ``app.api.chats``), consumed by the ingest worker.
@@ -15,6 +15,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.treatment import _default_fetch_citing, _FetchCiting, derive_treatment_for_message
+from app.clients.gateway import GatewayClient, get_gateway_client
 from app.db.session import get_session_factory
 
 log = logging.getLogger(__name__)
@@ -25,17 +26,43 @@ async def run_treatment_derivation(
     *,
     message_id: uuid.UUID,
     fetch_citing: _FetchCiting = _default_fetch_citing,
+    gateway: GatewayClient | None = None,
 ) -> int:
     """Session-injected core (testable without arq/Redis).
+
+    Resolves a gateway + judge model for the PR2 judge pass; degrades to
+    graph-only (``gateway=None``) if the gateway or judge-model can't be
+    resolved (e.g. worker running without gateway config).
+
+    The ``gateway`` kwarg allows test injection; when omitted the
+    process-global :func:`get_gateway_client` is used.
 
     Calls ``derive_treatment_for_message`` with a UTC-aware *now*, then
     commits the session. Returns the number of ledger entries linked.
     """
+    # _gw is always a GatewayClient (ternary guarantees it); the separate
+    # derive_gateway variable starts as _gw and is cleared to None in the
+    # degrade path so mypy can track both states cleanly.
+    _gw: GatewayClient = gateway if gateway is not None else get_gateway_client()
+    judge_model = "fast"
+    derive_gateway: GatewayClient | None = _gw
+    try:
+        judge_model = await _gw.get_citation_engine_judge_model()
+    except Exception as exc:
+        log.warning(
+            "treatment judge-model resolve failed; degrading to graph-only: %r",
+            exc,
+            extra={"event": "treatment_judge_model_unavailable"},
+        )
+        derive_gateway = None
+
     linked = await derive_treatment_for_message(
         db,
         message_id=message_id,
         now=datetime.now(UTC),
         fetch_citing=fetch_citing,
+        gateway=derive_gateway,
+        judge_model=judge_model,
     )
     await db.commit()
     return linked

--- a/api/tests/citation/conftest.py
+++ b/api/tests/citation/conftest.py
@@ -1,0 +1,50 @@
+"""Shared pytest fixtures for api/tests/citation/."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.user import User
+
+
+@pytest.fixture
+async def seeded(db_session: AsyncSession):
+    """Seed: User → Chat → assistant Message → MessageCaselawCitation(cluster_id=2812209)
+    → CitationLedgerEntry.  Returns (msg_id, chat_id, cc, entry)."""
+    user = User(email=f"t-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="t")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
+    db_session.add(msg)
+    await db_session.flush()
+    cc = MessageCaselawCitation(
+        message_id=msg.id,
+        opinion_id=2812209,
+        cluster_id=2812209,
+        source_offset_start=0,
+        source_offset_end=5,
+        source_text="quote",
+        verified=True,
+        verification_method="exact_match",
+    )
+    db_session.add(cc)
+    await db_session.flush()
+    entry = CitationLedgerEntry(
+        chat_id=chat.id,
+        message_id=msg.id,
+        source_kind="caselaw",
+        message_caselaw_citation_id=cc.id,
+        verification_status="exact_match",
+    )
+    db_session.add(entry)
+    await db_session.flush()
+    return msg.id, chat.id, cc, entry

--- a/api/tests/citation/test_treatment_derivation.py
+++ b/api/tests/citation/test_treatment_derivation.py
@@ -5,13 +5,10 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.treatment import TREATMENT_TTL_DAYS, derive_treatment_for_message
 from app.models.chat import Chat, Message
-from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.citation_treatment import CitationTreatment
-from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.user import User
 
 pytestmark = pytest.mark.integration
@@ -33,41 +30,6 @@ def _citing(n: int) -> dict:
             for i in range(n)
         ],
     }
-
-
-@pytest.fixture
-async def seeded(db_session: AsyncSession):
-    user = User(email=f"t-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
-    db_session.add(user)
-    await db_session.flush()
-    chat = Chat(owner_id=user.id, title="t")
-    db_session.add(chat)
-    await db_session.flush()
-    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
-    db_session.add(msg)
-    await db_session.flush()
-    cc = MessageCaselawCitation(
-        message_id=msg.id,
-        opinion_id=2812209,
-        cluster_id=2812209,
-        source_offset_start=0,
-        source_offset_end=5,
-        source_text="quote",
-        verified=True,
-        verification_method="exact_match",
-    )
-    db_session.add(cc)
-    await db_session.flush()
-    entry = CitationLedgerEntry(
-        chat_id=chat.id,
-        message_id=msg.id,
-        source_kind="caselaw",
-        message_caselaw_citation_id=cc.id,
-        verification_status="exact_match",
-    )
-    db_session.add(entry)
-    await db_session.flush()
-    return msg.id, chat.id, cc, entry
 
 
 @pytest.mark.asyncio

--- a/api/tests/citation/test_treatment_judge_pass.py
+++ b/api/tests/citation/test_treatment_judge_pass.py
@@ -20,6 +20,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.citation.ledger import resolve_ledger_entries
 from app.citation.treatment import derive_treatment_for_message
 from app.models.citation_treatment import CitationTreatment
 from app.models.citation_treatment_signal import CitationTreatmentSignal
@@ -214,6 +215,31 @@ async def test_re_derive_replaces_signals(db_session: AsyncSession, seeded: Any)
     assert len(sigs) == 2  # delete-and-rewrite, not 4
 
 
+async def _fetch_with_dup_opinion_id(opinion_id: int) -> dict[str, Any]:
+    """Two citing refs sharing the same opinion_id — dedup guard under test."""
+    return {
+        "cited_by_count": 2,
+        "citing": [
+            {
+                "cluster_id": 90,
+                "opinion_id": 900,
+                "case_name": "A v. B",
+                "court": "ca9",
+                "date_filed": "2021-01-01",
+                "snippet": "First occurrence with opinion 900.",
+            },
+            {
+                "cluster_id": 90,
+                "opinion_id": 900,  # duplicate
+                "case_name": "A v. B",
+                "court": "ca9",
+                "date_filed": "2021-01-01",
+                "snippet": "Second occurrence — same opinion_id.",
+            },
+        ],
+    }
+
+
 class _BadGW:
     """Stub gateway that always returns malformed JSON → parse_treatment_response returns None."""
 
@@ -271,3 +297,199 @@ async def test_failed_refresh_leaves_consistent_graph_only(
     # Prior signals must be gone (deleted at the start of _run_judge_pass).
     sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
     assert sigs == []
+
+
+# ---------------------------------------------------------------------------
+# FIX 1 regression: orphaned child signals on a no-judge-pass stale refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_without_judge_pass_clears_prior_signals(
+    db_session: AsyncSession, seeded: Any
+) -> None:
+    """Stale refresh with gateway=None must delete prior signals (FIX 1).
+
+    Previously, the stale-refresh else-branch null-ed rollup columns but left
+    child CitationTreatmentSignal rows, producing a contradictory graph-only
+    parent with 'overruled' child signals visible on the read path.
+    """
+    message_id, chat_id, *_ = seeded
+    await _seed_cluster_metadata(db_session)
+
+    # First pass: working judge — writes 2 signals + full rollup.
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW,
+        fetch_citing=_fetch_with_snippets,
+        gateway=_GW(),
+        judge_model="fast",
+        ttl_days=0,
+    )
+    t = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == _CLUSTER_ID)
+        )
+    ).scalar_one()
+    assert t.derived_method == "citation_graph+judge"  # sanity: judge ran
+
+    # Second pass (stale, now+1d, ttl_days=0) with NO gateway — judge pass skipped.
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW + timedelta(days=1),
+        fetch_citing=_fetch_with_snippets,
+        gateway=None,
+        ttl_days=0,
+    )
+
+    await db_session.refresh(t)
+    # Parent row must be honest graph-only.
+    assert t.derived_method == "citation_graph"
+    assert t.strongest_negative_class is None
+    assert t.judged_count is None
+    assert t.judge_as_of is None
+    assert t.cited_by_count == 3  # graph still set
+
+    # Child signals cleared even though no judge pass ran (FIX 1).
+    remaining_sigs = (
+        (
+            await db_session.execute(
+                select(CitationTreatmentSignal).where(CitationTreatmentSignal.treatment_id == t.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining_sigs == []
+
+    # Read path must be consistent: no stale signals visible via resolve_ledger_entries.
+    ledger = await resolve_ledger_entries(db_session, chat_id=chat_id, message_id=message_id)
+    caselaw_entries = [e for e in ledger if e.get("source_kind") == "caselaw"]
+    assert len(caselaw_entries) == 1
+    treatment_dict = caselaw_entries[0]["treatment"]
+    assert treatment_dict["signals"] == []
+    assert treatment_dict["per_class_counts"] == {}
+    assert treatment_dict["case_confidence"] is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_without_judge_pass_clears_prior_signals_missing_case_name(
+    db_session: AsyncSession, seeded: Any
+) -> None:
+    """Stale refresh with gateway but no case_name must also delete prior signals (FIX 1).
+
+    The judge pass is skipped when ResearchClusterMetadata is absent/case_name blank.
+    Signals written in the first pass must still be deleted.
+    """
+    message_id, chat_id, *_ = seeded
+    await _seed_cluster_metadata(db_session)
+
+    # First pass: working judge — writes signals.
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW,
+        fetch_citing=_fetch_with_snippets,
+        gateway=_GW(),
+        judge_model="fast",
+        ttl_days=0,
+    )
+
+    # Remove ResearchClusterMetadata so the second pass cannot resolve case_name.
+    meta = (
+        await db_session.execute(
+            select(ResearchClusterMetadata).where(ResearchClusterMetadata.cluster_id == _CLUSTER_ID)
+        )
+    ).scalar_one()
+    await db_session.delete(meta)
+    await db_session.flush()
+
+    # Second pass (stale): gateway supplied but case_name unresolvable.
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW + timedelta(days=1),
+        fetch_citing=_fetch_with_snippets,
+        gateway=_GW(),
+        ttl_days=0,
+    )
+
+    t = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == _CLUSTER_ID)
+        )
+    ).scalar_one()
+    # Parent row must be graph-only.
+    assert t.derived_method == "citation_graph"
+    assert t.strongest_negative_class is None
+    assert t.judged_count is None
+    assert t.judge_as_of is None
+
+    # Child signals cleared despite gateway being present (FIX 1).
+    remaining_sigs = (
+        (
+            await db_session.execute(
+                select(CitationTreatmentSignal).where(CitationTreatmentSignal.treatment_id == t.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining_sigs == []
+
+    # Read path consistent.
+    ledger = await resolve_ledger_entries(db_session, chat_id=chat_id, message_id=message_id)
+    caselaw_entries = [e for e in ledger if e.get("source_kind") == "caselaw"]
+    assert len(caselaw_entries) == 1
+    treatment_dict = caselaw_entries[0]["treatment"]
+    assert treatment_dict["signals"] == []
+    assert treatment_dict["per_class_counts"] == {}
+    assert treatment_dict["case_confidence"] is None
+
+
+# ---------------------------------------------------------------------------
+# FIX 2 regression: dedup citing_opinion_id in judge loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dedup_citing_opinion_id_writes_single_signal(
+    db_session: AsyncSession, seeded: Any
+) -> None:
+    """Two citing refs sharing opinion_id=900 must produce only one signal row (FIX 2).
+
+    Without the dedup guard, the second insert would violate the
+    uq_treatment_signal_treatment_citing unique constraint, raising IntegrityError.
+    """
+    message_id, *_ = seeded
+    await _seed_cluster_metadata(db_session)
+
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW,
+        fetch_citing=_fetch_with_dup_opinion_id,
+        gateway=_GW(),
+        judge_model="fast",
+    )
+
+    t = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == _CLUSTER_ID)
+        )
+    ).scalar_one()
+
+    sigs = (
+        (
+            await db_session.execute(
+                select(CitationTreatmentSignal).where(CitationTreatmentSignal.treatment_id == t.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # Only one signal for opinion_id=900, not two (dedup guard in effect).
+    assert len(sigs) == 1
+    assert sigs[0].citing_opinion_id == 900

--- a/api/tests/citation/test_treatment_judge_pass.py
+++ b/api/tests/citation/test_treatment_judge_pass.py
@@ -1,0 +1,212 @@
+"""Integration tests for the treatment judge pass (WS-G PR2).
+
+Verifies that derive_treatment_for_message correctly:
+- Runs the judge when gateway is supplied + case_name is resolvable.
+- Writes CitationTreatmentSignal child rows and rolls up to the parent.
+- Strips snippets from persisted citing_opinions (P3).
+- Falls back to graph-only when gateway=None, budget=0, or case_name missing.
+- Replaces signals on re-derivation (idempotent refresh).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.treatment import derive_treatment_for_message
+from app.models.citation_treatment import CitationTreatment
+from app.models.citation_treatment_signal import CitationTreatmentSignal
+from app.models.research import ResearchClusterMetadata
+
+# `seeded` fixture is provided by tests/citation/conftest.py (auto-discovered by pytest).
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+_NOW = datetime(2026, 6, 26, tzinfo=UTC)
+_CLUSTER_ID = 2812209
+
+
+async def _fetch_with_snippets(opinion_id: int) -> dict[str, Any]:
+    return {
+        "cited_by_count": 3,
+        "citing": [
+            {
+                "cluster_id": 90,
+                "opinion_id": 900,
+                "case_name": "A v. B",
+                "court": "ca9",
+                "date_filed": "2021-01-01",
+                "snippet": "We overrule the cited case.",
+            },
+            {
+                "cluster_id": 91,
+                "opinion_id": 901,
+                "case_name": "C v. D",
+                "court": "ca2",
+                "date_filed": "2020-01-01",
+                "snippet": "Citing for background.",
+            },
+        ],
+    }
+
+
+class _GW:
+    """Stub gateway: returns 'overruled' if snippet contains 'overrule', else 'neutral'."""
+
+    async def chat_completion(self, request: Any, *, request_id: Any = None) -> Any:
+        body = request.messages[1].content
+        cls = "overruled" if "overrule" in body else "neutral"
+        conf = "high" if cls == "overruled" else "low"
+        payload = json.dumps({"treatment": cls, "confidence": conf, "justification": "x"})
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=payload))])
+
+
+async def _seed_cluster_metadata(db_session: AsyncSession) -> None:
+    db_session.add(ResearchClusterMetadata(cluster_id=_CLUSTER_ID, case_name="Smith v. Jones"))
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_judge_pass_writes_signals_and_rollup(db_session: AsyncSession, seeded: Any) -> None:
+    message_id, *_ = seeded
+    await _seed_cluster_metadata(db_session)
+
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW,
+        fetch_citing=_fetch_with_snippets,
+        gateway=_GW(),
+        judge_model="fast",
+    )
+
+    t = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == _CLUSTER_ID)
+        )
+    ).scalar_one()
+    assert t.derived_method == "citation_graph+judge"
+    assert t.strongest_negative_class == "overruled"
+    assert t.judged_count == 2
+
+    # P3: persisted refs carry NO snippet.
+    assert all("snippet" not in ref for ref in t.citing_opinions)
+
+    sigs = (
+        (
+            await db_session.execute(
+                select(CitationTreatmentSignal).where(CitationTreatmentSignal.treatment_id == t.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {s.classification for s in sigs} == {"overruled", "neutral"}
+
+
+@pytest.mark.asyncio
+async def test_graph_only_when_no_gateway(db_session: AsyncSession, seeded: Any) -> None:
+    message_id, *_ = seeded
+    await _seed_cluster_metadata(db_session)
+
+    # gateway omitted → graph-only
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW,
+        fetch_citing=_fetch_with_snippets,
+    )
+
+    t = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == _CLUSTER_ID)
+        )
+    ).scalar_one()
+    assert t.derived_method == "citation_graph"
+    assert t.strongest_negative_class is None
+
+    sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert sigs == []
+
+
+@pytest.mark.asyncio
+async def test_budget_stops_pass_but_keeps_graph(db_session: AsyncSession, seeded: Any) -> None:
+    message_id, *_ = seeded
+    await _seed_cluster_metadata(db_session)
+
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW,
+        fetch_citing=_fetch_with_snippets,
+        gateway=_GW(),
+        judge_model="fast",
+        judge_budget_usd=Decimal("0"),  # zero budget → no passages judged
+    )
+
+    t = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == _CLUSTER_ID)
+        )
+    ).scalar_one()
+    assert t.cited_by_count == 3  # graph survived
+    assert t.derived_method == "citation_graph"  # no passages judged
+
+    sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert sigs == []
+
+
+@pytest.mark.asyncio
+async def test_graph_only_when_no_case_name(db_session: AsyncSession, seeded: Any) -> None:
+    """When ResearchClusterMetadata is absent, judge pass is skipped (graph-only)."""
+    message_id, *_ = seeded
+    # deliberately do NOT seed ResearchClusterMetadata
+
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW,
+        fetch_citing=_fetch_with_snippets,
+        gateway=_GW(),
+        judge_model="fast",
+    )
+
+    t = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == _CLUSTER_ID)
+        )
+    ).scalar_one()
+    assert t.derived_method == "citation_graph"
+    assert t.strongest_negative_class is None
+
+    sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert sigs == []
+
+
+@pytest.mark.asyncio
+async def test_re_derive_replaces_signals(db_session: AsyncSession, seeded: Any) -> None:
+    """Re-derivation deletes prior signals — no duplicates, idempotent refresh."""
+    message_id, *_ = seeded
+    await _seed_cluster_metadata(db_session)
+
+    # Derive twice with TTL=0 to force a refetch both times.
+    for _ in range(2):
+        await derive_treatment_for_message(
+            db_session,
+            message_id=message_id,
+            now=_NOW,
+            fetch_citing=_fetch_with_snippets,
+            gateway=_GW(),
+            judge_model="fast",
+            ttl_days=0,
+        )
+
+    sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert len(sigs) == 2  # not 4 — prior signals replaced

--- a/api/tests/citation/test_treatment_judge_pass.py
+++ b/api/tests/citation/test_treatment_judge_pass.py
@@ -11,7 +11,7 @@ Verifies that derive_treatment_for_message correctly:
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any
@@ -196,12 +196,14 @@ async def test_re_derive_replaces_signals(db_session: AsyncSession, seeded: Any)
     message_id, *_ = seeded
     await _seed_cluster_metadata(db_session)
 
-    # Derive twice with TTL=0 to force a refetch both times.
-    for _ in range(2):
+    # Use distinct timestamps so the second pass is genuinely stale and re-runs the judge.
+    now1 = _NOW
+    now2 = _NOW + timedelta(days=1)  # forces stale on the second pass (ttl_days=0)
+    for now in (now1, now2):
         await derive_treatment_for_message(
             db_session,
             message_id=message_id,
-            now=_NOW,
+            now=now,
             fetch_citing=_fetch_with_snippets,
             gateway=_GW(),
             judge_model="fast",
@@ -209,4 +211,63 @@ async def test_re_derive_replaces_signals(db_session: AsyncSession, seeded: Any)
         )
 
     sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
-    assert len(sigs) == 2  # not 4 — prior signals replaced
+    assert len(sigs) == 2  # delete-and-rewrite, not 4
+
+
+class _BadGW:
+    """Stub gateway that always returns malformed JSON → parse_treatment_response returns None."""
+
+    async def chat_completion(self, request: Any, *, request_id: Any = None) -> Any:
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="not json"))]
+        )
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_leaves_consistent_graph_only(
+    db_session: AsyncSession, seeded: Any
+) -> None:
+    """Regression: a refresh where the judge yields no judgments must leave a consistent
+    graph-only row — derived_method='citation_graph', rollup columns all None, no signals."""
+    message_id, *_ = seeded
+    await _seed_cluster_metadata(db_session)
+
+    # First pass: working judge — writes signals + full rollup.
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW,
+        fetch_citing=_fetch_with_snippets,
+        gateway=_GW(),
+        judge_model="fast",
+        ttl_days=0,
+    )
+    t = (
+        await db_session.execute(
+            select(CitationTreatment).where(CitationTreatment.cluster_id == _CLUSTER_ID)
+        )
+    ).scalar_one()
+    assert t.derived_method == "citation_graph+judge"  # sanity
+
+    # Second pass (stale): bad gateway → parser returns None for every snippet.
+    await derive_treatment_for_message(
+        db_session,
+        message_id=message_id,
+        now=_NOW + timedelta(days=1),
+        fetch_citing=_fetch_with_snippets,
+        gateway=_BadGW(),
+        judge_model="fast",
+        ttl_days=0,
+    )
+
+    await db_session.refresh(t)
+    # Row must be honest graph-only — no stale judge fields.
+    assert t.derived_method == "citation_graph"
+    assert t.strongest_negative_class is None
+    assert t.judged_count is None
+    assert t.judge_as_of is None
+    # Graph signal must have survived (cited_by_count refreshed by fetch_citing).
+    assert t.cited_by_count == 3
+    # Prior signals must be gone (deleted at the start of _run_judge_pass).
+    sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert sigs == []

--- a/api/tests/integration/test_ledger_treatment_exposure.py
+++ b/api/tests/integration/test_ledger_treatment_exposure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,6 +10,7 @@ from app.citation.ledger import resolve_ledger_entries
 from app.models.chat import Chat, Message
 from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.citation_treatment import CitationTreatment
+from app.models.citation_treatment_signal import CitationTreatmentSignal
 from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.user import User
 
@@ -79,3 +81,169 @@ async def test_ledger_entry_carries_resolved_treatment(db_session: AsyncSession)
     assert by_treatment[True]["treatment"]["derived_method"] == "citation_graph"
     assert by_treatment[True]["treatment"]["citing"][0]["case_name"] == "A"
     assert by_treatment[False]["treatment"] is None
+
+
+@pytest.mark.asyncio
+async def test_ledger_exposes_treatment_rollup_and_signals(db_session: AsyncSession):
+    """WS-G PR2: treatment dict gains rollup + per-passage signals from judge run."""
+    user = User(email=f"trs-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="trs")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
+    db_session.add(msg)
+    await db_session.flush()
+    cc = MessageCaselawCitation(
+        message_id=msg.id,
+        opinion_id=9999001,
+        cluster_id=9999001,
+        source_offset_start=0,
+        source_offset_end=5,
+        source_text="q",
+        verified=True,
+        verification_method="exact_match",
+    )
+    db_session.add(cc)
+    await db_session.flush()
+
+    # Treatment with judge-populated rollup columns.
+    judge_ts = datetime(2026, 6, 27, 12, 0, 0, tzinfo=UTC)
+    treatment = CitationTreatment(
+        cluster_id=9999001,
+        opinion_id=9999001,
+        cited_by_count=5,
+        citing_opinions=[],
+        derived_method="citation_graph+judge",
+        strongest_negative_class="overruled",
+        judged_count=2,
+        judge_as_of=judge_ts,
+    )
+    db_session.add(treatment)
+    await db_session.flush()
+
+    sig1 = CitationTreatmentSignal(
+        treatment_id=treatment.id,
+        citing_opinion_id=111,
+        classification="overruled",
+        confidence=0.9,
+        justification="The later court explicitly overruled this decision.",
+    )
+    sig2 = CitationTreatmentSignal(
+        treatment_id=treatment.id,
+        citing_opinion_id=222,
+        classification="neutral",
+        confidence=0.5,
+        justification="Bare citation only.",
+    )
+    db_session.add_all([sig1, sig2])
+    await db_session.flush()
+
+    linked = CitationLedgerEntry(
+        chat_id=chat.id,
+        message_id=msg.id,
+        source_kind="caselaw",
+        message_caselaw_citation_id=cc.id,
+        verification_status="exact_match",
+        treatment_id=treatment.id,
+    )
+    db_session.add(linked)
+    await db_session.flush()
+
+    entries = await resolve_ledger_entries(db_session, chat_id=chat.id, message_id=msg.id)
+    assert len(entries) == 1
+    t = entries[0]["treatment"]
+    assert t is not None
+
+    # Rollup columns from CitationTreatment.
+    assert t["strongest_negative_class"] == "overruled"
+    assert t["judged_count"] == 2
+    assert t["judge_as_of"] == judge_ts.isoformat()
+
+    # Computed from signals via roll_up.
+    assert t["per_class_counts"]["overruled"] == 1
+    assert t["per_class_counts"]["neutral"] == 1
+    assert isinstance(t["case_confidence"], float)
+    assert t["case_confidence"] > 0.0
+
+    # Per-passage signals list.
+    sigs = t["signals"]
+    assert len(sigs) == 2
+    assert any(s["classification"] == "overruled" for s in sigs)
+    # P3: no snippet field in signals.
+    assert all("snippet" not in s for s in sigs)
+    # Required signal fields.
+    for s in sigs:
+        assert "citing_opinion_id" in s
+        assert "classification" in s
+        assert "confidence" in s
+        assert "justification" in s
+
+
+@pytest.mark.asyncio
+async def test_ledger_graph_only_treatment_yields_null_rollup(db_session: AsyncSession):
+    """WS-G PR2: graph-only treatment (no signals) yields new keys as null/empty."""
+    user = User(email=f"go-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, title="go")
+    db_session.add(chat)
+    await db_session.flush()
+    msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
+    db_session.add(msg)
+    await db_session.flush()
+    cc = MessageCaselawCitation(
+        message_id=msg.id,
+        opinion_id=9999002,
+        cluster_id=9999002,
+        source_offset_start=0,
+        source_offset_end=5,
+        source_text="q",
+        verified=True,
+        verification_method="exact_match",
+    )
+    db_session.add(cc)
+    await db_session.flush()
+
+    # PR1-style row: no judge columns, no signals.
+    treatment = CitationTreatment(
+        cluster_id=9999002,
+        opinion_id=9999002,
+        cited_by_count=10,
+        citing_opinions=[],
+        derived_method="citation_graph",
+        strongest_negative_class=None,
+        judged_count=None,
+        judge_as_of=None,
+    )
+    db_session.add(treatment)
+    await db_session.flush()
+
+    linked = CitationLedgerEntry(
+        chat_id=chat.id,
+        message_id=msg.id,
+        source_kind="caselaw",
+        message_caselaw_citation_id=cc.id,
+        verification_status="exact_match",
+        treatment_id=treatment.id,
+    )
+    db_session.add(linked)
+    await db_session.flush()
+
+    entries = await resolve_ledger_entries(db_session, chat_id=chat.id, message_id=msg.id)
+    assert len(entries) == 1
+    t = entries[0]["treatment"]
+    assert t is not None
+
+    # Original PR1 keys still present.
+    assert t["cited_by_count"] == 10
+    assert t["derived_method"] == "citation_graph"
+
+    # New PR2 keys: null/empty for graph-only row.
+    assert t["strongest_negative_class"] is None
+    assert t["judged_count"] is None
+    assert t["judge_as_of"] is None
+    assert t["per_class_counts"] == {}
+    assert t["case_confidence"] is None
+    assert t["signals"] == []

--- a/api/tests/integration/test_treatment_job.py
+++ b/api/tests/integration/test_treatment_job.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
 import pytest
 from sqlalchemy import select
@@ -11,12 +12,28 @@ from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.citation_treatment import CitationTreatment
 from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.user import User
+from app.workers import treatment_worker
 
 pytestmark = pytest.mark.integration
 
 
+class _FastGW:
+    """Stub gateway whose judge-model fetch always returns 'fast' without I/O.
+
+    Injected into the existing graph-only test so no real network call is made
+    after Task 6 adds get_gateway_client() resolution to run_treatment_derivation.
+    """
+
+    async def get_citation_engine_judge_model(self, *, fallback: str = "fast") -> str:
+        return fallback
+
+
 @pytest.mark.asyncio
 async def test_run_treatment_derivation_writes_row_and_links(db_session: AsyncSession, monkeypatch):
+    # Prevent any outbound HTTP attempt after Task 6 wires in get_gateway_client().
+    # The stub returns "fast" (the default) without hitting the network.
+    monkeypatch.setattr(treatment_worker, "get_gateway_client", lambda: _FastGW())
+
     # Seed a turn with a caselaw citation + ledger entry (as in Task 3's fixture).
     user = User(email=f"j-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
     db_session.add(user)
@@ -52,7 +69,7 @@ async def test_run_treatment_derivation_writes_row_and_links(db_session: AsyncSe
     # The job's _run helper takes an injected session + fetch so we can test it without Redis/arq.
     from app.workers.treatment_worker import run_treatment_derivation
 
-    async def fake_fetch(opinion_id: int) -> dict:
+    async def fake_fetch(opinion_id: int) -> dict:  # type: ignore[type-arg]
         return {
             "cited_by_count": 7,
             "citing": [
@@ -76,3 +93,70 @@ async def test_run_treatment_derivation_writes_row_and_links(db_session: AsyncSe
     assert row.cited_by_count == 7
     await db_session.refresh(entry)
     assert entry.treatment_id == row.id
+
+
+@pytest.mark.asyncio
+async def test_run_resolves_gateway_and_passes_it(db_session: AsyncSession, monkeypatch):
+    """When a gateway is injected and its judge-model fetch succeeds, derive is
+    called with that gateway instance and the returned model name."""
+    captured: dict[str, Any] = {}
+
+    async def fake_derive(
+        db: Any,
+        *,
+        message_id: Any,
+        now: Any,
+        fetch_citing: Any = None,
+        gateway: Any = None,
+        judge_model: str = "fast",
+    ) -> int:
+        captured["gateway"] = gateway
+        captured["judge_model"] = judge_model
+        return 0
+
+    monkeypatch.setattr(treatment_worker, "derive_treatment_for_message", fake_derive)
+
+    class GW:
+        async def get_citation_engine_judge_model(self, *, fallback: str = "fast") -> str:
+            return "balanced"
+
+    gw = GW()
+    await treatment_worker.run_treatment_derivation(
+        db_session,
+        message_id=uuid.uuid4(),
+        gateway=gw,  # type: ignore[arg-type]
+    )
+    assert captured["gateway"] is gw
+    assert captured["judge_model"] == "balanced"
+
+
+@pytest.mark.asyncio
+async def test_run_degrades_to_graph_only_on_gateway_failure(db_session: AsyncSession, monkeypatch):
+    """When the gateway's judge-model fetch raises, the worker degrades to
+    graph-only (gateway=None passed to derive)."""
+    captured: dict[str, Any] = {}
+
+    async def fake_derive(
+        db: Any,
+        *,
+        message_id: Any,
+        now: Any,
+        fetch_citing: Any = None,
+        gateway: Any = None,
+        judge_model: str = "fast",
+    ) -> int:
+        captured["gateway"] = gateway
+        return 0
+
+    monkeypatch.setattr(treatment_worker, "derive_treatment_for_message", fake_derive)
+
+    class BadGW:
+        async def get_citation_engine_judge_model(self, *, fallback: str = "fast") -> str:
+            raise RuntimeError("no gateway config")
+
+    await treatment_worker.run_treatment_derivation(
+        db_session,
+        message_id=uuid.uuid4(),
+        gateway=BadGW(),  # type: ignore[arg-type]
+    )
+    assert captured["gateway"] is None  # degraded to graph-only

--- a/api/tests/test_citation_treatment_signal_model.py
+++ b/api/tests/test_citation_treatment_signal_model.py
@@ -1,0 +1,81 @@
+import pytest
+from sqlalchemy import select
+
+from app.models.citation_treatment import CitationTreatment
+from app.models.citation_treatment_signal import CitationTreatmentSignal
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _treatment(db) -> CitationTreatment:
+    t = CitationTreatment(
+        cluster_id=111,
+        opinion_id=222,
+        cited_by_count=5,
+        citing_opinions=[],
+        derived_method="citation_graph+judge",
+        strongest_negative_class="questioned",
+        judged_count=3,
+    )
+    db.add(t)
+    await db.flush()
+    return t
+
+
+async def test_signal_round_trips_and_cascades(db_session) -> None:
+    t = await _treatment(db_session)
+    db_session.add(
+        CitationTreatmentSignal(
+            treatment_id=t.id,
+            citing_opinion_id=5000,
+            classification="questioned",
+            confidence=0.7,
+            justification="The citing court doubted the holding.",
+        )
+    )
+    await db_session.flush()
+    rows = (
+        (
+            await db_session.execute(
+                select(CitationTreatmentSignal).where(CitationTreatmentSignal.treatment_id == t.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1 and rows[0].classification == "questioned"
+    # CASCADE: deleting the parent removes its signals.
+    await db_session.delete(t)
+    await db_session.flush()
+    remaining = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert remaining == []
+
+
+async def test_bad_classification_rejected(db_session) -> None:
+    from sqlalchemy.exc import IntegrityError
+
+    t = await _treatment(db_session)
+    db_session.add(
+        CitationTreatmentSignal(
+            treatment_id=t.id,
+            citing_opinion_id=1,
+            classification="bogus",
+            confidence=0.5,
+            justification="x",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+async def test_parent_allows_graph_plus_judge_method(db_session) -> None:
+    db_session.add(
+        CitationTreatment(
+            cluster_id=9,
+            opinion_id=9,
+            cited_by_count=0,
+            citing_opinions=[],
+            derived_method="citation_graph+judge",
+        )
+    )
+    await db_session.flush()  # must not raise

--- a/api/tests/test_transparency_invariants.py
+++ b/api/tests/test_transparency_invariants.py
@@ -32,6 +32,7 @@ import app
 from app.models.audit import AuditLog
 from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.citation_treatment import CitationTreatment
+from app.models.citation_treatment_signal import CitationTreatmentSignal
 from app.models.inference import InferenceRoutingLog
 from app.models.tool_call_log import ToolCallLog
 from app.models.tool_egress import ToolEgressLog
@@ -55,6 +56,7 @@ _AUDIT_MODELS: tuple[type, ...] = (
     InferenceRoutingLog,
     CitationLedgerEntry,
     CitationTreatment,
+    CitationTreatmentSignal,
     WorkProductFiduciaryGate,
 )
 

--- a/api/tests/test_treatment_judge.py
+++ b/api/tests/test_treatment_judge.py
@@ -1,0 +1,86 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.citation.treatment_judge import (
+    TREATMENT_CLASSES,
+    TreatmentJudgment,
+    build_treatment_judge_prompt,
+    judge_treatment,
+    parse_treatment_response,
+)
+
+
+def _resp(content: str):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+
+def test_prompt_includes_case_and_snippet():
+    msgs = build_treatment_judge_prompt(
+        cited_case_name="Smith v. Jones", snippet="We overrule Smith."
+    )
+    assert msgs[0].role == "system" and msgs[1].role == "user"
+    assert "Smith v. Jones" in msgs[1].content and "We overrule Smith." in msgs[1].content
+
+
+@pytest.mark.parametrize("cls", TREATMENT_CLASSES)
+def test_parse_accepts_every_class(cls):
+    out = parse_treatment_response(
+        _resp(json.dumps({"treatment": cls, "confidence": "high", "justification": "x"}))
+    )
+    assert out == TreatmentJudgment(classification=cls, confidence=0.90, justification="x")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "not json",
+        json.dumps({"treatment": "bogus", "confidence": "high", "justification": "x"}),
+        json.dumps({"treatment": "overruled", "confidence": "??", "justification": "x"}),
+        json.dumps({"confidence": "high", "justification": "x"}),  # missing treatment
+        json.dumps(["overruled"]),  # not a dict
+        "",
+    ],
+)
+def test_parse_returns_none_on_garbage(bad):
+    assert parse_treatment_response(_resp(bad)) is None
+
+
+def test_parse_none_on_no_choices():
+    assert parse_treatment_response(SimpleNamespace(choices=[])) is None
+
+
+@pytest.mark.asyncio
+async def test_judge_treatment_swallows_gateway_error():
+    class Boom:
+        async def chat_completion(self, request, *, request_id=None):
+            raise RuntimeError("down")
+
+    assert (
+        await judge_treatment(cited_case_name="X", snippet="y", gateway=Boom(), judge_model="fast")
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_judge_treatment_tags_purpose_and_parses():
+    seen = {}
+
+    class GW:
+        async def chat_completion(self, request, *, request_id=None):
+            seen["purpose"] = request.lq_ai_purpose
+            seen["anonymize"] = request.anonymize
+            return _resp(
+                json.dumps(
+                    {
+                        "treatment": "questioned",
+                        "confidence": "medium",
+                        "justification": "doubted it",
+                    }
+                )
+            )
+
+    out = await judge_treatment(cited_case_name="X", snippet="y", gateway=GW(), judge_model="fast")
+    assert out == TreatmentJudgment("questioned", 0.70, "doubted it")
+    assert seen["purpose"] == "judge_treatment" and seen["anonymize"] is False

--- a/api/tests/test_treatment_judge.py
+++ b/api/tests/test_treatment_judge.py
@@ -41,6 +41,10 @@ def test_parse_accepts_every_class(cls):
         json.dumps({"confidence": "high", "justification": "x"}),  # missing treatment
         json.dumps(["overruled"]),  # not a dict
         "",
+        json.dumps(
+            {"treatment": "followed", "confidence": "high", "justification": "   "}
+        ),  # whitespace-only
+        json.dumps({"treatment": "followed", "confidence": "high"}),  # missing justification
     ],
 )
 def test_parse_returns_none_on_garbage(bad):
@@ -71,6 +75,8 @@ async def test_judge_treatment_tags_purpose_and_parses():
         async def chat_completion(self, request, *, request_id=None):
             seen["purpose"] = request.lq_ai_purpose
             seen["anonymize"] = request.anonymize
+            seen["temperature"] = request.temperature
+            seen["max_tokens"] = request.max_tokens
             return _resp(
                 json.dumps(
                     {
@@ -84,3 +90,5 @@ async def test_judge_treatment_tags_purpose_and_parses():
     out = await judge_treatment(cited_case_name="X", snippet="y", gateway=GW(), judge_model="fast")
     assert out == TreatmentJudgment("questioned", 0.70, "doubted it")
     assert seen["purpose"] == "judge_treatment" and seen["anonymize"] is False
+    assert seen["temperature"] == 0.0
+    assert seen["max_tokens"] == 400

--- a/api/tests/test_treatment_rollup.py
+++ b/api/tests/test_treatment_rollup.py
@@ -1,0 +1,55 @@
+from app.citation.treatment_judge import TreatmentJudgment
+from app.citation.treatment_rollup import NEGATIVE_SEVERITY, Rollup, roll_up
+
+
+def _j(cls, conf=0.7):
+    return TreatmentJudgment(classification=cls, confidence=conf, justification="x")
+
+
+def test_severity_order_is_fixed():
+    assert NEGATIVE_SEVERITY == (
+        "overruled",
+        "superseded",
+        "criticized",
+        "questioned",
+        "distinguished",
+    )
+
+
+def test_empty():
+    r = roll_up([])
+    assert r == Rollup(None, {}, None, 0)
+
+
+def test_all_non_negative_has_no_strongest():
+    r = roll_up([_j("followed"), _j("neutral"), _j("followed")])
+    assert r.strongest_negative_class is None
+    assert r.case_confidence is None
+    assert r.per_class_counts == {"followed": 2, "neutral": 1}
+    assert r.judged_count == 3
+
+
+def test_picks_most_severe_negative():
+    r = roll_up([_j("distinguished"), _j("questioned"), _j("overruled"), _j("followed")])
+    assert r.strongest_negative_class == "overruled"
+    assert r.per_class_counts["distinguished"] == 1
+
+
+def test_corroboration_bumps_confidence():
+    # two "questioned" @0.70 → 0.70 + 0.05*(2-1) = 0.75
+    r = roll_up([_j("questioned", 0.70), _j("questioned", 0.70), _j("followed")])
+    assert r.strongest_negative_class == "questioned"
+    assert abs(r.case_confidence - 0.75) < 1e-9
+
+
+def test_confidence_capped():
+    sig = [_j("criticized", 0.90)] * 6  # 0.90 + 0.05*5 = 1.15 → cap 0.95
+    r = roll_up(sig)
+    assert abs(r.case_confidence - 0.95) < 1e-9
+
+
+def test_confidence_uses_strongest_class_only():
+    # strongest = overruled (one @0.50); the questioned ones don't corroborate it
+    r = roll_up([_j("overruled", 0.50), _j("questioned", 0.90), _j("questioned", 0.90)])
+    assert r.strongest_negative_class == "overruled"
+    assert abs(r.case_confidence - 0.50) < 1e-9

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4839,6 +4839,21 @@ So the single longest phase (image pull) has neither a stream nor a poll. The re
 
 **When to ship:** Within WS-G (Phase 2), before the milestone closes — alongside DE-363 or PR2. Filed (not fixed) in PR1 to keep the security-gated slice scoped; the degradation is non-crashing and DE-363-recoverable in the interim.
 
+#### DE-365 — Launch-documentation pass: fiduciary-grade positioning + transparent-by-evidence comparison
+
+**Priority:** P2 · **Effort:** L · **Status: OPEN (end of Phase 2 / pre-launch)**
+
+**Context:** LQ.AI is plausibly one of the first **fiduciary-evidence-level** legal-tech products — and uniquely, it is **open source, open-telemetry, and self-hosted**, with educational transparency visualizations. The incumbents (Thomson Reuters / Westlaw / CoCounsel) have announced a fiduciary-grade legal-research direction but, per their public statements, are **not launching until later summer 2026**. The end-of-phase documentation does not yet convey the magnitude of what the project gives away for free, nor position it honestly against that announced-but-unshipped competition. Surfaced by the maintainer (2026-06-26).
+
+**Specific scope:**
+1. **Refresh README + docs** and add **clear transparency visualizations** that show how each core principle (derive-don't-assert, the Citation Ledger, the fiduciary-grade gate, governed gateway egress, P3 no-raw-payload, OpenTelemetry tracing, the validity/treatment layer) delivers transparent, auditable results "at every turn."
+2. **Pull the public TR/Westlaw/CoCounsel fiduciary-grade press release/announcement**, enumerate every promised feature/capability, and build an **honest feature-comparison chart**. Each LQ.AI "✓" must **link to the artifact that proves it** — the ADR, the code path, the test, or the live trace — so the comparison is *evidence-backed, not asserted* (a clickable audit trail cannot be FUD-ed; the transparency IS the proof).
+3. Frame the inspiration honestly (their announced direction inspired this) while making the defensible, demonstrable claim: massively-funded teams have **not** shipped this level of transparency, and LQ.AI delivers it transparently, open-source, now.
+
+**Constraint:** the conservative-engineering posture (CLAUDE.md principle 4 — never overclaim) binds every comparison claim: honest and unflinching, never hype. Where a capability is partial or roadmapped, say so. The standard for an LQ.AI "✓" is "demonstrable by an in-house lawyer on real documents," tied to a linkable artifact.
+
+**When to ship:** End of Phase 2 / pre-launch, after the fiduciary-grade workstreams (WS-G/D/E) have landed the capabilities the chart will claim. Relates to the [PR6 transparency-posture narration obligation](#13-transparency-as-a-founding-principle) (narrate the *why*, not just the mechanics).
+
 ---
 
 ## 10. Appendices

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4854,6 +4854,26 @@ So the single longest phase (image pull) has neither a stream nor a poll. The re
 
 **When to ship:** End of Phase 2 / pre-launch, after the fiduciary-grade workstreams (WS-G/D/E) have landed the capabilities the chart will claim. Relates to the [PR6 transparency-posture narration obligation](#13-transparency-as-a-founding-principle) (narrate the *why*, not just the mechanics).
 
+#### DE-366 — Treatment worker short-circuits the judge pass when no gateway is reachable
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** Surfaced by the WS-G PR2 Opus whole-branch review. `run_treatment_derivation` (`api/app/workers/treatment_worker.py`) resolves a `GatewayClient` via `get_gateway_client()` (which always returns a client — defaults present, `__init__` never raises) and then `get_citation_engine_judge_model()` (which catches all failures and returns its fallback rather than raising). So when the treatment worker runs against an **unconfigured or unreachable** gateway, `derive_gateway` is never set to `None` from the worker, and the judge pass is attempted: up to `n_judged_cap` per-cluster `chat_completion` calls are made and each fails+is swallowed → graph-only result. The **result data is correct** (graph-only, identical to PR1), so this is a latency / log-noise regression only — where PR1 made zero gateway calls, PR2 makes (and swallows) up to N failed connection attempts per cited case before degrading.
+
+**Specific scope:** Have the worker detect an unreachable/unconfigured gateway once (e.g. a cheap reachability/config probe, or treat a `get_citation_engine_judge_model` that returned the *fallback due to failure* as "no judge available") and pass `gateway=None` so `derive_treatment_for_message` short-circuits to graph-only without per-passage attempts. Keep the safe-degrade data outcome identical; only avoid the wasted calls.
+
+**When to ship:** Opportunistic; before the treatment worker is run at scale against operators who have not configured a gateway judge model.
+
+#### DE-367 — Materialize the treatment per-class rollup to avoid stored-vs-recomputed divergence
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** Surfaced by the WS-G PR2 reviews. The `/ledger` read (`api/app/citation/ledger.py`) exposes the stored parent column `citation_treatment.judged_count` alongside `per_class_counts` / `case_confidence`, which are **recomputed at read time** via `roll_up` over the current `citation_treatment_signal` rows. Today they always agree (the derivation writes `judged_count` and the signals atomically, and every refresh clears the child rows — DE-366's sibling fix in PR2), so there is no divergence. But a **future partial re-judge** that appended or removed signals without rewriting `judged_count` would desync the stored count from the recomputed per-class totals.
+
+**Specific scope:** When the partial-re-judge / incremental-refresh feature is designed, either (a) always update `judged_count` atomically with any signal write, or (b) drop the stored `judged_count` column and compute it at read time from the signals (single source of truth). Until then the current implementation is internally consistent.
+
+**When to ship:** Alongside any future incremental/partial treatment re-judge work.
+
 ---
 
 ## 10. Appendices

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4633,7 +4633,9 @@ No code change — the runtime already returns these with the correct typed `cod
 
 **Specific scope:** Add a per-provider external-tool cost model (e.g. a configured cost-per-call or cost-per-unit on the gateway `tool_providers` / `mcp.yaml` entry, or a rolling-average like the inference estimator) so `estimate_tool_cost` returns a real projection for `retrieve_caselaw` / `call_mcp_tool` and the R4 brake throttles expensive external tools. Record the realized cost on the `tool_call_log` row.
 
-**When to ship:** Before the autonomous layer (or chat) is pointed at a metered/paid third-party tool provider.
+**When to ship:** Before the autonomous layer (or chat) is pointed at a metered/paid third-party tool provider. **Landing point: WS-G PR2's per-case judge budget (the chat path's first real cost bound).** Its **trigger** is WS-E (content-source registry + free-source expansion), which introduces the first metered/paid sources and so satisfies this "when to ship" condition by construction.
+
+**Status (2026-06-26):** Partially addressed. WS-G PR2 (the treatment-classifying judge) shipped the **per-case judge budget** — a real, enforced USD cost bound on the treatment judge fan-out — as the milestone's first concrete external-work cost control (ADR 0019 D10). PR2 did **not** wire the autonomous-path `estimate_tool_cost`/R4 piece: the treatment judge runs in a background arq derivation job, not through the autonomous `guarded_tool_call` chokepoint, and `get_citing_opinions` is not a `ToolIntent` — so routing it through R4 would be incorrect, not merely deferred. Nothing metered ships before WS-E (CourtListener is free-tier/BYO-key today), so no spend escapes R4 in the interim. The remaining scope — a real per-provider `estimate_tool_cost` for `retrieve_caselaw` / `call_mcp_tool` + realized-cost recording on `tool_call_log` — lands in **WS-E**, on its first metered source.
 
 #### DE-345 — Extract a shared `_stream_loop_outcome` renderer for the chat tool-loop
 

--- a/docs/superpowers/plans/2026-06-26-wsg-pr2-treatment-judge.md
+++ b/docs/superpowers/plans/2026-06-26-wsg-pr2-treatment-judge.md
@@ -1,0 +1,1294 @@
+# WS-G PR2 — Treatment-Classifying Judge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Classify how each citing opinion treats a cited case (`followed/distinguished/criticized/questioned/overruled/superseded/neutral`) over a recency-capped, budget-bounded subset, and roll the per-passage classifications up to a strongest-negative case-level signal on `citation_treatment`.
+
+**Architecture:** Extends WS-G PR1's async `treatment_derivation_job` with a judge pass. A new treatment judge (new prompt + verdict schema over the existing judge rails) classifies CourtListener `snippet`s; results land in a new `citation_treatment_signal` child table + rollup columns on the parent. The raw snippet is transient judge input — never persisted (P3). Treatment never gates the fiduciary verdict.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2 (async), Alembic, arq, pytest, ruff, mypy. Gateway: CourtListener provider adapter.
+
+## Global Constraints
+
+- **Security-gated** (`gateway/**`, `api/app/citation/**`): Kevin/security merges; mirror `origin/main → tucuxi` after. Claude does NOT self-merge.
+- **Next migration = `0062`** (revises `0061`). **Next DE = DE-365.**
+- **Derive-don't-assert (ADR 0019 D1):** no "good/bad law" verdict; rollup surfaces strongest-negative + counts + per-signal links/confidence/reasoning, labeled "derived as of <date>."
+- **P3 (ADR 0016):** `citation_treatment_signal` stores derived classification + confidence + judge justification + refs ONLY. **Never the raw snippet or opinion text.** Add the child model to the `_AUDIT_MODELS` tripwire in the same PR.
+- **Strictly additive:** worker without gateway/judge-model config → graph-only (byte-identical to PR1). No gateway / no judge model / no snippet → PR1 row stands.
+- **Treatment never gates the turn** (ADR 0018 D3 / 0019 D2): no change to `gate.py` or the fiduciary verdict.
+- **Conservative judge calibration:** on uncertainty between a negative class and `neutral`, prefer `neutral` (a false negative-treatment flag is the worse error).
+- **DE-344 scope for PR2 (pinned to WS-E, maintainer-confirmed 2026-06-26):** the **per-case judge budget** is PR2's cost bound (ships + bites in the worker) — the milestone's first real external-work cost control. The autonomous-layer `estimate_tool_cost`/R4 wiring (`api/app/autonomous/cost.py`, keyed by `ToolIntent` — `get_citing_opinions` is not an autonomous intent and the worker bypasses R4) is **explicitly scheduled to land in WS-E**, whose first metered source is DE-344's own "when-to-ship" trigger. Update the DE-344 PRD entry to record this (per the Final-gate bookkeeping step). PR2 does not contort R4.
+- **Tests:** host venv + throwaway pgvector `lqai-test-pg` on `:55432`, `DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test` (conftest auto-migrates). Mocked gateway/fetch → no `-m provider`.
+- **CI gate (LESSON):** run, repo-wide: api `mypy app` (whole-app) + `ruff format --check api` + `ruff check api`; gateway `mypy app --strict` + `ruff format --check gateway` + `ruff check gateway`; both full suites. Per-file checks miss whole-app mypy + unformatted test files.
+- Commits: `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## Canonical constants (use verbatim across tasks)
+
+```python
+# Treatment taxonomy (ADR 0019 D5)
+TREATMENT_CLASSES = (
+    "followed", "distinguished", "criticized",
+    "questioned", "overruled", "superseded", "neutral",
+)
+# Negative classes, STRONGEST FIRST (index 0 = most severe).
+NEGATIVE_SEVERITY = ("overruled", "superseded", "criticized", "questioned", "distinguished")
+# Non-negative classes (never a "strongest negative"): "followed", "neutral".
+
+N_JUDGED_CAP = 10                              # top-N most-recent citing opinions judged
+TREATMENT_JUDGE_BUDGET_USD = Decimal("0.25")   # per-cited-case hard cap (B1b-style pre-flight)
+_TREATMENT_PURPOSE = "judge_treatment"         # cost-calibration + routing-log tag
+CORROBORATION_BUMP = 0.05                       # per additional agreeing passage
+CONFIDENCE_CAP = 0.95                           # rollup confidence ceiling
+```
+
+## File structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `gateway/app/providers/tool/courtlistener.py` | add `snippet` to each citing result | 1 |
+| `gateway/tests/test_courtlistener_adapter.py` | snippet present/absent tests | 1 |
+| `api/app/models/citation_treatment_signal.py` | NEW child model | 2 |
+| `api/app/models/citation_treatment.py` | add rollup cols + relax CHECK | 2 |
+| `api/alembic/versions/0062_citation_treatment_signal.py` | NEW migration | 2 |
+| `api/tests/test_transparency_invariants.py` | add child to `_AUDIT_MODELS` | 2 |
+| `api/app/citation/treatment_judge.py` | NEW: prompt + parser + judge + cost + `TreatmentJudgment` | 3 |
+| `api/app/citation/treatment_rollup.py` | NEW: pure `roll_up` | 4 |
+| `api/app/citation/treatment.py` | judge pass in `derive_treatment_for_message` | 5 |
+| `api/app/workers/treatment_worker.py` | thread gateway + judge_model; graph-only degrade | 6 |
+| `api/app/citation/ledger.py` | expose rollup + signals on `/ledger` read | 7 |
+
+---
+
+### Task 1: Gateway — return the citing `snippet`
+
+**Files:**
+- Modify: `gateway/app/providers/tool/courtlistener.py:319-329` (`_get_citing_opinions`)
+- Test: `gateway/tests/test_courtlistener_adapter.py`
+
+**Interfaces:**
+- Produces: each item in `payload["citing"]` gains `"snippet": str | None` (CourtListener's per-result highlighted excerpt; `None` when absent). Other ref fields unchanged.
+
+- [ ] **Step 1: Write the failing test** (append to `test_courtlistener_adapter.py`)
+
+```python
+@pytest.mark.unit
+async def test_get_citing_opinions_includes_snippet(monkeypatch) -> None:
+    adapter = _adapter(monkeypatch)
+    results = [
+        {
+            "cluster_id": 1000,
+            "caseName": "Citing Case",
+            "court": "ca9",
+            "dateFiled": "2021-05-01",
+            "opinions": [{"id": 5000, "snippet": "We decline to follow Smith v. Jones."}],
+        },
+        {  # no snippet anywhere → None, never raises
+            "cluster_id": 1001,
+            "caseName": "Quiet Case",
+            "court": "ca2",
+            "dateFiled": "2021-04-01",
+            "opinions": [{"id": 5001}],
+        },
+    ]
+    with respx.mock:
+        respx.get(f"{BASE}/search/").mock(
+            return_value=httpx.Response(200, json={"count": 2, "results": results, "next": None})
+        )
+        try:
+            result = await adapter.invoke_tool(
+                "get_citing_opinions", {"opinion_id": 42}, request_id="r"
+            )
+        finally:
+            await adapter.aclose()
+    citing = result.payload["citing"]
+    assert citing[0]["snippet"] == "We decline to follow Smith v. Jones."
+    assert citing[1]["snippet"] is None
+    assert "snippet" in set(citing[0])
+```
+
+> NOTE: CourtListener returns the opinion `snippet` inside each `result["opinions"][i]`. Verify the exact field against a live fixture during implementation; if upstream places it at the result top level instead, read `r.get("snippet")` as the fallback. The test above asserts the contract; adjust only the extraction expression, not the contract.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd gateway && python -m pytest tests/test_courtlistener_adapter.py::test_get_citing_opinions_includes_snippet -v`
+Expected: FAIL — `KeyError: 'snippet'`.
+
+- [ ] **Step 3: Implement** — in `_get_citing_opinions`, extend the comprehension:
+
+```python
+        citing = [
+            {
+                "cluster_id": r.get("cluster_id"),
+                "opinion_id": (r.get("opinions") or [{}])[0].get("id"),
+                "case_name": r.get("caseName"),
+                "court": r.get("court"),
+                "date_filed": r.get("dateFiled"),
+                # WS-G PR2: the highlighted excerpt around the citing match.
+                # Transient treatment-judge input — NEVER persisted (P3).
+                "snippet": (r.get("opinions") or [{}])[0].get("snippet") or r.get("snippet"),
+            }
+            for r in (data.get("results") or [])[:_CITING_TOP_N]
+        ]
+```
+
+- [ ] **Step 4: Update the existing shape test.** In `test_get_citing_opinions_shapes_count_and_capped_list`, change the field-set assertion:
+
+```python
+    assert set(payload["citing"][0]) == {
+        "cluster_id", "opinion_id", "case_name", "court", "date_filed", "snippet",
+    }
+```
+
+- [ ] **Step 5: Run the adapter tests**
+
+Run: `cd gateway && python -m pytest tests/test_courtlistener_adapter.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gateway/app/providers/tool/courtlistener.py gateway/tests/test_courtlistener_adapter.py
+git commit -s -m "feat(gateway): return citing snippet from get_citing_opinions (WS-G PR2)"
+```
+
+---
+
+### Task 2: Schema — `citation_treatment_signal` child + parent rollup columns + migration 0062 + P3 tripwire
+
+**Files:**
+- Create: `api/app/models/citation_treatment_signal.py`
+- Modify: `api/app/models/citation_treatment.py:26-33` (`__table_args__`) + add 3 columns
+- Create: `api/alembic/versions/0062_citation_treatment_signal.py`
+- Modify: `api/tests/test_transparency_invariants.py` (`_AUDIT_MODELS`)
+- Test: `api/tests/test_citation_treatment_signal_model.py` (new)
+
+**Interfaces:**
+- Produces:
+  - `CitationTreatmentSignal(id, treatment_id, citing_opinion_id, classification, confidence, justification, created_at)`; unique `(treatment_id, citing_opinion_id)`; `classification` CHECK ∈ `TREATMENT_CLASSES`; FK `ON DELETE CASCADE`.
+  - `CitationTreatment` gains `strongest_negative_class: str | None`, `judged_count: int | None`, `judge_as_of: datetime | None`; `derived_method` CHECK now ∈ `('citation_graph', 'citation_graph+judge')`.
+
+- [ ] **Step 1: Write the failing model test** (`api/tests/test_citation_treatment_signal_model.py`)
+
+```python
+import uuid
+import pytest
+from sqlalchemy import select
+from app.models.citation_treatment import CitationTreatment
+from app.models.citation_treatment_signal import CitationTreatmentSignal
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _treatment(db) -> CitationTreatment:
+    t = CitationTreatment(
+        cluster_id=111, opinion_id=222, cited_by_count=5,
+        citing_opinions=[], derived_method="citation_graph+judge",
+        strongest_negative_class="questioned", judged_count=3,
+    )
+    db.add(t)
+    await db.flush()
+    return t
+
+
+async def test_signal_round_trips_and_cascades(db_session) -> None:
+    t = await _treatment(db_session)
+    db_session.add(CitationTreatmentSignal(
+        treatment_id=t.id, citing_opinion_id=5000,
+        classification="questioned", confidence=0.7,
+        justification="The citing court doubted the holding.",
+    ))
+    await db_session.flush()
+    rows = (await db_session.execute(
+        select(CitationTreatmentSignal).where(CitationTreatmentSignal.treatment_id == t.id)
+    )).scalars().all()
+    assert len(rows) == 1 and rows[0].classification == "questioned"
+    # CASCADE: deleting the parent removes its signals.
+    await db_session.delete(t)
+    await db_session.flush()
+    remaining = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert remaining == []
+
+
+async def test_bad_classification_rejected(db_session) -> None:
+    from sqlalchemy.exc import IntegrityError
+    t = await _treatment(db_session)
+    db_session.add(CitationTreatmentSignal(
+        treatment_id=t.id, citing_opinion_id=1, classification="bogus", confidence=0.5,
+        justification="x",
+    ))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+async def test_parent_allows_graph_plus_judge_method(db_session) -> None:
+    db_session.add(CitationTreatment(
+        cluster_id=9, opinion_id=9, cited_by_count=0, citing_opinions=[],
+        derived_method="citation_graph+judge",
+    ))
+    await db_session.flush()  # must not raise
+```
+
+> Use the project's existing `db_session` fixture (the throwaway-pgvector session). If the fixture name differs, match the one used in `api/tests/test_citation_treatment_model.py`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test python -m pytest tests/test_citation_treatment_signal_model.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.models.citation_treatment_signal`.
+
+- [ ] **Step 3: Create the child model** (`api/app/models/citation_treatment_signal.py`)
+
+```python
+"""citation_treatment_signal — one judged citing passage's treatment (WS-G PR2).
+
+One row per citing opinion the treatment judge classified for a cited case.
+Stores the DERIVED classification + confidence + the judge's short
+justification (our reasoning) + the citing opinion ref — NEVER the raw
+snippet or opinion text (ADR 0016 P3 / ADR 0019 D7). Joins the P3 tripwire.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, CheckConstraint, DateTime, Float, ForeignKey, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+_CLASS_LIST = "'followed','distinguished','criticized','questioned','overruled','superseded','neutral'"
+
+
+class CitationTreatmentSignal(Base):
+    __tablename__ = "citation_treatment_signal"
+    __table_args__ = (
+        UniqueConstraint(
+            "treatment_id", "citing_opinion_id",
+            name="uq_treatment_signal_treatment_citing",
+        ),
+        CheckConstraint(
+            f"classification IN ({_CLASS_LIST})",
+            name="chk_treatment_signal_classification",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    treatment_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("citation_treatment.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    citing_opinion_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    classification: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    justification: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+```
+
+- [ ] **Step 4: Add parent columns + relax CHECK** (`api/app/models/citation_treatment.py`)
+
+In `__table_args__`, replace the `derived_method` CHECK:
+
+```python
+        CheckConstraint(
+            "derived_method IN ('citation_graph', 'citation_graph+judge')",
+            name="chk_citation_treatment_method_values",
+        ),
+        CheckConstraint(
+            "strongest_negative_class IS NULL OR strongest_negative_class IN "
+            "('overruled','superseded','criticized','questioned','distinguished')",
+            name="chk_citation_treatment_strongest_negative",
+        ),
+```
+
+Add three columns after `derived_method`:
+
+```python
+    strongest_negative_class: Mapped[str | None] = mapped_column(Text, nullable=True)
+    judged_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    judge_as_of: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+```
+
+- [ ] **Step 5: Create migration 0062** (`api/alembic/versions/0062_citation_treatment_signal.py`)
+
+```python
+"""citation_treatment_signal + parent rollup columns (WS-G PR2 treatment judge)
+
+Revision ID: 0062
+Revises: 0061
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0062"
+down_revision: str | None = "0061"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CLASSES = "'followed','distinguished','criticized','questioned','overruled','superseded','neutral'"
+_NEGATIVE = "'overruled','superseded','criticized','questioned','distinguished'"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "citation_treatment_signal",
+        sa.Column("id", postgresql.UUID(as_uuid=True),
+                  server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("treatment_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("citing_opinion_id", sa.BigInteger(), nullable=False),
+        sa.Column("classification", sa.Text(), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("justification", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["treatment_id"], ["citation_treatment.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("treatment_id", "citing_opinion_id",
+                            name="uq_treatment_signal_treatment_citing"),
+        sa.CheckConstraint(f"classification IN ({_CLASSES})",
+                           name="chk_treatment_signal_classification"),
+    )
+    op.create_index("ix_treatment_signal_treatment_id", "citation_treatment_signal", ["treatment_id"])
+
+    op.add_column("citation_treatment", sa.Column("strongest_negative_class", sa.Text(), nullable=True))
+    op.add_column("citation_treatment", sa.Column("judged_count", sa.Integer(), nullable=True))
+    op.add_column("citation_treatment", sa.Column("judge_as_of", sa.DateTime(timezone=True), nullable=True))
+
+    op.drop_constraint("chk_citation_treatment_method_values", "citation_treatment", type_="check")
+    op.create_check_constraint(
+        "chk_citation_treatment_method_values", "citation_treatment",
+        "derived_method IN ('citation_graph', 'citation_graph+judge')",
+    )
+    op.create_check_constraint(
+        "chk_citation_treatment_strongest_negative", "citation_treatment",
+        f"strongest_negative_class IS NULL OR strongest_negative_class IN ({_NEGATIVE})",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("chk_citation_treatment_strongest_negative", "citation_treatment", type_="check")
+    op.drop_constraint("chk_citation_treatment_method_values", "citation_treatment", type_="check")
+    op.create_check_constraint(
+        "chk_citation_treatment_method_values", "citation_treatment",
+        "derived_method IN ('citation_graph')",
+    )
+    op.drop_column("citation_treatment", "judge_as_of")
+    op.drop_column("citation_treatment", "judged_count")
+    op.drop_column("citation_treatment", "strongest_negative_class")
+    op.drop_index("ix_treatment_signal_treatment_id", table_name="citation_treatment_signal")
+    op.drop_table("citation_treatment_signal")
+```
+
+- [ ] **Step 6: Add the child model to the P3 tripwire** (`api/tests/test_transparency_invariants.py`)
+
+Add the import and extend `_AUDIT_MODELS`:
+
+```python
+from app.models.citation_treatment_signal import CitationTreatmentSignal
+# ... in _AUDIT_MODELS tuple, add:
+    CitationTreatmentSignal,
+```
+
+- [ ] **Step 7: Register the model + run.** Ensure `CitationTreatmentSignal` is imported wherever models are collected for metadata (mirror how `CitationTreatment` is imported in `app/models/__init__.py` if such a file exists; otherwise the alembic env / conftest import path used by `0061`).
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test python -m pytest tests/test_citation_treatment_signal_model.py tests/test_transparency_invariants.py -v`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/app/models/citation_treatment_signal.py api/app/models/citation_treatment.py \
+        api/alembic/versions/0062_citation_treatment_signal.py \
+        api/tests/test_transparency_invariants.py api/tests/test_citation_treatment_signal_model.py \
+        api/app/models/__init__.py
+git commit -s -m "feat(db): citation_treatment_signal child + rollup columns, mig 0062 (WS-G PR2)"
+```
+
+---
+
+### Task 3: API — the treatment judge (`treatment_judge.py`)
+
+**Files:**
+- Create: `api/app/citation/treatment_judge.py`
+- Test: `api/tests/test_treatment_judge.py`
+
+**Interfaces:**
+- Consumes: `build_judge_prompt` is NOT reused (new prompt); reuses `_JudgeGatewayProtocol`, `estimate_judge_call_cost_usd`, `_CONFIDENCE_MAP`, `ChatCompletionRequest`/`ChatCompletionMessage`.
+- Produces:
+  - `@dataclass TreatmentJudgment(classification: str, confidence: float, justification: str)`
+  - `build_treatment_judge_prompt(*, cited_case_name: str, snippet: str) -> list[ChatCompletionMessage]`
+  - `parse_treatment_response(response: Any) -> TreatmentJudgment | None`
+  - `async judge_treatment(*, cited_case_name: str, snippet: str, gateway: _JudgeGatewayProtocol, judge_model: str) -> TreatmentJudgment | None`
+  - `async estimate_treatment_cost_usd(db, *, judge_model: str) -> Decimal`
+  - `TREATMENT_CLASSES`, `_TREATMENT_PURPOSE`
+
+- [ ] **Step 1: Write failing tests** (`api/tests/test_treatment_judge.py`)
+
+```python
+import json
+import pytest
+from types import SimpleNamespace
+from app.citation.treatment_judge import (
+    TreatmentJudgment, build_treatment_judge_prompt, parse_treatment_response,
+    judge_treatment, TREATMENT_CLASSES,
+)
+
+
+def _resp(content: str):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+
+def test_prompt_includes_case_and_snippet():
+    msgs = build_treatment_judge_prompt(cited_case_name="Smith v. Jones", snippet="We overrule Smith.")
+    assert msgs[0].role == "system" and msgs[1].role == "user"
+    assert "Smith v. Jones" in msgs[1].content and "We overrule Smith." in msgs[1].content
+
+
+@pytest.mark.parametrize("cls", TREATMENT_CLASSES)
+def test_parse_accepts_every_class(cls):
+    out = parse_treatment_response(_resp(json.dumps(
+        {"treatment": cls, "confidence": "high", "justification": "x"})))
+    assert out == TreatmentJudgment(classification=cls, confidence=0.90, justification="x")
+
+
+@pytest.mark.parametrize("bad", [
+    "not json", json.dumps({"treatment": "bogus", "confidence": "high", "justification": "x"}),
+    json.dumps({"treatment": "overruled", "confidence": "??", "justification": "x"}),
+    json.dumps({"confidence": "high", "justification": "x"}),       # missing treatment
+    json.dumps(["overruled"]),                                       # not a dict
+    "",
+])
+def test_parse_returns_none_on_garbage(bad):
+    assert parse_treatment_response(_resp(bad)) is None
+
+
+def test_parse_none_on_no_choices():
+    assert parse_treatment_response(SimpleNamespace(choices=[])) is None
+
+
+@pytest.mark.asyncio
+async def test_judge_treatment_swallows_gateway_error():
+    class Boom:
+        async def chat_completion(self, request, *, request_id=None):
+            raise RuntimeError("down")
+    assert await judge_treatment(
+        cited_case_name="X", snippet="y", gateway=Boom(), judge_model="fast") is None
+
+
+@pytest.mark.asyncio
+async def test_judge_treatment_tags_purpose_and_parses():
+    seen = {}
+    class GW:
+        async def chat_completion(self, request, *, request_id=None):
+            seen["purpose"] = request.lq_ai_purpose
+            seen["anonymize"] = request.anonymize
+            return _resp(json.dumps({"treatment": "questioned", "confidence": "medium",
+                                     "justification": "doubted it"}))
+    out = await judge_treatment(cited_case_name="X", snippet="y", gateway=GW(), judge_model="fast")
+    assert out == TreatmentJudgment("questioned", 0.70, "doubted it")
+    assert seen["purpose"] == "judge_treatment" and seen["anonymize"] is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd api && python -m pytest tests/test_treatment_judge.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** (`api/app/citation/treatment_judge.py`)
+
+```python
+"""Treatment-classifying judge over a citing snippet (WS-G PR2).
+
+A NEW judge prompt + verdict schema (the cascade judge speaks yes/partial/no;
+this speaks the 7-class treatment taxonomy). Reuses the judge RAILS only:
+the gateway protocol, the cost estimator, the _CONFIDENCE_MAP scale, and the
+parse-or-skip discipline. The snippet is transient input — never persisted (P3).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.cost import estimate_judge_call_cost_usd
+from app.citation.verification import _CONFIDENCE_MAP, _JudgeGatewayProtocol
+from app.schemas.gateway import ChatCompletionMessage, ChatCompletionRequest
+
+log = logging.getLogger(__name__)
+
+TREATMENT_CLASSES = (
+    "followed", "distinguished", "criticized",
+    "questioned", "overruled", "superseded", "neutral",
+)
+_TREATMENT_PURPOSE = "judge_treatment"
+
+_SYSTEM_PROMPT = """\
+You are a Legal Treatment Classifier for a legal AI assistant.
+
+You are given the NAME of a CITED case and a SNIPPET from a LATER opinion
+that cites it. Classify how the later opinion TREATS the cited case, using
+EXACTLY ONE of these labels:
+
+* "overruled"    — the later court overrules/abrogates the cited case.
+* "superseded"   — the cited case is superseded (e.g., by statute/rule).
+* "criticized"   — the later court criticizes the cited case's reasoning.
+* "questioned"   — the later court doubts/questions the cited case.
+* "distinguished"— the later court distinguishes the cited case on its facts.
+* "followed"     — the later court follows/applies the cited case favorably.
+* "neutral"      — a bare citation with no discernible treatment signal.
+
+Respond with STRICTLY VALID JSON in this exact shape:
+
+  {"treatment": "<one label above>",
+   "confidence": "high" | "medium" | "low",
+   "justification": "<one or two sentences; DESCRIBE the treatment in your
+                      own words — do NOT quote the opinion text>"}
+
+CALIBRATION — IMPORTANT. When uncertain between a negative label
+(overruled/superseded/criticized/questioned/distinguished) and "neutral",
+choose "neutral". A false negative-treatment flag is worse than a missed
+one. Only assert a negative label when the snippet clearly supports it.
+
+Output ONLY the JSON object. No preamble, no markdown fencing."""
+
+
+@dataclass(slots=True)
+class TreatmentJudgment:
+    classification: str
+    confidence: float
+    justification: str
+
+
+def build_treatment_judge_prompt(*, cited_case_name: str, snippet: str) -> list[ChatCompletionMessage]:
+    user = (
+        f"CITED CASE:\n\"\"\"\n{cited_case_name}\n\"\"\"\n\n"
+        f"SNIPPET FROM THE LATER (CITING) OPINION:\n\"\"\"\n{snippet}\n\"\"\"\n\n"
+        "How does the later opinion treat the CITED CASE? Respond with the JSON object only."
+    )
+    return [
+        ChatCompletionMessage(role="system", content=_SYSTEM_PROMPT),
+        ChatCompletionMessage(role="user", content=user),
+    ]
+
+
+def parse_treatment_response(response: Any) -> TreatmentJudgment | None:
+    try:
+        choices = response.choices
+        if not choices:
+            return None
+        content = choices[0].message.content
+    except AttributeError:
+        return None
+    if not content:
+        return None
+    try:
+        payload = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        log.info("treatment judge produced non-JSON", extra={"event": "treatment_judge_malformed"})
+        return None
+    if not isinstance(payload, dict):
+        return None
+    treatment = payload.get("treatment")
+    confidence_label = payload.get("confidence")
+    justification = payload.get("justification")
+    if treatment not in TREATMENT_CLASSES:
+        log.info("treatment judge unknown class %r", treatment,
+                 extra={"event": "treatment_judge_unknown_class"})
+        return None
+    if confidence_label not in _CONFIDENCE_MAP:
+        return None
+    if not isinstance(justification, str) or not justification.strip():
+        return None
+    return TreatmentJudgment(
+        classification=treatment,
+        confidence=_CONFIDENCE_MAP[confidence_label],
+        justification=justification.strip(),
+    )
+
+
+async def judge_treatment(
+    *, cited_case_name: str, snippet: str,
+    gateway: _JudgeGatewayProtocol, judge_model: str,
+) -> TreatmentJudgment | None:
+    request = ChatCompletionRequest(
+        model=judge_model,
+        messages=build_treatment_judge_prompt(cited_case_name=cited_case_name, snippet=snippet),
+        max_tokens=400,
+        temperature=0.0,
+        anonymize=False,
+        lq_ai_purpose=_TREATMENT_PURPOSE,
+    )
+    try:
+        response = await gateway.chat_completion(request)
+    except Exception as exc:
+        log.warning("treatment judge gateway call failed: %r", exc,
+                    extra={"event": "treatment_judge_error", "error_type": type(exc).__name__})
+        return None
+    return parse_treatment_response(response)
+
+
+async def estimate_treatment_cost_usd(db: AsyncSession | None, *, judge_model: str) -> Decimal:
+    """Per-call estimate. The snippet is short + bounded, so (unlike the
+    whole-opinion judge) no opinion-length scaling is applied."""
+    return await estimate_judge_call_cost_usd(db, judge_model=judge_model, purpose=_TREATMENT_PURPOSE)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd api && python -m pytest tests/test_treatment_judge.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/citation/treatment_judge.py api/tests/test_treatment_judge.py
+git commit -s -m "feat(citation): treatment-classifying judge prompt+parser (WS-G PR2)"
+```
+
+---
+
+### Task 4: API — the rollup (`treatment_rollup.py`)
+
+**Files:**
+- Create: `api/app/citation/treatment_rollup.py`
+- Test: `api/tests/test_treatment_rollup.py`
+
+**Interfaces:**
+- Consumes: `TreatmentJudgment` (only `.classification`, `.confidence`).
+- Produces:
+  - `@dataclass Rollup(strongest_negative_class: str | None, per_class_counts: dict[str, int], case_confidence: float | None, judged_count: int)`
+  - `roll_up(signals: Sequence[TreatmentJudgment]) -> Rollup`
+  - `NEGATIVE_SEVERITY: tuple[str, ...]`
+
+- [ ] **Step 1: Write failing tests** (`api/tests/test_treatment_rollup.py`)
+
+```python
+from app.citation.treatment_judge import TreatmentJudgment
+from app.citation.treatment_rollup import roll_up, Rollup, NEGATIVE_SEVERITY
+
+
+def _j(cls, conf=0.7):
+    return TreatmentJudgment(classification=cls, confidence=conf, justification="x")
+
+
+def test_severity_order_is_fixed():
+    assert NEGATIVE_SEVERITY == ("overruled", "superseded", "criticized", "questioned", "distinguished")
+
+
+def test_empty():
+    r = roll_up([])
+    assert r == Rollup(None, {}, None, 0)
+
+
+def test_all_non_negative_has_no_strongest():
+    r = roll_up([_j("followed"), _j("neutral"), _j("followed")])
+    assert r.strongest_negative_class is None
+    assert r.case_confidence is None
+    assert r.per_class_counts == {"followed": 2, "neutral": 1}
+    assert r.judged_count == 3
+
+
+def test_picks_most_severe_negative():
+    r = roll_up([_j("distinguished"), _j("questioned"), _j("overruled"), _j("followed")])
+    assert r.strongest_negative_class == "overruled"
+    assert r.per_class_counts["distinguished"] == 1
+
+
+def test_corroboration_bumps_confidence():
+    # two "questioned" @0.70 → 0.70 + 0.05*(2-1) = 0.75
+    r = roll_up([_j("questioned", 0.70), _j("questioned", 0.70), _j("followed")])
+    assert r.strongest_negative_class == "questioned"
+    assert abs(r.case_confidence - 0.75) < 1e-9
+
+
+def test_confidence_capped():
+    sig = [_j("criticized", 0.90)] * 6  # 0.90 + 0.05*5 = 1.15 → cap 0.95
+    r = roll_up(sig)
+    assert abs(r.case_confidence - 0.95) < 1e-9
+
+
+def test_confidence_uses_strongest_class_only():
+    # strongest = overruled (one @0.50); the questioned ones don't corroborate it
+    r = roll_up([_j("overruled", 0.50), _j("questioned", 0.90), _j("questioned", 0.90)])
+    assert r.strongest_negative_class == "overruled"
+    assert abs(r.case_confidence - 0.50) < 1e-9
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd api && python -m pytest tests/test_treatment_rollup.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** (`api/app/citation/treatment_rollup.py`)
+
+```python
+"""Roll per-passage treatment judgments up to a case-level signal (WS-G PR2).
+
+Strongest-negative posture (ADR 0019 D5): the case-level signal is the most
+SEVERE negative class present; confidence (D6) is that class's strongest
+contributor confidence plus a small corroboration bump per additional
+agreeing passage, capped. Absence of any negative class → None (surfaced as
+"no negative treatment found as of <date>", never "good law"). Pure + total.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from app.citation.treatment_judge import TreatmentJudgment
+
+# Strongest first.
+NEGATIVE_SEVERITY: tuple[str, ...] = (
+    "overruled", "superseded", "criticized", "questioned", "distinguished",
+)
+_CORROBORATION_BUMP = 0.05
+_CONFIDENCE_CAP = 0.95
+
+
+@dataclass(slots=True)
+class Rollup:
+    strongest_negative_class: str | None
+    per_class_counts: dict[str, int]
+    case_confidence: float | None
+    judged_count: int
+
+
+def roll_up(signals: Sequence[TreatmentJudgment]) -> Rollup:
+    counts = Counter(s.classification for s in signals)
+    per_class = dict(counts)
+    strongest: str | None = next((c for c in NEGATIVE_SEVERITY if counts.get(c)), None)
+    if strongest is None:
+        return Rollup(None, per_class, None, len(signals))
+    agreeing = [s.confidence for s in signals if s.classification == strongest]
+    base = max(agreeing)
+    bumped = base + _CORROBORATION_BUMP * (len(agreeing) - 1)
+    confidence = min(bumped, _CONFIDENCE_CAP)
+    return Rollup(strongest, per_class, confidence, len(signals))
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd api && python -m pytest tests/test_treatment_rollup.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/citation/treatment_rollup.py api/tests/test_treatment_rollup.py
+git commit -s -m "feat(citation): treatment rollup (strongest-negative + corroboration) (WS-G PR2)"
+```
+
+---
+
+### Task 5: API — judge pass in `derive_treatment_for_message`
+
+**Files:**
+- Modify: `api/app/citation/treatment.py`
+- Test: `api/tests/test_treatment_judge_pass.py` (new)
+
+**Interfaces:**
+- Consumes: `judge_treatment`, `estimate_treatment_cost_usd`, `_TREATMENT_PURPOSE` (Task 3); `roll_up` (Task 4); `CitationTreatmentSignal` (Task 2); `_JudgeGatewayProtocol`.
+- Produces: `derive_treatment_for_message(..., gateway: _JudgeGatewayProtocol | None = None, judge_model: str = "fast", judge_budget_usd: Decimal = TREATMENT_JUDGE_BUDGET_USD, n_judged_cap: int = N_JUDGED_CAP)`. When `gateway is None` → behavior byte-identical to PR1 (graph-only). The fetched `citing` snippets feed the judge; the **persisted** `citing_opinions` JSONB strips `snippet` (P3).
+
+- [ ] **Step 1: Write failing integration tests** (`api/tests/test_treatment_judge_pass.py`)
+
+```python
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+import pytest
+from sqlalchemy import select
+from app.citation.treatment import derive_treatment_for_message
+from app.citation.treatment_judge import TreatmentJudgment
+from app.models.citation_treatment import CitationTreatment
+from app.models.citation_treatment_signal import CitationTreatmentSignal
+
+pytestmark = pytest.mark.asyncio
+
+# Build: a message with one caselaw citation + ledger entry, cluster 7 / opinion 700.
+# (Reuse the PR1 test's fixture helpers — import or copy _seed_caselaw_turn from
+#  tests/test_treatment.py so the message_caselaw_citation + ledger entry exist.)
+from tests.test_treatment import _seed_caselaw_turn  # noqa: E402
+
+
+async def _fetch_with_snippets(opinion_id: int):
+    return {
+        "cited_by_count": 3,
+        "citing": [
+            {"cluster_id": 90, "opinion_id": 900, "case_name": "A", "court": "ca9",
+             "date_filed": "2021-01-01", "snippet": "We overrule the cited case."},
+            {"cluster_id": 91, "opinion_id": 901, "case_name": "B", "court": "ca2",
+             "date_filed": "2020-01-01", "snippet": "Citing for background."},
+        ],
+    }
+
+
+class _GW:
+    """Returns 'overruled' for opinion 900's snippet, 'neutral' otherwise."""
+    async def chat_completion(self, request, *, request_id=None):
+        import json
+        from types import SimpleNamespace
+        body = request.messages[1].content
+        cls = "overruled" if "overrule" in body else "neutral"
+        conf = "high" if cls == "overruled" else "low"
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
+            content=json.dumps({"treatment": cls, "confidence": conf, "justification": "x"})))])
+
+
+async def test_judge_pass_writes_signals_and_rollup(db_session):
+    msg_id = await _seed_caselaw_turn(db_session, cluster_id=7, opinion_id=700)
+    await derive_treatment_for_message(
+        db_session, message_id=msg_id, now=datetime.now(UTC),
+        fetch_citing=_fetch_with_snippets, gateway=_GW(), judge_model="fast",
+    )
+    t = (await db_session.execute(
+        select(CitationTreatment).where(CitationTreatment.cluster_id == 7)
+    )).scalar_one()
+    assert t.derived_method == "citation_graph+judge"
+    assert t.strongest_negative_class == "overruled"
+    assert t.judged_count == 2
+    # P3: persisted refs carry NO snippet.
+    assert all("snippet" not in ref for ref in t.citing_opinions)
+    sigs = (await db_session.execute(
+        select(CitationTreatmentSignal).where(CitationTreatmentSignal.treatment_id == t.id)
+    )).scalars().all()
+    assert {s.classification for s in sigs} == {"overruled", "neutral"}
+
+
+async def test_graph_only_when_no_gateway(db_session):
+    msg_id = await _seed_caselaw_turn(db_session, cluster_id=8, opinion_id=800)
+    await derive_treatment_for_message(
+        db_session, message_id=msg_id, now=datetime.now(UTC), fetch_citing=_fetch_with_snippets,
+    )  # gateway omitted
+    t = (await db_session.execute(
+        select(CitationTreatment).where(CitationTreatment.cluster_id == 8)
+    )).scalar_one()
+    assert t.derived_method == "citation_graph"
+    assert t.strongest_negative_class is None
+    sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert sigs == []
+
+
+async def test_budget_stops_pass_but_keeps_graph(db_session):
+    msg_id = await _seed_caselaw_turn(db_session, cluster_id=9, opinion_id=900)
+    await derive_treatment_for_message(
+        db_session, message_id=msg_id, now=datetime.now(UTC), fetch_citing=_fetch_with_snippets,
+        gateway=_GW(), judge_model="fast", judge_budget_usd=Decimal("0"),  # zero budget
+    )
+    t = (await db_session.execute(
+        select(CitationTreatment).where(CitationTreatment.cluster_id == 9)
+    )).scalar_one()
+    assert t.cited_by_count == 3              # graph survived
+    assert t.derived_method == "citation_graph"  # no passages judged
+    sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert sigs == []
+
+
+async def test_re_derive_replaces_signals(db_session):
+    msg_id = await _seed_caselaw_turn(db_session, cluster_id=7, opinion_id=700)
+    now = datetime.now(UTC)
+    for _ in range(2):  # derive twice → no duplicate child rows, TTL forces refetch
+        await derive_treatment_for_message(
+            db_session, message_id=msg_id, now=now, fetch_citing=_fetch_with_snippets,
+            gateway=_GW(), judge_model="fast", ttl_days=0,
+        )
+    sigs = (await db_session.execute(select(CitationTreatmentSignal))).scalars().all()
+    assert len(sigs) == 2  # not 4
+```
+
+> If `_seed_caselaw_turn` does not already exist in `tests/test_treatment.py`, extract the turn-seeding setup from PR1's treatment test into that named helper as the first step of this task (it is shared fixture plumbing, not new behavior).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test python -m pytest tests/test_treatment_judge_pass.py -v`
+Expected: FAIL — `derive_treatment_for_message` rejects `gateway=` kwarg.
+
+- [ ] **Step 3: Implement.** Extend `treatment.py`:
+
+1. Imports + constants at module top:
+
+```python
+from decimal import Decimal
+
+from app.citation.treatment_judge import (
+    _TREATMENT_PURPOSE, estimate_treatment_cost_usd, judge_treatment,
+)
+from app.citation.treatment_rollup import roll_up
+from app.citation.verification import _JudgeGatewayProtocol
+from app.models.citation_treatment_signal import CitationTreatmentSignal
+
+N_JUDGED_CAP = 10
+TREATMENT_JUDGE_BUDGET_USD = Decimal("0.25")
+
+
+def _strip_snippet(citing: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Persist refs only — the snippet is transient judge input (P3)."""
+    return [{k: v for k, v in ref.items() if k != "snippet"} for ref in citing]
+```
+
+2. New signature (add the four kwargs, defaulting to PR1 behavior):
+
+```python
+async def derive_treatment_for_message(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    now: datetime,
+    ttl_days: int = TREATMENT_TTL_DAYS,
+    fetch_citing: _FetchCiting = _default_fetch_citing,
+    gateway: _JudgeGatewayProtocol | None = None,
+    judge_model: str = "fast",
+    judge_budget_usd: Decimal = TREATMENT_JUDGE_BUDGET_USD,
+    n_judged_cap: int = N_JUDGED_CAP,
+) -> int:
+```
+
+3. In the per-cluster loop, when building/refreshing the row, **strip the snippet** from the persisted JSONB and keep the raw `payload["citing"]` (with snippets) in a local for the judge pass:
+
+```python
+            payload = await fetch_citing(opinion_id)
+            raw_citing = list(payload.get("citing") or [])
+            persisted_citing = _strip_snippet(raw_citing)
+            # ... use persisted_citing for row.citing_opinions / existing.citing_opinions
+```
+
+   Replace both `list(payload.get("citing") or [])` assignments to `citing_opinions` with `persisted_citing`.
+
+4. After the row is upserted and flushed (so `row.id` exists), run the judge pass **only when `gateway is not None`**, in the same loop iteration, capturing `treatment_row` (the new or existing `CitationTreatment`):
+
+```python
+            if gateway is not None:
+                await _run_judge_pass(
+                    db, treatment_row=treatment_row, cited_case_name=<case_name>,
+                    raw_citing=raw_citing, now=now, gateway=gateway,
+                    judge_model=judge_model, judge_budget_usd=judge_budget_usd,
+                    n_judged_cap=n_judged_cap,
+                )
+```
+
+   `<case_name>`: load `ResearchClusterMetadata.case_name` by `cluster_id` (mirror B1c, which reads `ResearchClusterMetadata.case_name`). If unavailable, fall back to the citing ref's own context — but the cited case name is required for the prompt; if it cannot be resolved, skip the judge pass for that cluster (graph signal stands).
+
+5. New helper `_run_judge_pass`:
+
+```python
+async def _run_judge_pass(
+    db: AsyncSession,
+    *,
+    treatment_row: CitationTreatment,
+    cited_case_name: str,
+    raw_citing: list[dict[str, Any]],
+    now: datetime,
+    gateway: _JudgeGatewayProtocol,
+    judge_model: str,
+    judge_budget_usd: Decimal,
+    n_judged_cap: int,
+) -> None:
+    """Judge top-N citing snippets, write child signals + rollup. Non-fatal per passage."""
+    # Idempotent refresh: clear this row's prior signals.
+    await db.execute(
+        delete(CitationTreatmentSignal).where(
+            CitationTreatmentSignal.treatment_id == treatment_row.id
+        )
+    )
+    per_call = await estimate_treatment_cost_usd(db, judge_model=judge_model)
+    spent = Decimal("0")
+    judgments = []
+    # raw_citing is already recency-sorted; take the cap.
+    for ref in raw_citing[:n_judged_cap]:
+        snippet = ref.get("snippet")
+        citing_opinion_id = ref.get("opinion_id")
+        if not snippet or citing_opinion_id is None:
+            continue
+        if spent + per_call > judge_budget_usd:
+            break  # budget exhausted — keep what we judged
+        spent += per_call
+        try:
+            judgment = await judge_treatment(
+                cited_case_name=cited_case_name, snippet=snippet,
+                gateway=gateway, judge_model=judge_model,
+            )
+        except Exception as exc:  # defense in depth; judge_treatment already swallows
+            log.warning("treatment judge raised for opinion %s: %r", citing_opinion_id, exc)
+            continue
+        if judgment is None:
+            continue
+        db.add(CitationTreatmentSignal(
+            treatment_id=treatment_row.id, citing_opinion_id=int(citing_opinion_id),
+            classification=judgment.classification, confidence=judgment.confidence,
+            justification=judgment.justification,
+        ))
+        judgments.append(judgment)
+    if not judgments:
+        return  # nothing classified — leave graph-only
+    rollup = roll_up(judgments)
+    treatment_row.strongest_negative_class = rollup.strongest_negative_class
+    treatment_row.judged_count = rollup.judged_count
+    treatment_row.judge_as_of = now
+    treatment_row.derived_method = "citation_graph+judge"
+    await db.flush()
+```
+
+   Add `from sqlalchemy import delete, select` (extend the existing import). Track `treatment_row` in the loop: set it to the `row`/`existing` object on each branch so it is in scope for the judge pass. When a cluster reuses a fresh cache (the `existing.as_of >= stale_before` continue branch), do not re-run the judge pass (the cached row already carries its judged signals).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test python -m pytest tests/test_treatment_judge_pass.py tests/test_treatment.py -v`
+Expected: PASS (new + PR1 regression).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/citation/treatment.py api/tests/test_treatment_judge_pass.py api/tests/test_treatment.py
+git commit -s -m "feat(citation): judge pass + rollup in derive_treatment_for_message (WS-G PR2)"
+```
+
+---
+
+### Task 6: Worker — thread gateway + judge model (graph-only degrade)
+
+**Files:**
+- Modify: `api/app/workers/treatment_worker.py`
+- Test: `api/tests/test_treatment_worker.py` (extend or create)
+
+**Interfaces:**
+- Consumes: `derive_treatment_for_message(gateway=, judge_model=)` (Task 5); `get_gateway_client`, `GatewayClient.get_citation_engine_judge_model`.
+- Produces: `run_treatment_derivation` resolves a gateway + judge model and passes them; on any resolution failure → graph-only (gateway=None). A `gateway` kwarg allows test injection.
+
+- [ ] **Step 1: Write failing tests** (`api/tests/test_treatment_worker.py`)
+
+```python
+import uuid
+import pytest
+from app.workers import treatment_worker
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_run_resolves_gateway_and_passes_it(db_session, monkeypatch):
+    captured = {}
+    async def fake_derive(db, *, message_id, now, fetch_citing=None, gateway=None, judge_model="fast"):
+        captured["gateway"] = gateway
+        captured["judge_model"] = judge_model
+        return 0
+    monkeypatch.setattr(treatment_worker, "derive_treatment_for_message", fake_derive)
+
+    class GW:
+        async def get_citation_engine_judge_model(self, *, fallback="fast"):
+            return "balanced"
+    await treatment_worker.run_treatment_derivation(db_session, message_id=uuid.uuid4(), gateway=GW())
+    assert isinstance(captured["gateway"], GW)
+    assert captured["judge_model"] == "balanced"
+
+
+async def test_run_degrades_to_graph_only_on_gateway_failure(db_session, monkeypatch):
+    captured = {}
+    async def fake_derive(db, *, message_id, now, fetch_citing=None, gateway=None, judge_model="fast"):
+        captured["gateway"] = gateway
+        return 0
+    monkeypatch.setattr(treatment_worker, "derive_treatment_for_message", fake_derive)
+
+    class BadGW:
+        async def get_citation_engine_judge_model(self, *, fallback="fast"):
+            raise RuntimeError("no gateway config")
+    await treatment_worker.run_treatment_derivation(db_session, message_id=uuid.uuid4(), gateway=BadGW())
+    assert captured["gateway"] is None  # degraded
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test python -m pytest tests/test_treatment_worker.py -v`
+Expected: FAIL — `run_treatment_derivation` has no `gateway` kwarg.
+
+- [ ] **Step 3: Implement** (`treatment_worker.py`)
+
+```python
+from app.clients.gateway import GatewayClient, get_gateway_client
+
+
+async def run_treatment_derivation(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    fetch_citing: _FetchCiting = _default_fetch_citing,
+    gateway: GatewayClient | None = None,
+) -> int:
+    """Resolve a gateway + judge model for the PR2 judge pass; degrade to
+    graph-only if the gateway/judge-model can't be resolved (worker without
+    gateway config). Then derive + commit."""
+    resolved_gateway = gateway if gateway is not None else get_gateway_client()
+    judge_model = "fast"
+    try:
+        judge_model = await resolved_gateway.get_citation_engine_judge_model()
+    except Exception as exc:
+        log.warning("treatment judge-model resolve failed; graph-only: %r", exc,
+                    extra={"event": "treatment_judge_model_unavailable"})
+        resolved_gateway = None
+
+    linked = await derive_treatment_for_message(
+        db, message_id=message_id, now=datetime.now(UTC),
+        fetch_citing=fetch_citing, gateway=resolved_gateway, judge_model=judge_model,
+    )
+    await db.commit()
+    return linked
+```
+
+> Keep `treatment_derivation_job` unchanged — it calls `run_treatment_derivation(db, message_id=...)`, which now self-resolves the gateway.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test python -m pytest tests/test_treatment_worker.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/workers/treatment_worker.py api/tests/test_treatment_worker.py
+git commit -s -m "feat(worker): resolve gateway+judge model for treatment judge pass (WS-G PR2)"
+```
+
+---
+
+### Task 7: Read path — expose rollup + signals on `/chats/{id}/ledger`
+
+**Files:**
+- Modify: `api/app/citation/ledger.py` (`resolve_ledger_entries`, the `treatment` object builder)
+- Test: `api/tests/test_ledger_treatment_read.py` (new) — and extend the existing ledger read test if one asserts the `treatment` shape.
+
+**Interfaces:**
+- Consumes: `CitationTreatmentSignal`, `CitationTreatment` rollup columns; `roll_up` (for per-class counts + confidence at read time).
+- Produces: the `treatment` dict each caselaw ledger entry exposes gains:
+  `strongest_negative_class`, `judged_count`, `judge_as_of`, `per_class_counts: dict[str,int]`, `case_confidence: float | None`, and `signals: list[{citing_opinion_id, classification, confidence, justification}]`. Batch-loaded by `treatment_id` (no N+1). Graph-only rows return the new keys as null/empty.
+
+- [ ] **Step 1: Write failing test** (`api/tests/test_ledger_treatment_read.py`)
+
+```python
+import pytest
+pytestmark = pytest.mark.asyncio
+# Seed a turn whose ledger resolves to a treatment with judged signals
+# (reuse Task 5's fetch/_GW + _seed_caselaw_turn), then call the same
+# resolve_ledger_entries path the GET /chats/{id}/ledger handler uses.
+from app.citation.ledger import resolve_ledger_entries  # adjust to the real entry point
+
+
+async def test_ledger_exposes_treatment_rollup_and_signals(db_session):
+    # ... seed + derive (gateway=_GW) as in Task 5, get message_id ...
+    entries = await resolve_ledger_entries(db_session, message_id=msg_id)  # match real signature
+    caselaw = [e for e in entries if e["source_kind"] == "caselaw"][0]
+    t = caselaw["treatment"]
+    assert t["strongest_negative_class"] == "overruled"
+    assert t["per_class_counts"]["overruled"] == 1
+    assert isinstance(t["case_confidence"], float)
+    assert any(s["classification"] == "overruled" for s in t["signals"])
+    assert all("snippet" not in s for s in t["signals"])  # P3
+```
+
+> Match the real `resolve_ledger_entries` signature + return shape (it returns the resolved entry objects/dicts with a `treatment` key from PR1). Adjust the assertions' access pattern to the actual shape; keep the asserted *fields*.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test python -m pytest tests/test_ledger_treatment_read.py -v`
+Expected: FAIL — `treatment` dict lacks the rollup/signals keys.
+
+- [ ] **Step 3: Implement.** In `ledger.py` where PR1 builds the per-entry `treatment` object:
+
+1. Batch-load signals for all resolved `treatment_id`s once:
+
+```python
+    from app.citation.treatment_judge import TreatmentJudgment
+    from app.citation.treatment_rollup import roll_up
+    from app.models.citation_treatment_signal import CitationTreatmentSignal
+
+    signal_rows = (await db.execute(
+        select(CitationTreatmentSignal).where(
+            CitationTreatmentSignal.treatment_id.in_(treatment_ids)
+        )
+    )).scalars().all() if treatment_ids else []
+    signals_by_treatment: dict[uuid.UUID, list[CitationTreatmentSignal]] = {}
+    for s in signal_rows:
+        signals_by_treatment.setdefault(s.treatment_id, []).append(s)
+```
+
+2. When building each `treatment` dict, add the rollup + signals:
+
+```python
+        sigs = signals_by_treatment.get(treatment.id, [])
+        rollup = roll_up([
+            TreatmentJudgment(classification=s.classification, confidence=s.confidence,
+                              justification=s.justification)
+            for s in sigs
+        ])
+        treatment_obj.update({
+            "strongest_negative_class": treatment.strongest_negative_class,
+            "judged_count": treatment.judged_count,
+            "judge_as_of": treatment.judge_as_of.isoformat() if treatment.judge_as_of else None,
+            "per_class_counts": rollup.per_class_counts,
+            "case_confidence": rollup.case_confidence,
+            "signals": [
+                {"citing_opinion_id": s.citing_opinion_id, "classification": s.classification,
+                 "confidence": s.confidence, "justification": s.justification}
+                for s in sigs
+            ],
+        })
+```
+
+   `treatment_ids` = the set of non-null `treatment_id`s already gathered when PR1 batch-loads `CitationTreatment`. Reuse that collection; do not add a second pass.
+
+- [ ] **Step 4: Run to verify pass + full citation/ledger regression**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test python -m pytest tests/test_ledger_treatment_read.py tests/test_ledger.py tests/test_treatment.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/citation/ledger.py api/tests/test_ledger_treatment_read.py
+git commit -s -m "feat(citation): expose treatment rollup + signals on ledger read (WS-G PR2)"
+```
+
+---
+
+## Final gate (run before requesting review — the CI LESSON)
+
+- [ ] **api full gates (whole-app, not per-file):**
+```bash
+cd api
+ruff check app tests && ruff format --check app tests
+mypy app
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test python -m pytest -q
+```
+- [ ] **gateway full gates:**
+```bash
+cd gateway
+ruff check app tests && ruff format --check app tests
+mypy app --strict
+python -m pytest -q
+```
+- [ ] **OpenAPI conformance** if the `/ledger` response schema is pinned in `docs/api/backend-openapi.yaml` — update the `treatment` object schema there and run `tests/test_openapi.py`. (The ledger response is an object; adding keys is additive — confirm the schema test still passes.)
+- [ ] **PRD / DE bookkeeping:** the DE-344 PRD entry is updated (this PR) to pin its remaining autonomous-`estimate_tool_cost`/R4 scope to **WS-E** (its first-metered-source trigger) and record that PR2 shipped the per-case judge budget portion. Confirm that edit is on the branch. File **DE-365** if the court-seniority re-rank or whole-opinion low-confidence fallback warrants its own tracked item.
+- [ ] **Opus whole-branch review** (SDD final): it has caught a real gate-passing defect on every slice this milestone. Required before PR.
+
+## Plan self-review (completed)
+
+- **Spec coverage:** §1 in-scope items → Tasks 1–7; snippet localization (§2) → Task 1+5 (`_strip_snippet`); P3 ruling → Task 2 (tripwire) + Task 5 (`_strip_snippet`) + Task 7 (no-snippet assertion); taxonomy/rollup (§3.3) → Task 4; new judge (§3.4) → Task 3; schema (§3.5) → Task 2; worker (§3.4 wiring) → Task 6; read (§3.6) → Task 7; budget/DE-344 (§3.1/§6) → Task 5 budget + Global Constraints scope note. Deferred items (escalation, court-rank, whole-opinion fallback, trace UI) explicitly out.
+- **Placeholder scan:** all steps carry real code/commands. The two "match the real signature" notes (Tasks 5 helper `_seed_caselaw_turn`, Task 7 `resolve_ledger_entries`) are integration points against existing PR1 code, with the asserted contract fixed — not placeholders.
+- **Type consistency:** `TreatmentJudgment(classification, confidence, justification)`, `roll_up → Rollup`, `derive_treatment_for_message(gateway=, judge_model=, judge_budget_usd=, n_judged_cap=)`, `_TREATMENT_PURPOSE='judge_treatment'`, severity tuple, and the 7-class CHECK are identical across Tasks 2–7.

--- a/docs/superpowers/specs/2026-06-26-wsg-pr2-treatment-judge-design.md
+++ b/docs/superpowers/specs/2026-06-26-wsg-pr2-treatment-judge-design.md
@@ -1,0 +1,130 @@
+# WS-G PR2 — the treatment-classifying judge (design)
+
+**Date:** 2026-06-26
+**Milestone:** Fiduciary-grade agentic legal work — Phase 2, WS-G (transparent validity/treatment layer)
+**ADR:** [0019](../../adr/0019-transparent-validity-treatment-layer.md) — this spec resolves its §"Open questions" for PR2.
+**Builds on:** WS-G PR1 (`citation_treatment` graph signal, mig 0061, `derive_treatment_for_message`, the async `treatment_derivation_job`).
+**Security-gated:** yes — new judge egress reasoning + the citing-graph surface (`gateway/**`, `api/app/citation/**`). Kevin/security merges; mirror `origin/main → tucuxi` after.
+**Next migration:** `0062`. **Next DE:** DE-365.
+
+---
+
+## 1. What this delivers
+
+PR1 ships the *graph-level* treatment signal: "case X is cited by N later opinions; here they are (court + date)." PR2 adds the **classification**: for a prioritized, capped subset of those citing opinions, an LLM judge classifies *how* each one treats case X — `followed / distinguished / criticized / questioned / overruled / superseded / neutral` — and the per-passage classifications roll up to a **strongest-negative case-level signal** ("overruled by 1; questioned by 2; distinguished by 5; otherwise neutral — derived as of <date>").
+
+The signal stays **derived, not editorial** (ADR 0019 D1): every contributing classification links to the exact citing opinion and carries the judge's reasoning + confidence; the rollup never collapses to a single "good law / bad law" verdict. Treatment **never** gates the fiduciary verdict (ADR 0018 D3 / 0019 D2) — it enriches the ledger entry.
+
+### In scope
+- A new treatment judge (new prompt + verdict schema) over the existing judge rails.
+- Snippet-based passage localization (extend `get_citing_opinions` to return CourtListener's per-result `snippet`).
+- A `citation_treatment_signal` child table + rollup columns on `citation_treatment` (mig 0062).
+- A budget-bounded judge pass folded into the existing async `treatment_derivation_job`.
+- A real `estimate_tool_cost` for `get_citing_opinions` (DE-344 first bite).
+- P3 tripwire coverage for the new child table.
+
+### Out of scope (deferred, each its own slice)
+- **DE-360 cheap→capable escalation routing** — PR2 establishes the budget + `purpose='judge_treatment'` cost tag so calibration data accrues; the escalation loop (re-judge low-confidence passages with a capable model) is a follow-up.
+- **Court-seniority re-rank** — needs a CourtListener court-code → seniority map; deferred as a DE. PR2 prioritizes by recency (the stored order).
+- **Whole-opinion fallback** for low-confidence snippet classifications — deferred as a DE.
+- **Trace UI** for the classification (the PR1-UI analog for PR2) — its own web slice after this backend lands.
+- **Refresh/staleness re-derivation surfacing** beyond PR1's existing 30-day TTL.
+
+---
+
+## 2. The keystone: snippet localization + the P3 ruling
+
+To classify how citing opinion *B* treats case *X*, the judge needs *B*'s text where it discusses *X*. PR1 stores only refs (`cluster_id, opinion_id, case_name, court, date_filed`) — no text. CourtListener's `/search/?q=cites:(X)` returns a `snippet` (a highlighted excerpt around the citing match) that the gateway op currently discards. **PR2 judges that snippet.** Treatment language ("we decline to follow", "overruled", "we are not persuaded by") sits adjacent to the citation, which is exactly what the snippet captures. No per-citing-opinion materialization egress — honoring ADR 0019 D4/D10 ("phase the cost in").
+
+### The P3 ruling (load-bearing, maintainer-confirmed 2026-06-26)
+
+ADR 0019 D7 / ADR 0016 P3 forbid raw opinion payload in the index — the passage is to be "read from the content layer at trace time." The snippet model has **no materialized citing opinion** to read at trace time. Resolution:
+
+> **Persist the derived artifacts, never the raw snippet.** Each `citation_treatment_signal` row stores `citing_opinion_id`, `classification`, `confidence`, and the **judge's short justification** — our *derived reasoning* ("the citing court expressed doubt about X's holding"), not opinion payload. The raw snippet is **transient** input to the judge at derivation time and never lands in the index. The (future) trace UI shows classification + judge reasoning + a **link out to the opinion on CourtListener** for the full passage.
+
+This keeps `citation_treatment_signal` P3-clean (derived classifications + reasoning, same posture as PR1's refs-only JSONB). The judge prompt **instructs the judge to describe the treatment rather than quote the opinion**, so the persisted justification is our derived artifact. The new child table joins the ADR 0016 P3 no-raw-payload tripwire in this PR.
+
+---
+
+## 3. Components
+
+### 3.1 Gateway — extend `get_citing_opinions` (security-gated, `gateway/**`)
+- Add `snippet` to each citing result in `_get_citing_opinions` (`gateway/app/providers/tool/courtlistener.py`). CourtListener returns it on `/search/` opinion results; map the upstream snippet/highlight field, defensively (absent → `None`).
+- Add a **real** `estimate_tool_cost` for `get_citing_opinions` (currently `Decimal(0)`) — a small per-call metered-egress estimate so the R4 economic brake can read it (DE-344 first bite). Value + where R4 reads it pinned in the plan.
+
+### 3.2 API — the treatment judge (`api/app/citation/`)
+- **New** `treatment_judge.py`:
+  - `build_treatment_judge_prompt(*, cited_case_name, snippet)` — new system prompt; output contract `{"treatment": <one of 7 classes>, "confidence": "high|medium|low", "justification": "<≤2 sentences, describe don't quote>"}`. Conservative calibration: when uncertain between a negative class and `neutral`, **prefer `neutral`** (a false "overruled" is worse than a missed one — mirrors the cascade's conservative bias, inverted toward non-alarm).
+  - `parse_treatment_response(response) -> TreatmentJudgment | None` — new parser (the existing `_parse_judge_response` hard-codes `yes/partial/no`; not reused). Returns `None` (skip, classify nothing) on malformed JSON / unknown class / unknown confidence / gateway error — never raises.
+  - `judge_treatment(*, cited_case_name, snippet, gateway, judge_model) -> TreatmentJudgment | None` — one structured-JSON call, `purpose='judge_treatment'`, `temperature=0.0`, `anonymize=False`, `max_tokens≈400`.
+  - `estimate_treatment_cost_usd(db, *, judge_model)` — reuses `estimate_judge_call_cost_usd(purpose='judge_treatment')`; snippet is short + fixed-ish, so no opinion-length scaling (unlike `case_content_judge`).
+- **`TreatmentJudgment`** dataclass: `classification: str`, `confidence: float` (via `_CONFIDENCE_MAP`), `justification: str`.
+- **Rollup** (`treatment.py` or a small `treatment_rollup.py`): pure function `roll_up(signals) -> (strongest_negative_class | None, per_class_counts, case_confidence)`. Severity order `overruled > superseded > criticized > questioned > distinguished`; non-negative `followed`, `neutral`. Case confidence = strongest-negative contributor's confidence + `min(0.05·(K−1), …)` corroboration bump, capped `0.95`. Pure + unit-tested.
+
+### 3.3 API — extend the derivation (`api/app/citation/treatment.py`)
+`derive_treatment_for_message` (PR1) gains a judge pass **after** the graph upsert, per cited cluster:
+1. Take the stored `citing_opinions` (already capped 30, recency-sorted); select **top-N=10**.
+2. **Pre-flight budget:** `estimate_treatment_cost_usd × N ≤ per-case budget (~$0.25)`; if the full pass would exceed it, judge as many as the budget allows (greedy, in priority order) and stop — never abandon the graph signal.
+3. For each selected citing opinion with a non-empty snippet: `judge_treatment(...)`; on a real classification, write a `citation_treatment_signal` child row. Per-passage non-fatal (logged, skipped) — mirrors PR1's per-case posture.
+4. Compute the rollup; write `strongest_negative_class`, `judged_count`, `judge_as_of` onto the parent; set `derived_method='citation_graph+judge'`.
+- **Idempotent / refresh-safe:** re-derivation deletes-and-replaces this cluster's child signals (or upserts by `(treatment_id, citing_opinion_id)`), so a stale-TTL refresh re-judges cleanly. Pinned in the plan.
+
+### 3.4 Worker wiring (the integration risk)
+PR1's `treatment_derivation_job` is **async in the arq worker** and graph-only — it has no `GatewayClient`. PR2's judge needs a gateway **in the worker**. Resolution (settle in the plan, recommended path): construct/inject a `GatewayClient` + resolve the operator's treatment-judge model inside the job, exactly as the chat-send path resolves it for B1b, gated so a worker without gateway config degrades to **graph-only** (PR1 behavior) rather than failing. The judge pass is strictly additive: no gateway / no judge model / no snippet → the PR1 graph row stands unchanged.
+
+### 3.5 Schema (migration 0062)
+- **New** `citation_treatment_signal`: `id` (uuid pk), `treatment_id` (uuid FK → `citation_treatment.id`, `ON DELETE CASCADE`), `citing_opinion_id` (bigint), `classification` (text, CHECK ∈ the 7 classes), `confidence` (float), `justification` (text), `created_at`. Unique `(treatment_id, citing_opinion_id)`. **No snippet column** (P3). Add to `_AUDIT_MODELS` P3 tripwire.
+- **Alter** `citation_treatment`: add `strongest_negative_class` (text, nullable, CHECK ∈ negative classes), `judged_count` (int, nullable), `judge_as_of` (timestamptz, nullable); relax `chk_citation_treatment_method_values` → `IN ('citation_graph', 'citation_graph+judge')`.
+
+### 3.6 Read path
+`resolve_ledger_entries` (`ledger.py`) extends the `treatment` object it already exposes on `/chats/{id}/ledger` with the rollup fields + the per-signal child rows (batch-loaded by `treatment_id`, no N+1). Additive; existing graph-only consumers see the new fields as null/empty.
+
+---
+
+## 4. Data flow
+
+```
+turn finalize (×3 sites, unchanged)
+  └─ treatment_derivation_job (arq, async, off critical path)        [PR1]
+       └─ derive_treatment_for_message
+            ├─ per cited cluster: graph upsert (cited_by_count, refs) [PR1]
+            └─ JUDGE PASS (new):                                      [PR2]
+                 ├─ select top-N=10 citing (recency)
+                 ├─ pre-flight budget gate (~$0.25/case)
+                 ├─ per citing op w/ snippet → judge_treatment
+                 │     └─ write citation_treatment_signal child row
+                 ├─ roll_up(signals) → strongest-negative + counts + confidence
+                 └─ parent: strongest_negative_class, judged_count,
+                            judge_as_of, derived_method='citation_graph+judge'
+
+read: GET /chats/{id}/ledger
+  └─ resolve_ledger_entries → treatment{ graph + rollup + signals[] }  (no N+1)
+```
+
+## 5. Error handling & conservative posture
+- Per-passage judge failure (gateway error, malformed JSON, unknown class) → **skip that passage**, never raise; the case keeps its graph signal + whatever passages succeeded.
+- Budget exhausted mid-pass → judge what the budget covered, mark `judged_count` accordingly; the rollup reflects only judged passages ("derived from N of M citing opinions").
+- No snippet on a citing result → skip (cannot localize) — counts toward neither negative nor neutral.
+- Worker without gateway/judge-model config → graph-only (byte-identical to PR1).
+- Calibration bias: judge prefers `neutral` over a negative class on uncertainty (a false negative-treatment flag is the worse error for a derived validity signal).
+
+## 6. Testing
+- **Unit:** new prompt builder shape; `parse_treatment_response` across all 7 classes + every malformed/unknown path → `None`; `roll_up` severity ordering + corroboration-bump + cap (pure, exhaustive); budget pre-flight greedy selection; cost estimator.
+- **Integration (throwaway pgvector):** `derive_treatment_for_message` judge pass writes child rows + rollup; idempotent re-derivation; per-passage non-fatal; graph-only degradation with `gateway=None`; CHECK-constraint coverage on the new columns; `/ledger` read exposes the rollup + signals.
+- **Gateway:** `get_citing_opinions` returns `snippet`; `estimate_tool_cost` non-zero.
+- **P3:** tripwire asserts `citation_treatment_signal` holds no opinion payload.
+- **CI gate (LESSON):** Task-6 must run api `mypy app` (whole-app) + `ruff format --check` per-subsystem, gateway `mypy app` + `ruff format --check`, both full suites. Not per-file.
+
+## 7. Open items for the plan (not the brainstorm)
+- Exact per-case budget value + `estimate_tool_cost` value for `get_citing_opinions` + R4 read site (DE-344).
+- The upstream CourtListener snippet field name + its emptiness behavior (verify live or via fixture).
+- Worker gateway-client construction vs. injection.
+- Child-signal refresh strategy (delete-replace vs upsert) on TTL re-derivation.
+
+## 8. Decisions log (this spec)
+- **Localization:** search snippet, not whole-opinion materialization (cost; ADR 0019 D4/D10).
+- **P3:** persist derived classification + confidence + judge justification; never the raw snippet; trace links out to CourtListener.
+- **Prioritization:** recency-first, cap N=10, per-case budget; court-rank re-rank → DE.
+- **Schema:** child `citation_treatment_signal` table + parent rollup columns.
+- **Escalation (DE-360):** deferred; PR2 tags `purpose='judge_treatment'` so calibration accrues.
+- **Rollup:** most-severe-class present + per-class counts; confidence = strongest-negative confidence + corroboration bump (cap 0.95).

--- a/gateway/app/providers/tool/courtlistener.py
+++ b/gateway/app/providers/tool/courtlistener.py
@@ -323,6 +323,9 @@ class CourtListenerToolAdapter(ToolProviderAdapter):
                 "case_name": r.get("caseName"),
                 "court": r.get("court"),
                 "date_filed": r.get("dateFiled"),
+                # WS-G PR2: the highlighted excerpt around the citing match.
+                # Transient treatment-judge input — NEVER persisted (P3).
+                "snippet": (r.get("opinions") or [{}])[0].get("snippet") or r.get("snippet"),
             }
             for r in (data.get("results") or [])[:_CITING_TOP_N]
         ]

--- a/gateway/tests/test_courtlistener_adapter.py
+++ b/gateway/tests/test_courtlistener_adapter.py
@@ -340,6 +340,7 @@ async def test_get_citing_opinions_shapes_count_and_capped_list(monkeypatch) -> 
         "case_name",
         "court",
         "date_filed",
+        "snippet",
     }
 
 
@@ -351,3 +352,38 @@ async def test_get_citing_opinions_requires_integer_opinion_id(monkeypatch) -> N
             await adapter.invoke_tool("get_citing_opinions", {"opinion_id": "x"}, request_id="r")
     finally:
         await adapter.aclose()
+
+
+@pytest.mark.unit
+async def test_get_citing_opinions_includes_snippet(monkeypatch) -> None:
+    adapter = _adapter(monkeypatch)
+    results = [
+        {
+            "cluster_id": 1000,
+            "caseName": "Citing Case",
+            "court": "ca9",
+            "dateFiled": "2021-05-01",
+            "opinions": [{"id": 5000, "snippet": "We decline to follow Smith v. Jones."}],
+        },
+        {  # no snippet anywhere → None, never raises
+            "cluster_id": 1001,
+            "caseName": "Quiet Case",
+            "court": "ca2",
+            "dateFiled": "2021-04-01",
+            "opinions": [{"id": 5001}],
+        },
+    ]
+    with respx.mock:
+        respx.get(f"{BASE}/search/").mock(
+            return_value=httpx.Response(200, json={"count": 2, "results": results, "next": None})
+        )
+        try:
+            result = await adapter.invoke_tool(
+                "get_citing_opinions", {"opinion_id": 42}, request_id="r"
+            )
+        finally:
+            await adapter.aclose()
+    citing = result.payload["citing"]
+    assert citing[0]["snippet"] == "We decline to follow Smith v. Jones."
+    assert citing[1]["snippet"] is None
+    assert "snippet" in set(citing[0])


### PR DESCRIPTION
## WS-G PR2 — the treatment-classifying judge

Phase 2, WS-G (transparent validity/treatment layer). Builds on PR1's citation-graph signal (#233). Resolves ADR 0019 §Open-questions for PR2.

**🔒 Security-gated** (`gateway/**` + `api/app/citation/**`) — security/maintainer merges; **not self-merged**. Mirror `origin/main → tucuxi` after merge.

### What it does
For each case a turn cites, an LLM judge classifies how each citing opinion treats it — `followed / distinguished / criticized / questioned / overruled / superseded / neutral` — over a recency-capped (N=10), per-case-budget-bounded (\$0.25) subset, rolling up to a **strongest-negative** case-level signal on `citation_treatment`. Runs **off the turn's critical path** (PR1's arq job). **Treatment never gates the fiduciary verdict** (ADR 0018 D3 / 0019 D2).

### Design decisions (maintainer-approved; spec + plan in `docs/superpowers/`)
- **Snippet localization:** judges CourtListener's per-result `snippet` (no per-citing-opinion materialization egress) — ADR 0019 D4/D10 "phase the cost in."
- **P3 (load-bearing):** persists derived classification + confidence + the judge's **describe-don't-quote justification** + refs — **never the raw snippet or opinion text**. `_strip_snippet` keeps the persisted JSONB refs-only; the new child table has no snippet column and joins the P3 tripwire. Trace links out to CourtListener for the full passage.
- **Derive-don't-assert (D1):** no good/bad-law verdict; strongest-negative + per-class counts + per-signal confidence/reasoning. Judge prompt prefers `neutral` on uncertainty.
- **Schema (mig 0062):** new `citation_treatment_signal` child + parent rollup cols (`strongest_negative_class`/`judged_count`/`judge_as_of`); `derived_method` CHECK relaxed to `citation_graph+judge`.
- **Safe degrade:** no gateway / no judge model / no snippet / no case_name → byte-identical to PR1 graph-only.
- **Cost (DE-344 first bite):** the per-case judge budget is PR2's cost bound; the autonomous-R4 `estimate_tool_cost` wiring is pinned to **WS-E** (its first-metered-source trigger) — see the updated DE-344 PRD entry.
- **Escalation (DE-360):** deferred; PR2 tags `purpose='judge_treatment'` so calibration data accrues.

### 👀 For the security reviewer
- **One new gateway egress field:** `get_citing_opinions` now returns the CourtListener `snippet` (public search highlight). Defensive extraction; never raises on missing fields. BYO-key-gated exactly as today (no new provider/boundary).
- **New P3 surface:** `citation_treatment_signal` is metadata/derived-reasoning only and is added to the no-raw-payload tripwire in this PR. Confirm no opinion payload is persisted.
- **Intended behavior:** the persisted judge `justification` is our derived reasoning (prompt instructs describe-not-quote), surfaced on the ledger read alongside a link out to the opinion.

### Built via SDD (7 tasks, per-task spec+quality reviews + Opus whole-branch review)
The Opus whole-branch review caught a real gate-passing defect: a stale-refresh without a judge pass (gateway=None / missing case_name) left **orphaned child signals** that the read path resurfaced on a row reset to graph-only — a contradictory derived-validity claim. **Fixed** (unconditional child-signal delete on every refresh + 2 regression tests covering both uncovered paths), plus a `citing_opinion_id` dedup guard and a migration index-name alignment.

### Tests / gates
- api full suite **2381 passed / 1 skipped**; gateway **704 passed / 3 skipped**.
- api + gateway: `ruff check`, `ruff format --check`, whole-app `mypy` (`mypy --strict` gateway) — all clean.
- New: gateway snippet; child-model + migration + CHECK + tripwire; judge prompt/parser (all classes + every parse-failure → None); rollup (severity + corroboration + cap); judge-pass integration (P3 strip, budget, idempotent refresh, non-fatal, graph-only degrade, **refresh-clears-signals**, dedup); worker gateway-resolution + degrade; ledger read (no N+1, P3, graph-only safe).

### Follow-ups filed
- **DE-366** — worker short-circuits the judge pass when no gateway is reachable (latency/log-noise only; data correct).
- **DE-367** — materialize the rollup to avoid future stored-vs-recomputed `judged_count` divergence.
- Still committed before Phase 2 closes: **DE-363** (lazy-on-trace-open fallback), **DE-364** (per-cluster SAVEPOINT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)