### PR TITLE
docs(adr): propose ADR 0036 — lq design-system primitives for the /lq-ai shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Each subsystem (`api/`, `gateway/`, `web/`) is a self-contained service. They ta
 - **Linter:** ESLint per `.eslintrc`.
 - **TypeScript:** required for new files; legacy `.js` files migrate gradually.
 - **Framework:** SvelteKit. The `web/` subdirectory is a fork of OpenWebUI, which is a SvelteKit app — extensions and customizations stay in Svelte. We do **not** mix React into `web/`. The Word add-in (`word-addin/`, M3) uses Office.js with React; the `web/` codebase does not.
-- **Component conventions:** match the OpenWebUI conventions for shared components; use the project's design system primitives rather than ad-hoc Tailwind.
+- **Component conventions:** match the OpenWebUI conventions for shared components (`web/src/lib/components/**`, untouched per ADR 0009). For everything under `web/src/lib/lq-ai/**`, use the `lq` design-system primitives (`web/src/lib/lq-ai/components/shared/` — `LqButton`, `LqGroup`, `LqStack`, `LqText`, `LqTitle`, `LqAlert`, `LqPill`, `LqSwitch`, `LqCard`, `LqHoverCard`) and the shared token file (`shared/types.ts`) rather than ad-hoc Tailwind spacing/color/size classes. See [ADR 0022](docs/adr/0022-lq-design-system-primitives.md) for the full rationale and the rules for adding new primitives/tokens.
 
 ### Both
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ git rebase --signoff main                 # all commits since main diverged
 - **Linter:** ESLint with the project's `.eslintrc`. TypeScript-specific rules enforced for `.ts` files; Svelte rules for `.svelte` files.
 - **TypeScript:** required for new files; gradual migration of legacy `.js` files welcome but not required for unrelated changes.
 - **Framework:** SvelteKit. The `web/` codebase is a fork of OpenWebUI, which is a SvelteKit app — extensions and customizations stay in Svelte. Do **not** introduce React into `web/`. The Word add-in (`word-addin/`, M3) uses Office.js with React; the `web/` codebase does not.
-- **Component conventions:** match the OpenWebUI conventions for shared components; use the project's design system primitives rather than ad-hoc Tailwind.
+- **Component conventions:** match the OpenWebUI conventions for shared components (`web/src/lib/components/**`, untouched per ADR 0009). For everything under `web/src/lib/lq-ai/**`, use the `lq` design-system primitives (`web/src/lib/lq-ai/components/shared/` — `LqButton`, `LqGroup`, `LqStack`, `LqText`, `LqTitle`, `LqAlert`, `LqPill`, `LqSwitch`, `LqCard`, `LqHoverCard`) and the shared token file (`shared/types.ts`) rather than ad-hoc Tailwind spacing/color/size classes. See [ADR 0022](docs/adr/0022-lq-design-system-primitives.md) for the full rationale and the rules for adding new primitives/tokens.
 
 ### Configuration files
 

