### PR TITLE
WS-D PR1 — governed agentic loop + matter intake (Phase 2)

### DIFF
--- a/api/app/autonomous/cost.py
+++ b/api/app/autonomous/cost.py
@@ -7,7 +7,7 @@ rolling-average estimator; local-only intents have zero marginal cost.
 
 Cost model (per M4 implementation plan)
 ----------------------------------------
-* ``run_skill`` / ``run_playbook`` — inference-bearing; delegate to
+* ``run_skill`` / ``run_playbook`` / ``plan`` — inference-bearing; delegate to
   :func:`~app.citation.cost.estimate_judge_call_cost_usd` which uses a
   per-model rolling average over the last 100 judge calls.
 * ``retrieve_chunks`` / ``propose_memory`` / ``propose_precedent`` /
@@ -42,7 +42,7 @@ from app.autonomous.enums import ToolIntent
 from app.citation.cost import estimate_judge_call_cost_usd
 
 _INFERENCE_INTENTS: frozenset[ToolIntent] = frozenset(
-    {ToolIntent.run_skill, ToolIntent.run_playbook}
+    {ToolIntent.run_skill, ToolIntent.run_playbook, ToolIntent.plan}
 )
 
 
@@ -54,7 +54,7 @@ async def estimate_tool_cost(
     """Project the USD cost of a tool call for the R4 pre-flight check.
 
     Inference-bearing intents (:attr:`~ToolIntent.run_skill`,
-    :attr:`~ToolIntent.run_playbook`) reuse the M2-E2 rolling-average
+    :attr:`~ToolIntent.run_playbook`, :attr:`~ToolIntent.plan`) reuse the M2-E2 rolling-average
     estimator keyed by model name. The ``params`` dict is expected to carry
     ``"judge_model"`` (preferred) or ``"model"`` for these intents.
 

--- a/api/app/autonomous/enums.py
+++ b/api/app/autonomous/enums.py
@@ -51,6 +51,9 @@ class ToolIntent(StrEnum):
     notify = "notify"
     retrieve_caselaw = "retrieve_caselaw"
     call_mcp_tool = "call_mcp_tool"
+    # WS-D PR1: the planner's next-step decision call (a gateway inference).
+    # Granted only in analysis; the agentic loop dispatches it each iteration.
+    plan = "plan"
 
 
 PHASE_GRANTS: dict[Phase, frozenset[ToolIntent]] = {
@@ -67,6 +70,8 @@ PHASE_GRANTS: dict[Phase, frozenset[ToolIntent]] = {
             # lookups; granted at analysis only (PR5a D-a4).
             ToolIntent.retrieve_caselaw,
             ToolIntent.call_mcp_tool,
+            # WS-D PR1: the agentic planner decision call.
+            ToolIntent.plan,
         }
     ),
     Phase.drafting: frozenset(

--- a/api/app/autonomous/executor.py
+++ b/api/app/autonomous/executor.py
@@ -175,8 +175,13 @@ async def run_autonomous_session(
         await db.commit()
 
     except Exception as exc:
-        # Any in-graph exception: persist the failure and don't re-raise.
-        # The arq worker already accepted the job; the caller polls the row.
+        # C1b defense-in-depth: a poisoned AsyncSession (e.g. a DBAPIError
+        # from a bad SQL arg that reached the handler) leaves the transaction
+        # in an aborted state.  The commit() below would then also raise a
+        # PendingRollbackError, stranding the session at status='running'
+        # (zombie).  rollback() first so the subsequent get()/commit() always
+        # succeeds, regardless of whether the tx was poisoned or clean.
+        await db.rollback()
         logger.exception(
             "autonomous executor crashed mid-graph",
             extra={
@@ -185,10 +190,14 @@ async def run_autonomous_session(
                 "error_type": type(exc).__name__,
             },
         )
-        session.status = "failed"
-        session.error = f"{type(exc).__name__}: {exc}"[:2000]
-        session.completed_at = datetime.now(UTC)
-        await db.commit()
+        # Re-fetch after rollback: the rollback may have expired or detached
+        # the in-memory row; a fresh get() is always safe here.
+        session = await db.get(AutonomousSession, session_id)
+        if session is not None:
+            session.status = "failed"
+            session.error = f"{type(exc).__name__}: {exc}"[:2000]
+            session.completed_at = datetime.now(UTC)
+            await db.commit()
 
 
 def _build_graph(

--- a/api/app/autonomous/guard.py
+++ b/api/app/autonomous/guard.py
@@ -546,7 +546,7 @@ async def _dispatch(
     if intent == ToolIntent.retrieve_chunks:
         return await _handle_retrieve_chunks(params, db=db)
 
-    if intent in (ToolIntent.run_skill, ToolIntent.run_playbook):
+    if intent in (ToolIntent.run_skill, ToolIntent.run_playbook, ToolIntent.plan):
         return await _handle_gateway_inference(
             intent, params, gateway=gateway, estimated_cost=estimated_cost
         )

--- a/api/app/autonomous/nodes.py
+++ b/api/app/autonomous/nodes.py
@@ -45,11 +45,18 @@ from app.autonomous.audit import autonomous_audit
 from app.autonomous.enums import ToolIntent
 from app.autonomous.guard import guarded_tool_call
 from app.autonomous.phases import run_phase_transition
-from app.autonomous.prompts import assemble_analysis_messages
+from app.autonomous.planner import (
+    PLANNER_ALLOWLIST,
+    build_planner_messages,
+    parse_planner_decision,
+    summarize_observation,
+)
+from app.autonomous.prompts import assemble_analysis_messages, assemble_synthesis_messages
 from app.autonomous.receipt import build_receipt_safe
 from app.autonomous.state import AutonomousSessionState
 from app.autonomous.structured_output import parse_structured_output
-from app.config import get_settings
+from app.config import DEFAULT_MAX_ANALYSIS_STEPS, get_settings
+from app.errors import AutonomousBrake
 from app.models.autonomous import AutonomousSession
 from app.schemas.autonomous import Phase
 
@@ -152,6 +159,108 @@ def make_intake_node(
     return intake_node
 
 
+async def _run_analysis_loop(
+    session: AutonomousSession,
+    *,
+    query: str,
+    params: dict[str, Any],
+    chunks: list[dict[str, Any]],
+    model: str,
+    db: AsyncSession,
+    gateway: Any,
+) -> dict[str, Any]:
+    """The governed plan→act→observe→replan loop for matter-scoped sessions (WS-D PR1).
+
+    Every step goes through :func:`~app.autonomous.guard.guarded_tool_call`
+    (R5→R6→R4); bounded by ``max_analysis_steps`` + R4's cost cap.
+
+    Brake invariant (addendum §A): :exc:`~app.errors.AutonomousBrake` from
+    the action dispatch propagates immediately (brake-commit contract); every
+    other exception from the action handler is caught as a non-fatal failed
+    observation so a bad model-supplied arg never crashes the loop.
+
+    P3 invariant: ``analysis_plan_trace`` carries counts/intents/short
+    rationales/halt-reason only — never raw tool payloads.
+    """
+    max_steps = int(params.get("max_analysis_steps") or DEFAULT_MAX_ANALYSIS_STEPS)
+    observations: list[str] = []
+    trace: list[dict[str, str]] = []
+    halt_reason = "step_cap"
+    steps = 0
+
+    while steps < max_steps:
+        plan_res = await guarded_tool_call(
+            session,
+            ToolIntent.plan,
+            {
+                "model": model,
+                "messages": build_planner_messages(
+                    goal=query,
+                    observations=observations,
+                    allowlist=PLANNER_ALLOWLIST,
+                ),
+                "anonymize": False,
+            },
+            db,
+            gateway,
+        )
+        decision = parse_planner_decision((plan_res.data or {}).get("content"))
+        if decision is None:
+            halt_reason = "planner_unparseable"
+            break
+        if decision.done:
+            halt_reason = "planner_done"
+            trace.append({"step": str(steps), "intent": "done", "rationale": decision.rationale})
+            break
+
+        assert decision.next_intent is not None  # parser guarantees: action ⇒ intent set
+        try:
+            act = await guarded_tool_call(session, decision.next_intent, decision.args, db, gateway)
+            observations.append(
+                summarize_observation(decision.next_intent, decision.rationale, act)
+            )
+        except AutonomousBrake:
+            raise  # brakes (SessionHalted/CostCapReached/ToolNotGranted) propagate
+        except Exception as exc:  # invariant #5: bad planner arg is a non-fatal failed observation
+            observations.append(f"{decision.next_intent.value} → failed ({type(exc).__name__})")
+        trace.append(
+            {
+                "step": str(steps),
+                "intent": decision.next_intent.value,
+                "rationale": decision.rationale,
+            }
+        )
+        steps += 1
+
+    synth = await guarded_tool_call(
+        session,
+        ToolIntent.run_skill,
+        {
+            "model": model,
+            "messages": await assemble_synthesis_messages(
+                session,
+                goal=query,
+                observations=observations,
+                chunks=chunks,
+                db=db,
+            ),
+            "anonymize": True,
+        },
+        db,
+        gateway,
+    )
+    return {
+        "current_phase": str(Phase.analysis),
+        "analysis_content": (synth.data or {}).get("content"),
+        "analysis_outcome": synth.outcome,
+        "analysis_plan_trace": {
+            "steps": steps,
+            "halt_reason": halt_reason,
+            "decisions": trace,
+        },
+    }
+
+
 def make_analysis_node(
     db: AsyncSession,
     gateway: Any = None,
@@ -224,12 +333,29 @@ def make_analysis_node(
                 "analysis_content": None,
             }
 
+        settings = get_settings()
+        model = params.get("model") or settings.autonomous_default_model
+        query = (state.get("query") or "").strip()
+
+        if query:
+            # Matter-scoped session: run the governed plan→act→observe→replan
+            # loop (WS-D PR1).  The loop gate only engages when the session
+            # carries a non-empty matter goal; query-less sessions (cron/watch/
+            # schedule) take the unchanged single-call path below.
+            return await _run_analysis_loop(
+                session,
+                query=query,
+                params=params,
+                chunks=state.get("retrieved_chunks") or [],
+                model=model,
+                db=db,
+                gateway=gateway,
+            )
+
+        # ---- unchanged single-call path (query-less sessions) ----
         chunks = state.get("retrieved_chunks") or []
         messages = await assemble_analysis_messages(session, chunks=chunks, db=db)
         intent = ToolIntent.run_playbook if playbook_id else ToolIntent.run_skill
-
-        settings = get_settings()
-        model = params.get("model") or settings.autonomous_default_model
 
         result = await guarded_tool_call(
             session,

--- a/api/app/autonomous/nodes.py
+++ b/api/app/autonomous/nodes.py
@@ -798,7 +798,17 @@ def make_delivery_node(
         # column is populated atomically with the terminal status update.
         # build_receipt reads audit rows that were flushed during the run
         # and are visible in the same session/transaction.
-        session.result = await build_receipt_safe(session, db)
+        receipt = await build_receipt_safe(session, db)
+        # D5 transparency: if the agentic-loop ran, merge its plan trace into
+        # the receipt under "plan_trace".  Strictly additive — only injected
+        # when the trace exists in state (query-less / non-matter sessions have
+        # no trace and their receipt shape is unchanged).  We must guard against
+        # build_receipt_safe returning None (DE-325 best-effort contract) —
+        # skip the merge in that case; the session still transitions to terminal.
+        plan_trace = state.get("analysis_plan_trace")
+        if isinstance(receipt, dict) and plan_trace is not None:
+            receipt["plan_trace"] = plan_trace
+        session.result = receipt
         await db.commit()
 
         return {"current_phase": str(Phase.delivery)}

--- a/api/app/autonomous/nodes.py
+++ b/api/app/autonomous/nodes.py
@@ -50,6 +50,7 @@ from app.autonomous.planner import (
     build_planner_messages,
     parse_planner_decision,
     summarize_observation,
+    validate_action_args,
 )
 from app.autonomous.prompts import assemble_analysis_messages, assemble_synthesis_messages
 from app.autonomous.receipt import build_receipt_safe
@@ -166,6 +167,7 @@ async def _run_analysis_loop(
     params: dict[str, Any],
     chunks: list[dict[str, Any]],
     model: str,
+    synthesis_intent: ToolIntent,
     db: AsyncSession,
     gateway: Any,
 ) -> dict[str, Any]:
@@ -213,15 +215,20 @@ async def _run_analysis_loop(
             trace.append({"step": str(steps), "intent": "done", "rationale": decision.rationale})
             break
 
-        assert decision.next_intent is not None  # parser guarantees: action ⇒ intent set
+        if decision.next_intent is None:  # parser guarantees this won't happen; -O-safe belt
+            halt_reason = "planner_unparseable"
+            break
         try:
+            validate_action_args(decision.next_intent, decision.args)
             act = await guarded_tool_call(session, decision.next_intent, decision.args, db, gateway)
             observations.append(
                 summarize_observation(decision.next_intent, decision.rationale, act)
             )
         except AutonomousBrake:
             raise  # brakes (SessionHalted/CostCapReached/ToolNotGranted) propagate
-        except Exception as exc:  # invariant #5: bad planner arg is a non-fatal failed observation
+        except (
+            Exception
+        ) as exc:  # invariant #5 / C1: bad arg → non-fatal failed observation, no DB poison
             observations.append(f"{decision.next_intent.value} → failed ({type(exc).__name__})")
         trace.append(
             {
@@ -234,7 +241,7 @@ async def _run_analysis_loop(
 
     synth = await guarded_tool_call(
         session,
-        ToolIntent.run_skill,
+        synthesis_intent,
         {
             "model": model,
             "messages": await assemble_synthesis_messages(
@@ -342,12 +349,16 @@ def make_analysis_node(
             # loop (WS-D PR1).  The loop gate only engages when the session
             # carries a non-empty matter goal; query-less sessions (cron/watch/
             # schedule) take the unchanged single-call path below.
+            # I1: choose the synthesis intent that matches the session target so
+            # the synthesis call audits honestly (run_playbook vs run_skill).
+            synthesis_intent = ToolIntent.run_playbook if playbook_id else ToolIntent.run_skill
             return await _run_analysis_loop(
                 session,
                 query=query,
                 params=params,
                 chunks=state.get("retrieved_chunks") or [],
                 model=model,
+                synthesis_intent=synthesis_intent,
                 db=db,
                 gateway=gateway,
             )

--- a/api/app/autonomous/planner.py
+++ b/api/app/autonomous/planner.py
@@ -1,0 +1,108 @@
+"""WS-D PR1 — the agentic planner: prompt, decision parser, observation summarizer.
+
+The planner is a gateway inference (ToolIntent.plan) that, given the matter
+goal + compact observations + the observe-intent allowlist, returns either the
+next governed action to take or a 'done' signal. It NEVER selects outside the
+closed allowlist (an out-of-set proposal parses to None → the loop stops
+conservatively). It does not execute anything — the loop dispatches its choice
+through guarded_tool_call (ADR 0020 D1).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.autonomous.enums import ToolIntent
+
+log = logging.getLogger(__name__)
+
+# The planner may choose ONLY observe intents (gather), or signal done.
+# run_skill/run_playbook are reserved for the final synthesis; emit/side-effect
+# intents are not planner-driven in PR1.
+PLANNER_ALLOWLIST: frozenset[ToolIntent] = frozenset(
+    {ToolIntent.retrieve_chunks, ToolIntent.retrieve_caselaw, ToolIntent.call_mcp_tool}
+)
+
+_SYSTEM_PROMPT = """\
+You are the research planner for a governed legal-matter agent. Given the
+MATTER GOAL and the OBSERVATIONS gathered so far, decide the SINGLE next
+research action, or that enough has been gathered.
+
+You may choose ONLY from this closed set of actions (you cannot invent tools):
+{allowlist}
+
+Respond with STRICTLY VALID JSON, one of:
+
+  {{"next_intent": "<one action above>",
+    "args": {{ ...arguments for that action... }},
+    "rationale": "<one sentence: why this next step>"}}
+
+or, when enough authority/context has been gathered:
+
+  {{"done": true, "rationale": "<one sentence: why you are finished>"}}
+
+Output ONLY the JSON object. No preamble, no markdown fencing."""
+
+
+@dataclass(slots=True)
+class PlannerDecision:
+    done: bool
+    next_intent: ToolIntent | None
+    args: dict[str, Any] = field(default_factory=dict)
+    rationale: str = ""
+
+
+def build_planner_messages(
+    *, goal: str, observations: list[str], allowlist: frozenset[ToolIntent]
+) -> list[dict[str, str]]:
+    allow = ", ".join(sorted(i.value for i in allowlist))
+    system = _SYSTEM_PROMPT.format(allowlist=allow)
+    obs = "\n".join(f"- {o}" for o in observations) if observations else "(none yet)"
+    user = f"MATTER GOAL:\n{goal}\n\nOBSERVATIONS SO FAR:\n{obs}\n\nDecide the next action as JSON."
+    return [{"role": "system", "content": system}, {"role": "user", "content": user}]
+
+
+def parse_planner_decision(content: str | None) -> PlannerDecision | None:
+    if not content:
+        return None
+    text = content.strip()
+    if text.startswith("```"):  # tolerate an accidental fence
+        text = text.strip("`")
+        text = text[text.find("{") :] if "{" in text else text
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        log.info("planner produced non-JSON", extra={"event": "autonomous_planner_malformed"})
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("done") is True:
+        return PlannerDecision(
+            done=True, next_intent=None, rationale=str(payload.get("rationale", ""))
+        )
+    raw_intent = payload.get("next_intent")
+    if not isinstance(raw_intent, str):
+        return None
+    try:
+        intent = ToolIntent(raw_intent)
+    except ValueError:
+        return None
+    if intent not in PLANNER_ALLOWLIST:
+        log.info(
+            "planner chose out-of-allowlist intent %r",
+            raw_intent,
+            extra={"event": "autonomous_planner_out_of_set"},
+        )
+        return None
+    args = payload.get("args")
+    if not isinstance(args, dict):
+        args = {}
+    return PlannerDecision(
+        done=False,
+        next_intent=intent,
+        args=args,
+        rationale=str(payload.get("rationale", "")),
+    )

--- a/api/app/autonomous/planner.py
+++ b/api/app/autonomous/planner.py
@@ -108,6 +108,31 @@ def parse_planner_decision(content: str | None) -> PlannerDecision | None:
     )
 
 
