### PR TITLE
fix(web): attach chat files to the model and keep their status live

### DIFF
--- a/web/src/lib/lq-ai/__tests__/ChatPanel-attach-file.test.ts
+++ b/web/src/lib/lq-ai/__tests__/ChatPanel-attach-file.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for the chat-attach-file-context bugfix.
+ *
+ * Convention note: matches the ChatPanel-slash-detect.test.ts pattern —
+ * pure helpers are exported from <script context="module"> in the .svelte
+ * file and exercised here without mounting the (large) component, since
+ * @testing-library/svelte is unavailable for this file (see that test's
+ * header for the full rationale).
+ *
+ * Covers two fixes:
+ *   - Attached chat files never reached the model because sendMessage()
+ *     never included file_ids in the request body. fileIdsForSend() is
+ *     the extracted mapping.
+ *   - The attached-file status badge stayed frozen at "pending" forever
+ *     because nothing re-fetched ingestion_status after upload.
+ *     hasPendingFileStatus() is the extracted predicate the polling loop
+ *     keys off.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { hasPendingFileStatus, fileIdsForSend } from '../components/ChatPanel.svelte';
+import type { FileMeta } from '../types';
+
+function makeFile(overrides: Partial<FileMeta> = {}): FileMeta {
+	return {
+		id: 'file-1',
+		owner_id: 'user-1',
+		filename: 'contract.pdf',
+		mime_type: 'application/pdf',
+		size_bytes: 1024,
+		ingestion_status: 'pending',
+		created_at: '2026-01-01T00:00:00Z',
+		...overrides
+	};
+}
+
+describe('hasPendingFileStatus', () => {
+	it('returns false for an empty file list', () => {
+		expect(hasPendingFileStatus([])).toBe(false);
+	});
+
+	it('returns true when a file is pending', () => {
+		expect(hasPendingFileStatus([makeFile({ ingestion_status: 'pending' })])).toBe(true);
+	});
+
+	it('returns true when a file is processing', () => {
+		expect(hasPendingFileStatus([makeFile({ ingestion_status: 'processing' })])).toBe(true);
+	});
+
+	it('returns false when all files are ready', () => {
+		expect(hasPendingFileStatus([makeFile({ ingestion_status: 'ready' })])).toBe(false);
+	});
+
+	it('returns false when all files are failed', () => {
+		expect(hasPendingFileStatus([makeFile({ ingestion_status: 'failed' })])).toBe(false);
+	});
+
+	it('returns true if any file among several is still pending', () => {
+		const files = [
+			makeFile({ id: 'a', ingestion_status: 'ready' }),
+			makeFile({ id: 'b', ingestion_status: 'pending' }),
+			makeFile({ id: 'c', ingestion_status: 'failed' })
+		];
+		expect(hasPendingFileStatus(files)).toBe(true);
+	});
+
+	it('returns false when ingestion_status is undefined (no non-terminal match)', () => {
+		expect(hasPendingFileStatus([makeFile({ ingestion_status: undefined })])).toBe(false);
+	});
+});
+
+describe('fileIdsForSend', () => {
+	it('returns undefined for an empty file list (omits the field, not [])', () => {
+		expect(fileIdsForSend([])).toBeUndefined();
+	});
+
+	it('returns the id of a single attached file', () => {
+		expect(fileIdsForSend([makeFile({ id: 'abc-123' })])).toEqual(['abc-123']);
+	});
+
+	it('preserves attachment order across multiple files', () => {
+		const files = [makeFile({ id: 'first' }), makeFile({ id: 'second' }), makeFile({ id: 'third' })];
+		expect(fileIdsForSend(files)).toEqual(['first', 'second', 'third']);
+	});
+});

--- a/web/src/lib/lq-ai/components/ChatPanel.svelte
+++ b/web/src/lib/lq-ai/components/ChatPanel.svelte
@@ -40,6 +40,30 @@
 			slashIndex
 		};
 	}
