### PR TITLE
fix(web): persist per-chat model selection across page refresh

### DIFF
--- a/web/src/lib/lq-ai/__tests__/ChatPanel-model-persist.test.ts
+++ b/web/src/lib/lq-ai/__tests__/ChatPanel-model-persist.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression test for the model-selection-persist-refresh bugfix.
+ *
+ * Convention note: mirrors ReceiptsDrawer.test.ts exactly — pure
+ * localStorage helpers exported from <script context="module"> in the
+ * .svelte file, exercised here with an injectable MockStorage, without
+ * mounting the (large) component (@testing-library/svelte is unavailable
+ * for this file — see ChatPanel-slash-detect.test.ts header).
+ *
+ * Bug: modelByChat was a component-local Record with no persistence, so a
+ * full page refresh remounted the component, reset modelByChat to {}, and
+ * currentModelId's reactive fallback silently picked the picker's default
+ * — discarding the user's chosen model for that chat.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+	modelStorageKeyForChat,
+	readPersistedModel,
+	writePersistedModel
+} from '../components/ChatPanel.svelte';
+
+class MockStorage implements Storage {
+	private map = new Map<string, string>();
+	get length() {
+		return this.map.size;
+	}
+	key(i: number): string | null {
+		return Array.from(this.map.keys())[i] ?? null;
+	}
+	getItem(k: string): string | null {
+		return this.map.get(k) ?? null;
+	}
+	setItem(k: string, v: string): void {
+		this.map.set(k, v);
+	}
+	removeItem(k: string): void {
+		this.map.delete(k);
+	}
+	clear(): void {
+		this.map.clear();
+	}
+}
+
+describe('modelStorageKeyForChat', () => {
+	it('namespaces by chat ID', () => {
+		expect(modelStorageKeyForChat('c1')).toBe('lq_ai_chat_model_c1');
+		expect(modelStorageKeyForChat('uuid-here')).toBe('lq_ai_chat_model_uuid-here');
+	});
+});
+
+describe('readPersistedModel', () => {
+	it('returns null for an unset chat', () => {
+		const s = new MockStorage();
+		expect(readPersistedModel('c1', s)).toBeNull();
+	});
+
+	it('returns the persisted model id', () => {
+		const s = new MockStorage();
+		s.setItem(modelStorageKeyForChat('c1'), 'anthropic-prod/claude-opus-4-8');
+		expect(readPersistedModel('c1', s)).toBe('anthropic-prod/claude-opus-4-8');
+	});
+
+	it('scopes reads per chat id (no cross-chat bleed)', () => {
+		const s = new MockStorage();
+		s.setItem(modelStorageKeyForChat('c1'), 'model-a');
+		s.setItem(modelStorageKeyForChat('c2'), 'model-b');
+		expect(readPersistedModel('c1', s)).toBe('model-a');
+		expect(readPersistedModel('c2', s)).toBe('model-b');
+	});
+});
+
+describe('writePersistedModel', () => {
+	it('writes the model id under the chat-scoped key', () => {
+		const s = new MockStorage();
+		writePersistedModel('c1', 'openai-prod/gpt-5', s);
+		expect(s.getItem(modelStorageKeyForChat('c1'))).toBe('openai-prod/gpt-5');
+	});
+
+	it('overwrites a prior selection for the same chat', () => {
+		const s = new MockStorage();
+		writePersistedModel('c1', 'model-a', s);
+		writePersistedModel('c1', 'model-b', s);
+		expect(readPersistedModel('c1', s)).toBe('model-b');
+	});
+});
+
+describe('write→read round-trip', () => {
+	it('survives a simulated refresh (new read using the same backing store)', () => {
+		const s = new MockStorage();
+		writePersistedModel('c1', 'anthropic-prod/claude-opus-4-8', s);
+		// Simulate remount: a fresh read against the same storage instance
+		// (localStorage itself survives a page refresh; only in-memory state
+		// like modelByChat does not).
+		expect(readPersistedModel('c1', s)).toBe('anthropic-prod/claude-opus-4-8');
+	});
+});

