### PR TITLE
chore: v0.6.0 — fiduciary-grade milestone version bump + release-readiness record

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI backend API service."""
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lq-ai-desktop",
-	"version": "0.5.2",
+	"version": "0.6.0",
 	"description": "LQ.AI for Mac — desktop launcher for the LQ.AI release stack",
 	"author": "Kevin Keller",
 	"license": "Apache-2.0",

--- a/docs/LQVern/HANDOFF-2026-07-03-v0.6.0-release-readiness.md
+++ b/docs/LQVern/HANDOFF-2026-07-03-v0.6.0-release-readiness.md
@@ -1,0 +1,35 @@
+# v0.6.0 release-readiness record — fiduciary-grade milestone
+
+**Date:** 2026-07-03 · **Driver:** Claude Code (release gate, Stage 1–2) · **Version:** 0.5.1 → **0.6.0**
+
+The fiduciary-grade milestone + DE-365 launch docs are complete on `main` (@ `da3fac39`). Per the standard release ritual (100%-honesty bar — exercise every flow, don't just claim it), Stage 1 (fresh-clone bring-up + live exercise) was run before bumping the version.
+
+## Stage 1 — fresh-clone, README-driven bring-up: ✅ PASS (no blockers)
+
+Fresh `git clone --recurse-submodules` of `main` into a clean dir → `.env` configured per README (4 required secrets generated; host ports remapped to the 3xxxx range + a distinct compose project `lqai-v06gate` to coexist with an unrelated running stack — both documented `.env` knobs, not README deviations; provider + CourtListener keys reused from the operator's dev env) → `docker compose up -d --build`.
+
+| Check | Evidence |
+|---|---|
+| Bring-up | All 8 services healthy; web HTTP 200 in ~0.01s |
+| Self-migration | alembic `alembic_version` = `0065` (= repo head `0065_users_role_add_auditor`), migrated `0001→0065` clean on first boot |
+| Admin login + RBAC | `reset-admin-password` (README Step 3) → login → JWT; `users/me` returns `role` field |
+| Real inference | gateway `/v1/chat/completions` (alias `fast`) → `anthropic-prod` / `claude-sonnet-4-6`, correct output + `routed_inference_tier` + `cost_estimate` + `anonymization_applied` envelope |
+| Citation Ledger (fiduciary) | owner `GET /chats/{id}/ledger` → 200 `{chat_id, entries, gates}` |
+| Authority-source registry | `GET /research/sources` → 200 |
+| Auditor role (new, #266) | DB `chk_users_role_enum` CHECK includes `auditor`; all read endpoints (`/ledger`, `/messages/{id}/citations`, `/receipts`, `/receipts/export.jsonl`, `/autonomous/sessions/{id}/ledger`, `PATCH /admin/users/{id}/role`) present in OpenAPI; `audit_log` table live |
+| Learn `/compare` page (new, #269) | `GET /lq-ai/learn/compare` → 200 |
+| Case-law default | `research/capabilities` = `{enabled:false}` — **correct honest default** (operator opt-in, ADR 0014); CourtListener token *is* forwarded to the gateway env (v0.5.0's forwarding fix held); enabling is the documented step-2 `gateway.yaml` `tool_providers` uncomment |
+
+**One robustness finding (non-blocking) → filed DE-380.** The web frontend hardcodes the API base URL as `http://localhost:8000` rather than deriving it from `API_HOST_PORT`. When the gate stack's api host port was remapped (to coexist with another running stack), the browser login failed with `ERR_CONNECTION_REFUSED` even though the backend was healthy. Resetting the api to the default `:8000` (web `:3000`) — the documented default path — fixed it immediately. The documented defaults work, so this is not a release blocker, but an operator who remaps `API_HOST_PORT` gets a broken UI; the web client should read the configured base URL (DE-380).
+
+**No product bugs found.** Honest limit of this verification: the full **2-user cross-user auditor exercise** (privileged 200 vs non-privileged 404 + audit-row write) was not run live — the smoke harness has no CLI create-user / public-signup path — but that authorization logic is covered by #266's test triad + the final security review, and the deployment is confirmed (migration 0065, endpoints, `audit_log` table).
+
+## Stage 2 — version bump: this PR
+`api/app/__init__.py` 0.5.1→0.6.0; `desktop/package.json` 0.5.2→0.6.0.
+
+## Stage 3 — REMAINING (maintainer-driven, Kevin's machine)
+1. `git tag v0.6.0 && git push origin v0.6.0` → `release.yml` builds + publishes multi-arch GHCR images (api/gateway/web/proxy) + SBOMs + Cosign.
+2. `git tag desktop-v0.6.0 && git push` → `desktop-release.yml` builds the signed/notarized `.dmg` (CI Apple creds; no local signing needed).
+3. Real-Mac run of the `.dmg` → confirm an external user gets a working stack from the pre-built GHCR images (install to /Applications; `down -v` any stale `lq-ai-desktop` volumes first; verify the asset is the `desktop-v0.6.0` one, since `.dmg` filenames repeat).
+
+Release infra already exists (`release.yml` / `desktop-release.yml` / `desktop/`) — this is a rebuild, not net-new.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4974,6 +4974,12 @@ Donna requested (`Donna/docs/upstream-requests/lq-ai-signed-attestation-export.m
 
 **Deferred deliberately.** The crux is not the endpoint but **key management**: a real signing key is a new long-lived backend secret to generate, protect, and rotate — a gateway-adjacent trust decision that deserves its own design + security-reviewed pass, not a bolt-on. Scope when picked up: payload canonicalisation (byte-stable), signature format + algorithm (JWS vs COSE), where the signing key lives + rotation, public-key vs verify-endpoint distribution, whether the signature covers ledger+gate or only `content_hash`es, whether to ship the Merkle layer now or a JWS-only v1 first, and the endpoint auth scope (owner-scoped; a reviewer variant composes with the [DE-378](#de-378)-adjacent auditor role, [PR #266](https://github.com/LegalQuants/lq-ai/pull/266), merged `e40b98c8`). An unsigned-but-canonical export endpoint would be a useful intermediate, but the value Donna's users want is the **verifiable** attestation.
 
+#### DE-380 — Web client should derive the API base URL from config, not hardcode `localhost:8000`
+
+**Priority:** P3 · **Effort:** S · **Status (2026-07-03): filed (v0.6.0 release-readiness gate).**
+
+The web frontend issues browser-side API calls to a hardcoded `http://localhost:8000` (observed at `auth/login`) rather than deriving the base URL from the operator-configured `API_HOST_PORT` / a public base-URL env var. Consequence: an operator who remaps `API_HOST_PORT` off the default `8000` (e.g. to run a second stack, or behind a different published port) gets a fully working backend but a browser UI that fails with `ERR_CONNECTION_REFUSED` on every call. The documented default path (`API_HOST_PORT=8000`) works, so this is not a blocker — but the web client should read the configured API base URL so a remapped deployment isn't silently broken. Surfaced during the v0.6.0 fresh-clone gate when the api was remapped to coexist with another running stack.
+
 ---
 
 ## 10. Appendices

--- a/docs/api/backend-openapi.generated.yaml
+++ b/docs/api/backend-openapi.generated.yaml
@@ -6448,7 +6448,7 @@ info:
     until then, all endpoints under /api/v1 return 501 with a structured 'not implemented'
     body that names the implementing task.
   title: LQ.AI Backend API
-  version: 0.5.1
+  version: 0.6.0
 openapi: 3.1.0
 paths:
   /api/v1/admin/aliases:


### PR DESCRIPTION
Bumps the version to **v0.6.0** for the fiduciary-grade milestone (Citation Ledger, fiduciary gate, governed matter sessions, 3 authority sources, treatment layer, cross-user auditor role, DE-365 launch docs + evidence-linked comparison) and records the Stage-1 release-gate outcome.

## Stage 1 gate — ✅ PASS (no product bugs)
Fresh `git clone` of main → `.env` per README → `docker compose up -d --build`. Live-exercised on the fresh stack: 8/8 services healthy; self-migration `0001→0065`; admin login + RBAC; **real inference** (gateway → anthropic-prod, tier/cost/anonymization envelope); fiduciary Citation Ledger endpoint (owner 200); authority-source registry (200); **auditor role** deployed (DB constraint includes `auditor`, endpoints + `audit_log` present); Learn `/compare` page renders. Case-law correctly default-off (operator opt-in, token forwarding held). Full record: `docs/LQVern/HANDOFF-2026-07-03-v0.6.0-release-readiness.md`.

- One non-blocking robustness finding → **DE-380** (web client hardcodes `localhost:8000` API base URL; documented default path works).

## Changes
- `api/app/__init__.py` 0.5.1→0.6.0; `desktop/package.json` 0.5.2→0.6.0
- Readiness record + DE-380 filed

## Remaining (maintainer, after merge — Stage 3)
`git tag v0.6.0` → GHCR images; `git tag desktop-v0.6.0` → signed/notarized .dmg; real-Mac launcher run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)