### PR TITLE
ci: stack-boot smoke test (build + boot the whole compose stack)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ name: CI
 #   - Cypress E2E (heavier; needs a stack-up step + LLM provider keys)
 #   - Coverage gates (no-decrease enforcement)
 #   - Dependency-license check (likely Wave F polish)
+#
+# Runtime boot validation (full compose build + up --wait + soak) lives in
+# stack-smoke.yml and runs on dependency-manifest PRs, pushes to main, and
+# manual dispatch — see issue #283.
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,11 @@ jobs:
     # Image matches docker-compose.yml: pgvector/pgvector:pg16 carries the
     # pgvector extension binary that migrations require (CREATE EXTENSION
     # IF NOT EXISTS vector). Plain postgres:16-alpine omits it.
+    # Pinned by multi-arch index digest (supply-chain hardening, same as the
+    # action SHA pins); bump the digest when moving to a newer pg16 build.
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: pgvector/pgvector:pg16@sha256:ad2e18408bf447f62092a8a5259e7df10505c5a0360bd1a1853ac8b8b0763da2
         env:
           POSTGRES_USER: lq_ai
           POSTGRES_PASSWORD: lq_ai

--- a/.github/workflows/stack-smoke.yml
+++ b/.github/workflows/stack-smoke.yml
@@ -1,4 +1,5 @@
-# Stack-boot smoke test (issue #283).
+# Stack-boot smoke test (issue #283). The check itself is
+# scripts/stack-smoke.sh — run that locally to reproduce this job.
 #
 # Builds the full default-profile compose stack and asserts it stands:
 # every service reaches its healthcheck, holds for a soak period without
@@ -64,69 +65,16 @@ jobs:
           sudo docker image prune -af
           df -h /
 
-      - name: Write CI .env
-        # Dummy values for the four secrets compose requires (see
-        # .env.example). Provider API keys stay unset — the stack boots
-        # without them and this workflow performs no inference.
-        run: |
-          cat > .env <<'EOF'
-          POSTGRES_PASSWORD=ci-smoke-postgres
-          MINIO_ROOT_PASSWORD=ci-smoke-minio-password
-          LQ_AI_GATEWAY_KEY=ci-smoke-gateway-key
-          JWT_SECRET=ci-smoke-jwt-secret-0123456789abcdef0123456789abcdef
-          EOF
-
-      - name: Build images
-        # api, ingest-worker, and arq-worker share the ./api build
-        # context and produce byte-identical images. Letting `up --build`
-        # build all three exports the ~12 GB image three times
-        # concurrently, which can exhaust runner disk mid-extraction
-        # (observed during local verification). Build each distinct
-        # image once and tag the worker images from the api image —
-        # compose image names are stable because docker-compose.yml
-        # pins the project name (`name: lq-ai`).
-        run: |
-          docker compose build gateway web
-          docker compose build api
-          docker tag lq-ai-api:latest lq-ai-ingest-worker:latest
-          docker tag lq-ai-api:latest lq-ai-arq-worker:latest
-
-      - name: Boot the stack
-        # --wait blocks until every default-profile service reports
-        # healthy (all of them define healthchecks) and fails the step
-        # if any container exits or never becomes healthy.
-        run: docker compose up -d --wait --wait-timeout 900 --no-build
-
-      - name: Probe health endpoints from the host
-        run: |
-          curl -fsS http://127.0.0.1:8000/health
-          curl -fsS http://127.0.0.1:8001/health
-          curl -fsS http://127.0.0.1:3000/health
-
-      - name: Probe lazily-imported dependencies
-        # The ingest worker defers docling imports into job functions
-        # (see api/app/workers/document_pipeline.py), so a broken
-        # docling survives boot. Import it explicitly.
-        run: docker compose exec -T ingest-worker python -c "from docling.document_converter import DocumentConverter"
-
-      - name: Soak
-        # Healthchecks can flicker healthy on a crash-looping service;
-        # hold long enough for a loop to show up as restarts.
-        run: sleep 75
-
-      - name: Assert no container restarted
-        run: |
-          failed=0
-          for id in $(docker compose ps -q); do
-            name=$(docker inspect --format '{{.Name}}' "$id")
-            restarts=$(docker inspect --format '{{.RestartCount}}' "$id")
-            status=$(docker inspect --format '{{.State.Status}}' "$id")
-            echo "$name status=$status restarts=$restarts"
-            if [ "$restarts" != "0" ] || [ "$status" != "running" ]; then
-              failed=1
-            fi
-          done
-          exit "$failed"
+      - name: Run the stack smoke
+        # The smoke itself lives in scripts/stack-smoke.sh — the single
+        # source of truth, so contributors can run the exact same check
+        # locally before submitting a risky change (see CONTRIBUTING.md
+        # "Stack smoke test"). It writes a dummy .env (no provider keys
+        # are needed; nothing performs inference), builds the images,
+        # boots the stack to healthy, probes health endpoints and
+        # lazily-imported deps, soaks, and asserts no container
+        # restarted.
+        run: ./scripts/stack-smoke.sh
 
       - name: Dump stack state on failure
         if: failure()

