### PR TITLE
chore: v0.6.1 — runtime tool-provider admin API + Research sources card

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI backend API service."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lq-ai-desktop",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "LQ.AI for Mac — desktop launcher for the LQ.AI release stack",
 	"author": "Kevin Keller",
 	"license": "Apache-2.0",

--- a/docs/api/backend-openapi.generated.yaml
+++ b/docs/api/backend-openapi.generated.yaml
@@ -6483,7 +6483,7 @@ info:
     until then, all endpoints under /api/v1 return 501 with a structured 'not implemented'
     body that names the implementing task.
   title: LQ.AI Backend API
-  version: 0.6.0
+  version: 0.6.1
 openapi: 3.1.0
 paths:
   /api/v1/admin/aliases:


### PR DESCRIPTION
## Summary

Point release wrapping the Donna #3 **runtime tool/authority-provider admin API + Research sources card** (shipped in #273, squash `44a1de54`): operators can enable/disable the four authority sources (CourtListener, GovInfo, SEC EDGAR, EUR-Lex) and manage keys **in-app, hot-applied, no restart**.

## Changes
- `api/app/__init__.py`: `__version__` 0.6.0 → **0.6.1**
- `desktop/package.json`: version 0.6.0 → **0.6.1**
- `docs/api/backend-openapi.generated.yaml`: `info.version` → 0.6.1 (regenerated via `make openapi`)

## Release steps after merge (gated)
- `git tag v0.6.1` → GHCR multi-arch images
- `git tag desktop-v0.6.1` → signed `.dmg`
- Real-Mac verify (maintainer)

## Note (pre-existing, not fixed here)
`desktop/package-lock.json` top-level version is stale at `0.5.2` (not regenerated when `package.json` went to 0.6.0 at the v0.6.0 cut). Left untouched — npm regenerates it on `npm install`; hand-editing risks desyncing the dep tree. Flagging for a maintainer decision / possible DE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>