### PR TITLE
feat: reference matter documents in chat

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -97,13 +97,13 @@ from app.config import get_settings
 from app.db.session import get_db
 from app.errors import Conflict, InternalError, LQAIError, NotFound, ValidationError
 from app.knowledge.embed import DEFAULT_EMBEDDING_MODEL, request_embedding_vector
-from app.knowledge.retrieval import HybridSearchResult, hybrid_search
+from app.knowledge.retrieval import HybridSearchResult, hybrid_search, hybrid_search_files
 from app.models.chat import Chat, Message, MessageCitation
 from app.models.chat_pending_tool_call import ChatPendingToolCall
 from app.models.document import Document
 from app.models.file import File
 from app.models.inference import InferenceRoutingLog
-from app.models.knowledge import KnowledgeBase
+from app.models.knowledge import KnowledgeBase, KnowledgeBaseFile
 from app.models.message_tool_source import MessageToolSource
 from app.models.project import Project
 from app.models.project_knowledge_base import ProjectKnowledgeBase
@@ -410,6 +410,92 @@ async def _validate_owned_file_ids(
             )
 
     return [str(fid) for fid in parsed]
+
+
+async def _validate_referenced_file_ids(
+    db: AsyncSession,
+    referenced_file_ids: list[str],
+    *,
+    owner_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+) -> tuple[list[str], dict[str, float]]:
+    """Validate caller-referenced files for file-scoped retrieval (referenced-files).
+
+    KB-only MVP + matter scope: each id must (1) parse as a UUID, (2)
+    resolve to a caller-owned, non-deleted, ``ingestion_status='ready'``
+    file that (3) is attached to a Knowledge Base which is itself
+    attached to the chat's ``project_id``. Any id failing any check —
+    including a projectless chat (no matter, so nothing is referenceable)
+    — raises :class:`NotFound` (404), id-probing-safe and message-
+    identical to the nonexistent-id case, consistent with
+    :func:`_validate_owned_file_ids`.
+
+    Returns ``(validated_ids, alpha_by_id)``: ids as strings (deduped,
+    order-preserving) and each file's retrieval alpha — the MIN
+    ``hybrid_alpha`` across the matter KBs containing it (deterministic
+    when a file sits in several attached KBs; MIN favors the vector
+    side). Empty input returns ``([], {})`` without a DB round-trip.
+    """
+
+    if not referenced_file_ids:
+        return [], {}
+
+    # Parse + dedupe while preserving first-seen order, mirroring
+    # _validate_owned_file_ids's id-probing-safe posture: a malformed id
+    # is a 404 (not a 422) so it's indistinguishable from "not yours".
+    parsed: list[uuid.UUID] = []
+    seen: set[uuid.UUID] = set()
+    for raw in referenced_file_ids:
+        try:
+            fid = uuid.UUID(raw)
+        except (ValueError, AttributeError) as exc:
+            raise NotFound(
+                f"File {raw} not found.",
+                details={"file_id": str(raw)},
+            ) from exc
+        if fid not in seen:
+            seen.add(fid)
+            parsed.append(fid)
+
+    # A projectless chat has no matter, so nothing is referenceable —
+    # fail restrictive rather than run a query that can never match (P4).
+    if project_id is None:
+        raise NotFound(
+            f"File {parsed[0]} not found.",
+            details={"file_id": str(parsed[0])},
+        )
+
+    # Single SELECT for all ids: owner-scoped, ready, and joined through
+    # to a KB attached to this chat's project. func.min(hybrid_alpha)
+    # collapses multi-KB membership to one conservative (vector-favoring)
+    # alpha per file in the same round-trip.
+    stmt = (
+        select(File.id, func.min(KnowledgeBase.hybrid_alpha))
+        .join(KnowledgeBaseFile, KnowledgeBaseFile.file_id == File.id)
+        .join(KnowledgeBase, KnowledgeBase.id == KnowledgeBaseFile.kb_id)
+        .join(
+            ProjectKnowledgeBase,
+            ProjectKnowledgeBase.knowledge_base_id == KnowledgeBaseFile.kb_id,
+        )
+        .where(
+            File.id.in_(parsed),
+            File.owner_id == owner_id,
+            File.deleted_at.is_(None),
+            File.ingestion_status == "ready",
+            ProjectKnowledgeBase.project_id == project_id,
+        )
+        .group_by(File.id)
+    )
+    rows = (await db.execute(stmt)).all()
+    alpha_by_id: dict[str, float] = {str(fid): float(alpha) for fid, alpha in rows}
+    for fid in parsed:
+        if str(fid) not in alpha_by_id:
+            raise NotFound(
+                f"File {fid} not found.",
+                details={"file_id": str(fid)},
+            )
+
+    return [str(fid) for fid in parsed], alpha_by_id
 
 
 async def _load_attached_file_contexts(
@@ -951,6 +1037,20 @@ RAG_TOP_K_PER_KB: int = 5
 # context-prepend size when many KBs are attached.
 RAG_MAX_TOTAL_CHUNKS: int = 10
 
+# referenced-files — file-scoped retrieval for explicitly referenced files. An
+# explicit reference means "answer over THIS document": each referenced
+# file gets its own top-k budget (round-robin interleaved, so no file is
+# starved by a dominant sibling), and referenced chunks take priority
+# over KB-wide RAG chunks in the merged context set. When references are
+# present the merged bound rises to MERGED_MAX_TOTAL_CHUNKS (explicit
+# reference justifies the context spend — ADR 0022); referenced chunks
+# are capped at REFERENCED_MAX_CHUNKS so KB RAG always retains at least
+# four slots when it has results. Pure-KB turns keep the shipped
+# RAG_MAX_TOTAL_CHUNKS bound — zero behavior change.
+REFERENCED_TOP_K_PER_FILE: int = 6
+REFERENCED_MAX_CHUNKS: int = 12
+MERGED_MAX_TOTAL_CHUNKS: int = 16
+
 
 async def _load_attached_kb_ids_for_chat(
     db: AsyncSession, project_id: uuid.UUID
@@ -979,20 +1079,24 @@ async def _retrieve_kb_context_for_chat(
     query: str,
     gateway: GatewayClient,
     request_id: str | None,
-) -> tuple[list[HybridSearchResult], list[uuid.UUID]]:
+) -> tuple[list[HybridSearchResult], list[uuid.UUID], list[float] | None]:
     """Run hybrid search across every KB attached to the chat's project.
 
-    Returns a 2-tuple ``(chunks, kb_ids_searched)`` where ``chunks`` is
-    the merged-then-truncated list of :class:`HybridSearchResult`
-    ordered by descending ``hybrid_score`` (capped at
-    :data:`RAG_MAX_TOTAL_CHUNKS`) and ``kb_ids_searched`` is the list of
-    KB ids we actually queried (empty if the chat has no project or the
-    project has no KBs attached).
+    Returns a 3-tuple ``(chunks, kb_ids_searched, query_embedding)`` where
+    ``chunks`` is the merged-then-truncated list of
+    :class:`HybridSearchResult` ordered by descending ``hybrid_score``
+    (capped at :data:`RAG_MAX_TOTAL_CHUNKS`), ``kb_ids_searched`` is the
+    list of KB ids we actually queried (empty if the chat has no project
+    or the project has no KBs attached), and ``query_embedding`` is the
+    vector computed for ``query`` (``None`` on the early exits, on
+    all-FTS KBs, or on embed-fetch failure).
 
     The embedding for ``query`` is computed once and reused across every
     KB call — embed-on-read is the same shape as ``query_kb``. If the
     embed fetch fails we downgrade to FTS-only retrieval per KB (the
-    same fallback ``query_kb`` uses).
+    same fallback ``query_kb`` uses). The embedding is returned so the
+    referenced-files referenced-file pass can reuse it without a second embed call
+    (referenced files live in the same attached KBs).
 
     The audit-row write is the caller's responsibility — this helper
     only does retrieval. Empty-result handling is the caller's too
@@ -1000,11 +1104,11 @@ async def _retrieve_kb_context_for_chat(
     """
 
     if chat.project_id is None:
-        return [], []
+        return [], [], None
 
     kb_ids = await _load_attached_kb_ids_for_chat(db, chat.project_id)
     if not kb_ids:
-        return [], []
+        return [], [], None
 
     # Load KB rows (for hybrid_alpha per KB). One SELECT for the set.
     kb_stmt = select(KnowledgeBase).where(KnowledgeBase.id.in_(kb_ids))
@@ -1064,11 +1168,105 @@ async def _retrieve_kb_context_for_chat(
         merged.extend(results)
 
     if not merged:
-        return [], [kb.id for kb in kb_rows]
+        return [], [kb.id for kb in kb_rows], query_embedding
 
     merged.sort(key=lambda r: r.hybrid_score, reverse=True)
     top = merged[:RAG_MAX_TOTAL_CHUNKS]
-    return top, [kb.id for kb in kb_rows]
+    return top, [kb.id for kb in kb_rows], query_embedding
+
+
+async def _retrieve_referenced_file_context(
+    db: AsyncSession,
+    *,
+    referenced_file_ids: list[str],
+    alpha_by_id: dict[str, float],
+    query: str,
+    query_embedding: list[float] | None,
+) -> list[HybridSearchResult]:
+    """Per-file hybrid search for explicitly referenced files (referenced-files).
+
+    Ids are already validated (owned + matter-KB + ready) by
+    :func:`_validate_referenced_file_ids`, which also supplied each
+    file's matter-KB ``hybrid_alpha`` (MIN across containing KBs).
+    ``query_embedding`` is the one computed by the KB pass — referenced
+    files live in the same attached KBs, so no second embed call is made
+    (``None`` degrades to FTS-only, the same fallback the KB path uses).
+
+    Each file gets its own :data:`REFERENCED_TOP_K_PER_FILE` budget
+    (per-file, not global top-k, so one dominant document cannot starve
+    the others), and the per-file result lists are round-robin
+    interleaved up to :data:`REFERENCED_MAX_CHUNKS`. A per-file search
+    failure is logged and skipped (fail-soft, mirroring the per-KB loop).
+    """
+    if not referenced_file_ids:
+        return []
+
+    per_file: list[list[HybridSearchResult]] = []
+    for fid in referenced_file_ids:
+        alpha = alpha_by_id.get(fid, 0.5)
+        try:
+            results = await hybrid_search_files(
+                db,
+                file_ids=[uuid.UUID(fid)],
+                query=query,
+                query_embedding=query_embedding,
+                top_k=REFERENCED_TOP_K_PER_FILE,
+                alpha=alpha,
+            )
+        except Exception:
+            log.exception(
+                "chat-send referenced-files: hybrid_search_files failed for file; skipping",
+                extra={"event": "chat_ref_file_search_failed", "file_id": fid},
+            )
+            continue
+        if results:
+            per_file.append(results)
+
+    # Round-robin interleave so every referenced file is represented
+    # before any file gets a second slot. Order determines the [N]
+    # citation indices, so this is also a fairness property of the
+    # context block.
+    merged: list[HybridSearchResult] = []
+    seen: set[uuid.UUID] = set()
+    for rank in range(REFERENCED_TOP_K_PER_FILE):
+        for results in per_file:
+            if rank >= len(results):
+                continue
+            chunk = results[rank]
+            if chunk.chunk_id in seen:
+                continue
+            seen.add(chunk.chunk_id)
+            merged.append(chunk)
+            if len(merged) >= REFERENCED_MAX_CHUNKS:
+                return merged
+    return merged
+
+
+def _merge_retrieved_chunks(
+    referenced: list[HybridSearchResult],
+    kb: list[HybridSearchResult],
+) -> list[HybridSearchResult]:
+    """Merge referenced-file chunks (priority) with KB-RAG chunks.
+
+    Referenced chunks come first (explicit user intent), then KB chunks
+    not already present (deduped by ``chunk_id``). The cap is
+    :data:`MERGED_MAX_TOTAL_CHUNKS` when referenced chunks are present
+    (referenced ≤ REFERENCED_MAX_CHUNKS, so KB retains ≥ 4 slots) and
+    the shipped :data:`RAG_MAX_TOTAL_CHUNKS` otherwise (pure-KB turns
+    are byte-identical to pre-referenced-files behavior). Order determines the
+    ``[N]`` citation indices in the context block.
+    """
+    cap = MERGED_MAX_TOTAL_CHUNKS if referenced else RAG_MAX_TOTAL_CHUNKS
+    out: list[HybridSearchResult] = []
+    seen: set[uuid.UUID] = set()
+    for chunk in [*referenced, *kb]:
+        if chunk.chunk_id in seen:
+            continue
+        seen.add(chunk.chunk_id)
+        out.append(chunk)
+        if len(out) >= cap:
+            break
+    return out
 
 
 def _format_retrieval_context_block(
@@ -1231,6 +1429,17 @@ async def send_message(
     # ``lq_ai_file_ids`` and echo back as ``applied_file_ids``. Empty /
     # omitted is a no-op (no DB round-trip) — back-compatible.
     effective_file_ids = await _validate_owned_file_ids(db, payload.file_ids, user.id)
+
+    # referenced-files — validate caller-referenced matter files (owned + in a KB
+    # attached to the chat's project + ready). 404 id-probing-safe on any
+    # miss; empty/omitted is a no-op. Also yields each file's matter-KB
+    # hybrid_alpha for the file-scoped retrieval below.
+    effective_referenced_file_ids, referenced_alpha_by_id = await _validate_referenced_file_ids(
+        db,
+        payload.referenced_file_ids,
+        owner_id=user.id,
+        project_id=chat.project_id,
+    )
 
     # Wave D.2 Task 3.0 — merge legacy ``skills`` with new
     # ``attached_skills``. Each ``attached_skills`` entry is XOR'd at
@@ -1417,14 +1626,11 @@ async def send_message(
             project_privileged = bool(project_row[1])
             project_ensemble_verification = bool(project_row[2])
 
-    # Wave D.1 T7b — RAG step: when the chat's project has KBs attached,
-    # run hybrid_search across all of them for the user's just-sent
-    # message, write the T7-shape audit row so Receipts surfaces the
-    # 📎 KB retrieval event, and prepend the retrieved chunks as a
-    # ``system`` message to the gateway request so the LLM actually
-    # sees them. Empty results → no audit row, no context injection
-    # (same guard as T7's query_kb path).
-    retrieved_chunks, kb_ids_searched = await _retrieve_kb_context_for_chat(
+    # Wave D.1 T7b — KB RAG across the project's attached KBs. Returns
+    # the query embedding it computed so the referenced-files referenced-file pass
+    # below can reuse it (referenced files live in the same attached
+    # KBs; one embed call per turn).
+    kb_chunks, kb_ids_searched, rag_query_embedding = await _retrieve_kb_context_for_chat(
         db,
         chat=chat,
         query=effective_content,
@@ -1432,14 +1638,23 @@ async def send_message(
         request_id=request.headers.get("x-request-id"),
     )
 
-    # Build the gateway messages list. T7b prepends a ``system``-role
-    # context block when we have retrieved chunks; this is the
-    # least-invasive injection point — the gateway treats it as a
-    # system message and the C2 / ADR 0007 prompt-assembly logic still
-    # runs on top (the gateway concatenates its own system messages
-    # before the user turn, so the retrieved context shows up at the
-    # very front of the prompt). The user's just-sent message
-    # remains the last entry, unchanged.
+    # referenced-files — per-file retrieval for explicitly referenced files.
+    referenced_chunks = await _retrieve_referenced_file_context(
+        db,
+        referenced_file_ids=effective_referenced_file_ids,
+        alpha_by_id=referenced_alpha_by_id,
+        query=effective_content,
+        query_embedding=rag_query_embedding,
+    )
+
+    # Merge: referenced first (explicit intent), then KB, deduped +
+    # capped. The single ``retrieved_chunks`` local flows to the context
+    # block AND to every _persist_message_citations call site, so both
+    # KB and referenced chunks become citable with no change to the
+    # citation path.
+    retrieved_chunks = _merge_retrieved_chunks(referenced_chunks, kb_chunks)
+    injected_chunk_ids = {c.chunk_id for c in retrieved_chunks}
+
     gw_messages: list[ChatCompletionMessage] = []
     if retrieved_chunks:
         context_block = _format_retrieval_context_block(retrieved_chunks)
@@ -1457,11 +1672,13 @@ async def send_message(
                 lq_ai_skip_anonymization=True,
             )
         )
-        # T7-shape audit row. Same details schema as query_kb (kb_ids
-        # plural here; query_kb is single-KB). The row commits with
-        # its own boundary so it's durable even if the gateway call
-        # later fails — Receipts must show retrieval happened
-        # regardless of LLM-call outcome.
+
+    # T7-shape audit row for KB retrieval. chunk_ids/chunk_count record
+    # what was actually INJECTED after the referenced-files merge (Receipts
+    # fidelity); retrieved_count records what the search returned. On
+    # pure-KB turns the two are identical, preserving T7 semantics.
+    if kb_chunks:
+        kb_injected = [c for c in kb_chunks if c.chunk_id in injected_chunk_ids]
         await audit_action(
             db,
             user_id=user.id,
@@ -1472,9 +1689,29 @@ async def send_message(
             request=request,
             details={
                 "kb_ids": [str(k) for k in kb_ids_searched],
-                "chunk_count": len(retrieved_chunks),
-                "chunk_ids": [str(c.chunk_id) for c in retrieved_chunks],
+                "chunk_count": len(kb_injected),
+                "chunk_ids": [str(c.chunk_id) for c in kb_injected],
+                "retrieved_count": len(kb_chunks),
                 "query_token_estimate": len(effective_content.split()),
+            },
+        )
+        await db.commit()
+
+    # referenced-files audit — counts/ids only (P3), own commit boundary (P5).
+    if effective_referenced_file_ids:
+        await audit_action(
+            db,
+            user_id=user.id,
+            action="inference.message_referenced_files",
+            resource_type="chat",
+            resource_id=str(cid),
+            project_id=chat.project_id,
+            request=request,
+            details={
+                "file_ids": list(effective_referenced_file_ids),
+                "referenced_count": len(effective_referenced_file_ids),
+                "chunk_count": len(referenced_chunks),
+                "chunk_ids": [str(c.chunk_id) for c in referenced_chunks],
             },
         )
         await db.commit()
@@ -1635,6 +1872,7 @@ async def send_message(
             user_message_id=user_message.id,
             request_id=request_id,
             retrieved_chunks=retrieved_chunks,
+            referenced_file_ids=effective_referenced_file_ids,
             http_request=request,
             attached_skill_provenance=attached_skill_provenance,
             project_ensemble_verification=project_ensemble_verification,
@@ -1650,6 +1888,7 @@ async def send_message(
         user_message_id=user_message.id,
         request_id=request_id,
         retrieved_chunks=retrieved_chunks,
+        referenced_file_ids=effective_referenced_file_ids,
         http_request=request,
         attached_skill_names=attached_skill_names,
         slash_unresolved=slash_unresolved,
@@ -2308,6 +2547,7 @@ async def resume_tool_call(
                 },
                 "applied_skills": last_applied_skills or [],
                 "applied_file_ids": [],
+                "applied_referenced_file_ids": [],
                 "citations": [],
                 "routed_inference_tier": last_tier,
                 "routed_provider": last_provider,
@@ -2864,6 +3104,7 @@ async def _non_streaming_response(
     user_message_id: uuid.UUID,
     request_id: str,
     retrieved_chunks: list[HybridSearchResult] | None = None,
+    referenced_file_ids: list[str] | None = None,
     http_request: Request | None = None,
     attached_skill_names: list[str] | None = None,
     slash_unresolved: bool = False,
@@ -3006,6 +3247,7 @@ async def _non_streaming_response(
                 cost_estimate=None,
                 applied_skills=applied_skills,
                 applied_file_ids=list(request.lq_ai_file_ids),
+                applied_referenced_file_ids=list(referenced_file_ids or []),
                 attached_skill_names=list(attached_skill_names or []),
                 slash_unresolved=slash_unresolved,
             )
@@ -3095,6 +3337,7 @@ async def _non_streaming_response(
                 message=placeholder_msg,
                 citations=[],
                 applied_file_ids=list(request.lq_ai_file_ids),
+                applied_referenced_file_ids=list(referenced_file_ids or []),
                 attached_skill_names=list(attached_skill_names or []),
                 slash_unresolved=slash_unresolved,
                 pending_tool_call=gate_payload,
@@ -3125,6 +3368,7 @@ async def _non_streaming_response(
                 message=placeholder_mcp,
                 citations=[],
                 applied_file_ids=list(request.lq_ai_file_ids),
+                applied_referenced_file_ids=list(referenced_file_ids or []),
                 attached_skill_names=list(attached_skill_names or []),
                 slash_unresolved=slash_unresolved,
                 mcp_authorization_required=mcp_payload,
@@ -3230,6 +3474,7 @@ async def _non_streaming_response(
         cost_estimate=response.cost_estimate,
         applied_skills=applied_skills,
         applied_file_ids=list(request.lq_ai_file_ids),
+        applied_referenced_file_ids=list(referenced_file_ids or []),
         attached_skill_names=list(attached_skill_names or []),
         slash_unresolved=slash_unresolved,
     )
@@ -3258,6 +3503,7 @@ async def _stream_response(
     user_message_id: uuid.UUID,
     request_id: str,
     retrieved_chunks: list[HybridSearchResult] | None = None,
+    referenced_file_ids: list[str] | None = None,
     http_request: Request | None = None,
     attached_skill_provenance: list[dict[str, str | None]] | None = None,
     project_ensemble_verification: bool = False,
@@ -3665,6 +3911,7 @@ async def _stream_response(
                 # were forwarded to the gateway for this turn (mirrors
                 # ``applied_skills``; turn-scoped, not persisted).
                 "applied_file_ids": list(request.lq_ai_file_ids),
+                "applied_referenced_file_ids": list(referenced_file_ids or []),
                 "citations": [],
                 "routed_inference_tier": last_tier,
                 "routed_provider": last_provider,

--- a/api/app/knowledge/retrieval.py
+++ b/api/app/knowledge/retrieval.py
@@ -121,6 +121,27 @@ async def hybrid_search(
             limit=candidate_limit,
         )
 
+    return await _combine_and_hydrate(
+        db, vector_rows=vector_rows, fts_rows=fts_rows, top_k=top_k, alpha=alpha
+    )
+
+
+async def _combine_and_hydrate(
+    db: AsyncSession,
+    *,
+    vector_rows: list[tuple[uuid.UUID, float]],
+    fts_rows: list[tuple[uuid.UUID, float]],
+    top_k: int,
+    alpha: float,
+) -> list[HybridSearchResult]:
+    """Min-max normalize, linearly combine, take top_k, hydrate.
+
+    Shared by :func:`hybrid_search` (KB-scoped) and
+    :func:`hybrid_search_files` (file-scoped) — the only difference
+    between the two is which candidate SQL produced ``vector_rows`` /
+    ``fts_rows``.
+    """
+
     if not vector_rows and not fts_rows:
         return []
 
@@ -178,6 +199,59 @@ async def hybrid_search(
     # Re-sort because _hydrate_chunks doesn't preserve order.
     results.sort(key=lambda r: r.hybrid_score, reverse=True)
     return results
+
+
+# ---------------------------------------------------------------------------
+# File-scoped hybrid search entry point
+# ---------------------------------------------------------------------------
+
+
+async def hybrid_search_files(
+    db: AsyncSession,
+    *,
+    file_ids: list[uuid.UUID],
+    query: str,
+    query_embedding: list[float] | None,
+    top_k: int,
+    alpha: float,
+) -> list[HybridSearchResult]:
+    """Hybrid search scoped to an explicit set of file ids.
+
+    Same score model as :func:`hybrid_search` (pgvector cosine + FTS,
+    min-max normalized, ``(1-alpha)*vec + alpha*fts``) but the candidate
+    set is ``document_chunks`` whose owning file is in ``file_ids`` (not
+    a KB join). Callers MUST have already authorized ``file_ids`` — this
+    primitive does no ownership check, matching :func:`hybrid_search`'s
+    contract (the handler enforces scope).
+    """
+    if not file_ids:
+        return []
+    alpha = max(0.0, min(1.0, alpha))
+    candidate_limit = top_k * CANDIDATE_OVERSHOOT
+    ids = [str(fid) for fid in file_ids]
+
+    vector_rows: list[tuple[uuid.UUID, float]] = []
+    if query_embedding is not None and alpha < 1.0:
+        result = await db.execute(
+            _VECTOR_SQL_FILES,
+            {"file_ids": ids, "q_emb": _format_vector(query_embedding), "limit": candidate_limit},
+        )
+        vector_rows = [
+            (uuid.UUID(str(r["chunk_id"])), float(r["vec_score"])) for r in result.mappings().all()
+        ]
+
+    fts_rows: list[tuple[uuid.UUID, float]] = []
+    if alpha > 0.0:
+        result = await db.execute(
+            _FTS_SQL_FILES, {"file_ids": ids, "q": query, "limit": candidate_limit}
+        )
+        fts_rows = [
+            (uuid.UUID(str(r["chunk_id"])), float(r["fts_rank"])) for r in result.mappings().all()
+        ]
+
+    return await _combine_and_hydrate(
+        db, vector_rows=vector_rows, fts_rows=fts_rows, top_k=top_k, alpha=alpha
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -264,6 +338,45 @@ async def _fts_candidates(
     result = await db.execute(_FTS_SQL, {"kb_id": str(kb_id), "q": query, "limit": limit})
     rows = result.mappings().all()
     return [(uuid.UUID(str(row["chunk_id"])), float(row["fts_rank"])) for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# File-scoped side queries
+# ---------------------------------------------------------------------------
+
+
+_VECTOR_SQL_FILES = text(
+    """
+    SELECT dc.id AS chunk_id,
+           1.0 - (dc.embedding <=> CAST(:q_emb AS vector)) AS vec_score
+      FROM document_chunks dc
+      JOIN documents d ON d.id = dc.document_id
+      JOIN files f ON f.id = d.file_id
+     WHERE f.id = ANY(:file_ids)
+       AND f.deleted_at IS NULL
+       AND f.ingestion_status = 'ready'
+       AND dc.embedding IS NOT NULL
+     ORDER BY dc.embedding <=> CAST(:q_emb AS vector)
+     LIMIT :limit
+    """
+)
+
+
+_FTS_SQL_FILES = text(
+    """
+    SELECT dc.id AS chunk_id,
+           ts_rank_cd(dc.content_tsv, plainto_tsquery('english', :q)) AS fts_rank
+      FROM document_chunks dc
+      JOIN documents d ON d.id = dc.document_id
+      JOIN files f ON f.id = d.file_id
+     WHERE f.id = ANY(:file_ids)
+       AND f.deleted_at IS NULL
+       AND f.ingestion_status = 'ready'
+       AND dc.content_tsv @@ plainto_tsquery('english', :q)
+     ORDER BY fts_rank DESC
+     LIMIT :limit
+    """
+)
 
 
 _HYDRATE_SQL = text(

--- a/api/app/schemas/chats.py
+++ b/api/app/schemas/chats.py
@@ -93,6 +93,17 @@ available to any authenticated user. 16 matches
 :data:`ATTACHED_SKILLS_MAX_LEN`; realistic per-turn document context is
 a handful of files. Requests over the cap 422 at schema time."""
 
+MESSAGE_REFERENCED_FILES_MAX_LEN: int = 16
+"""Hard cap on ``MessageCreateRequest.referenced_file_ids``.
+
+Referenced files drive file-scoped retrieval for a single turn: each id
+triggers an ownership + matter-KB validation SELECT and a per-file
+hybrid-search call. Without a cap a single message could reference
+thousands of files — workload-multiplication DoS available to any
+authenticated user. 16 matches :data:`MESSAGE_FILE_IDS_MAX_LEN`;
+realistic per-turn document references are a handful. Over the cap 422s
+at schema time."""
+
 KNOWN_ATTACHED_SKILL_SOURCES: frozenset[str] = frozenset(
     {"slash", "wizard-tryout", "tryit-tab", "capture", "manual"}
 )
@@ -428,6 +439,20 @@ class MessageCreateRequest(BaseModel):
     ``skill_inputs`` for scalar skill parameters. Omitted / empty is
     fully back-compatible (pre-existing wire shape unchanged)."""
 
+    referenced_file_ids: list[str] = Field(
+        default_factory=list, max_length=MESSAGE_REFERENCED_FILES_MAX_LEN
+    )
+    """referenced-files: caller-selected matter documents to ground THIS turn via
+    file-scoped retrieval. Distinct from :attr:`file_ids` (which injects
+    a file's full text verbatim with no citations): referenced files are
+    retrieved as chunks and merged into the turn's ``retrieved_chunks``
+    so the Citation Engine mints verified, deep-linkable citations for
+    them. KB-only MVP: each id must be caller-owned, ``ready``, and in a
+    Knowledge Base attached to the chat's project (matter scope);
+    otherwise it 404s id-probing-safe. Echoed back as
+    ``applied_referenced_file_ids``. Empty/omitted is a back-compatible
+    no-op."""
+
     stream: bool = False
     """Whether to stream the response as SSE. ``False`` returns a single
     JSON body."""
@@ -580,6 +605,14 @@ class MessagePostResponse(BaseModel):
     frame), not on rows read back via ``GET /chats/{id}/messages``. Empty
     when no file_ids were attached."""
 
+    applied_referenced_file_ids: list[str] = Field(default_factory=list)
+    """referenced-files: caller-selected file ids that were validated (owned +
+    matter-KB + ready) and whose chunks were retrieved to ground this
+    turn — the echo of :attr:`MessageCreateRequest.referenced_file_ids`.
+    Turn-scoped (no ``messages.referenced_file_ids`` column): surfaces on
+    the send response and the SSE ``complete`` frame only. Empty when
+    none were referenced or none validated."""
+
     attached_skill_names: list[str] = Field(default_factory=list)
     """Wave D.2 Task 2.7 — slugs the send-time slash fallback attached
     on the caller's behalf. Distinct from ``applied_skills`` (the
@@ -640,6 +673,7 @@ __all__ = [
     "LIST_LIMIT_DEFAULT",
     "LIST_LIMIT_MAX",
     "MESSAGE_FILE_IDS_MAX_LEN",
+    "MESSAGE_REFERENCED_FILES_MAX_LEN",
     "TITLE_MAX_LEN",
     "AttachedSkillRef",
     "ChatCreateRequest",

--- a/api/tests/integration/test_referenced_files_send.py
+++ b/api/tests/integration/test_referenced_files_send.py
@@ -1,0 +1,595 @@
+"""Task 3 (referenced-files) — ``_validate_referenced_file_ids`` direct-call tests.
+
+Exercises the handler-side validator that Task 4 wires into
+``send_message`` for caller-referenced file-scoped retrieval:
+
+* KB-only MVP scope: a referenced id must be (1) a well-formed UUID,
+  (2) a caller-owned, non-deleted, ``ingestion_status='ready'`` file,
+  (3) attached to a Knowledge Base that is itself attached to the
+  chat's ``project_id``.
+* Any failing referenced id, or a projectless chat, raises
+  :class:`NotFound` (404) with the same id-probing-safe message shape
+  used by :func:`_validate_owned_file_ids` — a foreign/nonexistent/
+  malformed/not-ready/not-in-matter-KB id is indistinguishable.
+* Success returns ``(validated_ids, alpha_by_id)`` — deduped,
+  order-preserving ids, and each file's retrieval alpha (MIN
+  ``hybrid_alpha`` across all containing, project-attached KBs).
+
+These are direct calls against ``_validate_referenced_file_ids`` (no
+HTTP client) — Task 4 will append endpoint-level tests exercising the
+wired-in ``send_message`` path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.chats import _validate_referenced_file_ids
+from app.clients.gateway import GatewayClient, set_gateway_client
+from app.db.session import get_db
+from app.errors import NotFound
+from app.main import app
+from app.models.audit import AuditLog
+from app.models.chat import Chat
+from app.models.document import Document, DocumentChunk
+from app.models.file import File
+from app.models.knowledge import KnowledgeBase, KnowledgeBaseFile
+from app.models.project import Project
+from app.models.project_knowledge_base import ProjectKnowledgeBase
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+GATEWAY_BASE = "http://test-gateway"
+GATEWAY_KEY = "test-gw-key"
+
+
+def _make_user() -> User:
+    return User(
+        email=f"ref-files-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Referenced Files Test User",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+
+
+def _make_project(owner_id: uuid.UUID) -> Project:
+    return Project(
+        owner_id=owner_id,
+        name="Referenced Files Matter",
+        slug=f"ref-files-matter-{uuid.uuid4().hex[:8]}",
+    )
+
+
+def _make_kb(owner_id: uuid.UUID, hybrid_alpha: float = 0.7) -> KnowledgeBase:
+    return KnowledgeBase(
+        owner_id=owner_id,
+        name="Referenced Files KB",
+        description="Task 3 direct-call tests",
+        hybrid_alpha=hybrid_alpha,
+    )
+
+
+def _make_ready_file(owner_id: uuid.UUID, ingestion_status: str = "ready") -> File:
+    return File(
+        owner_id=owner_id,
+        filename="doc.pdf",
+        mime_type="application/pdf",
+        size_bytes=10,
+        hash_sha256=uuid.uuid4().hex + uuid.uuid4().hex,
+        storage_path=str(uuid.uuid4()),
+        ingestion_status=ingestion_status,
+    )
+
+
+def _make_document(file_id: uuid.UUID) -> Document:
+    return Document(
+        file_id=file_id,
+        parser="pymupdf",
+        parser_version="1.0",
+        normalized_content="referenced file content",
+    )
+
+
+async def _seed_attached_ready_file(
+    db_session: AsyncSession,
+    *,
+    hybrid_alpha: float = 0.7,
+    ingestion_status: str = "ready",
+) -> tuple[User, Project, File]:
+    """Seed user + project + KB (attached to project) + ready file (in KB)."""
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    project = _make_project(user.id)
+    db_session.add(project)
+    await db_session.flush()
+
+    kb = _make_kb(user.id, hybrid_alpha=hybrid_alpha)
+    db_session.add(kb)
+    await db_session.flush()
+
+    db_session.add(ProjectKnowledgeBase(project_id=project.id, knowledge_base_id=kb.id))
+
+    file_row = _make_ready_file(user.id, ingestion_status=ingestion_status)
+    db_session.add(file_row)
+    await db_session.flush()
+
+    db_session.add(KnowledgeBaseFile(kb_id=kb.id, file_id=file_row.id))
+    db_session.add(_make_document(file_row.id))
+    await db_session.flush()
+
+    return user, project, file_row
+
+
+async def test_valid_file_returns_ids_and_alpha(db_session: AsyncSession) -> None:
+    user, project, file_row = await _seed_attached_ready_file(db_session, hybrid_alpha=0.7)
+
+    result = await _validate_referenced_file_ids(
+        db_session,
+        [str(file_row.id)],
+        owner_id=user.id,
+        project_id=project.id,
+    )
+
+    assert result == ([str(file_row.id)], {str(file_row.id): 0.7})
+
+
+async def test_empty_input_returns_empty_without_db_call(db_session: AsyncSession) -> None:
+    result = await _validate_referenced_file_ids(
+        db_session,
+        [],
+        owner_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+    )
+
+    assert result == ([], {})
+
+
+async def test_projectless_chat_raises_not_found(db_session: AsyncSession) -> None:
+    user, _project, file_row = await _seed_attached_ready_file(db_session)
+
+    with pytest.raises(NotFound):
+        await _validate_referenced_file_ids(
+            db_session,
+            [str(file_row.id)],
+            owner_id=user.id,
+            project_id=None,
+        )
+
+
+async def test_foreign_uuid_raises_not_found(db_session: AsyncSession) -> None:
+    user, project, _file_row = await _seed_attached_ready_file(db_session)
+
+    with pytest.raises(NotFound):
+        await _validate_referenced_file_ids(
+            db_session,
+            [str(uuid.uuid4())],
+            owner_id=user.id,
+            project_id=project.id,
+        )
+
+
+async def test_kb_not_attached_to_project_raises_not_found(db_session: AsyncSession) -> None:
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    project = _make_project(user.id)
+    db_session.add(project)
+    await db_session.flush()
+
+    # KB exists and holds a ready file, but is never attached to `project`
+    # via ProjectKnowledgeBase — not referenceable from this chat's matter.
+    kb = _make_kb(user.id, hybrid_alpha=0.7)
+    db_session.add(kb)
+    await db_session.flush()
+
+    file_row = _make_ready_file(user.id)
+    db_session.add(file_row)
+    await db_session.flush()
+
+    db_session.add(KnowledgeBaseFile(kb_id=kb.id, file_id=file_row.id))
+    db_session.add(_make_document(file_row.id))
+    await db_session.flush()
+
+    with pytest.raises(NotFound):
+        await _validate_referenced_file_ids(
+            db_session,
+            [str(file_row.id)],
+            owner_id=user.id,
+            project_id=project.id,
+        )
+
+
+async def test_processing_status_file_raises_not_found(db_session: AsyncSession) -> None:
+    user, project, file_row = await _seed_attached_ready_file(
+        db_session, ingestion_status="processing"
+    )
+
+    with pytest.raises(NotFound):
+        await _validate_referenced_file_ids(
+            db_session,
+            [str(file_row.id)],
+            owner_id=user.id,
+            project_id=project.id,
+        )
+
+
+async def test_malformed_id_raises_not_found(db_session: AsyncSession) -> None:
+    user, project, _file_row = await _seed_attached_ready_file(db_session)
+
+    with pytest.raises(NotFound):
+        await _validate_referenced_file_ids(
+            db_session,
+            ["not-a-uuid"],
+            owner_id=user.id,
+            project_id=project.id,
+        )
+
+
+async def test_duplicate_ids_deduped_order_preserving(db_session: AsyncSession) -> None:
+    user, project, file_row = await _seed_attached_ready_file(db_session, hybrid_alpha=0.7)
+
+    result = await _validate_referenced_file_ids(
+        db_session,
+        [str(file_row.id), str(file_row.id)],
+        owner_id=user.id,
+        project_id=project.id,
+    )
+
+    assert result == ([str(file_row.id)], {str(file_row.id): 0.7})
+
+
+# ---------------------------------------------------------------------------
+# Task 4 — endpoint-level: send_message wires referenced-file retrieval,
+# citation grounding, echo, and audit. The KB pass is stubbed empty and
+# the referenced-file primitive (``hybrid_search_files``) is patched to
+# point at real seeded rows, isolating the referenced-files wiring under test (the
+# real primitive is covered against the DB by Task 2's tests).
+# ---------------------------------------------------------------------------
+
+# A chunk body whose verbatim slice the model will quote back. QUOTE is a
+# substring so Stage-1 exact-match verification persists a citation row.
+CHUNK_BODY = "The parties agree to a mutual two-year non-compete covering the defined territory."
+QUOTE = "a mutual two-year non-compete"
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    """In-process AsyncClient with a gateway stub, mirroring the Task-3
+    integration siblings (ASGI transport + get_db override)."""
+
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    gw = GatewayClient(base_url=GATEWAY_BASE, gateway_key=GATEWAY_KEY)
+    set_gateway_client(gw)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    set_gateway_client(None)
+    await gw.aclose()
+    app.dependency_overrides.pop(get_db, None)
+
+
+def _h(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _success_payload(content: str) -> dict[str, Any]:
+    return {
+        "id": "chatcmpl-ref",
+        "object": "chat.completion",
+        "created": 1_700_000_000,
+        "model": "claude-sonnet-4-6",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 12, "total_tokens": 17},
+        "routed_inference_tier": 3,
+        "routed_provider": "anthropic-prod",
+        "cost_estimate": 0.0001,
+    }
+
+
+def _hybrid_result_for(chunk: DocumentChunk, document: Document, file: File) -> Any:
+    """HybridSearchResult-shaped stand-in pointing at real fixture rows."""
+
+    class _R:
+        def __init__(self) -> None:
+            self.chunk_id = chunk.id
+            self.document_id = document.id
+            self.file_id = file.id
+            self.file_name = file.filename
+            self.content = chunk.content
+            self.page_start = chunk.page_start
+            self.page_end = chunk.page_end
+            self.char_offset_start = chunk.char_offset_start
+            self.char_offset_end = chunk.char_offset_end
+            self.vector_score = 0.9
+            self.fts_score = 0.9
+            self.hybrid_score = 0.9
+
+    return _R()
+
+
+async def _seed_chat_with_referenced_file(
+    db_session: AsyncSession,
+) -> tuple[User, Chat, File, Document, DocumentChunk]:
+    """Seed user + project + KB(attached) + ready file(in KB) + Document +
+    DocumentChunk + a project-scoped Chat. The Document's
+    ``normalized_content`` carries CHUNK_BODY so the Stage-1 verifier can
+    slice the quoted passage byte-for-byte."""
+
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    project = _make_project(user.id)
+    db_session.add(project)
+    await db_session.flush()
+
+    # hybrid_alpha=1.0 keeps the (stubbed) KB pass from ever needing an
+    # embed call; the referenced primitive is patched regardless.
+    kb = _make_kb(user.id, hybrid_alpha=1.0)
+    db_session.add(kb)
+    await db_session.flush()
+
+    db_session.add(ProjectKnowledgeBase(project_id=project.id, knowledge_base_id=kb.id))
+
+    file_row = _make_ready_file(user.id)
+    db_session.add(file_row)
+    await db_session.flush()
+
+    db_session.add(KnowledgeBaseFile(kb_id=kb.id, file_id=file_row.id))
+
+    document = Document(
+        file_id=file_row.id,
+        parser="pymupdf",
+        parser_version="1.0",
+        normalized_content=CHUNK_BODY,
+    )
+    db_session.add(document)
+    await db_session.flush()
+
+    chunk = DocumentChunk(
+        document_id=document.id,
+        chunk_index=0,
+        content=CHUNK_BODY,
+        page_start=1,
+        page_end=1,
+        char_offset_start=0,
+        char_offset_end=len(CHUNK_BODY),
+    )
+    db_session.add(chunk)
+
+    chat = Chat(owner_id=user.id, project_id=project.id, title="ref-files-send")
+    db_session.add(chat)
+    await db_session.flush()
+
+    return user, chat, file_row, document, chunk
+
+
+@respx.mock
+async def test_send_with_referenced_file_grounds_and_cites(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """POST send with a referenced file → 200; the response echoes
+    ``applied_referenced_file_ids``, and the GET citations endpoint
+    surfaces a verified citation whose source file is the referenced
+    file (Stage-1 exact-match against the referenced chunk)."""
+
+    user, chat, file_row, _document, _chunk = await _seed_chat_with_referenced_file(db_session)
+    assistant_text = f'"{QUOTE}" (Source: [1])'
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(assistant_text)),
+    )
+
+    with (
+        patch(
+            "app.api.chats._retrieve_kb_context_for_chat",
+            new=AsyncMock(return_value=([], [], None)),
+        ),
+        patch(
+            "app.api.chats.hybrid_search_files",
+            new=AsyncMock(return_value=[_hybrid_result_for(_chunk, _document, file_row)]),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat.id}/messages",
+            headers=_h(user),
+            json={
+                "content": "Quote the non-compete clause.",
+                "model": "smart",
+                "referenced_file_ids": [str(file_row.id)],
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["applied_referenced_file_ids"] == [str(file_row.id)]
+
+    assistant_msg_id = body["message"]["id"]
+    cites_resp = await client.get(
+        f"/api/v1/chats/{chat.id}/messages/{assistant_msg_id}/citations",
+        headers=_h(user),
+    )
+    assert cites_resp.status_code == 200, cites_resp.text
+    cites = cites_resp.json()
+    assert any(c["source_file_id"] == str(file_row.id) and c["verified"] for c in cites), cites
+
+
+@respx.mock
+async def test_send_with_referenced_file_writes_audit_row(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """After the e2e send, exactly one ``inference.message_referenced_files``
+    audit row exists carrying ids/counts only — and NO content/query keys."""
+
+    user, chat, file_row, _document, _chunk = await _seed_chat_with_referenced_file(db_session)
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload(f'"{QUOTE}" (Source: [1])')),
+    )
+
+    with (
+        patch(
+            "app.api.chats._retrieve_kb_context_for_chat",
+            new=AsyncMock(return_value=([], [], None)),
+        ),
+        patch(
+            "app.api.chats.hybrid_search_files",
+            new=AsyncMock(return_value=[_hybrid_result_for(_chunk, _document, file_row)]),
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat.id}/messages",
+            headers=_h(user),
+            json={
+                "content": "Quote the non-compete clause.",
+                "model": "smart",
+                "referenced_file_ids": [str(file_row.id)],
+            },
+        )
+    assert resp.status_code == 200, resp.text
+
+    rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(AuditLog.action == "inference.message_referenced_files")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1, f"expected exactly one referenced-files audit row, got {len(rows)}"
+    details = rows[0].details or {}
+    assert details["file_ids"] == [str(file_row.id)]
+    assert details["referenced_count"] == 1
+    assert details["chunk_count"] == 1
+    assert len(details["chunk_ids"]) == 1
+    # P3 — counts/ids only; no message content or query text may leak.
+    assert "content" not in details
+    assert "query" not in details
+    assert "query_token_estimate" not in details
+
+
+@respx.mock
+async def test_send_foreign_referenced_id_returns_404(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A referenced id the caller doesn't own (random uuid) → 404,
+    id-probing-safe, and the gateway is never called."""
+
+    user, chat, _file_row, _document, _chunk = await _seed_chat_with_referenced_file(db_session)
+
+    route = respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload("unused")),
+    )
+
+    resp = await client.post(
+        f"/api/v1/chats/{chat.id}/messages",
+        headers=_h(user),
+        json={
+            "content": "hi",
+            "model": "smart",
+            "referenced_file_ids": [str(uuid.uuid4())],
+        },
+    )
+    assert resp.status_code == 404, resp.text
+    assert not route.called
+
+
+@respx.mock
+async def test_send_projectless_chat_with_referenced_id_returns_404(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A referenced id on a chat with no ``project_id`` → 404 (no matter
+    KB to reference into)."""
+
+    user = _make_user()
+    db_session.add(user)
+    await db_session.flush()
+    chat = Chat(owner_id=user.id, project_id=None, title="projectless")
+    db_session.add(chat)
+    await db_session.flush()
+
+    resp = await client.post(
+        f"/api/v1/chats/{chat.id}/messages",
+        headers=_h(user),
+        json={
+            "content": "hi",
+            "model": "smart",
+            "referenced_file_ids": [str(uuid.uuid4())],
+        },
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@respx.mock
+async def test_send_without_referenced_ids_is_backcompat_noop(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """POST without ``referenced_file_ids`` → 200,
+    ``applied_referenced_file_ids == []``, and NO
+    ``inference.message_referenced_files`` audit row."""
+
+    user, chat, _file_row, _document, _chunk = await _seed_chat_with_referenced_file(db_session)
+
+    respx.post(f"{GATEWAY_BASE}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_success_payload("plain reply")),
+    )
+
+    with patch(
+        "app.api.chats._retrieve_kb_context_for_chat",
+        new=AsyncMock(return_value=([], [], None)),
+    ):
+        resp = await client.post(
+            f"/api/v1/chats/{chat.id}/messages",
+            headers=_h(user),
+            json={"content": "hello", "model": "smart"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["applied_referenced_file_ids"] == []
+
+    rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(AuditLog.action == "inference.message_referenced_files")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []

--- a/api/tests/test_referenced_files_schema.py
+++ b/api/tests/test_referenced_files_schema.py
@@ -1,0 +1,48 @@
+"""referenced-files schema surface referenced_file_ids (pure Pydantic, no DB)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.chats import (
+    MESSAGE_REFERENCED_FILES_MAX_LEN,
+    MessageCreateRequest,
+    MessagePostResponse,
+    MessageResponse,
+)
+
+
+def _minimal_message_response() -> MessageResponse:
+    """Construct MessageResponse with exactly its required fields."""
+    return MessageResponse(
+        id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        chat_id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        role="assistant",
+        content="test",
+        created_at=datetime(2026, 5, 8, 12, 0, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.unit
+class TestReferencedFileIds:
+    def test_referenced_file_ids_defaults_empty(self) -> None:
+        req = MessageCreateRequest(content="hi")
+        assert req.referenced_file_ids == []
+
+    def test_referenced_file_ids_accepts_list(self) -> None:
+        ids = ["11111111-1111-1111-1111-111111111111"]
+        req = MessageCreateRequest(content="hi", referenced_file_ids=ids)
+        assert req.referenced_file_ids == ids
+
+    def test_referenced_file_ids_over_cap_rejected(self) -> None:
+        ids = ["11111111-1111-1111-1111-111111111111"] * (MESSAGE_REFERENCED_FILES_MAX_LEN + 1)
+        with pytest.raises(ValidationError):
+            MessageCreateRequest(content="hi", referenced_file_ids=ids)
+
+    def test_applied_referenced_file_ids_defaults_empty(self) -> None:
+        resp = MessagePostResponse(message=_minimal_message_response())
+        assert resp.applied_referenced_file_ids == []

--- a/api/tests/test_retrieval_files.py
+++ b/api/tests/test_retrieval_files.py
@@ -1,0 +1,190 @@
+"""DB-backed tests for the file-scoped hybrid retrieval primitive.
+
+:func:`hybrid_search_files` (referenced-files Task 2) is the file-scoped sibling
+of :func:`hybrid_search` — same score model, but the candidate set is
+``document_chunks`` whose owning file is in an explicit ``file_ids``
+list rather than a KB join. These tests exercise the FTS-only path
+(``alpha=1.0``, ``query_embedding=None``) deterministically against a
+real Postgres so the SQL (not a mock) is what's under test.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.knowledge.retrieval import hybrid_search_files
+from app.models.document import Document, DocumentChunk
+from app.models.file import File as FileModel
+from app.models.user import User
+from app.security import hash_password
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def owner_user(db_session: AsyncSession) -> User:
+    user = User(
+        email=f"retrieval-files-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+async def _make_ready_file(
+    db_session: AsyncSession,
+    owner: User,
+    *,
+    chunk_bodies: list[str],
+    ingestion_status: str = "ready",
+    deleted: bool = False,
+) -> FileModel:
+    f = FileModel(
+        owner_id=owner.id,
+        filename=f"retrieval-files-{uuid.uuid4().hex[:8]}.pdf",
+        mime_type="application/pdf",
+        size_bytes=1024,
+        hash_sha256=uuid.uuid4().hex + uuid.uuid4().hex,
+        storage_path=f"retrieval-files-fixture/{uuid.uuid4()}",
+        ingestion_status=ingestion_status,
+    )
+    if deleted:
+        f.deleted_at = datetime.now(UTC)
+    db_session.add(f)
+    await db_session.flush()
+
+    full_text = "\n\n".join(chunk_bodies)
+    doc = Document(
+        file_id=f.id,
+        parser="pymupdf-only",
+        parser_version="pymupdf=1.27",
+        page_count=1,
+        character_count=len(full_text),
+        normalized_content=full_text,
+        was_ocrd=False,
+    )
+    db_session.add(doc)
+    await db_session.flush()
+
+    offset = 0
+    for idx, body in enumerate(chunk_bodies):
+        chunk = DocumentChunk(
+            document_id=doc.id,
+            chunk_index=idx,
+            content=body,
+            page_start=1,
+            page_end=1,
+            char_offset_start=offset,
+            char_offset_end=offset + len(body),
+        )
+        db_session.add(chunk)
+        offset += len(body) + 2
+
+    await db_session.flush()
+    return f
+
+
+async def test_hybrid_search_files_scopes_to_requested_files(
+    db_session: AsyncSession, owner_user: User
+) -> None:
+    """Searching with file_ids=[file_a] returns only file_a's chunks."""
+
+    file_a = await _make_ready_file(
+        db_session,
+        owner_user,
+        chunk_bodies=[
+            "The termination clause governs early exit from the agreement.",
+            "Termination for cause requires thirty days written notice.",
+        ],
+    )
+    file_b = await _make_ready_file(
+        db_session,
+        owner_user,
+        chunk_bodies=[
+            "The confidentiality clause survives termination of the agreement.",
+        ],
+    )
+
+    results = await hybrid_search_files(
+        db_session,
+        file_ids=[file_a.id],
+        query="termination",
+        query_embedding=None,
+        top_k=10,
+        alpha=1.0,
+    )
+
+    assert results
+    assert {r.file_id for r in results} == {file_a.id}
+    assert file_b.id not in {r.file_id for r in results}
+
+
+async def test_hybrid_search_files_empty_file_ids_returns_empty_without_query(
+    db_session: AsyncSession,
+) -> None:
+    """file_ids=[] short-circuits to [] without touching the DB."""
+
+    results = await hybrid_search_files(
+        db_session,
+        file_ids=[],
+        query="termination",
+        query_embedding=None,
+        top_k=10,
+        alpha=1.0,
+    )
+
+    assert results == []
+
+
+async def test_hybrid_search_files_excludes_non_ready_file(
+    db_session: AsyncSession, owner_user: User
+) -> None:
+    """A file with ingestion_status='processing' contributes nothing even if requested."""
+
+    processing_file = await _make_ready_file(
+        db_session,
+        owner_user,
+        chunk_bodies=["The termination clause governs early exit from the agreement."],
+        ingestion_status="processing",
+    )
+
+    results = await hybrid_search_files(
+        db_session,
+        file_ids=[processing_file.id],
+        query="termination",
+        query_embedding=None,
+        top_k=10,
+        alpha=1.0,
+    )
+
+    assert results == []
+
+
+async def test_hybrid_search_files_excludes_soft_deleted_file(
+    db_session: AsyncSession, owner_user: User
+) -> None:
+    """A soft-deleted file contributes nothing even if its id is requested."""
+
+    deleted_file = await _make_ready_file(
+        db_session,
+        owner_user,
+        chunk_bodies=["The termination clause governs early exit from the agreement."],
+        deleted=True,
+    )
+
+    results = await hybrid_search_files(
+        db_session,
+        file_ids=[deleted_file.id],
+        query="termination",
+        query_embedding=None,
+        top_k=10,
+        alpha=1.0,
+    )
+
+    assert results == []

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -335,6 +335,8 @@ This section specifies each major capability. Every capability section follows t
 - `GET /api/v1/chats` — list user's chats.
 - `GET /api/v1/chats/{id}` — get chat with messages.
 - `POST /api/v1/chats/{id}/messages` — post message, stream response. Accepts a per-message `file_ids` list that attaches files for that turn only (passed to the gateway as `lq_ai_file_ids`, injected as document-context per Decision M2-1) and echoes the applied set back as `applied_file_ids`; this is a **separate channel from** `skill_inputs` (post-v0.4.0, #116/#117).
+  A parallel `referenced_file_ids` list references matter documents that are **retrieved and cited** (KB-only MVP), as opposed to `file_ids` which injects verbatim text without citations.
+The web composer surfaces this channel through two affordances: an inline `@`-mention popover and a multi-select document picker, converging on one deduped, cap-16 chip set; non-`ready` documents render disabled ("Preparing..."), so the UI can never assemble a set the backend would reject.
 - `PATCH /api/v1/chats/{id}` — update chat (rename, archive, pin, share).
 - `DELETE /api/v1/chats/{id}` — delete chat.
 - `GET /api/v1/chats/search?q=...` — search chats.
@@ -430,6 +432,8 @@ This section specifies each major capability. Every capability section follows t
 The verification entry point is [`api/app/citation/verification.py::verify`](../api/app/citation/verification.py); the M2-C2 UI rendering states are documented in [`docs/citation-engine.md`](citation-engine.md). Failed citations render as "unverified" rather than silently disappearing. The Anonymization Layer integration (M2-D2) skips pseudonymization on the retrieval-context system message so source quotes reach the model intact for citation grounding; see [§4.7](#47-anonymization-layer-m2) and [`docs/security/anonymization.md`](security/anonymization.md). Privileged-project audit-trail invariants are pinned in [`api/tests/test_chat_citations.py::test_chat_send_privileged_project_full_audit_trail`](../api/tests/test_chat_citations.py).
 
 The body of this section describes the design contract; deviations from the as-shipped pipeline (none currently known) would surface as PRD §9 entries.
+
+**Retrieval sources feeding verification.** The chunks a citation is verified against are not limited to project-wide KB retrieval: a caller can pass `referenced_file_ids` on the chat send (§3.1) to explicitly scope retrieval to specific matter documents. The same four-stage cascade above verifies citations against those file-scoped chunks exactly as it does against ordinary KB-search chunks — there is no separate verification path for explicitly referenced files, only a different, caller-directed *retrieval* step feeding the same verifier.
 
 **Scope clarification (2026-05-17).** The Citation Engine validates **KB-quote accuracy** — the model's response is an accurate representation of cited knowledge-base documents. Two related citation-checking surfaces are explicitly out of scope and tracked separately: **case citation validation** (Bluebook resolution via CourtListener) at [DE-279](#de-279--case-citation-validation-bluebook-resolution-via-courtlistener), and **case-content accuracy** (statement vs judicial opinion) at [DE-280](#de-280--case-content-accuracy-statement-vs-judicial-opinion). The three are architecturally distinct; see [`docs/citation-engine.md` §Scope](citation-engine.md#scope) for the taxonomy.
 
@@ -4959,6 +4963,16 @@ Two cosmetic follow-ups surfaced by the PR2b Opus whole-branch review, deliberat
 **Priority:** P3 · **Effort:** S · **Status (2026-07-02): filed (DE-365 sub-project 1 whole-branch review).**
 
 The README Slack/Teams intake-bridge paragraph disclaims a scope ("Light intake, deliberately not full triage/SLA/approvals — that is *Streamline AI's* category"). This is a scope-*narrowing* disclaimer, not a competitor-comparison overclaim, so it was left untouched by the DE-365 sub-project 1 honesty audit. But it is the one place the public docs name a specific third-party product, and the milestone's vendor-neutral posture (LQ.AI vs. the generic proprietary category, no named products — the constraint that also binds the DE-365 sub-project 3 comparison) would eventually genericize it (e.g. "dedicated legal-intake/triage platforms"). Small, cosmetic; fold into a later vendor-neutrality sweep or the sub-project 3 comparison work.
+
+#### Referenced files: file-scoped retrieved + cited grounding for chat
+
+**Priority:** P2 · **Effort:** M · **Status (2026-07-02): SHIPPED (backend); 2026-07-03: SHIPPED (frontend).**
+
+Adds a `referenced_file_ids` list (cap 16) to `POST /api/v1/chats/{id}/messages`, distinct from the existing `file_ids` verbatim-injection channel (§3.1): each referenced id names a caller-owned, `ready`, matter-scoped Knowledge Base document (else 404, id-probing-safe); `send_message` runs file-scoped hybrid retrieval (`hybrid_search_files`, top_k 6/file, referenced total capped at 12) per file, merges the results into the turn's retrieved-chunk set (merged cap raised 10→16 when references are present, unchanged at 10 for pure-KB-search turns, referenced chunks prioritized), and the model's citations against those chunks flow through the **existing** Citation Engine cascade unmodified (§3.3) — no parallel verifier.
+
+The per-file retrieval `hybrid_alpha` is the MIN of the alpha configured on each referenced file's matter Knowledge Base, honoring operator hybrid-search tuning rather than a hardcoded default. The validated set echoes back as `applied_referenced_file_ids` on the send response and the SSE `complete` frame (mirrors `applied_file_ids`); audit records a new `inference.message_referenced_files` entry and extends the existing `inference.kb_chunks_retrieved` entry with an additive `retrieved_count` so referenced-file contribution is distinguishable from ordinary KB-wide RAG in the trace.
+
+The web composer ships an `@`-mention popover plus a multi-select document picker, with one authoritative cap-16 referenced set fed by both. Known limitation: the composer's referenced set clears once the send stream opens, so an SSE-level failure or resend affordance retries the turn without `referenced_file_ids`; the user must re-reference manually.
 
 ---
 

--- a/docs/adr/0022-referenced-file-ids-chat.md
+++ b/docs/adr/0022-referenced-file-ids-chat.md
@@ -1,0 +1,74 @@
+# ADR 0022 — `referenced_file_ids`: file-scoped retrieved + cited grounding for chat
+
+**Status:** Accepted and shipped (2026-07-02) — Phase 1, implemented on `feat/referenced-file-ids` (Tasks 1–4) and documented in this task (Task 5).
+
+**Relates to:** [ADR 0016](0016-transparency-and-governance-invariants.md) (P2 closed-set/never-open-surface and P9 user-owns-their-data invariants, both load-bearing for this design), [ADR 0018](0018-citation-ledger-and-fiduciary-grade-output.md) (the citation cascade this feature feeds — unmodified). Realizes **PRD §3.1** (chat API surface) and **PRD §3.3** (Citation Engine retrieval sources).
+
+---
+
+## Context
+
+Chat send (`POST /api/v1/chats/{id}/messages`) already had two document-context channels: `file_ids` (per-message, caller-owned files injected **verbatim** into the prompt, uncited — Donna's ephemeral-document channel) and project-wide KB retrieval (`hybrid_search` over every Knowledge Base attached to the chat's project, feeding the Citation Engine). Neither channel let a caller say "ground this turn specifically in *these* matter documents, and cite what you use." A user reviewing a specific exhibit or a specific prior draft had to either dump its full text via `file_ids` (no citations, no verification) or hope project-wide KB search happened to surface the right chunks.
+
+referenced-files adds a third channel, `referenced_file_ids`: a caller-selected list of matter documents that are **retrieved and cited**, distinct from both `file_ids` (verbatim, uncited) and ordinary KB-wide RAG (implicit, whole-project).
+
+This ADR records the design forks resolved while implementing referenced-files Phase 1 (Tasks 1–4: schema, retrieval primitive, validation, `send_message` wiring) and the two known limitations shipped as-is.
+
+## Decisions
+
+### D1 — A new field, not an overload of `file_ids` (item a)
+
+`referenced_file_ids` is a **new** `MessageCreateRequest` field (cap 16, `MESSAGE_REFERENCED_FILES_MAX_LEN`), not a mode flag on `file_ids`.
+
+Rationale: `file_ids` is contractually verbatim-and-uncited (PRD §3.1, Donna's channel — already distinct from the scalar-only `skill_inputs` channel per the existing schema docstrings) — existing callers depend on that semantic. Overloading it with a "retrieve instead of inject" flag would be a breaking, silent semantic change for every existing caller of `file_ids` and would conflate two genuinely different retrieval strategies (whole-file verbatim injection vs. file-scoped chunk retrieval) behind one wire shape. A new, additive field is non-breaking (omitted/empty is a back-compatible no-op, matching the `file_ids` precedent) and keeps each channel's contract simple and independently documentable. Rejected: a `mode` enum on `file_ids` entries — forks the validation and injection code paths internally anyway, with none of the wire-compatibility benefit.
+
+### D2 — KB-only MVP + matter scope; embed-on-reference deferred to Phase 3 (item b)
+
+`_validate_referenced_file_ids` requires each id to be (1) a caller-owned, non-deleted file, (2) `ingestion_status == 'ready'`, and (3) attached to a Knowledge Base that is itself attached to the chat's `project_id` (the matter). A projectless chat has no matter, so nothing is referenceable — it fails restrictive (404) rather than running a query that can never match. Any failing id — malformed, foreign, unknown, soft-deleted, not-yet-ready, or outside the matter's attached KBs — returns 404, id-probing-safe and message-identical to "not found" (mirrors `_validate_owned_file_ids`'s posture for `file_ids`).
+
+This means a file must already be `ready` (fully ingested/embedded) to be referenceable — there is no "reference an arbitrary file and embed it on demand" path in Phase 1. That is intentionally deferred as **Phase 3 (embed-on-reference)**: eagerly (re-)triggering a file's embedding pipeline when it is first referenced, so a caller could reference a just-uploaded document before its normal ingestion completes. Phase 1 ships the narrower, already-ingested-only surface because it reuses the existing ingestion pipeline and KB-attachment model unchanged — no new ingestion trigger path, no new state machine. Phase 2 (an `@`-mention UI affordance for selecting referenced files while composing) is likewise deferred; Phase 1 is API-only.
+
+### D3 — Referenced-file chunks flow through the existing skip-anonymization context block, not a verbatim dump (item c, P9)
+
+Chunks retrieved via `hybrid_search_files` are merged into the turn's `retrieved_chunks` and rendered through the **same** `_format_retrieval_context_block` / skip-anonymization system message that ordinary KB-RAG chunks already use (`lq_ai_skip_anonymization=True` on that message) — not injected as a second verbatim block alongside `file_ids`' attached-files block.
+
+Rationale: this is PRD/ADR 0016 **P9** ("public inbound text stays verbatim only because citation grounding requires it") applied directly — referenced-file content is retrieval-grounded, citation-bearing context, the same trust class as KB-RAG chunks, so it gets the same anonymization exemption and the same rendering path. It is explicitly **not** a verbatim dump of the referenced file's full text (that is what `file_ids` is for); only the retrieved chunks — the ones the model can cite — enter the prompt.
+
+### D4 — A UI/caller-selected set, not a model-callable tool (item d, P2)
+
+`referenced_file_ids` is set by the caller on the `MessageCreateRequest` before the turn is dispatched. The model cannot select or expand this set mid-turn; there is no tool-call surface (no `ToolIntent` member, no planner-visible action) that lets the model choose which files to reference.
+
+Rationale: ADR 0016 **P2** ("the model... chooses among an operator-enabled allowlist; it can never reach beyond it... a new model-invokable capability is a new bounded, declared entry on an operator-controlled list, not a general-purpose hook"). File selection here is a **caller** decision (today: an API-level list; Phase 2 UI wraps it in an `@`-mention affordance), not a model decision — so it is deliberately kept off the closed-set tool-calling surface (ADR 0015) rather than added as a new governed tool intent. This also keeps the feature's blast radius small: no new grant in `PHASE_GRANTS`, no new audit-log tool-call shape, no new confirmation-gate surface.
+
+### D5 — Merged-chunk cap raised 10→16 only when references are present (item e)
+
+`_merge_retrieved_chunks` caps the merged (referenced + KB) chunk list at `MERGED_MAX_TOTAL_CHUNKS = 16` when `referenced_file_ids` is non-empty, and at the pre-existing `RAG_MAX_TOTAL_CHUNKS = 10` otherwise. Referenced chunks are capped at `REFERENCED_MAX_CHUNKS = 12` (round-robin interleaved across files, `REFERENCED_TOP_K_PER_FILE = 6` per file) and always take priority in the merge (referenced chunks first, then KB chunks not already present, deduped by `chunk_id`) — so ordinary KB retrieval retains at least 4 slots even when the referenced budget is maxed out.
+
+Rationale: pure-KB-search turns (no references) are **byte-identical** to pre-referenced-files behavior — the cap only moves when the caller opts in to referenced files, so this is non-breaking for every existing caller. The 16/12/6 split was sized so a turn referencing several files still leaves headroom for project-wide KB context, rather than referenced files crowding it out entirely.
+
+### D6 — Per-file retrieval alpha is the MIN of the file's matter-KB `hybrid_alpha` (item f, P8)
+
+`_validate_referenced_file_ids` returns, alongside the validated id list, each file's retrieval alpha: `MIN(hybrid_alpha)` across every attached, matter-scoped Knowledge Base containing that file (one SELECT, `func.min` grouped by file id). `_retrieve_referenced_file_context` passes this alpha into `hybrid_search_files` per file (falling back to 0.5 only if a file is somehow missing from the map, which should not happen given the validation contract).
+
+Rationale: `hybrid_alpha` is an existing **operator-tunable** per-KB setting (ADR 0016 P8 — operator visibility and control over every capability); referenced-file retrieval must honor that tuning rather than hardcoding a default, or an operator's deliberate alpha choice for a KB would silently stop applying the moment a caller references one of its files directly. MIN is the deterministic, conservative (vector-favoring) tie-break when a file sits in more than one attached KB with different alpha values — an arbitrary "pick one" or an average would be non-deterministic or not clearly traceable to an operator decision.
+
+### D7 — KB-wide RAG still runs alongside explicit references (item g)
+
+Referencing files does not disable or replace project-wide KB retrieval. Both `_retrieve_referenced_file_context` and the existing KB-wide `hybrid_search` loop run on every turn where the chat has attached KBs; their results are merged per D5, with referenced chunks prioritized.
+
+Rationale: a caller referencing a specific exhibit does not thereby withdraw consent for the model to also draw on the rest of the matter's Knowledge Base — the two channels answer different questions ("ground in *these* documents specifically" vs. "search across everything") and are additive, not exclusive. Running both also means D5's cap-raise is the only wire-visible effect of referencing files on the merged set — no separate "referenced-only mode" to reason about.
+
+## Consequences
+
+- Chat send gains a third document-context channel (`referenced_file_ids` / `applied_referenced_file_ids`) alongside `file_ids` (verbatim) and implicit KB-wide RAG, each with a distinct, now-documented contract (PRD §3.1, §3.3; `docs/api/backend-openapi.yaml`).
+- Audit gains `inference.message_referenced_files` (counts/ids only, per P3) and `inference.kb_chunks_retrieved` gains an additive `retrieved_count` field distinguishing "what the search returned" from "what was actually injected" (`chunk_count`/`chunk_ids`), so referenced-file contribution is traceable in the audit trail without payload exposure.
+- Operators' existing `hybrid_alpha` tuning extends automatically to referenced-file retrieval (D6) with no new config surface.
+- Two known limitations ship as-is in Phase 1 (item h):
+  1. **Confirmation-gate resume path persists no chunk citations.** The tool-call confirmation-gate resume path (`resume_tool_call`'s SSE `complete` frame) unconditionally emits `"citations": []` and `"applied_referenced_file_ids": []`, regardless of whether the original turn referenced files or retrieved citable chunks — the resume path is a continuation frame that does not re-run retrieval or citation extraction. This is a **pre-existing** gap in the confirmation-gate resume path (it predates referenced-files and affects `file_ids`/KB citations identically), not something referenced-files introduces, but referenced-files inherits it for `applied_referenced_file_ids` too. Tracked as a separate DE to file (not filed as part of this ADR — the gap is orthogonal to the referenced-files design and belongs with the broader tool-loop resume-path work).
+  2. **A validated referenced file can contribute zero chunks yet still echo as applied.** `applied_referenced_file_ids` echoes `effective_referenced_file_ids` — the full **validated** set — independent of whether `hybrid_search_files` actually returned any chunks for a given file (e.g., no chunk scored above the search's relevance floor for the turn's query). A file can therefore appear in `applied_referenced_file_ids` while contributing nothing to the model's context for that turn. This is not silent: the `inference.message_referenced_files` audit row's `chunk_count` (count of chunks actually retrieved/injected across all referenced files) exposes the gap between "validated as referenceable" and "actually retrieved," so an operator or auditor can distinguish the two from the audit trail even though the response echo alone cannot.
+
+## Open questions
+
+- **Phase 2 (`@`-mention UI).** The exact interaction design for selecting referenced files inline while composing — out of scope here; referenced-files's PRD §9 entry tracks it as deferred.
+- **Phase 3 (embed-on-reference).** Whether/how referencing a not-yet-`ready` file should trigger or prioritize its ingestion, and the UX for a reference that resolves only after ingestion completes — deferred; needs its own design pass on the ingestion-trigger surface.
+- **Resume-path citation persistence.** Whether to fix the confirmation-gate resume path's citation/echo gap as a targeted DE, or fold it into a broader tool-loop resume-path hardening pass — left to whichever DE is filed for it.

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -7450,6 +7450,18 @@ components:
             alongside `lq_ai_skills` and echoed back as `applied_file_ids`
             on the response / SSE `complete` frame. Capped at 16 entries.
             Omitted / empty is back-compatible.
+        referenced_file_ids:
+          type: array
+          maxItems: 16
+          items:
+            type: string
+            format: uuid
+          description: >
+            referenced-files. Caller-selected matter documents to ground this turn
+            via file-scoped retrieval; retrieved chunks are cited by the
+            Citation Engine. KB-only MVP: each id must be caller-owned,
+            ready, and in a Knowledge Base attached to the chat's project
+            (else 404). Distinct from file_ids (verbatim, uncited).
 
     MessagePostResponse:
       type: object
@@ -7498,6 +7510,12 @@ components:
             `messages.file_ids` column, so this surfaces only on the send
             response (and the SSE `complete` frame), not on rows read
             back via `GET /chats/{id}/messages`. Empty when none attached.
+        applied_referenced_file_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: referenced-files echo of the validated referenced_file_ids.
 
     MessageStreamEvent:
       oneOf:
@@ -7573,6 +7591,15 @@ components:
             `lq_ai_file_ids` for this turn — the echo of
             `MessageCreate.file_ids` (mirrors `applied_skills`).
             Turn-scoped; not persisted. Empty when none attached.
+        applied_referenced_file_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: >
+            referenced-files echo of the validated referenced_file_ids (SSE
+            `complete` frame). Turn-scoped; not persisted. Empty when
+            none attached.
         routed_inference_tier:
           type: integer
           enum: [1,2,3,4,5]

--- a/docs/superpowers/plans/2026-07-02-referenced-files-in-chat-backend-v2.md
+++ b/docs/superpowers/plans/2026-07-02-referenced-files-in-chat-backend-v2.md
@@ -1,0 +1,615 @@
+# Referenced Files in Chat — Backend (Phase 1 MVP) Implementation Plan — v2
+
+> v2 amends the original plan per the adversarial review (`fable_review.md` at repo parent):
+> fixed the broken echo step (threading via dispatcher params), fixed the cap arithmetic
+> (referenced 12 / merged 16, pure-KB turns unchanged at 10), per-file retrieval budget with
+> per-KB-derived alpha, single query-embedding, injected-aware audit rows, corrected test
+> locations (no `tests/unit/`), ADR number 0022, `KnowledgeBaseFile` import.
+
+**Goal:** Let a chat message carry a user-selected set of matter documents (`referenced_file_ids`) that are retrieved as grounding chunks so the assistant's answer returns verified, deep-linkable citations.
+
+**Architecture:** Add a `referenced_file_ids` field to the message-send request. Validate each id is caller-owned, `ready`, and in a Knowledge Base attached to the chat's project (matter scope, KB-only MVP) — the same validation query also returns each file's matter-KB `hybrid_alpha`. Retrieve chunks per referenced file (per-file budget, round-robin interleave) via a new file-scoped hybrid search, merge them ahead of KB-RAG chunks into the existing `retrieved_chunks` local in `send_message` so the shipped context-block + Citation Engine path cite them unchanged. Write a counts/ids-only audit row. Echo validated ids as `applied_referenced_file_ids` by threading them as a parameter into both dispatch helpers.
+
+**Tech Stack:** FastAPI, SQLAlchemy async, Pydantic v2, Postgres + pgvector, pytest.
+
+## Global Constraints
+
+- Python: `ruff format` + `ruff check` both pass (separate CI gates). Type annotations on all public functions. `async def` for I/O. Raise from `app.errors` hierarchy, never bare `Exception`.
+- Every new handler path gets tests; the citation wiring gets an integration regression.
+- **No raw payloads in audit/log rows (P3):** ids/counts only — never file content or query text.
+- **Fail restrictive (P4):** an unauthorized / out-of-matter / not-`ready` referenced id 404s id-probing-safe (message text identical to the nonexistent-id case), never error-open or broad-search fallback.
+- **Atomic audit (P5):** audit rows commit on their own boundary exactly like `inference.message_files_attached`.
+- **Contract is truth (P10):** update `docs/api/backend-openapi.yaml`, `docs/PRD.md`, and add ADR **0022** in the same PR. No new route → `IMPLEMENTED_ROUTES` / `EXPECTED_PATHS` unchanged.
+- **Additive/non-breaking:** omitting `referenced_file_ids` reproduces today's behavior exactly — including the pure-KB merge cap of 10 (`RAG_MAX_TOTAL_CHUNKS`).
+- Test invocation: `cd api && DATABASE_URL=postgresql+asyncpg://test:test@127.0.0.1:55432/lqai_test .venv/bin/pytest <paths> -q` (throwaway pgvector container; conftest auto-migrates). Linters: `.venv/bin/ruff format --check <files>` and `.venv/bin/ruff check <files>`.
+- Dev-env hard rules: never host-side `alembic upgrade` on the live dev DB (127.0.0.1:5432); never `docker compose down -v`.
+- Commits: imperative mood, `git commit -s`.
+
+## File Structure
+
+- `api/app/schemas/chats.py` — `MESSAGE_REFERENCED_FILES_MAX_LEN`, `MessageCreateRequest.referenced_file_ids`, `MessagePostResponse.applied_referenced_file_ids`.
+- `api/app/knowledge/retrieval.py` — extract `_combine_and_hydrate` from `hybrid_search`; add `hybrid_search_files`.
+- `api/app/api/chats.py` — `_validate_referenced_file_ids`, `_retrieve_referenced_file_context`, `_merge_retrieved_chunks`; `_retrieve_kb_context_for_chat` returns the query embedding; wire into `send_message`; thread echo through `_stream_response` / `_non_streaming_response`.
+- `api/tests/test_referenced_files_schema.py` — schema tests (pure Pydantic; flat per repo layout — there is NO `tests/unit/` dir).
+- `api/tests/test_retrieval_files.py` — DB-backed tests for `hybrid_search_files` (flat, like `test_knowledge_retrieval_unit.py`).
+- `api/tests/integration/test_referenced_files_send.py` — validator + end-to-end send/citation/echo tests (client fixture per `tests/integration/test_attached_skills_send.py`).
+- `docs/api/backend-openapi.yaml`, `docs/PRD.md`, `docs/adr/0022-referenced-file-ids-chat.md`.
+
+---
+
+### Task 1: Add `referenced_file_ids` to the message schema
+
+**Files:**
+- Modify: `api/app/schemas/chats.py` (constants block ~86-94; `MessageCreateRequest` ~343; `MessagePostResponse` ~563; `__all__` ~634)
+- Test: `api/tests/test_referenced_files_schema.py` (new, flat — do NOT create `tests/unit/`)
+
+**Steps (TDD):**
+
+1. Write the failing test `api/tests/test_referenced_files_schema.py`:
+
+```python
+"""referenced-files — schema surface for referenced_file_ids (pure Pydantic, no DB)."""
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from app.schemas.chats import (
+    MESSAGE_REFERENCED_FILES_MAX_LEN,
+    MessageCreateRequest,
+    MessagePostResponse,
+)
+
+
+def test_referenced_file_ids_defaults_empty():
+    req = MessageCreateRequest(content="hi")
+    assert req.referenced_file_ids == []
+
+
+def test_referenced_file_ids_accepts_list():
+    ids = ["11111111-1111-1111-1111-111111111111"]
+    req = MessageCreateRequest(content="hi", referenced_file_ids=ids)
+    assert req.referenced_file_ids == ids
+
+
+def test_referenced_file_ids_over_cap_rejected():
+    ids = ["11111111-1111-1111-1111-111111111111"] * (MESSAGE_REFERENCED_FILES_MAX_LEN + 1)
+    with pytest.raises(PydanticValidationError):
+        MessageCreateRequest(content="hi", referenced_file_ids=ids)
+
+
+def test_applied_referenced_file_ids_defaults_empty():
+    resp = MessagePostResponse(message=_minimal_message_response())
+    assert resp.applied_referenced_file_ids == []
+```
+
+   For `_minimal_message_response()`: construct a `MessageResponse` with exactly its required fields — read the class at `api/app/schemas/chats.py:462` and supply what it actually requires (id, chat_id, role, content, created_at at minimum; adapt to the real definition, do not guess).
+
+2. Run it — expect `ImportError: cannot import name 'MESSAGE_REFERENCED_FILES_MAX_LEN'`.
+
+3. Add the constant after `MESSAGE_FILE_IDS_MAX_LEN` (~line 94):
+
+```python
+MESSAGE_REFERENCED_FILES_MAX_LEN: int = 16
+"""Hard cap on ``MessageCreateRequest.referenced_file_ids``.
+
+Referenced files drive file-scoped retrieval for a single turn: each id
+triggers an ownership + matter-KB validation SELECT and a per-file
+hybrid-search call. Without a cap a single message could reference
+thousands of files — workload-multiplication DoS available to any
+authenticated user. 16 matches :data:`MESSAGE_FILE_IDS_MAX_LEN`;
+realistic per-turn document references are a handful. Over the cap 422s
+at schema time."""
+```
+
+4. Add the request field in `MessageCreateRequest`, after the `file_ids` field's docstring (~line 429):
+
+```python
+    referenced_file_ids: list[str] = Field(
+        default_factory=list, max_length=MESSAGE_REFERENCED_FILES_MAX_LEN
+    )
+    """referenced-files: caller-selected matter documents to ground THIS turn via
+    file-scoped retrieval. Distinct from :attr:`file_ids` (which injects
+    a file's full text verbatim with no citations): referenced files are
+    retrieved as chunks and merged into the turn's ``retrieved_chunks``
+    so the Citation Engine mints verified, deep-linkable citations for
+    them. KB-only MVP: each id must be caller-owned, ``ready``, and in a
+    Knowledge Base attached to the chat's project (matter scope);
+    otherwise it 404s id-probing-safe. Echoed back as
+    ``applied_referenced_file_ids``. Empty/omitted is a back-compatible
+    no-op."""
+```
+
+5. Add the response echo in `MessagePostResponse`, after `applied_file_ids` (~line 581):
+
+```python
+    applied_referenced_file_ids: list[str] = Field(default_factory=list)
+    """referenced-files: caller-selected file ids that were validated (owned +
+    matter-KB + ready) and whose chunks were retrieved to ground this
+    turn — the echo of :attr:`MessageCreateRequest.referenced_file_ids`.
+    Turn-scoped (no ``messages.referenced_file_ids`` column): surfaces on
+    the send response and the SSE ``complete`` frame only. Empty when
+    none were referenced or none validated."""
+```
+
+6. Add `"MESSAGE_REFERENCED_FILES_MAX_LEN",` to `__all__` (~line 634+, keep alpha order).
+
+7. Run test + `ruff format --check` + `ruff check` on the touched files — all pass.
+
+8. Commit: `git commit -s -m "feat(chats): add referenced_file_ids to message schema" -m "Refs referenced-files"`
+
+---
+
+### Task 2: File-scoped hybrid retrieval (`hybrid_search_files`)
+
+**Files:**
+- Modify: `api/app/knowledge/retrieval.py`
+- Test: `api/tests/test_retrieval_files.py` (new, flat; uses the `db_session` conftest fixture → requires `DATABASE_URL`)
+
+**Steps (TDD):**
+
+1. Write the failing test `api/tests/test_retrieval_files.py`. Two ready+embedded... correction: two `ready` files each with a `documents` row and 2-3 `document_chunks` rows with `content` + `content_tsv` populated (embedding may stay NULL — exercise the FTS-only path deterministically, `alpha=1.0`, `query_embedding=None`). Model the seeding on existing fixtures/tests that insert `File`/`Document`/chunk rows (grep `document_chunks` in `api/tests/`). Assertions:
+   - searching with `file_ids=[file_a]` returns only file_a's chunks (`{r.file_id for r in results} == {file_a}`), non-empty;
+   - `file_ids=[]` returns `[]` without touching the DB;
+   - a file with `ingestion_status='processing'` (or soft-deleted) contributes nothing even when its id is passed.
+
+2. Run — expect `ImportError: cannot import name 'hybrid_search_files'`.
+
+3. Extract the combine+hydrate tail of `hybrid_search` (`retrieval.py:124-180`, from the `if not vector_rows and not fts_rows` guard through the final return) into:
+
+```python
+async def _combine_and_hydrate(
+    db: AsyncSession,
+    *,
+    vector_rows: list[tuple[uuid.UUID, float]],
+    fts_rows: list[tuple[uuid.UUID, float]],
+    top_k: int,
+    alpha: float,
+) -> list[HybridSearchResult]:
+    """Min-max normalize, linearly combine, take top_k, hydrate.
+
+    Shared by :func:`hybrid_search` (KB-scoped) and
+    :func:`hybrid_search_files` (file-scoped) — the only difference
+    between the two is which candidate SQL produced ``vector_rows`` /
+    ``fts_rows``.
+    """
+```
+
+   Body: move lines 124-180 verbatim (guard, candidate-id union, `_min_max_normalize` both sides, `(1-alpha)*v + alpha*f`, sort, `[:top_k]`, `_hydrate_chunks`, rebuild `HybridSearchResult`s, re-sort by `hybrid_score`). Replace the moved body in `hybrid_search` with a single `return await _combine_and_hydrate(db, vector_rows=vector_rows, fts_rows=fts_rows, top_k=top_k, alpha=alpha)`.
+
+4. Add the file-scoped side queries + entry point (append to `retrieval.py`). SQL is identical to `_VECTOR_SQL`/`_FTS_SQL` except the `knowledge_base_files` join is replaced by `f.id = ANY(:file_ids)` (keep `f.deleted_at IS NULL`, `f.ingestion_status = 'ready'`, and `dc.embedding IS NOT NULL` on the vector side). Binding: pass `[str(fid) for fid in file_ids]` — the exact pattern `_HYDRATE_SQL` already uses at `retrieval.py:283,296`.
+
+```python
+async def hybrid_search_files(
+    db: AsyncSession,
+    *,
+    file_ids: list[uuid.UUID],
+    query: str,
+    query_embedding: list[float] | None,
+    top_k: int,
+    alpha: float,
+) -> list[HybridSearchResult]:
+    """Hybrid search scoped to an explicit set of file ids.
+
+    Same score model as :func:`hybrid_search` (pgvector cosine + FTS,
+    min-max normalized, ``(1-alpha)*vec + alpha*fts``) but the candidate
+    set is ``document_chunks`` whose owning file is in ``file_ids`` (not
+    a KB join). Callers MUST have already authorized ``file_ids`` — this
+    primitive does no ownership check, matching :func:`hybrid_search`'s
+    contract (the handler enforces scope).
+    """
+    if not file_ids:
+        return []
+    alpha = max(0.0, min(1.0, alpha))
+    candidate_limit = top_k * CANDIDATE_OVERSHOOT
+    ids = [str(fid) for fid in file_ids]
+
+    vector_rows: list[tuple[uuid.UUID, float]] = []
+    if query_embedding is not None and alpha < 1.0:
+        result = await db.execute(
+            _VECTOR_SQL_FILES,
+            {"file_ids": ids, "q_emb": _format_vector(query_embedding), "limit": candidate_limit},
+        )
+        vector_rows = [
+            (uuid.UUID(str(r["chunk_id"])), float(r["vec_score"])) for r in result.mappings().all()
+        ]
+
+    fts_rows: list[tuple[uuid.UUID, float]] = []
+    if alpha > 0.0:
+        result = await db.execute(
+            _FTS_SQL_FILES, {"file_ids": ids, "q": query, "limit": candidate_limit}
+        )
+        fts_rows = [
+            (uuid.UUID(str(r["chunk_id"])), float(r["fts_rank"])) for r in result.mappings().all()
+        ]
+
+    return await _combine_and_hydrate(
+        db, vector_rows=vector_rows, fts_rows=fts_rows, top_k=top_k, alpha=alpha
+    )
+```
+
+5. Run: the new tests AND every existing retrieval/KB-search test (`pytest tests/test_retrieval_files.py tests/test_knowledge_retrieval_unit.py -q`, then `-k hybrid_search` across `tests/`) — the refactor must leave `hybrid_search` behavior byte-identical. Linters on the touched file.
+
+6. Commit: `git commit -s -m "feat(retrieval): add file-scoped hybrid_search_files" -m "Refs referenced-files"`
+
+---
+
+### Task 3: Validate referenced ids (owned + matter-KB + ready) and fetch per-file alpha
+
+**Files:**
+- Modify: `api/app/api/chats.py` — add `_validate_referenced_file_ids` after `_validate_owned_file_ids` (which ends ~line 414); add `KnowledgeBaseFile` to the existing `from app.models.knowledge import KnowledgeBase` import at line 106 (`ProjectKnowledgeBase` is already imported at line 109; `NotFound` at 98; `select`/`func` at 70).
+- Test: `api/tests/integration/test_referenced_files_send.py` (new)
+
+**Signature (differs from v1 — the validation query also returns each file's matter-KB `hybrid_alpha`, so retrieval honors the operator-tuned per-KB knob without a second round-trip):**
+
+```python
+async def _validate_referenced_file_ids(
+    db: AsyncSession,
+    referenced_file_ids: list[str],
+    *,
+    owner_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+) -> tuple[list[str], dict[str, float]]:
+    """Validate caller-referenced files for file-scoped retrieval (referenced-files).
+
+    KB-only MVP + matter scope: each id must (1) parse as a UUID, (2)
+    resolve to a caller-owned, non-deleted, ``ingestion_status='ready'``
+    file that (3) is attached to a Knowledge Base which is itself
+    attached to the chat's ``project_id``. Any id failing any check —
+    including a projectless chat (no matter, so nothing is referenceable)
+    — raises :class:`NotFound` (404), id-probing-safe and message-
+    identical to the nonexistent-id case, consistent with
+    :func:`_validate_owned_file_ids`.
+
+    Returns ``(validated_ids, alpha_by_id)``: ids as strings (deduped,
+    order-preserving) and each file's retrieval alpha — the MIN
+    ``hybrid_alpha`` across the matter KBs containing it (deterministic
+    when a file sits in several attached KBs; MIN favors the vector
+    side). Empty input returns ``([], {})`` without a DB round-trip.
+    """
+```
+
+**Implementation:** mirror `_validate_owned_file_ids` (`chats.py:355-414`) exactly for parse/dedupe/404 (`NotFound(f"File {raw} not found.", details={"file_id": str(raw)})`). If `project_id is None` and ids were supplied, raise `NotFound` for the first parsed id (fail restrictive — P4). One SELECT:
+
+```python
+    stmt = (
+        select(File.id, func.min(KnowledgeBase.hybrid_alpha))
+        .join(KnowledgeBaseFile, KnowledgeBaseFile.file_id == File.id)
+        .join(KnowledgeBase, KnowledgeBase.id == KnowledgeBaseFile.kb_id)
+        .join(
+            ProjectKnowledgeBase,
+            ProjectKnowledgeBase.knowledge_base_id == KnowledgeBaseFile.kb_id,
+        )
+        .where(
+            File.id.in_(parsed),
+            File.owner_id == owner_id,
+            File.deleted_at.is_(None),
+            File.ingestion_status == "ready",
+            ProjectKnowledgeBase.project_id == project_id,
+        )
+        .group_by(File.id)
+    )
+```
+
+Build `alpha_by_id: dict[str, float]` (`str(fid) -> float(alpha)`); 404 any parsed id absent from the result; return `([str(fid) for fid in parsed], alpha_by_id)`.
+
+**Tests (in `test_referenced_files_send.py`, direct-call, `pytestmark = pytest.mark.asyncio`):** seed user + project + KB (`hybrid_alpha` non-default, e.g. `0.7`) attached via `project_knowledge_bases` + `ready` file in `knowledge_base_files` + its `documents` row (grep existing tests for `ProjectKnowledgeBase`/`KnowledgeBaseFile` seeding patterns). Cases:
+- valid file → `([str(file_id)], {str(file_id): 0.7})`;
+- `project_id=None` → `NotFound`;
+- random foreign uuid → `NotFound`;
+- file in a KB **not** attached to the project → `NotFound`;
+- `ingestion_status='processing'` file → `NotFound`;
+- malformed id string → `NotFound`;
+- duplicate ids in input → deduped single entry, order preserved.
+
+Run tests + linters; commit: `git commit -s -m "feat(chats): validate referenced_file_ids (owned + matter-KB + ready, per-file alpha)" -m "Refs referenced-files"`
+
+---
+
+### Task 4: Retrieve (per-file budget), merge, audit, and echo in `send_message`
+
+**Files:**
+- Modify: `api/app/api/chats.py`
+- Test: `api/tests/integration/test_referenced_files_send.py` (append)
+
+**Step 4.1 — constants** (after `RAG_MAX_TOTAL_CHUNKS` ~line 952):
+
+```python
+# referenced-files — file-scoped retrieval for explicitly referenced files. An
+# explicit reference means "answer over THIS document": each referenced
+# file gets its own top-k budget (round-robin interleaved, so no file is
+# starved by a dominant sibling), and referenced chunks take priority
+# over KB-wide RAG chunks in the merged context set. When references are
+# present the merged bound rises to MERGED_MAX_TOTAL_CHUNKS (explicit
+# reference justifies the context spend — ADR 0022); referenced chunks
+# are capped at REFERENCED_MAX_CHUNKS so KB RAG always retains at least
+# four slots when it has results. Pure-KB turns keep the shipped
+# RAG_MAX_TOTAL_CHUNKS bound — zero behavior change.
+REFERENCED_TOP_K_PER_FILE: int = 6
+REFERENCED_MAX_CHUNKS: int = 12
+MERGED_MAX_TOTAL_CHUNKS: int = 16
+```
+
+**Step 4.2 — single query-embedding.** Change `_retrieve_kb_context_for_chat` (`:975`) to return a 3-tuple `(chunks, kb_ids_searched, query_embedding)` — it already computes the embedding at `:1021`; return it (or `None` on the early exits at `:1002-1007` and on embed-fetch failure). It has exactly ONE caller (`:1427`) and no test references — update the docstring and that call site. Rationale: referenced files are by construction in the project's attached KBs, so the KB pass has already embedded the query (or correctly decided not to: all-FTS KBs / embed failure). The referenced path must NOT issue a second embed call.
+
+**Step 4.3 — retrieval + merge helpers** (after `_retrieve_kb_context_for_chat`):
+
+```python
+async def _retrieve_referenced_file_context(
+    db: AsyncSession,
+    *,
+    referenced_file_ids: list[str],
+    alpha_by_id: dict[str, float],
+    query: str,
+    query_embedding: list[float] | None,
+) -> list[HybridSearchResult]:
+    """Per-file hybrid search for explicitly referenced files (referenced-files).
+
+    Ids are already validated (owned + matter-KB + ready) by
+    :func:`_validate_referenced_file_ids`, which also supplied each
+    file's matter-KB ``hybrid_alpha`` (MIN across containing KBs).
+    ``query_embedding`` is the one computed by the KB pass — referenced
+    files live in the same attached KBs, so no second embed call is made
+    (``None`` degrades to FTS-only, the same fallback the KB path uses).
+
+    Each file gets its own :data:`REFERENCED_TOP_K_PER_FILE` budget
+    (per-file, not global top-k, so one dominant document cannot starve
+    the others), and the per-file result lists are round-robin
+    interleaved up to :data:`REFERENCED_MAX_CHUNKS`. A per-file search
+    failure is logged and skipped (fail-soft, mirroring the per-KB loop).
+    """
+    if not referenced_file_ids:
+        return []
+
+    per_file: list[list[HybridSearchResult]] = []
+    for fid in referenced_file_ids:
+        alpha = alpha_by_id.get(fid, 0.5)
+        try:
+            results = await hybrid_search_files(
+                db,
+                file_ids=[uuid.UUID(fid)],
+                query=query,
+                query_embedding=query_embedding,
+                top_k=REFERENCED_TOP_K_PER_FILE,
+                alpha=alpha,
+            )
+        except Exception:
+            log.exception(
+                "chat-send referenced-files: hybrid_search_files failed for file; skipping",
+                extra={"event": "chat_ref_file_search_failed", "file_id": fid},
+            )
+            continue
+        if results:
+            per_file.append(results)
+
+    # Round-robin interleave so every referenced file is represented
+    # before any file gets a second slot. Order determines the [N]
+    # citation indices, so this is also a fairness property of the
+    # context block.
+    merged: list[HybridSearchResult] = []
+    seen: set[uuid.UUID] = set()
+    for rank in range(REFERENCED_TOP_K_PER_FILE):
+        for results in per_file:
+            if rank >= len(results):
+                continue
+            chunk = results[rank]
+            if chunk.chunk_id in seen:
+                continue
+            seen.add(chunk.chunk_id)
+            merged.append(chunk)
+            if len(merged) >= REFERENCED_MAX_CHUNKS:
+                return merged
+    return merged
+
+
+def _merge_retrieved_chunks(
+    referenced: list[HybridSearchResult],
+    kb: list[HybridSearchResult],
+) -> list[HybridSearchResult]:
+    """Merge referenced-file chunks (priority) with KB-RAG chunks.
+
+    Referenced chunks come first (explicit user intent), then KB chunks
+    not already present (deduped by ``chunk_id``). The cap is
+    :data:`MERGED_MAX_TOTAL_CHUNKS` when referenced chunks are present
+    (referenced ≤ REFERENCED_MAX_CHUNKS, so KB retains ≥ 4 slots) and
+    the shipped :data:`RAG_MAX_TOTAL_CHUNKS` otherwise (pure-KB turns
+    are byte-identical to pre-referenced-files behavior). Order determines the
+    ``[N]`` citation indices in the context block.
+    """
+    cap = MERGED_MAX_TOTAL_CHUNKS if referenced else RAG_MAX_TOTAL_CHUNKS
+    out: list[HybridSearchResult] = []
+    seen: set[uuid.UUID] = set()
+    for chunk in [*referenced, *kb]:
+        if chunk.chunk_id in seen:
+            continue
+        seen.add(chunk.chunk_id)
+        out.append(chunk)
+        if len(out) >= cap:
+            break
+    return out
+```
+
+**Step 4.4 — validate in `send_message`** (right after `effective_file_ids = ...` at ~`:1233`):
+
+```python
+    # referenced-files — validate caller-referenced matter files (owned + in a KB
+    # attached to the chat's project + ready). 404 id-probing-safe on any
+    # miss; empty/omitted is a no-op. Also yields each file's matter-KB
+    # hybrid_alpha for the file-scoped retrieval below.
+    effective_referenced_file_ids, referenced_alpha_by_id = await _validate_referenced_file_ids(
+        db,
+        payload.referenced_file_ids,
+        owner_id=user.id,
+        project_id=chat.project_id,
+    )
+```
+
+**Step 4.5 — replace the retrieval/injection block** (`:1420-1480`, from the Wave D.1 T7b comment + `_retrieve_kb_context_for_chat` call through the KB-audit `await db.commit()`):
+
+```python
+    # Wave D.1 T7b — KB RAG across the project's attached KBs. Returns
+    # the query embedding it computed so the referenced-files referenced-file pass
+    # below can reuse it (referenced files live in the same attached
+    # KBs; one embed call per turn).
+    kb_chunks, kb_ids_searched, rag_query_embedding = await _retrieve_kb_context_for_chat(
+        db,
+        chat=chat,
+        query=effective_content,
+        gateway=gateway,
+        request_id=request.headers.get("x-request-id"),
+    )
+
+    # referenced-files — per-file retrieval for explicitly referenced files.
+    referenced_chunks = await _retrieve_referenced_file_context(
+        db,
+        referenced_file_ids=effective_referenced_file_ids,
+        alpha_by_id=referenced_alpha_by_id,
+        query=effective_content,
+        query_embedding=rag_query_embedding,
+    )
+
+    # Merge: referenced first (explicit intent), then KB, deduped +
+    # capped. The single ``retrieved_chunks`` local flows to the context
+    # block AND to every _persist_message_citations call site, so both
+    # KB and referenced chunks become citable with no change to the
+    # citation path.
+    retrieved_chunks = _merge_retrieved_chunks(referenced_chunks, kb_chunks)
+    injected_chunk_ids = {c.chunk_id for c in retrieved_chunks}
+
+    gw_messages: list[ChatCompletionMessage] = []
+    if retrieved_chunks:
+        context_block = _format_retrieval_context_block(retrieved_chunks)
+        # M2-D2 / Decision M2-1: retrieved source documents are NOT
+        # pseudonymized when sent to the provider — the model needs
+        # intact source quotes for citation grounding. The skip flag
+        # tells the gateway's anonymization pre-middleware to leave
+        # this message's content unchanged even if the chat's other
+        # content is being pseudonymized. The pre-middleware still
+        # pseudonymizes the user turn + any chat-side system message.
+        gw_messages.append(
+            ChatCompletionMessage(
+                role="system",
+                content=context_block,
+                lq_ai_skip_anonymization=True,
+            )
+        )
+
+    # T7-shape audit row for KB retrieval. chunk_ids/chunk_count record
+    # what was actually INJECTED after the referenced-files merge (Receipts
+    # fidelity); retrieved_count records what the search returned. On
+    # pure-KB turns the two are identical, preserving T7 semantics.
+    if kb_chunks:
+        kb_injected = [c for c in kb_chunks if c.chunk_id in injected_chunk_ids]
+        await audit_action(
+            db,
+            user_id=user.id,
+            action="inference.kb_chunks_retrieved",
+            resource_type="chat",
+            resource_id=str(cid),
+            project_id=chat.project_id,
+            request=request,
+            details={
+                "kb_ids": [str(k) for k in kb_ids_searched],
+                "chunk_count": len(kb_injected),
+                "chunk_ids": [str(c.chunk_id) for c in kb_injected],
+                "retrieved_count": len(kb_chunks),
+                "query_token_estimate": len(effective_content.split()),
+            },
+        )
+        await db.commit()
+
+    # referenced-files audit — counts/ids only (P3), own commit boundary (P5).
+    if effective_referenced_file_ids:
+        await audit_action(
+            db,
+            user_id=user.id,
+            action="inference.message_referenced_files",
+            resource_type="chat",
+            resource_id=str(cid),
+            project_id=chat.project_id,
+            request=request,
+            details={
+                "file_ids": list(effective_referenced_file_ids),
+                "referenced_count": len(effective_referenced_file_ids),
+                "chunk_count": len(referenced_chunks),
+                "chunk_ids": [str(c.chunk_id) for c in referenced_chunks],
+            },
+        )
+        await db.commit()
+```
+
+   Note the original KB-audit was inside `if retrieved_chunks:`; it is now gated on `if kb_chunks:` — identical semantics on pure-KB turns (empty kb_chunks ⇔ empty retrieved_chunks there). Everything downstream (the `file_ids` verbatim block `:1482-1528`, history, gw_request build) stays untouched. Run `tests/test_chat_rag.py` and `tests/test_kb_retrieval_audit.py` after this step — they assert by action name, not exact details dicts, but verify; if any asserts an exact details dict, extend the expectation with `retrieved_count` (a deliberate, documented additive change).
+
+**Step 4.6 — thread the echo.** The `applied_file_ids` sites read `request.lq_ai_file_ids` off the gateway request inside the dispatch helpers, where `effective_referenced_file_ids` is NOT in scope. Do NOT touch the gateway `ChatCompletionRequest`. Instead:
+
+- Add parameter `referenced_file_ids: list[str] | None = None` to `_non_streaming_response` (~`:2856`) and `_stream_response` (~`:3250`).
+- Pass `referenced_file_ids=effective_referenced_file_ids` at both call sites (`:1637`, `:1652`).
+- `_non_streaming_response`: add `applied_referenced_file_ids=list(referenced_file_ids or [])` to all four `MessagePostResponse(...)` builds — tool-loop final (~`:3001`), confirmation-gate placeholder (~`:3094`), MCP-auth placeholder (~`:3124`), single-shot (~`:3225`). (Validation succeeded before the gate, so the placeholders echo too — the client's picker state survives the confirmation round-trip.)
+- `_stream_response`: add `"applied_referenced_file_ids": list(referenced_file_ids or []),` to the `complete` frame dict (~`:3648-3671`, next to `"applied_file_ids"`).
+- `resume_tool_call`'s `complete` frame (~`:2310`, the one with `"applied_file_ids": []`): add `"applied_referenced_file_ids": [],` for shape parity (turn state does not survive the pause — known limitation, ADR 0022).
+
+**Step 4.7 — integration tests** (append to `api/tests/integration/test_referenced_files_send.py`). Build the client fixture on the pattern in `tests/integration/test_attached_skills_send.py:64` (ASGI `AsyncClient`, dependency overrides, gateway stub). For the citation e2e, follow `tests/test_chat_citations.py` (~`:290`): patch `app.api.chats.hybrid_search_files` to return `HybridSearchResult`s pointing at REAL seeded `Document` rows whose `normalized_content` contains the quoted passage, and stub the gateway to reply `"<verbatim passage>" (Source: [1])` so Stage-1 verification persists a row. (The real `hybrid_search_files` is covered against the DB by Task 2's tests; patching here isolates the wiring under test.) Cases:
+
+- **Citation e2e:** POST send with `referenced_file_ids=[file_id]` (non-streaming) → 200; `applied_referenced_file_ids == [str(file_id)]`; GET `/chats/{id}/messages/{msg_id}/citations` contains a row whose source file is the referenced file.
+- **Foreign id:** POST with a random uuid → 404.
+- **Projectless chat:** POST to a chat with no `project_id` with any referenced id → 404.
+- **No-op back-compat:** POST without `referenced_file_ids` → 200, `applied_referenced_file_ids == []`, and no `inference.message_referenced_files` audit row.
+- **Audit row:** after the e2e send, one `inference.message_referenced_files` audit row exists with `file_ids`, `referenced_count`, `chunk_count`, `chunk_ids` and NO content/query keys.
+
+**Step 4.8 — gate:** run the new module + `tests/test_chat_rag.py` + `tests/test_kb_retrieval_audit.py` + `tests/test_chat_citations.py` + `tests/test_chats_send_message.py`; linters on `app/api/chats.py`.
+
+**Step 4.9 — commit:** `git commit -s -m "feat(chats): ground + cite referenced files in send_message" -m "Refs referenced-files"`
+
+---
+
+### Task 5: Contract + docs (OpenAPI, PRD, ADR 0022) and full-suite gate
+
+**Files:**
+- Modify: `docs/api/backend-openapi.yaml` (`MessageCreate` request schema + the send-response schema — find the exact schema names by grepping `file_ids` in the YAML; mirror how `applied_file_ids` is documented)
+- Modify: `docs/PRD.md` (§3.1 chat API surface; §3.3 Citation Engine)
+- Create: `docs/adr/0022-referenced-file-ids-chat.md` (follow the template/style of `docs/adr/0021-*.md`)
+
+**Steps:**
+
+1. OpenAPI — add to the message-create schema:
+
+```yaml
+        referenced_file_ids:
+          type: array
+          maxItems: 16
+          items:
+            type: string
+            format: uuid
+          description: >
+            referenced-files. Caller-selected matter documents to ground this turn
+            via file-scoped retrieval; retrieved chunks are cited by the
+            Citation Engine. KB-only MVP: each id must be caller-owned,
+            ready, and in a Knowledge Base attached to the chat's project
+            (else 404). Distinct from file_ids (verbatim, uncited).
+```
+
+   and to the send response schema:
+
+```yaml
+        applied_referenced_file_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: referenced-files echo of the validated referenced_file_ids.
+```
+
+2. Conformance (authoritative — never eyeball the YAML): `.venv/bin/pytest tests/test_openapi.py -q`. No new path → `EXPECTED_PATHS`/count untouched. NOTE: `docs/api/backend-openapi.yaml` does not parse with plain `yaml.safe_load` (pre-existing) — the test is the check. Also check whether the repo has a generated-OpenAPI drift guard (commit `c11e62e` added one — grep `.github/workflows` / `scripts` for openapi export) and regenerate the export if the guard requires it.
+
+3. PRD — in §3.1 after the `file_ids` channel description add:
+
+```markdown
+  A parallel `referenced_file_ids` list (referenced-files) references matter documents that are **retrieved and cited** (KB-only MVP), as opposed to `file_ids` which injects verbatim text without citations.
+```
+
+   In §3.3 note citations may be grounded in explicitly referenced files, not only project-wide KB retrieval. Add the referenced-files entry to §9 (after DE-376) recording this shipped Phase-1 scope and the deferred Phase 2 (`@`-mention) / Phase 3 (embed-on-reference).
+
+4. ADR 0022 — record ALL of: (a) new field vs overloading `file_ids` (chosen: new field; non-breaking, preserves verbatim small-doc channel); (b) KB-only MVP + matter scope, embed-on-reference deferred (Phase 3); (c) P9 rationale (retrieval-grounded chunks through the existing skip-anonymization context block, not a verbatim dump); (d) P2 (UI-selected set, not a model-callable tool); (e) merged-cap raise 10→16 when references present, referenced ≤ 12, pure-KB turns unchanged; (f) alpha derived per file as MIN matter-KB `hybrid_alpha` (honors operator tuning, P8; operator toggle inherits chat+KB enablement); (g) KB-wide RAG still runs alongside explicit references (referenced chunks take priority); (h) known limitations: confirmation-gate resume path persists no chunk citations (pre-existing, separate DE to file), and a validated file can contribute zero chunks yet echo as applied (audit `chunk_count` exposes it).
+
+5. Full gate: `cd api && .venv/bin/ruff format --check . && .venv/bin/ruff check . && DATABASE_URL=... .venv/bin/pytest -m "not provider and not slow" -q`.
+
+6. Commit: `git commit -s -m "docs(chats): document referenced_file_ids channel + ADR 0022" -m "Refs referenced-files"`

--- a/docs/superpowers/plans/2026-07-02-referenced-files-in-chat-backend.md
+++ b/docs/superpowers/plans/2026-07-02-referenced-files-in-chat-backend.md
@@ -1,0 +1,876 @@
+# Referenced Files in Chat — Backend (Phase 1 MVP) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a chat message carry a user-selected set of matter documents (`referenced_file_ids`) that are retrieved as grounding chunks so the assistant's answer returns verified, deep-linkable citations.
+
+**Architecture:** Add a `referenced_file_ids` field to the message-send request. Validate each id is caller-owned, `ready`, and in a Knowledge Base attached to the chat's project (matter scope, KB-only MVP). Retrieve chunks for those files via a new file-scoped hybrid search, merge them into the existing `retrieved_chunks` local in `send_message` so the shipped context-block + Citation Engine path cite them unchanged. Write a counts-only audit row.
+
+**Tech Stack:** FastAPI, SQLAlchemy async, Pydantic v2, Postgres + pgvector, pytest (unit + integration against real Postgres in Docker).
+
+**Companion docs:** spec `docs/superpowers/specs/2026-07-02-chat-at-mention-file-retrieval-design.md`; scope `summary_scope.md`; overlap/compliance `docpicker.md`. Frontend (composer picker + `@`-mention) is a **separate plan** — this plan is backend-only and independently testable via the API.
+
+## Global Constraints
+
+- Python: `ruff format` + `ruff check` both pass (separate CI gates). Type annotations on all public functions. `async def` for I/O. Raise from `app.errors` hierarchy, never bare `Exception`. (CLAUDE.md → Code style)
+- Coverage target 80%; every new endpoint/handler path gets unit + integration tests; this is a feature so it also gets an integration regression for the citation wiring. (CLAUDE.md → Testing)
+- **No raw payloads in audit/log rows (P3):** audit rows carry ids/counts/digests only — never file content or the query text.
+- **Fail restrictive (P4):** an unauthorized / out-of-matter / not-`ready` referenced id is dropped or 404'd (id-probing-safe), never an error-open or broad-search fallback.
+- **Atomic audit (P5):** audit writes flush inside the caller's transaction; the audit row for referenced files commits on its own boundary exactly like `inference.message_files_attached`.
+- **Contract is truth (P10):** update `docs/api/backend-openapi.yaml`, `docs/PRD.md`, and add an ADR in the same PR. No new route in this plan (reuses `GET /kb/{id}/files`), so `IMPLEMENTED_ROUTES` / `EXPECTED_PATHS` are unchanged.
+- **New field is additive/non-breaking:** omitting `referenced_file_ids` reproduces today's behavior exactly.
+- Dev-env hard rules (CLAUDE.md): never host-side `alembic upgrade` on the dev DB; never `docker compose down -v`; conftest auto-migrates a throwaway `pgvector/pgvector:pg16` container for integration tests.
+
+## File Structure
+
+- `api/app/schemas/chats.py` — add `MESSAGE_REFERENCED_FILES_MAX_LEN`, `MessageCreateRequest.referenced_file_ids`, `MessagePostResponse.applied_referenced_file_ids`. (Request/response surface; one responsibility.)
+- `api/app/knowledge/retrieval.py` — refactor the combine+hydrate tail of `hybrid_search` into a shared helper; add `hybrid_search_files` (file-id-scoped) reusing it. (Retrieval primitives.)
+- `api/app/api/chats.py` — add `_validate_referenced_file_ids`, `_retrieve_referenced_file_context`, `_merge_retrieved_chunks`; wire them into `send_message`. (Chat handler.)
+- `api/tests/unit/test_chats_schema.py` (or existing schema test module) — schema validation tests.
+- `api/tests/integration/test_referenced_files_send.py` — new integration test module for the end-to-end send + citation wiring.
+- `api/tests/unit/test_retrieval_files.py` — unit/integration for `hybrid_search_files`.
+- `docs/api/backend-openapi.yaml`, `docs/PRD.md`, `docs/adr/00NN-referenced-file-ids-chat.md` — contract + docs.
+
+---
+
+### Task 1: Add `referenced_file_ids` to the message schema
+
+**Files:**
+- Modify: `api/app/schemas/chats.py` (constants block ~86-94; `MessageCreateRequest` ~343-433; `MessagePostResponse` ~563-609; `__all__` ~634-662)
+- Test: `api/tests/unit/test_chats_schema.py`
+
+**Interfaces:**
+- Produces: `MESSAGE_REFERENCED_FILES_MAX_LEN: int`; `MessageCreateRequest.referenced_file_ids: list[str]` (default `[]`, capped); `MessagePostResponse.applied_referenced_file_ids: list[str]` (default `[]`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/unit/test_chats_schema.py
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from app.schemas.chats import (
+    MESSAGE_REFERENCED_FILES_MAX_LEN,
+    MessageCreateRequest,
+    MessagePostResponse,
+    MessageResponse,
+)
+
+
+def test_referenced_file_ids_defaults_empty():
+    req = MessageCreateRequest(content="hi")
+    assert req.referenced_file_ids == []
+
+
+def test_referenced_file_ids_accepts_list():
+    ids = ["11111111-1111-1111-1111-111111111111"]
+    req = MessageCreateRequest(content="hi", referenced_file_ids=ids)
+    assert req.referenced_file_ids == ids
+
+
+def test_referenced_file_ids_over_cap_rejected():
+    ids = ["11111111-1111-1111-1111-111111111111"] * (MESSAGE_REFERENCED_FILES_MAX_LEN + 1)
+    with pytest.raises(PydanticValidationError):
+        MessageCreateRequest(content="hi", referenced_file_ids=ids)
+
+
+def test_applied_referenced_file_ids_defaults_empty():
+    # minimal MessageResponse to satisfy the required nested field
+    msg = MessageResponse(
+        id="11111111-1111-1111-1111-111111111111",
+        chat_id="22222222-2222-2222-2222-222222222222",
+        role="assistant",
+        content="ok",
+        created_at="2026-07-02T00:00:00Z",
+    )
+    resp = MessagePostResponse(message=msg)
+    assert resp.applied_referenced_file_ids == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && python -m pytest tests/unit/test_chats_schema.py -v`
+Expected: FAIL — `ImportError: cannot import name 'MESSAGE_REFERENCED_FILES_MAX_LEN'`.
+
+- [ ] **Step 3: Add the constant** (in `api/app/schemas/chats.py`, after `MESSAGE_FILE_IDS_MAX_LEN` ~line 94)
+
+```python
+MESSAGE_REFERENCED_FILES_MAX_LEN: int = 16
+"""Hard cap on ``MessageCreateRequest.referenced_file_ids``.
+
+Referenced files drive file-scoped retrieval for a single turn: each id
+triggers an ownership + matter-KB validation SELECT and a per-file
+hybrid-search call. Without a cap a single message could reference
+thousands of files — workload-multiplication DoS available to any
+authenticated user. 16 matches :data:`MESSAGE_FILE_IDS_MAX_LEN`;
+realistic per-turn document references are a handful. Over the cap 422s
+at schema time."""
+```
+
+- [ ] **Step 4: Add the request field** (in `MessageCreateRequest`, after `file_ids` ~line 429)
+
+```python
+    referenced_file_ids: list[str] = Field(
+        default_factory=list, max_length=MESSAGE_REFERENCED_FILES_MAX_LEN
+    )
+    """referenced-files: caller-selected matter documents to ground THIS turn via
+    file-scoped retrieval. Distinct from :attr:`file_ids` (which injects
+    a file's full text verbatim with no citations): referenced files are
+    retrieved as chunks and merged into the turn's ``retrieved_chunks``
+    so the Citation Engine mints verified, deep-linkable citations for
+    them. KB-only MVP: each id must be caller-owned, ``ready``, and in a
+    Knowledge Base attached to the chat's project (matter scope);
+    otherwise it 404s id-probing-safe. Echoed back as
+    ``applied_referenced_file_ids``. Empty/omitted is a back-compatible
+    no-op."""
+```
+
+- [ ] **Step 5: Add the response echo** (in `MessagePostResponse`, after `applied_file_ids` ~line 581)
+
+```python
+    applied_referenced_file_ids: list[str] = Field(default_factory=list)
+    """referenced-files: caller-selected file ids that were validated (owned +
+    matter-KB + ready) and whose chunks were retrieved to ground this
+    turn — the echo of :attr:`MessageCreateRequest.referenced_file_ids`.
+    Turn-scoped (no ``messages.referenced_file_ids`` column): surfaces on
+    the send response and the SSE ``complete`` frame only. Empty when
+    none were referenced or none validated."""
+```
+
+- [ ] **Step 6: Export the constant** (add to `__all__` ~line 642, keeping alpha order)
+
+```python
+    "MESSAGE_REFERENCED_FILES_MAX_LEN",
+```
+
+- [ ] **Step 7: Run tests + linters to verify pass**
+
+Run: `cd api && python -m pytest tests/unit/test_chats_schema.py -v && ruff format --check app/schemas/chats.py && ruff check app/schemas/chats.py`
+Expected: PASS; ruff clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/app/schemas/chats.py api/tests/unit/test_chats_schema.py
+git commit -s -m "feat(chats): add referenced_file_ids to message schema (referenced-files)"
+```
+
+---
+
+### Task 2: File-scoped hybrid retrieval (`hybrid_search_files`)
+
+**Files:**
+- Modify: `api/app/knowledge/retrieval.py` (factor combine+hydrate out of `hybrid_search` ~127-180; add file-scoped side queries + `hybrid_search_files`)
+- Test: `api/tests/unit/test_retrieval_files.py`
+
+**Interfaces:**
+- Consumes: existing `HybridSearchResult`, `_min_max_normalize`, `_format_vector`, `_hydrate_chunks`.
+- Produces: `async def hybrid_search_files(db, *, file_ids: list[uuid.UUID], query: str, query_embedding: list[float] | None, top_k: int, alpha: float) -> list[HybridSearchResult]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/unit/test_retrieval_files.py
+import uuid
+import pytest
+
+from app.knowledge.retrieval import hybrid_search_files
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_hybrid_search_files_scopes_to_given_files(seeded_two_ready_files):
+    """Two ready+embedded files exist; searching one file's id returns
+    only that file's chunks."""
+    db, file_a, file_b, query = seeded_two_ready_files
+    results = await hybrid_search_files(
+        db,
+        file_ids=[file_a],
+        query=query,
+        query_embedding=None,  # FTS-only path, deterministic
+        top_k=10,
+        alpha=1.0,
+    )
+    assert results, "expected at least one chunk from file_a"
+    assert {r.file_id for r in results} == {file_a}
+
+
+async def test_hybrid_search_files_empty_ids_returns_empty(db_session):
+    results = await hybrid_search_files(
+        db_session, file_ids=[], query="x", query_embedding=None, top_k=5, alpha=1.0
+    )
+    assert results == []
+```
+
+> Fixture note: `seeded_two_ready_files` inserts two `files` rows
+> (`ingestion_status='ready'`), a `documents` row each, and a few
+> `document_chunks` with `content` + `content_tsv` populated (embedding may
+> be NULL — FTS path is exercised). Model it on the existing KB-retrieval
+> integration fixtures in `api/tests/` (search for `hybrid_search` usages).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && python -m pytest tests/unit/test_retrieval_files.py -v`
+Expected: FAIL — `ImportError: cannot import name 'hybrid_search_files'`.
+
+- [ ] **Step 3: Factor the combine+hydrate tail into a shared helper** (in `retrieval.py`, extract lines ~127-180 of `hybrid_search` into a new function and call it from `hybrid_search`)
+
+```python
+async def _combine_and_hydrate(
+    db: AsyncSession,
+    *,
+    vector_rows: list[tuple[uuid.UUID, float]],
+    fts_rows: list[tuple[uuid.UUID, float]],
+    top_k: int,
+    alpha: float,
+) -> list[HybridSearchResult]:
+    """Min-max normalize, linearly combine, take top_k, hydrate.
+
+    Shared by :func:`hybrid_search` (KB-scoped) and
+    :func:`hybrid_search_files` (file-scoped) — the only difference
+    between the two is which candidate SQL produced ``vector_rows`` /
+    ``fts_rows``.
+    """
+    if not vector_rows and not fts_rows:
+        return []
+
+    candidate_ids: set[uuid.UUID] = set()
+    candidate_ids.update(cid for cid, _ in vector_rows)
+    candidate_ids.update(cid for cid, _ in fts_rows)
+
+    vector_norm = _min_max_normalize(dict(vector_rows))
+    fts_norm = _min_max_normalize(dict(fts_rows))
+
+    combined: list[tuple[uuid.UUID, float, float, float]] = []
+    for cid in candidate_ids:
+        v_score = vector_norm.get(cid, 0.0)
+        f_score = fts_norm.get(cid, 0.0)
+        hybrid = (1.0 - alpha) * v_score + alpha * f_score
+        combined.append((cid, v_score, f_score, hybrid))
+
+    combined.sort(key=lambda row: row[3], reverse=True)
+    top = combined[:top_k]
+    if not top:
+        return []
+
+    score_map = {cid: (v, f, h) for cid, v, f, h in top}
+    rows = await _hydrate_chunks(db, [cid for cid, _, _, _ in top])
+
+    results: list[HybridSearchResult] = []
+    for row in rows:
+        cid = row["chunk_id"]
+        scores = score_map.get(cid)
+        if scores is None:
+            continue
+        v_score, f_score, hybrid_score = scores
+        results.append(
+            HybridSearchResult(
+                chunk_id=cid,
+                document_id=row["document_id"],
+                file_id=row["file_id"],
+                file_name=row["file_name"],
+                content=row["content"],
+                page_start=row["page_start"],
+                page_end=row["page_end"],
+                char_offset_start=row["char_offset_start"],
+                char_offset_end=row["char_offset_end"],
+                vector_score=v_score,
+                fts_score=f_score,
+                hybrid_score=hybrid_score,
+            )
+        )
+    results.sort(key=lambda r: r.hybrid_score, reverse=True)
+    return results
+```
+
+Then replace the body of `hybrid_search` from `# --- Combine ---` (line ~127) through the end with:
+
+```python
+    return await _combine_and_hydrate(
+        db, vector_rows=vector_rows, fts_rows=fts_rows, top_k=top_k, alpha=alpha
+    )
+```
+
+- [ ] **Step 4: Add the file-scoped side queries + entry point** (append to `retrieval.py`)
+
+```python
+_VECTOR_SQL_FILES = text(
+    """
+    SELECT dc.id AS chunk_id,
+           1.0 - (dc.embedding <=> CAST(:q_emb AS vector)) AS vec_score
+      FROM document_chunks dc
+      JOIN documents d ON d.id = dc.document_id
+      JOIN files f ON f.id = d.file_id
+     WHERE f.id = ANY(:file_ids)
+       AND f.deleted_at IS NULL
+       AND f.ingestion_status = 'ready'
+       AND dc.embedding IS NOT NULL
+     ORDER BY dc.embedding <=> CAST(:q_emb AS vector)
+     LIMIT :limit
+    """
+)
+
+_FTS_SQL_FILES = text(
+    """
+    SELECT dc.id AS chunk_id,
+           ts_rank_cd(dc.content_tsv, plainto_tsquery('english', :q)) AS fts_rank
+      FROM document_chunks dc
+      JOIN documents d ON d.id = dc.document_id
+      JOIN files f ON f.id = d.file_id
+     WHERE f.id = ANY(:file_ids)
+       AND f.deleted_at IS NULL
+       AND f.ingestion_status = 'ready'
+       AND dc.content_tsv @@ plainto_tsquery('english', :q)
+     ORDER BY fts_rank DESC
+     LIMIT :limit
+    """
+)
+
+
+async def hybrid_search_files(
+    db: AsyncSession,
+    *,
+    file_ids: list[uuid.UUID],
+    query: str,
+    query_embedding: list[float] | None,
+    top_k: int,
+    alpha: float,
+) -> list[HybridSearchResult]:
+    """Hybrid search scoped to an explicit set of file ids.
+
+    Same score model as :func:`hybrid_search` (pgvector cosine + FTS,
+    min-max normalized, ``(1-alpha)*vec + alpha*fts``) but the candidate
+    set is ``document_chunks`` whose owning file is in ``file_ids`` (not
+    a KB join). Callers MUST have already authorized ``file_ids`` — this
+    primitive does no ownership check, matching :func:`hybrid_search`'s
+    contract (the handler enforces scope).
+    """
+    if not file_ids:
+        return []
+    alpha = max(0.0, min(1.0, alpha))
+    candidate_limit = top_k * CANDIDATE_OVERSHOOT
+    ids = [str(fid) for fid in file_ids]
+
+    vector_rows: list[tuple[uuid.UUID, float]] = []
+    if query_embedding is not None and alpha < 1.0:
+        result = await db.execute(
+            _VECTOR_SQL_FILES,
+            {"file_ids": ids, "q_emb": _format_vector(query_embedding), "limit": candidate_limit},
+        )
+        vector_rows = [
+            (uuid.UUID(str(r["chunk_id"])), float(r["vec_score"])) for r in result.mappings().all()
+        ]
+
+    fts_rows: list[tuple[uuid.UUID, float]] = []
+    if alpha > 0.0:
+        result = await db.execute(
+            _FTS_SQL_FILES, {"file_ids": ids, "q": query, "limit": candidate_limit}
+        )
+        fts_rows = [
+            (uuid.UUID(str(r["chunk_id"])), float(r["fts_rank"])) for r in result.mappings().all()
+        ]
+
+    return await _combine_and_hydrate(
+        db, vector_rows=vector_rows, fts_rows=fts_rows, top_k=top_k, alpha=alpha
+    )
+```
+
+- [ ] **Step 5: Run tests + linters to verify pass**
+
+Run: `cd api && python -m pytest tests/unit/test_retrieval_files.py tests/ -k "hybrid_search" -v && ruff format --check app/knowledge/retrieval.py && ruff check app/knowledge/retrieval.py`
+Expected: PASS (new file-scoped tests + existing KB `hybrid_search` tests still green after the refactor).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/app/knowledge/retrieval.py api/tests/unit/test_retrieval_files.py
+git commit -s -m "feat(retrieval): add file-scoped hybrid_search_files (referenced-files)"
+```
+
+---
+
+### Task 3: Validate referenced ids are owned + matter-KB + ready
+
+**Files:**
+- Modify: `api/app/api/chats.py` (add helper near `_validate_owned_file_ids` ~355; imports for `KnowledgeBaseFile`, `ProjectKnowledgeBase` if not present)
+- Test: `api/tests/integration/test_referenced_files_send.py`
+
+**Interfaces:**
+- Consumes: `File`, `KnowledgeBaseFile` (`app.models.knowledge`), `ProjectKnowledgeBase` (`app.models.project_knowledge_base`), `NotFound`.
+- Produces: `async def _validate_referenced_file_ids(db, referenced_file_ids: list[str], *, owner_id: uuid.UUID, project_id: uuid.UUID | None) -> list[str]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/integration/test_referenced_files_send.py
+import uuid
+import pytest
+
+from app.api.chats import _validate_referenced_file_ids
+from app.errors import NotFound
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_validate_referenced_ok(matter_with_kb_file):
+    """A ready file in a KB attached to the project validates."""
+    db, owner_id, project_id, file_id = matter_with_kb_file
+    out = await _validate_referenced_file_ids(
+        db, [str(file_id)], owner_id=owner_id, project_id=project_id
+    )
+    assert out == [str(file_id)]
+
+
+async def test_validate_referenced_projectless_404(matter_with_kb_file):
+    """Referencing anything from a projectless chat is a 404 (no matter)."""
+    db, owner_id, _project_id, file_id = matter_with_kb_file
+    with pytest.raises(NotFound):
+        await _validate_referenced_file_ids(
+            db, [str(file_id)], owner_id=owner_id, project_id=None
+        )
+
+
+async def test_validate_referenced_foreign_file_404(matter_with_kb_file):
+    db, owner_id, project_id, _file_id = matter_with_kb_file
+    with pytest.raises(NotFound):
+        await _validate_referenced_file_ids(
+            db, [str(uuid.uuid4())], owner_id=owner_id, project_id=project_id
+        )
+```
+
+> Fixture note: `matter_with_kb_file` seeds a user, a project, a KB
+> attached to the project (`project_knowledge_bases`), a `ready` file
+> attached to that KB (`knowledge_base_files`), and its `documents` row.
+> Reuse the KB/project fixtures already in `api/tests/` (grep for
+> `ProjectKnowledgeBase` and `KnowledgeBaseFile` in existing tests).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && python -m pytest tests/integration/test_referenced_files_send.py -v`
+Expected: FAIL — `ImportError: cannot import name '_validate_referenced_file_ids'`.
+
+- [ ] **Step 3: Add the validator** (in `api/app/api/chats.py`, after `_validate_owned_file_ids` ~line 412; ensure `KnowledgeBaseFile` and `ProjectKnowledgeBase` are imported at the top of the module)
+
+```python
+async def _validate_referenced_file_ids(
+    db: AsyncSession,
+    referenced_file_ids: list[str],
+    *,
+    owner_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+) -> list[str]:
+    """Validate caller-referenced files for file-scoped retrieval (referenced-files).
+
+    KB-only MVP + matter scope: each id must (1) parse as a UUID, (2)
+    resolve to a caller-owned, non-deleted, ``ingestion_status='ready'``
+    file that (3) is attached to a Knowledge Base which is itself
+    attached to the chat's ``project_id``. Any id failing any check —
+    including a projectless chat (no matter, so nothing is referenceable)
+    — raises :class:`NotFound` (404), id-probing-safe and consistent with
+    :func:`_validate_owned_file_ids`.
+
+    Returns validated ids as strings (deduped, order-preserving). Empty
+    input returns an empty list without a DB round-trip.
+    """
+    if not referenced_file_ids:
+        return []
+
+    parsed: list[uuid.UUID] = []
+    seen: set[uuid.UUID] = set()
+    for raw in referenced_file_ids:
+        try:
+            fid = uuid.UUID(raw)
+        except (ValueError, AttributeError) as exc:
+            raise NotFound(f"File {raw} not found.", details={"file_id": str(raw)}) from exc
+        if fid not in seen:
+            seen.add(fid)
+            parsed.append(fid)
+
+    # Projectless chat has no matter → nothing is referenceable. Fail
+    # restrictive (P4): 404 every id rather than silently returning none.
+    if project_id is None:
+        raise NotFound(
+            f"File {parsed[0]} not found.", details={"file_id": str(parsed[0])}
+        )
+
+    # One SELECT: owned + ready + in a KB attached to this project.
+    stmt = (
+        select(File.id)
+        .join(KnowledgeBaseFile, KnowledgeBaseFile.file_id == File.id)
+        .join(
+            ProjectKnowledgeBase,
+            ProjectKnowledgeBase.knowledge_base_id == KnowledgeBaseFile.kb_id,
+        )
+        .where(
+            File.id.in_(parsed),
+            File.owner_id == owner_id,
+            File.deleted_at.is_(None),
+            File.ingestion_status == "ready",
+            ProjectKnowledgeBase.project_id == project_id,
+        )
+        .distinct()
+    )
+    found = set((await db.execute(stmt)).scalars().all())
+    for fid in parsed:
+        if fid not in found:
+            raise NotFound(f"File {fid} not found.", details={"file_id": str(fid)})
+
+    return [str(fid) for fid in parsed]
+```
+
+- [ ] **Step 4: Run tests + linters to verify pass**
+
+Run: `cd api && python -m pytest tests/integration/test_referenced_files_send.py -k validate -v && ruff format --check app/api/chats.py && ruff check app/api/chats.py`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/app/api/chats.py api/tests/integration/test_referenced_files_send.py
+git commit -s -m "feat(chats): validate referenced_file_ids (owned + matter-KB + ready) (referenced-files)"
+```
+
+---
+
+### Task 4: Retrieve, merge, audit, and echo referenced-file context in `send_message`
+
+**Files:**
+- Modify: `api/app/api/chats.py` (RAG constants ~948-952; `send_message` validation site ~1233; retrieval/injection block ~1427-1480; the `MessagePostResponse`/SSE `complete` assembly where `applied_file_ids` is set — grep `applied_file_ids=`)
+- Test: `api/tests/integration/test_referenced_files_send.py`
+
+**Interfaces:**
+- Consumes: `hybrid_search_files` (Task 2), `_validate_referenced_file_ids` (Task 3), `request_embedding_vector`, `DEFAULT_EMBEDDING_MODEL`, `_format_retrieval_context_block`, `_persist_message_citations` (unchanged — consumes the merged `retrieved_chunks`).
+- Produces: `_retrieve_referenced_file_context(...)`, `_merge_retrieved_chunks(...)`; `send_message` now grounds + cites referenced files and echoes `applied_referenced_file_ids`.
+
+- [ ] **Step 1: Write the failing end-to-end test**
+
+```python
+# api/tests/integration/test_referenced_files_send.py  (append)
+async def test_send_with_referenced_file_produces_citation(client, matter_with_kb_file, chat_in_project, stub_gateway_quoting_source):
+    """Referencing a matter-KB file and asking about it yields a persisted,
+    verified citation whose source_file_id is the referenced file."""
+    _db, _owner, _project, file_id = matter_with_kb_file
+    chat_id = chat_in_project  # a chat whose project_id == the matter project
+
+    resp = await client.post(
+        f"/api/v1/chats/{chat_id}/messages",
+        json={"content": "What does the contract say about liability?",
+              "referenced_file_ids": [str(file_id)]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["applied_referenced_file_ids"] == [str(file_id)]
+
+    msg_id = body["message"]["id"]
+    cites = await client.get(f"/api/v1/chats/{chat_id}/messages/{msg_id}/citations")
+    assert cites.status_code == 200
+    rows = cites.json()
+    assert any(c["source_file_id"] == str(file_id) for c in rows)
+
+
+async def test_send_with_foreign_referenced_file_404(client, chat_in_project):
+    resp = await client.post(
+        f"/api/v1/chats/{chat_in_project}/messages",
+        json={"content": "hi", "referenced_file_ids": [str(uuid.uuid4())]},
+    )
+    assert resp.status_code == 404
+```
+
+> Fixture note: `stub_gateway_quoting_source` returns an assistant
+> message that quotes a chunk verbatim in the required
+> `"..." (Source: [1])` format so the Stage-1 verifier persists a row —
+> mirror the existing citation integration stubs (grep
+> `get_citation_engine_judge_model` / `_persist_message_citations` in
+> `api/tests/`). `chat_in_project` creates a chat with `project_id` set to
+> the matter project.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && python -m pytest tests/integration/test_referenced_files_send.py -k "citation or foreign" -v`
+Expected: FAIL — `applied_referenced_file_ids` KeyError / referenced chunks not retrieved / 200 instead of 404.
+
+- [ ] **Step 3: Add RAG constants for referenced files** (in `chats.py`, after `RAG_MAX_TOTAL_CHUNKS` ~line 952)
+
+```python
+# referenced-files — file-scoped retrieval for explicitly referenced files. A
+# referenced file usually means "answer over THIS document", so we pull
+# more chunks per file than the KB-wide top_k and give referenced chunks
+# priority in the merged context set.
+REFERENCED_TOP_K_PER_FILE: int = 8
+REFERENCED_MAX_CHUNKS: int = 16
+# Alpha for file-scoped search. Balanced default; align with the
+# KnowledgeBase.hybrid_alpha server default if it differs.
+REFERENCED_FILE_ALPHA: float = 0.5
+```
+
+- [ ] **Step 4: Add the retrieval + merge helpers** (in `chats.py`, after `_retrieve_kb_context_for_chat` ~line 1072)
+
+```python
+async def _retrieve_referenced_file_context(
+    db: AsyncSession,
+    *,
+    referenced_file_ids: list[str],
+    query: str,
+    gateway: GatewayClient,
+    request_id: str | None,
+) -> list[HybridSearchResult]:
+    """Hybrid-search chunks for explicitly referenced files (referenced-files).
+
+    Ids are assumed already validated (owned + matter-KB + ready) by
+    :func:`_validate_referenced_file_ids`. Embeds the query once (FTS-only
+    fallback on embed failure, mirroring the KB path) and runs one
+    :func:`hybrid_search_files` call over the whole set.
+    """
+    if not referenced_file_ids:
+        return []
+    file_uuids = [uuid.UUID(fid) for fid in referenced_file_ids]
+
+    query_embedding: list[float] | None = None
+    if REFERENCED_FILE_ALPHA < 1.0:
+        try:
+            query_embedding = await request_embedding_vector(
+                query,
+                model=DEFAULT_EMBEDDING_MODEL,
+                gateway=gateway,
+                request_id=request_id,
+            )
+        except LQAIError as exc:
+            log.warning(
+                "chat-send referenced-files: query-embedding fetch failed; FTS-only fallback",
+                extra={"event": "chat_ref_embed_fetch_failed", "error_code": exc.effective_code},
+            )
+            query_embedding = None
+
+    return await hybrid_search_files(
+        db,
+        file_ids=file_uuids,
+        query=query,
+        query_embedding=query_embedding,
+        top_k=min(REFERENCED_TOP_K_PER_FILE * len(file_uuids), REFERENCED_MAX_CHUNKS),
+        alpha=REFERENCED_FILE_ALPHA,
+    )
+
+
+def _merge_retrieved_chunks(
+    referenced: list[HybridSearchResult],
+    kb: list[HybridSearchResult],
+) -> list[HybridSearchResult]:
+    """Merge referenced-file chunks (priority) with KB-RAG chunks.
+
+    Referenced chunks come first (explicit user intent), then KB chunks
+    not already present (deduped by ``chunk_id``), capped at
+    :data:`RAG_MAX_TOTAL_CHUNKS`. Order determines the ``[N]`` citation
+    indices in the context block.
+    """
+    out: list[HybridSearchResult] = []
+    seen: set[uuid.UUID] = set()
+    for chunk in [*referenced, *kb]:
+        if chunk.chunk_id in seen:
+            continue
+        seen.add(chunk.chunk_id)
+        out.append(chunk)
+        if len(out) >= RAG_MAX_TOTAL_CHUNKS:
+            break
+    return out
+```
+
+- [ ] **Step 5: Validate referenced ids in `send_message`** (in `chats.py`, right after the `effective_file_ids` validation ~line 1233)
+
+```python
+    # referenced-files — validate caller-referenced matter files (owned + in a KB
+    # attached to the chat's project + ready). 404 id-probing-safe on any
+    # miss; empty/omitted is a no-op.
+    effective_referenced_file_ids = await _validate_referenced_file_ids(
+        db,
+        payload.referenced_file_ids,
+        owner_id=user.id,
+        project_id=chat.project_id,
+    )
+```
+
+- [ ] **Step 6: Retrieve + merge + audit** (replace the block at ~lines 1427-1480, i.e. from the `retrieved_chunks, kb_ids_searched = await _retrieve_kb_context_for_chat(...)` call through the KB-audit `await db.commit()`, with the following)
+
+```python
+    # Wave D.1 T7b — KB RAG across the project's attached KBs.
+    kb_chunks, kb_ids_searched = await _retrieve_kb_context_for_chat(
+        db,
+        chat=chat,
+        query=effective_content,
+        gateway=gateway,
+        request_id=request.headers.get("x-request-id"),
+    )
+
+    # referenced-files — file-scoped retrieval for explicitly referenced files.
+    referenced_chunks = await _retrieve_referenced_file_context(
+        db,
+        referenced_file_ids=effective_referenced_file_ids,
+        query=effective_content,
+        gateway=gateway,
+        request_id=request.headers.get("x-request-id"),
+    )
+
+    # Merge: referenced first (explicit intent), then KB, deduped + capped.
+    # The single ``retrieved_chunks`` local flows to the context block AND
+    # to every _persist_message_citations call site, so both KB and
+    # referenced chunks become citable with no change to the citation path.
+    retrieved_chunks = _merge_retrieved_chunks(referenced_chunks, kb_chunks)
+
+    gw_messages: list[ChatCompletionMessage] = []
+    if retrieved_chunks:
+        context_block = _format_retrieval_context_block(retrieved_chunks)
+        gw_messages.append(
+            ChatCompletionMessage(
+                role="system",
+                content=context_block,
+                lq_ai_skip_anonymization=True,
+            )
+        )
+
+    # T7-shape audit for KB retrieval (unchanged semantics: KB chunks only).
+    if kb_chunks:
+        await audit_action(
+            db,
+            user_id=user.id,
+            action="inference.kb_chunks_retrieved",
+            resource_type="chat",
+            resource_id=str(cid),
+            project_id=chat.project_id,
+            request=request,
+            details={
+                "kb_ids": [str(k) for k in kb_ids_searched],
+                "chunk_count": len(kb_chunks),
+                "chunk_ids": [str(c.chunk_id) for c in kb_chunks],
+                "query_token_estimate": len(effective_content.split()),
+            },
+        )
+        await db.commit()
+
+    # referenced-files audit — counts/ids only (P3), own commit boundary (P5).
+    if effective_referenced_file_ids:
+        await audit_action(
+            db,
+            user_id=user.id,
+            action="inference.message_referenced_files",
+            resource_type="chat",
+            resource_id=str(cid),
+            project_id=chat.project_id,
+            request=request,
+            details={
+                "file_ids": list(effective_referenced_file_ids),
+                "referenced_count": len(effective_referenced_file_ids),
+                "chunk_count": len(referenced_chunks),
+                "chunk_ids": [str(c.chunk_id) for c in referenced_chunks],
+            },
+        )
+        await db.commit()
+```
+
+> Note: the subsequent per-message `file_ids` verbatim block (~1482-1528)
+> and everything downstream stay as-is. Confirm the merged `retrieved_chunks`
+> local is the same variable passed to `_persist_message_citations` at the
+> three call sites (grep `retrieved_chunks=retrieved_chunks`).
+
+- [ ] **Step 7: Echo `applied_referenced_file_ids`** (grep `applied_file_ids=` in `chats.py`; at each site — the `MessagePostResponse(...)` build and the SSE `complete` frame payload — add the sibling)
+
+```python
+        applied_referenced_file_ids=list(effective_referenced_file_ids),
+```
+
+- [ ] **Step 8: Run the full new integration module + linters**
+
+Run: `cd api && python -m pytest tests/integration/test_referenced_files_send.py -v && ruff format --check app/api/chats.py && ruff check app/api/chats.py`
+Expected: PASS (citation persisted; foreign id 404; projectless 404 from Task 3).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add api/app/api/chats.py api/tests/integration/test_referenced_files_send.py
+git commit -s -m "feat(chats): ground + cite referenced files in send_message (referenced-files)"
+```
+
+---
+
+### Task 5: Contract + docs (OpenAPI, PRD, ADR) and full-suite gate
+
+**Files:**
+- Modify: `docs/api/backend-openapi.yaml` (`MessageCreate` + `MessagePostResponse` schemas)
+- Modify: `docs/PRD.md` (§3.1 chat API surface note; §3.3 citation source note)
+- Create: `docs/adr/00NN-referenced-file-ids-chat.md`
+
+**Interfaces:** none (documentation + conformance).
+
+- [ ] **Step 1: Update the OpenAPI sketch** — add to the `MessageCreate` schema:
+
+```yaml
+        referenced_file_ids:
+          type: array
+          maxItems: 16
+          items:
+            type: string
+            format: uuid
+          description: >
+            referenced-files. Caller-selected matter documents to ground this turn
+            via file-scoped retrieval; retrieved chunks are cited by the
+            Citation Engine. KB-only MVP: each id must be caller-owned,
+            ready, and in a Knowledge Base attached to the chat's project
+            (else 404). Distinct from file_ids (verbatim, uncited).
+```
+
+and to the send response (`MessagePostResponse`):
+
+```yaml
+        applied_referenced_file_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: referenced-files echo of the validated referenced_file_ids.
+```
+
+- [ ] **Step 2: Verify OpenAPI conformance** (the authoritative check per CLAUDE.md — do not eyeball the YAML)
+
+Run: `cd api && python -m pytest tests/test_openapi.py -v`
+Expected: PASS. (No new path → `EXPECTED_PATHS` / path count unchanged; the schema-shape conformance for `MessageCreate` picks up the new optional field.)
+
+- [ ] **Step 3: Update the PRD** — in §3.1 (chat API surface), add one line after the `file_ids` description:
+
+```markdown
+  A parallel `referenced_file_ids` list (referenced-files) references matter documents that are **retrieved and cited** (KB-only MVP), as opposed to `file_ids` which injects verbatim text without citations.
+```
+
+and in §3.3 (Citation Engine), note that citations may be grounded in explicitly referenced files, not only project-wide KB retrieval.
+
+- [ ] **Step 4: Write the ADR** — `docs/adr/00NN-referenced-file-ids-chat.md` recording: the new-field-vs-overload decision, the matter-KB scope (KB-only MVP, embed-on-reference deferred to Phase 3), the P9 rationale (retrieval-grounded not verbatim), and the P2 rationale (UI-selected set, not a model tool). Follow the existing ADR template in `docs/adr/`.
+
+- [ ] **Step 5: Run the full api suite + both linters (the gate)**
+
+Run: `cd api && ruff format --check . && ruff check . && python -m pytest`
+Expected: PASS across the suite (collision guards `test_endpoints.py` / `test_openapi.py` green — no route added).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/api/backend-openapi.yaml docs/PRD.md docs/adr/00NN-referenced-file-ids-chat.md
+git commit -s -m "docs(chats): document referenced_file_ids channel + ADR (referenced-files)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against the design spec's Phase-1 backend scope):
+- New `referenced_file_ids` field → Task 1. ✓
+- File-scoped retrieval into `retrieved_chunks` → Tasks 2 + 4. ✓
+- Matter-KB + owned + ready validation (KB-only MVP, matter scope) → Task 3. ✓
+- Citations mint for referenced files → Task 4 (merge into the citation-fed local) + integration test. ✓
+- Audit counts-only (P3), atomic (P5) → Task 4. ✓
+- Fail restrictive (P4) → Task 3 (404 on miss / projectless). ✓
+- Contract/PRD/ADR in-PR (P10) → Task 5. ✓
+- `GET /api/v1/files` — **intentionally out of this plan**: KB-only MVP reuses `GET /kb/{id}/files`; the DE-296 endpoint is only needed for Phase-3 (non-KB files) / the frontend's unified picker. Logged here so it isn't a silent gap.
+- Embed-on-reference — **deferred to Phase 3** per locked decision; `hybrid_search_files` already works for any embedded file, so Phase 3 only adds the on-demand embed trigger.
+
+**Placeholder scan:** no TBD/TODO; every code step carries real code; SQL, constants, and signatures are concrete. The two "grep to confirm the call site" notes (Task 4 Steps 6–7) are verification steps, not placeholders — the code to add is given verbatim.
+
+**Type consistency:** `hybrid_search_files` / `_combine_and_hydrate` / `_retrieve_referenced_file_context` all traffic in `HybridSearchResult`; `_validate_referenced_file_ids` and the schema field both use `list[str]` UUID strings; `effective_referenced_file_ids` (validated strings) is the single name threaded through retrieval, audit, and the response echo.
+
+**Open items carried to other work (not this plan):** frontend picker + `@`-mention (separate plan); the orthogonal projectless/KB-not-attached passive-citation bug (separate bug); embed-on-reference (Phase 3).

--- a/docs/superpowers/plans/2026-07-03-referenced-files-frontend.md
+++ b/docs/superpowers/plans/2026-07-03-referenced-files-frontend.md
@@ -1,0 +1,1582 @@
+# Referenced Files in Chat — Frontend (referenced-files Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user reference matter documents from the chat composer — inline `@`-mention popover + multi-select document picker — sending `referenced_file_ids` on the message so answers come back with verified, deep-linkable citations (backend channel already shipped, ADR 0022).
+
+**Architecture:** One authoritative `referencedFiles` array in `ChatPanel.svelte` (deduped, cap 16), fed by both affordances, rendered as a removable chips row, sent as `referenced_file_ids`, cleared on successful send. The referenceable list is loaded client-side from `GET /projects/{id}` → `attached_knowledge_base_ids` → `GET /knowledge-bases/{kb_id}/files` (exactly the set the backend validates; no new backend surface). The `@`-mention clones the shipped slash-command machinery (`detectSlashAt` + `SlashPopover`); the picker follows the `AttachKBModal` checkbox-set + `SkillPicker` search patterns.
+
+**Tech Stack:** SvelteKit (Svelte 4, this is an OpenWebUI fork — no React, no runes), TypeScript, Vitest, Cypress.
+
+## Global Constraints
+
+- Repo: `/Users/abc/projs/lqAI/lq-ai`, branch `feat/referenced-files-referenced-file-ids` (frontend rides the same branch as the shipped backend; single referenced-files PR).
+- All new code under `web/src/lib/lq-ai/`. New files require TypeScript.
+- **No `@testing-library/svelte`** (not installed). Convention: export pure helpers from `<script context="module">` blocks and unit-test those; component wiring is covered by Cypress. See `web/src/lib/lq-ai/__tests__/ChatPanel-slash-detect.test.ts` header.
+- Callback props (`onSelect`, `onDismiss`, …), NOT `createEventDispatcher` — matches `SlashPopover`/`AttachKBModal`.
+- Design tokens: `--lq-*` custom properties with fallbacks, exactly as `SlashPopover.svelte` does. `data-testid` values prefixed `lq-ai-`.
+- No new npm dependencies.
+- Cap constant `MESSAGE_REFERENCED_FILES_MAX = 16` — must mirror backend `MESSAGE_REFERENCED_FILES_MAX_LEN` (`api/app/schemas/chats.py`).
+- Unit tests: `cd web && npx vitest run src/lib/lq-ai/__tests__/<file>.test.ts`.
+- Type gate: `cd web && npm run check:lq-ai` (svelte-check with the lq-ai tsconfig).
+- Format/lint touched files: `cd web && npx prettier --plugin-search-dir --write <files> && npx eslint <files>`.
+- Commits: imperative mood, `git commit -s`.
+- Dev-stack note (manual verification only): the `web` container serves a static bundle — rebuild `web` before checking the UI in the running stack. Never `docker compose down -v`.
+
+## File Structure
+
+- `web/src/lib/lq-ai/files/referenceable.ts` — NEW: referenceable-set domain module (types, cap, merge/dedupe, filter, add/remove, loader).
+- `web/src/lib/lq-ai/components/MentionPopover.svelte` — NEW: `@`-mention typeahead listbox (clone of `SlashPopover.svelte`, list passed in, client-side filtering).
+- `web/src/lib/lq-ai/components/ReferencedFilesChips.svelte` — NEW: chips row above composer.
+- `web/src/lib/lq-ai/components/FilePickerDropdown.svelte` — NEW: multi-select checkbox dropdown with search.
+- `web/src/lib/lq-ai/components/ChatPanel.svelte` — MODIFY: mention detection helpers (module block), state + wiring, send payload, template mounts.
+- `web/src/lib/lq-ai/components/MessageBubble.svelte` — MODIFY: compact "Referenced:" row on user bubbles.
+- `web/src/lib/lq-ai/types.ts` — MODIFY: `MessageCreate.referenced_file_ids`, `MessagePostResponse.applied_referenced_file_ids`, `MessageCompleteFrame.applied_referenced_file_ids`, `Message.referenced_files`.
+- Tests: `web/src/lib/lq-ai/__tests__/referenceable.test.ts`, `__tests__/ChatPanel-mention-detect.test.ts`, `__tests__/MentionPopover.test.ts`, `__tests__/FilePickerDropdown.test.ts`; `web/cypress/e2e/referenced-files-referenced-files.cy.ts`.
+- Docs: `docs/PRD.md` §3.1 + §9 (referenced-files entry).
+
+---
+
+### Task 1: Referenceable-files domain module
+
+**Files:**
+- Create: `web/src/lib/lq-ai/files/referenceable.ts`
+- Test: `web/src/lib/lq-ai/__tests__/referenceable.test.ts`
+
+**Interfaces:**
+- Consumes: `getProject` (`../api/projects`), `listKnowledgeBaseFiles` (`../api/knowledgeBases`), `KnowledgeBaseFile` type (`../types`).
+- Produces (later tasks import all of these from `$lib/lq-ai/files/referenceable`):
+  - `MESSAGE_REFERENCED_FILES_MAX: number` (= 16)
+  - `interface ReferencedFile { id: string; filename: string; ready: boolean }`
+  - `interface ReferenceableLoad { files: ReferencedFile[]; failedKbCount: number }`
+  - `toReferencedFile(row: KnowledgeBaseFile): ReferencedFile`
+  - `mergeKbFileLists(lists: KnowledgeBaseFile[][]): ReferencedFile[]`
+  - `filterReferenceable(files: ReferencedFile[], query: string): ReferencedFile[]`
+  - `type AddResult = { added: true; list: ReferencedFile[] } | { added: false; reason: 'duplicate' | 'cap' | 'not-ready' }`
+  - `addReferencedFile(list: ReferencedFile[], file: ReferencedFile, cap?: number): AddResult`
+  - `removeReferencedFile(list: ReferencedFile[], id: string): ReferencedFile[]`
+  - `loadReferenceableFiles(projectId: string): Promise<ReferenceableLoad>`
+
+- [ ] **Step 1: Write the failing test**
+
+`web/src/lib/lq-ai/__tests__/referenceable.test.ts`:
+
+```ts
+/**
+ * referenced-files Phase 2 — pure logic of the referenceable-files set.
+ * loadReferenceableFiles is NOT tested here (it is a thin fetch
+ * composition; Cypress covers it end-to-end with stubbed routes).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	MESSAGE_REFERENCED_FILES_MAX,
+	addReferencedFile,
+	filterReferenceable,
+	mergeKbFileLists,
+	removeReferencedFile,
+	toReferencedFile,
+	type ReferencedFile
+} from '../files/referenceable';
+import type { KnowledgeBaseFile } from '../types';
+
+function kbFile(overrides: Partial<KnowledgeBaseFile> & { id: string }): KnowledgeBaseFile {
+	return {
+		owner_id: 'u1',
+		filename: `${overrides.id}.pdf`,
+		mime_type: 'application/pdf',
+		size_bytes: 100,
+		hash_sha256: 'x',
+		ingestion_status: 'ready',
+		created_at: '2026-07-01T00:00:00Z',
+		attached_at: '2026-07-01T00:00:00Z',
+		...overrides
+	} as KnowledgeBaseFile;
+}
+
+function ref(id: string, filename = `${id}.pdf`, ready = true): ReferencedFile {
+	return { id, filename, ready };
+}
+
+describe('toReferencedFile', () => {
+	it('marks ready exactly when ingestion_status === "ready"', () => {
+		expect(toReferencedFile(kbFile({ id: 'a' })).ready).toBe(true);
+		expect(toReferencedFile(kbFile({ id: 'b', ingestion_status: 'processing' })).ready).toBe(false);
+		expect(toReferencedFile(kbFile({ id: 'c', ingestion_status: 'failed' })).ready).toBe(false);
+	});
+});
+
+describe('mergeKbFileLists', () => {
+	it('dedupes a file present in several KBs (first occurrence wins)', () => {
+		const merged = mergeKbFileLists([
+			[kbFile({ id: 'a', filename: 'alpha.pdf' })],
+			[kbFile({ id: 'a', filename: 'alpha.pdf' }), kbFile({ id: 'b', filename: 'beta.pdf' })]
+		]);
+		expect(merged.map((f) => f.id)).toEqual(['a', 'b']);
+	});
+
+	it('sorts by filename', () => {
+		const merged = mergeKbFileLists([
+			[kbFile({ id: '1', filename: 'zeta.pdf' }), kbFile({ id: '2', filename: 'alpha.pdf' })]
+		]);
+		expect(merged.map((f) => f.filename)).toEqual(['alpha.pdf', 'zeta.pdf']);
+	});
+
+	it('returns [] for no KBs', () => {
+		expect(mergeKbFileLists([])).toEqual([]);
+	});
+});
+
+describe('filterReferenceable', () => {
+	const files = [ref('1', 'Master Agreement.pdf'), ref('2', 'exhibit-a.pdf')];
+
+	it('returns everything for an empty/whitespace query', () => {
+		expect(filterReferenceable(files, '')).toEqual(files);
+		expect(filterReferenceable(files, '  ')).toEqual(files);
+	});
+
+	it('matches case-insensitive substrings', () => {
+		expect(filterReferenceable(files, 'master')).toEqual([files[0]]);
+		expect(filterReferenceable(files, 'EXHIBIT')).toEqual([files[1]]);
+	});
+
+	it('returns [] when nothing matches', () => {
+		expect(filterReferenceable(files, 'zzz')).toEqual([]);
+	});
+});
+
+describe('addReferencedFile', () => {
+	it('adds a ready file', () => {
+		const r = addReferencedFile([], ref('1'));
+		expect(r).toEqual({ added: true, list: [ref('1')] });
+	});
+
+	it('rejects a duplicate id', () => {
+		const r = addReferencedFile([ref('1')], ref('1'));
+		expect(r).toEqual({ added: false, reason: 'duplicate' });
+	});
+
+	it('rejects a non-ready file', () => {
+		const r = addReferencedFile([], ref('1', '1.pdf', false));
+		expect(r).toEqual({ added: false, reason: 'not-ready' });
+	});
+
+	it('rejects past the cap', () => {
+		const full = Array.from({ length: MESSAGE_REFERENCED_FILES_MAX }, (_, i) => ref(`f${i}`));
+		const r = addReferencedFile(full, ref('overflow'));
+		expect(r).toEqual({ added: false, reason: 'cap' });
+	});
+
+	it('does not mutate the input list', () => {
+		const list = [ref('1')];
+		addReferencedFile(list, ref('2'));
+		expect(list).toEqual([ref('1')]);
+	});
+});
+
+describe('removeReferencedFile', () => {
+	it('removes by id and leaves others', () => {
+		expect(removeReferencedFile([ref('1'), ref('2')], '1')).toEqual([ref('2')]);
+	});
+
+	it('is a no-op for an unknown id', () => {
+		expect(removeReferencedFile([ref('1')], 'nope')).toEqual([ref('1')]);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/lib/lq-ai/__tests__/referenceable.test.ts`
+Expected: FAIL — cannot resolve `../files/referenceable`.
+
+- [ ] **Step 3: Write the module**
+
+`web/src/lib/lq-ai/files/referenceable.ts`:
+
+```ts
+/**
+ * referenced-files Phase 2 — the referenceable-files set for the chat composer.
+ *
+ * "Referenceable" = exactly what the backend accepts in
+ * `referenced_file_ids` (ADR 0022, KB-only MVP + matter scope): files in
+ * Knowledge Bases attached to the chat's project. Loading walks
+ * GET /projects/{id} → attached_knowledge_base_ids →
+ * GET /knowledge-bases/{kb_id}/files and merges/dedupes (a file may sit
+ * in several matter KBs). There is deliberately NO GET /files list call
+ * here — that route does not exist (DE-296 unbuilt).
+ *
+ * `ready` mirrors the backend's ingestion_status === 'ready' send gate:
+ * non-ready files render disabled ("Preparing…") and are never
+ * selectable — fail-restrictive made visible (P4), so the UI can never
+ * assemble a set the backend would 404.
+ */
+import { listKnowledgeBaseFiles } from '../api/knowledgeBases';
+import { getProject } from '../api/projects';
+import type { KnowledgeBaseFile } from '../types';
+
+/** Mirrors MESSAGE_REFERENCED_FILES_MAX_LEN (api/app/schemas/chats.py). */
+export const MESSAGE_REFERENCED_FILES_MAX = 16;
+
+export interface ReferencedFile {
+	id: string;
+	filename: string;
+	ready: boolean;
+}
+
+export interface ReferenceableLoad {
+	files: ReferencedFile[];
+	/** KBs whose file listing failed; the union of the rest still loads. */
+	failedKbCount: number;
+}
+
+export function toReferencedFile(row: KnowledgeBaseFile): ReferencedFile {
+	return {
+		id: row.id,
+		filename: row.filename,
+		ready: row.ingestion_status === 'ready'
+	};
+}
+
+export function mergeKbFileLists(lists: KnowledgeBaseFile[][]): ReferencedFile[] {
+	const byId = new Map<string, ReferencedFile>();
+	for (const list of lists) {
+		for (const row of list) {
+			// Same File row can be attached to several KBs; its
+			// ingestion_status is file-level, so first occurrence wins.
+			if (!byId.has(row.id)) byId.set(row.id, toReferencedFile(row));
+		}
+	}
+	return [...byId.values()].sort((a, b) => a.filename.localeCompare(b.filename));
+}
+
+export function filterReferenceable(files: ReferencedFile[], query: string): ReferencedFile[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return files;
+	return files.filter((f) => f.filename.toLowerCase().includes(q));
+}
+
+export type AddResult =
+	| { added: true; list: ReferencedFile[] }
+	| { added: false; reason: 'duplicate' | 'cap' | 'not-ready' };
+
+export function addReferencedFile(
+	list: ReferencedFile[],
+	file: ReferencedFile,
+	cap: number = MESSAGE_REFERENCED_FILES_MAX
+): AddResult {
+	if (!file.ready) return { added: false, reason: 'not-ready' };
+	if (list.some((f) => f.id === file.id)) return { added: false, reason: 'duplicate' };
+	if (list.length >= cap) return { added: false, reason: 'cap' };
+	return { added: true, list: [...list, file] };
+}
+
+export function removeReferencedFile(list: ReferencedFile[], id: string): ReferencedFile[] {
+	return list.filter((f) => f.id !== id);
+}
+
+/**
+ * Load the referenceable set for a project. A single KB listing failure
+ * degrades to the union of the KBs that did load (surfaced via
+ * `failedKbCount` as a non-blocking note); a getProject failure
+ * propagates — with no project there is no referenceable set at all.
+ */
+export async function loadReferenceableFiles(projectId: string): Promise<ReferenceableLoad> {
+	const project = await getProject(projectId);
+	const kbIds = project.attached_knowledge_base_ids ?? [];
+	const settled = await Promise.allSettled(kbIds.map((id) => listKnowledgeBaseFiles(id)));
+	const lists = settled
+		.filter((s): s is PromiseFulfilledResult<KnowledgeBaseFile[]> => s.status === 'fulfilled')
+		.map((s) => s.value);
+	return { files: mergeKbFileLists(lists), failedKbCount: settled.length - lists.length };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npx vitest run src/lib/lq-ai/__tests__/referenceable.test.ts`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+cd web && npx prettier --plugin-search-dir --write src/lib/lq-ai/files/referenceable.ts src/lib/lq-ai/__tests__/referenceable.test.ts && npx eslint src/lib/lq-ai/files/referenceable.ts src/lib/lq-ai/__tests__/referenceable.test.ts
+cd /Users/abc/projs/lqAI/lq-ai && git add web/src/lib/lq-ai/files/referenceable.ts web/src/lib/lq-ai/__tests__/referenceable.test.ts
+git commit -s -m "feat(web): add referenceable-files domain module for composer references" -m "Refs referenced-files"
+```
+
+---
+
+### Task 2: Mention detection + splice helpers (ChatPanel module block)
+
+**Files:**
+- Modify: `web/src/lib/lq-ai/components/ChatPanel.svelte` — the `<script context="module">` block at the top (currently lines 1–43, holding `detectSlashAt`). Append the new helpers INSIDE that block; do not touch `detectSlashAt`/`isAtLineStart`.
+- Test: `web/src/lib/lq-ai/__tests__/ChatPanel-mention-detect.test.ts`
+
+**Interfaces:**
+- Produces (importable from `'../components/ChatPanel.svelte'`):
+  - `type MentionDetection = { open: false } | { open: true; query: string; atIndex: number }`
+  - `detectMentionAt(text: string, caret: number): MentionDetection`
+  - `completeMentionAt(text: string, atIndex: number, queryLength: number, filename: string): string`
+
+**Contract:** the popover opens when an `@` sits at a word start (position 0 or preceded by whitespace, including newline) and everything between the `@` and the caret matches `[^\s@]` (filenames: letters any case, digits, dots, hyphens, underscores; a space terminates the query). `a@b` (email-like) never opens. Unlike the slash, mid-line triggers ARE allowed.
+
+- [ ] **Step 1: Write the failing test**
+
+`web/src/lib/lq-ai/__tests__/ChatPanel-mention-detect.test.ts`:
+
+```ts
+/**
+ * referenced-files Phase 2 — @-mention detection + splice helpers. Same convention
+ * as ChatPanel-slash-detect.test.ts: pure module-scope helpers exported
+ * from ChatPanel.svelte, tested without mounting the component.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { completeMentionAt, detectMentionAt } from '../components/ChatPanel.svelte';
+
+describe('detectMentionAt', () => {
+	it('does not open when caret is at position 0', () => {
+		expect(detectMentionAt('', 0)).toEqual({ open: false });
+		expect(detectMentionAt('@foo', 0)).toEqual({ open: false });
+	});
+
+	it('opens with empty query when text is just "@"', () => {
+		expect(detectMentionAt('@', 1)).toEqual({ open: true, query: '', atIndex: 0 });
+	});
+
+	it('opens at start of textarea with a query', () => {
+		expect(detectMentionAt('@nda', 4)).toEqual({ open: true, query: 'nda', atIndex: 0 });
+	});
+
+	it('opens mid-line after a space (unlike slash detection)', () => {
+		expect(detectMentionAt('summarize @exh', 14)).toEqual({
+			open: true,
+			query: 'exh',
+			atIndex: 10
+		});
+	});
+
+	it('opens after a newline', () => {
+		expect(detectMentionAt('line one\n@doc', 13)).toEqual({
+			open: true,
+			query: 'doc',
+			atIndex: 9
+		});
+	});
+
+	it('does NOT open for email-like text (@ not at word start)', () => {
+		expect(detectMentionAt('a@b', 3)).toEqual({ open: false });
+		expect(detectMentionAt('user@example.com', 16)).toEqual({ open: false });
+	});
+
+	it('accepts dots, hyphens, underscores, uppercase in the query', () => {
+		expect(detectMentionAt('@Master-Agreement_v2.pdf', 25)).toEqual({
+			open: true,
+			query: 'Master-Agreement_v2.pdf',
+			atIndex: 0
+		});
+	});
+
+	it('closes when the query is interrupted by a space', () => {
+		expect(detectMentionAt('@exh ibit', 9)).toEqual({ open: false });
+	});
+
+	it('does not open when the caret sits before the @', () => {
+		expect(detectMentionAt('hi @doc', 2)).toEqual({ open: false });
+	});
+
+	it('does not treat @@ as a mention', () => {
+		expect(detectMentionAt('@@', 2)).toEqual({ open: false });
+	});
+});
+
+describe('completeMentionAt', () => {
+	it('completes "@query" at the start of the text', () => {
+		expect(completeMentionAt('@nda tell me', 0, 3, 'NDA-2024.pdf')).toBe('@NDA-2024.pdf tell me');
+	});
+
+	it('completes "@query" mid-text without doubling spaces', () => {
+		expect(completeMentionAt('summarize @exh please', 10, 3, 'exhibit-a.pdf')).toBe(
+			'summarize @exhibit-a.pdf please'
+		);
+	});
+
+	it('appends a separating space at the end of the text', () => {
+		expect(completeMentionAt('summarize @exh', 10, 3, 'exhibit-a.pdf')).toBe(
+			'summarize @exhibit-a.pdf '
+		);
+	});
+
+	it('completes a bare "@" (empty query)', () => {
+		expect(completeMentionAt('hello @', 6, 0, 'a.pdf')).toBe('hello @a.pdf ');
+	});
+
+	it('keeps filenames containing spaces inline', () => {
+		expect(completeMentionAt('@ber', 0, 3, 'BERGE SISAR.HL.2002.pdf')).toBe(
+			'@BERGE SISAR.HL.2002.pdf '
+		);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/lib/lq-ai/__tests__/ChatPanel-mention-detect.test.ts`
+Expected: FAIL — `detectMentionAt` is not exported.
+
+- [ ] **Step 3: Append the helpers to ChatPanel's module block**
+
+Inside `<script context="module" lang="ts">` in `ChatPanel.svelte`, after `detectSlashAt` (before the closing `</script>` at line 43), add:
+
+```ts
+	/**
+	 * referenced-files Phase 2 — @-mention detection for referenced files.
+	 *
+	 * Differs from detectSlashAt on purpose:
+	 *   - Triggers ANYWHERE the `@` starts a word (position 0 or preceded
+	 *     by whitespace), not only at line start — "summarize @exhibit-a"
+	 *     is the core use case.
+	 *   - Query char class is [^\s@] (filenames carry uppercase, dots,
+	 *     underscores); a space terminates the candidate query.
+	 *   - `a@b` / "user@example.com" never trigger (word-start guard).
+	 */
+	export type MentionDetection =
+		| { open: false }
+		| { open: true; query: string; atIndex: number };
+
+	export function detectMentionAt(text: string, caret: number): MentionDetection {
+		if (caret === 0) return { open: false };
+		let scan = caret;
+		while (scan > 0 && /[^\s@]/.test(text[scan - 1])) scan--;
+		if (scan === 0 || text[scan - 1] !== '@') return { open: false };
+		const atIndex = scan - 1;
+		if (atIndex > 0 && !/\s/.test(text[atIndex - 1])) return { open: false };
+		return { open: true, query: text.slice(atIndex + 1, caret), atIndex };
+	}
+
+	/**
+	 * Complete a mention selection inline: replace the partial "@query"
+	 * with "@<filename>" so the case name stays readable in the message
+	 * AND rides into the sent content as part of the query (the
+	 * referenced-files set carries the id; the text carries the meaning).
+	 * A separating space is ensured after the completed mention so typing
+	 * continues naturally and the popover does not immediately reopen.
+	 */
+	export function completeMentionAt(
+		text: string,
+		atIndex: number,
+		queryLength: number,
+		filename: string
+	): string {
+		const before = text.slice(0, atIndex);
+		const after = text.slice(atIndex + 1 + queryLength);
+		const sep = /^\s/.test(after) ? '' : ' ';
+		return `${before}@${filename}${sep}${after}`;
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npx vitest run src/lib/lq-ai/__tests__/ChatPanel-mention-detect.test.ts`
+Expected: PASS. Also run `npx vitest run src/lib/lq-ai/__tests__/ChatPanel-slash-detect.test.ts` — must still PASS (no regression to the slash helpers).
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+cd web && npx prettier --plugin-search-dir --write src/lib/lq-ai/components/ChatPanel.svelte src/lib/lq-ai/__tests__/ChatPanel-mention-detect.test.ts && npx eslint src/lib/lq-ai/components/ChatPanel.svelte src/lib/lq-ai/__tests__/ChatPanel-mention-detect.test.ts
+cd /Users/abc/projs/lqAI/lq-ai && git add web/src/lib/lq-ai/components/ChatPanel.svelte web/src/lib/lq-ai/__tests__/ChatPanel-mention-detect.test.ts
+git commit -s -m "feat(web): add @-mention detection + splice helpers to ChatPanel" -m "Refs referenced-files"
+```
+
+---
+
+### Task 3: MentionPopover component
+
+**Files:**
+- Create: `web/src/lib/lq-ai/components/MentionPopover.svelte`
+- Test: `web/src/lib/lq-ai/__tests__/MentionPopover.test.ts`
+
+**Interfaces:**
+- Consumes: `ReferencedFile`, `filterReferenceable` from `$lib/lq-ai/files/referenceable` (Task 1); `nextIndex` re-used from `./SlashPopover.svelte` (already exported from its module block).
+- Produces:
+  - Component props: `query: string`, `files: ReferencedFile[]` (the FULL referenceable list — filtering happens inside), `loading: boolean`, `error: string | null`, `onSelect: (file: ReferencedFile) => void`, `onDismiss: () => void`, `onRetry: () => void`.
+  - Module-block helpers (unit-tested): `mentionResults(files, query)`, `mentionStateKind(state)`, `decideMentionKeyAction(key, state)`, and types `MentionPopoverState`, `MentionStateKind`, `MentionKeyAction`.
+
+**Behavior notes:** results are the ready-only subset (`mentionResults` filters `f.ready`) — the mention flow is keyboard-driven and never offers a row that can't be selected; non-ready files remain visible (disabled) in the picker (Task 4) instead. Keyboard/mousedown/race semantics are identical to `SlashPopover`.
+
+- [ ] **Step 1: Write the failing test**
+
+`web/src/lib/lq-ai/__tests__/MentionPopover.test.ts`:
+
+```ts
+/**
+ * referenced-files Phase 2 — MentionPopover pure helpers (module-block exports,
+ * SlashPopover convention: no component mount).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	decideMentionKeyAction,
+	mentionResults,
+	mentionStateKind,
+	type MentionPopoverState
+} from '../components/MentionPopover.svelte';
+import type { ReferencedFile } from '../files/referenceable';
+
+function ref(id: string, filename = `${id}.pdf`, ready = true): ReferencedFile {
+	return { id, filename, ready };
+}
+
+function state(overrides: Partial<MentionPopoverState> = {}): MentionPopoverState {
+	return { results: [], activeIndex: 0, loading: false, error: null, query: '', ...overrides };
+}
+
+describe('mentionResults', () => {
+	it('filters by query and drops non-ready files', () => {
+		const files = [ref('1', 'alpha.pdf'), ref('2', 'beta.pdf', false), ref('3', 'gamma.pdf')];
+		expect(mentionResults(files, 'a').map((f) => f.id)).toEqual(['1', '3']);
+	});
+
+	it('returns all ready files for an empty query', () => {
+		const files = [ref('1'), ref('2', '2.pdf', false)];
+		expect(mentionResults(files, '').map((f) => f.id)).toEqual(['1']);
+	});
+});
+
+describe('mentionStateKind', () => {
+	it('orders loading > error > empty > results', () => {
+		expect(mentionStateKind(state({ loading: true, error: 'x' }))).toBe('loading');
+		expect(mentionStateKind(state({ error: 'x' }))).toBe('error');
+		expect(mentionStateKind(state({ query: 'q' }))).toBe('empty-with-query');
+		expect(mentionStateKind(state())).toBe('empty-no-query');
+		expect(mentionStateKind(state({ results: [ref('1')] }))).toBe('results');
+	});
+});
+
+describe('decideMentionKeyAction', () => {
+	const two = state({ results: [ref('1'), ref('2')], activeIndex: 0 });
+
+	it('Escape dismisses even with no results', () => {
+		expect(decideMentionKeyAction('Escape', state())).toEqual({ kind: 'dismiss' });
+	});
+
+	it('Enter selects the active row', () => {
+		expect(decideMentionKeyAction('Enter', two)).toEqual({ kind: 'select', result: ref('1') });
+	});
+
+	it('ArrowDown/ArrowUp wrap around', () => {
+		expect(decideMentionKeyAction('ArrowDown', { ...two, activeIndex: 1 })).toEqual({
+			kind: 'move',
+			nextIndex: 0
+		});
+		expect(decideMentionKeyAction('ArrowUp', two)).toEqual({ kind: 'move', nextIndex: 1 });
+	});
+
+	it('is a noop for other keys and for Enter with no results', () => {
+		expect(decideMentionKeyAction('a', two)).toEqual({ kind: 'noop' });
+		expect(decideMentionKeyAction('Enter', state())).toEqual({ kind: 'noop' });
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/lib/lq-ai/__tests__/MentionPopover.test.ts`
+Expected: FAIL — cannot resolve `../components/MentionPopover.svelte`.
+
+- [ ] **Step 3: Write the component**
+
+`web/src/lib/lq-ai/components/MentionPopover.svelte`. Structure it as a clone of `SlashPopover.svelte` (read that file first — same two-script layout, same `<svelte:window on:keydown>`, same mousedown-not-click row handler, same a11y attributes with ids `lq-mention-row-{i}`, same five render states). Differences only:
+
+1. Module block (replaces SlashPopover's fetch-oriented helpers):
+
+```ts
+	/**
+	 * MentionPopover — typeahead listbox for @-referencing matter
+	 * documents (referenced-files Phase 2). Clone of SlashPopover with the fetch
+	 * replaced by client-side filtering over the caller-loaded
+	 * referenceable list: the whole matter file set is already in memory
+	 * (files/referenceable.ts), so there is no per-keystroke request and
+	 * no request-token race guard.
+	 *
+	 * Only READY files are offered — the mention flow is keyboard-driven
+	 * and never renders a disabled row; non-ready files surface as
+	 * "Preparing…" rows in FilePickerDropdown instead.
+	 */
+	import { filterReferenceable, type ReferencedFile } from '../files/referenceable';
+	import { nextIndex } from './SlashPopover.svelte';
+
+	export type MentionPopoverState = {
+		results: ReferencedFile[];
+		activeIndex: number;
+		loading: boolean;
+		error: string | null;
+		query: string;
+	};
+
+	export type MentionStateKind =
+		| 'loading'
+		| 'error'
+		| 'empty-with-query'
+		| 'empty-no-query'
+		| 'results';
+
+	export type MentionKeyAction =
+		| { kind: 'select'; result: ReferencedFile }
+		| { kind: 'dismiss' }
+		| { kind: 'move'; nextIndex: number }
+		| { kind: 'noop' };
+
+	export function mentionResults(files: ReferencedFile[], query: string): ReferencedFile[] {
+		return filterReferenceable(files, query).filter((f) => f.ready);
+	}
+
+	export function mentionStateKind(state: MentionPopoverState): MentionStateKind {
+		if (state.loading) return 'loading';
+		if (state.error) return 'error';
+		if (state.results.length === 0) {
+			return state.query ? 'empty-with-query' : 'empty-no-query';
+		}
+		return 'results';
+	}
+
+	export function decideMentionKeyAction(
+		key: string,
+		state: MentionPopoverState
+	): MentionKeyAction {
+		if (key === 'Escape') return { kind: 'dismiss' };
+		const len = state.results.length;
+		if (len === 0) return { kind: 'noop' };
+		if (key === 'Enter') {
+			const result = state.results[state.activeIndex];
+			if (!result) return { kind: 'noop' };
+			return { kind: 'select', result };
+		}
+		if (key === 'ArrowDown') {
+			return { kind: 'move', nextIndex: nextIndex(state.activeIndex, len, 1) };
+		}
+		if (key === 'ArrowUp') {
+			return { kind: 'move', nextIndex: nextIndex(state.activeIndex, len, -1) };
+		}
+		return { kind: 'noop' };
+	}
+```
+
+2. Instance script:
+
+```ts
+	export let query: string;
+	export let files: ReferencedFile[];
+	export let loading: boolean = false;
+	export let error: string | null = null;
+	export let onSelect: (file: ReferencedFile) => void;
+	export let onDismiss: () => void;
+	export let onRetry: () => void;
+
+	let activeIndex = 0;
+	let lastQuery: string | undefined;
+
+	$: results = mentionResults(files, query);
+	// Reset the active row on ANY query change (matching SlashPopover's
+	// semantics): after an edit, position N of the new result set is an
+	// unrelated file, so a stale highlight must never survive the edit.
+	$: if (query !== lastQuery) {
+		lastQuery = query;
+		activeIndex = 0;
+	}
+	// Clamp if the file list itself shrinks (e.g. a reload) with no query change.
+	$: if (activeIndex >= results.length) activeIndex = 0;
+	$: kind = mentionStateKind({ results, activeIndex, loading, error, query });
+
+	function onWindowKey(e: KeyboardEvent) {
+		const action = decideMentionKeyAction(e.key, { results, activeIndex, loading, error, query });
+		switch (action.kind) {
+			case 'select':
+				e.preventDefault();
+				e.stopPropagation();
+				onSelect(action.result);
+				return;
+			case 'dismiss':
+				e.preventDefault();
+				e.stopPropagation();
+				onDismiss();
+				return;
+			case 'move':
+				e.preventDefault();
+				e.stopPropagation();
+				activeIndex = action.nextIndex;
+				return;
+			case 'noop':
+				return;
+		}
+	}
+
+	function onRowMouseDown(e: MouseEvent, file: ReferencedFile) {
+		e.preventDefault();
+		onSelect(file);
+	}
+```
+
+3. Template: same shape as SlashPopover with `aria-label="Document suggestions"`, root class `lq-mention-popover`, `data-testid="lq-ai-mention-popover"` on the root div, and these state texts:
+   - loading → `Loading documents…`
+   - error → `Couldn't load documents ·` + retry button calling `onRetry`
+   - empty-with-query → `No matching documents · Esc to dismiss`
+   - empty-no-query → `No documents ready to reference in this matter`
+   - results rows: icon `📄`, title `{r.filename}`, no description line; row ids `lq-mention-row-{i}`, row `data-testid="lq-ai-mention-row"`.
+
+4. Styles: copy SlashPopover's `<style>` block verbatim, renaming every `lq-slash-popover` class to `lq-mention-popover` (drop the unused `__desc`/`__link` rules).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npx vitest run src/lib/lq-ai/__tests__/MentionPopover.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+cd web && npx prettier --plugin-search-dir --write src/lib/lq-ai/components/MentionPopover.svelte src/lib/lq-ai/__tests__/MentionPopover.test.ts && npx eslint src/lib/lq-ai/components/MentionPopover.svelte src/lib/lq-ai/__tests__/MentionPopover.test.ts
+cd /Users/abc/projs/lqAI/lq-ai && git add web/src/lib/lq-ai/components/MentionPopover.svelte web/src/lib/lq-ai/__tests__/MentionPopover.test.ts
+git commit -s -m "feat(web): add MentionPopover for @-referencing matter documents" -m "Refs referenced-files"
+```
+
+---
+
+### Task 4: ReferencedFilesChips + FilePickerDropdown components
+
+**Files:**
+- Create: `web/src/lib/lq-ai/components/ReferencedFilesChips.svelte`
+- Create: `web/src/lib/lq-ai/components/FilePickerDropdown.svelte`
+- Test: `web/src/lib/lq-ai/__tests__/FilePickerDropdown.test.ts`
+
+**Interfaces:**
+- Consumes: `ReferencedFile`, `filterReferenceable` (Task 1).
+- Produces:
+  - `ReferencedFilesChips` props: `files: ReferencedFile[]`, `notice: string | null`, `onRemove: (id: string) => void`.
+  - `FilePickerDropdown` props: `files: ReferencedFile[]`, `loading: boolean`, `error: string | null`, `failedKbCount: number`, `selectedIds: string[]`, `capReached: boolean`, `onToggle: (file: ReferencedFile) => void`, `onClose: () => void`, `onRetry: () => void`.
+  - `FilePickerDropdown` module helper (unit-tested): `rowDisabled(file: ReferencedFile, selected: boolean, capReached: boolean): boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+`web/src/lib/lq-ai/__tests__/FilePickerDropdown.test.ts`:
+
+```ts
+/** referenced-files Phase 2 — FilePickerDropdown row-disable logic. */
+import { describe, expect, it } from 'vitest';
+
+import { rowDisabled } from '../components/FilePickerDropdown.svelte';
+import type { ReferencedFile } from '../files/referenceable';
+
+function ref(ready: boolean): ReferencedFile {
+	return { id: '1', filename: 'a.pdf', ready };
+}
+
+describe('rowDisabled', () => {
+	it('disables non-ready rows regardless of selection state', () => {
+		expect(rowDisabled(ref(false), false, false)).toBe(true);
+		expect(rowDisabled(ref(false), true, true)).toBe(true);
+	});
+
+	it('disables unselected rows at the cap', () => {
+		expect(rowDisabled(ref(true), false, true)).toBe(true);
+	});
+
+	it('keeps SELECTED rows enabled at the cap so they can be unchecked', () => {
+		expect(rowDisabled(ref(true), true, true)).toBe(false);
+	});
+
+	it('enables ready rows below the cap', () => {
+		expect(rowDisabled(ref(true), false, false)).toBe(false);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/lib/lq-ai/__tests__/FilePickerDropdown.test.ts`
+Expected: FAIL — cannot resolve the component.
+
+- [ ] **Step 3: Write both components**
+
+`web/src/lib/lq-ai/components/ReferencedFilesChips.svelte`:
+
+```svelte
+<script lang="ts">
+	/**
+	 * referenced-files Phase 2 — the authoritative referenced-files set, rendered
+	 * as removable chips above the composer. Both entry affordances
+	 * (FilePickerDropdown, MentionPopover) converge on this one row.
+	 */
+	import type { ReferencedFile } from '../files/referenceable';
+
+	export let files: ReferencedFile[];
+	export let notice: string | null = null;
+	export let onRemove: (id: string) => void;
+</script>
+
+{#if files.length > 0 || notice}
+	<div class="lq-ref-chips" data-testid="lq-ai-referenced-chips">
+		{#each files as f (f.id)}
+			<span class="lq-ref-chip" data-testid="lq-ai-referenced-chip">
+				<span class="lq-ref-chip__icon" aria-hidden="true">📄</span>
+				<span class="lq-ref-chip__name" title={f.filename}>{f.filename}</span>
+				<button
+					type="button"
+					class="lq-ref-chip__remove"
+					aria-label={`Remove ${f.filename}`}
+					on:click={() => onRemove(f.id)}
+				>
+					×
+				</button>
+			</span>
+		{/each}
+		{#if notice}
+			<span class="lq-ref-chips__notice" data-testid="lq-ai-referenced-notice">{notice}</span>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.lq-ref-chips {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--lq-space-1, 4px);
+		padding: var(--lq-space-1, 4px) 0;
+		font-family: var(--lq-font-sans);
+		font-size: 12px;
+	}
+
+	.lq-ref-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		max-width: 220px;
+		padding: 2px var(--lq-space-2, 8px);
+		border: 1px solid var(--lq-accent-border, #cfe4d8);
+		border-radius: 999px;
+		background: var(--lq-accent-soft, #e8f4ec);
+		color: var(--lq-text, #1a1a1a);
+	}
+
+	.lq-ref-chip__name {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.lq-ref-chip__remove {
+		background: none;
+		border: 0;
+		padding: 0 2px;
+		font: inherit;
+		color: var(--lq-text-tertiary, #9ca3af);
+		cursor: pointer;
+	}
+
+	.lq-ref-chip__remove:hover {
+		color: var(--lq-text, #1a1a1a);
+	}
+
+	.lq-ref-chips__notice {
+		color: var(--lq-text-tertiary, #9ca3af);
+	}
+</style>
+```
+
+`web/src/lib/lq-ai/components/FilePickerDropdown.svelte`:
+
+```svelte
+<script context="module" lang="ts">
+	/**
+	 * FilePickerDropdown — multi-select referenced-documents picker
+	 * (referenced-files Phase 2). Checkbox-set pattern from AttachKBModal, search
+	 * pattern from SkillPicker. Unlike MentionPopover this DOES render
+	 * non-ready files — disabled, with a "Preparing…" badge — so the user
+	 * can see why a document isn't offered yet (P4 made visible).
+	 */
+	import {
+		MESSAGE_REFERENCED_FILES_MAX,
+		filterReferenceable,
+		type ReferencedFile
+	} from '../files/referenceable';
+
+	export function rowDisabled(
+		file: ReferencedFile,
+		selected: boolean,
+		capReached: boolean
+	): boolean {
+		if (!file.ready) return true;
+		return capReached && !selected;
+	}
+</script>
+
+<script lang="ts">
+	export let files: ReferencedFile[];
+	export let loading: boolean = false;
+	export let error: string | null = null;
+	export let failedKbCount: number = 0;
+	export let selectedIds: string[];
+	export let capReached: boolean = false;
+	export let onToggle: (file: ReferencedFile) => void;
+	export let onClose: () => void;
+	export let onRetry: () => void;
+
+	let searchTerm = '';
+
+	$: filtered = filterReferenceable(files, searchTerm);
+	$: selectedSet = new Set(selectedIds);
+
+	function onWindowKey(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopPropagation();
+			onClose();
+		}
+	}
+</script>
+
+<svelte:window on:keydown={onWindowKey} />
+
+<div class="lq-file-picker" data-testid="lq-ai-file-picker" role="dialog" aria-label="Reference documents">
+	<div class="lq-file-picker__head">
+		<input
+			type="search"
+			class="lq-file-picker__search"
+			placeholder="Search matter documents…"
+			bind:value={searchTerm}
+			data-testid="lq-ai-file-picker-search"
+		/>
+		<button type="button" class="lq-file-picker__done" on:click={onClose} data-testid="lq-ai-file-picker-done">
+			Done
+		</button>
+	</div>
+
+	{#if loading}
+		<div class="lq-file-picker__status">Loading documents…</div>
+	{:else if error}
+		<div class="lq-file-picker__status lq-file-picker__status--error">
+			Couldn't load documents ·
+			<button type="button" class="lq-file-picker__retry" on:click={onRetry}>retry</button>
+		</div>
+	{:else if files.length === 0}
+		<div class="lq-file-picker__status" data-testid="lq-ai-file-picker-empty">
+			No documents in this matter's knowledge bases yet.
+		</div>
+	{:else}
+		{#if failedKbCount > 0}
+			<div class="lq-file-picker__status lq-file-picker__status--error">
+				{failedKbCount} knowledge base{failedKbCount === 1 ? '' : 's'} failed to load ·
+				<button type="button" class="lq-file-picker__retry" on:click={onRetry}>retry</button>
+			</div>
+		{/if}
+		{#if capReached}
+			<div class="lq-file-picker__status" data-testid="lq-ai-file-picker-cap">
+				Reference limit reached ({MESSAGE_REFERENCED_FILES_MAX} documents per message).
+			</div>
+		{/if}
+		{#each filtered as f (f.id)}
+			{@const disabled = rowDisabled(f, selectedSet.has(f.id), capReached)}
+			<label class="lq-file-picker__row" class:disabled data-testid="lq-ai-file-picker-row">
+				<input
+					type="checkbox"
+					checked={selectedSet.has(f.id)}
+					{disabled}
+					on:change={() => onToggle(f)}
+				/>
+				<span class="lq-file-picker__name" title={f.filename}>{f.filename}</span>
+				{#if !f.ready}
+					<span class="lq-file-picker__badge">Preparing…</span>
+				{/if}
+			</label>
+		{:else}
+			<div class="lq-file-picker__status">No documents match “{searchTerm}”.</div>
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.lq-file-picker {
+		display: flex;
+		flex-direction: column;
+		min-width: 300px;
+		max-width: clamp(300px, 90vw, 440px);
+		max-height: 340px;
+		overflow-y: auto;
+		background: var(--lq-surface, var(--lq-canvas, #ffffff));
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius, 6px);
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+		padding: var(--lq-space-1, 4px);
+		font-family: var(--lq-font-sans);
+		font-size: 13px;
+		color: var(--lq-text, #1a1a1a);
+	}
+
+	.lq-file-picker__head {
+		display: flex;
+		gap: var(--lq-space-1, 4px);
+		padding: var(--lq-space-1, 4px);
+	}
+
+	.lq-file-picker__search {
+		flex: 1;
+		font: inherit;
+		padding: 4px var(--lq-space-2, 8px);
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius-sm, 4px);
+	}
+
+	.lq-file-picker__done {
+		background: none;
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius-sm, 4px);
+		padding: 4px var(--lq-space-2, 8px);
+		font: inherit;
+		cursor: pointer;
+	}
+
+	.lq-file-picker__status {
+		padding: var(--lq-space-2, 8px) var(--lq-space-3, 12px);
+		color: var(--lq-text-tertiary, #9ca3af);
+		font-size: 12px;
+	}
+
+	.lq-file-picker__status--error {
+		color: var(--lq-error, #b54848);
+	}
+
+	.lq-file-picker__retry {
+		background: none;
+		border: 0;
+		padding: 0;
+		color: inherit;
+		font: inherit;
+		text-decoration: underline;
+		cursor: pointer;
+	}
+
+	.lq-file-picker__row {
+		display: flex;
+		align-items: center;
+		gap: var(--lq-space-2, 8px);
+		padding: var(--lq-space-2, 8px) var(--lq-space-3, 12px);
+		border-radius: var(--lq-radius-sm, 4px);
+		cursor: pointer;
+	}
+
+	.lq-file-picker__row:hover:not(.disabled) {
+		background: var(--lq-accent-soft, #e8f4ec);
+	}
+
+	.lq-file-picker__row.disabled {
+		color: var(--lq-text-tertiary, #9ca3af);
+		cursor: not-allowed;
+	}
+
+	.lq-file-picker__name {
+		flex: 1;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.lq-file-picker__badge {
+		font-size: 11px;
+		color: var(--lq-text-tertiary, #9ca3af);
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: 999px;
+		padding: 0 6px;
+	}
+</style>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npx vitest run src/lib/lq-ai/__tests__/FilePickerDropdown.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+cd web && npx prettier --plugin-search-dir --write src/lib/lq-ai/components/ReferencedFilesChips.svelte src/lib/lq-ai/components/FilePickerDropdown.svelte src/lib/lq-ai/__tests__/FilePickerDropdown.test.ts && npx eslint src/lib/lq-ai/components/ReferencedFilesChips.svelte src/lib/lq-ai/components/FilePickerDropdown.svelte src/lib/lq-ai/__tests__/FilePickerDropdown.test.ts
+cd /Users/abc/projs/lqAI/lq-ai && git add web/src/lib/lq-ai/components/ReferencedFilesChips.svelte web/src/lib/lq-ai/components/FilePickerDropdown.svelte web/src/lib/lq-ai/__tests__/FilePickerDropdown.test.ts
+git commit -s -m "feat(web): add referenced-files chips row + multi-select file picker" -m "Refs referenced-files"
+```
+
+---
+
+### Task 5: Wire it all into ChatPanel + message types
+
+**Files:**
+- Modify: `web/src/lib/lq-ai/types.ts` (`MessageCreate` ~line 347, `MessagePostResponse` ~line 375, `MessageCompleteFrame` ~line 400, `Message` ~line 295)
+- Modify: `web/src/lib/lq-ai/components/ChatPanel.svelte`
+
+**Interfaces:**
+- Consumes: everything produced by Tasks 1–4.
+- Produces: the send payload field `referenced_file_ids: string[]` (wire), the optimistic user `Message.referenced_files: Array<{ id: string; filename: string }>` that Task 6 renders.
+
+Line numbers below are as of commit `124502d` — verify each anchor by its quoted code before editing (earlier tasks shift them slightly).
+
+- [ ] **Step 1: Extend the types** (`web/src/lib/lq-ai/types.ts`)
+
+In `MessageCreate` (after the `set_sticky` field, ~line 372):
+
+```ts
+	/**
+	 * referenced-files Phase 2 — caller-selected matter documents grounding THIS
+	 * turn via file-scoped retrieval + verified citations (ADR 0022).
+	 * Distinct from the (unwired) verbatim file_ids channel. Cap 16
+	 * (MESSAGE_REFERENCED_FILES_MAX, enforced UI-side so the backend 422
+	 * is unreachable through this client).
+	 */
+	referenced_file_ids?: string[];
+```
+
+In `MessagePostResponse` (after `applied_skills`, ~line 381):
+
+```ts
+	/** referenced-files — echo of the validated referenced_file_ids. */
+	applied_referenced_file_ids?: string[];
+```
+
+In `MessageCompleteFrame` (after `routed_provider`, ~line 407):
+
+```ts
+	/** referenced-files — echo of the validated referenced_file_ids (parity with applied_skills). */
+	applied_referenced_file_ids?: string[];
+```
+
+In `Message` (after `citations?: Citation[];`, ~line 321):
+
+```ts
+	/**
+	 * referenced-files Phase 2 — client-side stamp of the documents referenced when
+	 * THIS user message was sent ({id, filename} pairs). NOT persisted:
+	 * the backend stores no messages.referenced_file_ids column (ADR
+	 * 0022), so the row disappears on reload. Set only on the optimistic
+	 * user message at send time.
+	 */
+	referenced_files?: Array<{ id: string; filename: string }>;
+```
+
+- [ ] **Step 2: ChatPanel — imports + state**
+
+In the instance `<script>` of `ChatPanel.svelte`: add to the component imports (after the `SlashPopover` import, ~line 103):
+
+```ts
+	import MentionPopover from '$lib/lq-ai/components/MentionPopover.svelte';
+	import FilePickerDropdown from '$lib/lq-ai/components/FilePickerDropdown.svelte';
+	import ReferencedFilesChips from '$lib/lq-ai/components/ReferencedFilesChips.svelte';
+	import {
+		MESSAGE_REFERENCED_FILES_MAX,
+		addReferencedFile,
+		loadReferenceableFiles,
+		removeReferencedFile,
+		type ReferencedFile
+	} from '$lib/lq-ai/files/referenceable';
+```
+
+After the slash state block (`let slashStartIndex = -1;`, ~line 799), add:
+
+```ts
+	// referenced-files Phase 2 — referenced files. One authoritative, deduped,
+	// cap-16 list feeding `referenced_file_ids`; both the @-mention
+	// popover and the picker mutate it. Plain array reassignment (not
+	// Map mutation) so Svelte 4 reactivity tracks changes.
+	let referencedFiles: ReferencedFile[] = [];
+	let referencedNotice: string | null = null;
+
+	// The referenceable set (all files across the matter's attached KBs),
+	// lazily loaded per project and cached until a chat/project switch or
+	// an explicit refresh (picker re-open / retry).
+	let referenceable: ReferencedFile[] = [];
+	let referenceableLoading = false;
+	let referenceableError: string | null = null;
+	let referenceableFailedKbCount = 0;
+	let referenceableLoadedForProject: string | null = null;
+
+	let filePickerOpen = false;
+	let mentionOpen = false;
+	let mentionQuery = '';
+	let mentionAtIndex = -1;
+
+	async function ensureReferenceable(force = false): Promise<void> {
+		if (!composerProjectId) return;
+		if (!force && referenceableLoadedForProject === composerProjectId) return;
+		referenceableLoading = true;
+		referenceableError = null;
+		try {
+			const load = await loadReferenceableFiles(composerProjectId);
+			referenceable = load.files;
+			referenceableFailedKbCount = load.failedKbCount;
+			referenceableLoadedForProject = composerProjectId;
+		} catch (e: unknown) {
+			referenceableError = e instanceof Error ? e.message : 'Failed to load documents';
+			referenceable = [];
+			referenceableFailedKbCount = 0;
+			referenceableLoadedForProject = null;
+		} finally {
+			referenceableLoading = false;
+		}
+	}
+
+	function addReference(file: ReferencedFile): void {
+		const result = addReferencedFile(referencedFiles, file);
+		if (result.added) {
+			referencedFiles = result.list;
+			referencedNotice = null;
+		} else if (result.reason === 'cap') {
+			referencedNotice = `You can reference up to ${MESSAGE_REFERENCED_FILES_MAX} documents per message.`;
+		}
+		// 'duplicate' and 'not-ready' are silent no-ops: the picker
+		// disables those rows and the mention popover never offers them.
+	}
+
+	function removeReference(id: string): void {
+		referencedFiles = removeReferencedFile(referencedFiles, id);
+		referencedNotice = null;
+	}
+
+	function toggleReference(file: ReferencedFile): void {
+		if (referencedFiles.some((f) => f.id === file.id)) removeReference(file.id);
+		else addReference(file);
+	}
+
+	function toggleFilePicker(): void {
+		filePickerOpen = !filePickerOpen;
+		if (filePickerOpen) {
+			mentionOpen = false;
+			void ensureReferenceable(true);
+		}
+	}
+
+	function onMentionSelect(file: ReferencedFile): void {
+		if (mentionAtIndex >= 0) {
+			composerText = completeMentionAt(
+				composerText,
+				mentionAtIndex,
+				mentionQuery.length,
+				file.filename
+			);
+		}
+		addReference(file);
+		mentionOpen = false;
+		mentionQuery = '';
+		mentionAtIndex = -1;
+	}
+
+	function onMentionDismiss(): void {
+		mentionOpen = false;
+		mentionQuery = '';
+		mentionAtIndex = -1;
+	}
+```
+
+- [ ] **Step 3: ChatPanel — extend `onComposerInput`** (~line 801)
+
+Replace the body so it runs BOTH detections (they are mutually exclusive by trigger char — slash requires `/` at line start, mention requires `@` at word start):
+
+```ts
+	function onComposerInput(e: Event): void {
+		const ta = e.target as HTMLTextAreaElement;
+		// `bind:value` has already updated `composerText` before this
+		// handler fires; we read from the textarea directly anyway so the
+		// caret position and value are guaranteed consistent.
+		const detection = detectSlashAt(ta.value, ta.selectionStart);
+		if (detection.open) {
+			slashOpen = true;
+			slashQuery = detection.query;
+			slashStartIndex = detection.slashIndex;
+		} else {
+			slashOpen = false;
+			slashQuery = '';
+			slashStartIndex = -1;
+		}
+
+		// referenced-files Phase 2 — @-mention detection. Only offered in project
+		// chats (a projectless chat has no referenceable set; the backend
+		// 404s any referenced id there — never render the affordance).
+		const mention = composerProjectId ? detectMentionAt(ta.value, ta.selectionStart) : { open: false as const };
+		if (mention.open) {
+			mentionOpen = true;
+			mentionQuery = mention.query;
+			mentionAtIndex = mention.atIndex;
+			filePickerOpen = false;
+			void ensureReferenceable();
+		} else {
+			mentionOpen = false;
+			mentionQuery = '';
+			mentionAtIndex = -1;
+		}
+	}
+```
+
+- [ ] **Step 4: ChatPanel — reset on chat switch** (`selectChat`, after `skillInputs = {};` ~line 332)
+
+```ts
+		// referenced-files — referenced files are per-draft; the referenceable cache
+		// is per-project and re-validated lazily by ensureReferenceable().
+		referencedFiles = [];
+		referencedNotice = null;
+		filePickerOpen = false;
+		mentionOpen = false;
+		mentionQuery = '';
+		mentionAtIndex = -1;
+```
+
+- [ ] **Step 5: ChatPanel — send payload + stamp + clear** (`sendMessage`)
+
+In the optimistic user message build (~line 591, `const userMsg: Message = {...}`), add after `is_enhanced: isEnhancedSend,`:
+
+```ts
+			referenced_files:
+				referencedFiles.length > 0
+					? referencedFiles.map(({ id, filename }) => ({ id, filename }))
+					: undefined,
+```
+
+In the `sendMessageStream` body (~lines 633–645), add after `skill_inputs: ...`:
+
+```ts
+						// referenced-files Phase 2 — ground this turn in the user-selected
+						// matter documents (file-scoped retrieval + citations).
+						referenced_file_ids:
+							referencedFiles.length > 0 ? referencedFiles.map((f) => f.id) : undefined,
+```
+
+Right after `composerText = '';` (~line 648, the send-in-flight point where the draft clears), add:
+
+```ts
+				// Referenced files are turn-scoped (like the backend channel):
+				// clear on a successfully-initiated send, preserve on failure so
+				// the user can adjust and retry.
+				referencedFiles = [];
+				referencedNotice = null;
+				filePickerOpen = false;
+```
+
+- [ ] **Step 6: ChatPanel — template mounts**
+
+(a) Chips row — insert immediately BEFORE `<div class="flex items-end gap-2">` (~line 1071):
+
+```svelte
+				<ReferencedFilesChips
+					files={referencedFiles}
+					notice={referencedNotice}
+					onRemove={removeReference}
+				/>
+```
+
+(b) Mention popover — inside `<div class="lq-composer-wrap flex-1">`, right after the existing `{#if slashOpen}...{/if}` block (~line 1090):
+
+```svelte
+							{#if mentionOpen}
+								<div class="lq-composer-popover" data-testid="lq-ai-mention-popover-anchor">
+									<MentionPopover
+										query={mentionQuery}
+										files={referenceable}
+										loading={referenceableLoading}
+										error={referenceableError}
+										onSelect={onMentionSelect}
+										onDismiss={onMentionDismiss}
+										onRetry={() => void ensureReferenceable(true)}
+									/>
+								</div>
+							{/if}
+```
+
+(c) Picker button + dropdown — inside the existing `{#if composerProjectId}` toolbar block (~line 1102), after the Attach-KB button (`data-testid="lq-ai-attach-kb-btn"`), add:
+
+```svelte
+								<div class="lq-file-picker-anchor">
+									<button
+										type="button"
+										class="lq-btn-secondary text-sm"
+										aria-label="Reference matter documents"
+										title="Reference matter documents in this message"
+										on:click={toggleFilePicker}
+										data-testid="lq-ai-file-picker-btn"
+									>
+										📄
+									</button>
+									{#if filePickerOpen}
+										<div class="lq-composer-popover">
+											<FilePickerDropdown
+												files={referenceable}
+												loading={referenceableLoading}
+												error={referenceableError}
+												failedKbCount={referenceableFailedKbCount}
+												selectedIds={referencedFiles.map((f) => f.id)}
+												capReached={referencedFiles.length >= MESSAGE_REFERENCED_FILES_MAX}
+												onToggle={toggleReference}
+												onClose={() => (filePickerOpen = false)}
+												onRetry={() => void ensureReferenceable(true)}
+											/>
+										</div>
+									{/if}
+								</div>
+```
+
+(d) Anchor style — `lq-composer-popover` is an existing class (used by the slash popover anchor). For the picker anchor add to ChatPanel's `<style>` block:
+
+```css
+	.lq-file-picker-anchor {
+		position: relative;
+	}
+```
+
+Check how `.lq-composer-popover` is positioned (grep ChatPanel's style block / `web/src/lib/lq-ai/styles`); if it is absolutely positioned relative to `.lq-composer-wrap`, the picker's copy inside `.lq-file-picker-anchor` will anchor to the button — verify visually in Cypress `cy.get('[data-testid="lq-ai-file-picker"]').should('be.visible')`.
+
+- [ ] **Step 7: Run the full frontend unit suite + type gate**
+
+```bash
+cd web && npx vitest run src/lib/lq-ai/__tests__/ && npm run check:lq-ai
+```
+Expected: all vitest files PASS (including the pre-existing ones); svelte-check reports no NEW errors in the touched files (note any pre-existing baseline errors and leave them).
+
+- [ ] **Step 8: Format, lint, commit**
+
+```bash
+cd web && npx prettier --plugin-search-dir --write src/lib/lq-ai/types.ts src/lib/lq-ai/components/ChatPanel.svelte && npx eslint src/lib/lq-ai/types.ts src/lib/lq-ai/components/ChatPanel.svelte
+cd /Users/abc/projs/lqAI/lq-ai && git add web/src/lib/lq-ai/types.ts web/src/lib/lq-ai/components/ChatPanel.svelte
+git commit -s -m "feat(web): wire referenced files into composer send path" -m "Refs referenced-files"
+```
+
+---
+
+### Task 6: "Referenced:" row on the user message bubble
+
+**Files:**
+- Modify: `web/src/lib/lq-ai/components/MessageBubble.svelte`
+
+**Interfaces:**
+- Consumes: `Message.referenced_files` (Task 5's type addition; stamped on the optimistic user message at send time).
+
+- [ ] **Step 1: Read `MessageBubble.svelte`** and locate the user-role content rendering (the component renders both roles; find where the message content/pills render for `message.role === 'user'`).
+
+- [ ] **Step 2: Add the row** — immediately after the user message's content rendering, add:
+
+```svelte
+	{#if message.role === 'user' && message.referenced_files?.length}
+		<!-- referenced-files Phase 2 — session-only stamp (not persisted server-side;
+		     disappears on reload). Shows which matter documents grounded
+		     this turn. -->
+		<div class="lq-msg-referenced" data-testid="lq-ai-referenced-row">
+			📄 Referenced: {message.referenced_files.map((f) => f.filename).join(', ')}
+		</div>
+	{/if}
+```
+
+And to the component's `<style>` block:
+
+```css
+	.lq-msg-referenced {
+		margin-top: 4px;
+		font-size: 12px;
+		color: var(--lq-text-tertiary, #9ca3af);
+	}
+```
+
+Match the component's existing markup/indentation idiom; if user-message pills (e.g. the ✨ enhanced pill) render in a specific footer area, put the row there instead — same visual tier.
+
+- [ ] **Step 3: Gate + commit**
+
+```bash
+cd web && npx vitest run src/lib/lq-ai/__tests__/ && npm run check:lq-ai && npx prettier --plugin-search-dir --write src/lib/lq-ai/components/MessageBubble.svelte && npx eslint src/lib/lq-ai/components/MessageBubble.svelte
+cd /Users/abc/projs/lqAI/lq-ai && git add web/src/lib/lq-ai/components/MessageBubble.svelte
+git commit -s -m "feat(web): show referenced documents on sent user messages" -m "Refs referenced-files"
+```
+
+---
+
+### Task 7: Cypress e2e + PRD docs + full gate
+
+**Files:**
+- Create: `web/cypress/e2e/referenced-files-referenced-files.cy.ts`
+- Modify: `docs/PRD.md` (§3.1 ~line 338; §9 referenced-files entry ~lines 4942–4948)
+
+- [ ] **Step 1: Read an existing chat spec for the harness pattern** — `web/cypress/e2e/chat.cy.ts` (auth/bootstrap, how chats/projects/messages routes are stubbed, how the composer is driven). Reuse its login/bootstrap helpers exactly; the new spec must run in the same way (`npx cypress run --spec cypress/e2e/referenced-files-referenced-files.cy.ts` or the repo's documented Cypress invocation).
+
+- [ ] **Step 2: Write the spec.** Adapt the setup to the harness pattern found in Step 1; the scenario bodies must cover exactly these five cases (testids are fixed by Tasks 4–5):
+
+```ts
+/**
+ * referenced-files Phase 2 — referenced files in the chat composer.
+ * All API routes stubbed; asserts the wire contract (referenced_file_ids
+ * on POST /messages) and the two entry affordances.
+ */
+describe('referenced-files referenced files', () => {
+	// Stub set (adapt names to the chat.cy.ts harness):
+	//  - GET  **/api/v1/projects/proj-1            → { id: 'proj-1', attached_knowledge_base_ids: ['kb-1'], ... }
+	//  - GET  **/api/v1/knowledge-bases/kb-1/files → [
+	//      { id: 'file-1', filename: 'master-agreement.pdf', ingestion_status: 'ready', ... },
+	//      { id: 'file-2', filename: 'exhibit-a.pdf',        ingestion_status: 'ready', ... },
+	//      { id: 'file-3', filename: 'pending-upload.pdf',   ingestion_status: 'processing', ... }
+	//    ]
+	//  - POST **/api/v1/chats/*/messages           → cy.intercept(...).as('send') with an SSE-ish stub
+	//    per the chat.cy.ts pattern.
+
+	it('picker flow: select two files, chips render, send carries both ids, set clears', () => {
+		// open picker → search 'agreement' → check row → clear search →
+		// check 'exhibit-a' → Done → two chips visible →
+		// type a message → Send → cy.wait('@send').its('request.body')
+		//   .should((b) => expect(b.referenced_file_ids).to.deep.equal(['file-1', 'file-2'])) →
+		// chips row empties after send.
+	});
+
+	it('mention flow: typing @exh opens popover, Enter splices text and adds chip', () => {
+		// type 'summarize @exh' → popover visible with exhibit-a.pdf →
+		// {enter} → composer value === 'summarize ' →
+		// chip 'exhibit-a.pdf' visible → popover closed.
+	});
+
+	it('non-ready file shows disabled "Preparing…" row in the picker and is absent from the mention popover', () => {
+		// picker: row for pending-upload.pdf has a disabled checkbox + badge.
+		// mention: '@pending' → 'No matching documents' empty state.
+	});
+
+	it('chip remove (×) drops the file from the set', () => {
+		// add via picker → click chip × → chips row empty →
+		// send → request body has NO referenced_file_ids key.
+	});
+
+	it('projectless chat: no picker button, @ never opens the popover', () => {
+		// bootstrap a chat with project_id: null →
+		// composer visible, lq-ai-file-picker-btn does not exist →
+		// type '@doc' → lq-ai-mention-popover-anchor does not exist.
+	});
+});
+```
+
+Every `it` body must be fully implemented (the comments above are the scenario contract, not placeholders to leave in).
+
+- [ ] **Step 3: Run the spec** against the dev stack if it is up (`docker compose ps` — if the stack is down, note it and rely on CI; do NOT start/rebuild the stack destructively). If runnable: `cd web && npx cypress run --spec cypress/e2e/referenced-files-referenced-files.cy.ts`. Expected: all 5 passing.
+
+- [ ] **Step 4: PRD edits**
+
+(a) §3.1 (~line 338), append to the `referenced_file_ids` sentence added by the backend PR:
+
+```markdown
+The web composer surfaces this channel through two affordances (referenced-files Phase 2): an inline `@`-mention popover and a multi-select document picker, converging on one deduped, cap-16 chip set; non-`ready` documents render disabled ("Preparing…"), so the UI can never assemble a set the backend would reject.
+```
+
+(b) §9 referenced-files entry (~line 4948): replace the `**Deferred:**` paragraph with:
+
+```markdown
+**Phase 2 (SHIPPED 2026-07-03):** composer `@`-mention popover + multi-select document picker (web), one authoritative cap-16 referenced-set fed by both, KB-file listing composed client-side from `GET /projects/{id}` + `GET /knowledge-bases/{kb_id}/files` (no DE-296 dependency). **Deferred:** Phase 3 — embed-on-reference, where selecting a file eagerly (re-)triggers its embedding pipeline rather than requiring pre-existing `ready` status.
+```
+
+- [ ] **Step 5: Full gate**
+
+```bash
+cd web && npx vitest run src/lib/lq-ai/__tests__/ && npm run check:lq-ai && npx prettier --plugin-search-dir --check "src/lib/lq-ai/**/*.{ts,svelte}" "cypress/e2e/referenced-files-referenced-files.cy.ts"
+```
+(If prettier flags files this feature did not touch, leave them — check only the touched set.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/abc/projs/lqAI/lq-ai && git add web/cypress/e2e/referenced-files-referenced-files.cy.ts docs/PRD.md
+git commit -s -m "test(web): e2e for composer referenced files + PRD Phase 2 docs" -m "Refs referenced-files"
+```

--- a/docs/superpowers/specs/2026-07-02-chat-at-mention-file-retrieval-design.md
+++ b/docs/superpowers/specs/2026-07-02-chat-at-mention-file-retrieval-design.md
@@ -1,0 +1,256 @@
+# Reference matter documents in a chat message (`@`-mention + multi-select picker) with verified citations
+
+> **Type:** New feature.
+> **Affected subsystem:** Web (chat UI), Backend (API).
+> **Related:** Resolves Contract QA scoping open
+> question (`docs/PRD.md` §3, "user-selected document set"); builds on §3.1 per-message file channel
+> and §3.3 Citation Engine.
+
+---
+
+## Use case
+
+Let a user **reference documents from the current matter inside a chat message** — by typing an
+inline `@filename` mention **or** by picking files from a multi-select dropdown — and **ask
+questions about those files**, getting back an answer with **verified citations that deep-link into
+the referenced document(s)** via the doc panel.
+
+Two entry interfaces, one destination:
+
+- **Inline `@`-mention** — type `@`, a dropdown filters the matter's files as you type; selecting inserts a token.
+- **Multi-select file picker** — a composer toolbar button opens a dropdown of the matter's files; check several, confirm.
+
+Both feed the **same authoritative referenced-files set**, sent on the message, which drives
+**file-scoped retrieval + citations**.
+
+---
+
+## Why this can't be met today
+
+The rails exist but are disconnected. Concretely:
+
+1. **The per-message file channel injects verbatim text and never produces citations.**
+   Chat send accepts `file_ids`, but `_load_attached_file_contexts` pulls each file's full
+   `Document.normalized_content` and `_format_attached_files_block` injects it verbatim as a system
+   block (`api/app/api/chats.py:415`, `:1129`, `:1494-1505`). Citations are minted only from
+   `retrieved_chunks`: `_persist_message_citations` early-returns on empty and is called at every
+   site with `retrieved_chunks` only, never the attached-file contexts (`chats.py:2560`, `:2604`,
+   call sites `:2934/:3187/:3530`). **So attaching a file today can make the model read it, but can
+   never yield a citation.**
+
+2. **Retrieval is KB-and-project-scoped only, with no per-file scope.**
+   `_retrieve_kb_context_for_chat` returns `([],[])` unless `chat.project_id` is set **and** a KB is
+   attached to that project (`chats.py:975`, gates `:1002-1007`). `hybrid_search` filters
+   `kbf.kb_id = :kb_id AND f.ingestion_status = 'ready'` (`api/app/knowledge/retrieval.py:71`,
+   `:190-201`) — there is no way to scope retrieval to a user-selected set of files.
+
+3. **Only KB-attach embeds.** `enqueue_embed_job` fires on KB attach only
+   (`api/app/api/knowledge_bases.py:518-532`); project-attached and loose-uploaded files are chunked
+   but keep `embedding = NULL` (`api/app/knowledge/embed.py:266`) → invisible to vector search. A
+   file a user wants to reference may have no embeddings.
+
+4. **No file-list surface to populate a picker or `@`-dropdown.** Only `POST /api/v1/files`,
+   `GET /api/v1/files/{id}`, `DELETE` exist — there is no `GET /api/v1/files` list route.
+   (This is exactly what **DE-296** proposes to build.)
+
+5. **No `@`-mention affordance and no composer file picker** exist in `web/`. The only "file
+   picker" UIs are skill-input forms (`docs/PRD.md` §3.4/§3.9) and the tabular wizard (DE-296).
+
+What *is* already shipped and reused unchanged: the **Citation Engine** (extract → verbatim/tolerant/
+paraphrase/ensemble verify → persist) and its **side-panel deep-link viewer**
+(`api/app/citation/*`, `GET /api/v1/documents/{id}/render?page&highlight`, `docs/PRD.md` §3.3
+lines ~436-503). This feature's citations flow straight into that surface.
+
+---
+
+## Proposed approach
+
+**Scope:** how a user-selected referenced-files set is *collected* in the composer and *grounded*
+for retrieval + citations. Reuses the shipped Citation Engine, verification cascade, and doc-panel
+viewer as-is.
+
+### Backend
+
+**New request field — `referenced_file_ids` (do not overload `file_ids`).**
+Add an optional `referenced_file_ids: list[UUID]` to `MessageCreateRequest`
+(`api/app/schemas/chats.py`), distinct from the existing verbatim `file_ids` channel. Semantics:
+referenced files are **routed through retrieval as chunks** (citation-eligible), whereas `file_ids`
+keeps its current verbatim-full-text behavior (small-doc, no citations). Cap with a new
+`MESSAGE_REFERENCED_FILES_MAX` constant, mirroring `MESSAGE_FILE_IDS_MAX_LEN`.
+
+*Fork surfaced (P10):* alternative is to change `file_ids` to be retrieval-grounded — rejected as a
+breaking change to a shipped channel (#116/#117). See "Decisions to surface."
+
+**Generalize retrieval to a file-id set.**
+Extend `hybrid_search` (`api/app/knowledge/retrieval.py`) with an optional `file_ids` filter that
+searches `document_chunks` scoped by `f.id = ANY(:file_ids)` directly (bypassing the `kbf` join), so
+referenced files may span multiple KBs, project files, or loose uploads. Keep the existing
+`kb_id` path intact. Retain the `ingestion_status='ready'` + `deleted_at IS NULL` guards. Reuse the
+existing vector-cosine + FTS + `hybrid_alpha` combination — no new search path.
+
+**Retrieval strategy for explicit references.**
+Unlike KB-wide top-k, an explicitly-referenced file usually means "answer over *this* document." Use
+a per-referenced-file budget (e.g. all chunks of a referenced file up to a token cap, query-ranked)
+rather than a global top-k that could starve a referenced file of representation. Merge referenced-
+file chunks with any KB-RAG chunks into the single `retrieved_chunks` set the Citation Engine
+already consumes; enforce a total cap (extend `RAG_MAX_TOTAL_CHUNKS`).
+
+**Wire referenced chunks into citations.**
+Include the referenced-file chunks in `retrieved_chunks` at all three `_persist_message_citations`
+call sites so extraction/verification/persistence runs over them unchanged. The system-prompt
+retrieval-context block (`_format_retrieval_context_block`, `chats.py:1074`) already carries the
+`"…verbatim…" (Source: [N])` instruction — referenced chunks join the same numbered set.
+
+**Embedding of referenced-but-unembedded files.**
+Referencing a file that has `embedding = NULL` (project-attached / loose upload) must either embed on
+demand or be disallowed. *Fork surfaced (P10)* — see "Decisions to surface." Whichever path, an
+un-embedded / still-`processing` referenced file **fails restrictive (P4)**: it is reported as
+"preparing / not yet available," never silently dropped and never falling back to broad search.
+
+**`GET /api/v1/files` (dependency on DE-296).**
+The picker and `@`-dropdown need the list endpoint DE-296 specifies (cursor pagination,
+`search`, optional `project_id`, `document_id` via LEFT JOIN `documents`, caller-owned + admin-all,
+soft-deleted excluded). **Do not re-spec it here** — depend on DE-296; if DE-296 has not landed,
+this feature delivers the endpoint to that spec (and DE-296 consumes it). Adding the route requires
+the collision-guard updates: `IMPLEMENTED_ROUTES` (`api/tests/test_endpoints.py`) and the path
+count + `EXPECTED_PATHS` in `api/tests/test_openapi.py`, plus the entry in
+`docs/api/backend-openapi.yaml`.
+
+**Audit (P3, P5).**
+Record an `inference.message_referenced_files` audit row modeled on the existing
+`inference.message_files_attached` — `referenced_file_ids`, requested/resolved/retrieved counts,
+digests only, **never** content or the query text — flushed inside the caller's transaction.
+
+### Frontend (`web/`, SvelteKit — no React)
+
+- **Referenced-files state:** one authoritative, deduped set keyed by `file_id`, fed by both entry
+  interfaces, sent as `referenced_file_ids`. Disable rows without a `document_id` ("Not yet parsed"),
+  mirroring DE-296's picker.
+- **Multi-select picker:** composer toolbar button → dropdown backed by `listFiles({ project_id?,
+  search?, cursor? })` (`web/src/lib/lq-ai/api/files.ts`; reuse patterns from
+  `MatterRailFiles.svelte`, `AttachedFilesPanel.svelte`, `PlaybookExecuteModal.svelte`).
+- **`@`-mention:** composer decorator that opens the same filtered list on `@`, resolves selection to
+  a `file_id` token, and syncs token add/remove with the referenced-files set.
+- **Citations:** existing citation chips + side-panel deep-link viewer — no new UI; referenced-file
+  citations render through the shipped surface.
+
+### Tests & docs
+
+- Backend: unit (schema/validation/cap), integration (`hybrid_search` file-id scope; referenced
+  chunks reach `retrieved_chunks`; citations persist; authz; `ready`-gating; embed-on-reference path
+  if chosen), OpenAPI-conformance for `GET /api/v1/files`.
+- Frontend: `files.ts` unit tests; composer picker + `@`-mention; Cypress e2e (reference a file →
+  ask → verified citation → deep-link opens viewer).
+- Docs (part of the change per CLAUDE.md): PRD §3.1/§3.3 note the referenced-files channel; DB schema
+  doc if a column/index is added; `backend-openapi.yaml`; an ADR for the `referenced_file_ids`-vs-
+  `file_ids` decision and the file-id retrieval scope.
+
+### Delivery (recommended phasing)
+
+Backend is built once; the two entry interfaces layer on top.
+
+1. **Phase 1 (MVP):** `referenced_file_ids` + file-id-scoped retrieval + citation wiring + **picker**
+   UI (+ `GET /api/v1/files` if DE-296 hasn't landed). Restrict referenceable files to
+   already-embedded (KB) files if embed-on-reference is deferred.
+2. **Phase 2:** `@`-mention composer affordance (same backend).
+3. **Phase 3 (optional):** embed-on-reference for project/loose files, if deferred from Phase 1.
+
+---
+
+## Acceptance criteria
+
+- A user can reference one or more matter files in a chat message via **either** the multi-select
+  picker **or** an inline `@`-mention; both produce the same `referenced_file_ids` set.
+- Asking a question about referenced files returns an answer whose claims carry **verified**
+  citations (Citation Engine cascade), and clicking a citation **deep-links into the doc panel** at
+  the cited passage.
+- Retrieval is scoped to the referenced files (spanning KBs / project files / loose uploads as
+  applicable); un-`ready`/un-embedded referenced files are reported as "preparing," never silently
+  dropped (**P4**).
+- `referenced_file_ids` is capped (`MESSAGE_REFERENCED_FILES_MAX`); over-cap is rejected.
+- The existing verbatim `file_ids` channel is unchanged (no regression).
+- Audit row records counts/digests only, in-transaction (**P3/P5**); OpenAPI + PRD + schema updated
+  in the same PR (**P10**).
+
+---
+
+## Decisions to surface (forks for the maintainer — not decided here, per P10)
+
+1. **`referenced_file_ids` (new field) vs. repurposing `file_ids`.** Recommendation: **new field**
+   (non-breaking; preserves verbatim-injection use-case). Confirm.
+2. **Embedding of non-KB referenced files.** (a) **KB/embedded-only MVP** (simplest; picker offers
+   only embedded files); (b) **embed-on-reference** with a "preparing" state (broadest; adds latency +
+   a pending path to test). Recommendation: (a) for Phase 1, (b) as Phase 3.
+3. **Picker scope — owner vs. matter.** Files owned by the user vs. files in the current
+   matter/project (ties to DE-296's `project_id` filter and authz). Recommendation: **matter-scoped**
+   when the chat has a project; owner-scoped fallback for projectless chats.
+4. **Retrieval strategy for explicit references** — per-file all-chunks-up-to-budget vs. global
+   top-k. Recommendation: per-file budget so a referenced file is never starved.
+5. **Operator control (P8).** Inherit chat+KB enablement vs. a dedicated capability toggle.
+   Recommendation: inherit; state it in the ADR.
+
+---
+
+## Guiding-principles compliance (summary)
+
+- **P1** egress: reuses gateway embedding/generation; no new third-party egress. ✅
+- **P2** closed set: referenced set is **UI-selected** and fed to retrieval — **not** a model-callable
+  "fetch any file" tool. Keep it that way. ✅
+- **P3** payloads: audit counts/digests only. ✅ (must follow)
+- **P4** fail restrictive: unauthorized/out-of-matter/un-`ready`/un-embedded → omit or "preparing,"
+  never error-open or broad-search fallback. ✅
+- **P5** atomic audit: flush in caller transaction (existing pattern). ✅
+- **P6** reuse: extend `hybrid_search` / reuse `extract_citations` + `verify`; no re-derivation. ✅
+- **P7** irreversibility: read-only. n/a.
+- **P8** operator control: decision #5 above.
+- **P9** user owns data: **route referenced files through retrieval + the Anonymization Layer as
+  grounding chunks**, not a verbatim full-text dump — verbatim is permitted only where citation
+  grounding requires it. This is *why* the retrieval-grounded path (not the `file_ids` verbatim path)
+  is the correct one. ✅
+- **P10** contract-as-truth: OpenAPI/schema/ADR in-PR; forks above surfaced. ✅
+
+The Citation Engine invariant (cite only *retrieved* chunks, verbatim-verified — `docs/PRD.md`
+§3.3 / Appendix E) confirms the design: referenced files **must** enter `retrieved_chunks` for
+citations to be mintable, so the verbatim-injection path can never yield compliant citations.
+
+---
+
+## Scoped out / explicitly not doing
+
+- **Passive-KB citations bug (orthogonal — file separately).** "KB docs exist but a normal chat
+  returns no citations" has two causes: (a) attached files never cite — **fixed** by this feature;
+  (b) the chat is projectless or the KB isn't attached to the chat's project, so
+  `_retrieve_kb_context_for_chat` short-circuits (`chats.py:1002-1007`) — **not** fixed here, because
+  this feature is *explicit* reference. Recommend a **separate bug/DE** for (b) (auto-attach UX, a
+  default/owner KB fallback, or clearer "attach KB to project" affordance).
+- **Tabular wizard file selection** — owned by **DE-296**; this feature only *depends on* its
+  `GET /api/v1/files`.
+- **Changing KB-wide RAG behavior for un-referenced chats** — out of scope.
+- **New doc-panel viewer** — already shipped (§3.3); reused unchanged.
+- **Autonomous-layer file access** — out of scope.
+- **Non-PDF citation highlight fidelity** — the viewer highlights via bbox for PDF (§3.3); text-only
+  formats may support offset-based highlight only. Documented as a known limitation, not solved here.
+
+---
+
+## Alternatives considered
+
+- **Overload `file_ids` to be retrieval-grounded** — rejected: breaking change to a shipped channel;
+  loses the verbatim small-doc use-case.
+- **Model-callable "fetch file by name" tool** — rejected: violates **P2** (open surface). Keep the
+  set UI-selected.
+- **`@`-mention only / picker only** — rejected as the end state; both are wanted. Phasing (picker
+  first) is a *delivery* choice, not a scope cut.
+- **Standalone `POST /knowledge-bases/{id}/query`** as the mechanism — rejected: it's a raw search
+  API decoupled from chat, produces no message/citation persistence.
+
+---
+
+## Additional context
+
+- Depends-on: **DE-296** (`GET /api/v1/files`, picker UX).
+- Rides on shipped rails: per-message file channel (`docs/PRD.md` §3.1, `chats.py:337`-equivalent),
+  Citation Engine + viewer (`docs/PRD.md` §3.3).
+- Resolves for the chat surface the Contract QA open question: *"How does the skill scope a
+  multi-document question? … user-selected document set is another [mechanism]."*
+- Companion analysis: `docpicker.md` (scope, DE-296/PRD overlap, compliance).

--- a/docs/superpowers/specs/2026-07-03-referenced-files-frontend-design.md
+++ b/docs/superpowers/specs/2026-07-03-referenced-files-frontend-design.md
@@ -1,0 +1,135 @@
+# Referenced files in the chat composer — `@`-mention + multi-select picker (referenced-files Phase 2, frontend)
+
+> **Type:** Frontend delivery of a shipped backend channel (referenced-files Phase 1, ADR 0022).
+> **Affected subsystem:** Web (`web/src/lib/lq-ai/`) only. **No backend changes.**
+> **Related:** referenced-files PRD §9 entry (Phase 2 deferred item), ADR 0022, spec
+> `2026-07-02-chat-at-mention-file-retrieval-design.md` (parent design; this document narrows its
+> frontend section to what Phase 1 actually shipped).
+
+---
+
+## Goal
+
+Let a user reference matter documents in a chat message from the composer — via an inline
+`@filename` mention or a multi-select file dropdown — so the message is sent with
+`referenced_file_ids` and the answer comes back with verified, deep-linkable citations grounded in
+those files. The backend channel (validation, file-scoped retrieval, citation wiring, audit, echo)
+is fully shipped on `feat/referenced-files-referenced-file-ids`; this spec covers only the composer UX and
+wire-up.
+
+## Constraints inherited from the shipped backend (ADR 0022)
+
+- KB-only MVP + matter scope: a referenceable file is caller-owned, `ready`, and in a Knowledge
+  Base attached to the chat's project. Anything else 404s the whole send, id-probing-safe.
+- Projectless chats can reference nothing (404). The UI must not offer the affordance there.
+- Cap: `MESSAGE_REFERENCED_FILES_MAX_LEN = 16` ids per message (422 over-cap).
+- Echo: validated ids return as `applied_referenced_file_ids` on the non-streaming response and the
+  SSE `complete` frame. On success it always equals the requested set (validation is all-or-nothing).
+- `GET /api/v1/files` (DE-296) does not exist. The referenceable set is reachable today via
+  `GET /projects/{id}` → `attached_knowledge_base_ids` → `GET /knowledge-bases/{kb_id}/files`.
+
+## Design
+
+### One authoritative set
+
+`ChatPanel.svelte` gains `referencedFiles: Map<string, ReferencedFile>` where
+`ReferencedFile = { id, filename, ready }`. Both entry interfaces mutate this one map; it is
+deduped by construction and capped at 16 (adds beyond the cap are rejected with a visible hint).
+The set is:
+
+- sent as `referenced_file_ids: [...referencedFiles.keys()]` on the message body when non-empty;
+- cleared after a successful send (turn-scoped, like the backend channel);
+- preserved on send failure so the user can adjust and retry;
+- rendered as a chips row above the composer (`ReferencedFilesChips.svelte`), each chip removable.
+
+### Referenceable-files loading (`src/lib/lq-ai/files/referenceable.ts`, new)
+
+`loadReferenceableFiles(projectId)`:
+`projectsApi.getProject(projectId)` → for each `attached_knowledge_base_ids`, call
+`knowledgeBasesApi.listKnowledgeBaseFiles(kbId)` (`Promise.all`) → merge, dedupe by file id, sort
+by filename. Every row carries `ready = (ingestion status === 'ready')`; non-ready rows render
+disabled with a "Preparing…" badge — visible but never selectable (fail-restrictive made visible,
+P4). A per-KB fetch failure degrades to the union of the KBs that did load, with a non-blocking
+error note in the picker.
+
+Fetched on first open of either affordance for the current chat's project; cached in component
+state; refreshed on picker re-open. Client-side substring filtering (pure helper
+`filterReferenceable(files, query)`) — no server autocomplete endpoint is added.
+
+### Entry interface 1 — multi-select picker (`FilePickerDropdown.svelte`, new)
+
+A composer toolbar button (document icon, beside the existing Attach-KB 📎, rendered only when the
+chat has a project) opens a dropdown: search input on top (pattern: `SkillPicker`), checkbox rows
+(pattern: `AttachKBModal`'s `Set` + checkbox rows), live-toggling `referencedFiles` directly — no
+confirm step; the chips row reflects changes immediately. Empty states: "No knowledge bases
+attached to this matter" / "No documents ready to reference" / no-search-hits.
+
+### Entry interface 2 — inline `@`-mention (`MentionPopover.svelte`, new)
+
+Clone of `SlashPopover.svelte` (same keyboard-nav, race-guard, five render states, pure exported
+helpers), backed by the same loaded referenceable list with client-side filtering rather than a
+server autocomplete.
+
+- `detectMentionAt(text, caret)` — module-scope pure helper in `ChatPanel.svelte` mirroring
+  `detectSlashAt`, but triggering on `@` at a word start **anywhere** in the text (start of text or
+  preceded by whitespace; `a@b` never triggers). Returns `{ open, query, atIndex }`.
+- Selection behavior: complete the mention inline — the partial `@query` becomes `@<filename>` in the composer, stays readable as part of the message, and rides into the sent `content` (so the case name is part of the retrieval query). The file is added to `referencedFiles`; the chips row remains the authoritative id set (removing a chip removes the reference, not the text).
+- Coexistence with the slash popover: slash triggers only at line start with `/`; mention triggers
+  on `@`; at most one popover is open (the most recent trigger wins, the other closes).
+
+### Send / receive wiring
+
+- `types.ts`: `MessageCreate.referenced_file_ids?: string[]`;
+  `MessagePostResponse.applied_referenced_file_ids?: string[]`;
+  `MessageCompleteFrame.applied_referenced_file_ids?: string[]`.
+- `ChatPanel.sendMessage()`: include the field when the set is non-empty; on success clear the set.
+  Stamp the sent user message (local model) with the referenced `{id, filename}` list so the user
+  bubble shows a compact "Referenced: …" row.
+- SSE `onComplete` (and the non-streaming path): read `applied_referenced_file_ids`; it is
+  informational parity with `applied_file_ids` (on success it equals the request set — asserted in
+  tests, not re-rendered separately).
+- Send failure 404 (a file went un-ready / was detached between load and send): existing error
+  surface shows the message; the set is preserved; the picker's refresh-on-open picks up the new
+  state. No special-case UI.
+- Citations: zero changes. Referenced-file citations arrive through the shipped
+  `M2Citations` chips / ledger panel / deep-link viewer.
+
+### Out of scope
+
+- Phase 3 embed-on-reference (backend), any new backend route or autocomplete endpoint.
+- Fixing `MatterRailFiles.openPicker()`'s call to the nonexistent `GET /files?owner_id=me`
+  (405 today) — **pre-existing bug, file as a separate DE**.
+- Wiring `AttachedFilesPanel`'s local-only chat attach into the verbatim `file_ids` channel
+  (explicitly TBD-post-M1 in `files.ts`; unrelated channel).
+- Rich contenteditable token pills in the composer.
+
+## Testing
+
+- **Vitest** (fork convention: pure module-scope helpers, no `@testing-library/svelte`):
+  `detectMentionAt` (trigger positions, mid-word non-trigger, query extraction, caret edge cases);
+  `filterReferenceable`; set add/remove/dedupe/cap-16 logic; the mention splice function;
+  `MentionPopover` exported helpers (nextIndex/decideKeyAction parity with `SlashPopover`);
+  merge/dedupe in `referenceable.ts` (multi-KB overlap, non-ready flagging, partial KB failure).
+- **Cypress** (`web/cypress/e2e/referenced-files-referenced-files.cy.ts`, stubbed API): picker flow (open →
+  search → check two files → chips appear → send → intercepted request body carries both ids →
+  chips clear); mention flow (`@con` → popover → Enter → text spliced, chip added); disabled
+  "Preparing…" row not selectable; no picker button on a projectless chat.
+- Dev-stack check: the `web` container serves a static bundle — rebuild `web` to verify in the
+  running stack.
+
+## Documentation (same PR)
+
+- PRD §9 referenced-files section: move Phase 2 from **Deferred** to shipped, describing both affordances.
+- PRD §3.1: one line noting the composer affordances feeding `referenced_file_ids`.
+- No OpenAPI change (no contract change), no new ADR (no new design fork; ADR 0022 already records
+  the channel).
+
+## Acceptance criteria
+
+- With a project chat whose matter KBs contain ready files: both the picker and `@`-mention add
+  files to one deduped chip set; a selected mention stays inline in the message text and in the sent content; sending produces a request with `referenced_file_ids`; the answer
+  renders verified citations that deep-link into the referenced document(s) via the existing panel.
+- Non-ready files are visible but not selectable ("Preparing…").
+- Cap 16 enforced client-side (and the backend 422 is never triggerable through the UI).
+- Projectless chats show neither affordance.
+- Pure-helper unit tests and the Cypress spec pass; existing chat specs unaffected.

--- a/web/cypress/e2e/referenced-files.cy.ts
+++ b/web/cypress/e2e/referenced-files.cy.ts
@@ -1,0 +1,306 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../support/index.d.ts" />
+
+type ChatStub = {
+	id: string;
+	title: string;
+	owner_id: string;
+	project_id: string | null;
+	created_at: string;
+	updated_at: string;
+	sticky_skills: string[];
+};
+
+const now = '2026-07-03T00:00:00.000Z';
+const projectId = 'proj-1';
+const chatId = 'chat-1';
+
+// This spec is fully API-stubbed. The shared support hook only skips its
+// upstream live signup bootstrap for wave-/lq-ai-/m*-named specs, so keep this
+// referenced-files spec from making an unstubbed /auths/signup request before tests run.
+Cypress.Commands.overwrite('registerAdmin', () => cy.wrap(Cypress.$('<div />')[0], { log: false }));
+
+const user = {
+	id: 'user-1',
+	email: 'admin@lq.ai',
+	name: 'Admin User',
+	role: 'admin',
+	is_admin: true,
+	must_change_password: false
+};
+
+const project = {
+	id: projectId,
+	name: 'Cypress Matter',
+	slug: 'cypress-matter',
+	description: null,
+	context_md: null,
+	owner_id: 'user-1',
+	privileged: false,
+	minimum_inference_tier: null,
+	attached_skill_names: [],
+	attached_file_ids: [],
+	attached_knowledge_base_ids: ['kb-1'],
+	archived_at: null,
+	created_at: now,
+	updated_at: now
+};
+
+const referenceableFiles = [
+	{
+		id: 'file-1',
+		owner_id: 'user-1',
+		project_id: projectId,
+		filename: 'master-agreement.pdf',
+		mime_type: 'application/pdf',
+		size_bytes: 1000,
+		hash_sha256: 'hash-file-1',
+		ingestion_status: 'ready',
+		ingestion_error: null,
+		document_id: 'doc-1',
+		attached_at: now,
+		created_at: now
+	},
+	{
+		id: 'file-2',
+		owner_id: 'user-1',
+		project_id: projectId,
+		filename: 'exhibit-a.pdf',
+		mime_type: 'application/pdf',
+		size_bytes: 1000,
+		hash_sha256: 'hash-file-2',
+		ingestion_status: 'ready',
+		ingestion_error: null,
+		document_id: 'doc-2',
+		attached_at: now,
+		created_at: now
+	},
+	{
+		id: 'file-3',
+		owner_id: 'user-1',
+		project_id: projectId,
+		filename: 'pending-upload.pdf',
+		mime_type: 'application/pdf',
+		size_bytes: 1000,
+		hash_sha256: 'hash-file-3',
+		ingestion_status: 'processing',
+		ingestion_error: null,
+		document_id: null,
+		attached_at: now,
+		created_at: now
+	}
+];
+
+function chat(overrides: Partial<ChatStub> = {}): ChatStub {
+	return {
+		id: chatId,
+		title: 'Referenced files test chat',
+		owner_id: 'user-1',
+		project_id: projectId,
+		created_at: now,
+		updated_at: now,
+		sticky_skills: [],
+		...overrides
+	};
+}
+
+function sseBody(appliedReferencedFileIds: string[] = []): string {
+	const assistant = {
+		id: 'assistant-1',
+		chat_id: chatId,
+		role: 'assistant',
+		content: 'Done.',
+		applied_skills: [],
+		created_at: now,
+		citations: []
+	};
+
+	return [
+		`data: ${JSON.stringify({ type: 'start', lq_ai_message_id: assistant.id, chat_id: chatId })}`,
+		`data: ${JSON.stringify({ type: 'delta', delta: 'Done.' })}`,
+		`data: ${JSON.stringify({ type: 'complete', lq_ai_message_id: assistant.id, message: assistant, citations: [], applied_referenced_file_ids: appliedReferencedFileIds })}`,
+		'data: [DONE]',
+		''
+	].join('\n\n');
+}
+
+function stubApis(activeChat: ChatStub = chat()): void {
+	cy.intercept('GET', '**/api/v1/users/me', user);
+	cy.intercept('GET', '**/api/v1/models', {
+		object: 'list',
+		data: [
+			{
+				id: 'smart',
+				object: 'model',
+				created: 0,
+				owned_by: 'lq-ai',
+				lq_ai_kind: 'alias',
+				lq_ai_resolves_to: 'test/model',
+				lq_ai_fallback_count: 0
+			}
+		]
+	});
+	cy.intercept('GET', '**/api/v1/skills*', []);
+	cy.intercept('GET', /\/api\/v1\/projects(?:\?.*)?$/, activeChat.project_id ? [project] : []);
+	cy.intercept('GET', `**/api/v1/projects/${projectId}`, project).as('project');
+	cy.intercept('GET', /\/api\/v1\/chats(?:\?.*)?$/, {
+		items: [activeChat],
+		next_cursor: null
+	});
+	cy.intercept('GET', `**/api/v1/chats/${activeChat.id}/messages*`, {
+		items: [],
+		next_cursor: null
+	});
+	cy.intercept('GET', '**/api/v1/knowledge-bases/kb-1/files', referenceableFiles).as('kbFiles');
+	cy.intercept('POST', /\/api\/v1\/chats\/[^/]+\/messages$/, (req) => {
+		const ids = (req.body as { referenced_file_ids?: string[] }).referenced_file_ids ?? [];
+		req.reply({
+			statusCode: 200,
+			headers: { 'content-type': 'text/event-stream' },
+			body: sseBody(ids)
+		});
+	}).as('send');
+}
+
+function visitChat(activeChat: ChatStub = chat()): void {
+	stubApis(activeChat);
+	cy.visit(`/lq-ai/chats?id=${activeChat.id}`, {
+		onBeforeLoad(win) {
+			win.localStorage.setItem(
+				'lq_ai_auth',
+				JSON.stringify({
+					access_token: 'test-access-token',
+					refresh_token: 'test-refresh-token',
+					expires_at: Date.now() + 60 * 60 * 1000,
+					user
+				})
+			);
+		}
+	});
+	cy.get('[data-testid="lq-ai-composer-input"]', { timeout: 10000 }).should('be.visible');
+}
+
+function openPicker(): void {
+	cy.get('[data-testid="lq-ai-file-picker-btn"]').click();
+	cy.get('[data-testid="lq-ai-file-picker"]').should('be.visible');
+	cy.wait('@kbFiles');
+}
+
+function selectPickerRow(filename: string): void {
+	cy.contains('[data-testid="lq-ai-file-picker-row"]', filename)
+		.find('input[type="checkbox"]')
+		.check({ force: true });
+}
+
+describe('referenced-files referenced files', () => {
+	it('picker flow: select two files, chips render, send carries both ids, set clears', () => {
+		visitChat();
+
+		openPicker();
+		cy.get('[data-testid="lq-ai-file-picker-search"]').type('agreement');
+		selectPickerRow('master-agreement.pdf');
+		cy.get('[data-testid="lq-ai-file-picker-search"]').clear();
+		selectPickerRow('exhibit-a.pdf');
+		cy.get('[data-testid="lq-ai-file-picker-done"]').click();
+
+		cy.get('[data-testid="lq-ai-referenced-chip"]').should('have.length', 2);
+		cy.contains('[data-testid="lq-ai-referenced-chip"]', 'master-agreement.pdf').should(
+			'be.visible'
+		);
+		cy.contains('[data-testid="lq-ai-referenced-chip"]', 'exhibit-a.pdf').should('be.visible');
+
+		cy.get('[data-testid="lq-ai-composer-input"]').type('Summarize these documents.');
+		cy.get('[data-testid="lq-ai-send-btn"]').click();
+
+		cy.wait('@send')
+			.its('request.body')
+			.should((body) => {
+				const payload = body as { referenced_file_ids?: string[] };
+				expect(payload.referenced_file_ids).to.deep.equal(['file-1', 'file-2']);
+			});
+		cy.get('@send')
+			.its('response.body')
+			.should((body: string) => {
+				expect(body).to.contain('"applied_referenced_file_ids":["file-1","file-2"]');
+			});
+		cy.get('[data-testid="lq-ai-referenced-row"]').should('contain', 'master-agreement.pdf');
+		cy.get('[data-testid="lq-ai-referenced-chips"]').should('not.exist');
+	});
+
+	it('mention flow: typing @exh opens the popover, Enter completes the mention inline and adds a chip', () => {
+		visitChat();
+
+		cy.get('[data-testid="lq-ai-composer-input"]').type('summarize @exh');
+		cy.wait('@kbFiles');
+		cy.get('[data-testid="lq-ai-mention-popover"]').should('be.visible');
+		cy.contains('[data-testid="lq-ai-mention-row"]', 'exhibit-a.pdf').should('be.visible');
+
+		cy.get('[data-testid="lq-ai-composer-input"]').type('{enter}');
+
+		cy.get('[data-testid="lq-ai-composer-input"]').should(
+			'have.value',
+			'summarize @exhibit-a.pdf '
+		);
+		cy.contains('[data-testid="lq-ai-referenced-chip"]', 'exhibit-a.pdf').should('be.visible');
+		cy.get('[data-testid="lq-ai-mention-popover"]').should('not.exist');
+		cy.get('[data-testid="lq-ai-composer-input"]').type('on causation');
+		cy.get('[data-testid="lq-ai-send-btn"]').click();
+		cy.wait('@send')
+			.its('request.body')
+			.should((body) => {
+				const payload = body as { content: string; referenced_file_ids?: string[] };
+				expect(payload.content).to.equal('summarize @exhibit-a.pdf on causation');
+				expect(payload.referenced_file_ids).to.deep.equal(['file-2']);
+			});
+	});
+
+	it('non-ready file shows a disabled "Preparing…" row in the picker and is absent from the mention popover', () => {
+		visitChat();
+
+		openPicker();
+		cy.contains('[data-testid="lq-ai-file-picker-row"]', 'pending-upload.pdf').within(() => {
+			cy.get('input[type="checkbox"]').should('be.disabled');
+			cy.contains('Preparing…').should('be.visible');
+		});
+		cy.get('[data-testid="lq-ai-file-picker-done"]').click();
+
+		cy.get('[data-testid="lq-ai-composer-input"]').type('@pending');
+		cy.get('[data-testid="lq-ai-mention-popover"]').should('be.visible');
+		cy.get('[data-testid="lq-ai-mention-popover"]').should('not.contain', 'pending-upload.pdf');
+		cy.contains('[data-testid="lq-ai-mention-popover"]', 'No matching documents').should(
+			'be.visible'
+		);
+	});
+
+	it('chip remove (×) drops the file from the set', () => {
+		visitChat();
+
+		openPicker();
+		selectPickerRow('master-agreement.pdf');
+		cy.get('[data-testid="lq-ai-file-picker-done"]').click();
+		cy.contains('[data-testid="lq-ai-referenced-chip"]', 'master-agreement.pdf').should(
+			'be.visible'
+		);
+
+		cy.get('button[aria-label="Remove master-agreement.pdf"]').click();
+		cy.get('[data-testid="lq-ai-referenced-chips"]').should('not.exist');
+
+		cy.get('[data-testid="lq-ai-composer-input"]').type('Send without references.');
+		cy.get('[data-testid="lq-ai-send-btn"]').click();
+		cy.wait('@send')
+			.its('request.body')
+			.should((body) => {
+				const payload = body as { referenced_file_ids?: string[] };
+				expect(payload).not.to.have.property('referenced_file_ids');
+			});
+	});
+
+	it('projectless chat: no picker button, @ never opens the popover', () => {
+		visitChat(chat({ project_id: null }));
+
+		cy.get('[data-testid="lq-ai-composer-input"]').should('be.visible');
+		cy.get('[data-testid="lq-ai-file-picker-btn"]').should('not.exist');
+		cy.get('[data-testid="lq-ai-composer-input"]').type('@doc');
+		cy.get('[data-testid="lq-ai-mention-popover-anchor"]').should('not.exist');
+	});
+});

--- a/web/src/lib/lq-ai/__tests__/ChatPanel-mention-detect.test.ts
+++ b/web/src/lib/lq-ai/__tests__/ChatPanel-mention-detect.test.ts
@@ -1,0 +1,92 @@
+/**
+ * referenced-files Phase 2 - @-mention detection + completion helpers. Same convention as
+ * ChatPanel-slash-detect.test.ts: pure module-scope helpers exported from
+ * ChatPanel.svelte, tested without mounting the component.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { completeMentionAt, detectMentionAt } from '../components/ChatPanel.svelte';
+
+describe('detectMentionAt', () => {
+	it('does not open when caret position is 0', () => {
+		expect(detectMentionAt('', 0)).toEqual({ open: false });
+		expect(detectMentionAt('@foo', 0)).toEqual({ open: false });
+	});
+
+	it('opens on empty query when text is just "@"', () => {
+		expect(detectMentionAt('@', 1)).toEqual({ open: true, query: '', atIndex: 0 });
+	});
+
+	it('opens on start of textarea query', () => {
+		expect(detectMentionAt('@nda', 4)).toEqual({ open: true, query: 'nda', atIndex: 0 });
+	});
+
+	it('opens mid-line after a space (unlike slash detection)', () => {
+		expect(detectMentionAt('summarize @exh', 14)).toEqual({
+			open: true,
+			query: 'exh',
+			atIndex: 10
+		});
+	});
+
+	it('opens after a newline', () => {
+		expect(detectMentionAt('line one\n@doc', 13)).toEqual({
+			open: true,
+			query: 'doc',
+			atIndex: 9
+		});
+	});
+
+	it('does NOT open on email-like text (@ is not at a word start)', () => {
+		expect(detectMentionAt('a@b', 3)).toEqual({ open: false });
+		expect(detectMentionAt('user@example.com', 16)).toEqual({ open: false });
+	});
+
+	it('accepts dots, hyphens, underscores, and uppercase in the query', () => {
+		expect(detectMentionAt('@Master-Agreement_v2.pdf', 25)).toEqual({
+			open: true,
+			query: 'Master-Agreement_v2.pdf',
+			atIndex: 0
+		});
+	});
+
+	it('closes when the query is interrupted by a space', () => {
+		expect(detectMentionAt('@exh ibit', 9)).toEqual({ open: false });
+	});
+
+	it('does not open when the caret sits before @', () => {
+		expect(detectMentionAt('hi @doc', 2)).toEqual({ open: false });
+	});
+
+	it('does not treat @@ as a mention', () => {
+		expect(detectMentionAt('@@', 2)).toEqual({ open: false });
+	});
+});
+
+describe('completeMentionAt', () => {
+	it('completes "@query" at the start of the text', () => {
+		expect(completeMentionAt('@nda tell me', 0, 3, 'NDA-2024.pdf')).toBe('@NDA-2024.pdf tell me');
+	});
+
+	it('completes "@query" mid-text without doubling spaces', () => {
+		expect(completeMentionAt('summarize @exh please', 10, 3, 'exhibit-a.pdf')).toBe(
+			'summarize @exhibit-a.pdf please'
+		);
+	});
+
+	it('appends a separating space at the end of the text', () => {
+		expect(completeMentionAt('summarize @exh', 10, 3, 'exhibit-a.pdf')).toBe(
+			'summarize @exhibit-a.pdf '
+		);
+	});
+
+	it('completes a bare "@" (empty query)', () => {
+		expect(completeMentionAt('hello @', 6, 0, 'a.pdf')).toBe('hello @a.pdf ');
+	});
+
+	it('keeps filenames containing spaces inline', () => {
+		expect(completeMentionAt('@ber', 0, 3, 'BERGE SISAR.HL.2002.pdf')).toBe(
+			'@BERGE SISAR.HL.2002.pdf '
+		);
+	});
+});

--- a/web/src/lib/lq-ai/__tests__/FilePickerDropdown.test.ts
+++ b/web/src/lib/lq-ai/__tests__/FilePickerDropdown.test.ts
@@ -1,0 +1,28 @@
+/** referenced-files Phase 2 — FilePickerDropdown row-disable logic. */
+import { describe, expect, it } from 'vitest';
+
+import { rowDisabled } from '../components/FilePickerDropdown.svelte';
+import type { ReferencedFile } from '../files/referenceable';
+
+function ref(ready: boolean): ReferencedFile {
+	return { id: '1', filename: 'a.pdf', ready };
+}
+
+describe('rowDisabled', () => {
+	it('disables non-ready rows regardless of selection state', () => {
+		expect(rowDisabled(ref(false), false, false)).toBe(true);
+		expect(rowDisabled(ref(false), true, true)).toBe(true);
+	});
+
+	it('disables unselected rows at the cap', () => {
+		expect(rowDisabled(ref(true), false, true)).toBe(true);
+	});
+
+	it('keeps SELECTED rows enabled at the cap so they can be unchecked', () => {
+		expect(rowDisabled(ref(true), true, true)).toBe(false);
+	});
+
+	it('enables ready rows below the cap', () => {
+		expect(rowDisabled(ref(true), false, false)).toBe(false);
+	});
+});

--- a/web/src/lib/lq-ai/__tests__/MentionPopover.test.ts
+++ b/web/src/lib/lq-ai/__tests__/MentionPopover.test.ts
@@ -1,0 +1,68 @@
+/**
+ * referenced-files Phase 2 — MentionPopover pure helpers (module-block exports,
+ * SlashPopover convention: no component mount).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	decideMentionKeyAction,
+	mentionResults,
+	mentionStateKind,
+	type MentionPopoverState
+} from '../components/MentionPopover.svelte';
+import type { ReferencedFile } from '../files/referenceable';
+
+function ref(id: string, filename = `${id}.pdf`, ready = true): ReferencedFile {
+	return { id, filename, ready };
+}
+
+function state(overrides: Partial<MentionPopoverState> = {}): MentionPopoverState {
+	return { results: [], activeIndex: 0, loading: false, error: null, query: '', ...overrides };
+}
+
+describe('mentionResults', () => {
+	it('filters by query and drops non-ready files', () => {
+		const files = [ref('1', 'alpha.pdf'), ref('2', 'beta.pdf', false), ref('3', 'gamma.pdf')];
+		expect(mentionResults(files, 'a').map((f) => f.id)).toEqual(['1', '3']);
+	});
+
+	it('returns all ready files for an empty query', () => {
+		const files = [ref('1'), ref('2', '2.pdf', false)];
+		expect(mentionResults(files, '').map((f) => f.id)).toEqual(['1']);
+	});
+});
+
+describe('mentionStateKind', () => {
+	it('orders loading > error > empty > results', () => {
+		expect(mentionStateKind(state({ loading: true, error: 'x' }))).toBe('loading');
+		expect(mentionStateKind(state({ error: 'x' }))).toBe('error');
+		expect(mentionStateKind(state({ query: 'q' }))).toBe('empty-with-query');
+		expect(mentionStateKind(state())).toBe('empty-no-query');
+		expect(mentionStateKind(state({ results: [ref('1')] }))).toBe('results');
+	});
+});
+
+describe('decideMentionKeyAction', () => {
+	const two = state({ results: [ref('1'), ref('2')], activeIndex: 0 });
+
+	it('Escape dismisses even with no results', () => {
+		expect(decideMentionKeyAction('Escape', state())).toEqual({ kind: 'dismiss' });
+	});
+
+	it('Enter selects the active row', () => {
+		expect(decideMentionKeyAction('Enter', two)).toEqual({ kind: 'select', result: ref('1') });
+	});
+
+	it('ArrowDown/ArrowUp wrap around', () => {
+		expect(decideMentionKeyAction('ArrowDown', { ...two, activeIndex: 1 })).toEqual({
+			kind: 'move',
+			nextIndex: 0
+		});
+		expect(decideMentionKeyAction('ArrowUp', two)).toEqual({ kind: 'move', nextIndex: 1 });
+	});
+
+	it('is a noop for other keys and for Enter with no results', () => {
+		expect(decideMentionKeyAction('a', two)).toEqual({ kind: 'noop' });
+		expect(decideMentionKeyAction('Enter', state())).toEqual({ kind: 'noop' });
+	});
+});

--- a/web/src/lib/lq-ai/__tests__/referenceable.test.ts
+++ b/web/src/lib/lq-ai/__tests__/referenceable.test.ts
@@ -1,0 +1,123 @@
+/**
+ * referenced-files Phase 2 — pure logic of the referenceable-files set.
+ * loadReferenceableFiles is NOT tested here (it is a thin fetch
+ * composition; Cypress covers it end-to-end with stubbed routes).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	MESSAGE_REFERENCED_FILES_MAX,
+	addReferencedFile,
+	filterReferenceable,
+	mergeKbFileLists,
+	removeReferencedFile,
+	toReferencedFile,
+	type ReferencedFile
+} from '../files/referenceable';
+import type { KnowledgeBaseFile } from '../types';
+
+function kbFile(overrides: Partial<KnowledgeBaseFile> & { id: string }): KnowledgeBaseFile {
+	return {
+		owner_id: 'u1',
+		filename: `${overrides.id}.pdf`,
+		mime_type: 'application/pdf',
+		size_bytes: 100,
+		hash_sha256: 'x',
+		ingestion_status: 'ready',
+		created_at: '2026-07-01T00:00:00Z',
+		attached_at: '2026-07-01T00:00:00Z',
+		...overrides
+	} as KnowledgeBaseFile;
+}
+
+function ref(id: string, filename = `${id}.pdf`, ready = true): ReferencedFile {
+	return { id, filename, ready };
+}
+
+describe('toReferencedFile', () => {
+	it('marks ready exactly when ingestion_status === "ready"', () => {
+		expect(toReferencedFile(kbFile({ id: 'a' })).ready).toBe(true);
+		expect(toReferencedFile(kbFile({ id: 'b', ingestion_status: 'processing' })).ready).toBe(false);
+		expect(toReferencedFile(kbFile({ id: 'c', ingestion_status: 'failed' })).ready).toBe(false);
+	});
+});
+
+describe('mergeKbFileLists', () => {
+	it('dedupes a file present in several KBs (first occurrence wins)', () => {
+		const merged = mergeKbFileLists([
+			[kbFile({ id: 'a', filename: 'alpha.pdf' })],
+			[kbFile({ id: 'a', filename: 'alpha.pdf' }), kbFile({ id: 'b', filename: 'beta.pdf' })]
+		]);
+
+		expect(merged.map((f) => f.id)).toEqual(['a', 'b']);
+	});
+
+	it('sorts by filename', () => {
+		const merged = mergeKbFileLists([
+			[kbFile({ id: '1', filename: 'zeta.pdf' }), kbFile({ id: '2', filename: 'alpha.pdf' })]
+		]);
+
+		expect(merged.map((f) => f.filename)).toEqual(['alpha.pdf', 'zeta.pdf']);
+	});
+
+	it('returns [] for no KBs', () => {
+		expect(mergeKbFileLists([])).toEqual([]);
+	});
+});
+
+describe('filterReferenceable', () => {
+	const files = [ref('1', 'Master Agreement.pdf'), ref('2', 'exhibit-a.pdf')];
+
+	it('returns everything for an empty/whitespace query', () => {
+		expect(filterReferenceable(files, '')).toEqual(files);
+		expect(filterReferenceable(files, ' ')).toEqual(files);
+	});
+
+	it('matches case-insensitive substrings', () => {
+		expect(filterReferenceable(files, 'master')).toEqual([files[0]]);
+		expect(filterReferenceable(files, 'EXHIBIT')).toEqual([files[1]]);
+	});
+
+	it('returns [] when nothing matches', () => {
+		expect(filterReferenceable(files, 'zzz')).toEqual([]);
+	});
+});
+
+describe('addReferencedFile', () => {
+	it('adds a ready file', () => {
+		const r = addReferencedFile([], ref('1'));
+		expect(r).toEqual({ added: true, list: [ref('1')] });
+	});
+
+	it('rejects a duplicate id', () => {
+		const r = addReferencedFile([ref('1')], ref('1'));
+		expect(r).toEqual({ added: false, reason: 'duplicate' });
+	});
+
+	it('rejects a non-ready file', () => {
+		const r = addReferencedFile([], ref('1', '1.pdf', false));
+		expect(r).toEqual({ added: false, reason: 'not-ready' });
+	});
+
+	it('rejects past the cap', () => {
+		const full = Array.from({ length: MESSAGE_REFERENCED_FILES_MAX }, (_, i) => ref(`f${i}`));
+		const r = addReferencedFile(full, ref('overflow'));
+		expect(r).toEqual({ added: false, reason: 'cap' });
+	});
+
+	it('does not mutate the input list', () => {
+		const list = [ref('1')];
+		addReferencedFile(list, ref('2'));
+		expect(list).toEqual([ref('1')]);
+	});
+});
+
+describe('removeReferencedFile', () => {
+	it('removes by id and leaves others', () => {
+		expect(removeReferencedFile([ref('1'), ref('2')], '1')).toEqual([ref('2')]);
+	});
+
+	it('is a no-op for an unknown id', () => {
+		expect(removeReferencedFile([ref('1')], 'nope')).toEqual([ref('1')]);
+	});
+});

--- a/web/src/lib/lq-ai/components/ChatPanel.svelte
+++ b/web/src/lib/lq-ai/components/ChatPanel.svelte
@@ -40,6 +40,49 @@
 			slashIndex
 		};
 	}
+
+	/**
+	 * referenced-files Phase 2 — @-mention detection for referenced files.
+	 *
+	 * Differs from detectSlashAt on purpose:
+	 *   - Triggers ANYWHERE the `@` starts a word (position 0 or preceded
+	 *     by whitespace), not only at line start — "summarize @exhibit-a"
+	 *     is the core use case.
+	 *   - Query char class is [^\s@] (filenames carry uppercase, dots,
+	 *     underscores); a space terminates the candidate query.
+	 *   - `a@b` / "user@example.com" never trigger (word-start guard).
+	 */
+	export type MentionDetection = { open: false } | { open: true; query: string; atIndex: number };
+
+	export function detectMentionAt(text: string, caret: number): MentionDetection {
+		if (caret === 0) return { open: false };
+		let scan = caret;
+		while (scan > 0 && /[^\s@]/.test(text[scan - 1])) scan--;
+		if (scan === 0 || text[scan - 1] !== '@') return { open: false };
+		const atIndex = scan - 1;
+		if (atIndex > 0 && !/\s/.test(text[atIndex - 1])) return { open: false };
+		return { open: true, query: text.slice(atIndex + 1, caret), atIndex };
+	}
+
+	/**
+	 * Complete a mention selection inline: replace the partial "@query"
+	 * with "@<filename>" so the case name stays readable in the message
+	 * AND rides into the sent content as part of the query (the
+	 * referenced-files set carries the id; the text carries the meaning).
+	 * A separating space is ensured after the completed mention so typing
+	 * continues naturally and the popover does not immediately reopen.
+	 */
+	export function completeMentionAt(
+		text: string,
+		atIndex: number,
+		queryLength: number,
+		filename: string
+	): string {
+		const before = text.slice(0, atIndex);
+		const after = text.slice(atIndex + 1 + queryLength);
+		const sep = /^\s/.test(after) ? '' : ' ';
+		return `${before}@${filename}${sep}${after}`;
+	}
 </script>
 
 <script lang="ts">
@@ -101,6 +144,16 @@
 		readPersistedOpen as readReceiptsDrawerOpen
 	} from '$lib/lq-ai/components/ReceiptsDrawer.svelte';
 	import SlashPopover from '$lib/lq-ai/components/SlashPopover.svelte';
+	import MentionPopover from '$lib/lq-ai/components/MentionPopover.svelte';
+	import FilePickerDropdown from '$lib/lq-ai/components/FilePickerDropdown.svelte';
+	import ReferencedFilesChips from '$lib/lq-ai/components/ReferencedFilesChips.svelte';
+	import {
+		MESSAGE_REFERENCED_FILES_MAX,
+		addReferencedFile,
+		loadReferenceableFiles,
+		removeReferencedFile,
+		type ReferencedFile
+	} from '$lib/lq-ai/files/referenceable';
 	import type { SkillAutocompleteItem } from '$lib/lq-ai/types';
 	import { auth } from '$lib/lq-ai/auth/store';
 	import { createEventDispatcher } from 'svelte';
@@ -330,6 +383,14 @@
 		attachedSkillNames = [];
 		attachmentSources = {};
 		skillInputs = {};
+		// referenced-files — referenced files are per-draft; the referenceable cache
+		// is per-project and re-validated lazily by ensureReferenceable().
+		referencedFiles = [];
+		referencedNotice = null;
+		filePickerOpen = false;
+		mentionOpen = false;
+		mentionQuery = '';
+		mentionAtIndex = -1;
 		// Load messages.
 		try {
 			const page = await messagesApi.listMessages(chat.id, { limit: 100 });
@@ -595,6 +656,10 @@
 			content: composerText,
 			applied_skills: sentSkillsForUser,
 			is_enhanced: isEnhancedSend,
+			referenced_files:
+				referencedFiles.length > 0
+					? referencedFiles.map(({ id, filename }) => ({ id, filename }))
+					: undefined,
 			created_at: new Date().toISOString()
 		};
 		messagesStore.update(($m) => [...$m, userMsg]);
@@ -641,11 +706,24 @@
 					// Issue #207 finding 4 — only send set_sticky on a real toggle
 					// change; otherwise leave the chat's sticky set unchanged.
 					set_sticky: stickyDirty ? stickyEnabled : undefined,
+					// referenced-files Phase 2 — ground this turn in the user-selected
+					// matter documents (file-scoped retrieval + citations).
+					referenced_file_ids:
+						referencedFiles.length > 0 ? referencedFiles.map((f) => f.id) : undefined,
 					stream: true
 				},
 				streamAbort.signal
 			);
 			composerText = '';
+			// Referenced files are turn-scoped (like the backend channel):
+			// clear on a successfully-initiated send, preserve on failure so
+			// the user can adjust and retry.
+			referencedFiles = [];
+			referencedNotice = null;
+			filePickerOpen = false;
+			mentionOpen = false;
+			mentionQuery = '';
+			mentionAtIndex = -1;
 			// The toggle change has now been applied server-side for this turn.
 			stickyDirty = false;
 			// Clear the pending-enhancement marker now that the send is in
@@ -769,13 +847,13 @@
 	}
 
 	function handleComposerKeydown(e: KeyboardEvent): void {
-		// When the slash popover is open it owns Arrow/Enter/Escape via its
+		// When the slash or mention popover is open it owns Arrow/Enter/Escape via its
 		// own <svelte:window on:keydown>, which stopPropagation()s. Those
 		// keystrokes don't reach this handler. We only need to prevent the
 		// composer's own shortcuts (Cmd/Ctrl+E) from firing while the
 		// popover is open so the operator can finish skill selection
 		// without accidentally launching Enhance Prompt.
-		if (slashOpen) return;
+		if (slashOpen || mentionOpen) return;
 		if ((e.metaKey || e.ctrlKey) && e.key === 'e') {
 			e.preventDefault();
 			expansionPanel?.open();
@@ -798,6 +876,104 @@
 	let slashQuery = '';
 	let slashStartIndex = -1;
 
+	// referenced-files Phase 2 — referenced files. One authoritative, deduped,
+	// cap-16 list feeding `referenced_file_ids`; both the @-mention
+	// popover and the picker mutate it. Plain array reassignment (not
+	// Map mutation) so Svelte 4 reactivity tracks changes.
+	let referencedFiles: ReferencedFile[] = [];
+	let referencedNotice: string | null = null;
+
+	// The referenceable set (all files across the matter's attached KBs),
+	// lazily loaded per project and cached until a chat/project switch or
+	// an explicit refresh (picker re-open / retry).
+	let referenceable: ReferencedFile[] = [];
+	let referenceableLoading = false;
+	let referenceableError: string | null = null;
+	let referenceableFailedKbCount = 0;
+	let referenceableLoadedForProject: string | null = null;
+
+	let filePickerOpen = false;
+	let mentionOpen = false;
+	let mentionQuery = '';
+	let mentionAtIndex = -1;
+
+	async function ensureReferenceable(force = false): Promise<void> {
+		// Capture the project id at entry: a chat/project switch while the
+		// load is in flight must not let project-A files be cached as
+		// project-B's referenceable set (whole-send 404 risk, ADR 0022).
+		const pid = composerProjectId;
+		if (!pid) return;
+		if (!force && referenceableLoadedForProject === pid) return;
+		referenceableLoading = true;
+		referenceableError = null;
+		try {
+			const load = await loadReferenceableFiles(pid);
+			if (pid !== composerProjectId) return; // superseded by a switch
+			referenceable = load.files;
+			referenceableFailedKbCount = load.failedKbCount;
+			referenceableLoadedForProject = pid;
+		} catch (e: unknown) {
+			if (pid !== composerProjectId) return;
+			referenceableError = e instanceof Error ? e.message : 'Failed to load documents';
+			referenceable = [];
+			referenceableFailedKbCount = 0;
+			referenceableLoadedForProject = null;
+		} finally {
+			if (pid === composerProjectId) referenceableLoading = false;
+		}
+	}
+
+	function addReference(file: ReferencedFile): void {
+		const result = addReferencedFile(referencedFiles, file);
+		if (result.added) {
+			referencedFiles = result.list;
+			referencedNotice = null;
+		} else if (result.reason === 'cap') {
+			referencedNotice = `You can reference up to ${MESSAGE_REFERENCED_FILES_MAX} documents per message.`;
+		}
+		// 'duplicate' and 'not-ready' are silent no-ops: the picker
+		// disables those rows and the mention popover never offers them.
+	}
+
+	function removeReference(id: string): void {
+		referencedFiles = removeReferencedFile(referencedFiles, id);
+		referencedNotice = null;
+	}
+
+	function toggleReference(file: ReferencedFile): void {
+		if (referencedFiles.some((f) => f.id === file.id)) removeReference(file.id);
+		else addReference(file);
+	}
+
+	function toggleFilePicker(): void {
+		filePickerOpen = !filePickerOpen;
+		if (filePickerOpen) {
+			mentionOpen = false;
+			void ensureReferenceable(true);
+		}
+	}
+
+	function onMentionSelect(file: ReferencedFile): void {
+		if (mentionAtIndex >= 0) {
+			composerText = completeMentionAt(
+				composerText,
+				mentionAtIndex,
+				mentionQuery.length,
+				file.filename
+			);
+		}
+		addReference(file);
+		mentionOpen = false;
+		mentionQuery = '';
+		mentionAtIndex = -1;
+	}
+
+	function onMentionDismiss(): void {
+		mentionOpen = false;
+		mentionQuery = '';
+		mentionAtIndex = -1;
+	}
+
 	function onComposerInput(e: Event): void {
 		const ta = e.target as HTMLTextAreaElement;
 		// `bind:value` has already updated `composerText` before this
@@ -812,6 +988,24 @@
 			slashOpen = false;
 			slashQuery = '';
 			slashStartIndex = -1;
+		}
+
+		// referenced-files Phase 2 — @-mention detection. Only offered in project
+		// chats (a projectless chat has no referenceable set; the backend
+		// 404s any referenced id there — never render the affordance).
+		const mention = composerProjectId
+			? detectMentionAt(ta.value, ta.selectionStart)
+			: { open: false as const };
+		if (mention.open) {
+			mentionOpen = true;
+			mentionQuery = mention.query;
+			mentionAtIndex = mention.atIndex;
+			filePickerOpen = false;
+			void ensureReferenceable();
+		} else {
+			mentionOpen = false;
+			mentionQuery = '';
+			mentionAtIndex = -1;
 		}
 	}
 
@@ -1068,6 +1262,12 @@
 					</div>
 				{/if}
 
+				<ReferencedFilesChips
+					files={referencedFiles}
+					notice={referencedNotice}
+					onRemove={removeReference}
+				/>
+
 				<div class="flex items-end gap-2">
 					<div class="lq-composer-wrap flex-1">
 						<textarea
@@ -1085,6 +1285,20 @@
 									query={slashQuery}
 									onSelect={onSlashSelect}
 									onDismiss={onSlashDismiss}
+								/>
+							</div>
+						{/if}
+
+						{#if mentionOpen}
+							<div class="lq-composer-popover" data-testid="lq-ai-mention-popover-anchor">
+								<MentionPopover
+									query={mentionQuery}
+									files={referenceable}
+									loading={referenceableLoading}
+									error={referenceableError}
+									onSelect={onMentionSelect}
+									onDismiss={onMentionDismiss}
+									onRetry={() => void ensureReferenceable(true)}
 								/>
 							</div>
 						{/if}
@@ -1110,6 +1324,34 @@
 							>
 								📎
 							</button>
+
+							<div class="lq-file-picker-anchor">
+								<button
+									type="button"
+									class="lq-btn-secondary text-sm"
+									aria-label="Reference matter documents"
+									title="Reference matter documents in this message"
+									on:click={toggleFilePicker}
+									data-testid="lq-ai-file-picker-btn"
+								>
+									📄
+								</button>
+								{#if filePickerOpen}
+									<div class="lq-composer-popover">
+										<FilePickerDropdown
+											files={referenceable}
+											loading={referenceableLoading}
+											error={referenceableError}
+											failedKbCount={referenceableFailedKbCount}
+											selectedIds={referencedFiles.map((f) => f.id)}
+											capReached={referencedFiles.length >= MESSAGE_REFERENCED_FILES_MAX}
+											onToggle={toggleReference}
+											onClose={() => (filePickerOpen = false)}
+											onRetry={() => void ensureReferenceable(true)}
+										/>
+									</div>
+								{/if}
+							</div>
 						{/if}
 						<button
 							type="button"
@@ -1215,6 +1457,10 @@
 		bottom: calc(100% + 4px);
 		left: 0;
 		z-index: 50;
+	}
+
+	.lq-file-picker-anchor {
+		position: relative;
 	}
 
 	.lq-composer {

--- a/web/src/lib/lq-ai/components/FilePickerDropdown.svelte
+++ b/web/src/lib/lq-ai/components/FilePickerDropdown.svelte
@@ -1,0 +1,212 @@
+<script context="module" lang="ts">
+	/**
+	 * FilePickerDropdown — multi-select referenced-documents picker
+	 * (referenced-files Phase 2). Checkbox-set pattern from AttachKBModal, search
+	 * pattern from SkillPicker. Unlike MentionPopover this DOES render
+	 * non-ready files — disabled, with a "Preparing…" badge — so the user
+	 * can see why a document isn't offered yet (P4 made visible).
+	 */
+	import {
+		MESSAGE_REFERENCED_FILES_MAX,
+		filterReferenceable,
+		type ReferencedFile
+	} from '../files/referenceable';
+
+	export function rowDisabled(
+		file: ReferencedFile,
+		selected: boolean,
+		capReached: boolean
+	): boolean {
+		if (!file.ready) return true;
+		return capReached && !selected;
+	}
+</script>
+
+<script lang="ts">
+	export let files: ReferencedFile[];
+	export let loading: boolean = false;
+	export let error: string | null = null;
+	export let failedKbCount: number = 0;
+	export let selectedIds: string[];
+	export let capReached: boolean = false;
+	export let onToggle: (file: ReferencedFile) => void;
+	export let onClose: () => void;
+	export let onRetry: () => void;
+
+	let searchTerm = '';
+
+	$: filtered = filterReferenceable(files, searchTerm);
+	$: selectedSet = new Set(selectedIds);
+
+	function onWindowKey(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopPropagation();
+			onClose();
+		}
+	}
+</script>
+
+<svelte:window on:keydown={onWindowKey} />
+
+<div
+	class="lq-file-picker"
+	data-testid="lq-ai-file-picker"
+	role="dialog"
+	aria-label="Reference documents"
+>
+	<div class="lq-file-picker__head">
+		<input
+			type="search"
+			class="lq-file-picker__search"
+			placeholder="Search matter documents…"
+			bind:value={searchTerm}
+			data-testid="lq-ai-file-picker-search"
+		/>
+		<button
+			type="button"
+			class="lq-file-picker__done"
+			on:click={onClose}
+			data-testid="lq-ai-file-picker-done"
+		>
+			Done
+		</button>
+	</div>
+
+	{#if loading}
+		<div class="lq-file-picker__status">Loading documents…</div>
+	{:else if error}
+		<div class="lq-file-picker__status lq-file-picker__status--error">
+			Couldn't load documents ·
+			<button type="button" class="lq-file-picker__retry" on:click={onRetry}>retry</button>
+		</div>
+	{:else if files.length === 0}
+		<div class="lq-file-picker__status" data-testid="lq-ai-file-picker-empty">
+			No documents in this matter's knowledge bases yet.
+		</div>
+	{:else}
+		{#if failedKbCount > 0}
+			<div class="lq-file-picker__status lq-file-picker__status--error">
+				{failedKbCount} knowledge base{failedKbCount === 1 ? '' : 's'} failed to load ·
+				<button type="button" class="lq-file-picker__retry" on:click={onRetry}>retry</button>
+			</div>
+		{/if}
+		{#if capReached}
+			<div class="lq-file-picker__status" data-testid="lq-ai-file-picker-cap">
+				Reference limit reached ({MESSAGE_REFERENCED_FILES_MAX} documents per message).
+			</div>
+		{/if}
+		{#each filtered as f (f.id)}
+			{@const disabled = rowDisabled(f, selectedSet.has(f.id), capReached)}
+			<label class="lq-file-picker__row" class:disabled data-testid="lq-ai-file-picker-row">
+				<input
+					type="checkbox"
+					checked={selectedSet.has(f.id)}
+					{disabled}
+					on:change={() => onToggle(f)}
+				/>
+				<span class="lq-file-picker__name" title={f.filename}>{f.filename}</span>
+				{#if !f.ready}
+					<span class="lq-file-picker__badge">Preparing…</span>
+				{/if}
+			</label>
+		{:else}
+			<div class="lq-file-picker__status">No documents match “{searchTerm}”.</div>
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.lq-file-picker {
+		display: flex;
+		flex-direction: column;
+		min-width: 300px;
+		max-width: clamp(300px, 90vw, 440px);
+		max-height: 340px;
+		overflow-y: auto;
+		background: var(--lq-surface, var(--lq-canvas, #ffffff));
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius, 6px);
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+		padding: var(--lq-space-1, 4px);
+		font-family: var(--lq-font-sans);
+		font-size: 13px;
+		color: var(--lq-text, #1a1a1a);
+	}
+
+	.lq-file-picker__head {
+		display: flex;
+		gap: var(--lq-space-1, 4px);
+		padding: var(--lq-space-1, 4px);
+	}
+
+	.lq-file-picker__search {
+		flex: 1;
+		font: inherit;
+		padding: 4px var(--lq-space-2, 8px);
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius-sm, 4px);
+	}
+
+	.lq-file-picker__done {
+		background: none;
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius-sm, 4px);
+		padding: 4px var(--lq-space-2, 8px);
+		font: inherit;
+		cursor: pointer;
+	}
+
+	.lq-file-picker__status {
+		padding: var(--lq-space-2, 8px) var(--lq-space-3, 12px);
+		color: var(--lq-text-tertiary, #9ca3af);
+		font-size: 12px;
+	}
+
+	.lq-file-picker__status--error {
+		color: var(--lq-error, #b54848);
+	}
+
+	.lq-file-picker__retry {
+		background: none;
+		border: 0;
+		padding: 0;
+		color: inherit;
+		font: inherit;
+		text-decoration: underline;
+		cursor: pointer;
+	}
+
+	.lq-file-picker__row {
+		display: flex;
+		align-items: center;
+		gap: var(--lq-space-2, 8px);
+		padding: var(--lq-space-2, 8px) var(--lq-space-3, 12px);
+		border-radius: var(--lq-radius-sm, 4px);
+		cursor: pointer;
+	}
+
+	.lq-file-picker__row:hover:not(.disabled) {
+		background: var(--lq-accent-soft, #e8f4ec);
+	}
+
+	.lq-file-picker__row.disabled {
+		color: var(--lq-text-tertiary, #9ca3af);
+		cursor: not-allowed;
+	}
+
+	.lq-file-picker__name {
+		flex: 1;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.lq-file-picker__badge {
+		font-size: 11px;
+		color: var(--lq-text-tertiary, #9ca3af);
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: 999px;
+		padding: 0 6px;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/MentionPopover.svelte
+++ b/web/src/lib/lq-ai/components/MentionPopover.svelte
@@ -1,0 +1,262 @@
+<script context="module" lang="ts">
+	/**
+	 * MentionPopover — typeahead listbox for @-referencing matter
+	 * documents (referenced-files Phase 2). Clone of SlashPopover with the fetch
+	 * replaced by client-side filtering over the caller-loaded
+	 * referenceable list: the whole matter file set is already in memory
+	 * (files/referenceable.ts), so there is no per-keystroke request and
+	 * no request-token race guard.
+	 *
+	 * Only READY files are offered — the mention flow is keyboard-driven
+	 * and never renders a disabled row; non-ready files surface as
+	 * "Preparing…" rows in FilePickerDropdown instead.
+	 */
+	import { filterReferenceable, type ReferencedFile } from '../files/referenceable';
+	import { nextIndex } from './SlashPopover.svelte';
+
+	export type MentionPopoverState = {
+		results: ReferencedFile[];
+		activeIndex: number;
+		loading: boolean;
+		error: string | null;
+		query: string;
+	};
+
+	export type MentionStateKind =
+		| 'loading'
+		| 'error'
+		| 'empty-with-query'
+		| 'empty-no-query'
+		| 'results';
+
+	export type MentionKeyAction =
+		| { kind: 'select'; result: ReferencedFile }
+		| { kind: 'dismiss' }
+		| { kind: 'move'; nextIndex: number }
+		| { kind: 'noop' };
+
+	export function mentionResults(files: ReferencedFile[], query: string): ReferencedFile[] {
+		return filterReferenceable(files, query).filter((f) => f.ready);
+	}
+
+	export function mentionStateKind(state: MentionPopoverState): MentionStateKind {
+		if (state.loading) return 'loading';
+		if (state.error) return 'error';
+		if (state.results.length === 0) {
+			return state.query ? 'empty-with-query' : 'empty-no-query';
+		}
+		return 'results';
+	}
+
+	export function decideMentionKeyAction(
+		key: string,
+		state: MentionPopoverState
+	): MentionKeyAction {
+		if (key === 'Escape') return { kind: 'dismiss' };
+		const len = state.results.length;
+		if (len === 0) return { kind: 'noop' };
+		if (key === 'Enter') {
+			const result = state.results[state.activeIndex];
+			if (!result) return { kind: 'noop' };
+			return { kind: 'select', result };
+		}
+		if (key === 'ArrowDown') {
+			return { kind: 'move', nextIndex: nextIndex(state.activeIndex, len, 1) };
+		}
+		if (key === 'ArrowUp') {
+			return { kind: 'move', nextIndex: nextIndex(state.activeIndex, len, -1) };
+		}
+		return { kind: 'noop' };
+	}
+</script>
+
+<script lang="ts">
+	export let query: string;
+	export let files: ReferencedFile[];
+	export let loading: boolean = false;
+	export let error: string | null = null;
+	export let onSelect: (file: ReferencedFile) => void;
+	export let onDismiss: () => void;
+	export let onRetry: () => void;
+
+	let activeIndex = 0;
+	let lastQuery: string | undefined;
+
+	$: results = mentionResults(files, query);
+	// Reset the active row on ANY query change (matching SlashPopover's
+	// semantics): after an edit, position N of the new result set is an
+	// unrelated file, so a stale highlight must never survive the edit.
+	$: if (query !== lastQuery) {
+		lastQuery = query;
+		activeIndex = 0;
+	}
+	// Clamp if the file list itself shrinks (e.g. a reload) with no query change.
+	$: if (activeIndex >= results.length) activeIndex = 0;
+	$: kind = mentionStateKind({ results, activeIndex, loading, error, query });
+
+	function onWindowKey(e: KeyboardEvent) {
+		const action = decideMentionKeyAction(e.key, { results, activeIndex, loading, error, query });
+		switch (action.kind) {
+			case 'select':
+				e.preventDefault();
+				e.stopPropagation();
+				onSelect(action.result);
+				return;
+			case 'dismiss':
+				e.preventDefault();
+				e.stopPropagation();
+				onDismiss();
+				return;
+			case 'move':
+				e.preventDefault();
+				e.stopPropagation();
+				activeIndex = action.nextIndex;
+				return;
+			case 'noop':
+				return;
+		}
+	}
+
+	function onRowMouseDown(e: MouseEvent, file: ReferencedFile) {
+		e.preventDefault();
+		onSelect(file);
+	}
+</script>
+
+<svelte:window on:keydown={onWindowKey} />
+
+<!-- tabindex="-1" required by a11y rule when aria-activedescendant is set; composer retains focus and keyboard events are caught by window handler above, so this listbox is never tab-focused. -->
+<div
+	class="lq-mention-popover"
+	role="listbox"
+	tabindex="-1"
+	aria-label="Document suggestions"
+	data-testid="lq-ai-mention-popover"
+	aria-activedescendant={kind === 'results' ? `lq-mention-row-${activeIndex}` : undefined}
+>
+	{#if kind === 'loading'}
+		<div class="lq-mention-popover__status" role="presentation">Loading documents…</div>
+	{:else if kind === 'error'}
+		<div class="lq-mention-popover__status lq-mention-popover__status--error" role="presentation">
+			Couldn't load documents ·
+			<button type="button" class="lq-mention-popover__retry" on:click={onRetry}>retry</button>
+		</div>
+	{:else if kind === 'empty-with-query'}
+		<div class="lq-mention-popover__status" role="presentation">
+			No matching documents · Esc to dismiss
+		</div>
+	{:else if kind === 'empty-no-query'}
+		<div class="lq-mention-popover__status" role="presentation">
+			No documents ready to reference in this matter
+		</div>
+	{:else}
+		{#each results as r, i}
+			<button
+				type="button"
+				role="option"
+				id={`lq-mention-row-${i}`}
+				class="lq-mention-popover__row"
+				class:active={i === activeIndex}
+				aria-selected={i === activeIndex}
+				data-testid="lq-ai-mention-row"
+				on:mousedown={(e) => onRowMouseDown(e, r)}
+				on:mouseenter={() => (activeIndex = i)}
+			>
+				<span class="lq-mention-popover__icon" aria-hidden="true">📄</span>
+				<span class="lq-mention-popover__body">
+					<span class="lq-mention-popover__title">{r.filename}</span>
+				</span>
+			</button>
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.lq-mention-popover {
+		display: flex;
+		flex-direction: column;
+		min-width: 280px;
+		max-width: clamp(280px, 90vw, 420px);
+		max-height: 320px;
+		overflow-y: auto;
+		background: var(--lq-surface, var(--lq-canvas, #ffffff));
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius, 6px);
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+		padding: var(--lq-space-1, 4px);
+		font-family: var(--lq-font-sans);
+		font-size: 13px;
+		color: var(--lq-text, #1a1a1a);
+	}
+
+	.lq-mention-popover__status {
+		padding: var(--lq-space-2, 8px) var(--lq-space-3, 12px);
+		color: var(--lq-text-tertiary, #9ca3af);
+		font-size: 12px;
+	}
+
+	.lq-mention-popover__status--error {
+		color: var(--lq-error, #b54848);
+	}
+
+	.lq-mention-popover__retry {
+		background: none;
+		border: 0;
+		padding: 0;
+		margin: 0;
+		color: inherit;
+		font: inherit;
+		text-decoration: underline;
+		cursor: pointer;
+	}
+
+	.lq-mention-popover__retry:focus-visible {
+		outline: 2px solid var(--lq-accent, #1f7a6b);
+		outline-offset: 2px;
+	}
+
+	.lq-mention-popover__row {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--lq-space-2, 8px);
+		width: 100%;
+		text-align: left;
+		background: none;
+		border: 0;
+		padding: var(--lq-space-2, 8px) var(--lq-space-3, 12px);
+		border-radius: var(--lq-radius-sm, 4px);
+		color: inherit;
+		font: inherit;
+		cursor: pointer;
+	}
+
+	.lq-mention-popover__row.active {
+		background: var(--lq-accent-soft, #e8f4ec);
+	}
+
+	.lq-mention-popover__row:focus-visible {
+		outline: 2px solid var(--lq-accent, #1f7a6b);
+		outline-offset: -2px;
+	}
+
+	.lq-mention-popover__icon {
+		font-size: 14px;
+		line-height: 1.3;
+		padding-top: 1px;
+		flex: 0 0 auto;
+	}
+
+	.lq-mention-popover__body {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+
+	.lq-mention-popover__title {
+		font-weight: 500;
+		color: var(--lq-text, #1a1a1a);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/MessageBubble.svelte
+++ b/web/src/lib/lq-ai/components/MessageBubble.svelte
@@ -263,6 +263,15 @@
 			</div>
 		{/if}
 
+		{#if message.role === 'user' && message.referenced_files?.length}
+			<!-- referenced-files Phase 2 — session-only stamp (not persisted server-side;
+			     disappears on reload). Shows which matter documents grounded
+			     this turn. -->
+			<div class="lq-msg-referenced" data-testid="lq-ai-referenced-row">
+				📄 Referenced: {message.referenced_files.map((f) => f.filename).join(', ')}
+			</div>
+		{/if}
+
 		{#if message.role === 'user' && message.is_enhanced}
 			<div
 				class="mt-1 flex items-center gap-2 flex-wrap justify-end"
@@ -390,3 +399,11 @@
 		{/if}
 	</div>
 {/if}
+
+<style>
+	.lq-msg-referenced {
+		margin-top: 4px;
+		font-size: 12px;
+		color: var(--lq-text-tertiary, #9ca3af);
+	}
+</style>

--- a/web/src/lib/lq-ai/components/ReferencedFilesChips.svelte
+++ b/web/src/lib/lq-ai/components/ReferencedFilesChips.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	/**
+	 * referenced-files Phase 2 — the authoritative referenced-files set, rendered
+	 * as removable chips above the composer. Both entry affordances
+	 * (FilePickerDropdown, MentionPopover) converge on this one row.
+	 */
+	import type { ReferencedFile } from '../files/referenceable';
+
+	export let files: ReferencedFile[];
+	export let notice: string | null = null;
+	export let onRemove: (id: string) => void;
+</script>
+
+{#if files.length > 0 || notice}
+	<div class="lq-ref-chips" data-testid="lq-ai-referenced-chips">
+		{#each files as f (f.id)}
+			<span class="lq-ref-chip" data-testid="lq-ai-referenced-chip">
+				<span class="lq-ref-chip__icon" aria-hidden="true">📄</span>
+				<span class="lq-ref-chip__name" title={f.filename}>{f.filename}</span>
+				<button
+					type="button"
+					class="lq-ref-chip__remove"
+					aria-label={`Remove ${f.filename}`}
+					on:click={() => onRemove(f.id)}
+				>
+					×
+				</button>
+			</span>
+		{/each}
+		{#if notice}
+			<span class="lq-ref-chips__notice" data-testid="lq-ai-referenced-notice">{notice}</span>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.lq-ref-chips {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--lq-space-1, 4px);
+		padding: var(--lq-space-1, 4px) 0;
+		font-family: var(--lq-font-sans);
+		font-size: 12px;
+	}
+
+	.lq-ref-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		max-width: 220px;
+		padding: 2px var(--lq-space-2, 8px);
+		border: 1px solid var(--lq-accent-border, #cfe4d8);
+		border-radius: 999px;
+		background: var(--lq-accent-soft, #e8f4ec);
+		color: var(--lq-text, #1a1a1a);
+	}
+
+	.lq-ref-chip__name {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.lq-ref-chip__remove {
+		background: none;
+		border: 0;
+		padding: 0 2px;
+		font: inherit;
+		color: var(--lq-text-tertiary, #9ca3af);
+		cursor: pointer;
+	}
+
+	.lq-ref-chip__remove:hover {
+		color: var(--lq-text, #1a1a1a);
+	}
+
+	.lq-ref-chips__notice {
+		color: var(--lq-text-tertiary, #9ca3af);
+	}
+</style>

--- a/web/src/lib/lq-ai/files/referenceable.ts
+++ b/web/src/lib/lq-ai/files/referenceable.ts
@@ -1,0 +1,94 @@
+/**
+ * referenced-files Phase 2 — the referenceable-files set for the chat composer.
+ *
+ * "Referenceable" = exactly what the backend accepts in
+ * `referenced_file_ids` (ADR 0022, KB-only MVP + matter scope): files in
+ * Knowledge Bases attached to the chat's project. Loading walks
+ * GET /projects/{id} → attached_knowledge_base_ids →
+ * GET /knowledge-bases/{kb_id}/files and merges/dedupes (a file may sit
+ * in several matter KBs). There is deliberately NO GET /files list call
+ * here — that route does not exist (DE-296 unbuilt).
+ *
+ * `ready` mirrors the backend's ingestion_status === 'ready' send gate:
+ * non-ready files render disabled ("Preparing…") and are never
+ * selectable — fail-restrictive made visible (P4), so the UI can never
+ * assemble a set the backend would 404.
+ */
+import { listKnowledgeBaseFiles } from '../api/knowledgeBases';
+import { getProject } from '../api/projects';
+import type { KnowledgeBaseFile } from '../types';
+
+/** Mirrors MESSAGE_REFERENCED_FILES_MAX_LEN (api/app/schemas/chats.py). */
+export const MESSAGE_REFERENCED_FILES_MAX = 16;
+
+export interface ReferencedFile {
+	id: string;
+	filename: string;
+	ready: boolean;
+}
+
+export interface ReferenceableLoad {
+	files: ReferencedFile[];
+	/** KBs whose file listing failed; the union of the rest still loads. */
+	failedKbCount: number;
+}
+
+export function toReferencedFile(row: KnowledgeBaseFile): ReferencedFile {
+	return { id: row.id, filename: row.filename, ready: row.ingestion_status === 'ready' };
+}
+
+export function mergeKbFileLists(lists: KnowledgeBaseFile[][]): ReferencedFile[] {
+	const byId = new Map<string, ReferencedFile>();
+
+	for (const list of lists) {
+		for (const row of list) {
+			// The same File row can be attached to several KBs; its
+			// ingestion_status is file-level, so first occurrence wins.
+			if (!byId.has(row.id)) byId.set(row.id, toReferencedFile(row));
+		}
+	}
+
+	return [...byId.values()].sort((a, b) => a.filename.localeCompare(b.filename));
+}
+
+export function filterReferenceable(files: ReferencedFile[], query: string): ReferencedFile[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return files;
+	return files.filter((f) => f.filename.toLowerCase().includes(q));
+}
+
+export type AddResult =
+	| { added: true; list: ReferencedFile[] }
+	| { added: false; reason: 'duplicate' | 'cap' | 'not-ready' };
+
+export function addReferencedFile(
+	list: ReferencedFile[],
+	file: ReferencedFile,
+	cap: number = MESSAGE_REFERENCED_FILES_MAX
+): AddResult {
+	if (!file.ready) return { added: false, reason: 'not-ready' };
+	if (list.some((f) => f.id === file.id)) return { added: false, reason: 'duplicate' };
+	if (list.length >= cap) return { added: false, reason: 'cap' };
+	return { added: true, list: [...list, file] };
+}
+
+export function removeReferencedFile(list: ReferencedFile[], id: string): ReferencedFile[] {
+	return list.filter((f) => f.id !== id);
+}
+
+/**
+ * Load the referenceable set for a project. A single KB listing failure
+ * degrades to the union of the KBs that did load (surfaced via
+ * `failedKbCount` as a non-blocking note); a getProject failure
+ * propagates — with no project there is no referenceable set at all.
+ */
+export async function loadReferenceableFiles(projectId: string): Promise<ReferenceableLoad> {
+	const project = await getProject(projectId);
+	const kbIds = project.attached_knowledge_base_ids ?? [];
+	const settled = await Promise.allSettled(kbIds.map((id) => listKnowledgeBaseFiles(id)));
+	const lists = settled
+		.filter((s): s is PromiseFulfilledResult<KnowledgeBaseFile[]> => s.status === 'fulfilled')
+		.map((s) => s.value);
+
+	return { files: mergeKbFileLists(lists), failedKbCount: settled.length - lists.length };
+}

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -319,6 +319,14 @@ export interface Message {
 	cost_estimate?: number | null;
 	error_code?: string | null;
 	citations?: Citation[];
+	/**
+	 * referenced-files Phase 2 — client-side stamp of the documents referenced when
+	 * THIS user message was sent ({id, filename} pairs). NOT persisted:
+	 * the backend stores no messages.referenced_file_ids column (ADR
+	 * 0022), so the row disappears on reload. Set only on the optimistic
+	 * user message at send time.
+	 */
+	referenced_files?: Array<{ id: string; filename: string }>;
 	created_at: string;
 	/**
 	 * Refusal-specific surfacings (only populated when `kind === 'refusal'`).
@@ -370,6 +378,14 @@ export interface MessageCreate {
 	 * `false` clears the set; omitted leaves it unchanged. Off by default.
 	 */
 	set_sticky?: boolean | null;
+	/**
+	 * referenced-files Phase 2 — caller-selected matter documents grounding THIS
+	 * turn via file-scoped retrieval + verified citations (ADR 0022).
+	 * Distinct from the (unwired) verbatim file_ids channel. Cap 16
+	 * (MESSAGE_REFERENCED_FILES_MAX, enforced UI-side so the backend 422
+	 * is unreachable through this client).
+	 */
+	referenced_file_ids?: string[];
 }
 
 export interface MessagePostResponse {
@@ -379,6 +395,8 @@ export interface MessagePostResponse {
 	routed_provider?: string | null;
 	cost_estimate?: number | null;
 	applied_skills?: string[];
+	/** referenced-files — echo of the validated referenced_file_ids. */
+	applied_referenced_file_ids?: string[];
 }
 
 // ----- SSE message-stream events -----
@@ -405,6 +423,8 @@ export interface MessageCompleteFrame {
 	applied_skills?: string[];
 	routed_inference_tier?: 1 | 2 | 3 | 4 | 5 | null;
 	routed_provider?: string | null;
+	/** referenced-files — echo of the validated referenced_file_ids (parity with applied_skills). */
+	applied_referenced_file_ids?: string[];
 }
 
 export interface MessageErrorFrame {


### PR DESCRIPTION
## What this PR does

  Adds a `referenced_file_ids` chat-send channel so users can reference matter documents in a message and get answers grounded in retrieved chunks with verified citations. The web composer supports both inline `@` mentions and a multi-select document picker, converging on one deduped referenced-documents set.

  ## Why

  The existing `file_ids` channel injects full file text for a turn but does not produce citations. This adds a separate path for “answer over these matter documents” using file-scoped retrieval and the existing Citation Engine.

  ## What this PR does *not* do

  This does not change the existing `file_ids` verbatim attachment behavior.

  This does not add embed-on-reference or automatic ingestion retries for non-ready documents. Non-ready files are disabled in the UI and rejected fail-restrictive by the backend.

  ## Type of change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds capability)
  - [ ] Breaking change (fix or feature that would change existing behavior)
  - [x] Documentation update
  - [ ] Skill contribution (see attestation below)
  - [ ] Refactor (no behavioral change)
  - [x] Test / CI / tooling

  ## Testing

  - [x] Unit tests added/updated
  - [x] Integration tests added/updated (if applicable)
  - [ ] Manually tested against a real deployment (describe scenario below)
  - [ ] Acceptance test plan updated (if changing skill behavior)


  ## Documentation

  - [x] PRD updated (if user-facing behavior changes)
  - [ ] README updated (if quickstart or capability list changes)
  - [ ] Skill-authoring guide updated (if skill conventions change)
  - [ ] Deployment cookbook updated (if deployment changes)
  - [ ] Compliance documentation updated (if compliance posture changes)
  - [ ] OpenAPI schema regenerated (if API endpoints change)

  ## Transparency & governance invariants

## P1 Egress: checked

 The feature does not add a new outbound third-party call from `api/`. Backend retrieval is DB-local through `hybrid_search_files` in `api/app/knowledge/retrieval.py`. The only model/provider path remains the existing gateway send path in `api/app/api/chats.py`, where the existing `GatewayClient` flow is reused. The frontend only sends `referenced_file_ids` to the backend API in `web/src/lib/lq-ai/components/ChatPanel.svelte`.

## P2 Closed set: checked / effectively N/A

This PR does not add a new model, autonomous tool, MCP hook, or provider-invokable capability. It adds a bounded message field, capped at 16 in `api/app/schemas/chats.py`. The referenced files must already be in the user's matter KB set; `_validate_referenced_file_ids` enforces caller-owned, ready, project-attached KB files in `api/app/api/chats.py`. So there is no open-ended capability surface.

## P3 No raw payloads: checked

The new audit row stores ids and counts only: `file_ids`, `referenced_count`, `chunk_count`, `chunk_ids` in `api/app/api/chats.py`. The integration test explicitly asserts the audit row has no content/query payload keys in `api/tests/integration/test_referenced_files_send.py`. The retrieved text is sent to the model as context, but not added to the new audit details.

## P4 Fail restrictive: checked

Invalid references fail closed before gateway call. The validator returns `404` for malformed/non-owned/not-ready/not-in-matter/projectless cases in `api/app/api/chats.py`. Tests cover random foreign id returning `404` and assert the mocked gateway route was not called in `api/tests/integration/test_referenced_files_send.py`, plus projectless chat `404` in the same file. Non-ready and deleted file exclusion are covered in `api/tests/test_retrieval_files.py`.

## P5 Atomic audit: partially checked, caveat

"New retrieval audit event is written via shared audit helper and committed by the handler; no new durable referenced-file state is added." If the checklist is interpreted strictly, mark this **N/A/qualified**, not unconditionally checked.

## P6 One governance path: checked

The PR reuses existing gateway, retrieval-context injection, citation verification, and audit helpers. It does not create a separate citation verifier or custom routing/governance path. 

## P7 Human gate: N/A / checked as no new destructive path

This feature is not destructive or irreversible. It only selects documents for one chat turn. It does not add autonomous execution or a tool action requiring confirmation. 

## P8 Operator control: unchecked

 no new admin setting or operator enable/disable surface for referenced-file chat grounding. It is available as part of chat once matter KB files exist. There is bounded validation and KB readiness, but not an operator-facing feature flag/admin control.

## P9 User owns data: 

anonymization posture follows existing retrieved-context design."

## P10 Contract is truth: checked

This PR updates the API/schema contract and design docs. Schema adds `referenced_file_ids` and `applied_referenced_file_ids` in `api/app/schemas/chats.py`. OpenAPI has those fields in `docs/api/backend-openapi.yaml`. PRD adds the user/API/citation behavior in `docs/PRD.md`, and ADR 0022 records the design in `docs/adr/0022-referenced-file-ids-chat.md`.

  ## DCO sign-off

  - [x] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-
  developer-certificate-of-origin)

  ## Related issues

  N/A