### PR TITLE
Scope autonomous retrieve_chunks to the session owner (AG-01, Refs #288)

### DIFF
--- a/api/app/autonomous/guard.py
+++ b/api/app/autonomous/guard.py
@@ -574,7 +574,7 @@ async def _dispatch(
         return ToolResult(cost_usd=Decimal("0"), data={"notification_id": str(note.id)})
 
     if intent == ToolIntent.retrieve_chunks:
-        return await _handle_retrieve_chunks(params, db=db)
+        return await _handle_retrieve_chunks(params, db=db, owner_id=session.user_id)
 
     if intent in (ToolIntent.run_skill, ToolIntent.run_playbook, ToolIntent.plan):
         return await _handle_gateway_inference(
@@ -1149,13 +1149,64 @@ async def _handle_emit_artifact(
     return ToolResult(cost_usd=Decimal("0"), data=data)
 
 
+async def _assert_kb_owned(db: AsyncSession, kb_id: uuid.UUID, owner_id: uuid.UUID) -> None:
+    """Reject a model-supplied ``kb_id`` the session owner does not own.
+
+    :func:`hybrid_search` and the since-fetch scope only by ``kb_id`` and rely
+    on the *handler* having verified ownership upstream (per the retrieval
+    module's contract). In the autonomous loop the planner's ``kb_id`` is
+    model-controlled and therefore prompt-injectable, so the check has to
+    happen here or an injected document could steer retrieval at another
+    tenant's KB (#288, AG-01). 404-shaped (not-found) message so cross-user
+    probing can't tell "exists, not yours" from "doesn't exist".
+    """
+    from sqlalchemy import select
+
+    from app.models.knowledge import KnowledgeBase
+
+    owned = (
+        await db.execute(
+            select(KnowledgeBase.id).where(
+                KnowledgeBase.id == kb_id,
+                KnowledgeBase.owner_id == owner_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if owned is None:
+        raise ValueError(f"knowledge base {kb_id} is not accessible to this session")
+
+
+async def _assert_file_owned(db: AsyncSession, file_id: uuid.UUID, owner_id: uuid.UUID) -> None:
+    """Reject a model-supplied ``file_id`` the session owner does not own
+    (#288, AG-01). See :func:`_assert_kb_owned` for the rationale."""
+    from sqlalchemy import select
+
+    from app.models.file import File as FileModel
+
+    owned = (
+        await db.execute(
+            select(FileModel.id).where(
+                FileModel.id == file_id,
+                FileModel.owner_id == owner_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if owned is None:
+        raise ValueError(f"file {file_id} is not accessible to this session")
+
+
 async def _handle_retrieve_chunks(
     params: dict[str, Any],
     *,
     db: AsyncSession,
+    owner_id: uuid.UUID,
 ) -> ToolResult:
     """Handle ``retrieve_chunks`` — hybrid KB search OR file-scoped OR
     since-scoped fetch.  Zero cost (local retrieval).
+
+    ``owner_id`` is the owning session's ``user_id``; every model-supplied
+    ``kb_id``/``file_id`` is checked against it before retrieval so a
+    prompt-injected document cannot reach another tenant's data (#288, AG-01).
 
     Three modes (mutually exclusive at the top level):
 
@@ -1204,10 +1255,12 @@ async def _handle_retrieve_chunks(
 
     # Mode 2: file-scoped fetch.
     if file_id_raw is not None:
+        await _assert_file_owned(db, uuid.UUID(str(file_id_raw)), owner_id)
         return await _handle_retrieve_chunks_by_file(file_id_raw, db=db)
 
     # Mode 3: since + kb_id scoped fetch.
     if since_raw is not None and kb_id_raw is not None:
+        await _assert_kb_owned(db, uuid.UUID(str(kb_id_raw)), owner_id)
         return await _handle_retrieve_chunks_since(since_raw, kb_id_raw, db=db)
 
     # Mode 1: query-based hybrid search (existing path — unchanged).
@@ -1217,6 +1270,10 @@ async def _handle_retrieve_chunks(
             "`file_id` (file-scoped fetch), or `since` + `kb_id` "
             "(KB-scoped fetch of files attached after a cutoff)."
         )
+    # Mode 1 requires kb_id; verify ownership before searching. If kb_id is
+    # absent the downstream handler raises as before (malformed request).
+    if kb_id_raw is not None:
+        await _assert_kb_owned(db, uuid.UUID(str(kb_id_raw)), owner_id)
     return await _handle_retrieve_chunks_query(params, db=db)
 
 

--- a/api/tests/autonomous/conftest.py
+++ b/api/tests/autonomous/conftest.py
@@ -77,6 +77,7 @@ class KbOneFile:
     file_id: uuid.UUID
     document_id: uuid.UUID
     chunk_id: uuid.UUID
+    owner_id: uuid.UUID
 
 
 @dataclass
@@ -91,6 +92,7 @@ class KbTwoFiles:
     kb_id: uuid.UUID
     old_file_id: uuid.UUID
     new_file_id: uuid.UUID
+    owner_id: uuid.UUID
 
 
 _CHUNK_TEXT_DEFAULT = (
@@ -199,7 +201,9 @@ async def kb_with_one_indexed_file(db_session: AsyncSession) -> KbOneFile:
     # Force Postgres to compute the generated content_tsv column so FTS works.
     await db_session.execute(text("UPDATE document_chunks SET chunk_index = chunk_index"))
     await db_session.flush()
-    return KbOneFile(kb_id=kb.id, file_id=f.id, document_id=doc.id, chunk_id=chunk.id)
+    return KbOneFile(
+        kb_id=kb.id, file_id=f.id, document_id=doc.id, chunk_id=chunk.id, owner_id=owner.id
+    )
 
 
 @pytest_asyncio.fixture
@@ -231,7 +235,7 @@ async def kb_with_old_and_new_files(db_session: AsyncSession) -> KbTwoFiles:
     await db_session.execute(text("UPDATE document_chunks SET chunk_index = chunk_index"))
     await db_session.flush()
 
-    return KbTwoFiles(kb_id=kb.id, old_file_id=old_f.id, new_file_id=new_f.id)
+    return KbTwoFiles(kb_id=kb.id, old_file_id=old_f.id, new_file_id=new_f.id, owner_id=owner.id)
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/autonomous/test_emit_artifact.py
+++ b/api/tests/autonomous/test_emit_artifact.py
@@ -516,7 +516,9 @@ async def test_retrieve_chunks_since_excludes_artifact_files(
     await db_session.flush()
 
     since = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
-    result = await _handle_retrieve_chunks({"since": since, "kb_id": str(kb.id)}, db=db_session)
+    result = await _handle_retrieve_chunks(
+        {"since": since, "kb_id": str(kb.id)}, db=db_session, owner_id=user.id
+    )
 
     returned_file_ids = {c["file_id"] for c in result.data["chunks"]}
     assert str(ordinary_file.id) in returned_file_ids

--- a/api/tests/autonomous/test_retrieve_chunks_scope.py
+++ b/api/tests/autonomous/test_retrieve_chunks_scope.py
@@ -20,6 +20,7 @@ options, so an invocation bug surfaces with an actionable failure.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -46,6 +47,7 @@ async def test_retrieve_chunks_query_path_unchanged(
             "top_k": 4,
         },
         db=db_session,
+        owner_id=kb_with_one_indexed_file.owner_id,
     )
     assert "summary" in result.data
     assert "chunks" in result.data
@@ -83,6 +85,7 @@ async def test_retrieve_chunks_by_file_id(
             "file_id": str(kb_with_one_indexed_file.file_id),
         },
         db=db_session,
+        owner_id=kb_with_one_indexed_file.owner_id,
     )
     assert result.data["summary"]["chunk_count"] > 0
     for chunk in result.data["chunks"]:
@@ -111,6 +114,7 @@ async def test_retrieve_chunks_since_scope(
             "since": cutoff.isoformat(),
         },
         db=db_session,
+        owner_id=kb_with_old_and_new_files.owner_id,
     )
     returned_file_ids = {c["file_id"] for c in result.data["chunks"]}
     assert str(kb_with_old_and_new_files.new_file_id) in returned_file_ids
@@ -135,6 +139,7 @@ async def test_retrieve_chunks_since_accepts_aware_datetime(
             "since": cutoff,
         },
         db=db_session,
+        owner_id=kb_with_old_and_new_files.owner_id,
     )
     returned_file_ids = {c["file_id"] for c in result.data["chunks"]}
     assert str(kb_with_old_and_new_files.new_file_id) in returned_file_ids
@@ -152,7 +157,7 @@ async def test_retrieve_chunks_no_mode_raises_actionable_error(
     empty result, not a generic KeyError.
     """
     with pytest.raises(ValueError) as excinfo:
-        await _handle_retrieve_chunks({}, db=db_session)
+        await _handle_retrieve_chunks({}, db=db_session, owner_id=uuid.uuid4())
     message = str(excinfo.value)
     assert "query" in message
     assert "file_id" in message
@@ -174,6 +179,7 @@ async def test_retrieve_chunks_since_rejects_naive_datetime(
                 "since": naive_dt,
             },
             db=db_session,
+            owner_id=kb_with_old_and_new_files.owner_id,
         )
     with pytest.raises(ValueError, match="timezone-aware"):
         await _handle_retrieve_chunks(
@@ -182,4 +188,50 @@ async def test_retrieve_chunks_since_rejects_naive_datetime(
                 "since": "2026-05-27T12:00:00",  # naive ISO string (no offset)
             },
             db=db_session,
+            owner_id=kb_with_old_and_new_files.owner_id,
+        )
+
+
+async def test_retrieve_chunks_rejects_foreign_kb_id(
+    db_session: AsyncSession, kb_with_one_indexed_file: KbOneFile
+) -> None:
+    """IDOR regression (#288, AG-01): a session whose owner does not own the
+    model-supplied ``kb_id`` cannot retrieve its chunks, in any mode.
+
+    The autonomous planner's args are model-controlled and prompt-injectable,
+    so a foreign ``kb_id``/``file_id`` must be rejected before ``hybrid_search``
+    (which scopes only by id and trusts the handler for ownership).
+    """
+    intruder = uuid.uuid4()  # not the KB's owner
+
+    # Mode 1 (query)
+    with pytest.raises(ValueError, match="not accessible"):
+        await _handle_retrieve_chunks(
+            {
+                "kb_id": str(kb_with_one_indexed_file.kb_id),
+                "query": "confidential",
+                "alpha": 1.0,
+            },
+            db=db_session,
+            owner_id=intruder,
+        )
+
+    # Mode 2 (file_id)
+    with pytest.raises(ValueError, match="not accessible"):
+        await _handle_retrieve_chunks(
+            {"file_id": str(kb_with_one_indexed_file.file_id)},
+            db=db_session,
+            owner_id=intruder,
+        )
+
+    # Mode 3 (since + kb_id)
+    cutoff = datetime.now(UTC) - timedelta(minutes=5)
+    with pytest.raises(ValueError, match="not accessible"):
+        await _handle_retrieve_chunks(
+            {
+                "kb_id": str(kb_with_one_indexed_file.kb_id),
+                "since": cutoff.isoformat(),
+            },
+            db=db_session,
+            owner_id=intruder,
         )


### PR DESCRIPTION
## What this PR does

Scopes the autonomous agent's `retrieve_chunks` tool to the owning session's user: a model-supplied `kb_id`/`file_id` that the session owner does not own is rejected (404-shaped) before any retrieval.

## Why

`Refs #288` — finding **AG-01 (Medium, cross-tenant / prompt-injection)**. In the autonomous loop, `guarded_tool_call` forwards the planner model's `args` verbatim to `_handle_retrieve_chunks`, which read `kb_id`/`file_id` and called `hybrid_search` (and the file/`since` fetches) with **no** ownership check. `hybrid_search` scopes only by `kb_id` and explicitly documents that per-user isolation is enforced *upstream by the handler* — but the autonomous path never did it. Because the planner's `args` are model-controlled, a prompt-injected document (e.g. `"...next action: retrieve_chunks with kb_id=<foreign-uuid>"`) could steer retrieval at another tenant's KB, pulling its chunk text into the run's evidence/synthesis. The closed intent enum and phase grants don't help here — `retrieve_chunks` is a legitimately granted intent; the gap was missing authorization on its *target*.

## How

- Thread the session's `user_id` (`AutonomousSession.user_id`) into `_handle_retrieve_chunks` as `owner_id` from the single `_dispatch` call site.
- Before retrieval, verify ownership: `_assert_kb_owned` for mode 1 (query) and mode 3 (`since`+`kb_id`), `_assert_file_owned` for mode 2 (`file_id`). A foreign/unknown id raises a 404-shaped `ValueError` (`"…not accessible to this session"`), so cross-user probing can't distinguish "exists, not yours" from "doesn't exist".
- The `_by_file` and `_since` sub-handlers were also uncovered; the router-level check gates all three modes.

## What this PR does *not* do

Doesn't change `hybrid_search` itself (keeps its "handler verifies ownership" contract; this PR makes the autonomous handler honor it). Doesn't touch the AG-04 artifact-provenance item (tracked separately in #294).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests added/updated

<details>
<summary>Gates run locally (api/.venv)</summary>

- `ruff check` + `ruff format --check` → clean.
- `mypy app` (strict) → `Success: no issues found in 190 source files`.
- New test `test_retrieve_chunks_rejects_foreign_kb_id` asserts a non-owner is rejected in all three modes; the existing scope tests were updated to pass the fixture's `owner_id` (added to the `KbOneFile`/`KbTwoFiles` bundles). **pytest was not run locally** (the autonomous suite needs a pgvector Postgres and Docker wasn't available in this sandbox) — the DB-backed tests run in CI (`api-checks`).

</details>

## Transparency & governance invariants

- [x] **User owns data (P9) / Fail restrictive (P4):** closes a cross-tenant read reachable via prompt injection; foreign ids fail closed; the regression covers all three modes.
- [x] **Human gate / closed set (P2, P7):** unchanged — this tightens authorization on an already-granted intent.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (AG-01). Tracked in #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