+def validate_action_args(intent: ToolIntent, args: dict[str, Any]) -> None:
+    """Reject planner-supplied args that would fault at the SQL/handler layer
+    BEFORE they reach the chokepoint. Raises ValueError on an un-runnable arg
+    so the loop records a clean failed observation instead of poisoning the
+    AsyncSession with a DBAPIError (WS-D PR1 C1; ADR 0015 closed-set boundary).
+    A clean (no-SQL) ValueError keeps the session usable so synthesis still runs.
+
+    Only validates ``retrieve_chunks`` — the only local/SQL intent in the
+    planner allowlist.  ``retrieve_caselaw``/``call_mcp_tool`` are external;
+    their handler/HTTP errors are already non-poisoning.
+    """
+    if intent == ToolIntent.retrieve_chunks:
+        top_k = args.get("top_k")
+        if top_k is not None and (
+            not isinstance(top_k, int) or isinstance(top_k, bool) or top_k < 1
+        ):
+            raise ValueError(f"retrieve_chunks top_k must be a positive int, got {top_k!r}")
+        emb = args.get("query_embedding")
+        if emb is not None and (
+            not isinstance(emb, list)
+            or not all(isinstance(x, (int, float)) and not isinstance(x, bool) for x in emb)
+        ):
+            raise ValueError("retrieve_chunks query_embedding must be None or a list of numbers")
+
+
 _SNIPPET = 120
 
 

--- a/api/app/autonomous/planner.py
+++ b/api/app/autonomous/planner.py
@@ -106,3 +106,37 @@ def parse_planner_decision(content: str | None) -> PlannerDecision | None:
         args=args,
         rationale=str(payload.get("rationale", "")),
     )
+
+
+_SNIPPET = 120
+
+
+def summarize_observation(intent: ToolIntent, rationale: str, result: object) -> str:
+    """One-line, P3-clean summary of a tool result for the planner's context.
+
+    Never includes full opinion/chunk payloads — only counts, ids, case names,
+    and short snippets. ``result`` is a guard.ToolResult (duck-typed to avoid a
+    circular import: read ``.outcome`` and ``.data``)."""
+    outcome = getattr(result, "outcome", "success")
+    data = getattr(result, "data", None) or {}
+    if outcome != "success":
+        return f"{intent.value} → failed ({outcome})"
+    if intent == ToolIntent.retrieve_caselaw:
+        items = data.get("results") or data.get("matches") or []
+        names = [
+            f"{(i.get('case_name') or '?')} ({i.get('court') or '?'} {i.get('date_filed') or '?'})"
+            for i in items[:5]
+            if isinstance(i, dict)
+        ]
+        more = "" if len(items) <= 5 else f" +{len(items) - 5} more"
+        return f"{intent.value} → {len(items)} result(s): [{'; '.join(names)}]{more}"
+    if intent == ToolIntent.retrieve_chunks:
+        chunks = data.get("chunks") or []
+        files = sorted({fn for c in chunks if isinstance(c, dict) and (fn := c.get("file_name"))})
+        return f"{intent.value} → {len(chunks)} chunk(s) from {files or '(no files)'}"
+    if intent == ToolIntent.call_mcp_tool:
+        payload = data if isinstance(data, dict) else {}
+        keys = sorted(payload.keys())[:8]
+        return f"{intent.value} → payload keys {keys}"
+    snippet = str(data)[:_SNIPPET]
+    return f"{intent.value} → {snippet}"

--- a/api/app/autonomous/prompts.py
+++ b/api/app/autonomous/prompts.py
@@ -367,8 +367,66 @@ def _format_chunks_as_user_content(chunks: list[dict[str, Any]]) -> str:
     return "\n\n".join(blocks)
 
 
+async def assemble_synthesis_messages(
+    session: AutonomousSession,
+    *,
+    goal: str,
+    observations: list[str],
+    chunks: list[dict[str, Any]],
+    db: AsyncSession,
+    registry: SkillRegistry | None = None,
+) -> list[dict[str, str]]:
+    """Build the final-synthesis messages for the agentic loop (WS-D PR1).
+
+    Reuses :func:`assemble_analysis_messages` (so the skill/playbook system
+    prompt and :data:`STRUCTURED_OUTPUT_INSTRUCTION` are identical — the
+    synthesis must still emit the fenced-JSON findings the drafting node
+    parses), then appends a user block carrying the matter GOAL and the
+    loop's compact OBSERVATIONS.
+
+    Args:
+        session: The autonomous session.  ``session.params`` must carry a
+            resolvable target (``skill_ref`` or ``playbook_id``) — same
+            constraint as :func:`assemble_analysis_messages`.
+        goal: The matter goal text set at session spawn (e.g., "Is the
+            indemnification clause market-standard?").
+        observations: Compact strings produced by the planner loop — one
+            per research step (e.g., "retrieve_caselaw → 2 results: …").
+            May be empty when no steps ran.
+        chunks: Retrieved-chunks list (forwarded verbatim to the base
+            assembler so the system+user pair is identical to what the
+            standalone analysis path would have produced).
+        db: Active async ORM session.
+        registry: Optional skill registry snapshot.  Forwarded to the
+            base assembler; see :func:`assemble_analysis_messages`.
+
+    Returns:
+        A ``[system, user, user]`` list where the first two elements are
+        the base analysis messages and the third carries the goal + obs.
+    """
+    messages = await assemble_analysis_messages(session, chunks=chunks, db=db, registry=registry)
+    obs_block = (
+        "\n".join(f"- {o}" for o in observations)
+        if observations
+        else "(no research steps were run)"
+    )
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                f"MATTER GOAL:\n{goal}\n\n"
+                f"RESEARCH OBSERVATIONS (gathered by the agent):\n{obs_block}\n\n"
+                "Synthesize your analysis of the MATTER GOAL using the observations and any "
+                "chunks above, then return the final JSON object as instructed."
+            ),
+        }
+    )
+    return messages
+
+
 __all__ = [
     "ARTIFACT_OUTPUT_INSTRUCTION",
     "STRUCTURED_OUTPUT_INSTRUCTION",
     "assemble_analysis_messages",
+    "assemble_synthesis_messages",
 ]

--- a/api/app/autonomous/state.py
+++ b/api/app/autonomous/state.py
@@ -96,3 +96,11 @@ class AutonomousSessionState(TypedDict, total=False):
     # surfaces it as ``artifact_count`` in the notify payload and as
     # ``artifacts_count`` on the terminal ``completed`` audit row.
     artifacts_count: int
+
+    # WS-D PR1: agentic-loop plan trace. Set only when the loop ran
+    # (``state["query"]`` was non-empty and a ``skill_ref`` or
+    # ``playbook_id`` was configured). Carries counts/intents/short
+    # rationale/halt only — never raw tool payloads (P3). Shape:
+    # ``{"steps": int, "halt_reason": str, "decisions": list[dict]}``.
+    # Absent on the query-less single-call path.
+    analysis_plan_trace: dict | None

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -457,6 +457,11 @@ class Settings(BaseSettings):
     )
 
 
