### PR TITLE
Guard LLM provider base_url egress at build time (GW-04, Refs #288)

### DIFF
--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -74,6 +74,7 @@ from app.providers import (
     OpenAIAdapter,
     ProviderAdapter,
 )
+from app.providers.base_url_policy import validate_llm_base_url
 from app.providers.tool.base import ToolProviderAdapter
 from app.providers.tool.courtlistener import CourtListenerToolAdapter
 from app.providers.tool.echo import EchoToolAdapter
@@ -161,6 +162,11 @@ def build_adapter(provider: ProviderConfig) -> ProviderAdapter | None:
 
     if not provider.enabled:
         return None
+    # Egress guard (#288, GW-04): the prompt-carrying LLM path must not send
+    # cleartext to a public host or use a non-http(s) scheme. Validate before
+    # building any adapter so a bad base_url fails at startup — matching the
+    # build-time validation the tool path already does.
+    validate_llm_base_url(provider.base_url)
     if provider.type == "anthropic":
         return AnthropicAdapter.from_config(provider)
     if provider.type in ("openai", "openai_compatible"):

--- a/gateway/app/providers/base_url_policy.py
+++ b/gateway/app/providers/base_url_policy.py
@@ -1,0 +1,70 @@
+"""Egress policy for LLM provider ``base_url``s (#288, GW-04).
+
+The tool path (:mod:`app.providers.tool.egress`) enforces a strict
+https-only, host-allowlisted, public-IP egress guard. The LLM provider path
+needs a slightly looser but still-safe rule: public providers (Anthropic,
+OpenAI, Azure, Vertex, Bedrock) MUST use ``https``, but local providers
+(Ollama, vLLM) legitimately speak plaintext ``http`` to a loopback address
+or a compose service name (``http://ollama:11434``, ``http://vllm:8000/v1``).
+
+Before this guard ``ProviderConfig.base_url`` was validated only as
+``min_length=1``, so a misconfiguration or config tampering could point the
+crown-jewel prompt-egress path at ``http://attacker.example`` or an internal
+address in cleartext — the asymmetry the audit flagged versus the hardened
+tool path. This guard is applied at adapter build time so a bad ``base_url``
+fails fast at startup.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse
+
+
+class ProviderEgressRefused(Exception):
+    """Raised when a provider ``base_url`` violates LLM egress policy."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _is_local_host(host: str) -> bool:
+    """True when plaintext ``http`` egress to ``host`` is acceptable.
+
+    Acceptable local targets: a loopback/private/link-local/CGNAT IP literal,
+    ``localhost``, or a single-label hostname (no dot) — i.e. a container /
+    compose service name such as ``ollama`` or ``vllm`` that is not a routable
+    public host. A dotted FQDN (``api.openai.com``) is treated as public.
+    """
+    if host.lower() == "localhost":
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        # Not an IP literal: a single-label name is a private service name;
+        # a dotted (or IPv6-bracketed) name is a public FQDN.
+        return "." not in host and ":" not in host
+    return not ip.is_global
+
+
+def validate_llm_base_url(base_url: str) -> None:
+    """Validate an LLM provider ``base_url`` against egress policy.
+
+    ``https`` is always allowed; ``http`` is allowed only to a local host
+    (Ollama/vLLM). Any other scheme, a missing host, or plaintext ``http`` to
+    a public host raises :class:`ProviderEgressRefused`.
+    """
+    parsed = urlparse(base_url)
+    if parsed.scheme not in ("http", "https"):
+        raise ProviderEgressRefused(
+            f"provider base_url must use http or https, got scheme {parsed.scheme!r}"
+        )
+    host = parsed.hostname
+    if not host:
+        raise ProviderEgressRefused("provider base_url has no host")
+    if parsed.scheme == "http" and not _is_local_host(host):
+        raise ProviderEgressRefused(
+            "plaintext http base_url is only permitted for local providers "
+            f"(loopback/private/service name); public host {host!r} must use https"
+        )

--- a/gateway/tests/test_llm_base_url_policy.py
+++ b/gateway/tests/test_llm_base_url_policy.py
@@ -1,0 +1,81 @@
+"""Tests for the LLM provider base_url egress guard (#288, GW-04).
+
+The prompt-carrying LLM path must not send cleartext to a public host or use
+a non-http(s) scheme, mirroring the hardened tool-egress path. `https` is
+always allowed; `http` only to a local host (Ollama/vLLM).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import ProviderConfig
+from app.main import build_adapter
+from app.providers.base_url_policy import ProviderEgressRefused, validate_llm_base_url
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.anthropic.com",
+        "https://api.openai.com/v1",
+        "https://us-central1-aiplatform.googleapis.com",
+        "http://ollama:11434",  # compose service name
+        "http://vllm:8000/v1",
+        "http://localhost:11434",
+        "http://127.0.0.1:11434",
+        "http://[::1]:11434",
+        "http://10.0.0.5:8000",  # private
+    ],
+)
+def test_accepts_valid_targets(url: str) -> None:
+    validate_llm_base_url(url)  # does not raise
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://api.openai.com/v1",  # plaintext to a public host
+        "http://attacker.example/v1",
+        "http://8.8.8.8/v1",  # plaintext to a public IP
+        "ftp://api.openai.com",  # unsupported scheme
+        "file:///etc/passwd",
+        "https://",  # no host
+    ],
+)
+def test_rejects_bad_targets(url: str) -> None:
+    with pytest.raises(ProviderEgressRefused):
+        validate_llm_base_url(url)
+
+
+@pytest.mark.unit
+def test_build_adapter_rejects_plaintext_public_base_url() -> None:
+    """build_adapter fails fast when a provider is configured to send prompts
+    in cleartext to a public host."""
+    provider = ProviderConfig.model_validate(
+        {
+            "name": "evil",
+            "type": "ollama",  # ollama needs no API key, so build reaches the guard
+            "base_url": "http://attacker.example/v1",
+            "tier": 1,
+        }
+    )
+    with pytest.raises(ProviderEgressRefused):
+        build_adapter(provider)
+
+
+@pytest.mark.unit
+def test_build_adapter_allows_local_ollama() -> None:
+    """A normal local Ollama config over http builds without complaint."""
+    provider = ProviderConfig.model_validate(
+        {
+            "name": "ollama-local",
+            "type": "ollama",
+            "base_url": "http://ollama:11434",
+            "tier": 1,
+        }
+    )
+    adapter = build_adapter(provider)
+    assert adapter is not None


### PR DESCRIPTION
## What this PR does

Adds a build-time egress guard on LLM provider `base_url`s: `https` is always allowed, `http` only to a local host (Ollama/vLLM). A misconfigured provider now fails fast at startup instead of silently sending prompts in cleartext to a public host.

## Why

`Refs #288` — finding **GW-04 (Medium)**. `ProviderConfig.base_url` was validated only as `Field(min_length=1)`, and `build_adapter` handed it straight to the adapter with no scheme/host check. So the **crown-jewel prompt-egress path** could use a plaintext `http://` base_url or an internal/attacker-controlled address — while the **lower-trust tool path** is hardened (`build_tool_adapter` → `validate_base_url` → `validate_egress_target`: https-only, host allowlist, public-IP/DNS-rebind check). That asymmetry means a config mistake or tampering could silently exfiltrate every prompt.

## How

- New `gateway/app/providers/base_url_policy.py::validate_llm_base_url`, called at the top of `build_adapter` (main.py) before any adapter is constructed — mirroring how `build_tool_adapter` validates each tool provider at build time, so a bad `base_url` fails at startup.
- Policy is intentionally looser than the tool path because LLM providers differ: public providers (Anthropic/OpenAI/Azure/Vertex/Bedrock) **must** use `https`, but local providers legitimately speak plaintext `http` to a loopback address or a compose service name (`http://ollama:11434`, `http://vllm:8000/v1`). So: `https` any host; `http` only when the host is loopback / a private-or-link-local IP literal / `localhost` / a single-label service name. Everything else (plaintext to a public host, non-http(s) schemes, missing host) is refused.

## What this PR does *not* do

Doesn't add a per-provider host allowlist (the finding notes it as optional; the scheme/locality guard closes the cleartext-exfil path, and an allowlist can layer on later). Doesn't change the tool-egress path.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests added/updated

<details>
<summary>Gates run locally (gateway/.venv)</summary>

- `pytest tests/test_llm_base_url_policy.py` → **17 passed** — accepts the shipped configs (anthropic/openai/vertex https, ollama/vllm/localhost/private-IP http); rejects http-to-public, http-to-public-IP, non-http schemes, and missing host; `build_adapter` raises on a plaintext-public `base_url` and still builds a normal local Ollama.
- `ruff check` + `ruff format --check` → clean.
- `mypy app` (strict) → `Success: no issues found in 57 source files`.

</details>

## Transparency & governance invariants

- [x] **Egress (P1) / Fail restrictive (P4):** the sole audited egress boundary now refuses a cleartext-to-public or non-http(s) provider target and fails closed at startup; tests cover accept + reject paths.
- [x] **One governance path (P6):** applied at the same `build_adapter` build-time hook the tool path uses.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (GW-04).

> `gateway/**` is a security-sensitive path — routes to `@legalquants/security` per `.github/CODEOWNERS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