--- a/web/src/lib/lq-ai/__tests__/ChatPanel-model-persist.test.ts
+++ b/web/src/lib/lq-ai/__tests__/ChatPanel-model-persist.test.ts
@@ -16,7 +16,8 @@ import { describe, it, expect } from 'vitest';
 import {
 	modelStorageKeyForChat,
 	readPersistedModel,
-	writePersistedModel
+	writePersistedModel,
+	readAvailablePersistedModel
 } from '../components/ChatPanel.svelte';
 
 class MockStorage implements Storage {
@@ -38,6 +39,32 @@ class MockStorage implements Storage {
 	}
 	clear(): void {
 		this.map.clear();
+	}
+}
+
+/**
+ * A Storage whose getItem/setItem throw, modelling Safari private mode, a
+ * disabled-storage policy, or a quota-exceeded write. The helpers must
+ * swallow the exception so chat selection keeps working.
+ */
+class ThrowingStorage implements Storage {
+	get length(): number {
+		return 0;
+	}
+	key(): string | null {
+		return null;
+	}
+	getItem(): string | null {
+		throw new DOMException('getItem blocked', 'SecurityError');
+	}
+	setItem(): void {
+		throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+	}
+	removeItem(): void {
+		throw new DOMException('removeItem blocked', 'SecurityError');
+	}
+	clear(): void {
+		throw new DOMException('clear blocked', 'SecurityError');
 	}
 }
 
@@ -92,5 +119,39 @@ describe('write→read round-trip', () => {
 		// (localStorage itself survives a page refresh; only in-memory state
 		// like modelByChat does not).
 		expect(readPersistedModel('c1', s)).toBe('anthropic-prod/claude-opus-4-8');
+	});
+});
+
+describe('Storage failure is non-fatal', () => {
+	it('readPersistedModel returns null when getItem throws', () => {
+		expect(readPersistedModel('c1', new ThrowingStorage())).toBeNull();
+	});
+
+	it('writePersistedModel swallows a throwing setItem (no exception)', () => {
+		expect(() =>
+			writePersistedModel('c1', 'anthropic-prod/claude-opus-4-8', new ThrowingStorage())
+		).not.toThrow();
+	});
+});
+
+describe('readAvailablePersistedModel', () => {
+	it('returns the persisted id when it is still in the catalog', () => {
+		const s = new MockStorage();
+		s.setItem(modelStorageKeyForChat('c1'), 'anthropic-prod/claude-opus-4-8');
+		expect(
+			readAvailablePersistedModel(
+				'c1',
+				['smart', 'anthropic-prod/claude-opus-4-8', 'openai-prod/gpt-5'],
+				s
+			)
+		).toBe('anthropic-prod/claude-opus-4-8');
+	});
+
+	it('returns null when the persisted id is no longer in the catalog', () => {
+		const s = new MockStorage();
+		s.setItem(modelStorageKeyForChat('c1'), 'anthropic-prod/claude-opus-4-7');
+		expect(
+			readAvailablePersistedModel('c1', ['smart', 'anthropic-prod/claude-opus-4-8'], s)
+		).toBeNull();
 	});
 });

--- a/web/src/lib/lq-ai/components/ChatPanel.svelte
+++ b/web/src/lib/lq-ai/components/ChatPanel.svelte
@@ -40,6 +40,35 @@
 			slashIndex
 		};
 	}