--- a/.github/workflows/stack-smoke.yml
+++ b/.github/workflows/stack-smoke.yml
@@ -76,11 +76,26 @@ jobs:
           JWT_SECRET=ci-smoke-jwt-secret-0123456789abcdef0123456789abcdef
           EOF
 
-      - name: Build and boot the stack
+      - name: Build images
+        # api, ingest-worker, and arq-worker share the ./api build
+        # context and produce byte-identical images. Letting `up --build`
+        # build all three exports the ~12 GB image three times
+        # concurrently, which can exhaust runner disk mid-extraction
+        # (observed during local verification). Build each distinct
+        # image once and tag the worker images from the api image —
+        # compose image names are stable because docker-compose.yml
+        # pins the project name (`name: lq-ai`).
+        run: |
+          docker compose build gateway web
+          docker compose build api
+          docker tag lq-ai-api:latest lq-ai-ingest-worker:latest
+          docker tag lq-ai-api:latest lq-ai-arq-worker:latest
+
+      - name: Boot the stack
         # --wait blocks until every default-profile service reports
         # healthy (all of them define healthchecks) and fails the step
         # if any container exits or never becomes healthy.
-        run: docker compose up -d --build --wait --wait-timeout 900
+        run: docker compose up -d --wait --wait-timeout 900 --no-build
 
       - name: Probe health endpoints from the host
         run: |

--- a/.github/workflows/stack-smoke.yml
+++ b/.github/workflows/stack-smoke.yml
@@ -51,13 +51,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Free runner disk space
-        # The ingest-worker image (docling/easyocr/torch) plus the other
-        # three built images need more space than a hosted runner has
-        # free by default. Dropping the pre-installed toolchains we
-        # don't use reclaims ~15 GB.
+        # The api-family image unpacks to ~12 GB on its own (docling
+        # pulls CUDA-enabled torch), and the BuildKit cache costs about
+        # as much again, so the default ~14 GB of free runner space is
+        # not enough. Dropping the pre-installed toolchains we don't
+        # use and the runner's preloaded docker images reclaims ~25 GB.
         run: |
           df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/lib/jvm /usr/share/swift \
+            /usr/local/.ghcup /usr/local/share/boost /usr/local/lib/node_modules
+          sudo docker image prune -af
           df -h /
 
       - name: Write CI .env

--- a/.github/workflows/stack-smoke.yml
+++ b/.github/workflows/stack-smoke.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Free runner disk space
         # The api-family image unpacks to ~12 GB on its own (docling
@@ -82,7 +82,7 @@ jobs:
       # logs to stack-smoke-logs/ — upload those for offline digging.
       - name: Upload failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: stack-smoke-logs
           path: stack-smoke-logs/

