### PR TITLE
DE-358 items 2-4: document tools/tool_choice, cap tools at 64, per-mode tool_choice tests

### DIFF
--- a/api/app/schemas/gateway.py
+++ b/api/app/schemas/gateway.py
@@ -112,10 +112,11 @@ class ChatCompletionRequest(BaseModel):
     stream: bool = False
     stop: list[str] | str | None = None
     n: int | None = Field(default=None, ge=1, le=1)
-    tools: list[dict[str, Any]] | None = None
+    tools: list[dict[str, Any]] | None = Field(default=None, max_length=64)
     """PR5b: per-turn closed allowlist of function schemas the backend
     assembles (research + operator-enabled MCP tools). Forwarded to the
-    gateway, which forwards to the provider."""
+    gateway, which forwards to the provider. Capped at 64 entries
+    (DE-358 item 3) to mirror the gateway-side bound."""
     tool_choice: str | dict[str, Any] | None = None
 
     # --- LQ.AI extensions (per gateway-openapi.yaml) -------------------------

--- a/api/tests/test_gateway_call_tool.py
+++ b/api/tests/test_gateway_call_tool.py
@@ -3,6 +3,7 @@ import json as _json
 import httpx
 import pytest
 import respx
+from pydantic import ValidationError
 
 from app.clients.gateway import GatewayClient
 from app.schemas.gateway import ChatCompletionRequest
@@ -75,6 +76,33 @@ def test_api_chat_request_carries_tools() -> None:
     )
     assert req.tools[0]["function"]["name"] == "x"  # type: ignore[index]
     assert req.tool_choice == "auto"
+
+
+def test_api_chat_request_accepts_tools_at_cap() -> None:
+    """DE-358 item 3: exactly 64 tool declarations pass the api boundary."""
+    req = ChatCompletionRequest(
+        model="smart",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {"type": "function", "function": {"name": f"tool_{i}", "parameters": {}}}
+            for i in range(64)
+        ],
+    )
+    assert req.tools is not None and len(req.tools) == 64
+
+
+def test_api_chat_request_rejects_tools_over_cap() -> None:
+    """DE-358 item 3: the 65th tool declaration fails validation, mirroring
+    the gateway-side bound (fail restrictive)."""
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(
+            model="smart",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {"type": "function", "function": {"name": f"tool_{i}", "parameters": {}}}
+                for i in range(65)
+            ],
+        )
 
 
 @pytest.mark.asyncio

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -1012,6 +1012,36 @@ components:
         temperature: {type: number, minimum: 0, maximum: 2}
         top_p: {type: number}
         stream: {type: boolean, default: false}
+        # Function/tool calling (PR5b, ADR 0015)
+        tools:
+          type: array
+          maxItems: 64
+          items:
+            type: object
+            additionalProperties: true
+          description: |
+            OpenAI-style tool/function declarations, forwarded to the
+            provider so the model may emit `tool_calls`. Per ADR 0015
+            the backend assembles this as a closed per-turn allowlist
+            (research + operator-enabled MCP tools) — the gateway
+            forwards the declarations but never executes a tool; the
+            eventual tool call re-enters through `/v1/tools/call` where
+            the per-provider egress tier and SSRF allowlist are always
+            enforced. Capped at 64 entries (DE-358) to bound the
+            prompt-multiplication surface.
+        tool_choice:
+          description: |
+            OpenAI-style tool-choice directive: `"auto"`, `"none"`,
+            `"required"`, or a forced-function object
+            (`{"type": "function", "function": {"name": …}}`).
+            Translated per provider (e.g. Anthropic: `required` →
+            `{"type": "any"}`; `none` → tools omitted entirely).
+            Absent means provider default (`auto` when `tools` present).
+          oneOf:
+            - type: string
+              enum: [auto, none, required]
+            - type: object
+              additionalProperties: true
         # LQ.AI extensions
         minimum_inference_tier:
           type: integer

--- a/gateway/app/providers/openai_schema.py
+++ b/gateway/app/providers/openai_schema.py
@@ -167,11 +167,14 @@ class ChatCompletionRequest(BaseModel):
     """
 
     # --- Function/tool calling (PR5b) ---------------------------------------
