### PR TITLE
fix(desktop): pull images before 'up' so the launcher picks up releases (v0.6.2)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lq-ai-desktop",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"description": "LQ.AI for Mac — desktop launcher for the LQ.AI release stack",
 	"author": "Kevin Keller",
 	"license": "Apache-2.0",

--- a/desktop/src/core/compose.test.ts
+++ b/desktop/src/core/compose.test.ts
@@ -3,6 +3,7 @@ import {
 	parseComposePs,
 	composeBaseArgs,
 	psArgs,
+	pullArgs,
 	upArgs,
 	downArgs,
 	downVArgs,
@@ -27,6 +28,9 @@ describe('composeBaseArgs', () => {
 describe('argv builders', () => {
 	it('ps requests JSON', () => {
 		expect(psArgs(base)).toEqual([...base, 'ps', '--format', 'json'])
+	})
+	it('pull refreshes images for the configured tag', () => {
+		expect(pullArgs(base)).toEqual([...base, 'pull'])
 	})
 	it('up is detached', () => {
 		expect(upArgs(base)).toEqual([...base, 'up', '-d'])

--- a/desktop/src/core/compose.ts
+++ b/desktop/src/core/compose.ts
@@ -6,6 +6,14 @@ export function composeBaseArgs(composeFile: string, projectName: string): strin
 }
 
 export const psArgs = (base: string[]): string[] => [...base, 'ps', '--format', 'json']
+/**
+ * `pull` — refresh the images for the configured tag before `up`. Run as a
+ * best-effort step so a released update is actually fetched: `up -d` alone
+ * reuses whatever `:latest` (or pinned tag) is already cached locally and
+ * never picks up a new release. A failed pull (offline / registry hiccup) is
+ * non-fatal — the caller proceeds to `up` with the cached images.
+ */
+export const pullArgs = (base: string[]): string[] => [...base, 'pull']
 export const upArgs = (base: string[]): string[] => [...base, 'up', '-d']
 export const downArgs = (base: string[]): string[] => [...base, 'down']
 /** `down -v` — also removes volumes. Used by Reset to wipe all data for a fresh setup. */

--- a/desktop/src/main/orchestrator.test.ts
+++ b/desktop/src/main/orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { snapshot } from './orchestrator'
+import { snapshot, startStack } from './orchestrator'
 
 // Inject a fake runner so this stays a pure unit test (no real docker).
 function fakeRunner(map: Record<string, { code: number; stdout: string; stderr: string }>) {
@@ -38,5 +38,35 @@ describe('snapshot', () => {
 		})
 		const snap = await snapshot(['compose', '-f', 'x', '-p', 'lq-ai-desktop'], runner)
 		expect(snap.state).toBe('NO_ENGINE')
+	})
+})
+
+describe('startStack', () => {
+	const base = ['compose', '-f', 'x', '-p', 'lq-ai-desktop']
+
+	it('pulls images before bringing the stack up', async () => {
+		const calls: string[][] = []
+		const runner = async (args: string[]) => {
+			calls.push(args)
+			return { code: 0, stdout: '', stderr: '' }
+		}
+		await startStack(base, {}, runner)
+		expect(calls).toEqual([
+			[...base, 'pull'],
+			[...base, 'up', '-d']
+		])
+	})
+
+	it('still brings the stack up when the pull fails (offline)', async () => {
+		const calls: string[][] = []
+		// runDocker never throws — a failed pull resolves with a non-zero code.
+		const runner = async (args: string[]) => {
+			calls.push(args)
+			const failed = args.includes('pull')
+			return { code: failed ? 1 : 0, stdout: '', stderr: failed ? 'no network' : '' }
+		}
+		const result = await startStack(base, {}, runner)
+		expect(calls.map((c) => c[c.length - 1])).toEqual(['pull', '-d'])
+		expect(result.code).toBe(0) // the `up` result is returned, not the pull's
 	})
 })

--- a/desktop/src/main/orchestrator.ts
+++ b/desktop/src/main/orchestrator.ts
@@ -1,5 +1,13 @@
 import { parseEngineProbe } from '../core/engine'
-import { parseComposePs, psArgs, upArgs, downArgs, downVArgs, adminFixtureArgs } from '../core/compose'
+import {
+	parseComposePs,
+	psArgs,
+	pullArgs,
+	upArgs,
+	downArgs,
+	downVArgs,
+	adminFixtureArgs
+} from '../core/compose'
 import { deriveLauncherState } from '../core/state'
 import type { LauncherState, ServiceStatus } from '../core/types'
 import { runDocker, type RunResult } from './runner'
@@ -24,8 +32,31 @@ export async function snapshot(base: string[], runner: Runner = runDocker): Prom
 	return { state: deriveLauncherState(engine, services), services }
 }
 
-export const startStack = (base: string[], env: NodeJS.ProcessEnv): Promise<RunResult> =>
-	runDocker(upArgs(base), env)
+/** Runner that accepts the same (args, env?) shape as {@link runDocker}. */
+type StartRunner = (args: string[], env?: NodeJS.ProcessEnv) => Promise<RunResult>
+
+/**
+ * Start the stack: refresh images, then bring them up.
+ *
+ * The `pull` is best-effort. Without it, `up -d` reuses whatever image is
+ * already cached for the configured tag (`:latest` by default) and the
+ * launcher never picks up a new release — the exact "installed the update but
+ * the UI didn't change" trap. `runDocker` never throws, so a failed
+ * pull (offline, or a transient registry error) is non-fatal: we ignore its
+ * exit code and proceed to `up` with the cached images, so an offline launch
+ * still starts the last-known-good stack. When the pull does fetch a newer
+ * image, `up -d` recreates the affected containers automatically.
+ *
+ * The runner is injectable for tests; production uses {@link runDocker}.
+ */
+export const startStack = async (
+	base: string[],
+	env: NodeJS.ProcessEnv,
+	runner: StartRunner = runDocker
+): Promise<RunResult> => {
+	await runner(pullArgs(base), env) // best-effort refresh; failure is non-fatal
+	return runner(upArgs(base), env)
+}
 
 export const stopStack = (base: string[]): Promise<RunResult> => runDocker(downArgs(base))
 


### PR DESCRIPTION
## Problem
The desktop launcher runs `docker compose up -d` with **no pull**, and `docker-compose.release.yml` has **no `pull_policy`**. So it reuses whatever `:latest` images are already cached locally and never fetches a new release — you install an update but the UI never changes. Concretely: the v0.6.1 **Research sources** admin tab stays invisible on any stack whose `:latest` was cached before v0.6.1 (all four images were 12 days stale on a live install).

## Fix
`startStack` now runs a **best-effort `docker compose pull` before `up -d`**:
- `runDocker` never throws, so a failed pull (offline / transient registry error) is **non-fatal** — the launch proceeds with cached images (offline still starts the last-known-good stack).
- `release.yml` only moves `:latest` on a version tag, so `:latest` == the latest **release** — pulling it is a safe auto-update, not bleeding-edge.
- `up -d` recreates only the containers whose image actually changed.

No config migration needed — existing users keep their persisted `imageTag: "latest"` and simply start getting refreshes.

## Scope
**Desktop-only release.** Bumps `desktop/package.json` 0.6.1 → **0.6.2**. The api/gateway/web GHCR images are unchanged — the fix ships in the `.dmg`, which then pulls the existing **v0.6.1** images (that already contain the Research sources card). No `vX.Y.Z` GHCR tag needed; release step is `git tag desktop-v0.6.2` → signed `.dmg`.

## Tests
- `compose.ts`: `pullArgs` builder + unit test.
- `orchestrator.ts`: `startStack` pulls before up (injectable runner); tests assert (1) pull-then-up order, (2) a failed pull still brings the stack up and returns the `up` result.
- `npx vitest run` → 63 passed; `tsc --noEmit` clean.

Not security-gated (desktop launcher only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>