### PR TITLE
Refuse to start with the published dev JWT secret in production (API-04, Refs #288)

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -21,6 +21,11 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 LogLevel = Literal["debug", "info", "warning", "warn", "error", "critical"]
 
+# Published development default for the JWT signing secret. Refused at startup
+# outside dev mode (see ``assert_production_secrets``) so a deployment can never
+# silently ship with a public signing key.
+DEV_JWT_SECRET = "dev-jwt-secret-change-me"
+
 
 class Settings(BaseSettings):
     """Backend API configuration.
@@ -173,7 +178,7 @@ class Settings(BaseSettings):
 
     # ----- JWT (per ADR 0002 — backend owns auth) -----
     jwt_secret: str = Field(
-        default="dev-jwt-secret-change-me",
+        default=DEV_JWT_SECRET,
         description="Signing secret for JWT access and refresh tokens.",
     )
     jwt_access_token_ttl_seconds: int = Field(
@@ -470,6 +475,27 @@ def get_settings() -> Settings:
     monkeypatching environment variables.
     """
     return Settings()
+
+
+def assert_production_secrets(settings: Settings) -> None:
+    """Fail closed at startup if a known development default is used in prod.
+
+    Called from the app lifespan startup gate (``app.main.lifespan``), NOT as a
+    Settings validator — construction with the published defaults must stay
+    valid so ``test_config`` and any Settings() in tests keep working. The
+    guard fires only when the process actually starts serving.
+
+    ``jwt_secret`` signs and verifies every access/MFA token; shipping the
+    published default (``DEV_JWT_SECRET``) lets an attacker forge a token for
+    any user. Refuse to boot unless the operator sets a real secret, or opts
+    into ``LQ_AI_DEV_MODE`` for local development.
+    """
+    if settings.jwt_secret == DEV_JWT_SECRET and not settings.lq_ai_dev_mode:
+        raise RuntimeError(
+            "Refusing to start: JWT_SECRET is the published development default "
+            f"({DEV_JWT_SECRET!r}). Set JWT_SECRET to a strong random secret, or "
+            "set LQ_AI_DEV_MODE=true for local development."
+        )
 
 
 def is_allowed_return_url(url: str, settings: Settings) -> bool:

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -29,7 +29,7 @@ from app.admin_bootstrap import ensure_first_run_admin
 from app.api import api_router
 from app.cache import check_redis, close_redis
 from app.clients.gateway import close_gateway_client, get_gateway_client
-from app.config import get_settings
+from app.config import assert_production_secrets, get_settings
 from app.db.session import check_db, dispose_engine, get_session_factory
 from app.errors import LQAIError
 from app.skills import install_sighup_reload, install_skill_registry, resolve_skill_dirs
@@ -51,6 +51,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     settings = get_settings()
     logging.basicConfig(level=settings.log_level.upper())
     log.info("Starting %s v%s", SERVICE_NAME, __version__)
+
+    # Fail closed before serving if a published dev default (e.g. the JWT
+    # signing secret) is still in place outside dev mode. Unlike the
+    # best-effort startup steps below, this deliberately raises. #288 (API-04).
+    assert_production_secrets(settings)
 
     try:
         await ensure_bucket()

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from app.config import Settings, get_settings
+from app.config import DEV_JWT_SECRET, Settings, assert_production_secrets, get_settings
 
 
 @pytest.mark.unit
@@ -113,3 +113,40 @@ def test_get_settings_is_cached() -> None:
     get_settings.cache_clear()
     c = get_settings()
     assert c is not a
+
+
+@pytest.mark.unit
+def test_assert_production_secrets_refuses_dev_jwt_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup must fail closed when JWT_SECRET is the published dev default
+    and dev mode is off (#288, API-04)."""
+    monkeypatch.setenv("JWT_SECRET", DEV_JWT_SECRET)
+    monkeypatch.delenv("LQ_AI_DEV_MODE", raising=False)
+    s = Settings(_env_file=None)  # type: ignore[call-arg]
+    assert s.jwt_secret == DEV_JWT_SECRET
+    assert s.lq_ai_dev_mode is False
+    with pytest.raises(RuntimeError, match="published development default"):
+        assert_production_secrets(s)
+
+
+@pytest.mark.unit
+def test_assert_production_secrets_allows_dev_default_in_dev_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dev default is fine when LQ_AI_DEV_MODE is on."""
+    monkeypatch.setenv("JWT_SECRET", DEV_JWT_SECRET)
+    monkeypatch.setenv("LQ_AI_DEV_MODE", "true")
+    s = Settings(_env_file=None)  # type: ignore[call-arg]
+    assert_production_secrets(s)  # does not raise
+
+
+@pytest.mark.unit
+def test_assert_production_secrets_allows_real_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-default secret is accepted even outside dev mode."""
+    monkeypatch.setenv("JWT_SECRET", "a-strong-random-production-secret")
+    monkeypatch.delenv("LQ_AI_DEV_MODE", raising=False)
+    s = Settings(_env_file=None)  # type: ignore[call-arg]
+    assert_production_secrets(s)  # does not raise


### PR DESCRIPTION
## What this PR does

Makes the API refuse to start when `JWT_SECRET` is still the published development default (`dev-jwt-secret-change-me`) and dev mode is off.

## Why

`Refs #288` — finding **API-04 (Medium)**. `jwt_secret` defaulted to the hard-coded literal `dev-jwt-secret-change-me` and signs **and verifies** every HS256 access/MFA token. `Settings` had no validator and there was no startup guard, so an operator who forgot to set `JWT_SECRET` (a silent, missed `.env` line) would ship with a **public** signing key — an attacker can then forge an access token for any user id, including an admin's. The docstring told operators to override it, but that is documentation, not enforcement.

## How

- Add `assert_production_secrets(settings)` in `app/config.py` and call it from the `app.main.lifespan` startup gate. It raises `RuntimeError` when `jwt_secret == DEV_JWT_SECRET and not lq_ai_dev_mode`.
- Deliberately a **lifespan gate, not a Settings `@model_validator`** — construction with the published defaults must stay valid (e.g. `test_config.test_defaults_apply_when_env_unset`, and any `Settings()` in tests). No test enters the full `lifespan()` (the ASGI in-process client doesn't trigger it), so this doesn't disturb the suite; it fires only when the process actually serves.
- Extract the default into the `DEV_JWT_SECRET` constant so the `Field` default and the guard share one source of truth.
- `LQ_AI_DEV_MODE=true` remains the explicit escape hatch for local dev (the existing "relax some safety checks for local development" flag).

## What this PR does *not* do

Doesn't broaden the check to other secrets (gateway key etc.) — scoped to the JWT default called out in the finding. Doesn't change token logic.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests added/updated

<details>
<summary>Gates run locally (api/.venv)</summary>

- `pytest tests/test_config.py` → **7 passed** (incl. the 3 new: dev-default-off-dev-mode → raises; dev-default-in-dev-mode → ok; real secret → ok). These are pure unit tests (no DB), so they ran locally.
- `ruff check` + `ruff format --check` → clean.
- `mypy app` → `Success: no issues found in 190 source files`.

</details>

## Transparency & governance invariants

- [x] **Fail restrictive (P4):** a known-insecure default now fails the process closed at startup; tests cover the raise and both accept paths.
- [x] **Contract is truth (P10):** enforces the "MUST override" the config docstring already stated.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (API-04). The login/MFA rate-limiting item (API-03) from the same finding cluster is a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