+
+	/**
+	 * Per-chat model-selection persistence (bugfix: model-selection-persist-
+	 * refresh). `modelByChat` was a component-local `Record` with no
+	 * persistence, so a full page refresh remounted the component, reset
+	 * modelByChat to `{}`, and currentModelId's reactive fallback silently
+	 * picked the picker's default — discarding the user's choice. Mirrors
+	 * ReceiptsDrawer.svelte's storageKeyForChat/readPersistedOpen/
+	 * writePersistedOpen convention (same file also uses a per-chat
+	 * localStorage key prefix, same optional injectable Storage param for
+	 * testability).
+	 */
+	const MODEL_STORAGE_KEY_PREFIX = 'lq_ai_chat_model_';
+
+	export function modelStorageKeyForChat(chatId: string): string {
+		return `${MODEL_STORAGE_KEY_PREFIX}${chatId}`;
+	}
+
+	export function readPersistedModel(chatId: string, storage?: Storage): string | null {
+		const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : null);
+		if (!store) return null;
+		return store.getItem(modelStorageKeyForChat(chatId));
+	}
+
+	export function writePersistedModel(chatId: string, modelId: string, storage?: Storage): void {
+		const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : null);
+		if (!store) return;
+		store.setItem(modelStorageKeyForChat(chatId), modelId);
+	}
 </script>
 
 <script lang="ts">
@@ -334,6 +363,7 @@
 		const chat = $activeChatStore;
 		if (!chat) return;
 		modelByChat = { ...modelByChat, [chat.id]: id };
+		writePersistedModel(chat.id, id);
 	}
 
 	async function selectChat(chat: Chat) {
@@ -349,6 +379,15 @@
 		// their status polls) so chat A's files are never sent from chat B.
 		abortFilePolls();
 		chatFiles = [];
+		// Hydrate this chat's remembered model choice from localStorage if we
+		// don't already have one in-memory (survives a page refresh; a
+		// same-session choice already in modelByChat always wins).
+		if (!(chat.id in modelByChat)) {
+			const persisted = readPersistedModel(chat.id);
+			if (persisted) {
+				modelByChat = { ...modelByChat, [chat.id]: persisted };
+			}
+		}
 		// Load messages.
 		try {
 			const page = await messagesApi.listMessages(chat.id, { limit: 100 });

--- a/web/src/lib/lq-ai/components/ChatPanel.svelte
+++ b/web/src/lib/lq-ai/components/ChatPanel.svelte
@@ -51,6 +51,12 @@
 	 * writePersistedOpen convention (same file also uses a per-chat
 	 * localStorage key prefix, same optional injectable Storage param for
 	 * testability).
+	 *
+	 * All three helpers treat persistence as best-effort: a `Storage`
+	 * that throws (Safari private mode, a disabled-storage policy, a
+	 * quota-exceeded write) must never break chat selection, so the
+	 * read/write helpers swallow the exception and fall through to the
+	 * existing default-selection behaviour.
 	 */
 	const MODEL_STORAGE_KEY_PREFIX = 'lq_ai_chat_model_';
 
@@ -61,13 +67,42 @@
 	export function readPersistedModel(chatId: string, storage?: Storage): string | null {
 		const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : null);
 		if (!store) return null;
-		return store.getItem(modelStorageKeyForChat(chatId));
+		try {
+			return store.getItem(modelStorageKeyForChat(chatId));
+		} catch {
+			return null;
+		}
 	}
 
 	export function writePersistedModel(chatId: string, modelId: string, storage?: Storage): void {
 		const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : null);
 		if (!store) return;
-		store.setItem(modelStorageKeyForChat(chatId), modelId);
+		try {
+			store.setItem(modelStorageKeyForChat(chatId), modelId);
+		} catch {
+			/* best-effort: private-mode / quota / disabled storage — skip */
+		}
+	}
+
+	/**
+	 * Pure resolver for a chat's remembered model choice: return the
+	 * persisted id only when it is still in the supplied catalog.
+	 *
+	 * A model the operator has since removed from the gateway must not be
+	 * shown by the picker — `selectModel()` never ran for this session, so
+	 * `currentModelId` would surface the stale id while the send path
+	 * (`MessageCreate.model`) falls back to the default alias. The picker
+	 * would then display one model and the request would use another.
+	 * Gating on `availableIds` keeps the two in lockstep.
+	 */
+	export function readAvailablePersistedModel(
+		chatId: string,
+		availableIds: readonly string[],
+		storage?: Storage
+	): string | null {
+		const persisted = readPersistedModel(chatId, storage);
+		if (persisted === null) return null;
+		return availableIds.includes(persisted) ? persisted : null;
 	}
 </script>
 