--- a/.github/workflows/stack-smoke.yml
+++ b/.github/workflows/stack-smoke.yml
@@ -1,0 +1,116 @@
+# Stack-boot smoke test (issue #283).
+#
+# Builds the full default-profile compose stack and asserts it stands:
+# every service reaches its healthcheck, holds for a soak period without
+# restarting, and answers its health endpoint from the host. Building the
+# web image runs the Vite production build; booting the api runs
+# `alembic upgrade head` against real Postgres.
+#
+# This exists to validate what the per-subsystem CI jobs structurally
+# cannot: server boot (uvicorn), real Redis connections (arq workers),
+# lazily-imported heavy deps (docling), and the OpenWebUI-core build that
+# the scoped svelte-check never touches. It proves "builds, migrates,
+# boots, and holds" — NOT "features work"; E2E remains a future wave
+# (see ci.yml scope comment).
+#
+# Cold builds are expensive (~20-30 min; the ingest image pulls
+# docling/easyocr/torch), so this runs only where it earns its keep:
+# dependency-manifest changes (i.e. dependabot PRs), pushes to main,
+# and manual dispatch. Buildx layer caching is a follow-up (#283).
+
+name: Stack smoke
+
+on:
+  pull_request:
+    paths:
+      - api/pyproject.toml
+      - gateway/pyproject.toml
+      - web/package.json
+      - web/package-lock.json
+      - "**/Dockerfile"
+      - docker-compose.yml
+      - .github/workflows/stack-smoke.yml
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: stack-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  stack-smoke:
+    name: Boot the compose stack and hold
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free runner disk space
+        # The ingest-worker image (docling/easyocr/torch) plus the other
+        # three built images need more space than a hosted runner has
+        # free by default. Dropping the pre-installed toolchains we
+        # don't use reclaims ~15 GB.
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
+
+      - name: Write CI .env
+        # Dummy values for the four secrets compose requires (see
+        # .env.example). Provider API keys stay unset — the stack boots
+        # without them and this workflow performs no inference.
+        run: |
+          cat > .env <<'EOF'
+          POSTGRES_PASSWORD=ci-smoke-postgres
+          MINIO_ROOT_PASSWORD=ci-smoke-minio-password
+          LQ_AI_GATEWAY_KEY=ci-smoke-gateway-key
+          JWT_SECRET=ci-smoke-jwt-secret-0123456789abcdef0123456789abcdef
+          EOF
+
+      - name: Build and boot the stack
+        # --wait blocks until every default-profile service reports
+        # healthy (all of them define healthchecks) and fails the step
+        # if any container exits or never becomes healthy.
+        run: docker compose up -d --build --wait --wait-timeout 900
+
+      - name: Probe health endpoints from the host
+        run: |
+          curl -fsS http://127.0.0.1:8000/health
+          curl -fsS http://127.0.0.1:8001/health
+          curl -fsS http://127.0.0.1:3000/health
+
+      - name: Probe lazily-imported dependencies
+        # The ingest worker defers docling imports into job functions
+        # (see api/app/workers/document_pipeline.py), so a broken
+        # docling survives boot. Import it explicitly.
+        run: docker compose exec -T ingest-worker python -c "from docling.document_converter import DocumentConverter"
+
+      - name: Soak
+        # Healthchecks can flicker healthy on a crash-looping service;
+        # hold long enough for a loop to show up as restarts.
+        run: sleep 75
+
+      - name: Assert no container restarted
+        run: |
+          failed=0
+          for id in $(docker compose ps -q); do
+            name=$(docker inspect --format '{{.Name}}' "$id")
+            restarts=$(docker inspect --format '{{.RestartCount}}' "$id")
+            status=$(docker inspect --format '{{.State.Status}}' "$id")
+            echo "$name status=$status restarts=$restarts"
+            if [ "$restarts" != "0" ] || [ "$status" != "running" ]; then
+              failed=1
+            fi
+          done
+          exit "$failed"
+
+      - name: Dump stack state on failure
+        if: failure()
+        run: |
+          docker compose ps -a
+          docker compose logs --no-color --tail 200

--- a/.github/workflows/stack-smoke.yml
+++ b/.github/workflows/stack-smoke.yml
@@ -76,8 +76,15 @@ jobs:
         # restarted.
         run: ./scripts/stack-smoke.sh
 
-      - name: Dump stack state on failure
+      # On failure the script itself dumps diagnostics to the job log
+      # and the job summary (failed phase, container states, healthcheck
+      # probe output, disk space, recent logs) and writes full compose
+      # logs to stack-smoke-logs/ — upload those for offline digging.
+      - name: Upload failure diagnostics
         if: failure()
-        run: |
-          docker compose ps -a
-          docker compose logs --no-color --tail 200
+        uses: actions/upload-artifact@v4
+        with:
+          name: stack-smoke-logs
+          path: stack-smoke-logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/stack-smoke.yml
+++ b/.github/workflows/stack-smoke.yml
@@ -26,10 +26,20 @@ on:
     paths:
       - api/pyproject.toml
       - gateway/pyproject.toml
