### PR TITLE
Pin GitHub Actions to commit SHAs (E-02, Refs #288)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
         working-directory: web
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -87,10 +87,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -123,10 +123,10 @@ jobs:
         working-directory: gateway
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -28,8 +28,8 @@ jobs:
       run:
         working-directory: desktop
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
       - run: npm ci
@@ -56,7 +56,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run dist
       - name: Publish .dmg to the release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: desktop/dist/*.dmg
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
             file: proxy/Dockerfile
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Resolve image tag
         id: tag
@@ -68,14 +68,14 @@ jobs:
 
       - name: Set up QEMU
         # Enables cross-platform (linux/arm64) builds on the amd64 runner.
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GHCR
         if: ${{ github.event_name == 'push' || !inputs.dry_run }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: Generate SLSA build provenance
         if: ${{ github.event_name == 'push' || !inputs.dry_run }}
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -121,7 +121,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Resolve image tag
         id: tag
@@ -138,14 +138,14 @@ jobs:
       # this job was missing the equivalent step). packages:read on this job is
       # sufficient for the pull.
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate SBOM (SPDX JSON)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}:${{ steps.tag.outputs.tag }}
           format: spdx-json
@@ -181,7 +181,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Resolve image tag
         id: tag
@@ -193,19 +193,19 @@ jobs:
           fi
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
         with:
           cosign-release: v2.4.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download SBOM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ matrix.service }}.spdx.json
           path: ./sbom


### PR DESCRIPTION
## What this PR does

Pins every third-party GitHub Action in `ci.yml`, `release.yml`, and `desktop-release.yml` to the commit SHA its current major-version tag points to (with a `# vN` comment).

## Why

`Refs #288` — finding **E-02 (Low, supply chain)**. All 12 distinct actions were referenced by mutable tags (`actions/checkout@v4`, `docker/build-push-action@v5`, `sigstore/cosign-installer@v3`, …). A tag can be force-moved by a compromised action owner, and the **release** workflow runs with `packages: write`, `id-token`/`attestations: write`, a registry-push `GITHUB_TOKEN`, and (desktop-release) Apple signing material — so a hijacked action tag could exfiltrate signing secrets or push a poisoned image. SHA pins make the action content immutable.

(Confirmed no `pull_request_target` and no untrusted `${{ github.event.* }}` in shell bodies, so this closes the remaining supply-chain vector called out for CI.)

## How

22 `uses:` references pinned to the SHA each `@vN` tag currently resolves to (resolved via the GitHub API), each keeping a trailing `# vN` comment so Dependabot/Renovate continue to bump them.

## What this PR does *not* do

**E-03 (non-root containers) is intentionally not in this PR.** It needs a container **build** to validate — especially the gateway, whose entrypoint seeds a writable `gateway.yaml` into `/etc/lq-ai/` that a non-root UID must own, or startup breaks. PR CI does not build images (only the tag-triggered release workflow does), so a Dockerfile `USER`/`chown` mistake wouldn't surface until release. It's tracked in #294 for a Docker-validated follow-up rather than shipped unverified into security-sensitive infra.

## Type of change

- [x] Test / CI / tooling

## Testing

- [x] Verified all pins resolve and no floating `@vN` `uses:` remain; each SHA resolved from the action repo's current major tag via the GitHub API.

## Transparency & governance invariants

- [x] **Contract is truth (P10):** CI now runs immutable, auditable action versions.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (E-02). E-03 tracked in #294.

> `.github/workflows/**` is security-sensitive — routes to `@legalquants/security` per `.github/CODEOWNERS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
