### PR TITLE
WS-D PR2 — fiduciary ledger + gate for matter sessions (Phase 2)

### DIFF
--- a/api/alembic/versions/0063_chat_autonomous_session_id.py
+++ b/api/alembic/versions/0063_chat_autonomous_session_id.py
@@ -1,0 +1,43 @@
+"""chats.autonomous_session_id — hidden session-owned chats (WS-D PR2).
+
+Revision ID: 0063
+Revises: 0062
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0063"
+down_revision = "0062"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chats",
+        sa.Column("autonomous_session_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_chats_autonomous_session_id",
+        "chats",
+        "autonomous_sessions",
+        ["autonomous_session_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_chats_autonomous_session_id",
+        "chats",
+        ["autonomous_session_id"],
+        postgresql_where=sa.text("autonomous_session_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chats_autonomous_session_id", table_name="chats")
+    op.drop_constraint("fk_chats_autonomous_session_id", "chats", type_="foreignkey")
+    op.drop_column("chats", "autonomous_session_id")

--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -687,8 +687,17 @@ async def get_session_ledger(
     """
     await _load_owned_session(db, session_id=session_id, user_id=user.id)
     chat = (
-        await db.execute(select(Chat).where(Chat.autonomous_session_id == session_id))
-    ).scalar_one_or_none()
+        (
+            await db.execute(
+                select(Chat)
+                .where(Chat.autonomous_session_id == session_id)
+                .order_by(Chat.created_at)
+                .limit(1)
+            )
+        )
+        .scalars()
+        .first()
+    )
     if chat is None:
         raise HTTPException(status_code=404, detail="session has no ledger")
     entries = await resolve_ledger_entries(db, chat_id=chat.id)

--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -671,12 +671,14 @@ async def get_session_ledger(
 ) -> dict[str, Any]:
     """GET /api/v1/autonomous/sessions/{session_id}/ledger
 
-    Returns the citation ledger (entries + fiduciary gate) for the hidden
-    chat manufactured by ``build_session_ledger`` (WS-D PR2 Task 7).
+    Returns ``{chat_id, entries, gates}`` — the identical shape produced by
+    the chat ``GET /{chat_id}/ledger`` endpoint — so the PR2-UI can reuse
+    the chat ledger component directly without adaptation.  For a session
+    ledger ``gates`` always has exactly one element (the single fiduciary-
+    grade gate manufactured by ``build_session_ledger``).
+
     Reuses ``resolve_ledger_entries`` and ``resolve_gates`` — the same
-    functions the chat ``GET /{chat_id}/ledger`` endpoint calls — so the
-    response schema is identical and the PR2-UI can reuse the chat ledger
-    component.
+    functions the chat ledger endpoint calls.
 
     Owner-gated via ``_load_owned_session``; another user's ``session_id``
     or a missing session returns 404 (not 403) to avoid existence
@@ -691,7 +693,7 @@ async def get_session_ledger(
         raise HTTPException(status_code=404, detail="session has no ledger")
     entries = await resolve_ledger_entries(db, chat_id=chat.id)
     gates = await resolve_gates(db, chat_id=chat.id)
-    return {"entries": entries, "gate": gates[0] if gates else None}
+    return {"chat_id": str(chat.id), "entries": entries, "gates": gates}
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import func, select
@@ -53,6 +53,8 @@ from app.audit import audit_action
 from app.autonomous.audit import autonomous_audit
 from app.autonomous.cron import next_run_after, validate_cron_expr
 from app.autonomous.receipt import build_receipt
+from app.citation.gate import resolve_gates
+from app.citation.ledger import resolve_ledger_entries
 from app.config import get_settings
 from app.db.session import get_db
 from app.models.autonomous import (
@@ -66,6 +68,7 @@ from app.models.autonomous import (
     PrecedentEntry,
     ProjectContextProposal,
 )
+from app.models.chat import Chat
 from app.models.document import Document
 from app.models.knowledge import KnowledgeBase
 from app.models.project import Project
@@ -651,6 +654,44 @@ async def list_session_artifacts(
         limit=limit,
         offset=offset,
     )
+
+
+@router.get(
+    "/sessions/{session_id}/ledger",
+    summary="Citation ledger + fiduciary gate for an autonomous session (WS-D PR2 C5)",
+    responses={
+        404: {"description": "Session not found or has no ledger"},
+        401: {"description": "Not authenticated"},
+    },
+)
+async def get_session_ledger(
+    session_id: uuid.UUID,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, Any]:
+    """GET /api/v1/autonomous/sessions/{session_id}/ledger
+
+    Returns the citation ledger (entries + fiduciary gate) for the hidden
+    chat manufactured by ``build_session_ledger`` (WS-D PR2 Task 7).
+    Reuses ``resolve_ledger_entries`` and ``resolve_gates`` — the same
+    functions the chat ``GET /{chat_id}/ledger`` endpoint calls — so the
+    response schema is identical and the PR2-UI can reuse the chat ledger
+    component.
+
+    Owner-gated via ``_load_owned_session``; another user's ``session_id``
+    or a missing session returns 404 (not 403) to avoid existence
+    disclosure.  Returns 404 if the session exists but ``build_session_ledger``
+    has not been called yet (no hidden chat manufactured).
+    """
+    await _load_owned_session(db, session_id=session_id, user_id=user.id)
+    chat = (
+        await db.execute(select(Chat).where(Chat.autonomous_session_id == session_id))
+    ).scalar_one_or_none()
+    if chat is None:
+        raise HTTPException(status_code=404, detail="session has no ledger")
+    entries = await resolve_ledger_entries(db, chat_id=chat.id)
+    gates = await resolve_gates(db, chat_id=chat.id)
+    return {"entries": entries, "gate": gates[0] if gates else None}
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -652,6 +652,7 @@ async def search_chats(
         .where(
             Chat.owner_id == user.id,
             Chat.archived_at.is_(None),
+            Chat.autonomous_session_id.is_(None),
             sa_text("chats.title_tsv @@ websearch_to_tsquery('english', :q)"),
         )
         .params(q=q)
@@ -679,6 +680,7 @@ async def search_chats(
         .where(
             Chat.owner_id == user.id,
             Chat.archived_at.is_(None),
+            Chat.autonomous_session_id.is_(None),
             sa_text("messages.content_tsv @@ websearch_to_tsquery('english', :q)"),
         )
         .params(q=q)
@@ -740,7 +742,10 @@ async def list_chats(
         Query(ge=1, le=LIST_LIMIT_MAX, description="Page size; capped at 100."),
     ] = LIST_LIMIT_DEFAULT,
 ) -> ChatListResponse:
-    stmt = select(Chat).where(Chat.owner_id == user.id)
+    stmt = select(Chat).where(
+        Chat.owner_id == user.id,
+        Chat.autonomous_session_id.is_(None),
+    )
     if archived is True:
         stmt = stmt.where(Chat.archived_at.is_not(None))
     else:

--- a/api/app/autonomous/ledger_bridge.py
+++ b/api/app/autonomous/ledger_bridge.py
@@ -23,8 +23,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.caselaw import _CaselawCandidate, locate_passage, opinion_target
 from app.citation.extraction import CitationCandidate, locate_in_chunk
+from app.citation.gate import compute_and_record_gate
+from app.citation.ledger import assemble_ledger_entries
 from app.citation.verification import verify
-from app.models.chat import MessageCitation
+from app.models.autonomous import AutonomousSession
+from app.models.chat import Chat, Message, MessageCitation
 from app.models.document import Document, DocumentChunk
 from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.research import ResearchOpinionMetadata
@@ -296,3 +299,98 @@ async def build_caselaw_citations(
 
     await db.flush()
     return added
+
+
+# ---------------------------------------------------------------------------
+# Session-level bridge (WS-D PR2 Task 7)
+# ---------------------------------------------------------------------------
+
+
+async def build_session_ledger(
+    db: AsyncSession,
+    *,
+    session: AutonomousSession,
+    work_product_text: str,
+    findings: list[dict[str, Any]],
+    evidence: list[dict[str, Any]],
+    gateway: Any,
+    judge_model: str = "fast",
+) -> dict[str, Any] | None:
+    """Manufacture a hidden chat+message, build citation rows, and compute the gate.
+
+    Splits each finding's ``citations`` (``{quote, source}``) by the evidence
+    registry entry's ``kind`` (``"kb"`` vs ``"caselaw"``) into ``(quote, ref)``
+    tuples, then delegates to :func:`build_kb_citations` and
+    :func:`build_caselaw_citations` (Tasks 5/6).  Runs
+    :func:`~app.citation.ledger.assemble_ledger_entries` and
+    :func:`~app.citation.gate.compute_and_record_gate` on the manufactured
+    message.
+
+    Returns a ``dict`` with ``gate_status``, ``pass_count``, ``supported_count``,
+    ``fail_count``, ``total_assertions``, and ``confidence`` when at least one
+    citation is ledgerable, or ``None`` when there are no citable citations
+    (so no hidden chat is manufactured and the caller's transaction is
+    untouched).
+
+    This function only flushes; it never commits.  The caller is responsible
+    for wrapping it in a SAVEPOINT (``async with db.begin_nested()``) so a
+    flush error cannot poison the outer transaction.
+    """
+    # Build index: evidence n → evidence entry (n is always an int per EvidenceItem).
+    by_n: dict[int, dict[str, Any]] = {
+        int(e["n"]): e for e in evidence if isinstance(e.get("n"), int)
+    }
+
+    # Split citations by kind using the evidence registry.
+    kb: list[tuple[str, str]] = []
+    cl: list[tuple[str, str]] = []
+    for f in findings:
+        for c in f.get("citations") or []:
+            ev = by_n.get(c.get("source"))
+            if ev is None or not isinstance(c.get("quote"), str):
+                continue
+            if ev["kind"] == "kb":
+                kb.append((c["quote"], ev["ref"]))
+            elif ev["kind"] == "caselaw":
+                cl.append((c["quote"], ev["ref"]))
+
+    # Nothing citable → no manufactured chat, no gate, no transaction writes.
+    if not kb and not cl:
+        return None
+
+    # Manufacture the hidden chat + assistant message.
+    chat = Chat(
+        owner_id=session.user_id,
+        project_id=session.project_id,
+        title=f"Matter session {session.id}",
+        autonomous_session_id=session.id,
+    )
+    db.add(chat)
+    await db.flush()
+
+    message = Message(chat_id=chat.id, role="assistant", content=work_product_text)
+    db.add(message)
+    await db.flush()
+
+    # Build citation rows (Tasks 5/6).  Each builder flushes once internally.
+    await build_kb_citations(
+        db, message_id=message.id, citations=kb, gateway=gateway, judge_model=judge_model
+    )
+    await build_caselaw_citations(
+        db, message_id=message.id, citations=cl, gateway=gateway, judge_model=judge_model
+    )
+
+    # Assemble the ledger index + compute the gate verdict.
+    await assemble_ledger_entries(db, message_id=message.id)
+    gate = await compute_and_record_gate(db, message_id=message.id)
+    if gate is None:
+        return None
+
+    return {
+        "gate_status": gate.gate_status,
+        "pass_count": gate.pass_count,
+        "supported_count": gate.supported_count,
+        "fail_count": gate.fail_count,
+        "total_assertions": gate.total_assertions,
+        "confidence": float(gate.confidence) if gate.confidence is not None else None,
+    }

--- a/api/app/autonomous/ledger_bridge.py
+++ b/api/app/autonomous/ledger_bridge.py
@@ -15,15 +15,20 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.citation.caselaw import _CaselawCandidate, locate_passage, opinion_target
 from app.citation.extraction import CitationCandidate, locate_in_chunk
 from app.citation.verification import verify
 from app.models.chat import MessageCitation
 from app.models.document import Document, DocumentChunk
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.research import ResearchOpinionMetadata
+from app.research.service import read_opinion as _default_read_opinion
 
 log = logging.getLogger(__name__)
 
@@ -64,6 +69,12 @@ async def build_kb_citations(
     added = 0
 
     for quote, chunk_id_str in citations:
+        if not quote.strip():
+            log.debug(
+                "kb citation build: empty quote, skipping",
+                extra={"event": "autonomous_kb_citation_skip"},
+            )
+            continue
         try:
             chunk_uuid = uuid.UUID(str(chunk_id_str))
         except ValueError:
@@ -150,6 +161,136 @@ async def build_kb_citations(
             log.warning(
                 "kb citation build: unexpected error, skipping citation",
                 extra={"event": "autonomous_kb_citation_skip", "chunk_id": chunk_id_str},
+                exc_info=True,
+            )
+
+    await db.flush()
+    return added
+
+
+# ---------------------------------------------------------------------------
+# Caselaw structured-citation builder
+# ---------------------------------------------------------------------------
+
+_LoadOpinion = Callable[..., Awaitable[dict[str, Any]]]
+
+
+async def build_caselaw_citations(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    citations: list[tuple[str, str]],  # (quote, cluster_id)
+    gateway: Any,
+    judge_model: str = "fast",
+    load_opinion_text: _LoadOpinion = _default_read_opinion,
+) -> int:
+    """Resolve, verify, and persist caselaw structured citations into the ledger.
+
+    For each ``(quote, cluster_id)`` pair:
+
+    1. Guard: skip empty / whitespace-only quotes (prevents the poisoned-flush
+       class: ``locate_passage`` returns ``None`` for empty needles, but the
+       guard fires before any DB lookup for clarity and defense-in-depth).
+    2. Resolve ``ResearchOpinionMetadata`` by ``cluster_id``.  Unknown → skip.
+    3. Load opinion text via ``load_opinion_text(db, opinion_id=...)``.
+    4. Locate ``quote`` in opinion text via :func:`locate_passage`.  Miss → skip.
+    5. Build an :class:`_OpinionVerificationTarget` and a
+       :class:`_CaselawCandidate`.
+    6. Run the verifier cascade via :func:`verify`.  Miss → skip (honest-
+       degradation invariant — no fabrication).
+    7. ``db.add`` a verified ``MessageCaselawCitation`` row; accumulate count.
+
+    ``db.flush()`` is called once at the end so callers can roll back the
+    entire block as a unit.
+
+    Returns the number of rows added (0 when every citation was unverifiable,
+    the cluster was unknown, or the passage was not found in the opinion text).
+    Never fabricates rows.
+    """
+    added = 0
+
+    for quote, cluster_id_str in citations:
+        if not quote.strip():
+            log.debug(
+                "caselaw citation build: empty quote, skipping",
+                extra={"event": "autonomous_caselaw_citation_skip"},
+            )
+            continue
+
+        try:
+            meta = (
+                (
+                    await db.execute(
+                        select(ResearchOpinionMetadata).where(
+                            ResearchOpinionMetadata.cluster_id == int(cluster_id_str)
+                        )
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if meta is None:
+                log.debug(
+                    "caselaw citation build: no metadata for cluster, skipping",
+                    extra={
+                        "event": "autonomous_caselaw_citation_skip",
+                        "cluster_id": cluster_id_str,
+                    },
+                )
+                continue
+
+            opinion = await load_opinion_text(db, opinion_id=meta.opinion_id)
+            text = str((opinion or {}).get("text") or "")
+
+            span = locate_passage(quote, text)
+            if span is None:
+                log.debug(
+                    "caselaw citation build: locate miss, skipping",
+                    extra={
+                        "event": "autonomous_caselaw_citation_skip",
+                        "cluster_id": cluster_id_str,
+                    },
+                )
+                continue
+
+            start, end = span
+            target = opinion_target(meta.opinion_id, text)
+            candidate = _CaselawCandidate(
+                source_offset_start=start,
+                source_offset_end=end,
+                source_text=quote,
+                source_document_id=target.id,
+            )
+
+            result = await verify(candidate, target, gateway=gateway, judge_model=judge_model)
+            if not result.verified:
+                continue
+
+            db.add(
+                MessageCaselawCitation(
+                    message_id=message_id,
+                    opinion_id=meta.opinion_id,
+                    cluster_id=meta.cluster_id,
+                    source_offset_start=start,
+                    source_offset_end=end,
+                    source_text=quote,
+                    verified=True,
+                    verification_method=result.method,
+                    verification_confidence=result.confidence,
+                    partial=result.partial,
+                )
+            )
+            added += 1
+
+        except Exception:
+            # One bad citation must not sink the rest (per honest-degradation
+            # invariant). Log and continue so remaining citations still get a chance.
+            log.warning(
+                "caselaw citation build: unexpected error, skipping citation",
+                extra={
+                    "event": "autonomous_caselaw_citation_skip",
+                    "cluster_id": cluster_id_str,
+                },
                 exc_info=True,
             )
 

--- a/api/app/autonomous/ledger_bridge.py
+++ b/api/app/autonomous/ledger_bridge.py
@@ -1,0 +1,157 @@
+"""WS-D PR2 — bridge a matter session's structured citations into the chat-path
+ledger + fiduciary gate.
+
+Reuses the character-fidelity verifier cascade (exact/tolerant/paraphrase)
+and assembles ``MessageCitation`` rows in the same shape the chat path uses,
+with no duplication of verification logic.
+
+Only the citation-candidate front-end is session-specific: instead of
+extracting citations from assistant text + retrieved chunks (the chat path),
+here the planner hands us explicit ``(quote, chunk_id)`` pairs resolved
+during the autonomous analysis turn.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.extraction import CitationCandidate, locate_in_chunk
+from app.citation.verification import verify
+from app.models.chat import MessageCitation
+from app.models.document import Document, DocumentChunk
+
+log = logging.getLogger(__name__)
+
+
+async def build_kb_citations(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    citations: list[tuple[str, str]],  # (quote, chunk_id)
+    gateway: Any,
+    judge_model: str = "fast",
+) -> int:
+    """Resolve, verify, and persist KB structured citations into the ledger.
+
+    For each ``(quote, chunk_id)`` pair:
+
+    1. Fetch the ``DocumentChunk`` by ``chunk_id``.
+    2. Locate ``quote`` inside ``chunk.content`` via :func:`locate_in_chunk`
+       (exact, then fuzzy).  Miss → drop without a row.
+    3. Fetch the ``Document`` the chunk belongs to.
+    4. Build a :class:`CitationCandidate` with byte-precise offsets into
+       ``normalized_content`` (``chunk.char_offset_start + in_chunk_offset``).
+    5. Run the verifier cascade via :func:`verify`.  MISS → drop without a
+       row (honest-degradation invariant).
+    6. ``db.add`` a ``MessageCitation`` row; accumulate the count.
+
+    ``db.flush()`` is called once at the end so callers can roll back the
+    entire block as a unit if needed.
+
+    Returns the number of rows added (0 when every citation was unverifiable
+    or the chunk / document was not found).  Never fabricates rows.
+
+    Note on lazy-relationship avoidance: ``chunk.document`` is NOT accessed
+    (it is a lazy SQLAlchemy relationship that raises ``MissingGreenlet``
+    inside an async session).  ``doc.file_id`` is read from the separately
+    fetched ``Document`` row instead.
+    """
+    added = 0
+
+    for quote, chunk_id_str in citations:
+        try:
+            chunk_uuid = uuid.UUID(str(chunk_id_str))
+        except ValueError:
+            log.warning(
+                "kb citation build: invalid chunk_id",
+                extra={"event": "autonomous_kb_citation_skip", "chunk_id": chunk_id_str},
+            )
+            continue
+
+        try:
+            chunk = (
+                await db.execute(select(DocumentChunk).where(DocumentChunk.id == chunk_uuid))
+            ).scalar_one_or_none()
+            if chunk is None:
+                log.warning(
+                    "kb citation build: chunk not found",
+                    extra={"event": "autonomous_kb_citation_skip", "chunk_id": chunk_id_str},
+                )
+                continue
+
+            span = locate_in_chunk(quote, chunk.content)
+            if span is None:
+                # Quote not found in chunk — honest drop; no row.
+                log.debug(
+                    "kb citation build: locate miss",
+                    extra={"event": "autonomous_kb_citation_skip", "chunk_id": chunk_id_str},
+                )
+                continue
+            in_start, in_end = span
+
+            doc = (
+                await db.execute(select(Document).where(Document.id == chunk.document_id))
+            ).scalar_one_or_none()
+            if doc is None:
+                log.warning(
+                    "kb citation build: document not found",
+                    extra={
+                        "event": "autonomous_kb_citation_skip",
+                        "document_id": str(chunk.document_id),
+                    },
+                )
+                continue
+
+            # Use doc.file_id directly — never access chunk.document (lazy
+            # relationship; raises MissingGreenlet in async sessions).
+            candidate = CitationCandidate(
+                source_file_id=doc.file_id,
+                source_document_id=chunk.document_id,
+                source_offset_start=chunk.char_offset_start + in_start,
+                source_offset_end=chunk.char_offset_start + in_end,
+                source_page=chunk.page_start,
+                source_text=quote,
+            )
+
+            # Pass raw Document — it satisfies _DocumentProtocol directly
+            # (has id, normalized_content, was_ocrd).  Mirrors what
+            # _persist_message_citations in chats.py does.
+            result = await verify(candidate, doc, gateway=gateway, judge_model=judge_model)
+            if not result.verified:
+                # Every stage rejected — honest drop; no row.
+                continue
+
+            db.add(
+                MessageCitation(
+                    message_id=message_id,
+                    source_file_id=candidate.source_file_id,
+                    source_offset_start=candidate.source_offset_start,
+                    source_offset_end=candidate.source_offset_end,
+                    source_page=candidate.source_page,
+                    source_text=quote,
+                    verified=True,
+                    verification_method=result.method,
+                    verification_confidence=result.confidence,
+                    partial=result.partial,
+                    tier_envelope=result.tier_envelope,
+                )
+            )
+            added += 1
+
+        except Exception:
+            # One bad citation must not sink the rest (per honest-degradation
+            # invariant).  Log and continue so the remaining citations still
+            # get a chance.
+            log.warning(
+                "kb citation build: unexpected error, skipping citation",
+                extra={"event": "autonomous_kb_citation_skip", "chunk_id": chunk_id_str},
+                exc_info=True,
+            )
+
+    await db.flush()
+    return added

