### PR TITLE
build(windows): enforce LF line endings on entrypoint scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce LF line endings for all shell scripts to prevent Docker execution failures on Windows
+*.sh text eol=lf


### PR DESCRIPTION
## What this PR does

This PR adds a root-level `.gitattributes` file to enforce LF (Linux-style) line endings for all shell scripts (`*.sh`).

## Why

On Windows hosts, Git often defaults to converting line endings to CRLF (`core.autocrlf = true`) upon checkout. When copied into Linux-based Docker containers, these carriage returns (`\r`) corrupt the shebang execution, causing immediate startup crashes such as:
`exec /usr/local/bin/lq-ai-gateway-entrypoint.sh: no such file or directory`

Enforcing LF endings at the repository level ensures the stack boots out-of-the-box on Windows development environments without manual line-ending conversion.

## What this PR does *not* do

This PR does not modify any application logic, database schemas, or API endpoints. It is strictly limited to file formatting and repository-level Git configurations for Windows compatibility.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Skill contribution (see attestation below)
- [ ] Refactor (no behavioral change)
- [x] Test / CI / tooling

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] Manually tested against a real deployment (describe scenario below)
- [ ] Acceptance test plan updated (if changing skill behavior)

<details>
<summary>Manual testing notes (if applicable)</summary>

* **Environment:** Windows 11 host running Docker Desktop (without WSL backend) and PowerShell.
* **Initial State:** Running `docker compose up -d` on a fresh checkout resulted in `lq-ai-gateway-1` failing its healthcheck and immediately exiting with the `no such file or directory` entrypoint execution error.
* **Action:** Created `.gitattributes` with `*.sh text eol=lf`, converted `gateway/entrypoint.sh` and `api/entrypoint.sh` line endings from CRLF to LF, and ran `docker compose build --no-cache gateway api` to rebuild.
* **Result:** Ran `docker compose up -d` again. All 9 containers successfully started, passed their respective healthchecks, and entered a `Healthy` state.

</details>

## Documentation

- [ ] PRD updated (if user-facing behavior changes)
- [ ] README updated (if quickstart or capability list changes)
- [ ] Skill-authoring guide updated (if skill conventions change)
- [ ] Deployment cookbook updated (if deployment changes)
- [ ] Compliance documentation updated (if compliance posture changes)
- [ ] OpenAPI schema regenerated (if API endpoints change)

## Transparency & governance invariants

- [ ] **Egress (P1):** n/a
- [ ] **Closed set (P2):** n/a
- [ ] **No raw payloads (P3):** n/a
- [ ] **Fail restrictive (P4):** n/a
- [ ] **Atomic audit (P5):** n/a
- [ ] **One governance path (P6):** n/a
- [ ] **Human gate (P7):** n/a
- [ ] **Operator control (P8):** n/a
- [ ] **User owns data (P9):** n/a
- [x] **Contract is truth (P10):** Included `.gitattributes` inside this PR to maintain repository environment standards.

## DCO sign-off

- [x] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

## Related issues

Resolves local Windows development startup failures.

---

## Reviewer notes

None. The change is lightweight and standard for cross-platform repositories containing executable scripts.