@@ -381,9 +416,14 @@
 		chatFiles = [];
 		// Hydrate this chat's remembered model choice from localStorage if we
 		// don't already have one in-memory (survives a page refresh; a
-		// same-session choice already in modelByChat always wins).
+		// same-session choice already in modelByChat always wins). Only accept
+		// a persisted id the current catalog still offers, so the picker can
+		// never show a model the send path would silently drop.
 		if (!(chat.id in modelByChat)) {
-			const persisted = readPersistedModel(chat.id);
+			const persisted = readAvailablePersistedModel(
+				chat.id,
+				availableModels.data.map((m) => m.id)
+			);
 			if (persisted) {
 				modelByChat = { ...modelByChat, [chat.id]: persisted };
 			}


### PR DESCRIPTION
## What this PR does

Persists a chat's selected model across a page refresh, by saving it to `localStorage`.

## Why

If a user picked a model for a chat and then refreshed the page, their choice was silently thrown away — the chat reverted to the default model with no warning. Root cause: the selected model was only ever held in memory (`modelByChat`, a component-local `Record`), never saved anywhere durable. A refresh remounts the component from scratch, so that in-memory value resets, and the picker's fallback logic quietly picks the default instead.

## What this PR does *not* do

Does not change the per-chat scoping of model selection (a deliberate, pre-existing design — different chats can already use different models; this PR only makes each chat's choice survive a refresh). Does not add cross-device/cross-browser persistence — this is a `localStorage` fix, scoped to one browser on one device, matching the severity of the bug.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests added/updated

`web/src/lib/lq-ai/__tests__/ChatPanel-model-persist.test.ts` — 7 tests, mirroring `ReceiptsDrawer.test.ts`'s `MockStorage` pattern exactly (same file already does per-chat `localStorage` persistence for a different feature — the receipts-drawer open state). Covers key-namespacing, read/write, cross-chat isolation, overwrite, and round-trip.

<details>
<summary>Manual testing notes</summary>

Verified against a locally running stack: picked a non-default model for a chat, sent a message, hard-refreshed the page — the picker still showed the previously-selected model instead of resetting to the default (`anthropic-prod`/`claude-opus-4-7`).

Also verified the race-condition concern doesn't apply: `loadShell()` (which populates `availableModels`, the picker's source list) is `await`ed in `onMount` before `selectChat` ever runs, so by the time a persisted model id is hydrated from `localStorage`, the picker's model list is already loaded.

</details>

## Documentation

*(no boxes checked — internal bugfix, no user-facing capability or doc change)*

## Transparency & governance invariants

- [x] **Egress (P1):** n/a — no outbound call involved; `localStorage` is a browser-local read/write.
- [x] **Closed set (P2):** n/a.
- [x] **No raw payloads (P3):** n/a — only a model-id string is persisted, no message content.
- [x] **Fail restrictive (P4):** `readPersistedModel`/`writePersistedModel` both no-op safely if `localStorage` is unavailable (SSR/private-browsing edge cases) — falls through to the existing default-selection behavior.
- [x] **Atomic audit (P5):** n/a.
- [x] **One governance path (P6):** n/a.
- [x] **Human gate (P7):** n/a.
- [x] **Operator control (P8):** n/a.
- [x] **User owns data (P9):** n/a — client-local preference only, not sent to the backend.
- [x] **Contract is truth (P10):** n/a — no API/schema change.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO

## Related issues

None filed — found during manual testing of an unrelated feature.

## Reviewer notes

`selectModel()` write-throughs to `localStorage` on every pick; `selectChat()` hydrates `modelByChat[chat.id]` from `localStorage` only when no in-session choice already exists, so a same-session pick is never clobbered by a stale persisted value.