-    tools: list[dict[str, Any]] | None = None
+    tools: list[dict[str, Any]] | None = Field(default=None, max_length=64)
     """OpenAI-style tool/function declarations. Forwarded to the provider
     so the model may emit ``tool_calls``. The backend assembles a closed
     allowlist per turn (research + operator-enabled MCP tools); the
-    gateway's egress-tier / SSRF guards still gate the eventual call."""
+    gateway's egress-tier / SSRF guards still gate the eventual call.
+    Capped at 64 entries (DE-358 item 3) to bound the
+    prompt-multiplication surface — mirrors the ``lq_ai_skills`` /
+    ``lq_ai_inline_skills`` cap idiom."""
 
     tool_choice: str | dict[str, Any] | None = None
     """OpenAI-style tool_choice (``"auto"`` / ``"none"`` / a forced

--- a/gateway/tests/test_anthropic_adapter.py
+++ b/gateway/tests/test_anthropic_adapter.py
@@ -745,3 +745,116 @@ async def test_anthropic_round_trips_assistant_tool_use_for_follow_up() -> None:
     assert resp2.choices[0].finish_reason == "stop"
     assert resp2.choices[0].message.content == "Confirmed."
     assert call_count == 2
+
+
+# --- DE-358 item 4: granular tool_choice mode coverage ------------------------
+
+
+def _plain_text_response(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "msg_tc",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": {"input_tokens": 5, "output_tokens": 2},
+        },
+    )
+
+
+def _tools_request(tool_choice: object) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "verify_citations",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        tool_choice=tool_choice,
+    )
+
+
+async def _capture_request_body(req: ChatCompletionRequest) -> dict:
+    captured: dict[str, object] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return _plain_text_response(request)
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(side_effect=_capture)
+    adapter = _make_adapter()
+    try:
+        await adapter.chat_completion(req, model="claude-sonnet-4-6", stream=False)
+    finally:
+        await adapter.aclose()
+    body = captured["body"]
+    assert isinstance(body, dict)
+    return body
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_anthropic_tool_choice_none_drops_tools() -> None:
+    """DE-358 item 4: ``tool_choice="none"`` — Anthropic has no ``none``
+    mode, so the adapter honors it by omitting ``tools`` (and therefore
+    ``tool_choice``) from the provider request entirely."""
+
+    body = await _capture_request_body(_tools_request("none"))
+    assert "tools" not in body
+    assert "tool_choice" not in body
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_anthropic_tool_choice_required_maps_to_any() -> None:
+    """DE-358 item 4: ``tool_choice="required"`` maps to Anthropic
+    ``{"type": "any"}`` with tools forwarded."""
+
+    body = await _capture_request_body(_tools_request("required"))
+    assert body["tools"][0]["name"] == "verify_citations"
+    assert body["tool_choice"] == {"type": "any"}
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_anthropic_tool_choice_forced_function_maps_to_tool() -> None:
+    """DE-358 item 4: an OpenAI forced-function object maps to Anthropic
+    ``{"type": "tool", "name": ...}``."""
+
+    body = await _capture_request_body(
+        _tools_request({"type": "function", "function": {"name": "verify_citations"}})
+    )
+    assert body["tools"][0]["name"] == "verify_citations"
+    assert body["tool_choice"] == {"type": "tool", "name": "verify_citations"}
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_anthropic_tool_choice_absent_defaults_to_auto() -> None:
+    """DE-358 item 4: with tools present and no explicit ``tool_choice``,
+    ``main`` emits ``{"type": "auto"}`` (unlike the closed PR5b branches,
+    which omitted the field — assertions follow ``main``'s behavior)."""
+
+    body = await _capture_request_body(_tools_request(None))
+    assert body["tools"][0]["name"] == "verify_citations"
+    assert body["tool_choice"] == {"type": "auto"}
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_anthropic_forced_function_without_name_omits_tool_choice() -> None:
+    """DE-358 item 4: a malformed forced-function object (no ``name``)
+    forwards tools but sets no ``tool_choice`` — the provider default
+    applies rather than a fabricated directive."""
+
+    body = await _capture_request_body(_tools_request({"type": "function", "function": {}}))
+    assert body["tools"][0]["name"] == "verify_citations"
+    assert "tool_choice" not in body

--- a/gateway/tests/test_openai_schema.py
+++ b/gateway/tests/test_openai_schema.py
@@ -7,6 +7,7 @@ and the explicit ``tools``/``tool_choice`` fields added in PR5b.
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from app.providers.openai_schema import ChatCompletionRequest
 
@@ -28,3 +29,32 @@ def test_chat_completion_request_accepts_tools_and_tool_choice() -> None:
     # Round-trips through model_dump (the OpenAI adapter serializes this).
     dumped = req.model_dump(mode="json", exclude_none=True)
     assert "tools" in dumped and "tool_choice" in dumped
+
+
+def _tool_decl(i: int) -> dict:
+    return {"type": "function", "function": {"name": f"tool_{i}", "parameters": {}}}
+
+
+@pytest.mark.unit
+def test_chat_completion_request_accepts_tools_at_cap() -> None:
+    """DE-358 item 3: exactly 64 tool declarations are accepted."""
+
+    req = ChatCompletionRequest(
+        model="smart",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[_tool_decl(i) for i in range(64)],
+    )
+    assert req.tools is not None and len(req.tools) == 64
+
+
+@pytest.mark.unit
+def test_chat_completion_request_rejects_tools_over_cap() -> None:
+    """DE-358 item 3: the 65th tool declaration fails validation (fail
+    restrictive — the prompt-multiplication surface is bounded at 64)."""
+
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(
+            model="smart",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[_tool_decl(i) for i in range(65)],
+        )


### PR DESCRIPTION
Part of DE-358 (PRD §9 tool-use hardening backlog), refs #275. Rebuilt against current main — nothing cherry-picked from the closed #185/#186 branches.

**Item 2 — OpenAPI documentation.** `ChatCompletionRequest` in `docs/api/gateway-openapi.yaml` (hand-maintained) now documents `tools` and `tool_choice`: the closed-allowlist posture per ADR 0015, the per-provider `tool_choice` translation, and the new `maxItems: 64` bound.

**Item 3 — tools count cap.** `Field(max_length=64)` on `tools` at both boundaries (`gateway/app/providers/openai_schema.py`, `api/app/schemas/gateway.py`), following the existing `lq_ai_skills` cap idiom. 64 is the number proposed in the reviewed PRs. Validation failure is a 422, fail-restrictive. Tests assert accept-at-64 / reject-at-65 on both models.

**Item 4 — granular tool_choice tests.** The Anthropic adapter's four `tool_choice` modes each get direct coverage: `none` drops tools entirely, `required` maps to `{"type":"any"}`, forced-function maps to `{"type":"tool","name":…}`, absent defaults to `{"type":"auto"}` (asserting main's actual behavior, which differs from the closed PRs), plus the malformed forced-function case (no fabricated directive).

**Contributor checklist:** no new egress; no payload in any log or row; docs updated in this PR; tests in this PR; no new dependency. Touches `gateway/**` so it routes to security review per CODEOWNERS — the only behavior change is the cap (tightens the closed set, P2/P4).

Gates run locally: `ruff format` + `ruff check` clean, `mypy --strict` gateway clean, gateway + api unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