+
+	/**
+	 * Pure helpers for attached-file status polling / send-payload wiring
+	 * (bugfix: chat-attach-file-context). Exposed here for the same reason
+	 * as detectSlashAt above — vitest exercises them without mounting the
+	 * component, since @testing-library/svelte is unavailable for this file
+	 * (see ChatPanel-slash-detect.test.ts header). FileMeta is imported
+	 * once, in the instance <script> below — svelte-check treats a .svelte
+	 * file's module + instance scripts as one type-checking unit, so
+	 * importing the same named type in both blocks is flagged as a
+	 * duplicate identifier even though they're separate JS scopes at
+	 * runtime.
+	 */
+	import type { FileMeta } from '$lib/lq-ai/types';
+
+	export function hasPendingFileStatus(files: FileMeta[]): boolean {
+		return files.some(
+			(f) => f.ingestion_status === 'pending' || f.ingestion_status === 'processing'
+		);
+	}
+
+	export function fileIdsForSend(files: FileMeta[]): string[] | undefined {
+		return files.length > 0 ? files.map((f) => f.id) : undefined;
+	}
 </script>
 
 <script lang="ts">
@@ -61,7 +85,7 @@
 	 * surfaced per-message.
 	 */
 	import { get } from 'svelte/store';
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 
 	import {
@@ -84,7 +108,10 @@
 	} from '$lib/lq-ai/stores';
 	import { consumeMessageStream } from '$lib/lq-ai/sse/parser';
 	import { buildAuthorizeUrl, type PendingGate } from '$lib/lq-ai/chat/toolGate';
-	import type { Chat, FileMeta, Message, Project, Skill } from '$lib/lq-ai/types';
+	// FileMeta is imported in the module <script> above; svelte-check
+	// treats module + instance scripts as one type-checking unit, so
+	// re-importing it here is flagged as a duplicate identifier.
+	import type { Chat, Message, Project, Skill } from '$lib/lq-ai/types';
 
 	import ChatSidebar from '$lib/lq-ai/components/ChatSidebar.svelte';
 	import AttachedFilesPanel from '$lib/lq-ai/components/AttachedFilesPanel.svelte';
@@ -435,6 +462,44 @@
 	}
 
 	// ---- file panel handlers ----
+
+	// Ingestion runs async in the ingest-worker after the upload response
+	// returns, so chatFiles' ingestion_status is frozen at upload-time
+	// ("pending"/"processing") until something re-fetches it. Poll while any
+	// attached file is non-terminal; stop once all are ready/failed.
+	// hasPendingFileStatus is the pure predicate, exported from the module
+	// block above so it's unit-testable without mounting this component.
+	const FILE_STATUS_POLL_INTERVAL_MS = 3000;
+	let fileStatusPollHandle: ReturnType<typeof setInterval> | null = null;
+
+	function stopFileStatusPoll(): void {
+		if (fileStatusPollHandle !== null) {
+			clearInterval(fileStatusPollHandle);
+			fileStatusPollHandle = null;
+		}
+	}
+
+	function ensureFileStatusPoll(): void {
+		if (fileStatusPollHandle !== null || !hasPendingFileStatus(chatFiles)) return;
+		fileStatusPollHandle = setInterval(async () => {
+			const pending = chatFiles.filter(
+				(f) => f.ingestion_status === 'pending' || f.ingestion_status === 'processing'
+			);
+			if (pending.length === 0) {
+				stopFileStatusPoll();
+				return;
+			}
+			try {
+				const refreshed = await Promise.all(pending.map((f) => filesApi.getFile(f.id)));
+				const byId = new Map(refreshed.map((f) => [f.id, f]));
+				chatFiles = chatFiles.map((f) => byId.get(f.id) ?? f);
+			} catch (e) {
+				console.error('lq-ai: file status poll failed', e);
+			}
+			if (!hasPendingFileStatus(chatFiles)) stopFileStatusPoll();
+		}, FILE_STATUS_POLL_INTERVAL_MS);
+	}
+
 	async function uploadAttached(file: File) {
 		uploading = true;
 		try {
@@ -442,6 +507,7 @@
 				project_id: $activeChatStore?.project_id ?? undefined
 			});
 			chatFiles = [...chatFiles, uploaded];
+			ensureFileStatusPoll();
 		} catch (e) {
 			console.error('lq-ai: upload failed', e);
 		} finally {
@@ -638,6 +704,7 @@
 						Object.keys(skillInputs).length > 0
 							? (skillInputs as Record<string, Record<string, unknown>>)
 							: undefined,
+					file_ids: fileIdsForSend(chatFiles),
 					// Issue #207 finding 4 — only send set_sticky on a real toggle
 					// change; otherwise leave the chat's sticky set unchanged.
 					set_sticky: stickyDirty ? stickyEnabled : undefined,
@@ -862,6 +929,10 @@
 				composerText = stash;
 			}
 		}
