### PR TITLE
docs: add GOVERNANCE.md and ADR 0022 (committee governance and meeting records)

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,77 @@
+# LQ.AI Governance
+
+> **Status:** Proposed. This document codifies how the LQ.AI project is governed
+> during its current phase. It was drafted by houfu (Ang Hou Fu) following the
+> committee call of 2026-07-19 and is adopted when the PR introducing it is approved
+> by the committee. The decision record behind it is
+> [ADR 0022](docs/adr/0022-committee-governance-and-meeting-records.md).
+
+## Background
+
+LQ.AI began as a founder-led project. It has grown into a community effort carried
+by a committee of practicing lawyers and legal engineers. This document records how
+that committee makes decisions, so that contributors can see not just *what* was
+decided (the ADRs, the PRD) but *how* decisions get made and by whom.
+
+Transparency is the project's founding principle, and it applies to governance the
+same way it applies to skills: the process that shapes the project is visible work
+product.
+
+## Roles
+
+- **Founder.** Kevin Keller authored the project's guiding principles, initial
+  architecture, and roadmap. The founder's documents remain canonical unless amended
+  through the process below. The founder is welcome at any committee call.
+- **Committee.** The group that steers the project between releases: sets priorities,
+  decides scope questions, and appoints maintainers and review-committee members.
+  Membership is currently by invitation of the existing committee.
+- **Maintainers.** Hold write access to the repository; ack claims, triage issues,
+  review and merge PRs, and keep CI healthy.
+- **Review committee.** Maintainers and appointed members responsible for PR merge
+  decisions, established at the committee call of 2026-06-28. Volunteers apply
+  through an existing member.
+- **Contributors.** Anyone who opens an issue or PR. The contribution path is in
+  [CONTRIBUTING.md](CONTRIBUTING.md); the skill-specific path (including
+  practicing-attorney attestation) is in [skills/CONTRIBUTING.md](skills/CONTRIBUTING.md).
+
+## How decisions are made
+
+1. **Architectural and product decisions are ADR-first.** Before a significant issue
+   or PR is accepted, the underlying architectural question is settled in a proposed
+   ADR in [docs/adr/](docs/adr/), opened as a PR for community comment. PRs that
+   implement an undecided architectural choice wait for their anchor ADR. (Agreed at
+   the committee call of 2026-07-19.)
+2. **Routine maintenance uses lazy consensus.** Dependency bumps, bug fixes with
+   regression tests, and small self-explanatory hardening PRs need a maintainer
+   review, not a committee decision.
+3. **Scope, governance, and roadmap decisions belong to the committee**, discussed
+   at the weekly call or asynchronously in a tracking issue, and recorded in the
+   meeting minutes and — when structural — an ADR or PRD amendment.
+4. **Security-sensitive paths** follow the stricter routing in
+   [CLAUDE.md](CLAUDE.md#security-sensitive-paths) and
+   [.github/CODEOWNERS](.github/CODEOWNERS); vulnerabilities follow
+   [SECURITY.md](SECURITY.md), never public PRs.
+
+## Meetings
+
+- The committee holds a **weekly call on Sundays** (currently 2pm GMT, on Zoom).
+- **Minutes are public.** Decisions, action items, and attendee lists are published
+  as meeting records (see ADR 0022 for where they live). Raw transcripts and
+  recordings are not published; the minutes are the record.
+- **Async ratification:** committee members who miss a call may register agreement
+  or objection on the posted minutes within 7 days. Silence after 7 days is assent
+  to the recorded decisions.
+
+## Claiming work
+
+Roadmap items and deferred enhancements are claimed by opening a GitHub issue titled
+with the item ID (e.g. "DE-202") and commenting "I'd like to take this". A maintainer
+acts within about 7 days. Claims live as GitHub issues — not chat messages or
+screenshots — so they are visible to anyone reading the repo. For anything XL or
+architectural, open a discussion first so the boundary is agreed before anyone spends
+a weekend.
+
+## Amending this document
+
+Governance changes are proposed as a PR to this file, announced at the weekly call,
+and merged after committee approval under the async-ratification rule above.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -28,8 +28,10 @@ product.
 - **Maintainers.** Hold write access to the repository; ack claims, triage issues,
   review and merge PRs, and keep CI healthy.
 - **Review committee.** Maintainers and appointed members responsible for PR merge
-  decisions, established at the committee call of 2026-06-28. Volunteers apply
-  through an existing member.
+  decisions, established at the committee call of 2026-06-28.
+  [CONTRIBUTING.md](CONTRIBUTING.md) sets the merge threshold
+  (one maintainer approval; two preferred for multi-subsystem changes).
+  Volunteers apply through an existing member.
 - **Contributors.** Anyone who opens an issue or PR. The contribution path is in
   [CONTRIBUTING.md](CONTRIBUTING.md); the skill-specific path (including
   practicing-attorney attestation) is in [skills/CONTRIBUTING.md](skills/CONTRIBUTING.md).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1715,10 +1715,10 @@ PyMuPDF (AGPL) is used server-side only and not redistributed as a library; the 
 
 ### 7.4 Governance
 
-- **Initial model: BDFL.** Kevin Keller is the initial maintainer.
+- **Model: committee-carried.** The committee steers the project between releases; `GOVERNANCE.md` at the repository root is the living record of the roles, the decision workflow, and the amendment process. Kevin Keller, the project's founder and initial maintainer, authored the guiding principles, initial architecture, and roadmap; those documents remain canonical unless amended through the process in `GOVERNANCE.md`.
 - LegalQuants stewards the project (owns the GitHub org, controls trademark, employs maintainer).
 - Documented commitment to community contribution: "LQ.AI welcomes contributions from any lawyer, legal-ops practitioner, or engineer who wants to advance open legal AI."
-- Path to broader governance documented but not implemented in v1: as the project matures, consider transition to a maintainer team and formal governance (see CNCF or Apache Software Foundation models).
+- The transition to a maintainer team and formal governance, deferred at v1, was taken up by the committee over the calls of 2026-06-28 through 2026-07-19 and is recorded in `GOVERNANCE.md` and ADR 0022.
 
 ### 7.5 Contribution Model
 

--- a/docs/adr/0022-committee-governance-and-meeting-records.md
+++ b/docs/adr/0022-committee-governance-and-meeting-records.md
@@ -1,0 +1,103 @@
+# ADR 0022 — Committee governance document and public meeting records
+
+**Status:** Proposed
+**Date:** 2026-07-20
+**Owner:** Committee (action item from the 2026-07-19 weekly call)
+
+## Context
+
+The project has moved from founder-led to committee-carried. The
+2026-07-19 committee call concluded that the primary bottleneck is
+governance and decision-making structure, not technical capability, and
+adopted an ADR-first workflow for architectural consensus.
+
+The governance rules themselves, however, live nowhere durable: the
+claim process, the review-committee mandate, the weekly-call cadence,
+and the async-ratification practice exist only in Slack scrollback and
+meeting memory. Two placement questions need deciding:
+
+1. **Where do the governance rules live?** They are read by people
+   deciding how to participate, not how to build — a different audience
+   from the ADR series.
+2. **Where do meeting records live?** The committee wants meetings and
+   progress visible to the community, but material committed to this
+   repo is pulled by everyone who clones it, and every minutes commit
+   would pass through code-review ceremony (PRs, CODEOWNERS routing).
+
+No prior ADR, PRD section, or DE entry decides either question.
+
+## Decision
+
+1. **Governance rules live in `GOVERNANCE.md` at the repo root** — the
+   conventional, discoverable location (surfaced by GitHub's community
+   profile). It is a living document amended by PR with committee
+   approval. The ADR series stays reserved for architectural and
+   product decisions, keeping the ADR-first review gate legible.
+2. **Meeting minutes are published in a separate `LegalQuants/lq-ai-community`
+   repository** (to be created), linked from `GOVERNANCE.md`. One folder
+   per meeting: `meetings/YYYY-MM-DD-<topic>/` containing `notes.md`
+   (attendees, decisions, action items) and any shareable artifacts.
+3. **Raw transcripts and recordings are not published.** They contain
+   candid, unpolished discussion not spoken for the public record. The
+   published minutes are the record; transcripts remain with the
+   participants.
+4. **Async ratification is the approval mechanism for minutes and
+   governance changes:** committee members absent from a call may
+   object on the posted record within 7 days; silence is assent.
+
+## Alternatives considered
+
+- **Record governance rules as ADRs in `docs/adr/`.** The "A" in ADR
+  can read as "any decision" (the MADR convention), so this is not
+  wrong — but it mixes participation rules into a series contributors
+  consult for build decisions, and dilutes the ADR-first gate the
+  committee just adopted. A single ADR (this one) recording the
+  *adoption* of the governance process preserves the numbered audit
+  trail without moving the rules themselves into the series.
+- **Keep meeting minutes in this repo under `docs/meetings/`.** The
+  byte cost is trivial (minutes are kilobytes of markdown), but every
+  clone carries committee plumbing a contributor building the product
+  never needs, and every minutes update passes through code-repo PR
+  review and CODEOWNERS routing. Rejected on signal-to-noise, not size.
+  This is also the pattern large committee-run projects converged away
+  from: Kubernetes (`kubernetes/community`), Node.js (`nodejs/TSC`),
+  and Rust (`rust-lang/compiler-team`) all keep governance records in
+  satellite repos.
+- **GitHub Discussions for minutes.** Zero clone weight and reactions
+  give a natural async-ratification surface, but content is not
+  version-controlled, is harder to cite from PRs and ADRs, and lives
+  or dies with platform features. Retained as an optional announcement
+  mirror, not the system of record.
+- **The repo wiki.** A separate git tree, so no clone weight — but
+  edits bypass review, it is poorly discoverable, and wikis rot.
+  Rejected.
+- **Publish transcripts alongside minutes.** Maximally transparent,
+  but transcripts capture candid assessments and half-formed positions
+  the speakers did not offer publicly; publishing them would chill the
+  candor the calls depend on. Minutes-not-transcripts is the norm in
+  the projects above. Rejected.
+
+## Consequences
+
+- `GOVERNANCE.md` lands at the repo root (this PR) and becomes the
+  entry point for how the project is run; README gains a pointer in a
+  follow-up.
+- A `LegalQuants/lq-ai-community` repo needs creating (org-owner action),
+  seeded with minutes from the four committee calls held to date
+  (2026-06-28, 07-05, 07-12, 07-19) and the meeting-folder convention.
+  Until it exists, minutes continue to be posted to the committee
+  channel.
+- The claims process, review-committee mandate, and async-ratification
+  rule stop being oral tradition; new contributors can read how
+  decisions are made without joining a call.
+- The ADR series keeps a single governance entry (this ADR) rather
+  than absorbing process documents, so ADR review remains an
+  architecture gate.
+- This ADR is Proposed until the committee approves the PR under the
+  async-ratification rule it introduces.
+
+---
+
+*Drafted by houfu (Ang Hou Fu) from the 2026-06-28 through 2026-07-19
+committee-call records; proposed for committee comment per the
+ADR-first workflow adopted 2026-07-19.*

--- a/docs/adr/0022-committee-governance-and-meeting-records.md
+++ b/docs/adr/0022-committee-governance-and-meeting-records.md
@@ -28,20 +28,20 @@ No prior ADR, PRD section, or DE entry decides either question.
 
 ## Decision
 
-1. **Governance rules live in `GOVERNANCE.md` at the repo root** — the
-   conventional, discoverable location (surfaced by GitHub's community
-   profile). It is a living document amended by PR with committee
+1. **Governance rules live in `GOVERNANCE.md` at the repo root** — the conventional
+   root-level location alongside the community health files.
+   It is a living document amended by PR with committee
    approval. The ADR series stays reserved for architectural and
    product decisions, keeping the ADR-first review gate legible.
-2. **Meeting minutes are published in a separate `LegalQuants/lq-ai-community`
+3. **Meeting minutes are published in a separate `LegalQuants/lq-ai-community`
    repository** (to be created), linked from `GOVERNANCE.md`. One folder
    per meeting: `meetings/YYYY-MM-DD-<topic>/` containing `notes.md`
    (attendees, decisions, action items) and any shareable artifacts.
-3. **Raw transcripts and recordings are not published.** They contain
+4. **Raw transcripts and recordings are not published.** They contain
    candid, unpolished discussion not spoken for the public record. The
    published minutes are the record; transcripts remain with the
    participants.
-4. **Async ratification is the approval mechanism for minutes and
+5. **Async ratification is the approval mechanism for minutes and
    governance changes:** committee members absent from a call may
    object on the posted record within 7 days; silence is assent.
 


### PR DESCRIPTION
## What this is

Codifies how the committee runs the project, per the action items from the 2026-07-19 weekly call ("governance is the bottleneck, not technical capability").

Two files:

- **`GOVERNANCE.md`** (repo root) — the living rules: roles (founder / committee / maintainers / review committee / contributors), the ADR-first decision workflow we agreed on 2026-07-19, lazy consensus for routine maintenance, the claims process, weekly-call cadence, public minutes with async ratification (7-day objection window, silence is assent), and how to amend the document itself.
- **`docs/adr/0022-committee-governance-and-meeting-records.md`** (Status: **Proposed**) — the decision record. It documents the options we discussed and evaluates them, ADR-style:
  - governance rules as ADRs vs a root `GOVERNANCE.md`;
  - meeting minutes in-repo (`docs/meetings/`) vs a separate `LegalQuants/lq-ai-community` repo vs GitHub Discussions vs the wiki;
  - publishing transcripts vs minutes-only.

  Recommendation: `GOVERNANCE.md` for rules, a satellite `community` repo for minutes (the Kubernetes / Node.js / Rust pattern), transcripts stay private.

## What this asks of the committee

1. Review and comment — this PR **is** the ADR-first consultation; the ADR stays Proposed until the committee approves.
2. If accepted, an org owner creates `LegalQuants/lq-ai-community`, seeded with minutes from the four calls to date (Jun 28, Jul 5, Jul 12, Jul 19).

## What this deliberately does not do

- No Debian-style constitution — the 2026-07-19 call agreed the group is too small for that yet; this codifies only what we already practice.
- Does not decide the jurisdiction, litigation, or technical-maintenance ADRs — those are drafted or in progress separately and will take the next numbers when proposed.
- Does not amend PRD or CONTRIBUTING.md beyond linking.

Refs: committee calls 2026-06-28 → 2026-07-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRpcgBT9MCVcpvWdaVJBgW