+      # The web image installs its Python backend from these (web/Dockerfile);
+      # a bump here can break the web build just like the JS manifests below.
+      - web/pyproject.toml
+      - web/backend/requirements.txt
       - web/package.json
       - web/package-lock.json
       - "**/Dockerfile"
       - docker-compose.yml
+      # A migration runs on api boot (alembic upgrade head) — the header of
+      # scripts/stack-smoke.sh lists a new migration as a reason to run this.
+      - api/alembic/versions/**
+      # The check itself: a PR that only edits the script (or workflow) must
+      # re-run it, or a regression lands untested and first breaks on main.
+      - scripts/stack-smoke.sh
       - .github/workflows/stack-smoke.yml
   push:
     branches: [main]

--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,6 @@ artifacts/
 # Launch announcement drafts (private — used in posts, not in the repo)
 ANNOUNCEMENT.md
 LAUNCH-POST.md
+
+# stack smoke failure diagnostics (scripts/stack-smoke.sh)
+stack-smoke-logs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,26 @@ Pytest coverage target is **80%** across `api/` and `gateway/`. The CI configura
 - **End-to-end tests** — Playwright tests covering happy paths in the web UI. Run on every PR.
 - **Fuzzing** — the Inference Gateway's OpenAI compatibility surface is fuzzed continuously in CI against the OpenAI API spec.
 
+### Stack smoke test (build + boot the whole stack)
+
+The suites above run in-process and never boot the real servers, so they miss whole classes of breakage: a server that won't start (uvicorn), a Redis client that fails on connect (the arq workers), a lazily-imported dependency that breaks (docling is only imported inside ingest jobs), or an OpenWebUI-core build failure (the `web` production build is outside the scoped typecheck and the Vitest suite). The stack smoke test closes that gap by building every default-profile image, booting the full compose stack, waiting for every healthcheck, probing the api/gateway/web health endpoints and the ingest worker's lazy imports, then holding for a soak period and failing if any container restarted.
+
+CI runs it (`.github/workflows/stack-smoke.yml`) on PRs that touch dependency manifests — `pyproject.toml`, `web/package.json`/`package-lock.json`, Dockerfiles, `docker-compose.yml` — which covers dependabot PRs, plus pushes to `main` and manual dispatch.
+
+**Run it locally** before submitting a change that could break the stack at build or boot time (a dependency bump, a Dockerfile or compose edit, a new migration):
+
+```bash
+./scripts/stack-smoke.sh
+```
+
+Notes for local runs:
+
+- **No provider API keys are needed** — nothing in the smoke performs inference. If you have no `.env`, the script writes one with dummy secrets; an existing `.env` is respected.
+- It operates on the same compose project as your dev stack and recreates the containers (`--force-recreate`) so the restart-count assertion starts from zero. Named volumes (Postgres data, MinIO objects, model caches) are untouched. As always, never `docker compose down -v`.
+- A cold build needs roughly 25 GB of free disk and 20–30 minutes (the api image pulls docling/torch); warm rebuilds are much faster.
+- Tune with `SOAK_SECONDS` (default 75) and `WAIT_TIMEOUT` (default 900) environment variables.
+- It proves "builds, migrates, boots, and holds" — it does **not** prove features work. Feature-level verification still belongs to the test categories above.
+
 ### Test stack conventions (Python)
 
 Locked-in choices so new tests don't drift across `api/` and `gateway/`. Changes to these defaults need a PR with rationale.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,7 @@ Notes for local runs:
 - It operates on the same compose project as your dev stack and recreates the containers (`--force-recreate`) so the restart-count assertion starts from zero. Named volumes (Postgres data, MinIO objects, model caches) are untouched. As always, never `docker compose down -v`.
 - A cold build needs roughly 25 GB of free disk and 20–30 minutes (the api image pulls docling/torch); warm rebuilds are much faster.
 - Tune with `SOAK_SECONDS` (default 75) and `WAIT_TIMEOUT` (default 900) environment variables.
+- **On failure** the script reports which phase failed (build / boot / probes / soak), each container's state (exit code, OOM kill, restart count), the last healthcheck probe outputs, disk space, and the last 60 log lines per service; full compose logs land in `stack-smoke-logs/` (gitignored). CI additionally uploads that directory as a workflow artifact and writes the state dump to the job summary.
 - It proves "builds, migrates, boots, and holds" — it does **not** prove features work. Feature-level verification still belongs to the test categories above.
 
 ### Test stack conventions (Python)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,9 @@ services:
   # ============================================================
 
   postgres:
-    image: pgvector/pgvector:pg16
+    # Digest-pinned for reproducible boots (matches the pin in
+    # .github/workflows/ci.yml). Bump the tag and digest together.
+    image: pgvector/pgvector:pg16@sha256:ad2e18408bf447f62092a8a5259e7df10505c5a0360bd1a1853ac8b8b0763da2
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-lq_ai}
@@ -40,7 +42,8 @@ services:
       retries: 10
 
   redis:
-    image: redis:7-alpine
+    # Digest-pinned for reproducible boots. Bump the tag and digest together.
+    image: redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     restart: unless-stopped
     command: ["redis-server", "--appendonly", "yes"]
     volumes:
@@ -54,7 +57,9 @@ services:
       retries: 10
 
   minio:
-    image: minio/minio:latest
+    # Digest-pinned: `latest` alone is not reproducible. Bump the digest
+    # deliberately (re-resolve `minio/minio:latest`) rather than drifting.
+    image: minio/minio:latest@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
@@ -418,7 +423,9 @@ services:
   # ============================================================
 
   ollama:
-    image: ollama/ollama:latest
+    # Digest-pinned: `latest` alone is not reproducible. Bump the digest
+    # deliberately (re-resolve `ollama/ollama:latest`) rather than drifting.
+    image: ollama/ollama:latest@sha256:f1a705f2bd113fb8d15f85f7c217f0dc5f6bebda6b0cc42b82c3ad165ffcb9dc
     profiles: ["local"]
     restart: unless-stopped
     volumes:

--- a/scripts/stack-smoke.sh
+++ b/scripts/stack-smoke.sh
@@ -24,6 +24,58 @@ cd "$(dirname "$0")/.."
 SOAK_SECONDS="${SOAK_SECONDS:-75}"
 WAIT_TIMEOUT="${WAIT_TIMEOUT:-900}"
 
+# On failure, dump enough context to diagnose without re-running: the
+# phase that failed, per-container state (exit code, OOM kill, restart
+# count), the last healthcheck probe outputs (the reason a service never
+# went healthy lives only here), disk space (the build's known failure
+# mode), and recent logs. Full logs go to stack-smoke-logs/ (gitignored;
+# uploaded as a CI artifact). In CI the same state is appended to the
+# job summary.
+LOG_DIR="stack-smoke-logs"
+PHASE="startup"
+
+dump_diagnostics() {
+  local rc=$?
+  [ "$rc" -eq 0 ] && return 0
+  # Diagnostics must never die halfway — errexit stays off in here, and
+  # a failed mkdir (e.g. disk full, one of the failure modes we report
+  # on) must not stop the console dump.
+  set +e
+  echo
+  echo "stack-smoke: FAILED during phase: ${PHASE} (exit ${rc})" >&2
+  mkdir -p "$LOG_DIR" 2>/dev/null
+  {
+    echo "== stack-smoke failed during phase: ${PHASE} (exit ${rc})"
+    echo
+    echo "== docker compose ps -a"
+    docker compose ps -a || true
+    echo
+    echo "== disk space"
+    df -h . || true
+    echo
+    echo "== container state and last healthcheck probes"
+    for id in $(docker compose ps -aq 2>/dev/null); do
+      docker inspect --format '{{.Name}} status={{.State.Status}} exit={{.State.ExitCode}} restarts={{.RestartCount}} oom={{.State.OOMKilled}}' "$id" || true
+      docker inspect --format '{{if .State.Health}}{{range .State.Health.Log}}  probe exit={{.ExitCode}}: {{printf "%.400s" .Output}}{{"\n"}}{{end}}{{end}}' "$id" || true
+    done
+  } 2>&1 | tee "$LOG_DIR/state.txt" >&2
+  docker compose logs --no-color > "$LOG_DIR/logs.txt" 2>&1 || true
+  echo "stack-smoke: last 60 log lines per service follow; full logs in ${LOG_DIR}/" >&2
+  docker compose logs --no-color --tail=60 >&2 || true
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "## Stack smoke failed during phase: \`${PHASE}\`"
+      echo
+      echo '```'
+      cat "$LOG_DIR/state.txt"
+      echo '```'
+      echo
+      echo 'Full compose logs are in the `stack-smoke-logs` workflow artifact.'
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+trap dump_diagnostics EXIT
+
 if [ ! -f .env ]; then
   echo "stack-smoke: no .env found — writing dummy secrets (boot-only; no provider keys needed)"
   cat > .env <<'EOF'
@@ -40,6 +92,7 @@ fi
 # disk mid-extraction. Build each distinct image once and tag the worker
 # images from the api image — image names are stable because
 # docker-compose.yml pins the project name (`name: lq-ai`).
+PHASE="build"
 echo "stack-smoke: building images"
 docker compose build gateway web
 docker compose build api
@@ -51,9 +104,11 @@ docker tag lq-ai-api:latest lq-ai-arq-worker:latest
 # becomes healthy. --force-recreate starts every container fresh so the
 # RestartCount assertion below counts only restarts this run caused —
 # named volumes (pgdata, miniodata, model caches) are untouched.
+PHASE="boot"
 echo "stack-smoke: booting the stack (waiting up to ${WAIT_TIMEOUT}s for healthchecks)"
 docker compose up -d --wait --wait-timeout "$WAIT_TIMEOUT" --no-build --force-recreate
 
+PHASE="health probes"
 echo "stack-smoke: probing health endpoints from the host"
 curl -fsS http://127.0.0.1:8000/health && echo
 curl -fsS http://127.0.0.1:8001/health && echo
@@ -62,11 +117,13 @@ curl -fsS http://127.0.0.1:3000/health && echo
 # The ingest worker defers docling imports into job functions (see
 # api/app/workers/document_pipeline.py), so a broken docling survives
 # boot. Import it explicitly.
+PHASE="lazy-import probes"
 echo "stack-smoke: probing lazily-imported dependencies"
 docker compose exec -T ingest-worker python -c "from docling.document_converter import DocumentConverter; print('docling import OK')"
 
 # Healthchecks can flicker healthy on a crash-looping service; hold long
 # enough for a loop to show up as restarts.
+PHASE="soak / restart assertion"
 echo "stack-smoke: soaking for ${SOAK_SECONDS}s"
 sleep "$SOAK_SECONDS"
 

--- a/scripts/stack-smoke.sh
+++ b/scripts/stack-smoke.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Stack-boot smoke test — the single source of truth for the check that
+# .github/workflows/stack-smoke.yml runs in CI (issue #283). Contributors
+# run it locally before submitting a change that can break the stack at
+# build or boot time: a dependency bump, a Dockerfile or docker-compose.yml
+# edit, a new migration.
+#
+# What it does: builds every default-profile image, boots the full compose
+# stack, waits for every healthcheck, probes the api/gateway/web health
+# endpoints and the ingest worker's lazily-imported dependencies (docling),
+# holds for a soak period, and fails if any container restarted.
+#
+# What it does NOT do: perform inference or exercise features. No provider
+# API keys are required. If no .env exists, a dummy one is written; an
+# existing .env is respected.
+#
+# Requirements: docker compose v2; ~25 GB free disk and 20-30 minutes for
+# a cold build (the api image pulls docling/torch). Warm rebuilds are much
+# faster. Tunables: SOAK_SECONDS (default 75), WAIT_TIMEOUT (default 900).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SOAK_SECONDS="${SOAK_SECONDS:-75}"
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-900}"
+
+if [ ! -f .env ]; then
+  echo "stack-smoke: no .env found — writing dummy secrets (boot-only; no provider keys needed)"
+  cat > .env <<'EOF'
+POSTGRES_PASSWORD=ci-smoke-postgres
+MINIO_ROOT_PASSWORD=ci-smoke-minio-password
+LQ_AI_GATEWAY_KEY=ci-smoke-gateway-key
+JWT_SECRET=ci-smoke-jwt-secret-0123456789abcdef0123456789abcdef
+EOF
+fi
+
+# api, ingest-worker, and arq-worker share the ./api build context and
+# produce byte-identical images. Letting `up --build` build all three
+# exports the ~12 GB image three times concurrently, which can exhaust
+# disk mid-extraction. Build each distinct image once and tag the worker
+# images from the api image — image names are stable because
+# docker-compose.yml pins the project name (`name: lq-ai`).
+echo "stack-smoke: building images"
+docker compose build gateway web
+docker compose build api
+docker tag lq-ai-api:latest lq-ai-ingest-worker:latest
+docker tag lq-ai-api:latest lq-ai-arq-worker:latest
+
+# --wait blocks until every default-profile service reports healthy (all
+# of them define healthchecks) and fails if any container exits or never
+# becomes healthy. --force-recreate starts every container fresh so the
+# RestartCount assertion below counts only restarts this run caused —
+# named volumes (pgdata, miniodata, model caches) are untouched.
+echo "stack-smoke: booting the stack (waiting up to ${WAIT_TIMEOUT}s for healthchecks)"
+docker compose up -d --wait --wait-timeout "$WAIT_TIMEOUT" --no-build --force-recreate
+
+echo "stack-smoke: probing health endpoints from the host"
+curl -fsS http://127.0.0.1:8000/health && echo
+curl -fsS http://127.0.0.1:8001/health && echo
+curl -fsS http://127.0.0.1:3000/health && echo
+
+# The ingest worker defers docling imports into job functions (see
+# api/app/workers/document_pipeline.py), so a broken docling survives
+# boot. Import it explicitly.
+echo "stack-smoke: probing lazily-imported dependencies"
+docker compose exec -T ingest-worker python -c "from docling.document_converter import DocumentConverter; print('docling import OK')"
+
+# Healthchecks can flicker healthy on a crash-looping service; hold long
+# enough for a loop to show up as restarts.
+echo "stack-smoke: soaking for ${SOAK_SECONDS}s"
+sleep "$SOAK_SECONDS"
+
+failed=0
+for id in $(docker compose ps -q); do
+  name=$(docker inspect --format '{{.Name}}' "$id")
+  restarts=$(docker inspect --format '{{.RestartCount}}' "$id")
+  status=$(docker inspect --format '{{.State.Status}}' "$id")
+  echo "stack-smoke: ${name} status=${status} restarts=${restarts}"
+  if [ "$restarts" != "0" ] || [ "$status" != "running" ]; then
+    failed=1
+  fi
+done
+
+if [ "$failed" != "0" ]; then
+  echo "stack-smoke: FAIL — a container restarted or is not running" >&2
+  exit 1
+fi
+echo "stack-smoke: PASS — stack built, booted, and held for ${SOAK_SECONDS}s"

--- a/scripts/stack-smoke.sh
+++ b/scripts/stack-smoke.sh
@@ -110,9 +110,13 @@ docker compose up -d --wait --wait-timeout "$WAIT_TIMEOUT" --no-build --force-re
 
 PHASE="health probes"
 echo "stack-smoke: probing health endpoints from the host"
-curl -fsS http://127.0.0.1:8000/health && echo
-curl -fsS http://127.0.0.1:8001/health && echo
-curl -fsS http://127.0.0.1:3000/health && echo
+# Each curl is its own simple command so `set -e` aborts on a failed
+# probe. `curl ... && echo` would NOT: only the command after the final
+# `&&` in a list is subject to errexit, so a 5xx / refused connection
+# would be swallowed and the smoke would still report PASS.
+curl -fsS http://127.0.0.1:8000/health; echo
+curl -fsS http://127.0.0.1:8001/health; echo
+curl -fsS http://127.0.0.1:3000/health; echo
 
 # The ingest worker defers docling imports into job functions (see
 # api/app/workers/document_pipeline.py), so a broken docling survives
@@ -127,19 +131,28 @@ PHASE="soak / restart assertion"
 echo "stack-smoke: soaking for ${SOAK_SECONDS}s"
 sleep "$SOAK_SECONDS"
 
+# A crash-loop shows up as restarts>0 / not-running. But `restart:
+# unless-stopped` only restarts on process EXIT — a service that stays
+# alive while its healthcheck goes red (deadlocked worker, dropped DB
+# pool) keeps status=running / restarts=0. Every default service defines
+# a healthcheck, so also fail on an unhealthy container. ('starting' is
+# tolerated — a slow probe mid-cycle after the soak is not a failure;
+# the {{if .State.Health}} guard keeps this robust if a service ever
+# drops its healthcheck.)
 failed=0
 for id in $(docker compose ps -q); do
   name=$(docker inspect --format '{{.Name}}' "$id")
   restarts=$(docker inspect --format '{{.RestartCount}}' "$id")
   status=$(docker inspect --format '{{.State.Status}}' "$id")
-  echo "stack-smoke: ${name} status=${status} restarts=${restarts}"
-  if [ "$restarts" != "0" ] || [ "$status" != "running" ]; then
+  health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$id")
+  echo "stack-smoke: ${name} status=${status} restarts=${restarts} health=${health}"
+  if [ "$restarts" != "0" ] || [ "$status" != "running" ] || [ "$health" = "unhealthy" ]; then
     failed=1
   fi
 done
 
 if [ "$failed" != "0" ]; then
-  echo "stack-smoke: FAIL — a container restarted or is not running" >&2
+  echo "stack-smoke: FAIL — a container restarted, is not running, or went unhealthy" >&2
   exit 1
 fi
 echo "stack-smoke: PASS — stack built, booted, and held for ${SOAK_SECONDS}s"


### PR DESCRIPTION
## What this PR does

Adds a `stack-smoke` check that builds every default-profile image, boots the full compose stack, waits for every healthcheck, probes the api/gateway/web health endpoints and the ingest worker's lazily-imported deps (docling), soaks, and fails if any container restarted or went unhealthy. The check lives in `scripts/stack-smoke.sh` (runnable locally) and `.github/workflows/stack-smoke.yml` runs it in CI. Also digest-pins the images the stack pulls.

## Why

The per-subsystem CI jobs run in-process and never boot the real servers, so they miss exactly what dependency bumps break: server boot (uvicorn), real Redis connections (arq workers), lazily-imported heavy deps (docling), and the OpenWebUI-core production build that the scoped svelte-check never touches. This proves "builds, migrates, boots, and holds."

Closes #283

## What this PR does *not* do

Prove features work — no inference, no authenticated round-trip. E2E remains a future wave (see the `ci.yml` scope comment). It does not add buildx layer caching (cold builds are ~20–30 min), so it runs only on dependency-manifest PRs, pushes to `main`, and manual dispatch.

## Type of change

- [x] Test / CI / tooling

## Testing

- [x] Manually tested against a real deployment (describe scenario below)

<details>
<summary>Manual testing notes</summary>

- **Full pass:** built + booted the whole default stack locally; all 8 services reached healthy and held the soak; script printed PASS and (on success) wrote no diagnostics.
- **Induced boot-timeout failure** (`WAIT_TIMEOUT=5`): the trap reported the `boot` phase, per-container states, healthcheck probe output, and wrote both the artifact files and the job-summary markdown.
- **Review-fix verification:**
  - Health-probe swallow — confirmed `set -e; false && echo x; echo y` prints `y` (bug) vs `set -e; false; echo y` aborts (fix).
  - Soak health check — ran a container that stays alive but reports `unhealthy`: old logic (`restarts`/`status` only) → false PASS; new logic (adds `State.Health.Status`) → correctly fails.
- **Pins** — `docker compose config` validates with all four service-image digests; pgvector digest matches `ci.yml`.

</details>

## Documentation

- [x] CONTRIBUTING.md gains a "Stack smoke test" section; `ci.yml` scope comment updated to point at the new workflow. (No PRD/README/OpenAPI/DB surface changes — CI-only.)

## Transparency & governance invariants

- [x] n/a — CI/tooling only; no runtime code, egress, data, or audit paths touched.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

**Closes #283.** Follow-ups deliberately left out of scope are filed as their own issues: build caching #298, local-run compose-project isolation #299, local-run correctness on non-default envs #300, Dockerfile-base pinning + docker dependabot #301, additional lazy-import probes #302, authenticated ingest round-trip #303.

## Reviewer notes

- `.github/workflows/**` is a CODEOWNERS security-review path, so this is auto-routed to security reviewers.
- Actions are SHA-pinned and the compose service images are digest-pinned (pgvector matches `ci.yml`), consistent with #296. Dockerfile `FROM` bases are intentionally left for a separate pass — #301.
- The script operates on the shared `lq-ai` compose project and `--force-recreate`s it; whether to isolate it under its own project name is tracked in #299.