### PR TITLE
fix(compose): forward LQ_AI_GATEWAY_MASTER_KEY in the gateway service (Donna #3 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,15 @@ MINIO_CONSOLE_HOST_PORT=9001
 #   python -c 'import secrets; print(secrets.token_urlsafe(32))'
 LQ_AI_GATEWAY_KEY=
 
+# [OPTIONAL] urlsafe-base64 Fernet master key that enables the runtime
+# encrypted-at-rest key store (ADR 0011). Set it to use the in-app admin key
+# setters — Configure → Provider keys and Admin → Research sources (enable
+# CourtListener/GovInfo). Left empty, the stack boots fine but those write
+# endpoints return 400 failed_precondition. Distinct from LQ_AI_BRIDGE_MASTER_KEY
+# (different threat model). Mint with:
+#   python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
+LQ_AI_GATEWAY_MASTER_KEY=
+
 # [OPTIONAL] Override gateway URL (default reaches Compose service).
 LQ_AI_GATEWAY_URL=http://gateway:8001
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,13 @@ services:
       # Auth — backend → gateway (and gateway → backend for C2 skill fetches).
       # The gateway uses the SAME shared secret in BOTH directions.
       LQ_AI_GATEWAY_KEY: ${LQ_AI_GATEWAY_KEY:?LQ_AI_GATEWAY_KEY is required}
+      # Enables the runtime encrypted-at-rest key store (ADR 0011). Optional for
+      # boot, but forwarded so `docker compose up` supports the in-app admin key
+      # setters — Configure → Provider keys AND Admin → Research sources (enable
+      # CourtListener/GovInfo). Without it those write endpoints return
+      # 400 failed_precondition. Defaults empty (runtime key storage disabled);
+      # set it in .env to enable. Mirrors docker-compose.release.yml.
+      LQ_AI_GATEWAY_MASTER_KEY: ${LQ_AI_GATEWAY_MASTER_KEY:-}
       # C2 — backend HTTP client for skill prompt assembly (ADR 0007).
       LQ_AI_API_URL: ${LQ_AI_API_URL:-http://api:8000}
       LQ_AI_SKILL_CACHE_TTL_SECONDS: ${LQ_AI_SKILL_CACHE_TTL_SECONDS:-60}


### PR DESCRIPTION
## Ask (from Donna-CC)
Forward `LQ_AI_GATEWAY_MASTER_KEY: ${LQ_AI_GATEWAY_MASTER_KEY:-}` in the root `docker-compose.yml` gateway `environment:` block, beside `LQ_AI_GATEWAY_KEY`, so a plain `docker compose up` enables runtime encrypted-at-rest key storage (in-app provider/research key setting) without a per-consumer compose override.

## Verified premise
- Root `docker-compose.yml` forwarded `LQ_AI_GATEWAY_KEY` + `COURTLISTENER_API_TOKEN` to `gateway` but **not** `LQ_AI_GATEWAY_MASTER_KEY`. So with a source `docker compose up`, `MASTER_KEY_ENV` (`gateway/app/secrets.py` = `LQ_AI_GATEWAY_MASTER_KEY`) was never present → the runtime key store was off → `POST /api/v1/admin/{provider-keys,tool-providers}` with a key returned **400 `failed_precondition`**.
- `docker-compose.release.yml` **already** forwards it (line 117) — this just brings the root file to parity.

## Change
- `docker-compose.yml`: add `LQ_AI_GATEWAY_MASTER_KEY: ${LQ_AI_GATEWAY_MASTER_KEY:-}` in the gateway env (right after `LQ_AI_GATEWAY_KEY`), with a comment covering both the Provider keys and the new Research sources key setters.
- `.env.example`: add a settable, documented `LQ_AI_GATEWAY_MASTER_KEY=` beside `LQ_AI_GATEWAY_KEY` (optional; empty = runtime key storage disabled; mint with Fernet). Otherwise operators forward an empty var and the feature stays off.

## Security note
Forwards a secret env var, exactly mirroring the existing `LQ_AI_GATEWAY_KEY` forward and the release compose. Defaults empty (`:-`), so no behavior change unless an operator sets it. The value is a Fernet master key (ADR 0011) — never logged, never returned.

## Validation
`docker compose -f docker-compose.yml config` interpolates `LQ_AI_GATEWAY_MASTER_KEY` into the gateway service cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>