### PR TITLE
docs(adr): ADR 0023 — uv-managed lockfiles for gateway/ and api/ (Proposed)

### DIFF
--- a/docs/adr/0023-uv-lockfiles-gateway-api.md
+++ b/docs/adr/0023-uv-lockfiles-gateway-api.md
@@ -1,0 +1,89 @@
+# ADR 0023 — uv-managed lockfiles for gateway/ and api/
+
+**Status:** Proposed
+**Date:** 2026-07-19
+**Owner:** Issue #310 (dependency locking); arising from the PR #308 security review
+
+## Context
+
+The PRD commits to "pinned and audited dependencies (lockfiles enforced
+in CI)" (Appendix E, supply-chain procurement response) and lists
+"pinned dependencies enforced in CI" as a supply-chain-compromise
+mitigation (Appendix C, risk 10). DE-114 (reproducible builds) requires
+deterministic dependency installation.
+
+Today neither `gateway/` nor `api/` has a lockfile. Both images run
+`pip install .` from range-style manifests, so:
+
+- the transitive dependency tree re-resolves on every image build —
+  two builds of the same commit can ship different trees;
+- CI's stack smoke test validates only the single version resolved at
+  build time, a moving target;
+- dependabot's pip ecosystem responds to range-style requirements by
+  widening ranges (open #308, #306, #177, #175, #131), eroding the
+  manifests' tight-window convention; and
+- dependency PRs at the security boundary carry no concrete versions in
+  the diff, so mechanical vetting (OSV advisory lookup, release-age
+  cooldown, new-package detection in lockfile churn) has nothing to
+  check.
+
+No prior ADR, PRD section, roadmap item, or DE entry decides the Python
+dependency toolchain. Nearest canon: ADR 0001 (fork-pinning precedent)
+and CLAUDE.md's decide-once and dependency-justification rules. The
+repo's current uv exposure is minimal, and this is a deliberate
+migration: `web/uv.lock` is inherited from the OpenWebUI fork and
+unconsumed by any build; `web/Dockerfile` uses uv only as a faster pip.
+
+## Decision
+
+uv is the Python dependency toolchain for `gateway/` and `api/`:
+
+1. Dependencies are locked in committed `uv.lock` files generated from
+   the existing `pyproject.toml` range declarations, which remain the
+   policy layer (tight windows with rationale comments).
+2. CI and container images install from the lock (`uv sync --frozen`),
+   and CI gates lock freshness with `uv lock --check` — fulfilling the
+   PRD's "lockfiles enforced in CI" claim.
+3. `.github/dependabot.yml` runs the `uv` package-ecosystem for both
+   directories, so updates arrive as lock-pinned version bumps rather
+   than range widenings.
+
+## Alternatives considered
+
+- **Keep the status quo (range windows, no lock).** Rejected: the PRD's
+  "lockfiles enforced in CI" claim remains unmet (or must be amended);
+  transitives stay unpinned; every dependency PR at the security
+  boundary remains a manual review of an unverifiable range.
+- **pip-tools (`requirements.in` → compiled `requirements.txt`).**
+  Least new tooling, but lockfiles are per-platform (uv's are
+  universal), and dependabot's native lockfile ecosystem support is
+  uv-only.
+- **Exact-pin everything in `pyproject.toml` (`==`).** Pins direct
+  dependencies only; transitives still float; loses the policy/fact
+  separation between declared ranges and locked resolution.
+
+## Consequences
+
+- The shipped dependency tree becomes a reviewed artifact: the
+  `uv.lock` diff is what ships, and the per-release SBOM becomes
+  predictable rather than discovered post-build.
+- Dependabot PRs for gateway/api become concrete pinned bumps that
+  mechanical checks can vet; the open range-widening PR family
+  (#308, #306, #177, #175, #131) is superseded and closed by
+  maintainers after the migration lands.
+- One-time costs in the implementation PR: two large generated
+  `uv.lock` diffs; Dockerfile and CI changes; contributor-doc updates
+  (`CONTRIBUTING.md`, `gateway/README.md`, `api/README.md` move from
+  `pip install -e ".[dev]"` to `uv sync`);
+  `docs/security/dependencies.md` gains the lockfile story.
+- The implementation PR spans gateway + api + CI; this ADR is the
+  single anchor spanning those subsystems and is cited from that PR.
+- Follow-up (tracked separately, not decided here): the web image
+  consuming the fork's upstream-maintained `uv.lock` instead of
+  `requirements.txt`.
+
+---
+
+*Drafted by lq-maintainer-agent v0.2.0 from the issue #310 decision
+ledger; reviewed and proposed for committee comment by houfu
+(Ang Hou Fu) (proposal, issue #310).*


### PR DESCRIPTION
## What this is

The decision record for **issue #310** — adopting uv-managed lockfiles for `gateway/` and `api/` so the PRD's "lockfiles enforced in CI" claim (Appendix E; Appendix C risk 10) becomes true. Opened ADR-first per the workflow proposed in #311: this PR settles the *decision*; the implementation PR follows once the ADR is accepted.

**ADR 0023 (Status: Proposed)** decides, contingent on committee comment here:

1. Committed `uv.lock` files for both services, generated from the existing `pyproject.toml` range declarations — ranges stay as the policy layer (tight windows + rationale comments), the lock pins fact (what ships).
2. CI and container images install from the lock (`uv sync --frozen`); CI gates freshness with `uv lock --check`.
3. Dependabot moves both directories to the native `uv` ecosystem, so bumps arrive as lock-pinned version changes instead of range widenings.

Alternatives evaluated in the ADR: status quo (range windows, no lock), pip-tools, and exact-pinning in `pyproject.toml`. Full research grounding — including that dependabot's historical inability to maintain lockfiles is gone (native uv ecosystem support) — is in #310.

## Why now

The #308 security review (uvicorn range-widening at the gateway boundary) showed the structural problem: dependency PRs against ranges carry no concrete versions, so mechanical vetting (OSV lookup, release-age cooldown, new-package detection) has nothing to check. The open range-widening family (#308, #306, #177, #175, #131) is held pending this decision and would be superseded by lock-pinned bumps.

## What this PR does not do

- No implementation — no lockfiles, Dockerfile, CI, or dependabot changes yet. That PR spans `gateway/` + `api/` + CI, will cite this ADR as its cross-subsystem anchor, and routes to security review via CODEOWNERS (`gateway/**`, workflows).
- Does not decide the web image consuming the fork's upstream `uv.lock` — noted in the ADR as a tracked follow-up.

Refs #310. Anchors verified at `main` @ `fdeced2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRpcgBT9MCVcpvWdaVJBgW