--- a/docs/adr/0022-lq-design-system-primitives.md
+++ b/docs/adr/0022-lq-design-system-primitives.md
@@ -1,0 +1,80 @@
+# ADR 0022 — `lq` design-system primitives for the LQ.AI shell
+
+**Status:** Accepted (2026-07-06)
+**Decision-makers:** Simon Booth
+**Affected components:** `web/src/lib/lq-ai/**`
+**Supersedes:** none. **Refers to:** [ADR 0009](0009-web-lq-ai-shell-coexistence.md), [ADR 0001](0001-openwebui-fork-pin.md), [CONTRIBUTING.md](../../CONTRIBUTING.md), [CLAUDE.md](../../CLAUDE.md).
+
+---
+
+## Context
+
+CONTRIBUTING.md and CLAUDE.md have both carried this line since M1:
+
+> Component conventions: match the OpenWebUI conventions for shared components; use the project's design system primitives rather than ad-hoc Tailwind.
+
+Until now, "the project's design system primitives" pointed at nothing concrete for `/lq-ai/*`. Every component under `lib/lq-ai/components/**` independently decided its own spacing, color, size, and interaction logic in raw Tailwind utility classes — TrustPill's tone-mapping, the old `.lq-btn-secondary`/`.lq-btn-send`/`.lq-btn-abort` classes hand-rolled inside `ChatPanel.svelte`, ad hoc `flex items-center gap-2` layout soup repeated across a dozen files, a tier→description mapping independently duplicated (with drifting wording) across `TierBadge.svelte`, `TierDetailsPanel.svelte`, and `MessageBubble.svelte`. Nothing was wrong file-by-file; the absence of a shared vocabulary meant every file was its own small design decision.
+
+A React/Mantine migration and a "push the fix upstream into OpenWebUI" option were both considered and rejected in favor of a design-system layer native to this codebase (see discussion trail; not separately documented as those were explicitly rejected, not adopted). The rejection reasoning: a framework migration reverses ADR 0009/ADR 0001's SvelteKit-only decision and its rebase-cost rationale for no real benefit — the actual problem is missing convention + discipline, not the framework.
+
+## Decision
+
+Adopt a small primitive layer at `web/src/lib/lq-ai/components/shared/`, modeled on Mantine's component API shape (`variant`/`size`/`tone`/`shadow` props, `Component.Part` compound namespacing) as a naming and ergonomics reference only — not an added runtime dependency. Every primitive is plain Svelte + CSS custom properties, plus two existing pieces of `web/`'s dependency tree used rather than reimplemented (`bits-ui`'s headless `Switch`/`Portal`; see below). One genuinely new dependency was added alongside this effort — `@tabler/icons-svelte`, justified in "Typography and iconography" below — consistent with CLAUDE.md's "don't add libraries without justification" (the justification being the actual reason, not an exemption from it).
+
+**Token layer** (`shared/types.ts`): every option list is a `const` array with a type derived via `(typeof X)[number]`, never a hand-typed string-literal union — one file to extend, full autocomplete everywhere. This is a deliberate, load-bearing design goal, not an incidental side effect: every prop on every primitive is typed specifically so the editor's IntelliSense surfaces the full set of valid values at the call site — a contributor should never need to open `types.ts` or another component's source to discover what `tone`/`variant`/`gap`/etc. accept. Current scales: `LqVariant`, `LqTone`, `LqSize`, `LqGap`, `LqShadow`, `LqWeight`, `LqTextSize`, `LqTextTone`, `LqJustify`, `LqAlign`, and the lower-level `LqColor`+`LqShade` pair (`lqColorShade()`, computed via CSS `color-mix()` off five base `--lq-*` vars rather than a hand-authored shade table).
+
+**Primitives:**
+- `LqButton` — `variant` × `tone` × `size`.
+- `LqGroup` / `LqStack` — Mantine `Group`/`Stack`-style flex layout (`gap`, `justify`, `align`, `maxWidth`), replacing repeated Tailwind flex-utility soup.
+- `LqText` / `LqTitle` — semantic text (`as`/`order` pick the rendered tag) instead of styled `<div>`s.
+- `LqAlert` — status banner; fills its container width by default (no `w-full`/`max-w-full` escape hatch needed).
+- `LqPill` — tag/chip with an optional removable-✕ affordance.
+- `LqSwitch` — styled wrapper around `bits-ui`'s headless `Switch` (behavior/a11y from bits-ui, tone-based look from us).
+- `LqCard` — static container (padding/shadow).
+- `LqHoverCard` — compound component (`LqHoverCard` / `.Target` / `.Dropdown`, assembled via direct property assignment on the Root export — the same technique this codebase's own `bits-ui` usage already relies on for `Button.Root`). Portaled through `bits-ui`'s `Portal` to `document.body` so it isn't clipped by a scrolling ancestor's `overflow: hidden`/`auto`.
+
+**Governing rules for new primitives:**
+1. Reuse an existing scale from `types.ts` before adding a new one; only add a new scale when no existing one fits (e.g. `LqTextSize` was added separately from `LqSize` because Button's `sm/md/lg` has no `xs`/`xl` CSS defined).
+2. Spacing between sibling elements is the parent `LqGroup`/`LqStack`'s `gap` — never a self-margin (`mt-*`/`mb-*`) on the child. A component needing to visually span its row (`w-full`) is a legitimate exception; a component reaching for a margin utility to create breathing room from its neighbor is not.
+3. A component that should always fill its container (e.g. `LqAlert`) declares `width: 100%` in its own default CSS — the caller should never need to say so.
+4. Any primitive taking arbitrary attributes (`data-testid`, `aria-*`) forwards `$$restProps`; any primitive taking an additional class forwards it via the `let klass = ''; export { klass as class };` pattern, not by relying on Svelte's spread-vs-static-class merging.
+5. Prefer a primitive's typed props over its `class` escape hatch. `class` exists only for concerns with no corresponding prop and no sane default — a one-off test hook, a genuinely unsupported CSS need. It is not a shortcut around adding a real option to a scale in `types.ts` when the same value will recur (if a second call site wants the same "unsupported" thing, that's the signal to promote it to a prop, not to keep copy-pasting the class string). Reaching for `class` where a prop already exists (e.g. a raw `flex` utility class instead of `LqGroup`, a color utility instead of `tone`) defeats the IntelliSense goal described in the token-layer paragraph above — the whole point is that the typed prop is discoverable at the call site and the raw class is not.
+
+## Typography and iconography
+
+**Fonts:** the `/lq-ai/*` shell self-hosts Inter Variable (`@fontsource-variable/inter`, loaded by `styles/typography.css`, which the `/lq-ai/*` layout imports — not loaded globally, so the OpenWebUI shell's own font stack is untouched per ADR 0009's boundary). `--lq-font-sans` is the single font-family var; `.lq-shell` applies it at the root of the `/lq-ai` tree.
+
+`typography.css` already carries a pre-existing "Practice type scale" (`.lq-text-label`, `.lq-text-caption`, `.lq-text-body-sm`, `.lq-text-body`, `.lq-text-panel-h`, `.lq-text-page-h`, `.lq-text-welcome` — fixed px sizes per spec §5.4), predating this ADR's `LqText`/`LqTitle` primitives and their own `LqTextSize` (12–18px, `xs`–`xl`) and `LqTitle` order (14–34px, 1–6) scales. These are two parallel, unreconciled type-scale systems as of this writing — exactly the "different decisions in different files" failure mode CLAUDE.md warns against. Reconciling them (either retiring the `.lq-text-*` classes in favor of `LqText`, or deriving `LqTextSize`'s px values from the same scale) is follow-up work, not done here.
+
+**Icons:** `@tabler/icons-svelte` is a **new dependency, introduced as part of this design-system effort** (not a pre-existing one being reused — `web/package.json`/`package-lock.json` carry it as an uncommitted addition alongside this work). It's the icon source for every primitive built under this ADR (`IconX` in `LqPill`/`LqAlert`, plus the icons already wired into `ChatPanel.svelte`'s composer row). Justification per CLAUDE.md's "new dependencies need justification" rule:
+
+Emoji glyphs are the thing being replaced, and the problem with them isn't taste — it's that every call site using an emoji as an icon ends up hand-tuning inline styles (`font-size`, `line-height`, manual margin nudges) to make the glyph sit correctly next to text or inside a button, because an emoji has no `size` prop and no predictable box model. That's exactly the failure mode this whole primitive effort exists to eliminate: inline one-off styling that produces inconsistent spacing and sizing across call sites, the same problem `LqGroup`'s `gap` solves for layout. An SVG icon component (`<IconX size={14} />`) has a real, explicit size and a predictable geometry, so it composes cleanly with the `LqGap`/`LqTextSize` scales already established — no inline style needed to make it line up.
+
+Secondary reasons emoji specifically are a poor icon vocabulary, independent of the inline-style problem:
+- **Not stylable.** An emoji is a font glyph rendered by the OS/browser's emoji font — it can't inherit `currentColor`, so it can't pick up a button's `tone` the way an SVG icon does.
+- **Not visually consistent.** The same emoji renders differently per OS/browser (Apple's colorful emoji set vs. Windows'/Linux's, or a missing glyph entirely on some platforms) — a security/legal product where "what does this icon mean" matters shouldn't depend on the reader's OS to render it recognizably.
+
+The emoji glyphs still in `ProvenancePill`/`TrustPill`/the capture button are pre-existing and out of scope for this ADR to migrate wholesale — flagged as a natural Tabler-icon migration candidate for later, not undone here.
+
+## Scope / boundary
+
+Everything above lives under `web/src/lib/lq-ai/**`. Per ADR 0009, the OpenWebUI shell at `/` (`web/src/lib/components/**`) is untouched — this doesn't reopen that boundary. ADR 0009 already anticipated this: "the LQ.AI shell can be redesigned, refactored, or rewritten without touching upstream code."
+
+## Consequences
+
+**Positive:** one place to change a spacing/color/size decision for the whole `/lq-ai` shell; new components have an actual answer to "what do I use instead of Tailwind" instead of reverse-engineering convention from nearby files; several latent bugs surfaced and were fixed while migrating existing call sites to these primitives (a `gap={2}` typo silently falling through to a raw-number branch; a tier-description mapping duplicated three times with drifting wording; a hover popover clipped by a scrolling ancestor).
+
+**Negative:** components under `lib/lq-ai/components/**` not yet migrated remain inconsistent until touched — this is an incremental migration, not a rewrite. Two visual-language systems still coexist in `web/` (Tailwind-utility for the OpenWebUI shell, tone/token-based for `lq-ai/**`), which is accepted as the cost of ADR 0009's boundary, not something this ADR changes.
+
+**Reversibility:** low cost either way — primitives are additive Svelte files with no external dependency; abandoning them means falling back to Tailwind per-file, no migration required in the other direction beyond the components already converted.
+
+## Follow-up
+
+- Audit `lib/lq-ai/components/**` for the highest-traffic remaining ad hoc Tailwind patterns (badges/pills/buttons) as a punch list, rather than a big-bang rewrite.
+- `LqCard` and `lqColorShade()` have no consumer yet as of this ADR; both exist because a concrete near-term need was anticipated, not speculatively.
+- Reconcile the two parallel type scales described above (`typography.css`'s `.lq-text-*` classes vs. `LqText`/`LqTitle`'s own scales).
+
+**Do next:**
+1. **Migrate the base color tokens to OKLCH.** `practice.css`'s five tone base vars (`--lq-accent`, `--lq-tier`, `--lq-warn`, `--lq-error`, and the text/border grays) are still authored as flat hex/sRGB. `lqColorShade()` already mixes *from* those bases `in oklab` (a perceptually uniform space) — but the bases themselves aren't, so the shade ramp only gets partway to perceptually-even. Authoring the base tokens directly as `oklch(L C H)` (independently tunable lightness/chroma/hue) would close that gap. This isn't a new idea for this codebase — `web/src/tailwind.css` already defines OpenWebUI's own gray scale in `oklch()` (`--color-gray-50: oklch(0.98 0 0)`, etc.); the `lq-ai` tone palette is the one part of `web/` still on hex.
+2. **Add `LqPopover`.** Same Root/Target/Dropdown/context/Portal architecture as `LqHoverCard`, but click-triggered with click-outside-to-close instead of hover/focus — Mantine ships both `HoverCard` and `Popover` as siblings for exactly this reason (glance-and-go vs. deliberate open). This is the primitive the modals correctly *not* converted to `LqHoverCard` earlier (interactive/mutating content, or simple click-triggered menus that don't need full modal backdrop+focus-trap treatment) should eventually sit on.
+3. **Add `LqSimpleGrid`.** Mantine's `SimpleGrid` (`cols`, `spacing`, responsive breakpoints) has no equivalent here — `LqGroup`/`LqStack` only cover row/column flex layouts. Several components already hand-roll `grid grid-cols-*` Tailwind utilities for card-grid layouts (`TierDetailsPanel`, `FeaturedToolsRow`, `PlaybookEditor`, among others) — real, existing call sites to migrate once it exists.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
 				"@pyscript/core": "^0.4.32",
 				"@sveltejs/adapter-node": "^2.0.0",
 				"@sveltejs/svelte-virtual-list": "^3.0.1",
+				"@tabler/icons-svelte": "^3.44.0",
 				"@tiptap/core": "^3.0.7",
 				"@tiptap/extension-bubble-menu": "^3.0.7",
 				"@tiptap/extension-code": "^3.0.7",
@@ -3678,6 +3679,32 @@
 			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
+			}
+		},
+		"node_modules/@tabler/icons": {
+			"version": "3.44.0",
+			"resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
+			"integrity": "sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/codecalm"
+			}
+		},
+		"node_modules/@tabler/icons-svelte": {
+			"version": "3.44.0",
+			"resolved": "https://registry.npmjs.org/@tabler/icons-svelte/-/icons-svelte-3.44.0.tgz",
+			"integrity": "sha512-ZJJMCHoqpvb9hLVn9dU+pn8LCdX/e+mJ/fC+EUaJT5nHEm0+IW4aKKYkYQI+rFMzN8ivj36MnMC5TGFi4H6zew==",
+			"license": "MIT",
+			"dependencies": {
+				"@tabler/icons": "3.44.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/codecalm"
+			},
+			"peerDependencies": {
+				"svelte": ">=3 <6 || >=5.0.0-next.0"
 			}
 		},
 		"node_modules/@tailwindcss/container-queries": {

--- a/web/package.json
+++ b/web/package.json
@@ -66,6 +66,7 @@
 		"@pyscript/core": "^0.4.32",
 		"@sveltejs/adapter-node": "^2.0.0",
 		"@sveltejs/svelte-virtual-list": "^3.0.1",
+		"@tabler/icons-svelte": "^3.44.0",
 		"@tiptap/core": "^3.0.7",
 		"@tiptap/extension-bubble-menu": "^3.0.7",
 		"@tiptap/extension-code": "^3.0.7",

--- a/web/src/lib/lq-ai/chat/tierDescriptions.ts
+++ b/web/src/lib/lq-ai/chat/tierDescriptions.ts
@@ -1,0 +1,46 @@
+import type { TrustTone } from '../components/TrustPill.svelte';
+
+export type Tier = 1 | 2 | 3 | 4 | 5;
+
+export interface TierDescription {
+	label: string;
+	blurb: string;
+	tone: TrustTone;
+}
+
+/**
+ * Single source of truth for "what does Tier N mean" — was previously
+ * duplicated (with drifting wording) across TierBadge's hover title,
+ * TierDetailsPanel's modal body, and MessageBubble's tier hover-popover.
+ */
+export const TIER_DESCRIPTIONS: Record<Tier, TierDescription> = {
+	1: {
+		label: 'Tier 1 — On-prem / air-gapped',
+		blurb: 'Local-only inference — runs on this computer. Your data never leaves the deployment.',
+		tone: 'sage'
+	},
+	2: {
+		label: 'Tier 2 — Private cloud (no provider data retention)',
+		blurb: 'Customer-hosted cloud inference — runs in your own cloud account.',
+		tone: 'neutral'
+	},
+	3: {
+		label: 'Tier 3 — Commercial enterprise (ZDR addendum)',
+		blurb: 'Enterprise managed inference — provider has signed ZDR / no-training commitments.',
+		tone: 'amber'
+	},
+	4: {
+		label: 'Tier 4 — Standard commercial API',
+		blurb: 'Standard cloud API — provider terms govern data handling.',
+		tone: 'amber'
+	},
+	5: {
+		label: 'Tier 5 — Consumer / free-tier API',
+		blurb: 'Consumer or free tier — the provider may train on your data.',
+		tone: 'red'
+	}
+};
+
+export function tierDescriptionFor(tier: Tier | null | undefined): TierDescription | null {
+	return tier ? (TIER_DESCRIPTIONS[tier] ?? null) : null;
+}

--- a/web/src/lib/lq-ai/components/ChatPanel.svelte
+++ b/web/src/lib/lq-ai/components/ChatPanel.svelte
@@ -100,10 +100,19 @@
 	import ReceiptsDrawer, {
 		readPersistedOpen as readReceiptsDrawerOpen
 	} from '$lib/lq-ai/components/ReceiptsDrawer.svelte';
+	import { IconPaperclip, IconSparkles, IconReceipt, IconSparkleHighlight, IconBabyCarriage } from '@tabler/icons-svelte';
+	import LqButton from '$lib/lq-ai/components/shared/LqButton.svelte';
+	import LqGroup from '$lib/lq-ai/components/shared/LqGroup.svelte';
+	import LqStack from '$lib/lq-ai/components/shared/LqStack.svelte';
+	import LqText from '$lib/lq-ai/components/shared/LqText.svelte';
+	import LqTitle from '$lib/lq-ai/components/shared/LqTitle.svelte';
+	import LqAlert from '$lib/lq-ai/components/shared/LqAlert.svelte';
+	import LqSwitch from '$lib/lq-ai/components/shared/LqSwitch.svelte';
 	import SlashPopover from '$lib/lq-ai/components/SlashPopover.svelte';
 	import type { SkillAutocompleteItem } from '$lib/lq-ai/types';
 	import { auth } from '$lib/lq-ai/auth/store';
 	import { createEventDispatcher } from 'svelte';
+	import { space } from 'postcss/lib/list';
 
 	// ---- component props ----
 	export let projectIdFilter: string | undefined = undefined;
@@ -138,11 +147,6 @@
 	let stickyEnabled = false;
 	let stickyDirty = false;
 	let stickyInitChatId: string | null = null;
-
-	function toggleSticky(): void {
-		stickyEnabled = !stickyEnabled;
-		stickyDirty = true;
-	}
 
 	// Wave D.1 T20 follow-on (deferral A + B) — Enhance Prompt tracking.
 	// `pendingEnhancement` holds the most recent "Use enhanced" outcome
@@ -186,19 +190,19 @@
 	// T6 — Enhance Prompt panel reference. Parent calls expansionPanel.open().
 	let expansionPanel: EnhancePromptExpansion | null = null;
 
-	// T12 — Attach-KB modal state. The composer 📎 button mounts the shared
-	// AttachKBModal scoped to the active chat's project. Successful attaches
-	// bubble up to the matter workspace via the `kbsAttached` event so the
-	// matter rail can refresh its KB list. The modal is only meaningful when
-	// the active chat lives inside a project (legal matter); for project-less
-	// chats the 📎 button is hidden.
+	// T12 — Attach-KB modal state. The composer's attach-KB button (IconPaperclip)
+	// mounts the shared AttachKBModal scoped to the active chat's project.
+	// Successful attaches bubble up to the matter workspace via the
+	// `kbsAttached` event so the matter rail can refresh its KB list. The
+	// modal is only meaningful when the active chat lives inside a project
+	// (legal matter); for project-less chats the button is hidden.
 	let attachKbModalOpen = false;
 	const dispatch = createEventDispatcher<{ kbsAttached: { kbIds: string[] } }>();
 
-	// Wave D.1 T19 — Receipts drawer state. The composer 📜 button toggles
-	// the right-side receipts drawer (T18). Open state is restored from
-	// localStorage when the active chat changes, so it survives reloads and
-	// chat switches.
+	// Wave D.1 T19 — Receipts drawer state. The composer's receipts button
+	// (IconReceipt) toggles the right-side receipts drawer (T18). Open
+	// state is restored from localStorage when the active chat changes, so
+	// it survives reloads and chat switches.
 	let receiptsDrawerOpen = false;
 
 	function openAttachKbModal(): void {
@@ -963,34 +967,31 @@
 	/>
 
 	<section class="flex-1 flex flex-col overflow-hidden">
-		<div
-			class="px-4 py-2 border-b border-gray-200 dark:border-gray-800 flex items-center justify-between"
-			data-testid="lq-ai-chat-header"
-		>
+		<LqGroup justify="space-between" padding="xs" class="border-b border-gray-200" data-testid="lq-ai-chat-header">
 			{#if activeChat}
-				<div>
-					<h2 class="lq-text-panel-h">
+				<LqGroup justify="space-between">
+					<LqTitle order={5} weight="semibold">
 						{activeChat.title || 'Untitled chat'}
-					</h2>
+					</LqTitle>
 					{#if activeChat.project_id}
-						<p class="text-xs text-gray-500">
+						<LqText size="xs" tone="secondary">
 							In project: {$projectsStore.find((p) => p.id === activeChat.project_id)?.name ??
 								activeChat.project_id}
-						</p>
+						</LqText>
 					{/if}
-				</div>
-				<div class="flex items-center gap-2">
+					</LqGroup>
+				<LqGroup gap="sm">
 					{#if messages[messages.length - 1]?.role === 'assistant' && messages[messages.length - 1]?.routed_inference_tier}
 						<TierBadge
 							tier={messages[messages.length - 1].routed_inference_tier ?? null}
 							provider={messages[messages.length - 1].routed_provider ?? null}
 						/>
 					{/if}
-				</div>
+				</LqGroup>
 			{:else}
-				<h2 class="text-sm text-gray-500">Pick or create a chat to start.</h2>
+				<LqText size="sm" tone="secondary">Pick or create a chat to start.</LqText>
 			{/if}
-		</div>
+		</LqGroup>
 
 		<MessageList
 			{messages}
@@ -1009,11 +1010,8 @@
 		/>
 
 		{#if activeChat}
-			<div
-				class="border-t border-gray-200 dark:border-gray-800 p-3 space-y-2"
-				data-testid="lq-ai-composer"
-			>
-				<div class="flex items-center justify-between">
+			<LqStack gap="sm" class="border-t border-gray-200" data-testid="lq-ai-composer">
+				<LqGroup justify="space-between">
 					<ModelPicker
 						models={availableModels}
 						selectedId={currentModelId}
@@ -1022,25 +1020,21 @@
 					<!-- Issue #207 finding 4 — opt-in "sticky skills" toggle. Off by
 					     default; when on, the skills applied here stay applied to
 					     follow-up messages in this chat (resets for a new chat). -->
-					<button
-						type="button"
-						role="switch"
-						aria-checked={stickyEnabled}
-						on:click={toggleSticky}
+					<LqGroup
+						gap="xs"
 						data-testid="lq-ai-sticky-toggle"
 						title="Keep the skills applied here active for follow-up messages in this chat. Off by default; a new chat starts fresh."
-						class="flex items-center gap-2 text-xs font-medium px-2 py-1 rounded-md border transition-colors {stickyEnabled
-							? 'border-emerald-500 text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-950/40'
-							: 'border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400'}"
 					>
-						<span
-							class="inline-block w-2 h-2 rounded-full {stickyEnabled
-								? 'bg-emerald-500'
-								: 'bg-gray-300 dark:bg-gray-600'}"
-						></span>
-						Keep skills on
-					</button>
-				</div>
+						<LqSwitch
+							checked={stickyEnabled}
+							onCheckedChange={(value) => {
+								stickyEnabled = value;
+								stickyDirty = true;
+							}}
+						/>
+						<LqText size="xs" tone="secondary">Keep skills on</LqText>
+					</LqGroup>
+				</LqGroup>
 
 				<SkillPicker
 					availableSkills={$skillsStore}
@@ -1060,15 +1054,12 @@
 				/>
 
 				{#if sendError}
-					<div
-						class="text-sm text-rose-700 bg-rose-50 border border-rose-200 rounded px-2 py-1"
-						data-testid="lq-ai-send-error"
-					>
+					<LqAlert tone="red" data-testid="lq-ai-send-error">
 						{sendError}
-					</div>
+					</LqAlert>
 				{/if}
 
-				<div class="flex items-end gap-2">
+				<LqGroup align="flex-end" gap="sm">
 					<div class="lq-composer-wrap flex-1">
 						<textarea
 							class="lq-composer w-full text-sm resize-none"
@@ -1078,7 +1069,7 @@
 							data-testid="lq-ai-composer-input"
 							on:keydown={handleComposerKeydown}
 							on:input={onComposerInput}
-						></textarea>
+						/>
 						{#if slashOpen}
 							<div class="lq-composer-popover" data-testid="lq-ai-slash-popover-anchor">
 								<SlashPopover
@@ -1090,60 +1081,63 @@
 						{/if}
 					</div>
 					{#if streamingMessageId}
-						<button
-							type="button"
-							class="lq-btn-abort text-sm font-medium"
+						<LqButton
+							variant="filled"
+							tone="red"
 							on:click={abortStream}
 							data-testid="lq-ai-abort-btn"
 						>
 							Stop
-						</button>
+						</LqButton>
 					{:else}
 						{#if composerProjectId}
-							<button
-								type="button"
-								class="lq-btn-secondary text-sm"
+							<LqButton
+								variant="outline"
+								tone="sage"
+								size="sm"
 								aria-label="Attach knowledge base"
 								title="Attach a knowledge base to this matter"
+								disabled={true}
 								on:click={openAttachKbModal}
 								data-testid="lq-ai-attach-kb-btn"
 							>
-								📎
-							</button>
+								<IconPaperclip size={16} />
+							</LqButton>
 						{/if}
-						<button
-							type="button"
-							class="lq-btn-secondary text-sm"
+						<LqGroup gap="xs">
+						<LqButton
+							size="sm"
+							variant={enhanceIsRefine ? 'filled' : 'outline'}
 							aria-label={enhanceButtonAriaLabel}
 							title={enhanceButtonTitle}
-							on:click={() => expansionPanel?.open()}
+							onclick={() => expansionPanel?.open()}
 							disabled={!composerText.trim() || !!streamingMessageId}
 							data-testid="lq-ai-enhance-btn"
 							data-enhance-mode={enhanceIsRefine ? 'refine' : 'enhance'}
 						>
-							✨
-						</button>
-						<button
-							type="button"
-							class="lq-btn-secondary text-sm"
+							<IconSparkles size={16} />
+						</LqButton>
+						<LqButton
+							size="sm"
+							variant={receiptsDrawerOpen ? 'filled' : 'outline'}
 							aria-label="Toggle receipts drawer"
 							title="Toggle receipts"
 							on:click={() => (receiptsDrawerOpen = !receiptsDrawerOpen)}
 							data-testid="lq-ai-receipts-toggle"
 						>
-							📜
-						</button>
-						<button
-							type="button"
-							class="lq-btn-send text-sm font-medium disabled:opacity-50"
+							<IconReceipt size={16} />
+						</LqButton>
+						<LqButton
+							size="sm"
 							on:click={sendMessage}
 							disabled={!composerText.trim()}
 							data-testid="lq-ai-send-btn"
 						>
 							Send
-						</button>
+						</LqButton>
+						</LqGroup>
 					{/if}
-				</div>
+				</LqGroup>
 
 				<EnhancePromptExpansion
 					bind:this={expansionPanel}
@@ -1154,7 +1148,7 @@
 					onKeepOriginal={handleKeepOriginal}
 					onDismiss={handleEnhanceDismiss}
 				/>
-			</div>
+			</LqStack>
 		{/if}
 		<AmbientFooter provider={footerProvider} tier={footerTier} />
 	</section>
@@ -1232,52 +1226,4 @@
 		color: var(--lq-text-tertiary);
 	}
 
-	.lq-btn-send {
-		background: var(--lq-accent);
-		color: white;
-		border: 0;
-		border-radius: var(--lq-radius);
-		padding: 8px 16px;
-		cursor: pointer;
-	}
-	.lq-btn-send:hover {
-		filter: brightness(0.95);
-	}
-	.lq-btn-send:focus-visible {
-		outline: 2px solid var(--lq-accent);
-		outline-offset: 2px;
-	}
-
-	.lq-btn-abort {
-		background: #dc2626;
-		color: white;
-		border: 0;
-		border-radius: var(--lq-radius);
-		padding: 8px 16px;
-		cursor: pointer;
-	}
-	.lq-btn-abort:hover {
-		filter: brightness(0.95);
-	}
-
-	.lq-btn-secondary {
-		background: white;
-		color: var(--lq-accent);
-		border: 1px solid var(--lq-accent-border);
-		border-radius: var(--lq-radius);
-		padding: 8px 12px;
-		font-size: 14px;
-		cursor: pointer;
-	}
-	.lq-btn-secondary:hover {
-		background: var(--lq-accent-soft);
-	}
-	.lq-btn-secondary:disabled {
-		opacity: 0.5;
-		cursor: default;
-	}
-	.lq-btn-secondary:focus-visible {
-		outline: 2px solid var(--lq-accent);
-		outline-offset: 2px;
-	}
 </style>

--- a/web/src/lib/lq-ai/components/CitationLedgerPanel.svelte
+++ b/web/src/lib/lq-ai/components/CitationLedgerPanel.svelte
@@ -1,21 +1,20 @@
 <script lang="ts">
 	/**
-	 * CitationLedgerPanel — fiduciary-grade citation trace modal (P1-C1).
+	 * CitationLedgerPanel — fiduciary-grade citation trace display (P1-C1).
 	 *
-	 * Modal structure mirrors TierDetailsPanel.svelte (fixed inset-0 z-50,
-	 * backdrop click and Esc-to-close via onMount document listener, role="dialog"
-	 * aria-modal). Header carries the gateBadge TrustPill + InfoTip + per-tier
-	 * counts. Body is a list of LedgerEntryRow components.
+	 * Header carries the gateBadge TrustPill + InfoTip + per-tier counts.
+	 * Body is a list of LedgerEntryRow components.
+	 *
+	 * Pure display — no backdrop, no Esc/close handling, no `open`/`onClose`
+	 * props. Whatever renders this (a modal, a hover popover) owns the
+	 * presentation entirely.
 	 *
 	 * Props:
 	 *   entries  — ledger entries for this message turn.
 	 *   gate     — gate verdict row (undefined when no gate was computed).
-	 *   open     — whether the panel is visible.
-	 *   onClose  — callback invoked on Esc or backdrop click.
 	 *
 	 * Refs ADR 0018 D4.
 	 */
-	import { onMount } from 'svelte';
 	import type { LedgerEntry, LedgerGate } from '../types';
 	import { gateBadge } from '../citations/ledger-state';
 	import TrustPill from './TrustPill.svelte';
@@ -24,84 +23,42 @@
 
 	export let entries: LedgerEntry[] = [];
 	export let gate: LedgerGate | undefined = undefined;
-	export let open = false;
-	export let onClose: () => void;
 
 	$: badge = gateBadge(gate);
-
-	function handleKeydown(event: KeyboardEvent): void {
-		if (event.key === 'Escape') onClose();
-	}
-
-	function handleBackdropClick(event: MouseEvent): void {
-		if (event.target === event.currentTarget) onClose();
-	}
-
-	$: if (typeof document !== 'undefined') {
-		if (open) document.addEventListener('keydown', handleKeydown);
-		else document.removeEventListener('keydown', handleKeydown);
-	}
-
-	onMount(() => () => document.removeEventListener('keydown', handleKeydown));
 </script>
 
-{#if open}
-	<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-		on:click={handleBackdropClick}
-		on:keydown={handleKeydown}
-		role="dialog"
-		aria-modal="true"
-		aria-label="Citation ledger"
-		tabindex="-1"
-		data-testid="lq-ledger-backdrop"
-	>
-		<!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
-		<div
-			class="bg-white dark:bg-gray-900 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-lg w-full lq-ledger-panel"
-			on:click|stopPropagation
-			data-testid="lq-ledger-panel"
-		>
-			<header class="lq-ledger-header">
-				<div class="lq-ledger-header-top">
-					{#if badge}
-						<TrustPill variant="audit" tone={badge.tone} label={badge.label} />
-						<InfoTip content={badge.tip} />
-					{:else}
-						<span class="lq-ledger-no-gate">No gate verdict</span>
-					{/if}
-					<button
-						type="button"
-						class="lq-ledger-close"
-						on:click={onClose}
-						aria-label="Close citation ledger"
-						data-testid="lq-ledger-close"
-					>
-						&times;
-					</button>
-				</div>
-				{#if gate}
-					<p class="lq-ledger-counts">
-						{gate.pass_count} verbatim · {gate.supported_count} supported · {gate.fail_count} unverified
-					</p>
-				{/if}
-			</header>
-
-			<div class="lq-ledger-body">
-				{#if entries.length > 0}
-					<ul class="lq-ledger-list">
-						{#each entries as e (e.id)}
-							<LedgerEntryRow entry={e} />
-						{/each}
-					</ul>
-				{:else}
-					<p class="lq-ledger-empty">No sources were brought into context for this turn.</p>
-				{/if}
-			</div>
+<div
+	class="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 max-w-lg lq-ledger-panel"
+	data-testid="lq-ledger-panel"
+>
+	<header class="lq-ledger-header">
+		<div class="lq-ledger-header-top">
+			{#if badge}
+				<TrustPill variant="audit" tone={badge.tone} label={badge.label} />
+				<InfoTip content={badge.tip} />
+			{:else}
+				<span class="lq-ledger-no-gate">No gate verdict</span>
+			{/if}
 		</div>
+		{#if gate}
+			<p class="lq-ledger-counts">
+				{gate.pass_count} verbatim · {gate.supported_count} supported · {gate.fail_count} unverified
+			</p>
+		{/if}
+	</header>
+
+	<div class="lq-ledger-body">
+		{#if entries.length > 0}
+			<ul class="lq-ledger-list">
+				{#each entries as e (e.id)}
+					<LedgerEntryRow entry={e} />
+				{/each}
+			</ul>
+		{:else}
+			<p class="lq-ledger-empty">No sources were brought into context for this turn.</p>
+		{/if}
 	</div>
-{/if}
+</div>
 
 <style>
 	.lq-ledger-panel {
@@ -130,25 +87,6 @@
 		font-size: 13px;
 		color: var(--lq-text-tertiary);
 		font-style: italic;
-	}
-
-	.lq-ledger-close {
-		margin-left: auto;
-		background: transparent;
-		border: none;
-		font-size: 1.25rem;
-		line-height: 1;
-		color: var(--lq-text-secondary);
-		cursor: pointer;
-		padding: 0 2px;
-		border-radius: var(--lq-radius-sm);
-	}
-	.lq-ledger-close:hover {
-		color: var(--lq-text);
-	}
-	.lq-ledger-close:focus-visible {
-		outline: 2px solid var(--lq-accent);
-		outline-offset: 2px;
 	}
 
 	.lq-ledger-counts {

--- a/web/src/lib/lq-ai/components/EnhancedDiffModal.svelte
+++ b/web/src/lib/lq-ai/components/EnhancedDiffModal.svelte
@@ -23,75 +23,42 @@
 	 * via `diff-match-patch`) is a v1.1+ refinement; the SBOM does not
 	 * currently include that dep and adding it for a single operator
 	 * inspection surface is not justified per CLAUDE.md guidance.
+	 *
+	 * Pure display — no backdrop, no Esc/close handling, no dispatched
+	 * events. Whatever renders this (a modal, a hover popover) owns the
+	 * presentation; this component owns none of it.
 	 */
-	import { createEventDispatcher } from 'svelte';
-
 	export let original: string | undefined = undefined;
 	export let enhanced: string;
-
-	const dispatch = createEventDispatcher<{ close: void }>();
-
-	function close(): void {
-		dispatch('close');
-	}
-
-	function handleKey(e: KeyboardEvent): void {
-		if (e.key === 'Escape') close();
-	}
 </script>
 
-<svelte:window on:keydown={handleKey} />
+<div class="diff-panel" data-testid="enhanced-diff-modal">
+	<header>
+		<h2 id="enhanced-diff-title">✨ Enhance Prompt — original vs. enhanced</h2>
+	</header>
 
-<div
-	class="diff-overlay"
-	role="dialog"
-	aria-modal="true"
-	aria-labelledby="enhanced-diff-title"
-	data-testid="enhanced-diff-modal"
-	tabindex="-1"
-	on:click|self={close}
-	on:keydown|self={(e) => {
-		if (e.key === 'Enter' || e.key === ' ') close();
-	}}
->
-	<div class="diff-panel">
-		<header>
-			<h2 id="enhanced-diff-title">✨ Enhance Prompt — original vs. enhanced</h2>
-			<button class="close" on:click={close} aria-label="Close" data-testid="enhanced-diff-close">×</button>
-		</header>
+	<div class="cols">
+		<section>
+			<h3>Original</h3>
+			{#if original !== undefined && original !== ''}
+				<pre data-testid="enhanced-diff-original">{original}</pre>
+			{:else}
+				<p class="empty" data-testid="enhanced-diff-original-missing">
+					Original prompt not preserved — only the enhanced version was
+					committed at send time. (Earlier-session originals are not
+					currently persisted server-side. v1.1+ refinement candidate.)
+				</p>
+			{/if}
+		</section>
 
-		<div class="cols">
-			<section>
-				<h3>Original</h3>
-				{#if original !== undefined && original !== ''}
-					<pre data-testid="enhanced-diff-original">{original}</pre>
-				{:else}
-					<p class="empty" data-testid="enhanced-diff-original-missing">
-						Original prompt not preserved — only the enhanced version was
-						committed at send time. (Earlier-session originals are not
-						currently persisted server-side. v1.1+ refinement candidate.)
-					</p>
-				{/if}
-			</section>
-
-			<section>
-				<h3>Enhanced</h3>
-				<pre data-testid="enhanced-diff-enhanced">{enhanced}</pre>
-			</section>
-		</div>
+		<section>
+			<h3>Enhanced</h3>
+			<pre data-testid="enhanced-diff-enhanced">{enhanced}</pre>
+		</section>
 	</div>
 </div>
 
 <style>
-	.diff-overlay {
-		position: fixed;
-		inset: 0;
-		background: rgba(15, 23, 42, 0.55);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		z-index: 60;
-	}
 	.diff-panel {
 		background: #fff;
 		border-radius: 8px;
@@ -99,7 +66,6 @@
 		max-height: 80vh;
 		display: flex;
 		flex-direction: column;
-		box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
 	}
 	header {
 		display: flex;
@@ -113,14 +79,6 @@
 		font-weight: 600;
 		margin: 0;
 		color: #111827;
-	}
-	.close {
-		background: transparent;
-		border: 0;
-		font-size: 22px;
-		color: #6b7280;
-		cursor: pointer;
-		padding: 0 6px;
 	}
 	.cols {
 		display: grid;

--- a/web/src/lib/lq-ai/components/MessageBubble.svelte
+++ b/web/src/lib/lq-ai/components/MessageBubble.svelte
@@ -29,6 +29,11 @@
 	import M2Citations from './M2Citations.svelte';
 	import MessageOverflowMenu from './MessageOverflowMenu.svelte';
 	import ProvenancePill from './ProvenancePill.svelte';
+	import LqGroup from './shared/LqGroup.svelte';
+	import LqStack from './shared/LqStack.svelte';
+	import LqHoverCard from './shared/LqHoverCard';
+	import LqAlert from './shared/LqAlert.svelte';
+	import LqButton from './shared/LqButton.svelte';
 	import RefusalMessageBubble from './RefusalMessageBubble.svelte';
 	import TierBadge from './TierBadge.svelte';
 	import TierDetailsPanel from './TierDetailsPanel.svelte';
@@ -37,6 +42,7 @@
 	import CitationLedgerPanel from './CitationLedgerPanel.svelte';
 	import TrustPill from './TrustPill.svelte';
 	import type { PendingGate } from '../chat/toolGate';
+	import { IconEdit } from '@tabler/icons-svelte';
 
 	export let message: Message;
 	export let isStreaming: boolean = false;
@@ -69,17 +75,11 @@
 	export let onGateDeny: () => void = () => {};
 	export let onGateConnect: () => void = () => {};
 
-	// D2: tier badge opens a click-for-details panel surfacing the
-	// resolved provider/model + token usage. Per PRD §1.3 the user
-	// can always answer "what just ran?" from the message they
-	// received. State stays local to this bubble so multiple open
-	// panels are not possible (the modal is exclusive).
-	let tierDetailsOpen = false;
+	// D2: tier badge surfaces routing info via a hover popover (LqHoverCard) —
+	// replaces the earlier click-for-details modal for this spot. Description
+	// text comes from TIER_DESCRIPTIONS (chat/tierDescriptions.ts), the same
+	// source TierBadge and TierDetailsPanel use.
 
-	// Wave D.1 T20 follow-on — ✨ enhanced pill state. Per-message-local
-	// so the diff modal is exclusive: clicking the pill on one message
-	// does not surface another message's diff.
-	let enhancedDiffOpen = false;
 
 	// Wave D.2 Task 5.3 — capture-as-skill modal trigger. Per-message-local
 	// so each bubble owns its own modal instance and the right
@@ -171,7 +171,6 @@
 	// means "fetched, no rows". Degrades silently on error.
 	let fetchedLedger: ChatLedger | null = null;
 	let ledgerFetchInflight = false;
-	let ledgerPanelOpen = false;
 
 	async function loadLedger(chatId: string, messageId: string): Promise<void> {
 		ledgerFetchInflight = true;
@@ -213,7 +212,7 @@
 </script>
 
 {#if message.kind === 'refusal'}
-	<div class="flex flex-col max-w-3xl items-start mb-3" data-testid={`lq-ai-message-${message.id}`}>
+	<LqStack gap={0} align="flex-start" maxWidth="48rem" data-testid={`lq-ai-message-${message.id}`}>
 		<RefusalMessageBubble
 			{message}
 			{currentUserRole}
@@ -221,10 +220,12 @@
 			onOverrideRequested={() => onRefusalOverrideRequested(message)}
 			onExplainerRequested={() => onRefusalExplainerRequested(message)}
 		/>
-	</div>
+	</LqStack>
 {:else}
-	<div
-		class="flex flex-col max-w-3xl {message.role === 'user' ? 'items-end' : 'items-start'} mb-3"
+	<LqStack
+		gap="sm"
+		align={message.role === 'user' ? 'flex-end' : 'flex-start'}
+		maxWidth="48rem"
 		data-testid={`lq-ai-message-${message.id}`}
 	>
 		<div class="rounded-lg px-3 py-2 {bubbleClasses} max-w-full">
@@ -250,7 +251,7 @@
 		</div>
 
 		{#if gateForMessage}
-			<div class="mt-2 w-full max-w-full" data-testid="lq-ai-tool-gate">
+			<div class="w-full" data-testid="lq-ai-tool-gate">
 				<ToolGatePrompt
 					variant={gateForMessage.kind}
 					confirm={gateForMessage.kind === 'confirm' ? gateForMessage.frame : null}
@@ -264,34 +265,42 @@
 		{/if}
 
 		{#if message.role === 'user' && message.is_enhanced}
-			<div
-				class="mt-1 flex items-center gap-2 flex-wrap justify-end"
-				data-testid="provenance-pill-enhanced"
-			>
-				<ProvenancePill
-					kind="enhanced"
-					summary="enhanced"
-					onTap={() => (enhancedDiffOpen = true)}
-				/>
-			</div>
-			{#if enhancedDiffOpen}
-				<EnhancedDiffModal
-					original={originalEnhancedPrompt}
-					enhanced={message.content}
-					on:close={() => (enhancedDiffOpen = false)}
-				/>
-			{/if}
+			<LqGroup gap="sm" justify="flex-end" class="w-full" data-testid="provenance-pill-enhanced">
+				<LqHoverCard>
+					<LqHoverCard.Target>
+						<ProvenancePill kind="enhanced" summary="enhanced" />
+					</LqHoverCard.Target>
+					<LqHoverCard.Dropdown padding={0} width="min(900px, 90vw)">
+						<EnhancedDiffModal original={originalEnhancedPrompt} enhanced={message.content} />
+					</LqHoverCard.Dropdown>
+				</LqHoverCard>
+			</LqGroup>
 		{/if}
 
 		{#if message.role === 'assistant'}
-			<div class="mt-1 flex items-center gap-2 flex-wrap justify-start w-full">
-				<div class="flex items-center gap-2 flex-wrap">
+			<LqGroup gap="sm">
+				<LqGroup gap="sm">
 					{#if message.routed_inference_tier}
-						<TierBadge
-							tier={message.routed_inference_tier}
-							provider={message.routed_provider ?? null}
-							on:open={() => (tierDetailsOpen = true)}
-						/>
+						<LqHoverCard>
+							<LqHoverCard.Target>
+								<TierBadge
+									tier={message.routed_inference_tier}
+									provider={message.routed_provider ?? null}
+									interactive={false}
+								/>
+							</LqHoverCard.Target>
+							<LqHoverCard.Dropdown padding={0}>
+								<TierDetailsPanel
+									tier={message.routed_inference_tier ?? null}
+									provider={message.routed_provider ?? null}
+									model={message.routed_model ?? null}
+									requestedModel={message.requested_model ?? null}
+									promptTokens={message.prompt_tokens ?? null}
+									completionTokens={message.completion_tokens ?? null}
+									costEstimate={message.cost_estimate ?? null}
+								/>
+							</LqHoverCard.Dropdown>
+						</LqHoverCard>
 					{/if}
 					<AppliedSkillsChip
 						appliedSkills={message.applied_skills ?? []}
@@ -301,19 +310,21 @@
 						<ProvenancePill kind="caselaw" summary={sourcesPillLabel(fetchedSources.length)} />
 					{/if}
 					{#if ledgerBadge && (fetchedLedger?.entries.length || ledgerGate)}
-						<TrustPill
-							variant="audit"
-							tone={ledgerBadge.tone}
-							label={ledgerBadge.label}
-							onClick={() => (ledgerPanelOpen = true)}
-						/>
+						<LqHoverCard>
+							<LqHoverCard.Target>
+								<TrustPill variant="audit" tone={ledgerBadge.tone} label={ledgerBadge.label} />
+							</LqHoverCard.Target>
+							<LqHoverCard.Dropdown padding={0}>
+								<CitationLedgerPanel entries={fetchedLedger?.entries ?? []} gate={ledgerGate} />
+							</LqHoverCard.Dropdown>
+						</LqHoverCard>
 					{/if}
-				</div>
-				<div class="flex items-center gap-1">
+				</LqGroup>
+				<LqGroup gap="xs" wrap="nowrap">
 					{#if $captureAffordanceInline}
-						<button
-							type="button"
-							class="text-base leading-none px-2 py-1 rounded text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+						<LqButton
+							tone="neutral"
+							size="sm"
 							aria-label={isStreaming
 								? 'Capture as skill (available when streaming completes)'
 								: 'Capture as skill'}
@@ -322,42 +333,28 @@
 								: 'Capture as skill'}
 							disabled={isStreaming}
 							data-testid="lq-ai-message-capture-inline"
-							on:click={() => (captureOpen = true)}>📝</button
+							on:click={() => (captureOpen = true)}
 						>
+							<IconEdit size="12" />
+						</LqButton>
 					{/if}
 					<MessageOverflowMenu
 						captureInOverflow={!$captureAffordanceInline}
 						captureDisabled={isStreaming}
 						onCapture={() => (captureOpen = true)}
 					/>
-				</div>
-			</div>
+				</LqGroup>
+			</LqGroup>
 
 			{#if captureOpen}
 				<CaptureSkillModal sourceMessage={message} onClose={() => (captureOpen = false)} />
 			{/if}
 
-			{#if tierDetailsOpen}
-				<TierDetailsPanel
-					tier={message.routed_inference_tier ?? null}
-					provider={message.routed_provider ?? null}
-					model={message.routed_model ?? null}
-					requestedModel={message.requested_model ?? null}
-					promptTokens={message.prompt_tokens ?? null}
-					completionTokens={message.completion_tokens ?? null}
-					costEstimate={message.cost_estimate ?? null}
-					on:close={() => (tierDetailsOpen = false)}
-				/>
-			{/if}
-
 			{#if message.error_code}
-				<div
-					class="mt-2 px-2 py-1 rounded border border-rose-300 bg-rose-50 text-rose-800 text-xs max-w-full"
-					data-testid="lq-ai-message-error"
-				>
+				<LqAlert tone="red" data-testid="lq-ai-message-error">
 					Error: <strong>{message.error_code}</strong>. The assistant message was persisted with the
 					partial content above for audit.
-				</div>
+				</LqAlert>
 			{/if}
 
 			<!--
@@ -378,15 +375,6 @@
 			{#if fetchedSources && fetchedSources.length > 0}
 				<ToolSourcesPanel sources={fetchedSources} />
 			{/if}
-
-			{#if fetchedLedger}
-				<CitationLedgerPanel
-					entries={fetchedLedger.entries}
-					gate={ledgerGate}
-					open={ledgerPanelOpen}
-					onClose={() => (ledgerPanelOpen = false)}
-				/>
-			{/if}
 		{/if}
-	</div>
+	</LqStack>
 {/if}

--- a/web/src/lib/lq-ai/components/MessageList.svelte
+++ b/web/src/lib/lq-ai/components/MessageList.svelte
@@ -4,6 +4,7 @@
 	import type { Message } from '../types';
 	import type { PendingGate } from '../chat/toolGate';
 	import MessageBubble from './MessageBubble.svelte';
+	import LqStack from './shared/LqStack.svelte';
 
 	export let messages: Message[] = [];
 	export let streamingMessageId: string | null = null;
@@ -47,26 +48,28 @@
 
 <div
 	bind:this={scroller}
-	class="flex-1 overflow-y-auto px-4 py-4 flex flex-col"
+	class="flex-1 overflow-y-auto px-4 py-4"
 	data-testid="lq-ai-message-list"
 >
-	{#each messages as msg (msg.id)}
-		<MessageBubble
-			message={msg}
-			isStreaming={streamingMessageId === msg.id}
-			{onAppliedSkillClicked}
-			{currentUserRole}
-			{onRefusalRerun}
-			{onRefusalOverrideRequested}
-			{onRefusalExplainerRequested}
-			originalEnhancedPrompt={enhancementOriginals[msg.content]}
-			gateForMessage={pendingGate && pendingGate.assistantId === msg.id ? pendingGate : null}
-			{gateBusy}
-			{onGateApprove}
-			{onGateDeny}
-			{onGateConnect}
-		/>
-	{/each}
+	<LqStack gap={12}>
+		{#each messages as msg (msg.id)}
+			<MessageBubble
+				message={msg}
+				isStreaming={streamingMessageId === msg.id}
+				{onAppliedSkillClicked}
+				{currentUserRole}
+				{onRefusalRerun}
+				{onRefusalOverrideRequested}
+				{onRefusalExplainerRequested}
+				originalEnhancedPrompt={enhancementOriginals[msg.content]}
+				gateForMessage={pendingGate && pendingGate.assistantId === msg.id ? pendingGate : null}
+				{gateBusy}
+				{onGateApprove}
+				{onGateDeny}
+				{onGateConnect}
+			/>
+		{/each}
+	</LqStack>
 
 	{#if messages.length === 0}
 		<div class="flex-1 flex items-center justify-center text-gray-400 text-sm italic">

--- a/web/src/lib/lq-ai/components/ProvenancePill.svelte
+++ b/web/src/lib/lq-ai/components/ProvenancePill.svelte
@@ -31,7 +31,7 @@
 		audit:
 			'Audit log — this action was recorded for compliance and review. Click to view the entry.',
 		enhanced:
-			'Enhanced Prompt — the AI rewrote your short prompt into a structured legal prompt before answering. Click to compare.',
+			'Enhanced Prompt — the AI rewrote your short prompt into a structured legal prompt before answering. Hover to compare.',
 		caselaw:
 			'Case law — this answer drew on external legal sources (e.g. CourtListener). Click to view sources consulted.'
 	};

--- a/web/src/lib/lq-ai/components/TierBadge.svelte
+++ b/web/src/lib/lq-ai/components/TierBadge.svelte
@@ -13,17 +13,14 @@
 	 * The component continues to dispatch a Svelte "open" event so existing
 	 * callers using `on:open` don't need to change.
 	 *
-	 * Tone mapping (closest match from TrustPill's palette):
-	 *   Tier 1 (was emerald) → sage
-	 *   Tier 2 (was sky)     → neutral
-	 *   Tier 3 (was amber)   → amber
-	 *   Tier 4 (was orange)  → amber
-	 *   Tier 5 (was rose)    → red
-	 *   unknown              → neutral
+	 * Tone + description per tier come from `chat/tierDescriptions.ts` — the
+	 * single source of truth also consumed by TierDetailsPanel and
+	 * MessageBubble's tier hover-popover, so the three don't drift.
 	 */
 	import { createEventDispatcher } from 'svelte';
 	import TrustPill from './TrustPill.svelte';
 	import type { TrustTone } from './TrustPill.svelte';
+	import { TIER_DESCRIPTIONS } from '../chat/tierDescriptions';
 
 	export let tier: 1 | 2 | 3 | 4 | 5 | null | undefined = null;
 	export let provider: string | null | undefined = null;
@@ -37,31 +34,11 @@
 
 	const dispatch = createEventDispatcher<{ open: void }>();
 
-	const tierTone: Record<number, TrustTone> = {
-		1: 'sage',
-		2: 'neutral',
-		3: 'amber',
-		4: 'amber',
-		5: 'red'
-	};
-
-	/**
-	 * Plain-English description per tier — surfaced in the hover title so
-	 * non-technical users learn what each tier means without having to
-	 * click through to the TierDetailsPanel. Matches the framing in PRD
-	 * §1.5.2 (lower number = stronger security).
-	 */
-	const tierDescription: Record<number, string> = {
-		1: 'Local-only inference — runs on this computer. Your data never leaves the deployment.',
-		2: 'Customer-hosted cloud inference — runs in your own cloud account.',
-		3: 'Enterprise managed inference — provider has signed ZDR / no-training commitments.',
-		4: 'Standard cloud API — provider terms govern data handling.',
-		5: 'Consumer or free tier — the provider may train on your data.'
-	};
-
 	$: label = tier ? `Tier ${tier}` : 'Tier ?';
-	$: tone = (tier ? tierTone[tier] : 'neutral') as TrustTone;
-	$: description = tier ? tierDescription[tier] : 'Tier unknown — routing source not yet resolved.';
+	$: tone = (tier ? TIER_DESCRIPTIONS[tier].tone : 'neutral') as TrustTone;
+	$: description = tier
+		? TIER_DESCRIPTIONS[tier].blurb
+		: 'Tier unknown — routing source not yet resolved.';
 	$: title = provider
 		? `${label} — ${provider}\n${description}\n(click for details)`
 		: `${label}\n${description}\n(click for details)`;

--- a/web/src/lib/lq-ai/components/TierDetailsPanel.svelte
+++ b/web/src/lib/lq-ai/components/TierDetailsPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	/**
-	 * Click-for-details panel that opens from TierBadge — D2.
+	 * Tier details display panel — D2.
 	 *
 	 * The transparency principle (PRD §1.3 + ADR 0011) requires every
 	 * user to be able to answer "what just ran?" for any assistant
@@ -10,12 +10,12 @@
 	 *   • Resolved provider + model.
 	 *   • Token usage + cost estimate (when populated).
 	 *
-	 * The panel is a focus-trapped modal — small + intentionally
-	 * lightweight. Clicking outside or pressing Esc closes it. The
-	 * close button has data-testid for the D2 e2e smoke.
+	 * Pure display — no backdrop, no close button, no keyboard/click
+	 * handling, no dispatched events. It's rendered as-is by whatever
+	 * container the caller chooses (a modal, a hover popover, an inline
+	 * panel); this component owns none of that presentation.
 	 */
-	import { createEventDispatcher } from 'svelte';
-	import { onMount } from 'svelte';
+	import { TIER_DESCRIPTIONS } from '../chat/tierDescriptions';
 
 	export let tier: 1 | 2 | 3 | 4 | 5 | null | undefined = null;
 	export let provider: string | null | undefined = null;
@@ -31,37 +31,7 @@
 	export let completionTokens: number | null | undefined = null;
 	export let costEstimate: number | null | undefined = null;
 
-	const dispatch = createEventDispatcher<{ close: void }>();
-
-	const tierDescriptions: Record<number, { label: string; blurb: string }> = {
-		1: {
-			label: 'Tier 1 — On-prem / air-gapped',
-			blurb:
-				'Inference ran fully inside your environment. No data left the deployment. Local Ollama or self-hosted LLM.'
-		},
-		2: {
-			label: 'Tier 2 — Private cloud (no provider data retention)',
-			blurb:
-				'Inference ran in your private cloud account; the provider has contractual zero-data-retention. Bedrock / Vertex with appropriate agreements.'
-		},
-		3: {
-			label: 'Tier 3 — Commercial enterprise (ZDR addendum)',
-			blurb:
-				'Commercial provider account with a zero-data-retention enterprise agreement. Anthropic / OpenAI enterprise tier with ZDR.'
-		},
-		4: {
-			label: 'Tier 4 — Standard commercial API',
-			blurb:
-				'Standard commercial API account. The provider may retain prompts for abuse review per their published policy.'
-		},
-		5: {
-			label: 'Tier 5 — Consumer / free-tier API',
-			blurb:
-				'Consumer or free-tier API. The provider likely retains prompts and may use them to train future models. Avoid for privileged content.'
-		}
-	};
-
-	$: tierInfo = tier ? tierDescriptions[tier] : null;
+	$: tierInfo = tier ? TIER_DESCRIPTIONS[tier] : null;
 	$: routedPair = provider && model ? `${provider}/${model}` : null;
 	$: providerModelLine =
 		provider && model
@@ -82,121 +52,82 @@
 		requestedModel != null && requestedModel !== '' && requestedModel !== routedPair;
 	$: showTokens = promptTokens != null || completionTokens != null;
 	$: showCost = costEstimate != null && costEstimate > 0;
-
-	function handleKeydown(event: KeyboardEvent): void {
-		if (event.key === 'Escape') dispatch('close');
-	}
-
-	function handleBackdropClick(event: MouseEvent): void {
-		// Only the backdrop (not the panel itself) dispatches close.
-		if (event.target === event.currentTarget) dispatch('close');
-	}
-
-	onMount(() => {
-		document.addEventListener('keydown', handleKeydown);
-		return () => document.removeEventListener('keydown', handleKeydown);
-	});
 </script>
 
 <div
-	class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-	on:click={handleBackdropClick}
-	on:keydown={handleKeydown}
-	role="dialog"
-	aria-modal="true"
-	aria-labelledby="lq-ai-tier-details-title"
-	tabindex="-1"
-	data-testid="lq-ai-tier-details-backdrop"
+	class="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 max-w-md p-4 space-y-3"
+	data-testid="lq-ai-tier-details-panel"
 >
-	<div
-		class="bg-white dark:bg-gray-900 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-md w-full p-4 space-y-3"
-		data-testid="lq-ai-tier-details-panel"
-	>
-		<div class="flex items-start justify-between gap-2">
-			<h3
-				id="lq-ai-tier-details-title"
-				class="text-sm font-semibold text-gray-900 dark:text-gray-100"
-			>
-				{tierInfo?.label ?? 'Inference details'}
-			</h3>
-			<button
-				type="button"
-				class="text-gray-500 hover:text-gray-800 dark:hover:text-gray-200 text-lg leading-none"
-				on:click={() => dispatch('close')}
-				aria-label="Close"
-				data-testid="lq-ai-tier-details-close"
-			>
-				&times;
-			</button>
-		</div>
+	<h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+		{tierInfo?.label ?? 'Inference details'}
+	</h3>
 
-		{#if tierInfo}
-			<p class="text-xs text-gray-600 dark:text-gray-300">{tierInfo.blurb}</p>
-		{:else}
-			<p class="text-xs text-gray-600 dark:text-gray-300">
-				This message did not record a routed inference tier. Older messages
-				and messages from before D1 / B5 do not carry this metadata.
-			</p>
-		{/if}
+	{#if tierInfo}
+		<p class="text-xs text-gray-600 dark:text-gray-300">{tierInfo.blurb}</p>
+	{:else}
+		<p class="text-xs text-gray-600 dark:text-gray-300">
+			This message did not record a routed inference tier. Older messages
+			and messages from before D1 / B5 do not carry this metadata.
+		</p>
+	{/if}
 
-		{#if showRequestedDelta}
-			<div class="border-t border-gray-200 dark:border-gray-800 pt-2">
-				<div class="text-[10px] uppercase tracking-wide text-gray-500">Requested</div>
-				<div
-					class="text-sm font-mono text-gray-800 dark:text-gray-100"
-					data-testid="lq-ai-tier-details-requested-model"
-				>
-					{requestedModel}
-				</div>
-				<div class="text-[10px] text-gray-500 italic mt-0.5">
-					Resolved server-side per ADR 0011.
-				</div>
-			</div>
-		{/if}
-
+	{#if showRequestedDelta}
 		<div class="border-t border-gray-200 dark:border-gray-800 pt-2">
-			<div class="text-[10px] uppercase tracking-wide text-gray-500">
-				{showRequestedDelta ? 'Routed to' : 'Provider / model'}
-			</div>
+			<div class="text-[10px] uppercase tracking-wide text-gray-500">Requested</div>
 			<div
 				class="text-sm font-mono text-gray-800 dark:text-gray-100"
-				data-testid="lq-ai-tier-details-provider-model"
+				data-testid="lq-ai-tier-details-requested-model"
 			>
-				{providerModelLine}
+				{requestedModel}
+			</div>
+			<div class="text-[10px] text-gray-500 italic mt-0.5">
+				Resolved server-side per ADR 0011.
 			</div>
 		</div>
+	{/if}
 
-		{#if showTokens || showCost}
-			<div class="border-t border-gray-200 dark:border-gray-800 pt-2 grid grid-cols-2 gap-2">
-				{#if promptTokens != null}
-					<div>
-						<div class="text-[10px] uppercase tracking-wide text-gray-500">Prompt tokens</div>
-						<div class="text-sm font-mono text-gray-800 dark:text-gray-100">{promptTokens}</div>
-					</div>
-				{/if}
-				{#if completionTokens != null}
-					<div>
-						<div class="text-[10px] uppercase tracking-wide text-gray-500">Completion tokens</div>
-						<div class="text-sm font-mono text-gray-800 dark:text-gray-100">{completionTokens}</div>
-					</div>
-				{/if}
-				{#if showCost}
-					<div class="col-span-2">
-						<div class="text-[10px] uppercase tracking-wide text-gray-500">Cost estimate</div>
-						<div class="text-sm font-mono text-gray-800 dark:text-gray-100">
-							${costEstimate?.toFixed(4)}
-						</div>
-					</div>
-				{/if}
-			</div>
-		{/if}
-
-		<div class="border-t border-gray-200 dark:border-gray-800 pt-2">
-			<p class="text-[11px] text-gray-500 italic">
-				Per the transparency principle (PRD §1.3): every artifact that shapes
-				your output is visible. The router decision behind this message is one
-				of those artifacts.
-			</p>
+	<div class="border-t border-gray-200 dark:border-gray-800 pt-2">
+		<div class="text-[10px] uppercase tracking-wide text-gray-500">
+			{showRequestedDelta ? 'Routed to' : 'Provider / model'}
 		</div>
+		<div
+			class="text-sm font-mono text-gray-800 dark:text-gray-100"
+			data-testid="lq-ai-tier-details-provider-model"
+		>
+			{providerModelLine}
+		</div>
+	</div>
+
+	{#if showTokens || showCost}
+		<div class="border-t border-gray-200 dark:border-gray-800 pt-2 grid grid-cols-2 gap-2">
+			{#if promptTokens != null}
+				<div>
+					<div class="text-[10px] uppercase tracking-wide text-gray-500">Prompt tokens</div>
+					<div class="text-sm font-mono text-gray-800 dark:text-gray-100">{promptTokens}</div>
+				</div>
+			{/if}
+			{#if completionTokens != null}
+				<div>
+					<div class="text-[10px] uppercase tracking-wide text-gray-500">Completion tokens</div>
+					<div class="text-sm font-mono text-gray-800 dark:text-gray-100">{completionTokens}</div>
+				</div>
+			{/if}
+			{#if showCost}
+				<div class="col-span-2">
+					<div class="text-[10px] uppercase tracking-wide text-gray-500">Cost estimate</div>
+					<div class="text-sm font-mono text-gray-800 dark:text-gray-100">
+						${costEstimate?.toFixed(4)}
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<div class="border-t border-gray-200 dark:border-gray-800 pt-2">
+		<p class="text-[11px] text-gray-500 italic">
+			Per the transparency principle (PRD §1.3): every artifact that shapes
+			your output is visible. The router decision behind this message is one
+			of those artifacts.
+		</p>
 	</div>
 </div>

--- a/web/src/lib/lq-ai/components/shared/LqAlert.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqAlert.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	/**
+	 * LqAlert — inline status banner, modeled on Mantine's Alert.
+	 *
+	 * Takes `tone` only for now (the bundled soft-bg/text/border look, same
+	 * as LqButton/LqPill) rather than the lower-level `color`+`shade` pair
+	 * from `./types` — nothing here needs finer control than a whole tone
+	 * yet. If that changes, `color`+`shade` props can be added alongside
+	 * `tone` without breaking existing callers.
+	 */
+	import { IconX } from '@tabler/icons-svelte';
+	import type { LqTone } from './types';
+
+	export let tone: LqTone = 'neutral';
+	export let title: string | undefined = undefined;
+	export let onClose: (() => void) | undefined = undefined;
+
+	let klass = '';
+	export { klass as class };
+</script>
+
+<div {...$$restProps} class="lq-alert lq-alert-tone-{tone} {klass}" role="alert">
+	<div class="lq-alert-body">
+		{#if title}
+			<div class="lq-alert-title">{title}</div>
+		{/if}
+		<div class="lq-alert-message"><slot /></div>
+	</div>
+	{#if onClose}
+		<button type="button" class="lq-alert-close" aria-label="Dismiss" on:click={onClose}>
+			<IconX size={14} />
+		</button>
+	{/if}
+</div>
+
+<style>
+	.lq-alert {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--lq-space-2, 8px);
+		width: 100%;
+		box-sizing: border-box;
+		padding: var(--lq-space-2, 8px) var(--lq-space-3, 12px);
+		border-radius: var(--lq-radius, 6px);
+		border: 1px solid transparent;
+		border-left-width: 3px;
+		font-size: 13px;
+		line-height: 1.4;
+	}
+
+	.lq-alert-body {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	.lq-alert-title {
+		font-weight: 600;
+		margin-bottom: 2px;
+	}
+
+	.lq-alert-close {
+		all: unset;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		border-radius: 999px;
+		padding: 2px;
+	}
+	.lq-alert-close:hover {
+		background: rgba(0, 0, 0, 0.08);
+	}
+	.lq-alert-close:focus-visible {
+		outline: 2px solid currentColor;
+		outline-offset: 1px;
+	}
+
+	.lq-alert-tone-sage {
+		background: var(--lq-accent-soft, #e8f4ec);
+		color: var(--lq-accent, #1f7a6b);
+		border-color: var(--lq-accent-border, #c5e6d1);
+		border-left-color: var(--lq-accent, #1f7a6b);
+	}
+	.lq-alert-tone-slate {
+		background: var(--lq-tier-soft, #e8eff7);
+		color: var(--lq-tier, #355a82);
+		border-color: var(--lq-tier-border, #d4e2f1);
+		border-left-color: var(--lq-tier, #355a82);
+	}
+	.lq-alert-tone-amber {
+		background: var(--lq-warn-soft, #fdf3e2);
+		color: var(--lq-warn, #a16e1f);
+		border-color: var(--lq-warn-border, #ead9c5);
+		border-left-color: var(--lq-warn, #a16e1f);
+	}
+	.lq-alert-tone-red {
+		background: var(--lq-error-soft, #fbeaea);
+		color: var(--lq-error, #b54848);
+		border-color: var(--lq-error-border, #f1d2d2);
+		border-left-color: var(--lq-error, #b54848);
+	}
+	.lq-alert-tone-neutral {
+		background: var(--lq-inset, #fafbfa);
+		color: var(--lq-text-secondary, #4b5563);
+		border-color: var(--lq-border, #e5e7eb);
+		border-left-color: var(--lq-border-strong, #d4d4d4);
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqButton.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqButton.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import type { LqVariant, LqTone, LqSize } from './types';
+
+	export let variant: LqVariant = 'filled';
+	export let tone: LqTone = 'sage';
+	export let size: LqSize = 'md';
+	export let disabled = false;
+	export let type: 'button' | 'submit' | 'reset' = 'button';
+</script>
+
+<button
+	{type}
+	{disabled}
+	{...$$restProps}
+	class="lq-btn lq-btn-{variant} lq-btn-{size} lq-tone-{tone}"
+	on:click
+>
+	<slot />
+</button>
+
+<style>
+	.lq-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--lq-space-1, 4px);
+		border-radius: var(--lq-radius, 6px);
+		border: 1.5px solid transparent;
+		font-weight: 500;
+		line-height: 1.2;
+		cursor: pointer;
+		transition:
+			background 120ms ease,
+			border-color 120ms ease,
+			color 120ms ease,
+			filter 120ms ease;
+	}
+
+	.lq-btn:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.lq-btn:focus-visible {
+		outline: 2px solid var(--lq-accent, #1f7a6b);
+		outline-offset: 2px;
+	}
+
+	/* sizes */
+	.lq-btn-sm {
+		font-size: 12px;
+		padding: var(--lq-space-1, 4px) var(--lq-space-2, 8px);
+	}
+	.lq-btn-md {
+		font-size: 14px;
+		padding: var(--lq-space-2, 8px) var(--lq-space-4, 16px);
+	}
+	.lq-btn-lg {
+		font-size: 16px;
+		padding: var(--lq-space-3, 12px) var(--lq-space-6, 24px);
+	}
+
+	/* tone: sage */
+	.lq-tone-sage.lq-btn-filled {
+		background: var(--lq-accent, #1f7a6b);
+		color: white;
+	}
+	.lq-tone-sage.lq-btn-outline {
+		border-color: var(--lq-accent, #1f7a6b);
+		color: var(--lq-accent, #1f7a6b);
+		background: transparent;
+	}
+	.lq-tone-sage.lq-btn-subtle {
+		background: var(--lq-accent-soft, #e8f4ec);
+		color: var(--lq-accent, #1f7a6b);
+	}
+	.lq-tone-sage.lq-btn-ghost {
+		background: transparent;
+		color: var(--lq-accent, #1f7a6b);
+	}
+
+	/* tone: slate */
+	.lq-tone-slate.lq-btn-filled {
+		background: var(--lq-tier, #355a82);
+		color: white;
+	}
+	.lq-tone-slate.lq-btn-outline {
+		border-color: var(--lq-tier, #355a82);
+		color: var(--lq-tier, #355a82);
+		background: transparent;
+	}
+	.lq-tone-slate.lq-btn-subtle {
+		background: var(--lq-tier-soft, #e8eff7);
+		color: var(--lq-tier, #355a82);
+	}
+	.lq-tone-slate.lq-btn-ghost {
+		background: transparent;
+		color: var(--lq-tier, #355a82);
+	}
+
+	/* tone: amber */
+	.lq-tone-amber.lq-btn-filled {
+		background: var(--lq-warn, #a16e1f);
+		color: white;
+	}
+	.lq-tone-amber.lq-btn-outline {
+		border-color: var(--lq-warn, #a16e1f);
+		color: var(--lq-warn, #a16e1f);
+		background: transparent;
+	}
+	.lq-tone-amber.lq-btn-subtle {
+		background: var(--lq-warn-soft, #fdf3e2);
+		color: var(--lq-warn, #a16e1f);
+	}
+	.lq-tone-amber.lq-btn-ghost {
+		background: transparent;
+		color: var(--lq-warn, #a16e1f);
+	}
+
+	/* tone: red */
+	.lq-tone-red.lq-btn-filled {
+		background: var(--lq-error, #b54848);
+		color: white;
+	}
+	.lq-tone-red.lq-btn-outline {
+		border-color: var(--lq-error, #b54848);
+		color: var(--lq-error, #b54848);
+		background: transparent;
+	}
+	.lq-tone-red.lq-btn-subtle {
+		background: var(--lq-error-soft, #fbeaea);
+		color: var(--lq-error, #b54848);
+	}
+	.lq-tone-red.lq-btn-ghost {
+		background: transparent;
+		color: var(--lq-error, #b54848);
+	}
+
+	/* tone: neutral */
+	.lq-tone-neutral.lq-btn-filled {
+		background: var(--lq-text-secondary, #4b5563);
+		color: white;
+	}
+	.lq-tone-neutral.lq-btn-outline {
+		border-color: var(--lq-border-strong, #d4d4d4);
+		color: var(--lq-text, #1a1a1a);
+		background: transparent;
+	}
+	.lq-tone-neutral.lq-btn-subtle {
+		background: var(--lq-inset, #fafbfa);
+		color: var(--lq-text, #1a1a1a);
+	}
+	.lq-tone-neutral.lq-btn-ghost {
+		background: transparent;
+		color: var(--lq-text, #1a1a1a);
+	}
+
+	.lq-btn:not(:disabled):hover {
+		filter: brightness(0.95);
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqCard.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqCard.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	/**
+	 * LqCard — static content container, modeled on Mantine's Paper/Card.
+	 * Same visual box (background/border/radius/shadow) LqHoverCard.Dropdown
+	 * uses, but with no hover/open state — just a container.
+	 */
+	import { LQ_GAPS, LQ_GAP_VAR, LQ_SHADOW_VAR, type LqGap, type LqShadow } from './types';
+
+	export let padding: LqGap | number | string = 'md';
+	export let shadow: LqShadow = 'xs';
+
+	let klass = '';
+	export { klass as class };
+
+	$: resolvedPadding =
+		typeof padding === 'string' && (LQ_GAPS as readonly string[]).includes(padding)
+			? LQ_GAP_VAR[padding as LqGap]
+			: typeof padding === 'number'
+				? `${padding}px`
+				: padding;
+</script>
+
+<div
+	{...$$restProps}
+	class="lq-card {klass}"
+	style:padding={resolvedPadding}
+	style:box-shadow={LQ_SHADOW_VAR[shadow]}
+>
+	<slot />
+</div>
+
+<style>
+	.lq-card {
+		background: var(--lq-canvas, #fff);
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius-lg, 8px);
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqGroup.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqGroup.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	/**
+	 * LqGroup — horizontal flex layout primitive, modeled on Mantine's Group.
+	 *
+	 * Exists to replace the repeated `flex items-center gap-2` Tailwind
+	 * incantations across lq-ai components with a single prop-driven layout
+	 * component, same spirit as Mantine's Group/Stack pair.
+	 */
+	import { LQ_GAPS, LQ_GAP_VAR, type LqGap, type LqJustify, type LqAlign } from './types';
+
+	export let gap: LqGap | number | string = 'sm';
+	export let justify: LqJustify = 'flex-start';
+	export let align: LqAlign = 'center';
+	export let wrap: 'wrap' | 'nowrap' | 'wrap-reverse' = 'wrap';
+	export let grow = false;
+	export let maxWidth: number | string | undefined = undefined;
+
+	let klass = '';
+	export { klass as class };
+
+	$: resolvedGap =
+		typeof gap === 'string' && (LQ_GAPS as readonly string[]).includes(gap)
+			? LQ_GAP_VAR[gap as LqGap]
+			: typeof gap === 'number'
+				? `${gap}px`
+				: gap;
+
+	$: resolvedMaxWidth = typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
+</script>
+
+<div
+	{...$$restProps}
+	class="lq-group {klass}"
+	class:lq-group-grow={grow}
+	style:gap={resolvedGap}
+	style:justify-content={justify}
+	style:align-items={align}
+	style:flex-wrap={wrap}
+	style:max-width={resolvedMaxWidth}
+>
+	<slot />
+</div>
+
+<style>
+	.lq-group {
+		display: flex;
+	}
+
+	.lq-group-grow > :global(*) {
+		flex-grow: 1;
+		flex-basis: 0;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqHoverCard/Dropdown.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqHoverCard/Dropdown.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	/**
+	 * LqHoverCard.Dropdown — the popover content, shown while `Root`'s hover
+	 * region reports `opened`. Visual props (shadow/width/padding) live here
+	 * rather than on Root, mirroring Mantine's HoverCard.Dropdown.
+	 *
+	 * Rendered through bits-ui's `Portal` into `document.body` so it isn't
+	 * clipped by an `overflow: hidden`/`auto` ancestor (e.g. the scrolling
+	 * message list) — z-index can't rescue an element from being clipped by
+	 * an ancestor's overflow, only a portal can. Because it's no longer a DOM
+	 * descendant of Root's hover-region div, position is computed from the
+	 * anchor's `getBoundingClientRect()` (not CSS `position: absolute`
+	 * relative to a parent), and this element needs its own mouseenter/
+	 * mouseleave — hovering it no longer implicitly counts as hovering Root's
+	 * region the way DOM nesting used to give us for free.
+	 */
+	import { getContext, onMount } from 'svelte';
+	import { Portal } from 'bits-ui';
+	import { LQ_GAPS, LQ_GAP_VAR, LQ_SHADOW_VAR, type LqGap, type LqShadow } from '../types';
+	import { LQ_HOVERCARD_CONTEXT_KEY, type LqHoverCardContext } from './context';
+
+	export let shadow: LqShadow = 'md';
+	export let width: number | string = 'max-content';
+	export let padding: LqGap | number | string = 'md';
+
+	const { opened, anchorEl, open, scheduleClose } =
+		getContext<LqHoverCardContext>(LQ_HOVERCARD_CONTEXT_KEY);
+
+	let top = 0;
+	let left = 0;
+
+	function reposition(): void {
+		const el = $anchorEl;
+		if (!el) return;
+		const rect = el.getBoundingClientRect();
+		top = rect.bottom + 4;
+		left = rect.left;
+	}
+
+	function handleWindowChange(): void {
+		if ($opened) reposition();
+	}
+
+	$: if ($opened) reposition();
+
+	onMount(() => {
+		// `scroll` doesn't bubble, but a capture-phase listener on window
+		// still sees it fire on any nested scrollable ancestor.
+		window.addEventListener('scroll', handleWindowChange, true);
+		window.addEventListener('resize', handleWindowChange);
+		return () => {
+			window.removeEventListener('scroll', handleWindowChange, true);
+			window.removeEventListener('resize', handleWindowChange);
+		};
+	});
+
+	$: resolvedPadding =
+		typeof padding === 'string' && (LQ_GAPS as readonly string[]).includes(padding)
+			? LQ_GAP_VAR[padding as LqGap]
+			: typeof padding === 'number'
+				? `${padding}px`
+				: padding;
+</script>
+
+{#if $opened}
+	<Portal to="body">
+		<div
+			class="lq-hovercard-dropdown"
+			style:top="{top}px"
+			style:left="{left}px"
+			style:width
+			style:padding={resolvedPadding}
+			style:box-shadow={LQ_SHADOW_VAR[shadow]}
+			role="tooltip"
+			on:mouseenter={open}
+			on:mouseleave={scheduleClose}
+		>
+			<slot />
+		</div>
+	</Portal>
+{/if}
+
+<style>
+	.lq-hovercard-dropdown {
+		position: fixed;
+		z-index: 50;
+		background: var(--lq-canvas, #fff);
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius-lg, 8px);
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqHoverCard/Root.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqHoverCard/Root.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	/**
+	 * LqHoverCard.Root — owns hover/focus-open state, shared via context so
+	 * `LqHoverCard.Target` and `LqHoverCard.Dropdown` (nested anywhere in the
+	 * default slot) don't need the state wired through manually. Assembled
+	 * onto one namespaced export in `./index.ts` — usage is:
+	 *
+	 *   <LqHoverCard>
+	 *     <LqHoverCard.Target>...</LqHoverCard.Target>
+	 *     <LqHoverCard.Dropdown>...</LqHoverCard.Dropdown>
+	 *   </LqHoverCard>
+	 *
+	 * Modeled on Mantine's HoverCard / HoverCard.Target / HoverCard.Dropdown.
+	 * Opens on mouseenter/focusin, closes on mouseleave/focusout after
+	 * `closeDelay` — the delay (and the fact both Target and Dropdown live
+	 * inside this same hover region) keeps it open while the pointer moves
+	 * from the target into the dropdown. Focus events (not just hover) keep
+	 * this reachable by keyboard, not just mouse.
+	 */
+	import { setContext } from 'svelte';
+	import { writable } from 'svelte/store';
+	import { LQ_HOVERCARD_CONTEXT_KEY, type LqHoverCardContext } from './context';
+
+	export let closeDelay = 100;
+
+	const opened = writable(false);
+	const anchorEl = writable<HTMLElement | null>(null);
+	let closeTimer: ReturnType<typeof setTimeout> | undefined;
+	let wrapperEl: HTMLDivElement;
+
+	function open(): void {
+		clearTimeout(closeTimer);
+		opened.set(true);
+	}
+
+	function scheduleClose(): void {
+		clearTimeout(closeTimer);
+		closeTimer = setTimeout(() => opened.set(false), closeDelay);
+	}
+
+	const context: LqHoverCardContext = { opened, anchorEl, open, scheduleClose };
+	setContext(LQ_HOVERCARD_CONTEXT_KEY, context);
+
+	$: anchorEl.set(wrapperEl ?? null);
+</script>
+
+<div
+	class="lq-hovercard-wrapper"
+	role="group"
+	bind:this={wrapperEl}
+	on:mouseenter={open}
+	on:mouseleave={scheduleClose}
+	on:focusin={open}
+	on:focusout={scheduleClose}
+>
+	<slot />
+</div>
+
+<style>
+	.lq-hovercard-wrapper {
+		position: relative;
+		display: inline-block;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqHoverCard/Target.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqHoverCard/Target.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	/**
+	 * LqHoverCard.Target — the trigger. No wrapper element, no props: it just
+	 * marks where the trigger content goes, so `LqHoverCard.Root`'s hover
+	 * region (which wraps this and the Dropdown together) picks up mouse/
+	 * focus events straight from whatever's slotted in here.
+	 */
+</script>
+
+<slot />

--- a/web/src/lib/lq-ai/components/shared/LqHoverCard/context.ts
+++ b/web/src/lib/lq-ai/components/shared/LqHoverCard/context.ts
@@ -1,0 +1,12 @@
+import type { Writable } from 'svelte/store';
+
+export const LQ_HOVERCARD_CONTEXT_KEY = Symbol('lq-hovercard');
+
+export interface LqHoverCardContext {
+	opened: Writable<boolean>;
+	/** The hover-region element — Dropdown reads its rect to position itself
+	 *  once it's portaled out (see Dropdown.svelte). */
+	anchorEl: Writable<HTMLElement | null>;
+	open: () => void;
+	scheduleClose: () => void;
+}

--- a/web/src/lib/lq-ai/components/shared/LqHoverCard/index.ts
+++ b/web/src/lib/lq-ai/components/shared/LqHoverCard/index.ts
@@ -1,0 +1,17 @@
+import Root from './Root.svelte';
+import Target from './Target.svelte';
+import Dropdown from './Dropdown.svelte';
+
+// Same namespacing technique bits-ui uses for `Button.Root` elsewhere in this
+// codebase: attach the parts as static properties on the Root component
+// itself, so `<LqHoverCard>` is the Root and `<LqHoverCard.Target>` /
+// `<LqHoverCard.Dropdown>` are the same objects imported above.
+//
+// `Object.assign(Root, { Target, Dropdown })` looks equivalent but confuses
+// svelte2tsx's prop-type inference into merging Root's and Dropdown's props
+// into one type — the explicit cast + direct assignment below avoids that.
+const LqHoverCard = Root as typeof Root & { Target: typeof Target; Dropdown: typeof Dropdown };
+LqHoverCard.Target = Target;
+LqHoverCard.Dropdown = Dropdown;
+
+export default LqHoverCard;

--- a/web/src/lib/lq-ai/components/shared/LqPill.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqPill.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+	/**
+	 * LqPill — general-purpose tag/chip pill, modeled on TrustPill's visual
+	 * language (same tone palette + shape) but generalized: TrustPill is
+	 * fixed to the ambient-trust chrome's variant→tone mapping, LqPill takes
+	 * a plain tone directly and adds a removable (✕) affordance, for the
+	 * "applied skills", "attached files" style use cases.
+	 *
+	 * The label and the remove button are two separate `<button>`s (not one
+	 * button wrapping the other — nested interactive elements are invalid
+	 * HTML) when both `onClick` and `onRemove` are supplied. If neither is
+	 * given, the label renders as plain (non-interactive) text.
+	 */
+	import { IconX } from '@tabler/icons-svelte';
+	import type { LqTone } from './types';
+
+	export let text: string;
+	export let tone: LqTone = 'neutral';
+	export let onClick: (() => void) | undefined = undefined;
+	export let onRemove: (() => void) | undefined = undefined;
+</script>
+
+<span class="lq-pill lq-pill-tone-{tone}">
+	{#if onClick}
+		<button type="button" class="lq-pill-label lq-pill-label-clickable" on:click={onClick}>
+			{text}
+		</button>
+	{:else}
+		<span class="lq-pill-label">{text}</span>
+	{/if}
+	{#if onRemove}
+		<button
+			type="button"
+			class="lq-pill-remove"
+			aria-label="Remove {text}"
+			on:click={onRemove}
+		>
+			<IconX size={12} />
+		</button>
+	{/if}
+</span>
+
+<style>
+	.lq-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--lq-space-1, 4px);
+		padding: 2px 10px;
+		border-radius: var(--lq-radius-pill, 999px);
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 1.4;
+		border: 1px solid transparent;
+		background: transparent;
+	}
+
+	.lq-pill-label {
+		all: unset;
+		display: inline;
+	}
+
+	.lq-pill-label-clickable {
+		cursor: pointer;
+	}
+	.lq-pill-label-clickable:hover {
+		text-decoration: underline;
+	}
+	.lq-pill-label-clickable:focus-visible {
+		outline: 2px solid currentColor;
+		outline-offset: 2px;
+	}
+
+	.lq-pill-remove {
+		all: unset;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		border-radius: 999px;
+		padding: 1px;
+		line-height: 0;
+	}
+	.lq-pill-remove:hover {
+		background: rgba(0, 0, 0, 0.08);
+	}
+	.lq-pill-remove:focus-visible {
+		outline: 2px solid currentColor;
+		outline-offset: 1px;
+	}
+
+	.lq-pill-tone-sage {
+		background: var(--lq-accent-soft, #e8f4ec);
+		color: var(--lq-accent, #1f7a6b);
+		border-color: var(--lq-accent-border, #c5e6d1);
+	}
+	.lq-pill-tone-slate {
+		background: var(--lq-tier-soft, #e8eff7);
+		color: var(--lq-tier, #355a82);
+		border-color: var(--lq-tier-border, #d4e2f1);
+	}
+	.lq-pill-tone-amber {
+		background: var(--lq-warn-soft, #fdf3e2);
+		color: var(--lq-warn, #a16e1f);
+		border-color: var(--lq-warn-border, #ead9c5);
+	}
+	.lq-pill-tone-red {
+		background: var(--lq-error-soft, #fbeaea);
+		color: var(--lq-error, #b54848);
+		border-color: var(--lq-error-border, #f1d2d2);
+	}
+	.lq-pill-tone-neutral {
+		background: var(--lq-inset, #fafbfa);
+		color: var(--lq-text-secondary, #4b5563);
+		border-color: var(--lq-border, #e5e7eb);
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqStack.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqStack.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	/**
+	 * LqStack — vertical flex layout primitive, modeled on Mantine's Stack.
+	 * Same gap vocabulary as LqGroup so the two compose predictably.
+	 */
+	import { LQ_GAPS, LQ_GAP_VAR, type LqGap, type LqJustify, type LqAlign } from './types';
+
+	export let gap: LqGap | number | string = 'sm';
+	export let justify: LqJustify = 'flex-start';
+	export let align: LqAlign = 'stretch';
+	export let maxWidth: number | string | undefined = undefined;
+
+	let klass = '';
+	export { klass as class };
+
+	$: resolvedGap =
+		typeof gap === 'string' && (LQ_GAPS as readonly string[]).includes(gap)
+			? LQ_GAP_VAR[gap as LqGap]
+			: typeof gap === 'number'
+				? `${gap}px`
+				: gap;
+
+	$: resolvedMaxWidth = typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
+</script>
+
+<div
+	{...$$restProps}
+	class="lq-stack {klass}"
+	style:gap={resolvedGap}
+	style:justify-content={justify}
+	style:align-items={align}
+	style:max-width={resolvedMaxWidth}
+>
+	<slot />
+</div>
+
+<style>
+	.lq-stack {
+		display: flex;
+		flex-direction: column;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqSwitch.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqSwitch.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	/**
+	 * LqSwitch — styled wrapper around bits-ui's headless Switch.
+	 *
+	 * bits-ui supplies behavior/accessibility (role="switch", keyboard
+	 * toggling, data-state) with zero visual opinion; this component supplies
+	 * the tone-based look, same pattern LqHoverCard uses for bits-ui's
+	 * Portal. Only the switch control itself — no label. Compose a label via
+	 * `LqGroup` + `LqText` alongside it, same as any other primitive.
+	 */
+	import { Switch } from 'bits-ui';
+	import type { LqTone } from './types';
+
+	export let checked = false;
+	export let disabled = false;
+	export let tone: LqTone = 'sage';
+	export let onCheckedChange: ((checked: boolean) => void) | undefined = undefined;
+</script>
+
+<Switch.Root
+	bind:checked
+	{disabled}
+	{onCheckedChange}
+	class="lq-switch lq-switch-tone-{tone}"
+>
+	<Switch.Thumb class="lq-switch-thumb" />
+</Switch.Root>
+
+<style>
+	:global(.lq-switch) {
+		all: unset;
+		box-sizing: border-box;
+		display: inline-flex;
+		align-items: center;
+		width: 32px;
+		height: 18px;
+		padding: 2px;
+		border-radius: 999px;
+		background: var(--lq-border, #e5e7eb);
+		cursor: pointer;
+		transition: background 120ms ease;
+	}
+	:global(.lq-switch:disabled) {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+	:global(.lq-switch:focus-visible) {
+		outline: 2px solid var(--lq-accent, #1f7a6b);
+		outline-offset: 2px;
+	}
+
+	:global(.lq-switch-tone-sage[data-state='checked']) {
+		background: var(--lq-accent, #1f7a6b);
+	}
+	:global(.lq-switch-tone-slate[data-state='checked']) {
+		background: var(--lq-tier, #355a82);
+	}
+	:global(.lq-switch-tone-amber[data-state='checked']) {
+		background: var(--lq-warn, #a16e1f);
+	}
+	:global(.lq-switch-tone-red[data-state='checked']) {
+		background: var(--lq-error, #b54848);
+	}
+	:global(.lq-switch-tone-neutral[data-state='checked']) {
+		background: var(--lq-text-secondary, #4b5563);
+	}
+
+	:global(.lq-switch-thumb) {
+		width: 14px;
+		height: 14px;
+		border-radius: 999px;
+		background: white;
+		transition: transform 120ms ease;
+	}
+	:global(.lq-switch-thumb[data-state='checked']) {
+		transform: translateX(14px);
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqText.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqText.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	/**
+	 * LqText — semantic text primitive, modeled on Mantine's Text.
+	 *
+	 * Exists to replace ad hoc `<div class="text-xs text-gray-600 ...">`
+	 * markup (which carries no semantics — a div is not text) with a
+	 * component that (a) renders the right element for the content
+	 * (`as`, default `p`) and (b) drives size/weight/color/mono/truncate
+	 * off this file's shared token scales instead of one-off Tailwind
+	 * color/size classes per call site.
+	 */
+	import {
+		LQ_TEXT_SIZE_VAR,
+		LQ_WEIGHT_VAR,
+		LQ_TEXT_TONE_VAR,
+		type LqTextSize,
+		type LqWeight,
+		type LqTextTone
+	} from './types';
+
+	export let as: 'p' | 'span' | 'div' | 'label' = 'p';
+	export let size: LqTextSize = 'md';
+	export let weight: LqWeight = 'normal';
+	export let tone: LqTextTone | undefined = undefined;
+	export let mono = false;
+	export let truncate = false;
+	export let align: 'left' | 'center' | 'right' | 'justify' | undefined = undefined;
+	export let transform: 'none' | 'uppercase' | 'lowercase' | 'capitalize' = 'none';
+
+	let klass = '';
+	export { klass as class };
+</script>
+
+<svelte:element
+	this={as}
+	{...$$restProps}
+	class="lq-text {klass}"
+	class:lq-text-mono={mono}
+	class:lq-text-truncate={truncate}
+	style:font-size={LQ_TEXT_SIZE_VAR[size]}
+	style:font-weight={LQ_WEIGHT_VAR[weight]}
+	style:color={tone ? LQ_TEXT_TONE_VAR[tone] : undefined}
+	style:text-align={align}
+	style:text-transform={transform === 'none' ? undefined : transform}
+>
+	<slot />
+</svelte:element>
+
+<style>
+	.lq-text {
+		margin: 0;
+		line-height: 1.4;
+	}
+
+	.lq-text-mono {
+		font-family: var(--lq-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	}
+
+	.lq-text-truncate {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/LqTitle.svelte
+++ b/web/src/lib/lq-ai/components/shared/LqTitle.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	/**
+	 * LqTitle — heading primitive, modeled on Mantine's Title. `order`
+	 * (1–6) picks both the rendered tag (`h1`–`h6`) and the size step —
+	 * separate from LqText's size scale, since headings and body text
+	 * shouldn't share one scale.
+	 */
+	import { LQ_TEXT_TONE_VAR, LQ_WEIGHT_VAR, type LqTextTone, type LqWeight } from './types';
+
+	export let order: 1 | 2 | 3 | 4 | 5 | 6 = 1;
+	export let tone: LqTextTone | undefined = undefined;
+	export let weight: LqWeight = 'bold';
+
+	const ORDER_SIZE: Record<1 | 2 | 3 | 4 | 5 | 6, string> = {
+		1: '34px',
+		2: '26px',
+		3: '22px',
+		4: '18px',
+		5: '16px',
+		6: '14px'
+	};
+
+	let klass = '';
+	export { klass as class };
+</script>
+
+<svelte:element
+	this={`h${order}`}
+	{...$$restProps}
+	class="lq-title {klass}"
+	style:font-size={ORDER_SIZE[order]}
+	style:font-weight={LQ_WEIGHT_VAR[weight]}
+	style:color={tone ? LQ_TEXT_TONE_VAR[tone] : undefined}
+>
+	<slot />
+</svelte:element>
+
+<style>
+	.lq-title {
+		margin: 0;
+		line-height: 1.3;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/shared/types.ts
+++ b/web/src/lib/lq-ai/components/shared/types.ts
@@ -1,0 +1,150 @@
+/**
+ * Shared prop vocabulary for the `lq` design-system primitives.
+ *
+ * Single source of truth: each option list is a `const` array, and every
+ * primitive's prop type is derived from it (`(typeof X)[number]`) rather than
+ * a hand-typed string-literal union. Adding an option here — and only here —
+ * updates every primitive's types and editor autocomplete at once.
+ */
+
+export const LQ_VARIANTS = ['filled', 'outline', 'subtle', 'ghost'] as const;
+export type LqVariant = (typeof LQ_VARIANTS)[number];
+
+export const LQ_TONES = ['sage', 'slate', 'amber', 'red', 'neutral'] as const;
+export type LqTone = (typeof LQ_TONES)[number];
+
+export const LQ_SIZES = ["xs", "sm", "md", "lg"] as const;
+export type LqSize = (typeof LQ_SIZES)[number];
+
+// justify-content / align-items vocabularies for LqGroup/LqStack. These were
+// plain `string` props until now — the one inconsistency in this file's
+// "every prop is a derived union, not a bare string" rule. Kept to the
+// values these two components actually support (flex containers), not the
+// full CSS justify-content/align-items keyword set.
+export const LQ_JUSTIFY = [
+	'flex-start',
+	'center',
+	'flex-end',
+	'space-between',
+	'space-around',
+	'space-evenly'
+] as const;
+export type LqJustify = (typeof LQ_JUSTIFY)[number];
+
+export const LQ_ALIGN = ['flex-start', 'center', 'flex-end', 'stretch', 'baseline'] as const;
+export type LqAlign = (typeof LQ_ALIGN)[number];
+
+// Mantine-style spacing scale, mapped onto this project's `--lq-space-*`
+// tokens (see styles/practice.css) so layout primitives (Group, Stack, ...)
+// share the same gap vocabulary as everything else.
+export const LQ_GAPS = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export type LqGap = (typeof LQ_GAPS)[number];
+
+export const LQ_GAP_VAR: Record<LqGap, string> = {
+	xs: 'var(--lq-space-1, 2px)',
+	sm: 'var(--lq-space-2, 4px)',
+	md: 'var(--lq-space-4, 8px)',
+	lg: 'var(--lq-space-6, 16px)',
+	xl: 'var(--lq-space-8, 24px)'
+};
+
+// Mantine-style elevation scale. Not backed by a practice.css token today
+// (there's no --lq-shadow-* set yet) — values are plain box-shadow strings
+// here, one place to promote them to CSS custom properties later without
+// touching any component that consumes LqShadow.
+export const LQ_SHADOWS = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export type LqShadow = (typeof LQ_SHADOWS)[number];
+
+export const LQ_SHADOW_VAR: Record<LqShadow, string> = {
+	xs: '0 1px 2px rgba(0, 0, 0, 0.05)',
+	sm: '0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06)',
+	md: '0 4px 6px rgba(0, 0, 0, 0.08), 0 2px 4px rgba(0, 0, 0, 0.06)',
+	lg: '0 10px 15px rgba(0, 0, 0, 0.1), 0 4px 6px rgba(0, 0, 0, 0.05)',
+	xl: '0 20px 25px rgba(0, 0, 0, 0.12), 0 8px 10px rgba(0, 0, 0, 0.06)'
+};
+
+// Text weight scale — named steps (rather than raw fw numbers, like
+// Mantine's Text `fw`) to match this file's semantic-name convention.
+export const LQ_WEIGHTS = ['normal', 'medium', 'semibold', 'bold'] as const;
+export type LqWeight = (typeof LQ_WEIGHTS)[number];
+
+export const LQ_WEIGHT_VAR: Record<LqWeight, string> = {
+	normal: '400',
+	medium: '500',
+	semibold: '600',
+	bold: '700'
+};
+
+// Text-specific size scale. Deliberately separate from LqSize (Button's
+// sm/md/lg) — Text needs an xs/xl step Button has no CSS for.
+export const LQ_TEXT_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export type LqTextSize = (typeof LQ_TEXT_SIZES)[number];
+
+export const LQ_TEXT_SIZE_VAR: Record<LqTextSize, string> = {
+	xs: '12px',
+	sm: '13px',
+	md: '14px',
+	lg: '16px',
+	xl: '18px'
+};
+
+// Text color: the text-hierarchy trio from practice.css (primary/secondary/
+// tertiary) plus the five semantic tones already used for emphasis/status
+// elsewhere (TrustPill, LqButton) — one color vocabulary for text everywhere.
+export const LQ_TEXT_TONES = ['primary', 'secondary', 'tertiary', ...LQ_TONES] as const;
+export type LqTextTone = (typeof LQ_TEXT_TONES)[number];
+
+export const LQ_TEXT_TONE_VAR: Record<LqTextTone, string> = {
+	primary: 'var(--lq-text, #1a1a1a)',
+	secondary: 'var(--lq-text-secondary, #4b5563)',
+	tertiary: 'var(--lq-text-tertiary, #9ca3af)',
+	sage: 'var(--lq-accent, #1f7a6b)',
+	slate: 'var(--lq-tier, #355a82)',
+	amber: 'var(--lq-warn, #a16e1f)',
+	red: 'var(--lq-error, #b54848)',
+	neutral: 'var(--lq-text-secondary, #4b5563)'
+};
+
+// --- Color + shade ---------------------------------------------------------
+//
+// `tone` (above) is the pre-bundled look every primitive has used so far:
+// pick "sage" and you get its soft background + base text + border all at
+// once. `LqColor` + `LqShade` is the lower-level primitive underneath that:
+// one hue (currently the same five as LqTone — there's no hue outside that
+// set yet) at a specific step on a 0–9 ramp, Mantine-style. Most components
+// should keep using `tone`; reach for `color`+`shade` only when the bundled
+// look doesn't fit (a component needing just the shade-2 background without
+// the shade-6 border, say).
+//
+// Shades are computed via CSS color-mix() from each color's single base
+// --lq-* var rather than 50 hand-authored hex values — repaint the five base
+// vars in practice.css and every shade of every color follows.
+export type LqColor = LqTone;
+
+export const LQ_SHADES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+export type LqShade = (typeof LQ_SHADES)[number];
+
+const LQ_COLOR_BASE_VAR: Record<LqColor, string> = {
+	sage: 'var(--lq-accent, #1f7a6b)',
+	slate: 'var(--lq-tier, #355a82)',
+	amber: 'var(--lq-warn, #a16e1f)',
+	red: 'var(--lq-error, #b54848)',
+	neutral: 'var(--lq-text-secondary, #4b5563)'
+};
+
+/**
+ * Shade 5 is the color's base value, unmixed. Shades 0–4 blend toward white
+ * (0 = lightest, ~90% white). Shades 6–9 blend toward black (9 = darkest,
+ * ~60% black). Chosen to mirror Mantine's "5/6 sit near the base color"
+ * convention without hand-tuning ten stops per color.
+ */
+export function lqColorShade(color: LqColor, shade: LqShade): string {
+	const base = LQ_COLOR_BASE_VAR[color];
+	if (shade === 5) return base;
+	if (shade < 5) {
+		const whitePercent = (5 - shade) * 18;
+		return `color-mix(in oklab, ${base} ${100 - whitePercent}%, white)`;
+	}
+	const blackPercent = (shade - 5) * 15;
+	return `color-mix(in oklab, ${base} ${100 - blackPercent}%, black)`;
+}


### PR DESCRIPTION
## Summary

- Adds a small primitive layer (`LqButton`, `LqGroup`, `LqStack`, `LqText`, `LqTitle`, `LqAlert`, `LqPill`, `LqSwitch`, `LqCard`, `LqHoverCard`) under `web/src/lib/lq-ai/components/shared/`, backed by one token file (`shared/types.ts`: variant/tone/size/gap/shadow/weight/justify/align scales, each a `const` array with a derived type for full editor autocomplete).
- Modeled on Mantine's component API shape (`variant`/`size`/`tone`, `Component.Part` compound namespacing) as a naming/ergonomics reference only — no framework dependency added. `LqHoverCard` reuses `bits-ui`'s headless `Portal`/`Switch` (already a dependency) rather than reimplementing positioning/accessibility behavior.
- Migrates `ChatPanel.svelte`, `MessageBubble.svelte`, and `MessageList.svelte` off ad hoc Tailwind spacing/color classes onto these primitives.
- Converts two **display-only** modals (`EnhancedDiffModal`, `CitationLedgerPanel`) into hover-triggered `LqHoverCard` popovers, portaled to `document.body` so they aren't clipped by the message list's `overflow-y-auto` scroll container. Modals with real mutation/interaction (`AttachKBModal`, `TierFloorOverrideModal`, `CaptureSkillModal`) were evaluated and deliberately left as modals — hover-triggering an audited security override, for example, would be a real regression, not a style choice.
- Deduplicates a tier→description mapping that had drifted across three independent copies (`TierBadge`, `TierDetailsPanel`, `MessageBubble`) into one source of truth, `chat/tierDescriptions.ts`.
- Adds `@tabler/icons-svelte` as the icon source for these primitives (new dependency — see ADR 0022 for justification: emoji-as-icons force inline-style hacks per call site to size/align them, which is the exact inconsistent-spacing/sizing problem this effort targets).
- Updates `CLAUDE.md` / `CONTRIBUTING.md`'s "use the project's design system primitives" line (previously pointed at nothing concrete for `/lq-ai`) to name this layer, and adds **ADR 0022** documenting the decision, the governing rules for new primitives/tokens, and follow-up work (OKLCH color migration, `LqPopover`, `LqSimpleGrid`).

Scoped entirely to `web/src/lib/lq-ai/**` — the OpenWebUI shell at `/` is untouched per ADR 0009.



## Why

`lib/lq-ai/components/**` had no shared vocabulary for spacing, color, sizing, or interaction — every component decided these independently in raw Tailwind utility classes. That wasn't a problem in any single file, but it compounded:

- **Duplicated, drifting logic.** The tier→description mapping (label, blurb, tone per inference tier) was hand-copied into three separate files — `TierBadge.svelte`, `TierDetailsPanel.svelte`, and `MessageBubble.svelte` — with the wording already diverging between copies. Nothing enforced that a change to "what Tier 3 means" would land in all three places.
- **Inconsistent spacing from self-margins instead of layout gap.** Sibling elements used ad hoc `mt-1`/`mt-2`/`mb-3` classes to create breathing room, chosen per element by feel rather than from one spacing scale — so adjacent elements in the same list ended up with 4px, 8px, or 0px gaps depending on which developer touched which line, not on any actual design intent.
- **A real bug, not just an aesthetic one.** `ChatPanel.svelte` had a `gap={2}` typo on an ad hoc flex wrapper that silently fell through to an unintended raw-pixel value instead of erroring, because there was no typed vocabulary to catch it.
- **Emoji as icons forced inline-style hacks.** Several components used emoji glyphs (🛠️🔒🧠📎📜✨) as icons, which have no `size` prop and no predictable box model — every call site ended up hand-tuning `font-size`/`line-height`/margin to make them sit correctly next to text, which is the same "inconsistent spacing via ad hoc styling" problem as the margin issue above, just applied to icons instead of layout.
- **The existing convention pointed at nothing.** CONTRIBUTING.md and CLAUDE.md have both said "use the project's design system primitives rather than ad-hoc Tailwind" since M1, but nothing concrete existed for `/lq-ai/*` to point to — so the guidance was unenforceable in practice.

This PR builds that shared vocabulary (a token file plus a small set of Svelte primitives), fixes the concrete bugs found while migrating real call sites onto it, and updates the convention docs to point at something real instead of nothing. See ADR 0022 for the full design rationale and the rules for extending it.


## What this PR does *not* do

Does not rewrite all existing components using new components.  Only selected components are modified to illustrate improved semantics, improved hierarchy, and reduced interaction/logic. Does not implement a color system that has semantic consistency, this is to do in later updates.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [x] Skill contribution (see attestation below)
- [ ] Refactor (no behavioral change)
- [ ] Test / CI / tooling

## Testing

<!-- How did you verify the change? -->

- [ ] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] Manually tested against a real deployment (describe scenario below)
- [ ] Acceptance test plan updated (if changing skill behavior)

<details>
<summary>Manual testing notes (if applicable)</summary>

Smoke tested using live data to validate correct layout.

</details>

## Documentation

- [ ] PRD updated (if user-facing behavior changes)
- [ ] README updated (if quickstart or capability list changes)
- [x] Skill-authoring guide updated (if skill conventions change)
- [ ] Deployment cookbook updated (if deployment changes)
- [ ] Compliance documentation updated (if compliance posture changes)
- [ ] OpenAPI schema regenerated (if API endpoints change)

## Transparency & governance invariants

<!-- The posture that *is* the product (ADR 0016). Check each box or mark it
n/a. If you can't, stop and either fix the change or surface the decision to a
maintainer. The cheap-to-check ones are enforced by
api/tests/test_transparency_invariants.py — but the judgment ones are on you. -->

- [ ] **Egress (P1):** any outbound third-party call goes through the gateway only — no direct egress from `api/`.
- [ ] **Closed set (P2):** any new model/autonomous-invokable capability is a bounded, operator-controlled allowlist entry, not an open hook.
- [ ] **No raw payloads (P3):** no row or log line I add carries raw content (message bodies, tool args/results, fetched text, keys) — counts, types, ids, digests, outcomes only.
- [ ] **Fail restrictive (P4):** missing/broken config fails closed, and I tested that path, not just the happy path.
- [ ] **Atomic audit (P5):** state changes get an audit row committed in the same transaction (helpers flush, the handler commits).
- [ ] **One governance path (P6):** I reused the shared governance/audit helpers rather than re-deriving tier/cost/audit logic.
- [ ] **Human gate (P7):** anything destructive/irreversible is behind the confirmation gate and excluded from unattended/autonomous execution.
- [ ] **Operator control (P8):** any new capability has an operator enable/disable and appears on an admin surface.
- [ ] **User owns data (P9):** outbound matter context is anonymized; the change respects export/delete and data-residency guarantees.
- [ ] **Contract is truth (P10):** OpenAPI sketch / DB schema doc / relevant ADR updated in this PR; any architectural/authz decision is recorded or surfaced, not made silently.

## DCO sign-off

- [x] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

<!-- Verify with: git log --show-signature -->

## Related issues

<!-- Closes #123, Refs DE-013, etc. -->

---

## Skill update

Updates the skills to apply the semantics from the design primitives for consistency and improved semantics. 

## Reviewer notes


