### PR TITLE
docs: document native frontend dev flow with Vite HMR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,7 +158,13 @@ WEBUI_URL=http://localhost:3000
 # [OPTIONAL] Backend URL for delegated auth + chat.
 LQ_AI_API_URL=http://api:8000
 
-# Host port the web client is exposed on.
+# Host port the web client is exposed on. Default (3000): normal
+# fully-dockerized flow, browse to :3000. Native frontend dev with Vite
+# HMR (see docs/contribute/frontend-dev.md) needs this container
+# republished on :8080 instead — Vite's dev mode hardcodes the
+# expectation that the OpenWebUI backend embedded in this container
+# lives at `<hostname>:8080`. Don't change the default here; override
+# inline for that flow instead: `WEB_HOST_PORT=8080 docker compose up -d web`.
 WEB_BIND_ADDR=127.0.0.1
 WEB_HOST_PORT=3000
 
@@ -173,8 +179,16 @@ WEB_HOST_PORT=3000
 PUBLIC_LQ_AI_API_BASE_URL=http://localhost:8000/api/v1
 
 # CORS allowed origins for the api/. Empty disables CORS entirely.
-# Production behind a same-origin reverse proxy: leave UNSET. Local
-# Compose dev: http://localhost:3000 so the LQ.AI shell can call api/.
+# Comma-separated; production behind a same-origin reverse proxy: leave
+# UNSET. Local Compose dev: http://localhost:3000 so the dockerized
+# LQ.AI shell can call api/. Running web/ natively with `npm run dev`
+# instead (see docs/contribute/frontend-dev.md) — Vite's default port
+# is 5173 — add it here too, e.g.
+# LQ_AI_CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+#
+# Note: this only covers CORS for LQ.AI's api/. The OpenWebUI backend
+# embedded in the web/ container (port 8080) has its own CORS_ALLOW_ORIGIN
+# env var, defaulted to `*` in docker-compose.yml — no change needed there.
 LQ_AI_CORS_ORIGINS=http://localhost:3000
 
 # ============================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,7 @@ When you need to find something quickly:
 | Implementation tasks | [docs/M1-IMPLEMENTATION-ORDER.md](docs/M1-IMPLEMENTATION-ORDER.md) |
 | Code style | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | Skill conventions | [docs/skill-authoring-guide.md](docs/skill-authoring-guide.md) |
+| Frontend dev loop (HMR) | [docs/contribute/frontend-dev.md](docs/contribute/frontend-dev.md) |
 | What's already implemented | Existing code in `api/`, `gateway/`, `web/` |
 | What's deferred | [docs/PRD.md §9](docs/PRD.md#9-deferred-enhancements-and-identified-future-work) |
 | Contributor-pickup mini-PRDs | [docs/proposals/](docs/proposals/) |

--- a/docs/contribute/coding-agent-onboarding.md
+++ b/docs/contribute/coding-agent-onboarding.md
@@ -90,7 +90,7 @@ These have each bitten this codebase. Violating them corrupts the running dev st
   To **apply** a migration to the dev stack, rebuild the workers (next bullet) — don't reach for host alembic.
 - **When a migration lands, rebuild `api` + `arq-worker` + `ingest-worker` together.** Stale sibling containers crash-loop with "Can't locate revision identified by …" after a daemon bounce — they're all built from the api image and pin the revision.
 - **NEVER `docker compose down -v`.** It wipes volumes — including acceptance/review data that's expensive to recreate. Rebuild a single service (`docker compose build web && docker compose up -d web`), don't nuke volumes.
-- **The `web` container serves a pre-built static bundle (no HMR).** Source can be many commits ahead of what the browser shows. If a UI change "isn't appearing," rebuild `web` before debugging the code.
+- **The `web` container serves a pre-built static bundle (no HMR).** Source can be many commits ahead of what the browser shows. If a UI change "isn't appearing," rebuild `web` before debugging the code — or, better, don't iterate against the container at all: see [docs/contribute/frontend-dev.md](frontend-dev.md) for running `web/` natively with Vite HMR against the dockerized backend.
 - **Run BOTH `ruff format` and `ruff check`** locally — CI runs them as separate gates. `ruff check` passing doesn't mean `ruff format` will.
 
 ---

