### PR TITLE
Require gateway key on inference endpoints (GW-01, Refs #288)

### DIFF
--- a/gateway/app/api/inference.py
+++ b/gateway/app/api/inference.py
@@ -57,7 +57,7 @@ import uuid
 from collections.abc import AsyncIterator
 from typing import Any, Final
 
-from fastapi import APIRouter, Request, status
+from fastapi import APIRouter, Depends, Request, status
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import ValidationError
 
@@ -68,6 +68,7 @@ from app.anonymization.middleware import (
     post_anonymize_response,
     pre_anonymize_request,
 )
+from app.api.dependencies import make_require_gateway_key
 from app.clients.backend import BackendClient, Skill, get_backend_client
 from app.config import GatewayConfig
 from app.errors import LQAIError
@@ -111,7 +112,9 @@ from app.tier_floor import TierFloor, is_refused, resolve_tier_floor
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/v1", tags=["inference"])
+require_gateway_key = make_require_gateway_key()
+
+router = APIRouter(prefix="/v1", tags=["inference"], dependencies=[Depends(require_gateway_key)])
 
 
 TIER_HEADER: Final[str] = "X-LQ-AI-Routed-Inference-Tier"

--- a/gateway/tests/test_inference_auth.py
+++ b/gateway/tests/test_inference_auth.py
@@ -1,0 +1,71 @@
+"""Regression tests for the inference router's gateway-key auth gate (GW-01).
+
+The inference router (``/v1/chat/completions``, ``/v1/embeddings``,
+``/v1/models``, ``/v1/citation-engine/config``) must enforce the
+``X-LQ-AI-Gateway-Key`` shared secret when one is configured, matching the
+admin/tools/oauth routers and the auth already declared in
+``docs/api/gateway-openapi.yaml``. Prior to the fix the router was mounted with
+no ``dependencies=[Depends(require_gateway_key)]``, so these endpoints accepted
+unauthenticated requests. Refs #288.
+
+These tests mount only the inference router on a bare app (the lightweight
+``_make_app`` idiom from ``test_tools_route.py``) so the auth gate is exercised
+in isolation, without the full gateway lifespan. The auth dependency runs before
+the path operation, so a 401 never reaches the handler and no router/adapter
+wiring is needed; the positive (authenticated) path is covered by the existing
+inference tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.api.inference import router as inference_router
+from app.config import GatewayConfig
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    # gateway_auth.enabled defaults to True; with LQ_AI_GATEWAY_KEY set in the
+    # environment the gate resolves a non-empty expected key and enforces it.
+    app.state.config = GatewayConfig.model_validate({})
+    app.include_router(inference_router)
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.unit
+async def test_chat_completions_requires_gateway_key_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /v1/chat/completions is 401 without a valid X-LQ-AI-Gateway-Key."""
+
+    monkeypatch.setenv("LQ_AI_GATEWAY_KEY", "expected-key-value")
+    app = _make_app()
+    async with _client(app) as c:
+        missing = await c.post("/v1/chat/completions", json={"model": "smart", "messages": []})
+        wrong = await c.post(
+            "/v1/chat/completions",
+            json={"model": "smart", "messages": []},
+            headers={"X-LQ-AI-Gateway-Key": "nope"},
+        )
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+
+
+@pytest.mark.unit
+async def test_embeddings_requires_gateway_key_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /v1/embeddings is 401 without a valid X-LQ-AI-Gateway-Key."""
+
+    monkeypatch.setenv("LQ_AI_GATEWAY_KEY", "expected-key-value")
+    app = _make_app()
+    async with _client(app) as c:
+        missing = await c.post("/v1/embeddings", json={"model": "embedding", "input": "hello"})
+    assert missing.status_code == 401


### PR DESCRIPTION
## What this PR does

Mounts the gateway's `/v1` inference router with `dependencies=[Depends(require_gateway_key)]`, so `POST /v1/chat/completions`, `POST /v1/embeddings`, `GET /v1/models`, and `GET /v1/citation-engine/config` now enforce the `X-LQ-AI-Gateway-Key` shared secret — matching the `admin`, `tools`, and `oauth` routers, which already gate on it. Adds a regression test (`gateway/tests/test_inference_auth.py`) asserting `401` on the chat and embeddings endpoints when a key is configured but the header is missing or wrong.

## Why

`Refs #288` — finding **GW-01** of the security audit. The inference router was constructed as `APIRouter(prefix="/v1", tags=["inference"])` with **no** auth dependency, while every sibling router (`admin.py`, `tools.py`, `oauth.py`) enforces `require_gateway_key`. This left the gateway's crown-jewel egress path (provider-key spend + privileged-data forwarding) reachable **without** the shared secret by anything on the compose network, bypassing the backend's per-user authz. It also contradicted the gateway's own OpenAPI contract: `docs/api/gateway-openapi.yaml` declares a global `security: - apiKeyAuth: []` from which only `/health` and `/ready` opt out — `/v1/chat/completions`, `/v1/embeddings`, and `/v1/models` never did, so they were already documented as requiring the key. This change makes the code match the contract.

The happy path is unaffected: the api service's `GatewayClient` already stamps `X-LQ-AI-Gateway-Key` as a default header on every request (`api/app/clients/gateway.py`), and every in-repo caller (workers, research, MCP, knowledge/embed) routes through that same client. The web UI reaches models via the api backend, not the gateway. `gateway_auth.enabled` defaults to `true` and `LQ_AI_GATEWAY_KEY` is a required compose var, so real deployments already share the secret on both sides.

## What this PR does *not* do

Does not change the empty-key/dev behavior (an unset `LQ_AI_GATEWAY_KEY` still resolves to "auth disabled" via `_resolve_required_key`, so local dev without a key keeps working — same as the other routers). Does not touch the OpenAPI sketch (it already required auth here). Does not add per-endpoint `security:` restatements (the router-level dependency is sufficient; no test enforces the redundant per-path form).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests added/updated

<details>
<summary>Gates run locally (gateway/.venv)</summary>

- `pytest tests/test_inference_auth.py` → **2 passed** (both endpoints return 401 without a valid key).
- `ruff check gateway` → clean.
- `ruff format --check` (changed files) → clean.
- `mypy app` (strict) → `Success: no issues found in 56 source files`.

The full gateway suite is deferred to CI: several lifespan-based tests (`gateway_app` fixture) perform model discovery against provider endpoints that aren't reachable in this local sandbox. This change is isolated to the router construction (no import cycle — `app.api.dependencies` is already imported by `tools.py`/`oauth.py`), so it does not affect other tests.

</details>

## Documentation

- [x] OpenAPI schema — no change needed; `docs/api/gateway-openapi.yaml` already declares `apiKeyAuth` on these paths (this PR aligns code to the existing contract).

## Transparency & governance invariants

- [x] **Fail restrictive (P4):** the endpoints now fail closed (401) when a key is configured and the header is missing/invalid; the regression test exercises exactly that missing/wrong-header path, not just the happy path.
- [x] **Contract is truth (P10):** the code now matches the auth already declared in the gateway OpenAPI; no silent authz decision.
- [x] Egress (P1), Closed set (P2), No raw payloads (P3 — the 401 envelope carries no key/content), Operator control (P8): n/a or preserved — no new egress, capability, logging, or admin surface.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (GW-01).

> `gateway/**` is a security-sensitive path, so per `.github/CODEOWNERS` this PR auto-routes to `@legalquants/security` review.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