+# WS-D PR1: default maximum number of plan→act steps in the agentic analysis loop.
+# Session params["max_analysis_steps"] overrides this per-session.
+DEFAULT_MAX_ANALYSIS_STEPS: int = 6
+
+
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:
     """Return the cached Settings instance.

--- a/api/tests/autonomous/conftest.py
+++ b/api/tests/autonomous/conftest.py
@@ -654,6 +654,53 @@ async def seeded_matter_session(
 
 
 @pytest_asyncio.fixture
+async def seeded_playbook_matter_session(
+    db_session: AsyncSession,
+) -> AutonomousSession:
+    """Running session with ``playbook_id`` + ``query`` for I1 synthesis-intent test.
+
+    Carries ``params["playbook_id"]`` + ``params["query"]`` so the analysis
+    node's loop gate engages AND the synthesis intent resolves to
+    ``ToolIntent.run_playbook`` (not ``run_skill``).  No skill registry is
+    required because the prompt assembler resolves the playbook from the DB.
+    """
+    user = await _make_optedin_user(db_session)
+    playbook = Playbook(
+        name="Agentic Loop Fixture Playbook",
+        contract_type="NDA",
+        description="Used by the I1 synthesis-intent test in test_agentic_loop.py.",
+    )
+    db_session.add(playbook)
+    await db_session.flush()
+    position = PlaybookPosition(
+        playbook_id=playbook.id,
+        issue="Confidentiality term",
+        description="Receiving Party obligation scope.",
+        standard_language=(
+            "The Receiving Party shall hold Confidential Information in confidence "
+            "and shall not disclose it to any third party."
+        ),
+        severity_if_missing="high",
+        detection_keywords=["confidential"],
+        detection_examples=[],
+        redline_strategy="Tighten to the standard language above.",
+        fallback_tiers=[],
+        position_order=0,
+    )
+    db_session.add(position)
+    await db_session.flush()
+    return await _make_running_session(
+        db_session,
+        user=user,
+        trigger_kind="manual",
+        params={
+            "playbook_id": str(playbook.id),
+            "query": "Is the indemnification clause market-standard?",
+        },
+    )
+
+
+@pytest_asyncio.fixture
 async def seeded_skill_session_no_query(
     db_session: AsyncSession,
     _installed_skill_registry: None,

--- a/api/tests/autonomous/conftest.py
+++ b/api/tests/autonomous/conftest.py
@@ -622,6 +622,59 @@ async def running_session_at_delivery(db_session: AsyncSession) -> AutonomousSes
     return await _make_running_session(db_session, user=user, trigger_kind="watch", params={})
 
 
+# ---------------------------------------------------------------------------
+# WS-D PR1 — agentic-loop fixtures (test_agentic_loop.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seeded_matter_session(
+    db_session: AsyncSession,
+    _installed_skill_registry: None,
+) -> AutonomousSession:
+    """Running, opted-in, skill-ref session with a matter query.
+
+    Carries ``params["skill_ref"]`` + ``params["query"]`` so the analysis
+    node's loop gate engages.  Tests must also set ``state["query"]``
+    (which the real executor seeds from ``session.params["query"]`` at
+    executor.py:116 — the fixture mirrors production params truthfully).
+    Requests :func:`_installed_skill_registry` so ``alpha-test-skill``
+    resolves during synthesis prompt assembly.
+    """
+    user = await _make_optedin_user(db_session)
+    return await _make_running_session(
+        db_session,
+        user=user,
+        trigger_kind="manual",
+        params={
+            "skill_ref": _FIXTURE_SKILL_REF,
+            "query": "Is the assignment clause enforceable?",
+        },
+    )
+
+
+@pytest_asyncio.fixture
+async def seeded_skill_session_no_query(
+    db_session: AsyncSession,
+    _installed_skill_registry: None,
+) -> AutonomousSession:
+    """Running, opted-in, skill-ref session WITHOUT a matter query.
+
+    Triggers the query-less single-call path in ``make_analysis_node``
+    (invariant #1 test).  ``params`` carries only ``skill_ref`` — no
+    ``query`` — so ``(state.get('query') or '').strip()`` is empty and
+    the loop gate does not engage.  Requests :func:`_installed_skill_registry`
+    so the single-call ``assemble_analysis_messages`` can resolve the skill.
+    """
+    user = await _make_optedin_user(db_session)
+    return await _make_running_session(
+        db_session,
+        user=user,
+        trigger_kind="manual",
+        params={"skill_ref": _FIXTURE_SKILL_REF},
+    )
+
+
 @pytest.fixture
 def mock_gateway_structured_response() -> MagicMock:
     """Gateway double whose ``chat_completion`` returns a structured-output stub.

--- a/api/tests/autonomous/test_agentic_loop.py
+++ b/api/tests/autonomous/test_agentic_loop.py
@@ -1,0 +1,323 @@
+"""Integration tests for the governed analysis-phase loop (WS-D PR1, Task 5).
+
+Tests the plan→act→observe→replan loop inside ``make_analysis_node`` and
+pins the five load-bearing invariants from the task brief CONTROLLER ADDENDUM.
+
+Gateway / planner are stubbed in-test — do NOT pass ``-m provider``.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.nodes import make_analysis_node
+from app.autonomous.state import AutonomousSessionState
+from app.models.audit import AuditLog
+from app.models.autonomous import AutonomousSession
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Scripted gateway stub
+# ---------------------------------------------------------------------------
+
+
+def _resp(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=10),
+    )
+
+
+_SYNTHESIS_JSON = (
+    '```json\n{"findings": [{"title": "t", "summary": "s", '
+    '"severity": "info", "source_chunk_ids": []}], "suggested_memories": [], '
+    '"suggested_precedents": [], "privilege_concerns": [], "scope_concerns": []}\n```'
+)
+
+
+class _ScriptedGateway:
+    """Minimal gateway stub that distinguishes planner from synthesis calls.
+
+    Planner calls have 'research planner' in ``messages[0].content`` (the
+    system prompt built by ``build_planner_messages``).  Synthesis / single
+    inference calls don't, and receive the fixed structured-JSON stub.
+    """
+
+    def __init__(self, planner_script: list[Any]) -> None:
+        self.planner_script = list(planner_script)
+
+    async def chat_completion(self, request: Any, *, request_id: object = None) -> SimpleNamespace:
+        system = request.messages[0].content
+        if "research planner" in system:
+            return _resp(json.dumps(self.planner_script.pop(0)))
+        # synthesis or single-call path → structured findings stub
+        return _resp(_SYNTHESIS_JSON)
+
+
+# ---------------------------------------------------------------------------
+# Audit-row helpers (mirror the pattern in test_executor_real_work.py)
+# ---------------------------------------------------------------------------
+
+
+async def _audit_rows(db: AsyncSession, session_id: str) -> list[Any]:
+    rows = (
+        (
+            await db.execute(
+                select(AuditLog)
+                .where(AuditLog.resource_type == "autonomous_session")
+                .where(AuditLog.resource_id == session_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return list(rows)
+
+
+def _tool_started_calls(rows: list[Any], tool: str) -> int:
+    """Count ``started`` audit rows for a specific tool intent."""
+    return sum(
+        1
+        for r in rows
+        if r.action == "autonomous_session.tool_call"
+        and (r.details or {}).get("tool") == tool
+        and (r.details or {}).get("outcome") == "started"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — query-less session is byte-identical to today's behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_query_less_session_is_unchanged(
+    db_session: AsyncSession,
+    seeded_skill_session_no_query: AutonomousSession,
+) -> None:
+    """No ``state['query']`` → single ``run_skill`` path; no ``plan`` intent audited.
+
+    Pins invariant #1: the query-less path must be behaviorally byte-identical
+    to the pre-loop behaviour.  No ``analysis_plan_trace`` key in the return.
+    """
+    gw = _ScriptedGateway([])  # planner_script is never consulted
+    node = make_analysis_node(db_session, gw)
+    state: AutonomousSessionState = {
+        "session_id": str(seeded_skill_session_no_query.id),
+        "retrieved_chunks": [],
+        # deliberately omit "query" — must take the single-call path
+    }
+    result = await node(state)
+
+    # Single-call path: analysis_content present, outcome success
+    assert "analysis_content" in result
+    assert result.get("analysis_outcome") == "success"
+    # No plan intent was dispatched (invariant #1)
+    rows = await _audit_rows(db_session, str(seeded_skill_session_no_query.id))
+    assert _tool_started_calls(rows, "plan") == 0
+    # No loop trace key on the query-less path
+    assert "analysis_plan_trace" not in result
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — loop runs planner then done, synthesis always follows
+# ---------------------------------------------------------------------------
+
+
+async def test_loop_runs_planner_then_done_then_synthesis(
+    db_session: AsyncSession,
+    seeded_matter_session: AutonomousSession,
+    kb_with_one_indexed_file: Any,  # KbOneFile from conftest
+) -> None:
+    """Planner returns one retrieve_chunks action then done.
+
+    Verifies: the action is dispatched through the chokepoint (audit row),
+    the synthesis runs and produces parseable analysis_content, and the
+    returned ``analysis_plan_trace`` carries the correct step count and
+    halt_reason.
+
+    ``retrieve_chunks`` (local, no HTTP) was chosen over ``retrieve_caselaw``
+    (external, HTTP to gateway) so the action actually SUCCEEDS — giving a
+    real observation assertion on chunk count.
+    """
+    kb_id = str(kb_with_one_indexed_file.kb_id)
+    gw = _ScriptedGateway(
+        [
+            {
+                "next_intent": "retrieve_chunks",
+                "args": {"kb_id": kb_id, "query": "confidential"},
+                "rationale": "gather clause context",
+            },
+            {"done": True, "rationale": "enough evidence"},
+        ]
+    )
+    node = make_analysis_node(db_session, gw)
+    state: AutonomousSessionState = {
+        "session_id": str(seeded_matter_session.id),
+        "query": "Is the assignment clause enforceable?",
+        "retrieved_chunks": [],
+    }
+    result = await node(state)
+
+    # Synthesis produced parseable analysis_content
+    assert result.get("analysis_content") is not None
+    assert "findings" in (result["analysis_content"] or "")
+
+    # Trace: 1 action step, halt_reason=planner_done
+    trace = result.get("analysis_plan_trace")
+    assert trace is not None
+    assert trace["steps"] == 1
+    assert trace["halt_reason"] == "planner_done"
+    assert isinstance(trace["decisions"], list)
+    # decisions = [action entry, done entry]
+    assert len(trace["decisions"]) == 2
+    assert trace["decisions"][0]["intent"] == "retrieve_chunks"
+    assert trace["decisions"][1]["intent"] == "done"
+
+    # Audit: plan was issued twice (action step + done step); retrieve_chunks once
+    rows = await _audit_rows(db_session, str(seeded_matter_session.id))
+    assert _tool_started_calls(rows, "plan") >= 2
+    assert _tool_started_calls(rows, "retrieve_chunks") == 1
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 + step cap — loop stops at max_analysis_steps, synthesis runs
+# ---------------------------------------------------------------------------
+
+
+async def test_step_cap_halts_and_still_synthesizes(
+    db_session: AsyncSession,
+    seeded_matter_session: AutonomousSession,
+) -> None:
+    """Planner never says done → loop stops at ``max_analysis_steps``; synthesis
+    always runs (partial-but-honest, never a crash).
+
+    Uses ``retrieve_chunks`` with empty args so the action raises ``ValueError``
+    immediately (no HTTP calls, deterministic failure) → caught per addendum §A.
+    """
+    # 20 action decisions; only 2 should be consumed with max_analysis_steps=2
+    gw = _ScriptedGateway([{"next_intent": "retrieve_chunks", "args": {}, "rationale": "x"}] * 20)
+    # Override cap via session params (node reads params["max_analysis_steps"])
+    seeded_matter_session.params = {
+        **(seeded_matter_session.params or {}),
+        "max_analysis_steps": 2,
+    }
+    await db_session.flush()
+
+    node = make_analysis_node(db_session, gw)
+    state: AutonomousSessionState = {
+        "session_id": str(seeded_matter_session.id),
+        "query": "Is the assignment clause enforceable?",
+        "retrieved_chunks": [],
+    }
+    result = await node(state)
+
+    # Synthesis still ran (partial-but-honest)
+    assert result.get("analysis_content") is not None
+
+    trace = result.get("analysis_plan_trace")
+    assert trace is not None
+    assert trace["steps"] == 2
+    assert trace["halt_reason"] == "step_cap"
+    # Exactly 2 action entries in decisions (no "done" entry on step_cap path)
+    assert len(trace["decisions"]) == 2
+    assert all(d["intent"] == "retrieve_chunks" for d in trace["decisions"])
+
+    # Audit: plan called twice, retrieve_chunks started twice (then caught)
+    rows = await _audit_rows(db_session, str(seeded_matter_session.id))
+    assert _tool_started_calls(rows, "retrieve_chunks") == 2
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — unparseable planner stops loop, synthesis still runs
+# ---------------------------------------------------------------------------
+
+
+async def test_unparseable_planner_stops_loop_then_synthesizes(
+    db_session: AsyncSession,
+    seeded_matter_session: AutonomousSession,
+) -> None:
+    """Planner returns garbage JSON → loop stops immediately; synthesis runs.
+
+    ``halt_reason`` is ``"planner_unparseable"`` and no action intent is
+    dispatched (only the plan call + the final synthesis call).
+    """
+    gw = _ScriptedGateway(["not json at all"])
+    node = make_analysis_node(db_session, gw)
+    state: AutonomousSessionState = {
+        "session_id": str(seeded_matter_session.id),
+        "query": "Is the assignment clause enforceable?",
+        "retrieved_chunks": [],
+    }
+    result = await node(state)
+
+    # Synthesis ran despite planner failure
+    assert result.get("analysis_content") is not None
+
+    trace = result.get("analysis_plan_trace")
+    assert trace is not None
+    assert trace["steps"] == 0
+    assert trace["halt_reason"] == "planner_unparseable"
+    # No action steps — decisions is empty
+    assert trace["decisions"] == []
+
+    # No action intent was dispatched (only plan + synthesis)
+    rows = await _audit_rows(db_session, str(seeded_matter_session.id))
+    assert _tool_started_calls(rows, "retrieve_chunks") == 0
+    assert _tool_started_calls(rows, "retrieve_caselaw") == 0
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5 (addendum §B) — bad planner arg is a non-fatal observation
+# ---------------------------------------------------------------------------
+
+
+async def test_action_error_is_nonfatal_observation(
+    db_session: AsyncSession,
+    seeded_matter_session: AutonomousSession,
+) -> None:
+    """A bad planner arg that makes the handler raise is a non-fatal observation.
+
+    ``retrieve_chunks`` with ``{}`` (no ``query``/``file_id``/``since``) raises
+    ``ValueError``.  The node must NOT propagate the exception; the step is
+    still counted in the trace; synthesis runs; ``halt_reason='planner_done'``.
+
+    This pins the milestone's partial-but-honest-over-crash thesis.
+    """
+    gw = _ScriptedGateway(
+        [
+            {"next_intent": "retrieve_chunks", "args": {}, "rationale": "x"},
+            {"done": True, "rationale": "enough evidence"},
+        ]
+    )
+    node = make_analysis_node(db_session, gw)
+    state: AutonomousSessionState = {
+        "session_id": str(seeded_matter_session.id),
+        "query": "Is the assignment clause enforceable?",
+        "retrieved_chunks": [],
+    }
+    # Must not raise — invariant #5
+    result = await node(state)
+
+    # Synthesis ran (partial-but-honest over crash)
+    assert result.get("analysis_content") is not None
+
+    trace = result.get("analysis_plan_trace")
+    assert trace is not None
+    assert trace["steps"] == 1  # the failed step is still counted
+    assert trace["halt_reason"] == "planner_done"
+
+    # The action is recorded in decisions despite the failure
+    action_decisions = [d for d in trace["decisions"] if d.get("intent") == "retrieve_chunks"]
+    assert len(action_decisions) == 1
+
+    # The ``started`` audit row for the action was written before the error
+    rows = await _audit_rows(db_session, str(seeded_matter_session.id))
+    assert _tool_started_calls(rows, "retrieve_chunks") >= 1

--- a/api/tests/autonomous/test_agentic_loop.py
+++ b/api/tests/autonomous/test_agentic_loop.py
@@ -321,3 +321,86 @@ async def test_action_error_is_nonfatal_observation(
     # The ``started`` audit row for the action was written before the error
     rows = await _audit_rows(db_session, str(seeded_matter_session.id))
     assert _tool_started_calls(rows, "retrieve_chunks") >= 1
+
+
+# ---------------------------------------------------------------------------
+# C1 — boundary-validate bad planner args before they reach the SQL layer
+# ---------------------------------------------------------------------------
+
+
+async def test_bad_top_k_is_nonfatal_validation_observation(
+    db_session: AsyncSession,
+    seeded_matter_session: AutonomousSession,
+) -> None:
+    """C1: planner emits retrieve_chunks with top_k=-1 → validate_action_args fires.
+
+    The validation raises ValueError BEFORE the SQL layer is touched, so the
+    AsyncSession is never poisoned by a DBAPIError.  The loop captures the error
+    as a non-fatal failed observation; synthesis runs and produces analysis_content;
+    halt_reason is 'planner_done'.
+    """
+    gw = _ScriptedGateway(
+        [
+            {
+                "next_intent": "retrieve_chunks",
+                "args": {"top_k": -1},
+                "rationale": "x",
+            },
+            {"done": True, "rationale": "enough evidence"},
+        ]
+    )
+    node = make_analysis_node(db_session, gw)
+    state: AutonomousSessionState = {
+        "session_id": str(seeded_matter_session.id),
+        "query": "Is the assignment clause enforceable?",
+        "retrieved_chunks": [],
+    }
+    # Must not raise — validation must degrade to a failed observation, not crash
+    result = await node(state)
+
+    assert result.get("analysis_content") is not None
+    trace = result.get("analysis_plan_trace")
+    assert trace is not None
+    assert trace["halt_reason"] == "planner_done"
+    assert trace["steps"] == 1  # the failed (validated) step is still counted
+
+    action_decisions = [d for d in trace["decisions"] if d.get("intent") == "retrieve_chunks"]
+    assert len(action_decisions) == 1
+
+
+# ---------------------------------------------------------------------------
+# I1 — playbook+query session synthesizes under run_playbook, not run_skill
+# ---------------------------------------------------------------------------
+
+
+async def test_playbook_session_synthesizes_under_run_playbook(
+    db_session: AsyncSession,
+    seeded_playbook_matter_session: AutonomousSession,
+) -> None:
+    """I1: a matter-scoped session with playbook_id synthesizes under run_playbook.
+
+    Previously _run_analysis_loop hardcoded ToolIntent.run_skill for the synthesis
+    call regardless of session target.  The fix computes the correct intent from
+    playbook_id / skill_ref and passes it through.  This test asserts the synthesis
+    call audits as run_playbook (not run_skill) when the session carries a playbook.
+    """
+    # Planner immediately signals done; synthesis is the only inference call.
+    gw = _ScriptedGateway([{"done": True, "rationale": "nothing to gather"}])
+    node = make_analysis_node(db_session, gw)
+    state: AutonomousSessionState = {
+        "session_id": str(seeded_playbook_matter_session.id),
+        "query": "Is the indemnification clause market-standard?",
+        "retrieved_chunks": [],
+    }
+    result = await node(state)
+
+    assert result.get("analysis_content") is not None
+
+    rows = await _audit_rows(db_session, str(seeded_playbook_matter_session.id))
+    # Synthesis must audit as run_playbook (I1 fix)
+    assert _tool_started_calls(rows, "run_playbook") >= 1, (
+        "synthesis for a playbook session must audit as run_playbook, not run_skill"
+    )
+    assert _tool_started_calls(rows, "run_skill") == 0, (
+        "run_skill must NOT appear in the audit log for a playbook session"
+    )

--- a/api/tests/autonomous/test_executor_skeleton.py
+++ b/api/tests/autonomous/test_executor_skeleton.py
@@ -356,22 +356,31 @@ async def test_executor_persists_failed_status_on_mid_graph_error(
 
         return _node
 
+    session_id = session.id  # save PK before executor's rollback detaches the object
+    # Commit the row into the outer test transaction so the executor's rollback()
+    # (C1b) only removes executor-owned changes (not the session row itself).
+    # Without this commit, rollback() would wipe the row and the re-fetch in the
+    # executor's crash handler would return None, skipping the status update.
+    await db_session.commit()
     executor_mod.make_intake_node = _exploding_intake  # type: ignore[assignment]
     try:
         gateway = _StubGateway()
         # Should NOT raise — exception is caught and persisted.
         await run_autonomous_session(
             db_session,
-            session_id=session.id,
+            session_id=session_id,
             gateway=gateway,  # type: ignore[arg-type]
         )
     finally:
         executor_mod.make_intake_node = original_make_intake  # type: ignore[assignment]
 
-    await db_session.refresh(session)
-    assert session.status == "failed"
-    assert session.error is not None
-    assert "RuntimeError" in session.error
+    # C1b: rollback() detaches the in-memory row; re-fetch by PK to see the
+    # committed failed status.
+    refreshed = await db_session.get(AutonomousSession, session_id)
+    assert refreshed is not None
+    assert refreshed.status == "failed"
+    assert refreshed.error is not None
+    assert "RuntimeError" in refreshed.error
 
 
 @pytest.mark.integration
@@ -423,6 +432,76 @@ async def test_executor_persists_failed_status_on_state_dict_error(
     assert session.error is not None
     assert "injected state-dict error" in session.error
     assert session.completed_at is not None, "completed_at must be set on the error state-dict path"
+
+
+@pytest.mark.integration
+async def test_executor_rollback_called_on_mid_graph_error(
+    db_session: AsyncSession,
+) -> None:
+    """C1b: the except Exception handler calls db.rollback() before persisting status='failed'.
+
+    Defends against a poisoned AsyncSession (e.g., a DBAPIError from a bad SQL arg
+    passed by the planner) whose uncleared error state would cause the subsequent
+    commit() to raise PendingRollbackError, stranding the session at 'running' (zombie).
+
+    Approach: inject a plain RuntimeError via make_intake_node patch and spy on
+    db.rollback.  We do NOT simulate a real DBAPIError/SQL-level poison here because
+    that would invalidate the per-test SAVEPOINT infrastructure; the spy directly
+    verifies the contract (rollback is called before commit in the crash handler).
+    The session ends at status='failed' and completed_at is populated, proving
+    the post-rollback re-fetch + commit succeeded.
+    """
+    user = await _make_user(db_session)
+    session = AutonomousSession(user_id=user.id, trigger_kind="manual")
+    db_session.add(session)
+    await db_session.flush()
+
+    import app.autonomous.executor as executor_mod
+
+    original_make_intake = executor_mod.make_intake_node
+
+    def _exploding_intake(db, gateway=None):  # type: ignore[no-untyped-def]
+        async def _node(state):  # type: ignore[no-untyped-def]
+            raise RuntimeError("injected failure for rollback test")
+
+        return _node
+
+    rollback_call_count = 0
+    _real_rollback = db_session.rollback
+
+    async def _spy_rollback() -> None:
+        nonlocal rollback_call_count
+        rollback_call_count += 1
+        await _real_rollback()
+
+    session_id = session.id  # save PK before executor's rollback detaches the object
+    # Commit the row into the outer test transaction so the executor's rollback()
+    # (C1b) only removes executor-owned changes (not the session row itself).
+    await db_session.commit()
+    executor_mod.make_intake_node = _exploding_intake  # type: ignore[assignment]
+    try:
+        gateway = _StubGateway()
+        with patch.object(db_session, "rollback", side_effect=_spy_rollback):
+            # Should NOT raise — crash is caught, rolled back, and persisted.
+            await run_autonomous_session(
+                db_session,
+                session_id=session_id,
+                gateway=gateway,  # type: ignore[arg-type]
+            )
+    finally:
+        executor_mod.make_intake_node = original_make_intake  # type: ignore[assignment]
+
+    assert rollback_call_count >= 1, (
+        "C1b: executor must call db.rollback() in the crash handler before committing "
+        f"status='failed'; rollback was called {rollback_call_count} time(s)"
+    )
+    # The rollback detaches the in-memory row; re-fetch by PK to see committed state.
+    refreshed = await db_session.get(AutonomousSession, session_id)
+    assert refreshed is not None
+    assert refreshed.status == "failed", (
+        f"Expected status='failed' after mid-graph crash, got '{refreshed.status}'"
+    )
+    assert refreshed.completed_at is not None, "completed_at must be set after rollback+commit"
 
 
 @pytest.mark.integration

--- a/api/tests/autonomous/test_executor_skeleton.py
+++ b/api/tests/autonomous/test_executor_skeleton.py
@@ -128,6 +128,8 @@ def test_phase_grants_exact_membership() -> None:
             # ONLY (gateway-brokered case-law + MCP lookups).
             ToolIntent.retrieve_caselaw,
             ToolIntent.call_mcp_tool,
+            # WS-D PR1: the agentic planner decision call; analysis-only.
+            ToolIntent.plan,
         }
     )
 
@@ -159,9 +161,10 @@ def test_phase_grants_covers_all_phases() -> None:
 
 @pytest.mark.unit
 def test_tool_intent_members() -> None:
-    """ToolIntent has exactly the ten members specified (M4-B2 adds
+    """ToolIntent has exactly the eleven members specified (M4-B2 adds
     propose_precedent; Donna #8 adds emit_artifact; PR5a adds the two
-    external-tool intents retrieve_caselaw + call_mcp_tool)."""
+    external-tool intents retrieve_caselaw + call_mcp_tool;
+    WS-D PR1 adds plan)."""
     expected = {
         "retrieve_chunks",
         "run_skill",
@@ -174,6 +177,8 @@ def test_tool_intent_members() -> None:
         # PR5a: gateway-brokered external-tool intents.
         "retrieve_caselaw",
         "call_mcp_tool",
+        # WS-D PR1: the agentic planner decision call.
+        "plan",
     }
     actual = {m.value for m in ToolIntent}
     assert actual == expected

--- a/api/tests/autonomous/test_observation_summary.py
+++ b/api/tests/autonomous/test_observation_summary.py
@@ -43,3 +43,28 @@ def test_failed_result_is_summarized_not_raised():
     result = ToolResult(data=None, outcome="gateway_error")
     s = summarize_observation(ToolIntent.retrieve_caselaw, "x", result)
     assert "failed" in s and "gateway_error" in s
+
+
+def test_mcp_tool_summary_emits_keys_not_values():
+    result = ToolResult(
+        data={"status": "ok", "citation": "X" * 500, "tool": "courtlistener"},
+        outcome="success",
+    )
+    s = summarize_observation(ToolIntent.call_mcp_tool, "fetch", result)
+    assert "citation" in s and "status" in s and "tool" in s
+    assert "XXXX" not in s  # P3: keys only, never values
+
+
+def test_caselaw_summary_caps_at_five_and_notes_more():
+    result = ToolResult(
+        data={
+            "results": [
+                {"case_name": f"Case {i}", "court": "ca9", "date_filed": "2021-01-01"}
+                for i in range(8)
+            ]
+        },
+        outcome="success",
+    )
+    s = summarize_observation(ToolIntent.retrieve_caselaw, "x", result)
+    assert "+3 more" in s  # 8 results, 5 shown
+    assert "Case 0" in s and "Case 7" not in s  # only first 5 listed

--- a/api/tests/autonomous/test_observation_summary.py
+++ b/api/tests/autonomous/test_observation_summary.py
@@ -1,0 +1,45 @@
+from app.autonomous.enums import ToolIntent
+from app.autonomous.guard import ToolResult
+from app.autonomous.planner import summarize_observation
+
+
+def test_caselaw_summary_lists_case_names_not_full_text():
+    result = ToolResult(
+        data={
+            "results": [
+                {
+                    "case_name": "Smith v. Jones",
+                    "court": "ca9",
+                    "date_filed": "2021-01-01",
+                    "opinion_text": "X" * 5000,
+                },
+                {"case_name": "Doe v. Roe", "court": "ca2", "date_filed": "2019-06-01"},
+            ]
+        },
+        outcome="success",
+    )
+    s = summarize_observation(ToolIntent.retrieve_caselaw, "find authority", result)
+    assert "Smith v. Jones" in s and "Doe v. Roe" in s
+    assert "XXXX" not in s  # no full opinion text
+    assert len(s) < 400
+
+
+def test_chunks_summary_counts_and_files():
+    result = ToolResult(
+        data={
+            "chunks": [
+                {"chunk_id": "c1", "file_name": "nda.pdf", "content": "Y" * 4000},
+                {"chunk_id": "c2", "file_name": "nda.pdf", "content": "Z" * 4000},
+            ]
+        },
+        outcome="success",
+    )
+    s = summarize_observation(ToolIntent.retrieve_chunks, "read clause", result)
+    assert "2" in s and "nda.pdf" in s
+    assert "YYYY" not in s
+
+
+def test_failed_result_is_summarized_not_raised():
+    result = ToolResult(data=None, outcome="gateway_error")
+    s = summarize_observation(ToolIntent.retrieve_caselaw, "x", result)
+    assert "failed" in s and "gateway_error" in s

--- a/api/tests/autonomous/test_plan_intent.py
+++ b/api/tests/autonomous/test_plan_intent.py
@@ -1,0 +1,38 @@
+"""Tests for ToolIntent.plan — WS-D PR1.
+
+Verifies that ``plan`` is:
+1. A member of the closed ``ToolIntent`` set with the expected string value.
+2. Granted in ``PHASE_GRANTS[Phase.analysis]`` and nowhere else.
+3. Included in ``_INFERENCE_INTENTS`` so R4 projects a non-zero cost.
+4. Costed by ``estimate_tool_cost`` as inference (non-zero Decimal), not zero.
+"""
+
+import pytest
+
+from app.autonomous.cost import _INFERENCE_INTENTS, estimate_tool_cost
+from app.autonomous.enums import PHASE_GRANTS, Phase, ToolIntent
+
+pytestmark = pytest.mark.asyncio
+
+
+def test_plan_is_a_tool_intent_granted_in_analysis():
+    assert ToolIntent.plan == "plan"
+    assert ToolIntent.plan in PHASE_GRANTS[Phase.analysis]
+    # not granted elsewhere
+    assert ToolIntent.plan not in PHASE_GRANTS[Phase.drafting]
+    assert ToolIntent.plan not in PHASE_GRANTS[Phase.intake]
+
+
+def test_plan_is_an_inference_intent():
+    assert ToolIntent.plan in _INFERENCE_INTENTS
+
+
+async def test_estimate_tool_cost_treats_plan_as_inference():
+    # db=None → estimator returns its conservative default (non-None Decimal), not 0
+    cost = await estimate_tool_cost(ToolIntent.plan, {"model": "fast"}, None)
+    from decimal import Decimal
+
+    assert isinstance(cost, Decimal)
+    # contrast: a non-inference intent is exactly 0
+    zero = await estimate_tool_cost(ToolIntent.retrieve_caselaw, {}, None)
+    assert zero == Decimal("0")

--- a/api/tests/autonomous/test_planner_decision.py
+++ b/api/tests/autonomous/test_planner_decision.py
@@ -8,6 +8,7 @@ from app.autonomous.planner import (
     PlannerDecision,
     build_planner_messages,
     parse_planner_decision,
+    validate_action_args,
 )
 
 
@@ -77,3 +78,60 @@ def test_parse_done_decision():
 )
 def test_parse_returns_none_on_garbage_or_out_of_set(bad):
     assert parse_planner_decision(bad) is None
+
+
+# ---------------------------------------------------------------------------
+# validate_action_args unit tests (C1 — WS-D PR1)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_action_args_valid_top_k_passes():
+    """A positive integer top_k is accepted."""
+    validate_action_args(ToolIntent.retrieve_chunks, {"top_k": 5, "query": "x", "kb_id": "k"})
+
+
+def test_validate_action_args_absent_top_k_passes():
+    """Omitted top_k (None default) is accepted — the handler supplies its own default."""
+    validate_action_args(ToolIntent.retrieve_chunks, {"query": "x", "kb_id": "k"})
+
+
+@pytest.mark.parametrize(
+    "bad_top_k",
+    [-1, 0, True, "5"],
+)
+def test_validate_action_args_bad_top_k_raises(bad_top_k):
+    """top_k=-1, 0, bool(True), or str('5') all raise ValueError."""
+    with pytest.raises(ValueError, match="top_k"):
+        validate_action_args(ToolIntent.retrieve_chunks, {"top_k": bad_top_k, "query": "x"})
+
+
+def test_validate_action_args_valid_embedding_passes():
+    """A list of floats is accepted."""
+    validate_action_args(
+        ToolIntent.retrieve_chunks,
+        {"query_embedding": [0.1, 0.2, 0.3], "query": "x", "kb_id": "k"},
+    )
+
+
+def test_validate_action_args_none_embedding_passes():
+    """Explicit None query_embedding is accepted (handler treats it as absent)."""
+    validate_action_args(
+        ToolIntent.retrieve_chunks,
+        {"query_embedding": None, "query": "x", "kb_id": "k"},
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_emb",
+    ["x", [("a",)]],
+)
+def test_validate_action_args_bad_embedding_raises(bad_emb):
+    """A string or a list of tuples for query_embedding raises ValueError."""
+    with pytest.raises(ValueError, match="query_embedding"):
+        validate_action_args(ToolIntent.retrieve_chunks, {"query_embedding": bad_emb, "query": "x"})
+
+
+def test_validate_action_args_non_retrieve_chunks_is_noop():
+    """Non-retrieve_chunks intents pass unconditionally (no SQL reach)."""
+    validate_action_args(ToolIntent.retrieve_caselaw, {"top_k": -999, "query_embedding": "bad"})
+    validate_action_args(ToolIntent.call_mcp_tool, {"top_k": -1})

--- a/api/tests/autonomous/test_planner_decision.py
+++ b/api/tests/autonomous/test_planner_decision.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+
+from app.autonomous.enums import ToolIntent
+from app.autonomous.planner import (
+    PLANNER_ALLOWLIST,
+    PlannerDecision,
+    build_planner_messages,
+    parse_planner_decision,
+)
+
+
+def test_allowlist_is_observe_intents_only():
+    assert (
+        frozenset(
+            {ToolIntent.retrieve_chunks, ToolIntent.retrieve_caselaw, ToolIntent.call_mcp_tool}
+        )
+        == PLANNER_ALLOWLIST
+    )
+
+
+def test_prompt_carries_goal_observations_and_allowlist():
+    msgs = build_planner_messages(
+        goal="Is the assignment clause enforceable?",
+        observations=["retrieve_caselaw → 2 results: [Smith (9th 2021); Doe (2d 2019)]"],
+        allowlist=PLANNER_ALLOWLIST,
+    )
+    assert msgs[0]["role"] == "system" and msgs[1]["role"] == "user"
+    body = msgs[0]["content"] + msgs[1]["content"]
+    assert "assignment clause" in body
+    assert "Smith (9th 2021)" in body
+    for intent in PLANNER_ALLOWLIST:
+        assert intent.value in body  # the allowlist is shown to the planner
+
+
+def test_parse_action_decision():
+    out = parse_planner_decision(
+        json.dumps(
+            {
+                "next_intent": "retrieve_caselaw",
+                "args": {"query": "assignment clause change of control"},
+                "rationale": "Need controlling authority on assignment survival.",
+            }
+        )
+    )
+    assert out == PlannerDecision(
+        done=False,
+        next_intent=ToolIntent.retrieve_caselaw,
+        args={"query": "assignment clause change of control"},
+        rationale="Need controlling authority on assignment survival.",
+    )
+
+
+def test_parse_done_decision():
+    out = parse_planner_decision(
+        json.dumps({"done": True, "rationale": "Enough authority gathered."})
+    )
+    assert out is not None and out.done is True and out.next_intent is None
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        None,
+        "",
+        "not json",
+        json.dumps(
+            {"next_intent": "emit_finding", "args": {}, "rationale": "x"}
+        ),  # out of allowlist
+        json.dumps(
+            {"next_intent": "run_skill", "args": {}, "rationale": "x"}
+        ),  # reserved for synthesis
+        json.dumps(["retrieve_caselaw"]),  # not a dict
+        json.dumps({"args": {}, "rationale": "x"}),  # no next_intent, no done
+    ],
+)
+def test_parse_returns_none_on_garbage_or_out_of_set(bad):
+    assert parse_planner_decision(bad) is None

--- a/api/tests/autonomous/test_receipt_plan_trace.py
+++ b/api/tests/autonomous/test_receipt_plan_trace.py
@@ -1,0 +1,134 @@
+"""WS-D PR1 Task 6 — plan trace surfaces in the session receipt.
+
+Two delivery-node tests verify the D5 transparency requirement:
+
+1. When ``analysis_plan_trace`` is present in state the delivery node
+   merges it into ``session.result`` under the key ``plan_trace``.  The
+   merged value carries the exact structure produced by Task 5
+   (``{steps, halt_reason, decisions: [{step, intent, rationale}]}``)
+   and every leaf string is short (P3 invariant — no tool payloads).
+
+2. When ``analysis_plan_trace`` is absent (query-less / non-matter
+   session) ``session.result`` has no ``plan_trace`` key at all
+   (strictly additive; no pollution of the bare receipt shape).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.nodes import make_delivery_node
+from app.autonomous.state import AutonomousSessionState
+from app.models.autonomous import AutonomousSession
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_TRACE: dict = {
+    "steps": 1,
+    "halt_reason": "planner_done",
+    "decisions": [
+        {
+            "step": "0",
+            "intent": "retrieve_caselaw",
+            "rationale": "find authority on assignment clause enforceability",
+        }
+    ],
+}
+
+
+def _all_leaf_strings(obj: object) -> list[str]:
+    """Recursively collect every str leaf value in a nested dict/list."""
+    if isinstance(obj, str):
+        return [obj]
+    if isinstance(obj, dict):
+        out: list[str] = []
+        for v in obj.values():
+            out.extend(_all_leaf_strings(v))
+        return out
+    if isinstance(obj, list):
+        out = []
+        for item in obj:
+            out.extend(_all_leaf_strings(item))
+        return out
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Test 1: plan_trace present in state → receipt carries it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_delivery_merges_plan_trace_into_receipt(
+    db_session: AsyncSession,
+    running_session_at_delivery: AutonomousSession,
+    mock_gateway: object,
+) -> None:
+    """delivery_node merges analysis_plan_trace into session.result["plan_trace"].
+
+    Asserts:
+    - halt_reason, steps, and the first decision's intent are preserved.
+    - Every leaf string in the trace is short (<300 chars — no raw payloads).
+    """
+    node = make_delivery_node(db_session, mock_gateway)
+    state: AutonomousSessionState = {
+        "session_id": str(running_session_at_delivery.id),
+        "findings": [],
+        "findings_count": 1,
+        "analysis_plan_trace": _SAMPLE_TRACE,
+    }
+    await node(state)
+
+    await db_session.refresh(running_session_at_delivery)
+    result = running_session_at_delivery.result
+    assert result is not None, "session.result must not be None after delivery"
+    assert "plan_trace" in result, "session.result must carry a 'plan_trace' key"
+
+    trace = result["plan_trace"]
+    assert trace["halt_reason"] == "planner_done"
+    assert trace["steps"] == 1
+    assert trace["decisions"][0]["intent"] == "retrieve_caselaw"
+
+    # P3 invariant: no leaf string exceeds 300 chars (proves no tool payloads)
+    for leaf in _all_leaf_strings(trace):
+        assert len(leaf) < 300, f"plan_trace leaf string too long (P3 violation): {leaf!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: plan_trace absent in state → receipt has NO plan_trace key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_delivery_omits_plan_trace_when_absent_from_state(
+    db_session: AsyncSession,
+    running_session_at_delivery: AutonomousSession,
+    mock_gateway: object,
+) -> None:
+    """delivery_node does NOT inject plan_trace when analysis_plan_trace is absent.
+
+    This covers the query-less / non-matter session path where the loop
+    never ran and state carries no trace.  The receipt shape must be
+    unchanged (strictly additive invariant).
+    """
+    node = make_delivery_node(db_session, mock_gateway)
+    state: AutonomousSessionState = {
+        "session_id": str(running_session_at_delivery.id),
+        "findings": [],
+        "findings_count": 1,
+        # analysis_plan_trace deliberately absent
+    }
+    await node(state)
+
+    await db_session.refresh(running_session_at_delivery)
+    result = running_session_at_delivery.result
+    # result may be None (unlikely on a good receipt build) or a dict without plan_trace
+    if result is not None:
+        assert "plan_trace" not in result, (
+            "plan_trace must NOT appear in session.result when absent from state"
+        )