--- a/docs/contribute/frontend-dev.md
+++ b/docs/contribute/frontend-dev.md
@@ -1,0 +1,119 @@
+# Frontend dev loop: running `web/` natively with HMR
+
+> **Problem this solves:** the `web` Compose service only builds a static
+> SvelteKit bundle (see its Dockerfile) — there's no source bind-mount and no
+> dev command wired up. Editing `web/src` and refreshing the browser shows
+> nothing until you `docker compose build web && docker compose up -d web`.
+> That's a multi-minute loop per change, which makes frontend iteration
+> painful.
+>
+> **The fix:** run Vite's dev server natively on the host for HMR, but keep
+> the dockerized `web` container running too, republished on port `8080`.
+> That container still exists — see below for why — and everything else
+> (`api`, `gateway`, `postgres`, `redis`, `minio`, workers) runs in Docker as
+> usual.
+
+## Why the dockerized `web` container is still needed
+
+The `web/` fork is OpenWebUI, and OpenWebUI ships its own embedded Python
+backend (`web/backend/`) inside the same image as the static bundle — this is
+separate from LQ.AI's `api/` service. That embedded backend serves
+`/api/config`, websockets, and other OpenWebUI-native endpoints that the SPA
+needs on boot.
+
+Vite's dev mode **hardcodes** the assumption that this backend lives at
+`<hostname>:8080` (`web/src/lib/constants.ts`):
+
+```ts
+export const WEBUI_HOSTNAME = browser ? (dev ? `${location.hostname}:8080` : ``) : '';
+```
+
+Running `npm run dev` with nothing listening on `:8080` fails silently
+(`getBackendConfig()` throws) and the SPA redirects to `/error` ("Backend
+Required" / "unsupported method (frontend only)").
+
+The upstream-correct fix is to also run OpenWebUI's own backend — it ships a
+`web/backend/dev.sh` for exactly this. We deliberately **don't** do that
+natively: its `requirements.txt` pulls in `torch`, `chromadb`,
+`sentence-transformers`, `onnxruntime` — a slow, heavy native install for
+code LQ.AI barely touches (LQ.AI's own customizations live in `web/src`; the
+embedded backend's RAG bits are already disabled via
+`RAG_EMBEDDING_ENGINE=openai` in `docker-compose.yml`).
+
+Instead: keep using the already-built `web` Docker image (no native Python
+install, no rebuild needed unless you touch `web/backend/`), just republish
+its port as `8080` so it lands where Vite expects it, and let Vite handle
+everything under `web/src`.
+
+## One-time setup
+
+Add Vite's origin (5173) to `LQ_AI_CORS_ORIGINS` in your repo-root `.env`,
+alongside the dockerized shell's origin, so LQ.AI's `api/` accepts
+cross-origin calls from both:
+
+```bash
+LQ_AI_CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+```
+
+(The OpenWebUI-embedded backend on :8080 doesn't need a CORS change — its
+`CORS_ALLOW_ORIGIN` is unset in `docker-compose.yml` and defaults to `*`.)
+
+**Don't** change `WEB_HOST_PORT` in `.env` itself — `:3000` stays the default
+for the normal fully-dockerized flow. Override it inline, per invocation,
+only when starting `web` for this dev flow (see below).
+
+Then install `web/`'s frontend dependencies on the host once:
+
+```bash
+cd web
+npm install
+```
+
+## Day to day
+
+Bring up the backend, including the dockerized `web` container — republished
+on `:8080` for this session only via an inline env override:
+
+```bash
+WEB_HOST_PORT=8080 docker compose up -d postgres redis minio gateway api ingest-worker arq-worker web
+```
+
+Then run the frontend natively:
+
+```bash
+cd web
+npm run dev
+```
+
+Browse to **`http://localhost:5173`** (not `:8080` or `:3000`). Vite serves
+with full HMR: edits to `.svelte`, `.ts`, and CSS files apply immediately in
+the browser, no rebuild, no container restart.
+
+- OpenWebUI-native calls (config, auth shell, websockets) go to
+  `http://localhost:8080` (the dockerized container).
+- LQ.AI-specific calls go to `http://localhost:8000/api/v1` (the `api`
+  container), per `web/.env`'s `PUBLIC_LQ_AI_API_BASE_URL`.
+
+To go back to the fully-dockerized stack (e.g. to sanity-check the production
+build before a PR), stop the Vite process and recreate `web` without the
+override — `.env`'s default (`WEB_HOST_PORT=3000`) takes over:
+
+```bash
+docker compose up -d web
+```
+
+## Known gaps
+
+- Vite dev mode is **not** a substitute for the production build. Before
+  shipping a frontend change, run `docker compose build web && docker
+  compose up -d web` at least once (with `WEB_HOST_PORT=3000`) and click
+  through the change there — Vite dev and the static-adapter production
+  build can diverge (see `svelte.config.js` / `web/Dockerfile`).
+- If you touch `web/backend/` (OpenWebUI's embedded Python backend, not
+  LQ.AI's `api/`), you must `docker compose build web` to pick up the
+  change — there's no native/hot loop for that code in this setup.
+- `npm run dev` runs `pyodide:fetch` first (downloads Pyodide artifacts into
+  `web/static/pyodide`); this is a one-time cost per checkout, not per
+  restart.
+- This doc covers `web/` only. The Word add-in (`word-addin/`) has its own
+  build step — see `word-addin/README.md`.


### PR DESCRIPTION
## What this PR does

docs: document native frontend dev flow with Vite HMR.  Modifies .env.example to show how to enable HMR on /web 

```enab

## Why

The web container only builds a static SvelteKit bundle with no source bind-mount, so iterating on web/src required a full image rebuild per change. Vite's dev server already works, but nothing documented the two extra pieces it needs: the LQ.AI api's CORS origins must include Vite's port, and the dockerized web container's embedded OpenWebUI backend (which Vite hardcodes an expectation for at <hostname>:8080) must stay running, republished on that port, instead of the default :3000.

## What this PR does *not* do

No functional changes.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Documentation update
- [ ] Skill contribution (see attestation below)
- [ ] Refactor (no behavioral change)
- [ ] Test / CI / tooling

## Testing

<!-- How did you verify the change? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Manually tested against a real deployment (describe scenario below)
- [ ] Acceptance test plan updated (if changing skill behavior)

<details>
<summary>Manual testing notes (if applicable)</summary>

<!-- What you ran, against what configuration, and what you observed. -->

</details>

## Documentation

- [ ] PRD updated (if user-facing behavior changes)
- [ ] README updated (if quickstart or capability list changes)
- [ ] Skill-authoring guide updated (if skill conventions change)
- [ ] Deployment cookbook updated (if deployment changes)
- [ ] Compliance documentation updated (if compliance posture changes)
- [ ] OpenAPI schema regenerated (if API endpoints change)

## Transparency & governance invariants

<!-- The posture that *is* the product (ADR 0016). Check each box or mark it
n/a. If you can't, stop and either fix the change or surface the decision to a
maintainer. The cheap-to-check ones are enforced by
api/tests/test_transparency_invariants.py — but the judgment ones are on you. -->

- [ ] **Egress (P1):** any outbound third-party call goes through the gateway only — no direct egress from `api/`.
- [ ] **Closed set (P2):** any new model/autonomous-invokable capability is a bounded, operator-controlled allowlist entry, not an open hook.
- [ ] **No raw payloads (P3):** no row or log line I add carries raw content (message bodies, tool args/results, fetched text, keys) — counts, types, ids, digests, outcomes only.
- [ ] **Fail restrictive (P4):** missing/broken config fails closed, and I tested that path, not just the happy path.
- [ ] **Atomic audit (P5):** state changes get an audit row committed in the same transaction (helpers flush, the handler commits).
- [ ] **One governance path (P6):** I reused the shared governance/audit helpers rather than re-deriving tier/cost/audit logic.
- [ ] **Human gate (P7):** anything destructive/irreversible is behind the confirmation gate and excluded from unattended/autonomous execution.
- [ ] **Operator control (P8):** any new capability has an operator enable/disable and appears on an admin surface.
- [ ] **User owns data (P9):** outbound matter context is anonymized; the change respects export/delete and data-residency guarantees.
- [ ] **Contract is truth (P10):** OpenAPI sketch / DB schema doc / relevant ADR updated in this PR; any architectural/authz decision is recorded or surfaced, not made silently.

## DCO sign-off

- [x] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

<!-- Verify with: git log --show-signature -->

## Related issues

<!-- Closes #123, Refs DE-013, etc. -->

---

<!-- ============================================================
SKILL CONTRIBUTION ATTESTATION (uncomment if this PR contributes
or substantively modifies a skill containing legal substance)

## Skill attestation

I have reviewed the substantive legal content of this skill and
certify that, to the best of my knowledge as a [practicing
attorney / legal professional / specific role], the patterns,
severity calibrations, recommended language, and reference
material reflect accurate and reasonable legal practice in
[jurisdiction(s)]. I understand that this skill will be used in
real practice and that errors could affect real legal work; I
have authored this skill with the same care I would apply to my
own client work.

Signed: [your name and any relevant qualifications]

If you are not a practicing attorney, follow the alternative
attestation paths in skills/CONTRIBUTING.md (pair with a
practicing-attorney co-author, or have a practicing attorney
review the skill before submission).
============================================================ -->

## Reviewer notes

<!-- Anything the reviewer should know — areas where you'd specifically
appreciate scrutiny, design decisions you considered alternatives for,
known limitations of this PR. -->