--- a/api/app/autonomous/ledger_bridge.py
+++ b/api/app/autonomous/ledger_bridge.py
@@ -384,7 +384,9 @@ async def build_session_ledger(
     await assemble_ledger_entries(db, message_id=message.id)
     gate = await compute_and_record_gate(db, message_id=message.id)
     if gate is None:
-        return None
+        raise RuntimeError(
+            "compute_and_record_gate returned None for a freshly-manufactured message"
+        )
 
     return {
         "gate_status": gate.gate_status,

--- a/api/app/autonomous/nodes.py
+++ b/api/app/autonomous/nodes.py
@@ -34,6 +34,7 @@ LangGraph node functions remain pure-ish over the state dict and
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
@@ -47,7 +48,9 @@ from app.autonomous.guard import guarded_tool_call
 from app.autonomous.phases import run_phase_transition
 from app.autonomous.planner import (
     PLANNER_ALLOWLIST,
+    EvidenceItem,
     build_planner_messages,
+    collect_evidence,
     parse_planner_decision,
     summarize_observation,
     validate_action_args,
@@ -187,6 +190,7 @@ async def _run_analysis_loop(
     max_steps = int(params.get("max_analysis_steps") or DEFAULT_MAX_ANALYSIS_STEPS)
     observations: list[str] = []
     trace: list[dict[str, str]] = []
+    evidence: list[EvidenceItem] = []
     halt_reason = "step_cap"
     steps = 0
 
@@ -224,6 +228,7 @@ async def _run_analysis_loop(
             observations.append(
                 summarize_observation(decision.next_intent, decision.rationale, act)
             )
+            evidence.extend(collect_evidence(decision.next_intent, act, start_n=len(evidence) + 1))
         except AutonomousBrake:
             raise  # brakes (SessionHalted/CostCapReached/ToolNotGranted) propagate
         except (
@@ -265,6 +270,9 @@ async def _run_analysis_loop(
             "halt_reason": halt_reason,
             "decisions": trace,
         },
+        "analysis_evidence": [
+            dataclasses.asdict(e) for e in evidence
+        ],  # JSONable; consumed by delivery (P3: not in trace)
     }
 
 

--- a/api/app/autonomous/nodes.py
+++ b/api/app/autonomous/nodes.py
@@ -244,6 +244,11 @@ async def _run_analysis_loop(
         )
         steps += 1
 
+    # Build the evidence dicts ONCE: used both as the synthesis prompt input
+    # and as analysis_evidence in the returned state.  vars() CANNOT be used
+    # here because EvidenceItem is @dataclass(slots=True); dataclasses.asdict
+    # is the correct serialiser.
+    evidence_dicts = [dataclasses.asdict(e) for e in evidence]
     synth = await guarded_tool_call(
         session,
         synthesis_intent,
@@ -254,6 +259,7 @@ async def _run_analysis_loop(
                 goal=query,
                 observations=observations,
                 chunks=chunks,
+                evidence=evidence_dicts,
                 db=db,
             ),
             "anonymize": True,
@@ -270,9 +276,7 @@ async def _run_analysis_loop(
             "halt_reason": halt_reason,
             "decisions": trace,
         },
-        "analysis_evidence": [
-            dataclasses.asdict(e) for e in evidence
-        ],  # JSONable; consumed by delivery (P3: not in trace)
+        "analysis_evidence": evidence_dicts,  # JSONable; consumed by delivery (P3: not in trace)
     }
 
 

--- a/api/app/autonomous/nodes.py
+++ b/api/app/autonomous/nodes.py
@@ -831,6 +831,42 @@ def make_delivery_node(
         plan_trace = state.get("analysis_plan_trace")
         if isinstance(receipt, dict) and plan_trace is not None:
             receipt["plan_trace"] = plan_trace
+        # WS-D PR2: fiduciary ledger + gate for matter sessions (best-effort).
+        # Re-parse analysis_content to recover findings WITH their citations
+        # (single source of truth — drafting node strips citations from the
+        # state "findings" list; re-parsing from the raw content is the correct
+        # approach). Isolated in a SAVEPOINT so a flush error inside the bridge
+        # rolls back ONLY the manufactured chat/citation rows and leaves the
+        # outer transaction (session status + audit rows) usable for the
+        # terminal commit — the PR1-C1 lesson.
+        parsed = parse_structured_output(state.get("analysis_content"))
+        findings = parsed.findings if parsed.is_structured else []
+        evidence = state.get("analysis_evidence") or []
+        work_product = state.get("analysis_content") or ""
+        if findings and evidence and work_product:
+            try:
+                from app.autonomous.ledger_bridge import build_session_ledger
+
+                async with db.begin_nested():  # SAVEPOINT — isolates best-effort enrichment
+                    verdict = await build_session_ledger(
+                        db,
+                        session=session,
+                        work_product_text=work_product,
+                        findings=findings,
+                        evidence=evidence,
+                        gateway=gateway,
+                    )
+                if verdict is not None and isinstance(receipt, dict):
+                    receipt["fiduciary_gate"] = verdict
+            except Exception:
+                logger.warning(
+                    "autonomous ledger bridge failed",
+                    extra={
+                        "event": "autonomous_ledger_bridge_failed",
+                        "session_id": session_id,
+                    },
+                    exc_info=True,
+                )
         session.result = receipt
         await db.commit()
 

--- a/api/app/autonomous/planner.py
+++ b/api/app/autonomous/planner.py
@@ -108,6 +108,60 @@ def parse_planner_decision(content: str | None) -> PlannerDecision | None:
     )
 
 
+@dataclass(slots=True)
+class EvidenceItem:
+    """A numbered piece of gathered authority the synthesis may quote-and-cite.
+
+    ``content`` is the authoritative text used at delivery to verify a quoted
+    span (chunk text for kb, opinion text for caselaw). Loop-local + synthesis
+    context only — NEVER written to analysis_plan_trace/audit (P3)."""
+
+    n: int
+    kind: str  # "kb" | "caselaw"
+    ref: str  # chunk_id (kb) | cluster_id (caselaw), as str
+    content: str
+    display: str
+
+
+def collect_evidence(intent: ToolIntent, result: object, start_n: int) -> list[EvidenceItem]:
+    outcome = getattr(result, "outcome", "success")
+    data = getattr(result, "data", None) or {}
+    if outcome != "success":
+        return []
+    items: list[EvidenceItem] = []
+    n = start_n
+    if intent == ToolIntent.retrieve_chunks:
+        for c in data.get("chunks") or []:
+            if not isinstance(c, dict) or not c.get("chunk_id"):
+                continue
+            items.append(
+                EvidenceItem(
+                    n=n,
+                    kind="kb",
+                    ref=str(c["chunk_id"]),
+                    content=str(c.get("content") or ""),
+                    display=f"{c.get('file_name') or '?'} (chunk {c['chunk_id']})",
+                )
+            )
+            n += 1
+    elif intent == ToolIntent.retrieve_caselaw:
+        rows = data.get("results") or data.get("matches") or []
+        for r in rows:
+            if not isinstance(r, dict) or not r.get("cluster_id"):
+                continue
+            items.append(
+                EvidenceItem(
+                    n=n,
+                    kind="caselaw",
+                    ref=str(r["cluster_id"]),
+                    content=str(r.get("opinion_text") or r.get("text") or ""),
+                    display=f"{r.get('case_name') or '?'} ({r.get('court') or '?'} {r.get('date_filed') or '?'})",
+                )
+            )
+            n += 1
+    return items
+
+
 def validate_action_args(intent: ToolIntent, args: dict[str, Any]) -> None:
     """Reject planner-supplied args that would fault at the SQL/handler layer
     BEFORE they reach the chokepoint. Raises ValueError on an un-runnable arg
@@ -149,7 +203,7 @@ def summarize_observation(intent: ToolIntent, rationale: str, result: object) ->
     if intent == ToolIntent.retrieve_caselaw:
         items = data.get("results") or data.get("matches") or []
         names = [
-            f"{(i.get('case_name') or '?')} ({i.get('court') or '?'} {i.get('date_filed') or '?'})"
+            f"{(i.get('case_name') or '?')} ({i.get('court') or '?'} {i.get('date_filed') or '?'}; cl={i.get('cluster_id') or '?'})"
             for i in items[:5]
             if isinstance(i, dict)
         ]

--- a/api/app/autonomous/prompts.py
+++ b/api/app/autonomous/prompts.py
@@ -373,16 +373,19 @@ async def assemble_synthesis_messages(
     goal: str,
     observations: list[str],
     chunks: list[dict[str, Any]],
+    evidence: list[dict[str, Any]] | None = None,
     db: AsyncSession,
     registry: SkillRegistry | None = None,
 ) -> list[dict[str, str]]:
-    """Build the final-synthesis messages for the agentic loop (WS-D PR1).
+    """Build the final-synthesis messages for the agentic loop (WS-D PR1/PR2).
 
     Reuses :func:`assemble_analysis_messages` (so the skill/playbook system
     prompt and :data:`STRUCTURED_OUTPUT_INSTRUCTION` are identical — the
     synthesis must still emit the fenced-JSON findings the drafting node
-    parses), then appends a user block carrying the matter GOAL and the
-    loop's compact OBSERVATIONS.
+    parses), then appends a user block carrying the matter GOAL, the loop's
+    compact OBSERVATIONS, and (when evidence is non-empty) a numbered SOURCES
+    block with a citation instruction directing the model to support each
+    finding with verbatim quotes tagged ``{"quote": "...", "source": N}``.
 
     Args:
         session: The autonomous session.  ``session.params`` must carry a
@@ -396,13 +399,22 @@ async def assemble_synthesis_messages(
         chunks: Retrieved-chunks list (forwarded verbatim to the base
             assembler so the system+user pair is identical to what the
             standalone analysis path would have produced).
+        evidence: Evidence items accumulated by the agentic loop — each a
+            dict with keys ``n`` (int), ``kind`` (str), ``ref`` (str),
+            ``content`` (str), ``display`` (str).  When non-empty, a
+            numbered SOURCES block and citation instruction are appended to
+            the trailing user message.  When ``None`` or empty, the citation
+            block is omitted and behaviour is identical to PR1 (no change in
+            prompt cost for sessions with no evidence).
         db: Active async ORM session.
         registry: Optional skill registry snapshot.  Forwarded to the
             base assembler; see :func:`assemble_analysis_messages`.
 
     Returns:
         A ``[system, user, user]`` list where the first two elements are
-        the base analysis messages and the third carries the goal + obs.
+        the base analysis messages and the third carries the goal + obs
+        (and, when evidence is non-empty, the numbered sources + citation
+        instruction).
     """
     messages = await assemble_analysis_messages(session, chunks=chunks, db=db, registry=registry)
     obs_block = (
@@ -410,14 +422,31 @@ async def assemble_synthesis_messages(
         if observations
         else "(no research steps were run)"
     )
+    _evidence: list[dict[str, Any]] = evidence if evidence is not None else []
+    if _evidence:
+        sources = "\n".join(
+            f'[{e["n"]}] ({e["kind"]}) {e["display"]}\n    """{e["content"][:1500]}"""'
+            for e in _evidence
+        )
+        cite_block = (
+            "\n\nNUMBERED SOURCES (cite these by number):\n"
+            + sources
+            + "\n\nFor every finding, support it with VERBATIM quotes from the numbered sources. "
+            'In each finding\'s JSON, include a "citations" array of objects '
+            '{"quote": "<exact text copied from the source>", "source": <source number>}. '
+            "Copy quotes character-for-character; do not paraphrase inside a quote."
+        )
+    else:
+        cite_block = ""
     messages.append(
         {
             "role": "user",
             "content": (
                 f"MATTER GOAL:\n{goal}\n\n"
-                f"RESEARCH OBSERVATIONS (gathered by the agent):\n{obs_block}\n\n"
-                "Synthesize your analysis of the MATTER GOAL using the observations and any "
-                "chunks above, then return the final JSON object as instructed."
+                f"RESEARCH OBSERVATIONS (gathered by the agent):\n{obs_block}"
+                f"{cite_block}\n\n"
+                "Synthesize your analysis of the MATTER GOAL using the observations, the numbered "
+                "sources, and any chunks above, then return the final JSON object as instructed."
             ),
         }
     )

--- a/api/app/autonomous/state.py
+++ b/api/app/autonomous/state.py
@@ -104,3 +104,9 @@ class AutonomousSessionState(TypedDict, total=False):
     # ``{"steps": int, "halt_reason": str, "decisions": list[dict]}``.
     # Absent on the query-less single-call path.
     analysis_plan_trace: dict | None
+
+    # WS-D PR2: loop-gathered evidence for the synthesis + delivery ledger
+    # bridge; NOT surfaced in the receipt/trace (P3). Each entry is a
+    # JSONable dict of EvidenceItem fields (n, kind, ref, content, display).
+    # Absent on the query-less single-call path (only the agentic loop sets it).
+    analysis_evidence: list[dict]

--- a/api/app/autonomous/structured_output.py
+++ b/api/app/autonomous/structured_output.py
@@ -83,7 +83,7 @@ def _as_dict_list(value: Any) -> list[dict[str, Any]]:
     """Coerce a JSON value to a list of dicts — tolerant, item-level.
 
     Non-list values yield []; non-dict items inside a list are silently
-    dropped. The dict-shaped arrays (``findings``, ``suggested_memories``,
+    dropped. The dict-shaped arrays (``suggested_memories``,
     ``suggested_precedents``, ``artifacts``) are consumed downstream with
     ``.get()`` calls, so a string or number smuggled into an otherwise
     valid array would raise ``AttributeError`` in the drafting node and
@@ -92,10 +92,52 @@ def _as_dict_list(value: Any) -> list[dict[str, Any]]:
     pre-existing dict-shaped loops too, not just ``artifacts``: a uniform
     posture beats per-loop drift (the failure mode is not "wrong decision"
     but "different decisions in different files").
+
+    Note: ``findings`` use :func:`_normalize_findings` instead, which
+    additionally sanitizes the ``citations`` key on each finding (WS-D PR2).
     """
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, dict)]
+
+
+def _normalize_findings(value: Any) -> list[dict[str, Any]]:
+    """Coerce the ``findings`` array and sanitize per-finding ``citations``.
+
+    Like :func:`_as_dict_list`, but additionally processes each finding to
+    produce a sanitized ``citations`` list (WS-D PR2):
+
+    * Non-dict items in the top-level list are dropped (same as _as_dict_list).
+    * Each finding gets a ``citations`` key set to a sanitized list of dicts
+      ``{"quote": str, "source": int}`` built from the raw ``citations``
+      value.  Any entry that is not a dict, has a non-str ``quote``, has a
+      non-int ``source``, or has a bool ``source`` (booleans are ints in
+      Python / JSON but semantically wrong here) is silently dropped.
+    * Absent ``citations`` key → empty list (``[]``).
+
+    This function never raises — it is part of the tolerant-parse contract.
+    """
+    if not isinstance(value, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        finding: dict[str, Any] = dict(item)
+        raw_citations = finding.get("citations")
+        citations: list[dict[str, Any]] = []
+        if isinstance(raw_citations, list):
+            for c in raw_citations:
+                if (
+                    isinstance(c, dict)
+                    and isinstance(c.get("quote"), str)
+                    and isinstance(c.get("source"), int)
+                    and not isinstance(c.get("source"), bool)
+                ):
+                    citations.append({"quote": c["quote"], "source": c["source"]})
+        finding["citations"] = citations
+        result.append(finding)
+    return result
 
 
 def parse_structured_output(content: str | None) -> StructuredResult:
@@ -141,7 +183,7 @@ def parse_structured_output(content: str | None) -> StructuredResult:
 
     return StructuredResult(
         is_structured=True,
-        findings=_as_dict_list(parsed.get("findings")),
+        findings=_normalize_findings(parsed.get("findings")),
         suggested_memories=_as_dict_list(parsed.get("suggested_memories")),
         suggested_precedents=_as_dict_list(parsed.get("suggested_precedents")),
         privilege_concerns=_as_list(parsed.get("privilege_concerns")),

--- a/api/app/citation/extraction.py
+++ b/api/app/citation/extraction.py
@@ -125,7 +125,7 @@ _CITATION_RE = re.compile(
 _ALIGNMENT_THRESHOLD = 85.0
 
 
-def _locate_in_chunk(quote: str, chunk_content: str) -> tuple[int, int] | None:
+def locate_in_chunk(quote: str, chunk_content: str) -> tuple[int, int] | None:
     """Find ``quote`` inside ``chunk_content`` — exact, then fuzzy.
 
     Returns the (start, end) offsets *into the chunk's content string*
@@ -190,7 +190,7 @@ def extract_citations(
             continue
 
         chunk = retrieved_chunks[index_1based - 1]
-        located = _locate_in_chunk(quote, chunk.content)
+        located = locate_in_chunk(quote, chunk.content)
         if located is not None:
             in_chunk_start, in_chunk_end = located
             offset_start = chunk.char_offset_start + in_chunk_start
@@ -214,7 +214,7 @@ def extract_citations(
                 # in the retrieved-chunk window.
                 continue
 
-            doc_located = _locate_in_chunk(quote, doc_content)
+            doc_located = locate_in_chunk(quote, doc_content)
             if doc_located is None:
                 # Quote is not in the document at all. Drop.
                 continue

--- a/api/app/models/chat.py
+++ b/api/app/models/chat.py
@@ -89,7 +89,9 @@ class Chat(Base):
     )
     autonomous_session_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("autonomous_sessions.id", ondelete="SET NULL"),
+        ForeignKey(
+            "autonomous_sessions.id", ondelete="SET NULL", name="fk_chats_autonomous_session_id"
+        ),
         nullable=True,
         index=False,  # partial index created in migration 0063
     )

--- a/api/app/models/chat.py
+++ b/api/app/models/chat.py
@@ -87,6 +87,12 @@ class Chat(Base):
         ForeignKey("projects.id", ondelete="SET NULL", name="fk_chats_project_id"),
         nullable=True,
     )
+    autonomous_session_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("autonomous_sessions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=False,  # partial index created in migration 0063
+    )
     title: Mapped[str] = mapped_column(
         Text,
         nullable=False,

--- a/api/tests/autonomous/test_evidence_registry.py
+++ b/api/tests/autonomous/test_evidence_registry.py
@@ -1,0 +1,67 @@
+from app.autonomous.enums import ToolIntent
+from app.autonomous.guard import ToolResult
+from app.autonomous.planner import collect_evidence, summarize_observation
+
+
+def test_caselaw_observation_includes_cluster_id():
+    result = ToolResult(
+        data={
+            "results": [
+                {
+                    "case_name": "Smith v. Jones",
+                    "court": "ca9",
+                    "date_filed": "2021-01-01",
+                    "cluster_id": 42,
+                },
+            ]
+        },
+        outcome="success",
+    )
+    s = summarize_observation(ToolIntent.retrieve_caselaw, "find authority", result)
+    assert "Smith v. Jones" in s
+    assert "42" in s  # cluster_id is shown so the synthesis can cite it
+
+
+def test_collect_evidence_numbers_kb_chunks():
+    result = ToolResult(
+        data={
+            "chunks": [
+                {
+                    "chunk_id": "c1",
+                    "file_name": "nda.pdf",
+                    "content": "Confidential Information clause text.",
+                },
+                {"chunk_id": "c2", "file_name": "nda.pdf", "content": "Term clause text."},
+            ]
+        },
+        outcome="success",
+    )
+    items = collect_evidence(ToolIntent.retrieve_chunks, result, start_n=1)
+    assert [i.n for i in items] == [1, 2]
+    assert items[0].kind == "kb" and items[0].ref == "c1"
+    assert items[0].content == "Confidential Information clause text."
+
+
+def test_collect_evidence_numbers_caselaw():
+    result = ToolResult(
+        data={
+            "results": [
+                {
+                    "case_name": "Smith v. Jones",
+                    "cluster_id": 42,
+                    "opinion_text": "It is held that...",
+                },
+            ]
+        },
+        outcome="success",
+    )
+    items = collect_evidence(ToolIntent.retrieve_caselaw, result, start_n=5)
+    assert items[0].n == 5 and items[0].kind == "caselaw" and items[0].ref == "42"
+    assert "held" in items[0].content
+
+
+def test_collect_evidence_empty_on_failure():
+    assert (
+        collect_evidence(ToolIntent.retrieve_caselaw, ToolResult(data=None, outcome="error"), 1)
+        == []
+    )

--- a/api/tests/autonomous/test_ledger_bridge_caselaw.py
+++ b/api/tests/autonomous/test_ledger_bridge_caselaw.py
@@ -1,0 +1,170 @@
+"""TDD test suite for build_caselaw_citations — Task 6 (WS-D PR2).
+
+Tests the caselaw half of the ledger bridge: given structured (quote, cluster_id)
+citations produced by the autonomous planner, build verified MessageCaselawCitation
+rows by reusing the character-fidelity verifier.
+
+All tests run with gateway=None so only the deterministic exact-match / tolerant-match
+stages fire (no LLM needed). ``load_opinion_text`` is stubbed to avoid object-storage
+calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat import Chat, Message
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.research import ResearchOpinionMetadata
+from app.models.user import User
+from app.security import hash_password
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+# A phrase that appears verbatim in OPINION_TEXT so locate_passage succeeds
+# and the exact-match stage in the verifier passes.
+OPINION_TEXT = "The court holds that the assignment clause survives the change of control."
+
+
+async def _msg(db: AsyncSession) -> Message:
+    """Create a minimal User + Chat + Message; returns the Message."""
+    import uuid
+
+    user = User(
+        email=f"cl-{uuid.uuid4().hex[:6]}@x.com",
+        hashed_password=hash_password("p"),
+        role="member",
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(user)
+    await db.flush()
+    chat = Chat(owner_id=user.id, title="t")
+    db.add(chat)
+    await db.flush()
+    msg = Message(chat_id=chat.id, role="assistant", content="wp")
+    db.add(msg)
+    await db.flush()
+    return msg
+
+
+async def test_build_caselaw_citations_verifies(db_session: AsyncSession) -> None:
+    """Exact-verbatim quote resolves cluster → opinion text → verified row."""
+    from app.autonomous.ledger_bridge import build_caselaw_citations
+
+    db_session.add(
+        ResearchOpinionMetadata(
+            opinion_id=900, cluster_id=42, storage_path="x/900", char_length=len(OPINION_TEXT)
+        )
+    )
+    await db_session.flush()
+    msg = await _msg(db_session)
+
+    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:  # type: ignore[type-arg]
+        return {"text": OPINION_TEXT}
+
+    n = await build_caselaw_citations(
+        db_session,
+        message_id=msg.id,
+        citations=[("assignment clause survives the change of control", "42")],
+        gateway=None,
+        load_opinion_text=fake_load,
+    )
+    assert n == 1
+    row = (
+        await db_session.execute(
+            select(MessageCaselawCitation).where(MessageCaselawCitation.message_id == msg.id)
+        )
+    ).scalar_one()
+    assert row.cluster_id == 42
+    assert row.opinion_id == 900
+    assert row.verified is True
+    assert row.verification_method is not None
+
+
+async def test_build_caselaw_citations_unknown_cluster_skipped(
+    db_session: AsyncSession,
+) -> None:
+    """No ResearchOpinionMetadata for the cited cluster → skip; returns 0."""
+    from app.autonomous.ledger_bridge import build_caselaw_citations
+
+    msg = await _msg(db_session)
+
+    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:  # type: ignore[type-arg]
+        return {"text": OPINION_TEXT}
+
+    n = await build_caselaw_citations(
+        db_session,
+        message_id=msg.id,
+        citations=[("assignment clause survives the change of control", "9999")],
+        gateway=None,
+        load_opinion_text=fake_load,
+    )
+    assert n == 0  # no metadata row for cluster 9999
+
+
+async def test_build_caselaw_citations_locate_miss_skipped(
+    db_session: AsyncSession,
+) -> None:
+    """Quote not found in opinion text → locate miss → skip; no row fabricated."""
+    from app.autonomous.ledger_bridge import build_caselaw_citations
+
+    db_session.add(
+        ResearchOpinionMetadata(
+            opinion_id=901, cluster_id=43, storage_path="x/901", char_length=len(OPINION_TEXT)
+        )
+    )
+    await db_session.flush()
+    msg = await _msg(db_session)
+
+    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:  # type: ignore[type-arg]
+        return {"text": OPINION_TEXT}
+
+    n = await build_caselaw_citations(
+        db_session,
+        message_id=msg.id,
+        citations=[("this text does not appear anywhere in the opinion", "43")],
+        gateway=None,
+        load_opinion_text=fake_load,
+    )
+    assert n == 0
+
+
+async def test_build_caselaw_citations_empty_quote_skipped(
+    db_session: AsyncSession,
+) -> None:
+    """Empty-string quote is dropped by the guard before any DB lookup — no row."""
+    from app.autonomous.ledger_bridge import build_caselaw_citations
+
+    db_session.add(
+        ResearchOpinionMetadata(
+            opinion_id=902, cluster_id=44, storage_path="x/902", char_length=len(OPINION_TEXT)
+        )
+    )
+    await db_session.flush()
+    msg = await _msg(db_session)
+
+    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:  # type: ignore[type-arg]
+        return {"text": OPINION_TEXT}
+
+    n = await build_caselaw_citations(
+        db_session,
+        message_id=msg.id,
+        citations=[("   ", "44")],  # whitespace-only — guard fires
+        gateway=None,
+        load_opinion_text=fake_load,
+    )
+    assert n == 0
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCaselawCitation).where(MessageCaselawCitation.message_id == msg.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 0

--- a/api/tests/autonomous/test_ledger_bridge_kb.py
+++ b/api/tests/autonomous/test_ledger_bridge_kb.py
@@ -1,0 +1,113 @@
+"""TDD test suite for build_kb_citations — Task 5 (WS-D PR2).
+
+Tests the KB half of the ledger bridge: given structured (quote, chunk_id)
+citations produced by the autonomous planner, build verified MessageCitation
+rows by reusing the character-fidelity verifier.
+
+Fixtures: kb_with_one_indexed_file from tests/autonomous/conftest.py.
+Runs without a gateway (gateway=None) — the deterministic exact/tolerant
+verification stages fire without an LLM.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.ledger_bridge import build_kb_citations
+from app.models.chat import Chat, Message, MessageCitation
+from app.models.document import DocumentChunk
+from app.models.user import User
+from app.security import hash_password
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def _msg(db: AsyncSession, owner_id: object) -> Message:
+    """Create a minimal Chat + Message owned by owner_id."""
+    chat = Chat(owner_id=owner_id, title="t")
+    db.add(chat)
+    await db.flush()
+    msg = Message(chat_id=chat.id, role="assistant", content="wp")
+    db.add(msg)
+    await db.flush()
+    return msg
+
+
+async def test_build_kb_citations_verifies_and_persists(
+    db_session: AsyncSession,
+    kb_with_one_indexed_file: object,
+) -> None:
+    """Exact-verbatim quote from chunk content produces one verified row."""
+    from tests.autonomous.conftest import KbOneFile
+
+    kb: KbOneFile = kb_with_one_indexed_file  # type: ignore[assignment]
+    chunk = (
+        await db_session.execute(select(DocumentChunk).where(DocumentChunk.id == kb.chunk_id))
+    ).scalar_one()
+    quote = chunk.content[:40]  # verbatim span — exact-match stage fires
+
+    user = User(
+        email="kb-bridge@x.com",
+        hashed_password=hash_password("p"),
+        role="member",
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    msg = await _msg(db_session, user.id)
+
+    n = await build_kb_citations(
+        db_session,
+        message_id=msg.id,
+        citations=[(quote, str(kb.chunk_id))],
+        gateway=None,
+    )
+
+    assert n == 1
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCitation).where(MessageCitation.message_id == msg.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].verified is True
+    assert rows[0].source_text == quote
+    assert rows[0].verification_method is not None
+
+
+async def test_build_kb_citations_drops_unverifiable(
+    db_session: AsyncSession,
+    kb_with_one_indexed_file: object,
+) -> None:
+    """Quote not found in chunk content is dropped — no row, no fabrication."""
+    user = User(
+        email="kb-bridge2@x.com",
+        hashed_password=hash_password("p"),
+        role="member",
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    msg = await _msg(db_session, user.id)
+
+    from tests.autonomous.conftest import KbOneFile
+
+    kb: KbOneFile = kb_with_one_indexed_file  # type: ignore[assignment]
+    n = await build_kb_citations(
+        db_session,
+        message_id=msg.id,
+        citations=[("text that does not appear anywhere", str(kb.chunk_id))],
+        gateway=None,
+    )
+
+    assert n == 0  # honest: unverifiable quote dropped, no row

--- a/api/tests/autonomous/test_ledger_bridge_kb.py
+++ b/api/tests/autonomous/test_ledger_bridge_kb.py
@@ -111,3 +111,50 @@ async def test_build_kb_citations_drops_unverifiable(
     )
 
     assert n == 0  # honest: unverifiable quote dropped, no row
+
+
+async def test_build_kb_citations_empty_quote_skipped(
+    db_session: AsyncSession,
+    kb_with_one_indexed_file: object,
+) -> None:
+    """Empty-string quote is dropped before any DB lookup — no row, no poisoned flush.
+
+    Python's str.find("") returns 0, so without the guard an empty quote would
+    produce a (start=0, end=0) span → a MessageCitation with
+    source_offset_start == source_offset_end — violating the DB CHECK constraint
+    at flush time and poisoning the entire batch.  The ``if not quote.strip()``
+    guard at the top of the loop body must fire first.
+    """
+    from tests.autonomous.conftest import KbOneFile
+
+    kb: KbOneFile = kb_with_one_indexed_file  # type: ignore[assignment]
+    user = User(
+        email="kb-bridge-empty@x.com",
+        hashed_password=hash_password("p"),
+        role="member",
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    msg = await _msg(db_session, user.id)
+
+    n = await build_kb_citations(
+        db_session,
+        message_id=msg.id,
+        citations=[("", str(kb.chunk_id))],
+        gateway=None,
+    )
+
+    assert n == 0
+    rows = (
+        (
+            await db_session.execute(
+                select(MessageCitation).where(MessageCitation.message_id == msg.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 0

--- a/api/tests/autonomous/test_session_ledger.py
+++ b/api/tests/autonomous/test_session_ledger.py
@@ -1,0 +1,123 @@
+"""TDD tests for build_session_ledger — WS-D PR2 Task 7.
+
+Tests the integration bridge that manufactures a hidden chat+message,
+splits structured citations by kind (kb vs caselaw), builds citation rows
+via Tasks 5/6, runs assemble_ledger_entries + compute_and_record_gate, and
+returns a gate verdict dict (or None when there is nothing to ledger).
+"""
+
+import pytest
+from sqlalchemy import select
+
+from app.autonomous.ledger_bridge import build_session_ledger
+from app.models.autonomous import AutonomousSession
+from app.models.chat import Chat
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.user import User
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+from app.security import hash_password
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def test_build_session_ledger_creates_hidden_chat_entries_and_gate(
+    db_session, kb_with_one_indexed_file
+):
+    from app.models.document import DocumentChunk
+
+    chunk = (
+        await db_session.execute(
+            select(DocumentChunk).where(DocumentChunk.id == kb_with_one_indexed_file.chunk_id)
+        )
+    ).scalar_one()
+    quote = chunk.content[:40]
+    user = User(
+        email="sl@x.com",
+        hashed_password=hash_password("p"),
+        role="member",
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    sess = AutonomousSession(user_id=user.id, trigger_kind="manual", params={"query": "q"})
+    db_session.add(sess)
+    await db_session.flush()
+
+    verdict = await build_session_ledger(
+        db_session,
+        session=sess,
+        work_product_text="Work product.",
+        findings=[
+            {
+                "title": "T",
+                "summary": "S",
+                "severity": "info",
+                "citations": [{"quote": quote, "source": 1}],
+            }
+        ],
+        evidence=[
+            {
+                "n": 1,
+                "kind": "kb",
+                "ref": str(kb_with_one_indexed_file.chunk_id),
+                "content": chunk.content,
+                "display": "nda.pdf",
+            }
+        ],
+        gateway=None,
+    )
+    assert verdict is not None and verdict["gate_status"] in {
+        "fiduciary_grade",
+        "supported_only",
+        "flagged",
+    }
+
+    chat = (
+        await db_session.execute(select(Chat).where(Chat.autonomous_session_id == sess.id))
+    ).scalar_one()  # hidden chat manufactured
+    entries = (
+        (
+            await db_session.execute(
+                select(CitationLedgerEntry).where(CitationLedgerEntry.chat_id == chat.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(entries) >= 1
+    gate = (
+        await db_session.execute(
+            select(WorkProductFiduciaryGate).where(WorkProductFiduciaryGate.chat_id == chat.id)
+        )
+    ).scalar_one()
+    assert gate.gate_status == verdict["gate_status"]
+
+
+async def test_build_session_ledger_no_citations_returns_none(db_session):
+    user = User(
+        email="sl2@x.com",
+        hashed_password=hash_password("p"),
+        role="member",
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    sess = AutonomousSession(user_id=user.id, trigger_kind="manual", params={"query": "q"})
+    db_session.add(sess)
+    await db_session.flush()
+    verdict = await build_session_ledger(
+        db_session,
+        session=sess,
+        work_product_text="No citations.",
+        findings=[{"title": "T", "summary": "S", "severity": "info", "citations": []}],
+        evidence=[],
+        gateway=None,
+    )
+    assert verdict is None  # nothing to ledger → no manufactured chat, no gate
+    assert (
+        await db_session.execute(select(Chat).where(Chat.autonomous_session_id == sess.id))
+    ).scalar_one_or_none() is None

--- a/api/tests/autonomous/test_session_ledger.py
+++ b/api/tests/autonomous/test_session_ledger.py
@@ -4,12 +4,23 @@ Tests the integration bridge that manufactures a hidden chat+message,
 splits structured citations by kind (kb vs caselaw), builds citation rows
 via Tasks 5/6, runs assemble_ledger_entries + compute_and_record_gate, and
 returns a gate verdict dict (or None when there is nothing to ledger).
+
+Also covers the delivery-node SAVEPOINT isolation (PR2 regression test):
+delivery_node wraps build_session_ledger in ``async with db.begin_nested()``
+so a bridge flush-failure rolls back ONLY the manufactured rows and leaves
+the terminal session status + audit row commiteable.
 """
+
+import json
+import uuid
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.autonomous.ledger_bridge import build_session_ledger
+from app.autonomous.nodes import make_delivery_node
+from app.models.audit import AuditLog
 from app.models.autonomous import AutonomousSession
 from app.models.chat import Chat
 from app.models.citation_ledger_entry import CitationLedgerEntry
@@ -121,3 +132,127 @@ async def test_build_session_ledger_no_citations_returns_none(db_session):
     assert (
         await db_session.execute(select(Chat).where(Chat.autonomous_session_id == sess.id))
     ).scalar_one_or_none() is None
+
+
+# ---------------------------------------------------------------------------
+# PR2 regression: SAVEPOINT isolation in delivery_node
+# ---------------------------------------------------------------------------
+
+
+async def test_delivery_node_savepoint_isolates_bridge_failure(
+    db_session: AsyncSession,
+    running_session_at_delivery: AutonomousSession,
+    mock_gateway: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bridge flush inside the SAVEPOINT must not poison the terminal commit.
+
+    The delivery_node wraps build_session_ledger in
+    ``async with db.begin_nested()`` (SAVEPOINT).  This test injects a stub
+    that does a REAL DB WRITE (Chat row) then raises, proving that:
+
+    (a) session.status == "completed"  — terminal commit went through
+    (b) the autonomous_session.completed audit row exists  — same
+    (c) NO Chat row with autonomous_session_id == session.id  — the
+        SAVEPOINT rolled the stub's partial write back
+    (d) session.result is set (receipt present, no fiduciary_gate key)
+
+    This is the PR1-C1 surface: the savepoint must prevent a bridge error
+    from orphaning rows AND from poisoning the outer terminal commit.
+    """
+
+    async def boom(
+        db,
+        *,
+        session,
+        work_product_text,
+        findings,
+        evidence,
+        gateway,
+        judge_model="fast",
+    ):
+        """Partial write then raise — exercises the SAVEPOINT rollback path."""
+        db.add(
+            Chat(
+                owner_id=session.user_id,
+                title="partial",
+                autonomous_session_id=session.id,
+            )
+        )
+        await db.flush()  # real write inside the savepoint
+        raise RuntimeError("bridge boom")
+
+    monkeypatch.setattr("app.autonomous.ledger_bridge.build_session_ledger", boom)
+
+    # Build analysis_content so delivery_node's `if findings and evidence and
+    # work_product` guard is True and the bridge block is entered.
+    analysis_content = (
+        "```json\n"
+        + json.dumps(
+            {
+                "findings": [
+                    {
+                        "title": "Test finding",
+                        "summary": "S",
+                        "severity": "info",
+                        "citations": [{"quote": "some quote text", "source": 1}],
+                    }
+                ],
+                "suggested_memories": [],
+                "suggested_precedents": [],
+                "privilege_concerns": [],
+                "scope_concerns": [],
+            }
+        )
+        + "\n```"
+    )
+
+    state = {
+        "session_id": running_session_at_delivery.id,
+        "findings": [],
+        "analysis_content": analysis_content,
+        "analysis_evidence": [
+            {
+                "n": 1,
+                "kind": "kb",
+                "ref": str(uuid.uuid4()),
+                "content": "some evidence text",
+                "display": "doc.pdf",
+            }
+        ],
+    }
+
+    node = make_delivery_node(db_session, mock_gateway)
+    await node(state)
+
+    # (a) Session reached 'completed' despite the bridge failure.
+    await db_session.refresh(running_session_at_delivery)
+    assert running_session_at_delivery.status == "completed"
+
+    # (b) The terminal audit row was committed.
+    audit_rows = (
+        (
+            await db_session.execute(
+                select(AuditLog)
+                .where(AuditLog.resource_type == "autonomous_session")
+                .where(AuditLog.resource_id == str(running_session_at_delivery.id))
+                .where(AuditLog.action == "autonomous_session.completed")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audit_rows) == 1, "terminal audit row must exist"
+
+    # (c) No orphaned Chat row — the SAVEPOINT rolled back the stub's flush.
+    orphan_chat = (
+        await db_session.execute(
+            select(Chat).where(Chat.autonomous_session_id == running_session_at_delivery.id)
+        )
+    ).scalar_one_or_none()
+    assert orphan_chat is None, "SAVEPOINT must have rolled back the stub's Chat row"
+
+    # (d) Receipt is set (delivery committed its terminal payload).
+    result = running_session_at_delivery.result
+    assert result is not None, "session.result must be set after delivery"
+    assert "fiduciary_gate" not in result, "bridge failed → no gate in receipt"

--- a/api/tests/autonomous/test_session_ledger_endpoint.py
+++ b/api/tests/autonomous/test_session_ledger_endpoint.py
@@ -1,0 +1,141 @@
+"""Integration tests for GET /autonomous/sessions/{id}/ledger (WS-D PR2 Task 8).
+
+Covers:
+- Happy path: a session with a manufactured ledger (via build_session_ledger)
+  returns 200 with entries + gate.
+- 404 when the session has no manufactured chat (no ledger built yet).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.autonomous.ledger_bridge import build_session_ledger
+from app.db.session import get_db
+from app.main import app
+from app.models.autonomous import AutonomousSession
+from app.models.document import DocumentChunk
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def owner_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"sl-ep-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        role="member",
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+def _bearer_for(user: User) -> str:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return f"Bearer {token}"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_session_ledger_endpoint_returns_entries(
+    db_session: AsyncSession,
+    client: AsyncClient,
+    kb_with_one_indexed_file,
+    owner_user: User,
+) -> None:
+    """200 + entries + gate when the session has a built ledger."""
+    chunk = (
+        await db_session.execute(
+            select(DocumentChunk).where(DocumentChunk.id == kb_with_one_indexed_file.chunk_id)
+        )
+    ).scalar_one()
+    quote = chunk.content[:40]
+    sess = AutonomousSession(user_id=owner_user.id, trigger_kind="manual", params={"query": "q"})
+    db_session.add(sess)
+    await db_session.flush()
+    await build_session_ledger(
+        db_session,
+        session=sess,
+        work_product_text="wp",
+        findings=[
+            {
+                "title": "T",
+                "summary": "S",
+                "severity": "info",
+                "citations": [{"quote": quote, "source": 1}],
+            }
+        ],
+        evidence=[
+            {
+                "n": 1,
+                "kind": "kb",
+                "ref": str(kb_with_one_indexed_file.chunk_id),
+                "content": chunk.content,
+                "display": "nda.pdf",
+            }
+        ],
+        gateway=None,
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/ledger",
+        headers={"Authorization": _bearer_for(owner_user)},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["gate"]["gate_status"] in {"fiduciary_grade", "supported_only", "flagged"}
+    assert len(body["entries"]) >= 1
+
+
+async def test_session_ledger_endpoint_404_without_ledger(
+    db_session: AsyncSession,
+    client: AsyncClient,
+    owner_user: User,
+) -> None:
+    """404 when the session exists but has no manufactured chat (no ledger)."""
+    sess = AutonomousSession(user_id=owner_user.id, trigger_kind="manual", params={})
+    db_session.add(sess)
+    await db_session.commit()
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/ledger",
+        headers={"Authorization": _bearer_for(owner_user)},
+    )
+    assert resp.status_code == 404

--- a/api/tests/autonomous/test_session_ledger_endpoint.py
+++ b/api/tests/autonomous/test_session_ledger_endpoint.py
@@ -2,8 +2,10 @@
 
 Covers:
 - Happy path: a session with a manufactured ledger (via build_session_ledger)
-  returns 200 with entries + gate.
+  returns 200 with entries + gates (identical shape to chat ledger endpoint).
 - 404 when the session has no manufactured chat (no ledger built yet).
+- 404 (not 403) when a different authenticated user requests another user's
+  session ledger (ownership enforcement, no existence leak).
 """
 
 from __future__ import annotations
@@ -53,6 +55,21 @@ async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
 async def owner_user(db_session: AsyncSession) -> User:
     user = User(
         email=f"sl-ep-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        role="member",
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def other_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"sl-ep-other-{uuid.uuid4().hex[:8]}@example.com",
         hashed_password=hash_password("pw"),
         role="member",
         is_admin=False,
@@ -121,7 +138,8 @@ async def test_session_ledger_endpoint_returns_entries(
     )
     assert resp.status_code == 200
     body = resp.json()
-    assert body["gate"]["gate_status"] in {"fiduciary_grade", "supported_only", "flagged"}
+    assert "chat_id" in body
+    assert body["gates"][0]["gate_status"] in {"fiduciary_grade", "supported_only", "flagged"}
     assert len(body["entries"]) >= 1
 
 
@@ -136,6 +154,30 @@ async def test_session_ledger_endpoint_404_without_ledger(
     await db_session.commit()
     resp = await client.get(
         f"/api/v1/autonomous/sessions/{sess.id}/ledger",
+        headers={"Authorization": _bearer_for(owner_user)},
+    )
+    assert resp.status_code == 404
+
+
+async def test_session_ledger_endpoint_cross_user_returns_404(
+    db_session: AsyncSession,
+    client: AsyncClient,
+    owner_user: User,
+    other_user: User,
+) -> None:
+    """404 (not 403) when user A requests user B's session ledger.
+
+    Ownership is enforced by ``_load_owned_session``; returning 404 rather
+    than 403 avoids leaking the existence of another user's session.
+    """
+    # Create a session owned by other_user (user B).
+    sess_b = AutonomousSession(user_id=other_user.id, trigger_kind="manual", params={})
+    db_session.add(sess_b)
+    await db_session.commit()
+
+    # Request as owner_user (user A) — must get 404, not 403.
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess_b.id}/ledger",
         headers={"Authorization": _bearer_for(owner_user)},
     )
     assert resp.status_code == 404

--- a/api/tests/autonomous/test_structured_output.py
+++ b/api/tests/autonomous/test_structured_output.py
@@ -188,7 +188,13 @@ def test_parse_non_dict_items_in_dict_shaped_arrays_are_dropped(key: str) -> Non
     raw = json.dumps({key: ["a string", 42, None, True, [1, 2], survivor]})
     r = parse_structured_output(raw)
     assert r.is_structured is True
-    assert getattr(r, key) == [survivor], f"key={key} should keep only dict items"
+    if key == "findings":
+        # _normalize_findings adds citations: [] to every surviving finding dict (WS-D PR2).
+        assert getattr(r, key) == [{**survivor, "citations": []}], (
+            f"key={key} should keep only dict items (with citations normalized)"
+        )
+    else:
+        assert getattr(r, key) == [survivor], f"key={key} should keep only dict items"
 
 
 def test_parse_mixed_contamination_across_all_dict_shaped_arrays() -> None:
@@ -207,7 +213,9 @@ def test_parse_mixed_contamination_across_all_dict_shaped_arrays() -> None:
     )
     r = parse_structured_output(raw)
     assert r.is_structured is True
-    assert r.findings == [{"title": "ok"}]
+    assert r.findings == [
+        {"title": "ok", "citations": []}
+    ]  # _normalize_findings adds citations (WS-D PR2)
     assert r.suggested_memories == [{"category": "preference", "content": "C"}]
     assert r.suggested_precedents == [{"pattern_kind": "clause"}]
     assert r.artifacts == [{"name": "a.md", "content_md": "x"}]
@@ -231,3 +239,57 @@ def test_parse_non_array_value_does_not_raise_on_any_array_key() -> None:
         assert r.is_structured is True
         # Read the coerced field via getattr to compare uniformly:
         assert getattr(r, key) == [], f"key={key} should coerce to []"
+
+
+def test_parse_finding_citations() -> None:
+    """Citations array is parsed and sanitized when present in a finding."""
+    raw = (
+        '```json\n{"findings": [{"title": "T", "summary": "S", "severity": "info", '
+        '"source_chunk_ids": [], "citations": [{"quote": "Confidential clause.", "source": 1}]}], '
+        '"suggested_memories": [], "suggested_precedents": [], '
+        '"privilege_concerns": [], "scope_concerns": []}\n```'
+    )
+    parsed = parse_structured_output(raw)
+    assert parsed.is_structured
+    assert parsed.findings[0]["citations"] == [{"quote": "Confidential clause.", "source": 1}]
+
+
+def test_parse_finding_citations_absent_defaults_empty() -> None:
+    """When citations key is absent from a finding, it defaults to []."""
+    raw = (
+        '```json\n{"findings": [{"title": "T", "summary": "S", "severity": "info", '
+        '"source_chunk_ids": []}], "suggested_memories": [], "suggested_precedents": [], '
+        '"privilege_concerns": [], "scope_concerns": []}\n```'
+    )
+    parsed = parse_structured_output(raw)
+    assert parsed.findings[0].get("citations", []) == []
+
+
+def test_parse_finding_citations_malformed_entries_dropped() -> None:
+    """Malformed citation entries (non-dict, wrong types, bool source) are silently dropped."""
+    raw = json.dumps(
+        {
+            "findings": [
+                {
+                    "title": "T",
+                    "summary": "S",
+                    "severity": "info",
+                    "source_chunk_ids": [],
+                    "citations": [
+                        {"quote": "valid", "source": 2},  # good
+                        "not a dict",  # dropped
+                        {"quote": 99, "source": 1},  # non-str quote dropped
+                        {"quote": "text", "source": True},  # bool source dropped
+                        {"quote": "text", "source": "1"},  # str source dropped
+                        {"quote": "also valid", "source": 3},  # good
+                    ],
+                }
+            ]
+        }
+    )
+    parsed = parse_structured_output(raw)
+    assert parsed.is_structured
+    assert parsed.findings[0]["citations"] == [
+        {"quote": "valid", "source": 2},
+        {"quote": "also valid", "source": 3},
+    ]

--- a/api/tests/autonomous/test_synthesis_messages.py
+++ b/api/tests/autonomous/test_synthesis_messages.py
@@ -107,3 +107,63 @@ async def test_synthesis_does_not_alter_system_prompt(
         db=db_session,
     )
     assert synthesis[0]["content"] == base[0]["content"]
+
+
+async def test_synthesis_includes_numbered_evidence_and_citation_instruction(
+    db_session: AsyncSession,
+    session_with_skill_ref: AutonomousSession,
+) -> None:
+    """When evidence items are provided, synthesis includes a numbered SOURCES
+    block and a citation instruction telling the model to use verbatim quotes."""
+    msgs = await assemble_synthesis_messages(
+        session_with_skill_ref,
+        goal="Is the clause enforceable?",
+        observations=["retrieve_caselaw → 1 result"],
+        chunks=[],
+        evidence=[
+            {
+                "n": 1,
+                "kind": "kb",
+                "ref": "c1",
+                "content": "Confidential clause.",
+                "display": "nda.pdf (chunk c1)",
+            },
+            {
+                "n": 2,
+                "kind": "caselaw",
+                "ref": "42",
+                "content": "It is held...",
+                "display": "Smith (ca9 2021; cl=42)",
+            },
+        ],
+        db=db_session,
+    )
+    blob = " ".join(m["content"] for m in msgs)
+    assert "[1]" in blob and "nda.pdf" in blob  # numbered source list
+    assert "[2]" in blob and "Smith" in blob
+    assert "quote" in blob and "source" in blob  # citation instruction present
+
+
+async def test_synthesis_empty_evidence_omits_citation_block(
+    db_session: AsyncSession,
+    session_with_skill_ref: AutonomousSession,
+) -> None:
+    """When evidence is empty (or not provided), the citation block is absent."""
+    msgs_none = await assemble_synthesis_messages(
+        session_with_skill_ref,
+        goal="Goal.",
+        observations=[],
+        chunks=[],
+        db=db_session,
+    )
+    msgs_empty = await assemble_synthesis_messages(
+        session_with_skill_ref,
+        goal="Goal.",
+        observations=[],
+        chunks=[],
+        evidence=[],
+        db=db_session,
+    )
+    for msgs in (msgs_none, msgs_empty):
+        blob = " ".join(m["content"] for m in msgs)
+        assert "NUMBERED SOURCES" not in blob

--- a/api/tests/citation/test_extraction.py
+++ b/api/tests/citation/test_extraction.py
@@ -246,3 +246,17 @@ def test_extract_smart_quote_alignment_pairs() -> None:
     candidates = extract_citations(response, [chunk])
     assert len(candidates) == 1
     assert candidates[0].source_text == "The agreement shall terminate."
+
+
+@pytest.mark.unit
+def test_locate_in_chunk_public_exact_and_miss() -> None:
+    """Test the public locate_in_chunk function directly."""
+
+    from app.citation.extraction import locate_in_chunk
+
+    content = "The Receiving Party shall hold Confidential Information in confidence."
+    span = locate_in_chunk("hold Confidential Information", content)
+    assert span is not None
+    start, end = span
+    assert content[start:end] == "hold Confidential Information"
+    assert locate_in_chunk("text that is absent", content) is None

--- a/api/tests/test_chats_endpoints.py
+++ b/api/tests/test_chats_endpoints.py
@@ -893,3 +893,47 @@ async def test_chat_cascade_delete_removes_messages(
         text("SELECT count(*) FROM messages WHERE chat_id = :cid"), {"cid": chat_id}
     )
     assert rows.scalar_one() == 0
+
+
+# ---------------------------------------------------------------------------
+# Hidden session-owned chats (WS-D PR2)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def owner_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"owner-chats-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Owner Chats User",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.mark.integration
+async def test_session_owned_chat_excluded_from_list(
+    db_session: AsyncSession, client: AsyncClient, owner_user: User
+) -> None:
+    from app.models.autonomous import AutonomousSession
+    from app.models.chat import Chat
+
+    sess = AutonomousSession(user_id=owner_user.id, trigger_kind="manual", params={})
+    db_session.add(sess)
+    await db_session.flush()
+    visible = Chat(owner_id=owner_user.id, title="Visible")
+    hidden = Chat(owner_id=owner_user.id, title="Session", autonomous_session_id=sess.id)
+    db_session.add_all([visible, hidden])
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/chats", headers={"Authorization": f"Bearer {_bearer_for(owner_user)}"}
+    )
+    assert resp.status_code == 200
+    titles = {c["title"] for c in resp.json()["items"]}
+    assert "Visible" in titles
+    assert "Session" not in titles  # session-owned chat is hidden from the list

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -306,6 +306,7 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("GET", "/api/v1/autonomous/sessions/{session_id}"),
     ("GET", "/api/v1/autonomous/sessions/{session_id}/artifacts"),
     ("GET", "/api/v1/autonomous/sessions/{session_id}/findings"),
+    ("GET", "/api/v1/autonomous/sessions/{session_id}/ledger"),
     ("POST", "/api/v1/autonomous/sessions/{session_id}/halt"),
     ("GET", "/api/v1/autonomous/watches"),
     ("POST", "/api/v1/autonomous/watches"),

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -169,6 +169,8 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/autonomous/sessions/{session_id}/findings",
         # Artifacts read-model — a run's document-grade artifact refs (Donna #8)
         "/api/v1/autonomous/sessions/{session_id}/artifacts",
+        # WS-D PR2 C5 — session citation ledger + fiduciary gate
+        "/api/v1/autonomous/sessions/{session_id}/ledger",
         # M4-B1 — per-user memory curation API (list, keep, dismiss, delete)
         "/api/v1/autonomous/memory",
         "/api/v1/autonomous/memory/{memory_id}/keep",
@@ -328,7 +330,9 @@ async def test_openapi_paths_match_sketch() -> None:
     # /api/v1/chats/{chat_id}/messages/{message_id}/sources
     # P1-A3 adds one new path (134 -> 135):
     # /api/v1/chats/{chat_id}/ledger
-    assert len(actual) == 135
+    # WS-D PR2 C5 adds one new path (135 -> 136):
+    # /api/v1/autonomous/sessions/{session_id}/ledger
+    assert len(actual) == 136
 
 
 @pytest.mark.unit

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -322,6 +322,12 @@ CREATE TABLE chats (
     -- When non-empty, these skill slugs are unioned into every turn's effective
     -- skills until cleared. Set via MessageCreate.set_sticky.
     sticky_skills TEXT[] NOT NULL DEFAULT '{}',
+    -- Session-owned chat marker (WS-D PR2, migration 0063). Non-null when this
+    -- chat was manufactured by an autonomous session to route its work product
+    -- through the citation ledger + fiduciary gate. Excluded from list_chats and
+    -- search_chats so it is invisible in the user's chat list. Direct GET by id
+    -- still works. ON DELETE SET NULL so archiving the session doesn't cascade.
+    autonomous_session_id UUID REFERENCES autonomous_sessions(id) ON DELETE SET NULL,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/docs/superpowers/plans/2026-06-28-wsd-pr2-ledger-gate.md
+++ b/docs/superpowers/plans/2026-06-28-wsd-pr2-ledger-gate.md
@@ -1,0 +1,1185 @@
+# WS-D PR2 — Fiduciary Ledger + Gate for Matter Sessions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an autonomous matter session produce the same citation-ledger + fiduciary-gate rows a chat turn does, by manufacturing a hidden session-owned chat/message and routing the session's structured citations through the existing character-fidelity verifier → `assemble_ledger_entries` → `compute_and_record_gate`.
+
+**Architecture:** Reuse, do not fork (ADR 0016 P6 / 0020 D6). The synthesis output gains structured per-finding citations (`{quote, source}`); the analysis loop accumulates a P3-safe evidence registry; at delivery a new `ledger_bridge` module manufactures a hidden `Chat`+`Message`, builds `MessageCitation`/`MessageCaselawCitation` rows from the structured citations via the existing `verify()` primitive, then calls the unchanged `assemble_ledger_entries` + `compute_and_record_gate`, and embeds the gate verdict in `session.result`. A read endpoint exposes the session's ledger.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2 (async), LangGraph, alembic, pytest, ruff, mypy. Subsystems: `api/app/autonomous/`, `api/app/citation/`, `api/app/api/chats.py`.
+
+## Global Constraints
+
+- **Security-gated** (`api/app/autonomous/**`, `api/app/citation/**`, `api/app/api/chats.py`, migration): security/maintainer merges; mirror `origin/main → tucuxi` after. Claude does NOT self-merge.
+- **Reuse, do not fork (load-bearing):** write the SAME `message_citations`/`message_caselaw_citations`/`citation_ledger_entry`/`work_product_fiduciary_gate` rows the chat path writes; reuse `verify()` (`api/app/citation/verification.py:545`), `assemble_ledger_entries` (`api/app/citation/ledger.py:32`), `compute_and_record_gate` (`api/app/citation/gate.py:33`) UNCHANGED. No parallel ledger/gate.
+- **Strictly additive / backward-compat (load-bearing):** only matter sessions (a parsed work product with citations) run the cascade. Query-less / non-matter sessions are byte-identical — no manufactured chat, no ledger/gate, `session.result` unchanged.
+- **Best-effort, never blocks delivery (load-bearing):** the cascade is wrapped (try/except → log `event="autonomous_ledger_bridge_failed"`); a failure leaves the session delivered with an honest receipt sans `fiduciary_gate`, never crash-loops the worker (DE-325 discipline).
+- **P3 (ADR 0016 / 0019 D7):** the planner keeps seeing only compact observations; audit / `analysis_plan_trace` / ledger rows store offsets/labels/status/ids — never raw payloads. The evidence registry is loop-local + synthesis context only; it is NOT written to `analysis_plan_trace`/audit.
+- **Hidden chat invisible:** a chat with `autonomous_session_id IS NOT NULL` never appears in `list_chats`/`search_chats`; reachable only by direct id.
+- **Honest labeling (ADR 0018 D3):** unverifiable quotes are dropped (KB) / FAIL-row (caselaw) exactly as the chat path — never fabricated to inflate the gate.
+- **No migration host-run against the dev DB** (port 15432). Tests use host venv `api/.venv` + throwaway pgvector on `:55432`, `DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test` (conftest auto-migrates). Mocked gateway → no `-m provider`.
+- **Run the api suite SOLO** (DE-368: concurrent pytest against the shared `lqai_test` DB produces spurious research-test failures).
+- **CI gate (repo root):** `ruff check api scripts` + `ruff format --check api scripts` + whole-app `mypy app` + both full suites. Next migration = `0063`. Next DE = DE-369.
+- Commits: `git commit -s` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File structure
+
+| File | Change | Task |
+|---|---|---|
+| `api/alembic/versions/0063_chat_autonomous_session_id.py` | NEW migration | 1 |
+| `api/app/models/chat.py` | `Chat.autonomous_session_id` column | 1 |
+| `api/app/api/chats.py` | filter session chats out of `list_chats` + `search_chats` | 1 |
+| `docs/db-schema.md` | document `chats.autonomous_session_id` | 1 |
+| `api/app/citation/extraction.py` | promote `_locate_in_chunk` → `locate_in_chunk` | 2 |
+| `api/app/autonomous/planner.py` | `summarize_observation` caselaw includes `cluster_id`; `EvidenceItem` | 3 |
+| `api/app/autonomous/nodes.py` | loop evidence registry; thread to synthesis + delivery | 3, 6 |
+| `api/app/autonomous/prompts.py` | numbered-source block + citation instruction in `assemble_synthesis_messages` | 4 |
+| `api/app/autonomous/structured_output.py` | tolerant parse of finding `citations` | 4 |
+| `api/app/autonomous/ledger_bridge.py` | NEW — KB + caselaw structured citation builders + `build_session_ledger` | 5, 6, 7 |
+| `api/app/api/autonomous.py` (or the sessions router) | `GET /sessions/{id}/ledger` | 8 |
+
+---
+
+### Task 1: Migration 0063 + hidden session-owned chat plumbing
+
+**Files:**
+- Create: `api/alembic/versions/0063_chat_autonomous_session_id.py`
+- Modify: `api/app/models/chat.py` (add `Chat.autonomous_session_id`)
+- Modify: `api/app/api/chats.py` (`list_chats` ~743, `search_chats` ~655/681)
+- Modify: `docs/db-schema.md` (chats table)
+- Test: `api/tests/test_chats_endpoints.py` (add a hidden-chat-excluded test) and a migration sanity assert in `api/tests/autonomous/test_session_ledger.py` (new file, reused by later tasks)
+
+**Interfaces:**
+- Produces: `Chat.autonomous_session_id: Mapped[uuid.UUID | None]` (FK `autonomous_sessions.id`, `ON DELETE SET NULL`); `list_chats`/`search_chats` exclude rows where it is non-null.
+
+- [ ] **Step 1: Write the failing test** — append to `api/tests/test_chats_endpoints.py`:
+
+```python
+@pytest.mark.integration
+async def test_session_owned_chat_excluded_from_list(
+    db_session: AsyncSession, client: AsyncClient, owner_user: User
+) -> None:
+    from app.models.autonomous import AutonomousSession
+    from app.models.chat import Chat
+
+    sess = AutonomousSession(user_id=owner_user.id, trigger_kind="manual", params={})
+    db_session.add(sess)
+    await db_session.flush()
+    visible = Chat(owner_id=owner_user.id, title="Visible")
+    hidden = Chat(owner_id=owner_user.id, title="Session", autonomous_session_id=sess.id)
+    db_session.add_all([visible, hidden])
+    await db_session.commit()
+
+    resp = await client.get("/api/v1/chats", headers={"Authorization": _bearer_for(owner_user)})
+    assert resp.status_code == 200
+    titles = {c["title"] for c in resp.json()}
+    assert "Visible" in titles
+    assert "Session" not in titles  # session-owned chat is hidden from the list
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/test_chats_endpoints.py::test_session_owned_chat_excluded_from_list -v`
+Expected: FAIL — `Chat` has no `autonomous_session_id` (and the column doesn't exist).
+
+- [ ] **Step 3: Write the migration** (`api/alembic/versions/0063_chat_autonomous_session_id.py`) — template `0056_chat_sticky_skills.py`:
+
+```python
+"""chats.autonomous_session_id — hidden session-owned chats (WS-D PR2).
+
+Revision ID: 0063
+Revises: 0062
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0063"
+down_revision = "0062"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chats",
+        sa.Column("autonomous_session_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_chats_autonomous_session_id",
+        "chats",
+        "autonomous_sessions",
+        ["autonomous_session_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_chats_autonomous_session_id",
+        "chats",
+        ["autonomous_session_id"],
+        postgresql_where=sa.text("autonomous_session_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chats_autonomous_session_id", table_name="chats")
+    op.drop_constraint("fk_chats_autonomous_session_id", "chats", type_="foreignkey")
+    op.drop_column("chats", "autonomous_session_id")
+```
+
+- [ ] **Step 4: Add the ORM column** in `api/app/models/chat.py` (in the `Chat` class, after `project_id` ~line 85):
+
+```python
+    autonomous_session_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("autonomous_sessions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=False,  # partial index created in migration 0063
+    )
+```
+
+(Confirm `ForeignKey` and `UUID` are already imported in chat.py; they are used by `owner_id`/`project_id`.)
+
+- [ ] **Step 5: Filter session chats out of the list + search.** In `api/app/api/chats.py` `list_chats` (~743), change the base statement:
+
+```python
+    stmt = select(Chat).where(
+        Chat.owner_id == user.id,
+        Chat.autonomous_session_id.is_(None),
+    )
+```
+
+In `search_chats` add `Chat.autonomous_session_id.is_(None)` to BOTH subquery WHERE clauses (~655 and ~681), pattern-matching the existing `Chat.archived_at.is_(None)` filter there.
+
+- [ ] **Step 6: Document the column.** In `docs/db-schema.md`, in the `chats` table section, add a row: `autonomous_session_id | uuid | nullable, FK→autonomous_sessions.id ON DELETE SET NULL | session-owned chat marker (WS-D PR2); excluded from chat list`.
+
+- [ ] **Step 7: Run — expect pass + chats regression**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/test_chats_endpoints.py -v`
+Expected: PASS (new test + no chats regressions).
+
+- [ ] **Step 8: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/alembic/versions/0063_chat_autonomous_session_id.py api/app/models/chat.py api/app/api/chats.py docs/db-schema.md api/tests/test_chats_endpoints.py
+git commit -s -m "feat(chats): hidden session-owned chat marker — migration 0063 (WS-D PR2)"
+```
+
+---
+
+### Task 2: Promote `_locate_in_chunk` → public `locate_in_chunk`
+
+**Files:**
+- Modify: `api/app/citation/extraction.py:128` (rename + keep a private alias if any internal caller uses it)
+- Test: `api/tests/citation/test_extraction.py` (add a direct call test)
+
+**Interfaces:**
+- Produces: `locate_in_chunk(quote: str, chunk_content: str) -> tuple[int, int] | None` (public; same body, same `_ALIGNMENT_THRESHOLD`). Used by the KB citation builder (Task 5).
+
+- [ ] **Step 1: Write the failing test** — append to `api/tests/citation/test_extraction.py`:
+
+```python
+def test_locate_in_chunk_public_exact_and_miss():
+    from app.citation.extraction import locate_in_chunk
+
+    content = "The Receiving Party shall hold Confidential Information in confidence."
+    span = locate_in_chunk("hold Confidential Information", content)
+    assert span is not None
+    start, end = span
+    assert content[start:end] == "hold Confidential Information"
+    assert locate_in_chunk("text that is absent", content) is None
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && .venv/bin/python -m pytest tests/citation/test_extraction.py::test_locate_in_chunk_public_exact_and_miss -v`
+Expected: FAIL — `cannot import name 'locate_in_chunk'`.
+
+- [ ] **Step 3: Rename.** In `api/app/citation/extraction.py`, rename `def _locate_in_chunk(` to `def locate_in_chunk(`. Update the internal call site inside `extract_citations` (~line 190/210) to `locate_in_chunk(...)`. If any other module imports `_locate_in_chunk`, add `_locate_in_chunk = locate_in_chunk` below the def as a back-compat alias (grep first: `grep -rn "_locate_in_chunk" api/app api/tests`).
+
+- [ ] **Step 4: Run — expect pass + extraction regression**
+
+Run: `cd api && .venv/bin/python -m pytest tests/citation/test_extraction.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/citation/extraction.py api/tests/citation/test_extraction.py
+git commit -s -m "refactor(citation): promote _locate_in_chunk to public locate_in_chunk (WS-D PR2)"
+```
+
+---
+
+### Task 3: Loop evidence registry + caselaw `cluster_id` in observation
+
+**Files:**
+- Modify: `api/app/autonomous/planner.py` (`summarize_observation` caselaw branch; add `EvidenceItem` dataclass + `collect_evidence`)
+- Modify: `api/app/autonomous/nodes.py` (`_run_analysis_loop` accumulates evidence; returns it in state)
+- Modify: `api/app/autonomous/state.py` (`analysis_evidence` state key — loop-local, NOT in trace)
+- Test: `api/tests/autonomous/test_evidence_registry.py` (new)
+
+**Interfaces:**
+- Produces:
+  - `@dataclass(slots=True) EvidenceItem(n: int, kind: str, ref: str, content: str, display: str)` — `kind` ∈ `{"kb","caselaw"}`; `ref` is the `chunk_id` (kb) or `cluster_id` (caselaw) as str; `content` is the authoritative text used for citation verification; `display` is a P3 one-liner.
+  - `collect_evidence(intent: ToolIntent, result, start_n: int) -> list[EvidenceItem]` — turns a `ToolResult` into numbered evidence items (empty on failure / non-observe intents).
+  - `summarize_observation(...)` caselaw line now includes `cluster_id` (P3-safe id).
+  - `_run_analysis_loop` returns `analysis_evidence: list[dict]` in its result dict (each `EvidenceItem` as a JSONable dict).
+
+- [ ] **Step 1: Write the failing tests** (`api/tests/autonomous/test_evidence_registry.py`):
+
+```python
+from app.autonomous.enums import ToolIntent
+from app.autonomous.guard import ToolResult
+from app.autonomous.planner import EvidenceItem, collect_evidence, summarize_observation
+
+
+def test_caselaw_observation_includes_cluster_id():
+    result = ToolResult(data={"results": [
+        {"case_name": "Smith v. Jones", "court": "ca9", "date_filed": "2021-01-01", "cluster_id": 42},
+    ]}, outcome="success")
+    s = summarize_observation(ToolIntent.retrieve_caselaw, "find authority", result)
+    assert "Smith v. Jones" in s
+    assert "42" in s  # cluster_id is shown so the synthesis can cite it
+
+
+def test_collect_evidence_numbers_kb_chunks():
+    result = ToolResult(data={"chunks": [
+        {"chunk_id": "c1", "file_name": "nda.pdf", "content": "Confidential Information clause text."},
+        {"chunk_id": "c2", "file_name": "nda.pdf", "content": "Term clause text."},
+    ]}, outcome="success")
+    items = collect_evidence(ToolIntent.retrieve_chunks, result, start_n=1)
+    assert [i.n for i in items] == [1, 2]
+    assert items[0].kind == "kb" and items[0].ref == "c1"
+    assert items[0].content == "Confidential Information clause text."
+
+
+def test_collect_evidence_numbers_caselaw():
+    result = ToolResult(data={"results": [
+        {"case_name": "Smith v. Jones", "cluster_id": 42, "opinion_text": "It is held that..."},
+    ]}, outcome="success")
+    items = collect_evidence(ToolIntent.retrieve_caselaw, result, start_n=5)
+    assert items[0].n == 5 and items[0].kind == "caselaw" and items[0].ref == "42"
+    assert "held" in items[0].content
+
+
+def test_collect_evidence_empty_on_failure():
+    assert collect_evidence(ToolIntent.retrieve_caselaw, ToolResult(data=None, outcome="error"), 1) == []
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && .venv/bin/python -m pytest tests/autonomous/test_evidence_registry.py -v`
+Expected: FAIL — `EvidenceItem`/`collect_evidence` undefined; caselaw summary lacks cluster_id.
+
+- [ ] **Step 3: Implement in `planner.py`.** Add near the top (after `summarize_observation`):
+
+```python
+@dataclass(slots=True)
+class EvidenceItem:
+    """A numbered piece of gathered authority the synthesis may quote-and-cite.
+
+    ``content`` is the authoritative text used at delivery to verify a quoted
+    span (chunk text for kb, opinion text for caselaw). Loop-local + synthesis
+    context only — NEVER written to analysis_plan_trace/audit (P3)."""
+
+    n: int
+    kind: str  # "kb" | "caselaw"
+    ref: str   # chunk_id (kb) | cluster_id (caselaw), as str
+    content: str
+    display: str
+
+
+def collect_evidence(intent: ToolIntent, result: "object", start_n: int) -> list[EvidenceItem]:
+    outcome = getattr(result, "outcome", "success")
+    data = getattr(result, "data", None) or {}
+    if outcome != "success":
+        return []
+    items: list[EvidenceItem] = []
+    n = start_n
+    if intent == ToolIntent.retrieve_chunks:
+        for c in data.get("chunks") or []:
+            if not isinstance(c, dict) or not c.get("chunk_id"):
+                continue
+            items.append(EvidenceItem(
+                n=n, kind="kb", ref=str(c["chunk_id"]), content=str(c.get("content") or ""),
+                display=f"{c.get('file_name') or '?'} (chunk {c['chunk_id']})",
+            ))
+            n += 1
+    elif intent == ToolIntent.retrieve_caselaw:
+        rows = data.get("results") or data.get("matches") or []
+        for r in rows:
+            if not isinstance(r, dict) or not r.get("cluster_id"):
+                continue
+            items.append(EvidenceItem(
+                n=n, kind="caselaw", ref=str(r["cluster_id"]),
+                content=str(r.get("opinion_text") or r.get("text") or ""),
+                display=f"{r.get('case_name') or '?'} ({r.get('court') or '?'} {r.get('date_filed') or '?'})",
+            ))
+            n += 1
+    return items
+```
+
+And in `summarize_observation`'s caselaw branch, include the cluster_id in each name entry, e.g.:
+
+```python
+        names = [
+            f"{(i.get('case_name') or '?')} ({i.get('court') or '?'} {i.get('date_filed') or '?'}; cl={i.get('cluster_id') or '?'})"
+            for i in items[:5] if isinstance(i, dict)
+        ]
+```
+
+- [ ] **Step 4: Accumulate evidence in `_run_analysis_loop`** (`nodes.py`). Add `from app.autonomous.planner import collect_evidence` to the existing planner import. Initialize `evidence: list[EvidenceItem] = []` before the loop; in the action branch, after a successful `act`, extend it:
+
+```python
+        try:
+            validate_action_args(decision.next_intent, decision.args)
+            act = await guarded_tool_call(session, decision.next_intent, decision.args, db, gateway)
+            observations.append(summarize_observation(decision.next_intent, decision.rationale, act))
+            evidence.extend(collect_evidence(decision.next_intent, act, start_n=len(evidence) + 1))
+        except AutonomousBrake:
+            raise
+        except Exception as exc:
+            observations.append(f"{decision.next_intent.value} → failed ({type(exc).__name__})")
+```
+
+Pass `evidence` into the synthesis messages (Task 4 adds the param) and include it in the return dict:
+
+```python
+    return {
+        "current_phase": str(Phase.analysis),
+        "analysis_content": (synth.data or {}).get("content"),
+        "analysis_outcome": synth.outcome,
+        "analysis_plan_trace": {"steps": steps, "halt_reason": halt_reason, "decisions": trace},
+        "analysis_evidence": [vars(e) for e in evidence],  # JSONable; consumed by delivery (P3: not in trace)
+    }
+```
+
+Add `analysis_evidence: list[dict]` to `AutonomousSessionState` in `state.py` with a comment: "loop-gathered evidence for the synthesis + delivery ledger bridge; NOT surfaced in the receipt/trace (P3)."
+
+- [ ] **Step 5: Run — expect pass + autonomous suite**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_evidence_registry.py tests/autonomous -q`
+Expected: PASS (new + no autonomous regressions; the query-less path emits no evidence and is unchanged).
+
+- [ ] **Step 6: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/planner.py api/app/autonomous/nodes.py api/app/autonomous/state.py api/tests/autonomous/test_evidence_registry.py
+git commit -s -m "feat(autonomous): loop evidence registry + cluster_id in observations (WS-D PR2)"
+```
+
+---
+
+### Task 4: Synthesis structured citations (schema + prompt + tolerant parse)
+
+**Files:**
+- Modify: `api/app/autonomous/prompts.py` (`assemble_synthesis_messages` gains `evidence` param + numbered-source block + citation instruction)
+- Modify: `api/app/autonomous/structured_output.py` (parse finding `citations`)
+- Modify: `api/app/autonomous/nodes.py` (pass `evidence` to `assemble_synthesis_messages`)
+- Test: `api/tests/autonomous/test_synthesis_messages.py` (extend), `api/tests/autonomous/test_structured_output.py` (extend)
+
+**Interfaces:**
+- Consumes: `EvidenceItem` (Task 3).
+- Produces:
+  - `assemble_synthesis_messages(session, *, goal, observations, chunks, evidence: list[dict], db, registry=None)` — appends a numbered SOURCES block (from `evidence`) and instructs: support each finding with verbatim quotes tagged `{"quote": "...", "source": N}`.
+  - `parse_structured_output(...)` — each parsed finding dict additionally carries `citations: list[dict]` (each `{"quote": str, "source": int}`); absent → `[]`; malformed entries dropped.
+
+- [ ] **Step 1: Write the failing tests.** Append to `api/tests/autonomous/test_synthesis_messages.py`:
+
+```python
+async def test_synthesis_includes_numbered_evidence_and_citation_instruction(
+    db_session, session_with_skill_ref
+):
+    msgs = await assemble_synthesis_messages(
+        session_with_skill_ref, goal="Is the clause enforceable?",
+        observations=["retrieve_caselaw → 1 result"],
+        chunks=[],
+        evidence=[
+            {"n": 1, "kind": "kb", "ref": "c1", "content": "Confidential clause.", "display": "nda.pdf (chunk c1)"},
+            {"n": 2, "kind": "caselaw", "ref": "42", "content": "It is held...", "display": "Smith (ca9 2021; cl=42)"},
+        ],
+        db=db_session,
+    )
+    blob = " ".join(m["content"] for m in msgs)
+    assert "[1]" in blob and "nda.pdf" in blob          # numbered source list
+    assert "[2]" in blob and "Smith" in blob
+    assert "quote" in blob and "source" in blob          # citation instruction present
+```
+
+Append to `api/tests/autonomous/test_structured_output.py`:
+
+```python
+def test_parse_finding_citations():
+    raw = (
+        "```json\n{\"findings\": [{\"title\": \"T\", \"summary\": \"S\", \"severity\": \"info\", "
+        "\"source_chunk_ids\": [], \"citations\": [{\"quote\": \"Confidential clause.\", \"source\": 1}]}], "
+        "\"suggested_memories\": [], \"suggested_precedents\": [], "
+        "\"privilege_concerns\": [], \"scope_concerns\": []}\n```"
+    )
+    parsed = parse_structured_output(raw)
+    assert parsed.is_structured
+    assert parsed.findings[0]["citations"] == [{"quote": "Confidential clause.", "source": 1}]
+
+
+def test_parse_finding_citations_absent_defaults_empty():
+    raw = (
+        "```json\n{\"findings\": [{\"title\": \"T\", \"summary\": \"S\", \"severity\": \"info\", "
+        "\"source_chunk_ids\": []}], \"suggested_memories\": [], \"suggested_precedents\": [], "
+        "\"privilege_concerns\": [], \"scope_concerns\": []}\n```"
+    )
+    parsed = parse_structured_output(raw)
+    assert parsed.findings[0].get("citations", []) == []
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_synthesis_messages.py tests/autonomous/test_structured_output.py -v`
+Expected: FAIL — `assemble_synthesis_messages` has no `evidence` param; findings carry no `citations`.
+
+- [ ] **Step 3: Implement the prompt.** In `prompts.py`, change `assemble_synthesis_messages` to accept `evidence: list[dict[str, Any]]` and build a numbered source block + instruction before the existing user append:
+
+```python
+async def assemble_synthesis_messages(
+    session: AutonomousSession,
+    *,
+    goal: str,
+    observations: list[str],
+    chunks: list[dict[str, Any]],
+    evidence: list[dict[str, Any]],
+    db: AsyncSession,
+    registry: SkillRegistry | None = None,
+) -> list[dict[str, str]]:
+    messages = await assemble_analysis_messages(session, chunks=chunks, db=db, registry=registry)
+    obs = "\n".join(f"- {o}" for o in observations) if observations else "(no research steps were run)"
+    if evidence:
+        sources = "\n".join(
+            f"[{e['n']}] ({e['kind']}) {e['display']}\n    \"\"\"{e['content'][:1500]}\"\"\""
+            for e in evidence
+        )
+        cite_block = (
+            "\n\nNUMBERED SOURCES (cite these by number):\n" + sources +
+            "\n\nFor every finding, support it with VERBATIM quotes from the numbered sources. "
+            "In each finding's JSON, include a \"citations\" array of objects "
+            "{\"quote\": \"<exact text copied from the source>\", \"source\": <source number>}. "
+            "Copy quotes character-for-character; do not paraphrase inside a quote."
+        )
+    else:
+        cite_block = ""
+    messages.append({
+        "role": "user",
+        "content": (
+            f"MATTER GOAL:\n{goal}\n\nRESEARCH OBSERVATIONS (gathered by the agent):\n{obs}{cite_block}\n\n"
+            "Synthesize your analysis of the MATTER GOAL using the observations, the numbered sources, and any "
+            "chunks above, then return the final JSON object as instructed."
+        ),
+    })
+    return messages
+```
+
+In `nodes.py` `_run_analysis_loop`, pass `evidence=[vars(e) for e in evidence]` to `assemble_synthesis_messages`.
+
+- [ ] **Step 4: Implement the parse.** In `structured_output.py`, where each finding dict is built from the parsed JSON, carry a sanitized `citations` list:
+
+```python
+        raw_citations = finding.get("citations")
+        citations: list[dict[str, Any]] = []
+        if isinstance(raw_citations, list):
+            for c in raw_citations:
+                if isinstance(c, dict) and isinstance(c.get("quote"), str) and isinstance(c.get("source"), int) \
+                        and not isinstance(c.get("source"), bool):
+                    citations.append({"quote": c["quote"], "source": c["source"]})
+        normalized_finding["citations"] = citations
+```
+
+(Adapt `finding`/`normalized_finding` to the existing variable names in `parse_structured_output`. Keep `citations` OUT of the dict that `emit_finding` dispatches if the handler is strict about keys — confirm `emit_finding` ignores extra keys; if it does not, strip `citations` before the `emit_finding` call in the drafting node. Grep `_handle_emit_finding` in `guard.py`.)
+
+- [ ] **Step 5: Run — expect pass + autonomous suite**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_synthesis_messages.py tests/autonomous/test_structured_output.py tests/autonomous -q`
+Expected: PASS.
+
+- [ ] **Step 6: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/prompts.py api/app/autonomous/structured_output.py api/app/autonomous/nodes.py api/tests/autonomous/test_synthesis_messages.py api/tests/autonomous/test_structured_output.py
+git commit -s -m "feat(autonomous): structured per-finding citations in synthesis (WS-D PR2)"
+```
+
+---
+
+### Task 5: KB structured-citation builder (`ledger_bridge.build_kb_citations`)
+
+**Files:**
+- Create: `api/app/autonomous/ledger_bridge.py`
+- Test: `api/tests/autonomous/test_ledger_bridge_kb.py` (new)
+
+**Interfaces:**
+- Consumes: `locate_in_chunk` (Task 2), `verify` (`verification.py:545`), `CitationCandidate` (`extraction.py:87`), `DocumentChunk`/`Document` models, `MessageCitation`.
+- Produces: `async build_kb_citations(db, *, message_id: uuid.UUID, citations: list[tuple[str, str]], gateway, judge_model: str = "fast") -> int` where each tuple is `(quote, chunk_id)`. Resolves the chunk + its document, verifies the quote, adds verified `MessageCitation` rows (`db.add` + flush), returns the count added.
+
+- [ ] **Step 1: Write the failing test** (`api/tests/autonomous/test_ledger_bridge_kb.py`). Reuse `kb_with_one_indexed_file` (gives a real chunk with known text) + a manufactured chat/message:
+
+```python
+import pytest
+from app.autonomous.ledger_bridge import build_kb_citations
+from app.models.chat import Chat, Message, MessageCitation
+from app.models.document import DocumentChunk
+from sqlalchemy import select
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def _msg(db, owner_id):
+    chat = Chat(owner_id=owner_id, title="t")
+    db.add(chat)
+    await db.flush()
+    msg = Message(chat_id=chat.id, role="assistant", content="wp")
+    db.add(msg)
+    await db.flush()
+    return msg
+
+
+async def test_build_kb_citations_verifies_and_persists(db_session, kb_with_one_indexed_file):
+    chunk = (await db_session.execute(
+        select(DocumentChunk).where(DocumentChunk.id == kb_with_one_indexed_file.chunk_id)
+    )).scalar_one()
+    quote = chunk.content[:40]  # an exact verbatim span
+    # owner: reuse the chunk's KB owner via the document's file owner is heavy; make a fresh user.
+    from app.models.user import User
+    from app.security import hash_password
+    user = User(email="kb-bridge@x.com", hashed_password=hash_password("p"), role="member",
+                is_admin=False, mfa_enabled=False, must_change_password=False)
+    db_session.add(user)
+    await db_session.flush()
+    msg = await _msg(db_session, user.id)
+
+    n = await build_kb_citations(
+        db_session, message_id=msg.id,
+        citations=[(quote, str(kb_with_one_indexed_file.chunk_id))], gateway=None,
+    )
+    assert n == 1
+    rows = (await db_session.execute(
+        select(MessageCitation).where(MessageCitation.message_id == msg.id)
+    )).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].verified is True
+    assert rows[0].source_text == quote
+    assert rows[0].verification_method is not None
+
+
+async def test_build_kb_citations_drops_unverifiable(db_session, kb_with_one_indexed_file):
+    from app.models.user import User
+    from app.security import hash_password
+    user = User(email="kb-bridge2@x.com", hashed_password=hash_password("p"), role="member",
+                is_admin=False, mfa_enabled=False, must_change_password=False)
+    db_session.add(user)
+    await db_session.flush()
+    msg = await _msg(db_session, user.id)
+    n = await build_kb_citations(
+        db_session, message_id=msg.id,
+        citations=[("text that does not appear anywhere", str(kb_with_one_indexed_file.chunk_id))],
+        gateway=None,
+    )
+    assert n == 0  # honest: unverifiable quote dropped, no row
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_ledger_bridge_kb.py -v`
+Expected: FAIL — module/function missing.
+
+- [ ] **Step 3: Implement** (`api/app/autonomous/ledger_bridge.py`):
+
+```python
+"""WS-D PR2 — bridge a matter session's structured citations into the chat-path
+ledger + fiduciary gate. Reuses the character-fidelity verifier + assemble +
+gate unchanged; only the citation-candidate front-end is session-specific.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.citation.extraction import CitationCandidate, locate_in_chunk
+from app.citation.verification import verify
+from app.models.chat import MessageCitation
+from app.models.document import Document, DocumentChunk
+
+log = logging.getLogger(__name__)
+
+
+async def build_kb_citations(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    citations: list[tuple[str, str]],  # (quote, chunk_id)
+    gateway: Any,
+    judge_model: str = "fast",
+) -> int:
+    added = 0
+    for quote, chunk_id in citations:
+        try:
+            chunk = (await db.execute(
+                select(DocumentChunk).where(DocumentChunk.id == uuid.UUID(str(chunk_id)))
+            )).scalar_one_or_none()
+            if chunk is None:
+                continue
+            span = locate_in_chunk(quote, chunk.content)
+            if span is None:
+                continue
+            in_start, in_end = span
+            doc = (await db.execute(
+                select(Document).where(Document.id == chunk.document_id)
+            )).scalar_one_or_none()
+            if doc is None:
+                continue
+            candidate = CitationCandidate(
+                source_file_id=chunk.document.file_id if hasattr(chunk, "document") else doc.file_id,
+                source_document_id=chunk.document_id,
+                source_offset_start=chunk.char_offset_start + in_start,
+                source_offset_end=chunk.char_offset_start + in_end,
+                source_page=chunk.page_start,
+                source_text=quote,
+            )
+            result = await verify(candidate, doc, gateway=gateway, judge_model=judge_model)
+            if not result.verified:
+                continue
+            db.add(MessageCitation(
+                message_id=message_id,
+                source_file_id=candidate.source_file_id,
+                source_offset_start=candidate.source_offset_start,
+                source_offset_end=candidate.source_offset_end,
+                source_page=candidate.source_page,
+                source_text=quote,
+                verified=True,
+                verification_method=result.method,
+                verification_confidence=result.confidence,
+                partial=result.partial,
+                tier_envelope=result.tier_envelope,
+            ))
+            added += 1
+        except Exception:  # one bad citation must not sink the rest (honest, per-item)
+            log.warning("kb citation build skipped", extra={"event": "autonomous_kb_citation_skip"}, exc_info=True)
+    await db.flush()
+    return added
+```
+
+(Confirm `verify`'s exact signature/kwargs at `verification.py:545` and `Document`'s document-protocol fields — it must satisfy `_DocumentProtocol` (`normalized_content`, `was_ocrd`, `id`). If `verify` needs a `_DocumentProtocol` wrapper rather than the raw `Document`, build the same wrapper `_persist_message_citations` uses — grep `chats.py:_persist_message_citations` for the doc object it passes.)
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_ledger_bridge_kb.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/ledger_bridge.py api/tests/autonomous/test_ledger_bridge_kb.py
+git commit -s -m "feat(autonomous): KB structured-citation ledger builder (WS-D PR2)"
+```
+
+---
+
+### Task 6: Caselaw structured-citation builder (`ledger_bridge.build_caselaw_citations`)
+
+**Files:**
+- Modify: `api/app/autonomous/ledger_bridge.py`
+- Test: `api/tests/autonomous/test_ledger_bridge_caselaw.py` (new)
+
+**Interfaces:**
+- Consumes: `locate_passage`/`opinion_target`/`_CaselawCandidate` (`caselaw.py:153/162/170`), `verify`, `ResearchOpinionMetadata`, `read_opinion` (`research/service.py:210`), `MessageCaselawCitation`.
+- Produces: `async build_caselaw_citations(db, *, message_id, citations: list[tuple[str, str]], gateway, judge_model="fast", load_opinion_text=...) -> int` where each tuple is `(quote, cluster_id)`.
+
+- [ ] **Step 1: Write the failing test** (`api/tests/autonomous/test_ledger_bridge_caselaw.py`). Seed a `ResearchOpinionMetadata` row + stub `read_opinion` to return known text:
+
+```python
+import pytest
+from app.autonomous.ledger_bridge import build_caselaw_citations
+from app.models.chat import Chat, Message
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.research import ResearchOpinionMetadata
+from app.models.user import User
+from app.security import hash_password
+from sqlalchemy import select
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+OPINION_TEXT = "The court holds that the assignment clause survives the change of control."
+
+
+async def _msg(db):
+    user = User(email=f"cl-{__import__('uuid').uuid4().hex[:6]}@x.com", hashed_password=hash_password("p"),
+                role="member", is_admin=False, mfa_enabled=False, must_change_password=False)
+    db.add(user)
+    await db.flush()
+    chat = Chat(owner_id=user.id, title="t")
+    db.add(chat)
+    await db.flush()
+    msg = Message(chat_id=chat.id, role="assistant", content="wp")
+    db.add(msg)
+    await db.flush()
+    return msg
+
+
+async def test_build_caselaw_citations_verifies(db_session):
+    db_session.add(ResearchOpinionMetadata(opinion_id=900, cluster_id=42, storage_path="x/900"))
+    await db_session.flush()
+    msg = await _msg(db_session)
+
+    async def fake_load(db, *, opinion_id):
+        return {"text": OPINION_TEXT}
+
+    n = await build_caselaw_citations(
+        db_session, message_id=msg.id,
+        citations=[("assignment clause survives the change of control", "42")],
+        gateway=None, load_opinion_text=fake_load,
+    )
+    assert n == 1
+    row = (await db_session.execute(
+        select(MessageCaselawCitation).where(MessageCaselawCitation.message_id == msg.id)
+    )).scalar_one()
+    assert row.cluster_id == 42 and row.opinion_id == 900 and row.verified is True
+
+
+async def test_build_caselaw_citations_unknown_cluster_skipped(db_session):
+    msg = await _msg(db_session)
+
+    async def fake_load(db, *, opinion_id):
+        return {"text": OPINION_TEXT}
+
+    n = await build_caselaw_citations(
+        db_session, message_id=msg.id, citations=[("x", "9999")], gateway=None, load_opinion_text=fake_load,
+    )
+    assert n == 0  # no metadata for cluster 9999
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_ledger_bridge_caselaw.py -v`
+Expected: FAIL — function missing.
+
+- [ ] **Step 3: Implement** — append to `ledger_bridge.py`:
+
+```python
+from collections.abc import Awaitable, Callable
+
+from app.citation.caselaw import _CaselawCandidate, locate_passage, opinion_target
+from app.models.message_caselaw_citation import MessageCaselawCitation
+from app.models.research import ResearchOpinionMetadata
+from app.research.service import read_opinion as _default_read_opinion
+
+_LoadOpinion = Callable[..., Awaitable[dict[str, Any]]]
+
+
+async def build_caselaw_citations(
+    db: AsyncSession,
+    *,
+    message_id: uuid.UUID,
+    citations: list[tuple[str, str]],  # (quote, cluster_id)
+    gateway: Any,
+    judge_model: str = "fast",
+    load_opinion_text: _LoadOpinion = _default_read_opinion,
+) -> int:
+    added = 0
+    for quote, cluster_id in citations:
+        try:
+            meta = (await db.execute(
+                select(ResearchOpinionMetadata).where(
+                    ResearchOpinionMetadata.cluster_id == int(cluster_id)
+                )
+            )).scalars().first()
+            if meta is None:
+                continue
+            opinion = await load_opinion_text(db, opinion_id=meta.opinion_id)
+            text = str((opinion or {}).get("text") or "")
+            span = locate_passage(quote, text)
+            if span is None:
+                continue
+            start, end = span
+            target = opinion_target(meta.opinion_id, text)
+            candidate = _CaselawCandidate(
+                source_offset_start=start, source_offset_end=end,
+                source_text=quote, source_document_id=target.id,
+            )
+            result = await verify(candidate, target, gateway=gateway, judge_model=judge_model)
+            if not result.verified:
+                continue
+            db.add(MessageCaselawCitation(
+                message_id=message_id, opinion_id=meta.opinion_id, cluster_id=meta.cluster_id,
+                source_offset_start=start, source_offset_end=end, source_text=quote,
+                verified=True, verification_method=result.method,
+                verification_confidence=result.confidence, partial=result.partial,
+            ))
+            added += 1
+        except Exception:
+            log.warning("caselaw citation build skipped",
+                        extra={"event": "autonomous_caselaw_citation_skip"}, exc_info=True)
+    await db.flush()
+    return added
+```
+
+(Confirm `locate_passage`/`opinion_target`/`_CaselawCandidate` are importable from `caselaw.py`; if module-private (`_`-prefixed), import them by their actual names — grep `caselaw.py`. Confirm `read_opinion`'s kwargs.)
+
+- [ ] **Step 4: Run — expect pass**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_ledger_bridge_caselaw.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/ledger_bridge.py api/tests/autonomous/test_ledger_bridge_caselaw.py
+git commit -s -m "feat(autonomous): caselaw structured-citation ledger builder (WS-D PR2)"
+```
+
+---
+
+### Task 7: Bridge orchestration (`build_session_ledger`) + delivery wiring
+
+**Files:**
+- Modify: `api/app/autonomous/ledger_bridge.py` (`build_session_ledger`)
+- Modify: `api/app/autonomous/nodes.py` (delivery node calls the bridge; embeds verdict in `session.result`)
+- Test: `api/tests/autonomous/test_session_ledger.py` (new — end-to-end-ish)
+
+**Interfaces:**
+- Consumes: `build_kb_citations`/`build_caselaw_citations` (Tasks 5/6), `assemble_ledger_entries` (`ledger.py:32`), `compute_and_record_gate` (`gate.py:33`), `Chat`/`Message` models, `AutonomousSession`.
+- Produces: `async build_session_ledger(db, *, session: AutonomousSession, work_product_text: str, findings: list[dict], evidence: list[dict], gateway, judge_model="fast") -> dict | None` — manufactures the hidden chat+message, splits each finding's `citations` into kb/caselaw by the evidence registry `kind`, builds rows, runs assemble+gate, returns `{gate_status, pass_count, supported_count, fail_count, total_assertions, confidence}` (or `None` if no citations resolved / on failure).
+
+- [ ] **Step 1: Write the failing test** (`api/tests/autonomous/test_session_ledger.py`):
+
+```python
+import pytest
+from app.autonomous.ledger_bridge import build_session_ledger
+from app.models.autonomous import AutonomousSession
+from app.models.chat import Chat
+from app.models.citation_ledger_entry import CitationLedgerEntry
+from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
+from app.models.user import User
+from app.security import hash_password
+from sqlalchemy import select
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def test_build_session_ledger_creates_hidden_chat_entries_and_gate(db_session, kb_with_one_indexed_file):
+    from app.models.document import DocumentChunk
+    chunk = (await db_session.execute(
+        select(DocumentChunk).where(DocumentChunk.id == kb_with_one_indexed_file.chunk_id)
+    )).scalar_one()
+    quote = chunk.content[:40]
+    user = User(email="sl@x.com", hashed_password=hash_password("p"), role="member",
+                is_admin=False, mfa_enabled=False, must_change_password=False)
+    db_session.add(user)
+    await db_session.flush()
+    sess = AutonomousSession(user_id=user.id, trigger_kind="manual", params={"query": "q"})
+    db_session.add(sess)
+    await db_session.flush()
+
+    verdict = await build_session_ledger(
+        db_session, session=sess, work_product_text="Work product.",
+        findings=[{"title": "T", "summary": "S", "severity": "info",
+                   "citations": [{"quote": quote, "source": 1}]}],
+        evidence=[{"n": 1, "kind": "kb", "ref": str(kb_with_one_indexed_file.chunk_id),
+                   "content": chunk.content, "display": "nda.pdf"}],
+        gateway=None,
+    )
+    assert verdict is not None and verdict["gate_status"] in {"fiduciary_grade", "supported_only", "flagged"}
+
+    chat = (await db_session.execute(
+        select(Chat).where(Chat.autonomous_session_id == sess.id)
+    )).scalar_one()  # hidden chat manufactured
+    entries = (await db_session.execute(
+        select(CitationLedgerEntry).where(CitationLedgerEntry.chat_id == chat.id)
+    )).scalars().all()
+    assert len(entries) >= 1
+    gate = (await db_session.execute(
+        select(WorkProductFiduciaryGate).where(WorkProductFiduciaryGate.chat_id == chat.id)
+    )).scalar_one()
+    assert gate.gate_status == verdict["gate_status"]
+
+
+async def test_build_session_ledger_no_citations_returns_none(db_session):
+    user = User(email="sl2@x.com", hashed_password=hash_password("p"), role="member",
+                is_admin=False, mfa_enabled=False, must_change_password=False)
+    db_session.add(user)
+    await db_session.flush()
+    sess = AutonomousSession(user_id=user.id, trigger_kind="manual", params={"query": "q"})
+    db_session.add(sess)
+    await db_session.flush()
+    verdict = await build_session_ledger(
+        db_session, session=sess, work_product_text="No citations.",
+        findings=[{"title": "T", "summary": "S", "severity": "info", "citations": []}],
+        evidence=[], gateway=None,
+    )
+    assert verdict is None  # nothing to ledger → no manufactured chat
+    assert (await db_session.execute(
+        select(Chat).where(Chat.autonomous_session_id == sess.id)
+    )).scalar_one_or_none() is None
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_session_ledger.py -v`
+Expected: FAIL — `build_session_ledger` missing.
+
+- [ ] **Step 3: Implement** — append to `ledger_bridge.py`:
+
+```python
+from app.citation.gate import compute_and_record_gate
+from app.citation.ledger import assemble_ledger_entries
+from app.models.autonomous import AutonomousSession
+from app.models.chat import Chat, Message
+
+
+async def build_session_ledger(
+    db: AsyncSession,
+    *,
+    session: AutonomousSession,
+    work_product_text: str,
+    findings: list[dict[str, Any]],
+    evidence: list[dict[str, Any]],
+    gateway: Any,
+    judge_model: str = "fast",
+) -> dict[str, Any] | None:
+    by_n = {int(e["n"]): e for e in evidence if isinstance(e.get("n"), int)}
+    kb: list[tuple[str, str]] = []
+    cl: list[tuple[str, str]] = []
+    for f in findings:
+        for c in f.get("citations") or []:
+            ev = by_n.get(c.get("source"))
+            if ev is None or not isinstance(c.get("quote"), str):
+                continue
+            if ev["kind"] == "kb":
+                kb.append((c["quote"], ev["ref"]))
+            elif ev["kind"] == "caselaw":
+                cl.append((c["quote"], ev["ref"]))
+    if not kb and not cl:
+        return None  # nothing citable → no manufactured chat, no gate
+
+    chat = Chat(
+        owner_id=session.user_id,
+        project_id=session.project_id,
+        title=f"Matter session {session.id}",
+        autonomous_session_id=session.id,
+    )
+    db.add(chat)
+    await db.flush()
+    message = Message(chat_id=chat.id, role="assistant", content=work_product_text)
+    db.add(message)
+    await db.flush()
+
+    await build_kb_citations(db, message_id=message.id, citations=kb, gateway=gateway, judge_model=judge_model)
+    await build_caselaw_citations(db, message_id=message.id, citations=cl, gateway=gateway, judge_model=judge_model)
+    await assemble_ledger_entries(db, message_id=message.id)
+    gate = await compute_and_record_gate(db, message_id=message.id)
+    if gate is None:
+        return None
+    return {
+        "gate_status": gate.gate_status,
+        "pass_count": gate.pass_count,
+        "supported_count": gate.supported_count,
+        "fail_count": gate.fail_count,
+        "total_assertions": gate.total_assertions,
+        "confidence": float(gate.confidence) if gate.confidence is not None else None,
+    }
+```
+
+- [ ] **Step 4: Wire the delivery node** (`nodes.py` `make_delivery_node` → `delivery_node`). Before `session.result = await build_receipt_safe(...)`, for a matter session, call the bridge best-effort and merge the verdict into the receipt:
+
+```python
+        receipt = await build_receipt_safe(session, db)
+        plan_trace = state.get("analysis_plan_trace")
+        if isinstance(receipt, dict) and plan_trace is not None:
+            receipt["plan_trace"] = plan_trace
+        # WS-D PR2: fiduciary ledger + gate for matter sessions (best-effort).
+        findings = state.get("findings") or []
+        evidence = state.get("analysis_evidence") or []
+        work_product = state.get("analysis_content") or ""
+        if findings and evidence and work_product:
+            try:
+                from app.autonomous.ledger_bridge import build_session_ledger
+
+                verdict = await build_session_ledger(
+                    db, session=session, work_product_text=work_product,
+                    findings=findings, evidence=evidence, gateway=gateway,
+                )
+                if verdict is not None and isinstance(receipt, dict):
+                    receipt["fiduciary_gate"] = verdict
+            except Exception:
+                logger.warning("autonomous ledger bridge failed",
+                               extra={"event": "autonomous_ledger_bridge_failed",
+                                      "session_id": session_id}, exc_info=True)
+        session.result = receipt
+```
+
+NOTE: `state["findings"]` carries the drafting node's emitted findings WITHOUT the `citations` key (drafting strips/ignores it). The bridge needs findings WITH `citations`. Resolve by having the drafting node forward the parsed findings (incl. `citations`) in a separate state key `analysis_findings_with_citations`, OR re-parse `analysis_content` in the delivery wiring via `parse_structured_output(work_product)`. PREFER re-parsing in delivery (single source, no extra state): replace `findings = state.get("findings") or []` with:
+
+```python
+        from app.autonomous.structured_output import parse_structured_output
+        parsed = parse_structured_output(state.get("analysis_content"))
+        findings = parsed.findings if parsed.is_structured else []
+```
+
+- [ ] **Step 5: Run — expect pass + autonomous suite (solo)**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_session_ledger.py tests/autonomous -q`
+Expected: PASS (incl. the existing delivery/receipt tests — query-less sessions emit no findings/evidence → bridge not called → `session.result` unchanged).
+
+- [ ] **Step 6: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/autonomous/ledger_bridge.py api/app/autonomous/nodes.py api/tests/autonomous/test_session_ledger.py
+git commit -s -m "feat(autonomous): session ledger bridge + delivery wiring (WS-D PR2)"
+```
+
+---
+
+### Task 8: Session-ledger read endpoint
+
+**Files:**
+- Modify: the autonomous sessions router (grep `@router.get` in `api/app/api/autonomous.py` — confirm the file/prefix; sessions live under `/api/v1/autonomous/sessions`)
+- Test: `api/tests/autonomous/test_session_ledger_endpoint.py` (new)
+
+**Interfaces:**
+- Consumes: the chat ledger read path — find the function the chat `GET /chats/{chat_id}/ledger` handler calls (grep `def .*ledger` in `api/app/api/chats.py` and `api/app/citation/ledger.py`; likely a `resolve_ledger`/`resolve_gates` pair). Reuse it scoped to the manufactured chat.
+- Produces: `GET /api/v1/autonomous/sessions/{session_id}/ledger` → the same response shape the chat ledger endpoint returns; `404` if the session has no ledger (no manufactured chat yet); `403`/`404` if the session is not owned by the caller.
+
+- [ ] **Step 1: Write the failing test** (`api/tests/autonomous/test_session_ledger_endpoint.py`). Build a session ledger via `build_session_ledger` (Task 7) then GET it:
+
+```python
+import pytest
+from app.autonomous.ledger_bridge import build_session_ledger
+from app.models.autonomous import AutonomousSession
+from app.models.document import DocumentChunk
+from sqlalchemy import select
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def test_session_ledger_endpoint_returns_entries(
+    db_session, client, kb_with_one_indexed_file, owner_user
+):
+    chunk = (await db_session.execute(
+        select(DocumentChunk).where(DocumentChunk.id == kb_with_one_indexed_file.chunk_id)
+    )).scalar_one()
+    quote = chunk.content[:40]
+    sess = AutonomousSession(user_id=owner_user.id, trigger_kind="manual", params={"query": "q"})
+    db_session.add(sess)
+    await db_session.flush()
+    await build_session_ledger(
+        db_session, session=sess, work_product_text="wp",
+        findings=[{"title": "T", "summary": "S", "severity": "info",
+                   "citations": [{"quote": quote, "source": 1}]}],
+        evidence=[{"n": 1, "kind": "kb", "ref": str(kb_with_one_indexed_file.chunk_id),
+                   "content": chunk.content, "display": "nda.pdf"}],
+        gateway=None,
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/ledger",
+        headers={"Authorization": _bearer_for(owner_user)},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["gate"]["gate_status"] in {"fiduciary_grade", "supported_only", "flagged"}
+    assert len(body["entries"]) >= 1
+
+
+async def test_session_ledger_endpoint_404_without_ledger(db_session, client, owner_user):
+    sess = AutonomousSession(user_id=owner_user.id, trigger_kind="manual", params={})
+    db_session.add(sess)
+    await db_session.commit()
+    resp = await client.get(
+        f"/api/v1/autonomous/sessions/{sess.id}/ledger",
+        headers={"Authorization": _bearer_for(owner_user)},
+    )
+    assert resp.status_code == 404
+```
+
+(Adapt `client`/`owner_user`/`_bearer_for` to the autonomous router's existing endpoint-test fixtures — grep `api/tests/autonomous/test_sessions_api.py` for the established client + auth pattern and reuse it verbatim.)
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_session_ledger_endpoint.py -v`
+Expected: FAIL — 404 route not found.
+
+- [ ] **Step 3: Implement the endpoint.** First grep the chat ledger handler to find the reusable resolve function:
+`grep -n "ledger" api/app/api/chats.py | head` and `grep -n "def resolve" api/app/citation/ledger.py api/app/citation/gate.py`.
+Then add to the autonomous sessions router (mirror the existing GET handlers' auth dependency + ownership check):
+
+```python
+@router.get("/sessions/{session_id}/ledger")
+async def get_session_ledger(
+    session_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    session = await db.get(AutonomousSession, session_id)
+    if session is None or session.user_id != user.id:
+        raise HTTPException(status_code=404, detail="session not found")
+    chat = (await db.execute(
+        select(Chat).where(Chat.autonomous_session_id == session_id)
+    )).scalar_one_or_none()
+    if chat is None:
+        raise HTTPException(status_code=404, detail="session has no ledger")
+    entries = await resolve_ledger(db, chat_id=chat.id)   # reuse the chat ledger read path
+    gates = await resolve_gates(db, chat_id=chat.id)
+    return {"entries": entries, "gate": gates[0] if gates else None}
+```
+
+(Use the EXACT reuse functions + response serialization the chat `/ledger` endpoint uses — match its response schema so the PR2-UI can reuse the chat ledger component. If the chat endpoint returns Pydantic models, return the same models, not raw dicts.)
+
+- [ ] **Step 4: Register the route count.** If `api/tests/test_openapi.py` pins the exact path count + `EXPECTED_PATHS`, add `/api/v1/autonomous/sessions/{session_id}/ledger` and bump the count; add the route to `IMPLEMENTED_ROUTES` in `api/tests/test_endpoints.py` if present (collision-guard — see CLAUDE.md).
+
+- [ ] **Step 5: Run — expect pass + openapi/endpoints guards**
+
+Run: `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest tests/autonomous/test_session_ledger_endpoint.py tests/test_openapi.py tests/test_endpoints.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Gates + commit**
+
+```bash
+cd api && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app
+git add api/app/api/autonomous.py api/tests/autonomous/test_session_ledger_endpoint.py api/tests/test_openapi.py api/tests/test_endpoints.py
+git commit -s -m "feat(autonomous): session-ledger read endpoint (WS-D PR2)"
+```
+
+---
+
+## Final gate (before requesting review — CI scope, repo root, SOLO suite)
+
+- [ ] **api full gates:**
+```bash
+cd /Users/kevinkeller/Code/lq-ai
+api/.venv/bin/ruff check api scripts && api/.venv/bin/ruff format --check api scripts
+cd api && .venv/bin/mypy app
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:55432/lqai_test .venv/bin/python -m pytest -q   # SOLO — no concurrent pytest (DE-368)
+```
+- [ ] **gateway full gates:** `cd gateway && .venv/bin/ruff check app tests && .venv/bin/ruff format --check app tests && .venv/bin/mypy app --strict && .venv/bin/python -m pytest -q` (PR2 doesn't touch gateway; confirm no incidental break).
+- [ ] **migration verified** on a throwaway pgvector (0063 up/down).
+- [ ] **PRD/ADR bookkeeping:** note WS-D PR2 status; file DE-369 only if one surfaces.
+- [ ] **Opus whole-branch review** (SDD final) — required; it has caught a real gate-passing defect on every slice this milestone.
+- [ ] **Push origin + tucuxi → open the security-gated PR (NO self-merge) → mirror after merge.**
+
+## Plan self-review (completed)
+
+- **Spec coverage:** C1 hidden chat → Task 1; `locate_in_chunk` promotion → Task 2; C2 evidence registry → Task 3; C3 structured citations → Task 4; C4 KB builder → Task 5, caselaw builder → Task 6, orchestration + delivery → Task 7; C5 read endpoint → Task 8. Best-effort/P3/backward-compat constraints are folded into Tasks 3/7. PR2-UI explicitly deferred.
+- **Placeholder scan:** real code + commands throughout. The two "grep + confirm" notes (verify()'s doc-protocol wrapper in Task 5; the chat ledger resolve function names in Task 8) are explicit verification steps against existing code, not logic placeholders — the implementer confirms the exact existing signature before calling it.
+- **Type consistency:** `EvidenceItem(n,kind,ref,content,display)`, `collect_evidence`, `build_kb_citations((quote,chunk_id))`, `build_caselaw_citations((quote,cluster_id))`, `build_session_ledger(...) -> dict|None` with `{gate_status,pass_count,supported_count,fail_count,total_assertions,confidence}`, and the `findings[*].citations=[{quote,source}]` shape are consistent across Tasks 3–8.

--- a/docs/superpowers/specs/2026-06-28-wsd-pr2-ledger-gate-design.md
+++ b/docs/superpowers/specs/2026-06-28-wsd-pr2-ledger-gate-design.md
@@ -1,0 +1,82 @@
+# WS-D PR2 — Fiduciary Ledger + Gate for Matter Sessions (Design)
+
+**Status:** Approved (2026-06-28, maintainer) · **Security-gated** (migration + `api/app/autonomous/**` + `api/app/citation/**` + `chats.py`).
+**ADR:** [0020](../../adr/0020-governed-agentic-legal-matter-sessions.md) D6 (PR2 scope) · reuse anchors: [0016](../../adr/0016-transparency-and-governance-invariants.md) P6 (one governance path), [0018](../../adr/0018-citation-ledger-and-fiduciary-grade-output.md) (ledger + gate), [0019](../../adr/0019-transparent-validity-treatment-layer.md) D7 (P3 storage).
+**Predecessor:** WS-D PR1 (#239, merged `7dd8ac6`) — the governed agentic loop + matter intake. PR1 produces `analysis_content` (fenced-JSON findings) + `analysis_plan_trace` and writes the receipt to `session.result`. PR2 adds **no ledger/gate fork** — it routes the session's work product through the *same* cascade the chat path uses.
+
+## Goal
+
+A matter-scoped autonomous session produces the **same** `citation_ledger_entry` + `work_product_fiduciary_gate` rows a chat turn produces, so a reviewer traces a session's citations exactly as they trace a chat turn's, and the work product is honestly labeled `fiduciary_grade` / `supported_only` / `flagged`. Achieved by manufacturing a **hidden session-owned chat + message** and feeding **structured citations** through the existing character-fidelity verifier → `assemble_ledger_entries` → `compute_and_record_gate`.
+
+## Non-goals (deferred)
+
+- The Svelte session-ledger **UI** → **PR2-UI follow-up** (self-merge after CI; mirrors the WS-G PR1 → PR1-UI split).
+- MCP source provenance in the session ledger (WS-F is Phase 3).
+- `treatment_id` linkage (WS-G; the column stays null per ADR 0018 D6).
+- Metered-source cost (DE-344 lands in WS-E).
+
+## Load-bearing invariants
+
+1. **Reuse, do not fork (ADR 0016 P6 / 0020 D6):** the session writes the *same* `message_citations` / `message_caselaw_citations` / `citation_ledger_entry` / `work_product_fiduciary_gate` rows the chat path writes; it reuses the fidelity verifier (`verify()`), `assemble_ledger_entries`, and `compute_and_record_gate` unchanged. No parallel ledger/gate.
+2. **Strictly additive / backward-compat:** query-less (non-matter) sessions are unchanged — no manufactured chat, no ledger/gate, `session.result` unchanged. Only sessions whose analysis produced a matter work product run the cascade.
+3. **Best-effort, never blocks delivery:** the entire cascade is wrapped (try/except → log) exactly like the chat path's three call sites and PR1's brake-commit discipline. A cascade failure leaves the session delivered with an honest receipt, never crash-loops the worker.
+4. **P3 (ADR 0016 / 0019 D7):** the planner keeps seeing only compact observations (counts/ids/case-names/short snippets); audit, `analysis_plan_trace`, and ledger rows store offsets/labels/status/ids — never raw opinion/chunk payloads. The synthesis call legitimately receives gathered evidence content (the model's working context), but that content is never persisted to audit/trace.
+5. **Hidden chat is invisible in the chat surface:** a session-owned chat (`autonomous_session_id IS NOT NULL`) never appears in `list_chats` / `search_chats`; it is reachable only by direct id (the read endpoint).
+6. **Honest labeling (ADR 0018 D3):** a work product is `fiduciary_grade` only when every assertion is ledger-backed and passing; unverifiable quotes are dropped/flagged exactly as the chat path does — never fabricated to inflate the gate.
+
+## Verified reuse surface (file:line)
+
+- `assemble_ledger_entries(db, *, message_id)` — `api/app/citation/ledger.py:32`. Self-derives `chat_id`/`project_id`; reads `message_citations` + `message_caselaw_citations` + `message_tool_sources` by `message_id` (tool-sources optional). Writes `citation_ledger_entry`, flushes, never commits.
+- `compute_and_record_gate(db, *, message_id)` — `api/app/citation/gate.py:33`. Reads `citation_ledger_entry` by `message_id`; upserts one `work_product_fiduciary_gate` row (pass/supported/fail counts + status). Flushes, never commits. `resolve_gates` (gate.py:111) is the read path.
+- Fidelity verifier — `verify(candidate, document, *, gateway=None, judge_model=...)` `api/app/citation/verification.py:545`; deterministic stages `verify_exact_match` (152), `verify_tolerant_match` (183). Takes `_CandidateProtocol` (offset_start/end, source_text, source_document_id) + `_DocumentProtocol`. **Separable from prose extraction.**
+- KB offset resolution — `_locate_in_chunk(quote, chunk_content)` `api/app/citation/extraction.py:128` → promote to public `locate_in_chunk` (single fidelity-threshold source). `CitationCandidate` dataclass at extraction.py:87.
+- Caselaw primitives — `locate_passage` `api/app/citation/caselaw.py:170`, `opinion_target` (162), `_CaselawCandidate` (153); cluster→opinion via `ResearchOpinionMetadata` (`api/app/models/research.py:31`); text via `read_opinion(db, opinion_id=...)` `api/app/research/service.py:210`.
+- `MessageCitation` model `api/app/models/chat.py:225` (NOT NULL: message_id, source_file_id, source_offset_start/end, source_text, verified, partial; if verified→verification_method required). `MessageCaselawCitation` `api/app/models/message_caselaw_citation.py:23` (NOT NULL: message_id, opinion_id, cluster_id, offsets, source_text, verified, partial).
+- `Chat` model `api/app/models/chat.py:54` (no visibility column today → migration). `list_chats` filter `api/app/api/chats.py:743`; `search_chats` 655/681. Chat manufacture pattern `create_chat` chats.py:556. `Message` minimal row: `chat_id`, `role="assistant"`, `content` (chat.py:123).
+- `AutonomousSession` `api/app/models/autonomous.py`: `user_id` (91), `project_id` (96), `result` JSON (124). No chat link today.
+- Latest migration `0062`; **next = `0063`**.
+
+## Components
+
+### C1 — Migration 0063: hidden session-owned chat
+Add `chats.autonomous_session_id UUID NULL FK → autonomous_sessions.id ON DELETE SET NULL` + partial index `WHERE autonomous_session_id IS NOT NULL`. Template: `0056_chat_sticky_skills.py`. Update `docs/db-schema.md` (chats table). Add `Chat.autonomous_session_id` to the ORM. Add `.where(Chat.autonomous_session_id.is_(None))` to the base `stmt` in `list_chats` (chats.py:743) and the two `search_chats` subqueries (655/681). `_load_visible_chat` (340) is left as-is (direct GET by id still resolves — the read endpoint needs it).
+
+### C2 — Loop evidence registry (planner stays P3)
+`_run_analysis_loop` (`api/app/autonomous/nodes.py`) accumulates a per-session **evidence registry**: each successful `retrieve_chunks` / `retrieve_caselaw` act appends entries with a stable source number `N` → `{n, kind: "kb"|"caselaw", chunk_id | cluster_id, content, ...display}`. The planner observation summaries are unchanged (P3). `summarize_observation` for caselaw additionally includes the `cluster_id` (an id, P3-OK) so the synthesis can reference it. The registry is loop-local state returned for synthesis + delivery; it is **not** written to `analysis_plan_trace`/audit.
+
+### C3 — Structured citations on the synthesis output
+Extend the synthesis structured-output schema: each finding gains `citations: [{quote: str, source: int}]` where `source` indexes the evidence registry. `assemble_synthesis_messages` presents the evidence as a **numbered source list** and instructs the model to support each finding with verbatim quotes tagged to a source number. `parse_structured_output` tolerantly parses the new key (absent → empty; unknown source numbers → dropped). Drafting/`emit_finding` is unchanged (ignores `citations`). The findings + registry flow to the delivery node via state.
+
+### C4 — Delivery cascade (structured → verifier → ledger → gate)
+New module `api/app/autonomous/ledger_bridge.py` (keeps `nodes.py` focused) exposing `build_session_ledger(db, *, session, work_product_text, findings, evidence, gateway) -> GateVerdict | None`. In the delivery node, for a matter session with a parsed work product, before `build_receipt_safe`:
+1. Manufacture `Chat`(autonomous_session_id=session.id, owner_id=session.user_id, project_id=session.project_id, title=f"Matter session {session.id}") + `Message`(role="assistant", content=work_product_text). Flush to get `message_id`.
+2. For each finding citation, resolve `source N` → evidence; **KB:** `DocumentChunk` by `chunk_id` → `locate_in_chunk(quote, content)` → doc-absolute offsets → `CitationCandidate` → `verify()` → `MessageCitation` (verified rows only). **Caselaw:** `cluster_id` → `ResearchOpinionMetadata` → `read_opinion` → `locate_passage` → `verify()` → `MessageCaselawCitation`.
+3. `assemble_ledger_entries(db, message_id)` → `compute_and_record_gate(db, message_id)`.
+4. Return the gate verdict; the delivery node embeds `{gate_status, pass_count, supported_count, fail_count, total_assertions, confidence}` into `session.result["fiduciary_gate"]` alongside `plan_trace`.
+All wrapped best-effort (invariant 3). The synthesis `judge_model` follows the session's model setting; tolerant/exact stages run deterministically, the judge stage opt-in via the gateway (same as chat).
+
+### C5 — Read endpoint
+`GET /api/v1/autonomous/sessions/{session_id}/ledger` (autonomous router): authorize the session owner, find the chat via `autonomous_session_id == session_id`, reuse the existing ledger-resolve + `resolve_gates` read path scoped to that chat, and return the same ledger/gate response shape the chat ledger endpoint returns (404 if the session has no ledger yet).
+
+## Error handling
+
+- Cascade wrapped best-effort in delivery; a failure logs (`event="autonomous_ledger_bridge_failed"`) and delivery proceeds with the receipt sans `fiduciary_gate`. Never crash the worker (DE-325 discipline).
+- Async-session safety (PR1 C1 lesson): the bridge does only well-formed ORM inserts + the existing flush-only cascade; no model-arg-driven SQL. A `DBAPIError` would propagate to the delivery node's existing handling; the bridge does not swallow exceptions in a way that poisons the session (it runs after the loop, before the terminal commit, and its try/except logs then skips — the terminal commit still persists status).
+- Unverifiable quotes: dropped (KB) / FAIL-row convention (caselaw, offsets 0..len) exactly as the chat path — honest, never fabricated.
+
+## Testing
+
+- **Unit:** the structured-citation adapter — KB (`locate_in_chunk` + `verify` → `MessageCitation`) and caselaw (`locate_passage` + `verify` → `MessageCaselawCitation`) for verified / unverified / partial; evidence-number → source resolution; tolerant parse of the new `citations` key.
+- **Integration:** scripted matter session end-to-end (PR1's `_ScriptedGateway` + seeded KB + seeded `ResearchOpinionMetadata`) → asserts real `citation_ledger_entry` + `work_product_fiduciary_gate` rows on the manufactured chat; `session.result["fiduciary_gate"].gate_status` set; the manufactured chat **excluded** from `list_chats`/`search_chats` but resolvable by the read endpoint; query-less session unchanged (no chat, no gate).
+- **Migration:** verified on a throwaway `pgvector` (conftest auto-migrates); `0063` up/down.
+- **Gates (CI scope, repo root):** `ruff check api scripts` + `ruff format --check api scripts` + whole-app `mypy app` + full api suite **run solo** (the PR1 lesson: do not run concurrent pytest against the shared `lqai_test` DB — DE-368).
+
+## PR structure & merge gating
+
+- **PR2 (this slice, security-gated):** migration 0063 + `chats.py` filters, loop evidence registry, synthesis schema, `ledger_bridge.py` + delivery wiring, read endpoint, tests. → security/maintainer merge, **no self-merge**; mirror `origin/main → tucuxi` after.
+- **PR2-UI (follow-up):** Svelte session-ledger view in `web/`, mirroring the chat ledger UI. Self-merge after CI.
+
+## Open items folded into the plan
+
+- Promote `_locate_in_chunk` → public `locate_in_chunk` (single fidelity-threshold source).
+- `next migration = 0063`; `next DE = DE-369` (DE-368 was filed in PR1 verification).


### PR DESCRIPTION
## WS-D PR2 — Fiduciary ledger + gate for matter sessions

Makes an autonomous **matter session** produce the *same* citation-ledger (`citation_ledger_entry`) + fiduciary-gate (`work_product_fiduciary_gate`) rows a chat turn produces — so a reviewer traces a session's citations exactly as they trace a chat turn's, and the work product is honestly labeled `fiduciary_grade` / `supported_only` / `flagged`. ADR [0020](docs/adr/0020-governed-agentic-legal-matter-sessions.md) D6. **Reuse, do not fork** (ADR 0016 P6): the session writes the same rows and calls `verify()` / `assemble_ledger_entries` / `compute_and_record_gate` unchanged.

Builds on WS-D PR1 (#239, the governed agentic loop). PR1 produced findings + a plan trace; PR2 makes them ledger-backed and gate-labeled.

### How it works
1. **Hidden session-owned chat (migration 0063):** `chats.autonomous_session_id` FK → `autonomous_sessions.id ON DELETE SET NULL`. At delivery, a matter session manufactures a `Chat`+`Message` carrying the work product, marked session-owned so it's **excluded from `list_chats`/`search_chats`** (reachable only by the read endpoint). This gives the cascade the `message_id → chat_id` identity it requires, with zero schema fork of the ledger/gate.
2. **Loop evidence registry (P3-safe):** the analysis loop accumulates a numbered registry of the authority it gathered (KB chunks + caselaw). The **planner** still sees only compact observations; the **synthesis** additionally receives the numbered evidence so it can quote-and-cite. Raw chunk/opinion content never enters the trace, audit, or receipt.
3. **Structured per-finding citations:** the synthesis emits `citations: [{quote, source}]` per finding, tagged to the evidence numbers.
4. **Delivery cascade:** for each citation, the existing **character-fidelity verifier** (`verify()`) checks the quoted span against the authoritative source (KB chunk / cached opinion) and persists a `MessageCitation`/`MessageCaselawCitation` **only when verified** — unverifiable quotes are dropped, never fabricated. Then the unchanged `assemble_ledger_entries` + `compute_and_record_gate` run, and the gate verdict is embedded in `session.result["fiduciary_gate"]` alongside PR1's `plan_trace`.
5. **Read endpoint:** `GET /api/v1/autonomous/sessions/{id}/ledger` → owner-scoped (404 for missing/non-owned), returns the **identical** `{chat_id, entries, gates}` shape as the chat ledger endpoint (so the PR2-UI follow-up reuses the chat ledger component directly).

### Load-bearing invariants (all test-pinned)
- **Reuse-not-fork:** same rows, verifier/assemble/gate called unchanged.
- **Strictly additive:** query-less / non-matter sessions are byte-identical — no manufactured chat, no ledger/gate, `session.result` unchanged.
- **Robustness (the PR1-C1 lesson):** the delivery-time bridge is **SAVEPOINT-isolated** (`db.begin_nested()`); a flush failure inside it rolls back only the bridge's writes and the terminal commit still succeeds — **no zombie running session**. A dedicated regression test injects a partial-write-then-raise bridge stub and asserts the session still reaches `completed` with no orphaned chat.
- **Honest labeling (ADR 0018 D3):** a citation row is persisted only when `verify()` confirms it; the gate reflects only verified assertions.
- **P3:** evidence `content` is synthesis-context only; ledger rows store offsets/labels/ids.
- **Security/authz:** read endpoint 404s (no existence leak) for non-owned sessions.

### Review trail (subagent-driven development)
8 TDD tasks, each implemented → spec-review → quality-review clean (Task 8 had one fix wave: response-shape harmonization + a cross-user 404 test). The **Opus whole-branch review** then found no Critical/Important *code* defect — savepoint isolation, evidence numbering (no fidelity false-positive), P3, honest-labeling, hidden-chat filter, and reuse-not-fork all verified — and one Important **test gap** (no regression test on the PR1-C1 savepoint surface), now fixed, plus two trivial hardenings (read-endpoint `.first()`; `raise` over `return None` on an unreachable gate-None path). A focused re-review confirmed the fixes and adjudicated a `SAWarning` on the new test as a **test-harness artifact** (the conftest's double-SAVEPOINT nesting; production has no outer harness savepoint) — proven non-actionable by the passing orphan-chat assertion.

### Test evidence
- Solo full api suite: **2460 passed, 1 skipped, 0 failed**. (Per DE-368, the suite is serial-only against the shared test DB; concurrent pytest runs produce spurious research/MCP/gateway failures — those are not real.)
- `ruff check`/`ruff format --check` (`api scripts`) + whole-app `mypy` clean. Gateway untouched.
- New tests: hidden-chat exclusion; `locate_in_chunk`; evidence registry; structured-citation parse; KB + caselaw structured-citation builders (verified/unverifiable/empty-quote); `build_session_ledger` (happy path + no-citations skip); the savepoint-isolation regression; the read endpoint (happy / no-ledger 404 / cross-user 404).

### Deferred / follow-ups (not blockers)
- **PR2-UI** (separate, self-merge after CI): the Svelte session-ledger view, reusing the chat ledger component.
- **DE-369 (product call):** `user_export` includes session-owned chats in the GDPR export ZIP — arguably correct (it's the user's own data; "hidden" was about the chat-list UI), surfaced for a decision.
- **Shared-gate semantics (note, not a PR2 fork):** a work product where every citation is unverifiable yields zero assertions → `fiduciary_grade` ("nothing checkable → top grade"). This is inherited from the shared gate and affects the chat path identically; flagging for a possible shared-gate DE.
- Cosmetic minors logged (db-schema partial-index doc line; backend-openapi.yaml sketch one path behind — `test_openapi.py` is the authoritative conformance check and is green).

### Scope deferred to later WS-D / WS-E
MCP source provenance in the ledger (WS-F, Phase 3); `treatment_id` linkage (WS-G; column stays null); metered-source cost (DE-344, WS-E).

🔒 **Security-gated** (migration + `api/app/autonomous/**` + `api/app/citation/**` + `chats.py` + a new authed endpoint) — routed to security review. **Do not self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