--- a/api/tests/autonomous/test_synthesis_messages.py
+++ b/api/tests/autonomous/test_synthesis_messages.py
@@ -1,0 +1,109 @@
+"""Tests for assemble_synthesis_messages (WS-D PR1, Task 4).
+
+Verifies that the synthesis message builder:
+- Preserves the structured-findings JSON contract from assemble_analysis_messages
+  (same system prompt → same fenced-JSON schema the drafting node parses).
+- Appends the matter GOAL and the loop's OBSERVATIONS to a trailing user message.
+- Handles the empty-observations edge case gracefully.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.prompts import STRUCTURED_OUTPUT_INSTRUCTION, assemble_synthesis_messages
+from app.models.autonomous import AutonomousSession
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_synthesis_preserves_structured_contract_and_adds_goal_and_observations(
+    db_session: AsyncSession,
+    session_with_skill_ref: AutonomousSession,
+    sample_chunks: list[dict[str, object]],
+) -> None:
+    """Core contract: system carries the JSON schema; trailing user carries goal + obs."""
+    msgs = await assemble_synthesis_messages(
+        session_with_skill_ref,
+        goal="Is the clause enforceable?",
+        observations=["retrieve_caselaw → 1 result: [Smith (9th 2021)]"],
+        chunks=sample_chunks,
+        db=db_session,
+    )
+
+    # Shape
+    assert all("role" in m and "content" in m for m in msgs)
+    assert msgs[0]["role"] == "system"
+    assert msgs[-1]["role"] == "user"
+
+    # Structured-output JSON contract is preserved in the system prompt
+    assert "findings" in msgs[0]["content"]
+    assert "```json" in msgs[0]["content"]
+    assert STRUCTURED_OUTPUT_INSTRUCTION in msgs[0]["content"]
+
+    # Goal and observation appear somewhere in the user messages
+    user_blob = " ".join(m["content"] for m in msgs if m["role"] == "user")
+    assert "Is the clause enforceable?" in user_blob
+    assert "Smith (9th 2021)" in user_blob
+
+
+async def test_synthesis_empty_observations_produces_placeholder(
+    db_session: AsyncSession,
+    session_with_skill_ref: AutonomousSession,
+    sample_chunks: list[dict[str, object]],
+) -> None:
+    """Empty observations list → a placeholder string in the trailing user message."""
+    msgs = await assemble_synthesis_messages(
+        session_with_skill_ref,
+        goal="Summarise liability exposure.",
+        observations=[],
+        chunks=sample_chunks,
+        db=db_session,
+    )
+
+    user_blob = " ".join(m["content"] for m in msgs if m["role"] == "user")
+    assert "Summarise liability exposure." in user_blob
+    assert "no research steps" in user_blob
+
+
+async def test_synthesis_message_count_is_base_plus_one(
+    db_session: AsyncSession,
+    session_with_skill_ref: AutonomousSession,
+    sample_chunks: list[dict[str, object]],
+) -> None:
+    """assemble_synthesis_messages appends exactly one message to the base [system, user] pair."""
+    from app.autonomous.prompts import assemble_analysis_messages
+
+    base = await assemble_analysis_messages(
+        session_with_skill_ref, chunks=sample_chunks, db=db_session
+    )
+    synthesis = await assemble_synthesis_messages(
+        session_with_skill_ref,
+        goal="Test goal.",
+        observations=["obs 1", "obs 2"],
+        chunks=sample_chunks,
+        db=db_session,
+    )
+    assert len(synthesis) == len(base) + 1
+
+
+async def test_synthesis_does_not_alter_system_prompt(
+    db_session: AsyncSession,
+    session_with_skill_ref: AutonomousSession,
+    sample_chunks: list[dict[str, object]],
+) -> None:
+    """The system prompt is identical to assemble_analysis_messages output."""
+    from app.autonomous.prompts import assemble_analysis_messages
+
+    base = await assemble_analysis_messages(
+        session_with_skill_ref, chunks=sample_chunks, db=db_session
+    )
+    synthesis = await assemble_synthesis_messages(
+        session_with_skill_ref,
+        goal="Goal text.",
+        observations=["some obs"],
+        chunks=sample_chunks,
+        db=db_session,
+    )
+    assert synthesis[0]["content"] == base[0]["content"]

--- a/docs/LQVern/HANDOFF-2026-06-28-wsd-pr1.md
+++ b/docs/LQVern/HANDOFF-2026-06-28-wsd-pr1.md
@@ -1,0 +1,59 @@
+# Handoff — 2026-06-28 — Phase 2: WS-G complete; WS-D started (PR1 mid-build)
+
+`main` (LegalQuants + tucuxi, both == **`b407de2`**). **Next migration = `0063`. Next DE = DE-368.**
+
+---
+
+## ⭐ SESSION-START NOTE — read first
+
+**WS-G (transparent validity/treatment layer) is COMPLETE and merged.** **WS-D (governed agentic legal-matter sessions) has started:** **ADR 0020 is accepted + merged** (`docs/adr/0020-governed-agentic-legal-matter-sessions.md`, #238), and **WS-D PR1 (the governed agentic loop + matter intake) is mid-build on a LOCAL branch** via subagent-driven development. **Tasks 1–4 of 6 are done and review-clean; Tasks 5–6 + the Opus whole-branch review + push/PR remain.** Resume the SDD loop at Task 5.
+
+### Immediate first action — resume WS-D PR1's SDD loop at Task 5
+- **Branch:** `feat/wsd-pr1-agentic-loop` (**LOCAL, NOT pushed** — 7 commits on `main` `b407de2`, head `dcaddae`).
+- **Plan:** `docs/superpowers/plans/2026-06-28-wsd-pr1-agentic-loop.md`. **Spec:** `docs/superpowers/specs/2026-06-28-wsd-pr1-agentic-loop-design.md`.
+- **SDD ledger (authoritative resume map):** `.superpowers/sdd/progress.md` — Tasks 1–4 marked complete with commit SHAs; **5 and 6 are `pending`.** Trust the ledger + `git log` over recollection.
+- **Re-enter SDD:** invoke `superpowers:subagent-driven-development`, read the ledger, generate the Task 5 brief (`<sdd>/scripts/task-brief docs/superpowers/plans/2026-06-28-wsd-pr1-agentic-loop.md 5`), dispatch the implementer (sonnet — Task 5 is the integration heart), review (sonnet), then Task 6 (sonnet), then the **Opus whole-branch review**, then push + PR.
+- **Task 5 = the loop in `analysis_node`** (backward-compat gate + the `plan→act→observe→replan` while-loop + step cap + final synthesis). Its tests have `...` bodies delegated to the existing autonomous node/receipt fixtures — the implementer must reuse `api/tests/autonomous/conftest.py` fixtures (`session_with_skill_ref`, `sample_chunks`, `db_session`) and the existing `make_analysis_node` test pattern; tell them to build `seeded_matter_session` = a skill-ref session with `params["query"]` set, and `seeded_skill_session_no_query` = without. **Task 6 = surface the plan trace in the receipt** (thread `analysis_plan_trace` from state → `session.result`).
+- **After Tasks 5–6 + Opus review:** run the **full gates at CI scope from the repo root** (`ruff check api scripts` + `ruff format --check api scripts` + `mypy app` whole-app + both full suites — the THRICE-burned lesson: format/lint scope is `api scripts` + `gateway` from root, never `app tests`), then **push origin + tucuxi → open the security-gated PR (NO self-merge; `api/app/autonomous/**` is the chokepoint) → after Kevin/security merges, mirror `origin/main → tucuxi`.**
+
+### WS-D PR1 load-bearing invariants (the tests pin these — do not let them slip)
+1. **Backward-compat:** the planner loop engages ONLY when `state["query"]` is non-empty. Query-less sessions (cron/watch/schedule) take the UNCHANGED single-`run_skill` path — byte-identical (same intents, audit rows, outputs; no `plan` intent emitted). Strictly additive.
+2. **Synthesis contract:** however the loop ends (`planner_done`/`step_cap`/`planner_unparseable`/`planner_out_of_set`), a final `run_skill` synthesis ALWAYS produces the fenced-JSON `findings` that `drafting.parse_structured_output` expects, as `analysis_content`. A cap-halt → partial-but-honest, never fabricated-complete.
+3. **Every loop step via `guarded_tool_call`** (R5→R6→R4); no bypass; **no new brake machinery** — bounded by `DEFAULT_MAX_ANALYSIS_STEPS=6` (`params["max_analysis_steps"]` override) + R4's $5 cap.
+4. **Planner allowlist = OBSERVE intents only** (`retrieve_chunks`, `retrieve_caselaw`, `call_mcp_tool`); `run_skill` reserved for synthesis; emit/side-effect intents not planner-driven.
+5. **Args model-generated, handler-validated** (closed-set boundary, ADR 0015). **P3:** observations + the plan trace hold counts/ids/case-names/short snippets/rationale — never full payloads.
+6. **No migration** (ToolIntent is a StrEnum; audit `action` is event-keyed, not an intent CHECK — verified in Task 1).
+
+## WS-D PR1 progress (SDD)
+| Task | State | Commit |
+|---|---|---|
+| 1 — `ToolIntent.plan` + grant + cost + dispatch | ✅ review-clean | `33337c4` |
+| 2 — planner prompt + decision parser (`planner.py`) | ✅ review-clean | `7602385` |
+| 3 — observation summarizer (P3-clean) | ✅ review-clean | `0695fef` + test-fix `6a25eb9` |
+| 4 — synthesis messages (preserve drafting contract) | ✅ review-clean | `dcaddae` |
+| 5 — the loop in `analysis_node` (gate + while + step cap + synthesis) | ⏳ pending | — |
+| 6 — receipt plan-trace (D5 transparency) | ⏳ pending | — |
+Minors logged in the ledger for the final review (test-local imports, fence-strip path untested, truthy-non-sequence guard). All gates green through Task 4 (autonomous suite 481+ pass; whole-app mypy + ruff clean).
+
+## Milestone arc (fiduciary-grade agentic legal work — Phase 2)
+- **Phase 1 COMPLETE** (WS-A ledger, WS-B gate, WS-C UI).
+- **WS-G COMPLETE** — ADR 0019 + PR1 graph signal (#233) + PR1-UI (#234) + PR2 treatment judge (#236) + PR3 hardening DE-363/364/364b (#237). The KeyCite-analog validity layer, derive-don't-assert.
+- **WS-D STARTED** — ADR 0020 accepted (#238); **PR1 mid-build (this handoff).** ADR 0020 D6 phases it: **PR1 = governed loop + intake (no ledger/gate); PR2 = WS-A ledger + WS-B gate integration, REUSING the chat-path `assemble_ledger_entries` + `compute_and_record_gate` (ADR 0016 P6, not a fork).**
+- **After WS-D:** **WS-E** (content-source registry + free-source expansion: GovInfo/EUR-Lex/SEC EDGAR; **where DE-344's R4 metered-tool cost wiring lands** — pinned to WS-E by its first-metered-source trigger). **WS-F** (MCP-server ingress) stays **Phase 3** (own ADR; largest new security surface).
+- **End of Phase 2 / pre-launch:** **DE-365** — the launch-documentation pass: README + transparency visualizations + an **evidence-linked** honest comparison vs TR/Westlaw/CoCounsel's announced-but-unshipped (later-summer-2026) fiduciary-grade direction. Kevin's framing (captured in memory `project-fiduciary-grade-positioning-and-launch-docs`): **"turn it up to 11" — honest but unflinching, fundamental truths NOT digs: every comparison cell links to proof (ADR/code/test/live trace); "we show the work, they ask you to trust them"; their editorial verdicts diffuse responsibility (no one on the line) vs. LQ.AI's named practicing-attorney attestation.** The conservative-engineering posture (never overclaim) still binds every claim.
+- Open PR2 follow-ups already filed: **DE-366** (treatment worker short-circuit when no gateway), **DE-367** (rollup materialization).
+
+## Workflow reminders (load-bearing)
+- **Security-gated** (`api/app/autonomous/**`, `gateway/**`, `api/app/citation/**`, `chats.py`, auth/authz/audit/crypto): Kevin/security merges; **Claude does NOT self-merge.** Docs-only + `web/`-only → self-merge after CI. Mirror `origin/main → tucuxi` after every merge; confirm `origin == tucuxi`.
+- **Branch off `main`** (never commit on `main`); push feature branches to **origin + tucuxi**.
+- **Tests:** host venv `api/.venv` + throwaway pgvector `lqai-test-pg` on `:55432`, `DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test` (conftest auto-migrates). Mocked gateway → no `-m provider`. NEVER host `alembic upgrade` the dev DB (port 15432).
+- **CI scope (thrice-burned):** `ruff format --check api scripts` + `ruff check api scripts` + gateway equivalents from the **repo root** (covers `api/alembic/`); `mypy app` whole-app (`--strict` gateway); both full suites. Full api suite ≈ 14 min; API CI check ≈ 18 min.
+- **Opus for the final whole-branch review** — it has caught a real gate-passing defect on EVERY slice this milestone (WS-G PR2 orphaned-signal; WS-G PR3 refresh-path race + a `MissingGreenlet`). Worth the cost every slice.
+- Commits: `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## Pointers
+- ADR: `docs/adr/0020-governed-agentic-legal-matter-sessions.md` (D1–D7; §Open-questions = PR1/PR2 inputs)
+- Strategy: `docs/proposals/fiduciary-grade-agentic-legal-work.md` (WS-D/E §"Phase 2"; WS-F = Phase 3)
+- Autonomous-layer map (the substrate WS-D builds on): `guarded_tool_call` chokepoint, closed `ToolIntent` set, `PHASE_GRANTS`, R4/R5/R6, the scripted LangGraph `intake→analysis→drafting→ethics_review→delivery`, `audit_log`+receipt. Today's analysis = ONE `run_skill` call; PR1 makes it a loop INSIDE the node (no graph change).
+- Memory: `project-fiduciary-grade-milestone` (current state), `project-fiduciary-grade-positioning-and-launch-docs` (DE-365 launch framing), `MEMORY.md` index.
+- Prior handoff: `docs/LQVern/HANDOFF-2026-06-26-wsg-phase2.md`.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4874,6 +4874,16 @@ So the single longest phase (image pull) has neither a stream nor a poll. The re
 
 **When to ship:** Alongside any future incremental/partial treatment re-judge work.
 
+#### DE-368 — Test suite is serial-only against one shared Postgres; parallelization needs per-worker DBs
+
+**Priority:** P3 · **Effort:** S
+
+**Context:** Surfaced during WS-D PR1 verification. The `api/` test suite shares a single Postgres test database with a single-process, shared-connection SAVEPOINT-rollback model (`api/tests/conftest.py`). CI runs the suite as one serial `pytest -q` (no `pytest-xdist` / `pytest-randomly` installed), so this is correct and green there (verified: a clean solo run is `2436 passed, 1 skipped`). The fragility appears only under **concurrent** access to that one DB: running a second `pytest` invocation locally against the dev test DB while the full suite runs produced 24 spurious failures, all in DB-state-sensitive tests — `tests/test_research_service.py` (read-through opinion-cache + exact gateway `call_count` assertions like "2nd call served from cache"). The failures were a false alarm from concurrent test processes sharing rows/connection state, **not** a code or test-isolation defect; the same tests pass in isolation and in a solo full run.
+
+**Specific scope:** If the suite is ever parallelized for speed (`pytest-xdist -n auto`), give each worker its own database/schema (e.g. `xdist`'s `worker_id` → per-worker DB name, or a template-DB clone per worker) and mark any remaining cross-worker-stateful tests (DB-cache + call-count assertions) `serial`. Until then: do not run parallel `pytest` against the shared dev test DB (`lqai_test` on `:55432`). Optionally add a one-line note to `api/tests/conftest.py` documenting the serial-only constraint.
+
+**When to ship:** Before/with any test-suite parallelization effort; no action needed for current serial CI.
+
 ---
 
 ## 10. Appendices

--- a/docs/superpowers/plans/2026-06-28-wsd-pr1-agentic-loop.md
+++ b/docs/superpowers/plans/2026-06-28-wsd-pr1-agentic-loop.md
@@ -1,0 +1,788 @@
+# WS-D PR1 — Governed Agentic Loop + Matter Intake Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the autonomous `analysis` phase into a governed `plan → act → observe → replan` loop for matter-scoped sessions — the planner picks the next observe-intent from `PHASE_GRANTS[analysis]` each step (all through `guarded_tool_call`), observations fold back compactly, and a final `run_skill` synthesis produces the structured findings the rest of the graph already consumes.
+
+**Architecture:** A new closed-set `ToolIntent.plan` (a gateway-inference intent). A `planner.py` module (prompt builder + parser + observation summarizer). The loop is a `while` inside `analysis_node` — **no LangGraph change** — gated on `state["query"]` so query-less sessions are byte-identical to today. Bounded by a step cap + the existing R4 budget. No ledger/gate (that is PR2).
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2 (async), LangGraph, arq, pytest, ruff, mypy. Subsystem: `api/app/autonomous/`.
+
+## Global Constraints
+
+- **Security-gated** (`api/app/autonomous/**` — the governance chokepoint): security/maintainer merges; mirror `origin/main → tucuxi` after. Claude does NOT self-merge.
+- **No migration** — `ToolIntent` is a `StrEnum` not persisted under a DB CHECK; the audit `action` is `autonomous_session.<event>` (event-keyed, Python-closed-set), not the intent. Task 1 confirms this before relying on it. Next migration stays `0063`; next DE = DE-368.
+- **Strictly additive / backward-compat (load-bearing):** the planner loop engages ONLY when `state["query"]` is non-empty. Query-less sessions (cron/watch/schedule) take the UNCHANGED single-`run_skill` path — same intents, same audit rows, same outputs.
+- **Every loop step is governed:** the planner call and every action go through `guarded_tool_call` (R5→R6→R4 unchanged). No tool path bypasses the chokepoint. No new brake machinery.
+- **Synthesis contract (load-bearing):** however the loop ends (`planner_done` / `step_cap` / `planner_unparseable` / `planner_out_of_set`), a final `run_skill` synthesis always produces the fenced-JSON structured findings that `drafting`'s `parse_structured_output` expects, as `analysis_content`. A cap-halt yields a partial-but-honest result, never a fabricated-complete one.
+- **Planner action allowlist:** the planner may choose ONLY observe intents — `retrieve_chunks`, `retrieve_caselaw`, `call_mcp_tool` — or signal done. `run_skill`/`run_playbook` are reserved for the final synthesis; `propose_precedent` and the emit intents are not planner-driven in PR1.
+- **Args are model-generated, handler-validated:** the planner emits `args` for the chosen intent; the intent's existing handler validates them (the closed-set boundary, ADR 0015). A bad arg is a non-fatal tool outcome summarized as a failed observation — it never escapes the governed path.
+- **P3:** observations + the plan trace hold counts / ids / case-names / short snippets / the planner's own rationale — NEVER full opinion or chunk payloads.
+- **Bounded:** `DEFAULT_MAX_ANALYSIS_STEPS = 6`, `params["max_analysis_steps"]` override, plus R4's `max_cost_usd` ($5 default).
+- **Tests:** host venv `api/.venv` + throwaway pgvector `:55432`, `DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test`. Stub gateway/planner → no `-m provider`.
+- **CI gate (thrice-burned LESSON):** from the **repo root** — `ruff check api scripts`, `ruff format --check api scripts`, gateway equivalents, `mypy app` whole-app, both full suites. Never per-file / `app tests`-only.
+- Commits: `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File structure
+
+| File | Change | Task |
+|---|---|---|
+| `api/app/autonomous/enums.py` | add `ToolIntent.plan` + grant in `PHASE_GRANTS[analysis]` | 1 |
+| `api/app/autonomous/cost.py` | `plan` ∈ `_INFERENCE_INTENTS` (R4 costs it as inference) | 1 |
+| `api/app/autonomous/guard.py` | route `plan` through `_handle_gateway_inference` in `_dispatch` | 1 |
+| `api/app/autonomous/planner.py` | NEW — `PlannerDecision`, `build_planner_messages`, `parse_planner_decision`, `summarize_observation`, `PLANNER_ALLOWLIST` | 2, 3 |
+| `api/app/autonomous/prompts.py` | NEW `assemble_synthesis_messages` | 4 |
+| `api/app/autonomous/nodes.py` | the loop + backward-compat gate in `make_analysis_node` | 5 |
+| `api/app/config.py` | `DEFAULT_MAX_ANALYSIS_STEPS` (or in `enums.py`) | 5 |
+| `api/app/autonomous/receipt.py` | surface the plan trace (P3) | 6 |
+
+---
+
+### Task 1: `ToolIntent.plan` — closed-set extension, grant, cost, dispatch
+
+**Files:**
+- Modify: `api/app/autonomous/enums.py` (`ToolIntent`, `PHASE_GRANTS[Phase.analysis]`)
+- Modify: `api/app/autonomous/cost.py` (`_INFERENCE_INTENTS`)
+- Modify: `api/app/autonomous/guard.py:549` (the inference branch in `_dispatch`)
+- Test: `api/tests/autonomous/test_plan_intent.py` (new)
+
+**Interfaces:**
+- Produces: `ToolIntent.plan = "plan"`, granted in `PHASE_GRANTS[Phase.analysis]`; `guarded_tool_call(session, ToolIntent.plan, {"model": ..., "messages": [...], "anonymize": False}, db, gateway)` runs a gateway inference and returns `ToolResult(data={"content": <text>, ...})`, costed by R4 as inference.
+
+- [ ] **Step 1: Verify no migration is needed.** Confirm `ToolIntent` is not persisted under a DB CHECK: `grep -rn "run_skill\|retrieve_chunks\|tool_intent" api/alembic/versions/` returns no CHECK on intent values, and `api/app/models/audit.py`'s `action` column is a free `String`. Record the finding in the task report. (If a CHECK is found, STOP and report — the plan's no-migration assumption is wrong.)
+
+- [ ] **Step 2: Write the failing test** (`api/tests/autonomous/test_plan_intent.py`)
+
+```python
+import pytest
+from app.autonomous.enums import PHASE_GRANTS, Phase, ToolIntent
+from app.autonomous.cost import _INFERENCE_INTENTS, estimate_tool_cost
+
+pytestmark = pytest.mark.asyncio
+
+
+def test_plan_is_a_tool_intent_granted_in_analysis():
+    assert ToolIntent.plan == "plan"
+    assert ToolIntent.plan in PHASE_GRANTS[Phase.analysis]
+    # not granted elsewhere
+    assert ToolIntent.plan not in PHASE_GRANTS[Phase.drafting]
+    assert ToolIntent.plan not in PHASE_GRANTS[Phase.intake]
+
+
+def test_plan_is_an_inference_intent():
+    assert ToolIntent.plan in _INFERENCE_INTENTS
+
+
+async def test_estimate_tool_cost_treats_plan_as_inference():
+    # db=None → estimator returns its conservative default (non-None Decimal), not 0
+    cost = await estimate_tool_cost(ToolIntent.plan, {"model": "fast"}, None)
+    from decimal import Decimal
+    assert isinstance(cost, Decimal)
+    # contrast: a non-inference intent is exactly 0
+    zero = await estimate_tool_cost(ToolIntent.retrieve_caselaw, {}, None)
+    assert zero == Decimal("0")
+```
+
+- [ ] **Step 3: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_plan_intent.py -v`
+Expected: FAIL — `ToolIntent` has no `plan`.
+
+- [ ] **Step 4: Implement.**
+
+In `enums.py`, add the member to `ToolIntent` (after `call_mcp_tool`):
+```python
+    call_mcp_tool = "call_mcp_tool"
+    # WS-D PR1: the planner's next-step decision call (a gateway inference).
+    # Granted only in analysis; the agentic loop dispatches it each iteration.
+    plan = "plan"
+```
+And add it to `PHASE_GRANTS[Phase.analysis]`:
+```python
+            ToolIntent.call_mcp_tool,
+            # WS-D PR1: the agentic planner decision call.
+            ToolIntent.plan,
+```
+
+In `cost.py`, add `plan` to `_INFERENCE_INTENTS` (find its definition — it currently holds `run_skill`, `run_playbook`):
+```python
+_INFERENCE_INTENTS = frozenset(
+    {ToolIntent.run_skill, ToolIntent.run_playbook, ToolIntent.plan}
+)
+```
+
+In `guard.py:549`, extend the inference branch:
+```python
+    if intent in (ToolIntent.run_skill, ToolIntent.run_playbook, ToolIntent.plan):
+        return await _handle_gateway_inference(
+            intent, params, gateway=gateway, estimated_cost=estimated_cost
+        )
+```
+(`_handle_gateway_inference` reads `params["messages"]`/`params["model"]`/`params["anonymize"]` and returns `ToolResult(data={"content": ...})` — the planner call is just another inference. Confirm its docstring/branching doesn't reject an unknown intent; it keys on `params`, not the intent name.)
+
+- [ ] **Step 5: Run — expect pass + the autonomous suite for regressions**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_plan_intent.py tests/autonomous -v`
+Expected: PASS (new + no autonomous regressions).
+
+- [ ] **Step 6: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/enums.py api/app/autonomous/cost.py api/app/autonomous/guard.py api/tests/autonomous/test_plan_intent.py
+git commit -s -m "feat(autonomous): ToolIntent.plan — closed-set planner intent (WS-D PR1)"
+```
+
+---
+
+### Task 2: planner prompt + decision parser
+
+**Files:**
+- Create: `api/app/autonomous/planner.py`
+- Test: `api/tests/autonomous/test_planner_decision.py` (new)
+
+**Interfaces:**
+- Produces:
+  - `PLANNER_ALLOWLIST: frozenset[ToolIntent]` = `{retrieve_chunks, retrieve_caselaw, call_mcp_tool}` (observe intents the planner may choose).
+  - `@dataclass(slots=True) PlannerDecision(done: bool, next_intent: ToolIntent | None, args: dict[str, Any], rationale: str)`
+  - `build_planner_messages(*, goal: str, observations: list[str], allowlist: frozenset[ToolIntent]) -> list[dict[str, str]]`
+  - `parse_planner_decision(content: str | None) -> PlannerDecision | None` — `None` on unparseable / unknown structure; a `done` decision when the planner signals completion; a valid action decision otherwise. A `next_intent` not in `allowlist` → `None` (the loop treats it as `planner_out_of_set`).
+
+- [ ] **Step 1: Write the failing tests** (`api/tests/autonomous/test_planner_decision.py`)
+
+```python
+import json
+import pytest
+from app.autonomous.enums import ToolIntent
+from app.autonomous.planner import (
+    PLANNER_ALLOWLIST, PlannerDecision, build_planner_messages, parse_planner_decision,
+)
+
+
+def test_allowlist_is_observe_intents_only():
+    assert PLANNER_ALLOWLIST == frozenset(
+        {ToolIntent.retrieve_chunks, ToolIntent.retrieve_caselaw, ToolIntent.call_mcp_tool}
+    )
+
+
+def test_prompt_carries_goal_observations_and_allowlist():
+    msgs = build_planner_messages(
+        goal="Is the assignment clause enforceable?",
+        observations=["retrieve_caselaw → 2 results: [Smith (9th 2021); Doe (2d 2019)]"],
+        allowlist=PLANNER_ALLOWLIST,
+    )
+    assert msgs[0]["role"] == "system" and msgs[1]["role"] == "user"
+    body = msgs[0]["content"] + msgs[1]["content"]
+    assert "assignment clause" in body
+    assert "Smith (9th 2021)" in body
+    for intent in PLANNER_ALLOWLIST:
+        assert intent.value in body  # the allowlist is shown to the planner
+
+
+def test_parse_action_decision():
+    out = parse_planner_decision(json.dumps({
+        "next_intent": "retrieve_caselaw",
+        "args": {"query": "assignment clause change of control"},
+        "rationale": "Need controlling authority on assignment survival.",
+    }))
+    assert out == PlannerDecision(
+        done=False, next_intent=ToolIntent.retrieve_caselaw,
+        args={"query": "assignment clause change of control"},
+        rationale="Need controlling authority on assignment survival.",
+    )
+
+
+def test_parse_done_decision():
+    out = parse_planner_decision(json.dumps({"done": True, "rationale": "Enough authority gathered."}))
+    assert out is not None and out.done is True and out.next_intent is None
+
+
+@pytest.mark.parametrize("bad", [
+    None, "", "not json",
+    json.dumps({"next_intent": "emit_finding", "args": {}, "rationale": "x"}),   # out of allowlist
+    json.dumps({"next_intent": "run_skill", "args": {}, "rationale": "x"}),       # reserved for synthesis
+    json.dumps(["retrieve_caselaw"]),                                            # not a dict
+    json.dumps({"args": {}, "rationale": "x"}),                                   # no next_intent, no done
+])
+def test_parse_returns_none_on_garbage_or_out_of_set(bad):
+    assert parse_planner_decision(bad) is None
+```
+
+- [ ] **Step 2: Run — expect failure** (module missing)
+
+Run: `cd api && .venv/bin/python -m pytest tests/autonomous/test_planner_decision.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.autonomous.planner`.
+
+- [ ] **Step 3: Implement** (`api/app/autonomous/planner.py`)
+
+```python
+"""WS-D PR1 — the agentic planner: prompt, decision parser, observation summarizer.
+
+The planner is a gateway inference (ToolIntent.plan) that, given the matter
+goal + compact observations + the observe-intent allowlist, returns either the
+next governed action to take or a 'done' signal. It NEVER selects outside the
+closed allowlist (an out-of-set proposal parses to None → the loop stops
+conservatively). It does not execute anything — the loop dispatches its choice
+through guarded_tool_call (ADR 0020 D1).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.autonomous.enums import ToolIntent
+
+log = logging.getLogger(__name__)
+
+# The planner may choose ONLY observe intents (gather), or signal done.
+# run_skill/run_playbook are reserved for the final synthesis; emit/side-effect
+# intents are not planner-driven in PR1.
+PLANNER_ALLOWLIST: frozenset[ToolIntent] = frozenset(
+    {ToolIntent.retrieve_chunks, ToolIntent.retrieve_caselaw, ToolIntent.call_mcp_tool}
+)
+
+_SYSTEM_PROMPT = """\
+You are the research planner for a governed legal-matter agent. Given the
+MATTER GOAL and the OBSERVATIONS gathered so far, decide the SINGLE next
+research action, or that enough has been gathered.
+
+You may choose ONLY from this closed set of actions (you cannot invent tools):
+{allowlist}
+
+Respond with STRICTLY VALID JSON, one of:
+
+  {{"next_intent": "<one action above>",
+    "args": {{ ...arguments for that action... }},
+    "rationale": "<one sentence: why this next step>"}}
+
+or, when enough authority/context has been gathered:
+
+  {{"done": true, "rationale": "<one sentence: why you are finished>"}}
+
+Output ONLY the JSON object. No preamble, no markdown fencing."""
+
+
+@dataclass(slots=True)
+class PlannerDecision:
+    done: bool
+    next_intent: ToolIntent | None
+    args: dict[str, Any] = field(default_factory=dict)
+    rationale: str = ""
+
+
+def build_planner_messages(
+    *, goal: str, observations: list[str], allowlist: frozenset[ToolIntent]
+) -> list[dict[str, str]]:
+    allow = ", ".join(sorted(i.value for i in allowlist))
+    system = _SYSTEM_PROMPT.format(allowlist=allow)
+    obs = "\n".join(f"- {o}" for o in observations) if observations else "(none yet)"
+    user = f"MATTER GOAL:\n{goal}\n\nOBSERVATIONS SO FAR:\n{obs}\n\nDecide the next action as JSON."
+    return [{"role": "system", "content": system}, {"role": "user", "content": user}]
+
+
+def parse_planner_decision(content: str | None) -> PlannerDecision | None:
+    if not content:
+        return None
+    text = content.strip()
+    if text.startswith("```"):  # tolerate an accidental fence
+        text = text.strip("`")
+        text = text[text.find("{") :] if "{" in text else text
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        log.info("planner produced non-JSON", extra={"event": "autonomous_planner_malformed"})
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("done") is True:
+        return PlannerDecision(done=True, next_intent=None, rationale=str(payload.get("rationale", "")))
+    raw_intent = payload.get("next_intent")
+    if not isinstance(raw_intent, str):
+        return None
+    try:
+        intent = ToolIntent(raw_intent)
+    except ValueError:
+        return None
+    if intent not in PLANNER_ALLOWLIST:
+        log.info("planner chose out-of-allowlist intent %r", raw_intent,
+                 extra={"event": "autonomous_planner_out_of_set"})
+        return None
+    args = payload.get("args")
+    if not isinstance(args, dict):
+        args = {}
+    return PlannerDecision(
+        done=False, next_intent=intent, args=args, rationale=str(payload.get("rationale", "")),
+    )
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `cd api && .venv/bin/python -m pytest tests/autonomous/test_planner_decision.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/planner.py api/tests/autonomous/test_planner_decision.py
+git commit -s -m "feat(autonomous): planner prompt + decision parser (WS-D PR1)"
+```
+
+---
+
+### Task 3: observation summarizer (compact, P3-clean)
+
+**Files:**
+- Modify: `api/app/autonomous/planner.py` (add `summarize_observation`)
+- Test: `api/tests/autonomous/test_observation_summary.py` (new)
+
+**Interfaces:**
+- Consumes: `ToolResult` from `app.autonomous.guard` (`.data`, `.outcome`).
+- Produces: `summarize_observation(intent: ToolIntent, rationale: str, result: ToolResult) -> str` — a one-line compact summary (counts / ids / case-names / short snippets), NEVER full payloads. A failed/`outcome != "success"` result → a `"<intent> → failed (<outcome>)"` line.
+
+- [ ] **Step 1: Write the failing tests** (`api/tests/autonomous/test_observation_summary.py`)
+
+```python
+from app.autonomous.enums import ToolIntent
+from app.autonomous.guard import ToolResult
+from app.autonomous.planner import summarize_observation
+
+
+def test_caselaw_summary_lists_case_names_not_full_text():
+    result = ToolResult(data={"results": [
+        {"case_name": "Smith v. Jones", "court": "ca9", "date_filed": "2021-01-01",
+         "opinion_text": "X" * 5000},
+        {"case_name": "Doe v. Roe", "court": "ca2", "date_filed": "2019-06-01"},
+    ]}, outcome="success")
+    s = summarize_observation(ToolIntent.retrieve_caselaw, "find authority", result)
+    assert "Smith v. Jones" in s and "Doe v. Roe" in s
+    assert "XXXX" not in s            # no full opinion text
+    assert len(s) < 400
+
+
+def test_chunks_summary_counts_and_files():
+    result = ToolResult(data={"chunks": [
+        {"chunk_id": "c1", "file_name": "nda.pdf", "content": "Y" * 4000},
+        {"chunk_id": "c2", "file_name": "nda.pdf", "content": "Z" * 4000},
+    ]}, outcome="success")
+    s = summarize_observation(ToolIntent.retrieve_chunks, "read clause", result)
+    assert "2" in s and "nda.pdf" in s
+    assert "YYYY" not in s
+
+
+def test_failed_result_is_summarized_not_raised():
+    result = ToolResult(data=None, outcome="gateway_error")
+    s = summarize_observation(ToolIntent.retrieve_caselaw, "x", result)
+    assert "failed" in s and "gateway_error" in s
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && .venv/bin/python -m pytest tests/autonomous/test_observation_summary.py -v`
+Expected: FAIL — `summarize_observation` undefined.
+
+- [ ] **Step 3: Implement** — append to `planner.py`:
+
+```python
+_SNIPPET = 120
+
+
+def summarize_observation(intent: ToolIntent, rationale: str, result: "object") -> str:
+    """One-line, P3-clean summary of a tool result for the planner's context.
+
+    Never includes full opinion/chunk payloads — only counts, ids, case names,
+    and short snippets. ``result`` is a guard.ToolResult (duck-typed to avoid a
+    circular import: read ``.outcome`` and ``.data``)."""
+    outcome = getattr(result, "outcome", "success")
+    data = getattr(result, "data", None) or {}
+    if outcome != "success":
+        return f"{intent.value} → failed ({outcome})"
+    if intent == ToolIntent.retrieve_caselaw:
+        items = data.get("results") or data.get("matches") or []
+        names = [
+            f"{(i.get('case_name') or '?')} ({i.get('court') or '?'} {i.get('date_filed') or '?'})"
+            for i in items[:5] if isinstance(i, dict)
+        ]
+        more = "" if len(items) <= 5 else f" +{len(items) - 5} more"
+        return f"{intent.value} → {len(items)} result(s): [{'; '.join(names)}]{more}"
+    if intent == ToolIntent.retrieve_chunks:
+        chunks = data.get("chunks") or []
+        files = sorted({c.get("file_name") for c in chunks if isinstance(c, dict) and c.get("file_name")})
+        return f"{intent.value} → {len(chunks)} chunk(s) from {files or '(no files)'}"
+    if intent == ToolIntent.call_mcp_tool:
+        payload = data if isinstance(data, dict) else {}
+        keys = sorted(payload.keys())[:8]
+        return f"{intent.value} → payload keys {keys}"
+    snippet = str(data)[:_SNIPPET]
+    return f"{intent.value} → {snippet}"
+```
+
+(Use a forward-ref / duck type for `result` to avoid importing `guard` into `planner` — `guard` already imports the enums; keep the dependency one-directional.)
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `cd api && .venv/bin/python -m pytest tests/autonomous/test_observation_summary.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/planner.py api/tests/autonomous/test_observation_summary.py
+git commit -s -m "feat(autonomous): compact P3-clean observation summarizer (WS-D PR1)"
+```
+
+---
+
+### Task 4: synthesis messages
+
+**Files:**
+- Modify: `api/app/autonomous/prompts.py` (add `assemble_synthesis_messages`)
+- Test: `api/tests/autonomous/test_synthesis_messages.py` (new)
+
+**Interfaces:**
+- Consumes: `assemble_analysis_messages(session, *, chunks, db)` (existing — returns `[system, user]` with the skill body + `STRUCTURED_OUTPUT_INSTRUCTION` in `system`).
+- Produces: `assemble_synthesis_messages(session, *, goal: str, observations: list[str], chunks: list[dict], db) -> list[dict[str, str]]` — the same `system` (so the structured-findings JSON contract holds), with the matter goal + observations appended to the `user` content.
+
+- [ ] **Step 1: Write the failing test** (`api/tests/autonomous/test_synthesis_messages.py`)
+
+```python
+import pytest
+from app.autonomous.prompts import assemble_synthesis_messages
+# Reuse the autonomous test helpers that seed a session with a skill_ref.
+# Match the seeding used by api/tests/autonomous/test_prompts*.py (a session
+# whose params carry a skill_ref pointing at a seeded skill).
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_synthesis_preserves_structured_contract_and_adds_goal_and_observations(
+    db_session, seeded_skill_session  # adapt fixture names to the existing prompts test
+):
+    msgs = await assemble_synthesis_messages(
+        seeded_skill_session, goal="Is the clause enforceable?",
+        observations=["retrieve_caselaw → 1 result: [Smith (9th 2021)]"],
+        chunks=[], db=db_session,
+    )
+    assert msgs[0]["role"] == "system" and msgs[-1]["role"] == "user"
+    # the structured-output JSON contract is still instructed (from assemble_analysis_messages)
+    assert "findings" in msgs[0]["content"] and "```json" in msgs[0]["content"]
+    # goal + observations are in the user content
+    user_blob = " ".join(m["content"] for m in msgs if m["role"] == "user")
+    assert "Is the clause enforceable?" in user_blob
+    assert "Smith (9th 2021)" in user_blob
+```
+
+> Adapt `seeded_skill_session` to whatever fixture `api/tests/autonomous/test_prompts*.py` already uses to build a session with a resolvable `skill_ref`. If none exists, seed inline following `assemble_analysis_messages`'s expectations (a `Skill` row with `content_md`, and `session.params["skill_ref"]`).
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_synthesis_messages.py -v`
+Expected: FAIL — `assemble_synthesis_messages` undefined.
+
+- [ ] **Step 3: Implement** — add to `prompts.py`:
+
+```python
+async def assemble_synthesis_messages(
+    session: AutonomousSession,
+    *,
+    goal: str,
+    observations: list[str],
+    chunks: list[dict[str, Any]],
+    db: AsyncSession,
+    registry: SkillRegistry | None = None,
+) -> list[dict[str, str]]:
+    """Build the final-synthesis messages for the agentic loop (WS-D PR1).
+
+    Reuses :func:`assemble_analysis_messages` (so the skill/playbook system
+    prompt and STRUCTURED_OUTPUT_INSTRUCTION are identical — the synthesis must
+    still emit the fenced-JSON findings the drafting node parses), then appends
+    a user block carrying the matter GOAL and the loop's compact OBSERVATIONS.
+    """
+    messages = await assemble_analysis_messages(session, chunks=chunks, db=db, registry=registry)
+    obs = "\n".join(f"- {o}" for o in observations) if observations else "(no research steps were run)"
+    messages.append({
+        "role": "user",
+        "content": (
+            f"MATTER GOAL:\n{goal}\n\nRESEARCH OBSERVATIONS (gathered by the agent):\n{obs}\n\n"
+            "Synthesize your analysis of the MATTER GOAL using the observations and any "
+            "chunks above, then return the final JSON object as instructed."
+        ),
+    })
+    return messages
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_synthesis_messages.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/prompts.py api/tests/autonomous/test_synthesis_messages.py
+git commit -s -m "feat(autonomous): synthesis messages preserve the structured-findings contract (WS-D PR1)"
+```
+
+---
+
+### Task 5: the governed loop in `analysis_node` (the integration heart)
+
+**Files:**
+- Modify: `api/app/autonomous/nodes.py` (`make_analysis_node` — add the gate + loop)
+- Modify: `api/app/config.py` (`DEFAULT_MAX_ANALYSIS_STEPS = 6`)
+- Test: `api/tests/autonomous/test_agentic_loop.py` (new)
+
+**Interfaces:**
+- Consumes: `build_planner_messages`, `parse_planner_decision`, `summarize_observation`, `PLANNER_ALLOWLIST` (Tasks 2-3); `assemble_synthesis_messages` (Task 4); `guarded_tool_call`, `ToolResult` (guard); `ToolIntent`, `Phase` (enums).
+- Produces: a matter-scoped (`state["query"]`) analysis node that runs the loop; query-less sessions unchanged. Returns `{"current_phase", "analysis_content", "analysis_outcome", "analysis_plan_trace"}`.
+
+- [ ] **Step 1: Write the failing integration tests** (`api/tests/autonomous/test_agentic_loop.py`)
+
+```python
+import json
+from types import SimpleNamespace
+import pytest
+from app.autonomous.enums import ToolIntent
+# Reuse the autonomous test seeding (a session with skill_ref + retrieved_chunks state).
+# Match the fixtures used by api/tests/autonomous/test_nodes*.py.
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+# A stub gateway whose chat_completion returns canned planner/synthesis JSON.
+# The loop calls guarded_tool_call(plan, ...) → _handle_gateway_inference →
+# gateway.chat_completion; and guarded_tool_call(run_skill, synthesis) likewise.
+# The stub distinguishes planner calls (system mentions "research planner")
+# from synthesis calls (system carries STRUCTURED_OUTPUT_INSTRUCTION).
+
+def _resp(content):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+                           usage=SimpleNamespace(prompt_tokens=10, completion_tokens=10))
+
+
+class _ScriptedGateway:
+    def __init__(self, planner_script):
+        self.planner_script = list(planner_script)  # list of dicts the planner returns in order
+    async def chat_completion(self, request, *, request_id=None):
+        system = request.messages[0].content
+        if "research planner" in system:
+            return _resp(json.dumps(self.planner_script.pop(0)))
+        # synthesis call → return the structured findings JSON
+        return _resp('```json\n{"findings": [{"title": "t", "summary": "s", '
+                     '"severity": "info", "source_chunk_ids": []}], "suggested_memories": [], '
+                     '"suggested_precedents": [], "privilege_concerns": [], "scope_concerns": []}\n```')
+
+
+async def test_query_less_session_is_unchanged(db_session, seeded_skill_session_no_query):
+    # No state["query"] → single run_skill path; NO plan intent ever audited.
+    ... # build the analysis node, run it with state lacking "query",
+        # assert analysis_content is the single-call content and no audit row has intent "plan".
+
+
+async def test_loop_runs_planner_then_done_then_synthesis(db_session, seeded_matter_session):
+    gw = _ScriptedGateway([
+        {"next_intent": "retrieve_caselaw", "args": {"query": "assignment clause"}, "rationale": "find authority"},
+        {"done": True, "rationale": "enough"},
+    ])
+    ... # build analysis node bound to gw; run with state["query"]="...".
+        # assert: retrieve_caselaw ran through guarded_tool_call (audit has it);
+        # the final synthesis produced analysis_content with parseable findings;
+        # the return dict's analysis_plan_trace has 1 step + halt_reason "planner_done".
+
+
+async def test_step_cap_halts_and_still_synthesizes(db_session, seeded_matter_session):
+    # planner never says done → loop stops at max_analysis_steps; synthesis still runs.
+    gw = _ScriptedGateway([{"next_intent": "retrieve_caselaw", "args": {}, "rationale": "x"}] * 20)
+    ... # set session.params["max_analysis_steps"]=2; assert exactly 2 act steps,
+        # halt_reason "step_cap", analysis_content still present (partial-but-honest).
+
+
+async def test_unparseable_planner_stops_loop_then_synthesizes(db_session, seeded_matter_session):
+    gw = _ScriptedGateway(["not json at all"])  # planner returns junk
+    ... # assert: no action dispatched, halt_reason "planner_unparseable",
+        # synthesis still runs, analysis_content present.
+```
+
+> Fill the `...` bodies against the existing autonomous node tests (`api/tests/autonomous/test_nodes*.py`) — reuse their session/skill/state seeding and their `make_analysis_node` invocation pattern. Build `seeded_matter_session` = a `seeded_skill_session` whose `params["query"]` is set; `seeded_skill_session_no_query` = the same without `query`. Assert audit intents via the `audit_log`/`autonomous_audit` rows those tests already query. If wiring the full node proves heavy, an acceptable interim is to test an extracted `_run_analysis_loop(...)` helper directly — but prefer the node.
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_agentic_loop.py -v`
+Expected: FAIL — node has no loop; query-sessions take the single-call path; no `analysis_plan_trace`.
+
+- [ ] **Step 3: Implement.** Add `DEFAULT_MAX_ANALYSIS_STEPS = 6` to `config.py` (a module constant near the other autonomous defaults). In `nodes.py`, add the imports (`build_planner_messages, parse_planner_decision, summarize_observation, PLANNER_ALLOWLIST` from `app.autonomous.planner`; `assemble_synthesis_messages` from `app.autonomous.prompts`) and insert the gate + loop. After the existing degenerate-target guard (the `if not skill_ref and not playbook_id` block) and before the existing single-call path, branch on the query:
+
+```python
+        query = (state.get("query") or "").strip()
+        settings = get_settings()
+        model = params.get("model") or settings.autonomous_default_model
+
+        if query:
+            return await _run_analysis_loop(
+                session, query=query, params=params, chunks=state.get("retrieved_chunks") or [],
+                model=model, db=db, gateway=gateway,
+            )
+
+        # ---- unchanged single-call path (query-less sessions) ----
+        chunks = state.get("retrieved_chunks") or []
+        messages = await assemble_analysis_messages(session, chunks=chunks, db=db)
+        intent = ToolIntent.run_playbook if playbook_id else ToolIntent.run_skill
+        result = await guarded_tool_call(
+            session, intent, {"model": model, "messages": messages, "anonymize": True}, db, gateway,
+        )
+        return {
+            "current_phase": str(Phase.analysis),
+            "analysis_content": (result.data or {}).get("content"),
+            "analysis_outcome": result.outcome,
+        }
+```
+
+Add the loop helper (module-level in `nodes.py`):
+
+```python
+async def _run_analysis_loop(
+    session: AutonomousSession, *, query: str, params: dict[str, Any],
+    chunks: list[dict[str, Any]], model: str, db: AsyncSession, gateway: Any,
+) -> dict[str, Any]:
+    """The governed plan→act→observe→replan loop (WS-D PR1). Every step goes
+    through guarded_tool_call (R5→R6→R4); bounded by max_analysis_steps + R4."""
+    from app.config import DEFAULT_MAX_ANALYSIS_STEPS
+
+    max_steps = int(params.get("max_analysis_steps") or DEFAULT_MAX_ANALYSIS_STEPS)
+    observations: list[str] = []
+    trace: list[dict[str, str]] = []
+    halt_reason = "step_cap"
+    steps = 0
+    while steps < max_steps:
+        plan_res = await guarded_tool_call(
+            session, ToolIntent.plan,
+            {"model": model,
+             "messages": build_planner_messages(
+                 goal=query, observations=observations, allowlist=PLANNER_ALLOWLIST),
+             "anonymize": False},
+            db, gateway,
+        )
+        decision = parse_planner_decision((plan_res.data or {}).get("content"))
+        if decision is None:
+            halt_reason = "planner_unparseable"
+            break
+        if decision.done:
+            halt_reason = "planner_done"
+            trace.append({"step": str(steps), "intent": "done", "rationale": decision.rationale})
+            break
+        assert decision.next_intent is not None  # parser guarantees: action ⇒ next_intent set
+        act = await guarded_tool_call(session, decision.next_intent, decision.args, db, gateway)
+        observations.append(summarize_observation(decision.next_intent, decision.rationale, act))
+        trace.append({"step": str(steps), "intent": decision.next_intent.value,
+                      "rationale": decision.rationale})
+        steps += 1
+
+    synth = await guarded_tool_call(
+        session, ToolIntent.run_skill,
+        {"model": model,
+         "messages": await assemble_synthesis_messages(
+             session, goal=query, observations=observations, chunks=chunks, db=db),
+         "anonymize": True},
+        db, gateway,
+    )
+    return {
+        "current_phase": str(Phase.analysis),
+        "analysis_content": (synth.data or {}).get("content"),
+        "analysis_outcome": synth.outcome,
+        "analysis_plan_trace": {"steps": steps, "halt_reason": halt_reason, "decisions": trace},
+    }
+```
+
+(`analysis_plan_trace` is a JSONable dict — counts/intents/rationales/halt only, P3. A mid-loop brake — `SessionHalted`/`CostCapReached` — propagates out of `guarded_tool_call` exactly as today; the executor's terminal handler owns it.)
+
+Add `analysis_plan_trace: dict | None` to `AutonomousSessionState` in `state.py`.
+
+- [ ] **Step 4: Run — expect pass + the full autonomous suite (regressions)**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous -v`
+Expected: PASS (new loop tests + every existing autonomous test — the query-less path must be untouched).
+
+- [ ] **Step 5: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/nodes.py api/app/autonomous/state.py api/app/config.py api/tests/autonomous/test_agentic_loop.py
+git commit -s -m "feat(autonomous): governed plan-act-observe-replan loop in the analysis phase (WS-D PR1)"
+```
+
+---
+
+### Task 6: surface the plan trace in the receipt (D5 transparency)
+
+**Files:**
+- Modify: `api/app/autonomous/receipt.py` (include the plan trace)
+- Modify: the delivery node / executor so `analysis_plan_trace` reaches the receipt (thread state → `session.result`)
+- Test: `api/tests/autonomous/test_receipt_plan_trace.py` (new)
+
+**Interfaces:**
+- Consumes: `analysis_plan_trace` from `AutonomousSessionState` (Task 5).
+- Produces: the session `result`/receipt carries `plan_trace` = `{steps, halt_reason, decisions:[{step, intent, rationale}]}` — counts/types/short-rationale only (P3).
+
+- [ ] **Step 1: Write the failing test** (`api/tests/autonomous/test_receipt_plan_trace.py`)
+
+```python
+import pytest
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+# Run a matter session end-to-end (scripted gateway from Task 5's helper) and
+# assert the persisted session.result / receipt includes plan_trace with the
+# step count, halt_reason, and per-decision intents+rationales — and NO full
+# tool payloads (P3).
+async def test_receipt_carries_plan_trace(db_session, seeded_matter_session):
+    ...  # drive the graph (or build_receipt over the state) and assert:
+    # result["plan_trace"]["halt_reason"] in {"planner_done","step_cap",...}
+    # result["plan_trace"]["decisions"][0]["intent"] == "retrieve_caselaw"
+    # no value in the trace exceeds a short length (no payloads)
+```
+
+> Match how the existing receipt tests (`api/tests/autonomous/test_receipt*.py`) drive `build_receipt` / read `session.result`. If the receipt is built purely from `audit_log`, thread `analysis_plan_trace` through the delivery node into `session.result` (the executor already writes `result` at delivery) and assert there; reuse the existing end-to-end session-run helper if one exists.
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_receipt_plan_trace.py -v`
+Expected: FAIL — no `plan_trace` in the receipt/result.
+
+- [ ] **Step 3: Implement.** Thread `analysis_plan_trace` from state into `session.result` where the receipt is assembled (the delivery node / `build_receipt`). Include it as `result["plan_trace"]`. Keep it counts/types/short-rationale only — do not add tool payloads. (Exact wiring: follow how `findings_count` / the existing receipt fields flow from state to `result`.)
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_receipt_plan_trace.py tests/autonomous -v`
+Expected: PASS.
+
+- [ ] **Step 5: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/receipt.py api/app/autonomous/nodes.py api/tests/autonomous/test_receipt_plan_trace.py
+git commit -s -m "feat(autonomous): surface the agentic plan trace in the receipt (WS-D PR1)"
+```
+
+---
+
+## Final gate (before requesting review — the thrice-burned CI LESSON)
+
+- [ ] **api full gates at CI scope (repo root):**
+```bash
+cd /Users/kevinkeller/Code/lq-ai
+api/.venv/bin/ruff check api scripts && api/.venv/bin/ruff format --check api scripts
+cd api && .venv/bin/mypy app
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest -q
+```
+- [ ] **gateway full gates:** `cd gateway && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app --strict && .venv/bin/python -m pytest -q` (PR1 doesn't touch gateway; confirm no incidental break).
+- [ ] **PRD/ADR bookkeeping:** note WS-D PR1 status; no DE unless one surfaces.
+- [ ] **Opus whole-branch review** (SDD final) — required; it has caught a real gate-passing defect on every slice this milestone.
+
+## Plan self-review (completed)
+
+- **Spec coverage:** `ToolIntent.plan` + grant + cost + dispatch → Task 1; planner prompt+parser → Task 2; observation summarizer → Task 3; synthesis-contract messages → Task 4; the loop + backward-compat gate + step cap → Task 5; receipt/D5 transparency → Task 6. Out-of-scope (ledger/gate, UI, source registry, intake-LLM step) explicitly deferred. Migration caveat resolved in Task 1 Step 1.
+- **Placeholder scan:** real code/commands throughout. The `...` test bodies in Tasks 5-6 are deliberately delegated to the existing autonomous test seeding (named: `test_nodes*.py`, `test_receipt*.py`) with the asserted contract fixed — integration points against existing fixtures, not logic placeholders.
+- **Type consistency:** `PlannerDecision(done, next_intent, args, rationale)`, `PLANNER_ALLOWLIST`, `build_planner_messages(*, goal, observations, allowlist)`, `parse_planner_decision(content) -> PlannerDecision | None`, `summarize_observation(intent, rationale, result) -> str`, `assemble_synthesis_messages(session, *, goal, observations, chunks, db)`, `_run_analysis_loop(...)`, and `analysis_plan_trace` are consistent across Tasks 1-6.

--- a/docs/superpowers/specs/2026-06-28-wsd-pr1-agentic-loop-design.md
+++ b/docs/superpowers/specs/2026-06-28-wsd-pr1-agentic-loop-design.md
@@ -1,0 +1,154 @@
+# WS-D PR1 — governed agentic loop + matter intake (design)
+
+**Date:** 2026-06-28
+**Milestone:** Fiduciary-grade agentic legal work — Phase 2, WS-D (agentic legal-matter sessions).
+**ADR:** [0020](../../adr/0020-governed-agentic-legal-matter-sessions.md) — this spec implements its PR1 (D1 the governed loop, D2 agency confined to analysis, D3 matter intake, D4 step cap, D5 transparent plan, D7 reuse the rails). Resolves the PR1 §Open-questions.
+**Builds on:** the autonomous layer (`api/app/autonomous/`) — `guarded_tool_call`, the closed `ToolIntent` set, `PHASE_GRANTS`, R4/R5/R6, the LangGraph `intake → analysis → drafting → ethics_review → delivery` backbone, the `audit_log` + receipt.
+**Security-gated:** yes — `api/app/autonomous/**` is the governance chokepoint. Security/maintainer merges; mirror `origin/main → tucuxi` after.
+**Migration:** likely none (the loop runs in-node; `state["query"]` already exists) — **but verify** the `audit_log` (and any tool-intent-bearing column) does not persist `ToolIntent` under a DB CHECK constraint; if it does, adding `plan` needs a migration to extend that CHECK. The plan's Task 1 must check this first. **If a migration is needed it is `0063`; otherwise next migration stays `0063`. Next DE = DE-368.**
+
+---
+
+## 1. What this delivers
+
+Today's autonomous `analysis` phase is a **single `run_skill` LLM call**. PR1 turns it into a **governed `plan → act → observe → replan` loop** for **matter-scoped** sessions: the planner picks the next `ToolIntent` from `PHASE_GRANTS[analysis]`, each step runs through the existing `guarded_tool_call` (R5→R6→R4 unchanged), observations fold back compactly, and a final synthesis produces the structured findings the rest of the graph already consumes. A plain-language matter (the `params["query"]` seam, currently unread) becomes the planner's goal.
+
+PR1 produces the session's **existing** outputs — `emit_finding` / `emit_artifact` / `propose_precedent` — over an *adaptively planned* research arc. **No WS-A ledger / WS-B gate** (that is PR2, ADR 0020 D6).
+
+### In scope
+- A new `ToolIntent.plan` (closed-set extension) + `PHASE_GRANTS[analysis]` grant.
+- The planner prompt + parser (next-intent + args + rationale, or done).
+- The `while` loop inside `analysis_node` (no LangGraph change), step-capped, every step through `guarded_tool_call`.
+- A pure per-intent observation `summarize(...)` formatter (compact, P3-clean).
+- The final-synthesis `run_skill` call that preserves the `analysis_content` → `drafting.parse_structured_output` contract.
+- Receipt/audit surfacing of the plan trace + cap-halt reason.
+
+### Out of scope (deferred)
+- **WS-A ledger / WS-B gate integration** → WS-D PR2.
+- **A WS-D session UI** → later PR.
+- **The WS-E source registry** the planner reasons over → WS-E.
+- **An LLM-structured matter-intake step** (decompose the matter into sub-questions before the loop) — the planner does this adaptively; revisit only if needed.
+- **Looping in intake/drafting** — ADR 0020 D2 keeps the backbone scripted; only analysis loops in PR1.
+- **DE-344 metered-source cost** — the loop is bounded by R4's inference-cost estimate + the step cap today; metered external-tool cost lands in WS-E.
+
+---
+
+## 2. The backward-compat gate (load-bearing)
+
+The planner loop engages **only when `state["query"]` is non-empty** — a matter-scoped session. Sessions with no query (today's cron / watch / schedule triggers) take the **unchanged** single-`run_skill` path. PR1 is **strictly additive**: every existing autonomous session is byte-identical (same intents, same audit rows, same outputs). The branch in `analysis_node`:
+
+```
+if not (state.get("query") or "").strip():
+    return <today's single-call analysis result, unchanged>
+# else: run the governed planner loop (§3)
+```
+
+This is the invariant the tests pin: a query-less session's audit trail and outputs do not change.
+
+---
+
+## 3. The governed loop
+
+In `analysis_node` (the phase is already transitioned to `analysis`; `PHASE_GRANTS[analysis]` applies to every step):
+
+```
+goal = state["query"]
+observations: list[str] = []          # compact summaries, oldest→newest
+max_steps = int(session.params.get("max_analysis_steps", DEFAULT_MAX_ANALYSIS_STEPS))
+steps = 0
+halt_reason = None
+
+while steps < max_steps:
+    decision = await guarded_tool_call(session, ToolIntent.plan,
+                  {"goal": goal, "observations": observations,
+                   "allowlist": _planner_allowlist(), "model": model}, db, gateway)
+    plan = parse_planner_decision(decision.data)        # parse-or-stop
+    if plan is None or plan.done:
+        halt_reason = "planner_done" if (plan and plan.done) else "planner_unparseable"
+        break
+    if plan.next_intent not in _planner_allowlist():     # defense-in-depth (R6 also guards)
+        halt_reason = "planner_out_of_set"
+        break
+    result = await guarded_tool_call(session, plan.next_intent, plan.args, db, gateway)
+    observations.append(summarize_observation(plan.next_intent, plan.rationale, result))
+    steps += 1
+else:
+    halt_reason = "step_cap"
+
+# Final synthesis — always runs; preserves the drafting contract (§4).
+synth = await guarded_tool_call(session, ToolIntent.run_skill,
+            {"model": model, "messages": assemble_synthesis_messages(session, goal, observations, db),
+             "anonymize": True}, db, gateway)
+
+return {
+    "current_phase": str(Phase.analysis),
+    "analysis_content": (synth.data or {}).get("content"),
+    "analysis_outcome": synth.outcome,
+    "analysis_plan_trace": _plan_trace(observations, steps, halt_reason),   # for the receipt (D5)
+}
+```
+
+- **`_planner_allowlist()`** = `PHASE_GRANTS[Phase.analysis]` minus `plan` itself and minus the emit/side-effect intents the planner shouldn't drive in the research arc (`propose_precedent` stays an analysis grant but is not a planner action in PR1 — the synthesis/drafting path emits). The exact set is fixed in the plan; the research/observe intents are `retrieve_chunks`, `retrieve_caselaw`, `call_mcp_tool`, plus `run_skill` if the planner wants an interim analysis pass.
+- **Every step is a `guarded_tool_call`** — R5 (halt), R6 (phase grant), R4 (budget) fire per step; `session.cost_total_usd` accrues in-place, so R4 throttles a runaway loop **and** the step cap bounds iteration. No new brake machinery (ADR 0020 D4).
+- **Args are model-generated, handler-validated.** The planner emits `args` for the chosen intent (e.g. a `retrieve_caselaw` query); the intent's existing handler validates them (the closed-set boundary, ADR 0015). A malformed/oversized arg fails in the handler as a non-fatal tool outcome, summarized as a failed observation — it never escapes the governed path.
+
+## 4. The synthesis contract (load-bearing)
+
+`drafting` reads `analysis_content` and calls `parse_structured_output` (expects the fenced-JSON `findings/…` shape). PR1 **preserves this**: regardless of how the loop terminates (`planner_done`, `step_cap`, `planner_unparseable`, `planner_out_of_set`), a **final `run_skill` synthesis call** turns the goal + accumulated observations into that structured-findings JSON, which becomes `analysis_content`. A cap-halt therefore yields a **partial-but-honest** structured result, not a fabricated-complete one. `assemble_synthesis_messages` reuses `assemble_analysis_messages`'s skill/playbook system prompt + structured-output instruction, with the observations rendered as the user content instead of (or alongside) the baseline chunks.
+
+## 5. New components
+
+| Component | File | Responsibility |
+|---|---|---|
+| `ToolIntent.plan` | `api/app/autonomous/enums.py` (+ `schemas/autonomous.py` enum + CHECK if persisted in audit) | closed-set planner intent; granted in `PHASE_GRANTS[analysis]` |
+| planner dispatch | `api/app/autonomous/guard.py` (`_dispatch`) | a `plan` handler: build planner messages → gateway inference → return `ToolResult(data={"content": ...})`; cost via R4 like `run_skill` |
+| planner prompt + parser | `api/app/autonomous/planner.py` (new) | `build_planner_messages(goal, observations, allowlist)`, `parse_planner_decision(data) -> PlannerDecision \| None` (next_intent ∈ allowlist + args + rationale, or done; parse-or-None) |
+| observation summarizer | `api/app/autonomous/planner.py` | `summarize_observation(intent, rationale, result) -> str` — compact, P3-clean (counts/ids/case-names/short snippets; never full opinion text) |
+| synthesis messages | `api/app/autonomous/prompts.py` | `assemble_synthesis_messages(session, goal, observations, db)` reusing the analysis system prompt + structured-output instruction |
+| the loop | `api/app/autonomous/nodes.py` (`make_analysis_node`) | the §3 loop; the §2 backward-compat gate; the plan trace in the return dict |
+| step-cap constant | `api/app/config.py` or `enums.py` | `DEFAULT_MAX_ANALYSIS_STEPS` (≈6), `params["max_analysis_steps"]` override |
+| receipt surfacing | `api/app/autonomous/receipt.py` | include the plan trace (step count, intents, rationales, halt reason) — counts/types only (P3) |
+
+## 6. Data flow
+
+```
+matter session (params["query"] set; project-scoped)
+  └─ executor → state["query"]                                  [exists]
+  └─ intake (baseline retrieve_chunks)                          [unchanged]
+  └─ ANALYSIS node:
+       ├─ no query?  → single run_skill (today's path)          [§2 additive]
+       └─ query?     → planner loop:                            [§3]
+            plan(guarded) → act(guarded) → summarize → replan   (≤ max_steps, R4-bounded)
+            → final run_skill synthesis → analysis_content      [§4 preserves contract]
+  └─ drafting parse_structured_output(analysis_content)         [unchanged]
+  └─ ethics_review → delivery                                   [unchanged, deterministic]
+  └─ receipt: + plan trace (intents/rationales/steps/halt)      [D5]
+```
+
+## 7. Error handling & invariants
+- **Strictly additive:** query-less sessions unchanged (§2). The graph backbone, ethics_review, and delivery are untouched (ADR 0020 D2).
+- **Every loop step governed:** no tool call bypasses `guarded_tool_call`; R4/R5/R6 fire per step. A mid-loop `SessionHalted` / `CostCapReached` propagates exactly as today (the executor's `except AutonomousBrake` handles it; a partial plan trace is still on the session).
+- **Parse-or-stop:** an unparseable / out-of-set planner decision stops the loop conservatively (no execution of an invalid intent) and proceeds to synthesis — never raises, never fabricates.
+- **Bounded:** `max_steps` + R4 `$5`. The loop cannot run unbounded.
+- **Transparent:** every plan decision (intent + rationale) is audited (the `plan` intent's `guarded_tool_call` rows) + in the receipt (D5).
+- **P3:** observations + the plan trace hold counts/ids/case-names/short snippets — never full opinion/chunk payloads.
+
+## 8. Testing
+- **Backward-compat (the load-bearing test):** a query-less session produces byte-identical audit rows + outputs to today (single `run_skill`, no `plan` intent emitted).
+- **Loop happy path:** a matter session where a stub planner returns e.g. `retrieve_caselaw` then `done` → asserts the act ran through `guarded_tool_call`, the observation was summarized, the final synthesis produced `analysis_content`, and the plan trace is in the return/receipt.
+- **Step cap:** a stub planner that never says done → loop stops at `max_steps`, `halt_reason="step_cap"`, synthesis still runs (partial result).
+- **Parse-or-stop:** planner returns malformed / out-of-set intent → loop stops (`planner_unparseable` / `planner_out_of_set`), no invalid intent dispatched, synthesis runs.
+- **R4 throttle:** a low `max_cost_usd` → the loop halts via `CostCapReached` mid-iteration (existing brake), partial trace recorded.
+- **Planner intent + grants:** `plan` ∈ `PHASE_GRANTS[analysis]`; `plan` dispatched outside analysis → `ToolNotGranted` (R6).
+- **Observation summarizer (unit):** each intent's result → compact P3-clean string (no full payloads).
+- **CI gate (twice-burned LESSON):** `ruff check api scripts` + `ruff format --check api scripts` + `ruff check gateway` + formats from **repo root**; `mypy app` whole-app; both full suites.
+
+## 9. Decisions log
+- **Planner intent:** a dedicated `ToolIntent.plan` (closed-set extension), not reused `run_skill` — the planner decision is audited distinctly (ADR 0020 D5).
+- **Observations:** compact structured summaries fed back to the planner; full payloads only to the final synthesis (bounded cost; P3).
+- **Loop topology:** a `while` inside `analysis_node` — no LangGraph change (the backbone stays scripted, ADR 0020 D2).
+- **Backward-compat:** the loop engages only for `state["query"]` sessions; query-less sessions unchanged.
+- **Synthesis contract:** a final `run_skill` synthesis always produces the structured `analysis_content` `drafting` expects, even on a cap-halt (partial-but-honest).
+- **Matter intake:** deterministic pass-through (`query` → planner goal); no separate intake-LLM step; matter = project.
+- **Step cap:** `DEFAULT_MAX_ANALYSIS_STEPS ≈ 6`, `params["max_analysis_steps"]` override; plus R4. No new brake machinery.
+- **No migration; no ledger/gate** (PR2).


### PR DESCRIPTION
## WS-D PR1 — Governed agentic loop + matter intake

Turns the autonomous `analysis` phase from a single `run_skill` inference into a governed **plan → act → observe → replan** loop **for matter-scoped sessions only**, while leaving query-less sessions (cron/watch/schedule) byte-identical. The planner picks the next observe-intent each step (all through `guarded_tool_call`), observations fold back compactly, and a final `run_skill` synthesis produces the structured findings the rest of the graph already consumes. ADR [0020](docs/adr/0020-governed-agentic-legal-matter-sessions.md). **No migration.**

### What changed
- **`ToolIntent.plan`** — closed-set planner-decision intent (a gateway inference), granted **only** in `PHASE_GRANTS[analysis]`, costed by R4 as inference. No DB CHECK → no migration.
- **`planner.py`** — `PLANNER_ALLOWLIST` (observe intents only), `PlannerDecision`, `build_planner_messages`, `parse_planner_decision` (parse-or-`None`, never raises), `summarize_observation` (P3-clean), and `validate_action_args` (closed-set arg boundary, see C1).
- **`prompts.assemble_synthesis_messages`** — reuses `assemble_analysis_messages` so the fenced-JSON `findings` contract the drafting node parses is byte-identical.
- **`nodes.py`** — the loop + backward-compat gate in `make_analysis_node` (`_run_analysis_loop`); the receipt plan-trace merge in the delivery node.
- **`state.py` / `config.py`** — `analysis_plan_trace` state field; `DEFAULT_MAX_ANALYSIS_STEPS = 6`.

### Load-bearing invariants (all test-pinned)
1. **Backward-compat:** the loop engages only when `state["query"]` is non-empty; query-less sessions take the unchanged single-call path — no `plan` intent, no `analysis_plan_trace` key.
2. **Synthesis contract:** however the loop ends (`planner_done`/`step_cap`/`planner_unparseable`), a final synthesis always produces the structured findings as `analysis_content` — partial-but-honest on a cap-halt, never fabricated-complete, never a crash.
3. **Every step via `guarded_tool_call`** (R5→R6→R4); no bypass; no new brake machinery; bounded by `max_analysis_steps` + R4's cost cap.
4. **Planner allowlist = observe intents only** (`retrieve_chunks`/`retrieve_caselaw`/`call_mcp_tool`); `run_skill`/`run_playbook` reserved for synthesis.
5. **Args model-generated, boundary-validated** (ADR 0015); P3: trace + observations hold counts/ids/case-names/short snippets/rationale only — never full payloads.

### Review trail (subagent-driven development)
6 TDD tasks, each implemented → spec-review → quality-review clean. The Opus whole-branch review then found a **Critical (C1)** + I1 + M1; all fixed and re-reviewed clean:

- **C1 (Critical, fixed):** a model-generated planner arg (e.g. `retrieve_chunks {top_k: -1}`) faulted at the SQL layer (`hybrid_search` doesn't clamp `top_k` → negative `LIMIT` → `DBAPIError`); the loop's catch swallowed it without rollback, poisoning the `AsyncSession` so the next call/synthesis raised `PendingRollbackError`, and the executor's failure-handler `commit()` (no prior `rollback()`) left a zombie `running` session. **Fix (maintainer-approved approach):** (a) `validate_action_args` rejects SQL-reaching bad args before dispatch so they degrade to a clean failed observation (no poisoning); (b) the executor's generic `except` now `rollback()`s before persisting `failed` (defense-in-depth). No savepoints.
- **I1 (fixed):** playbook matter-sessions now synthesize/audit under `run_playbook`, not `run_skill`.
- **M1 (fixed):** `assert next_intent` replaced with an `-O`-safe guard that keeps synthesis reachable.

### Test evidence
- Solo full api suite: **2436 passed, 1 skipped, 0 failed**. Autonomous suite: **522 passed**. `ruff check`/`ruff format --check` (`api scripts`) + whole-app `mypy` clean. Gateway untouched (0 files).
- New tests: agentic loop (planner→done→synthesis, step-cap, unparseable, bad-arg-nonfatal), `validate_action_args` unit matrix, observation summarizer, synthesis messages, plan-intent grant/cost, receipt plan-trace, executor rollback regression.

### Notes
- **DE-368** filed: the test suite is serial-only against one shared Postgres (CI runs it serially → green); flagged for any future `pytest-xdist` parallelization (needs per-worker DBs).
- Residual minor (logged, backstopped by C1b): `validate_action_args` doesn't dimension-check `query_embedding` — a wrong-dim vector would fault at pgvector but the executor rollback degrades it cleanly (no zombie). Low-probability (a text planner rarely emits raw vectors).

### Scope deferred to WS-D PR2
WS-A ledger + WS-B gate integration (reusing the chat-path `assemble_ledger_entries` + `compute_and_record_gate`). PR1 adds no ledger/gate.

🔒 **Security-gated** (`api/app/autonomous/**`, `guard.py` dispatch, `executor.py`) — routed to security review. **Do not self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