+	});
+
+	onDestroy(() => {
+		stopFileStatusPoll();
 	});
 
 	$: groups = $chatsByProject;

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -370,6 +370,12 @@ export interface MessageCreate {
 	 * `false` clears the set; omitted leaves it unchanged. Off by default.
 	 */
 	set_sticky?: boolean | null;
+	/**
+	 * IDs of files attached to this turn for document context (separate
+	 * channel from skill_inputs — see api/app/schemas/chats.py
+	 * MessageCreateRequest.file_ids). Echoed back as applied_file_ids.
+	 */
+	file_ids?: string[];
 }
 
 export interface MessagePostResponse {


### PR DESCRIPTION
## What this PR does

Fixes two bugs in the per-message attach-file flow: attached files never reached the model (the request body never included `file_ids`), and the attached-file status badge stayed frozen at "pending" forever after upload.

## Why

Uploading a file to a chat and asking the model about it silently failed — the model would answer as if no file was attached, with no error surfaced anywhere. Separately, the status badge never reflected real ingestion progress, so a user had no way to tell when a file was actually ready to be referenced.

## What this PR does *not* do

Does not touch the project-level attached-files feature (`attached_file_ids` on `Project`, surfaced read-only via `projectFiles`) — that's a separate, already-working code path. Does not add a UI affordance for manually retrying a failed ingestion; that's out of scope.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests added/updated

`web/src/lib/lq-ai/__tests__/ChatPanel-attach-file.test.ts` — 10 tests covering `hasPendingFileStatus()` and `fileIdsForSend()`, the two pure functions extracted into `ChatPanel.svelte`'s module block (mirroring the existing `detectSlashAt` convention, since `@testing-library/svelte` is unavailable for this file — see that test's header for the rationale).

<details>
<summary>Manual testing notes</summary>

Verified end-to-end against a locally running stack:
1. Uploaded a PDF to a chat, watched the attached-files panel badge transition from "pending" to "ready" within a few seconds (previously stayed on "pending" indefinitely).
2. Asked the model a question about the document's content — it answered from the real document text (previously it had no access to the file at all).
3. Confirmed via the gateway's audit log that `inference.message_files_attached` events show `injected_count` matching `attached_count` for the turn.
4. Confirmed via direct DB inspection that `documents.normalized_content` was populated and the ~33K-character contract text was genuinely being injected as a system message before the user turn.

</details>

## Documentation

*(no boxes checked — internal bugfix, no user-facing capability or doc change)*

## Transparency & governance invariants

- [x] **Egress (P1):** n/a — no new outbound call; uses the existing `GET /files/{id}` endpoint already called elsewhere in this file.
- [x] **Closed set (P2):** n/a — no new model/autonomous capability.
- [x] **No raw payloads (P3):** n/a — no new logging.
- [x] **Fail restrictive (P4):** the status-poll `catch` block logs and leaves the badge at its last-known state rather than throwing; a failed poll doesn't break the chat.
- [x] **Atomic audit (P5):** n/a — no new state-changing endpoint.
- [x] **One governance path (P6):** n/a.
- [x] **Human gate (P7):** n/a — no destructive action.
- [x] **Operator control (P8):** n/a.
- [x] **User owns data (P9):** n/a — no new data flow; `file_ids` uses the backend's pre-existing, already-anonymization-aware injection path.
- [x] **Contract is truth (P10):** n/a — `file_ids` was already documented in the backend's `MessageCreateRequest` schema; this PR only wires the frontend to use it.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO

## Related issues

None filed — found and fixed during manual testing of an unrelated feature.

## Reviewer notes

Two independent root causes in the same file, landed together since they were found and fixed in one pass:

1. `sendMessage()` never included `file_ids: chatFiles.map(f => f.id)` in the `messagesApi.sendMessageStream()` call — the backend's `file_ids` channel (`api/app/schemas/chats.py::MessageCreateRequest.file_ids`) was fully implemented and unused.
2. `uploadAttached()` pushed the upload-response file object into `chatFiles` once and nothing ever re-fetched it, so `ingestion_status` stayed frozen at its upload-time value. Added lightweight polling (3s interval, stops once every attached file reaches a terminal status) rather than reusing the existing chat-streaming SSE infrastructure — smaller diff, matches this repo's other non-realtime status patterns.

Would appreciate a second look at the polling interval/approach if there's a preference for SSE instead.
