### PR TITLE
fix(gateway): raise Anthropic default timeout to 300s; label client timeouts distinctly

### DIFF
--- a/gateway/app/api/inference.py
+++ b/gateway/app/api/inference.py
@@ -88,6 +88,7 @@ from app.providers import (
     ProviderAuthError,
     ProviderHTTPError,
     ProviderNetworkError,
+    ProviderTimeoutError,
     ProviderUnsupportedError,
 )
 from app.router import (
@@ -270,9 +271,16 @@ def _failure_reason(error: ProviderAdapterError) -> str:
     plus the upstream HTTP status when known — the distinguishing signal
     an operator needs to tell a request rejection from a genuine outage
     when reading inference_routing_log rows.
+
+    A gateway-side timeout (:class:`ProviderTimeoutError`) is prefixed
+    ``client_timeout:`` rather than ``upstream_error:`` — we gave up
+    waiting, the provider may be healthy — so operators can tell a
+    too-tight ``timeout_s`` from a genuine provider outage.
     """
 
     code, _ = _classify_provider_error(error)
+    if isinstance(error, ProviderTimeoutError):
+        return f"client_timeout:{code}"
     if isinstance(error, ProviderHTTPError):
         return f"upstream_error:{code}:status={error.upstream_status}"
     return f"upstream_error:{code}"

--- a/gateway/app/providers/__init__.py
+++ b/gateway/app/providers/__init__.py
@@ -24,6 +24,7 @@ from app.providers.base import (
     ProviderHealth,
     ProviderHTTPError,
     ProviderNetworkError,
+    ProviderTimeoutError,
     ProviderUnsupportedError,
 )
 from app.providers.ollama import OllamaAdapter, ProviderModelNotFound
@@ -69,5 +70,6 @@ __all__ = [
     "ProviderHealth",
     "ProviderModelNotFound",
     "ProviderNetworkError",
+    "ProviderTimeoutError",
     "ProviderUnsupportedError",
 ]

--- a/gateway/app/providers/anthropic.py
+++ b/gateway/app/providers/anthropic.py
@@ -50,6 +50,7 @@ from app.providers.base import (
     ProviderHealth,
     ProviderHTTPError,
     ProviderNetworkError,
+    ProviderTimeoutError,
     ProviderUnsupportedError,
 )
 from app.providers.openai_schema import (
@@ -73,9 +74,15 @@ ANTHROPIC_API_VERSION = "2023-06-01"
 """Pinned Anthropic API version. Update deliberately; bump in lockstep
 with changes to the request/response translation below."""
 
-DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_TIMEOUT_SECONDS = 300.0
 """Default per-request timeout. PRD §4.4 / gateway.yaml.example exposes
-``timeout_s`` on each provider; if absent we use this default."""
+``timeout_s`` on each provider; if absent we use this default.
+
+300s rather than the earlier 60s: frontier drafting responses of
+4-16K output tokens routinely exceed 60s of generation time, and a
+client-side timeout mid-generation surfaced as a provider outage even
+though Anthropic was healthy. Operators wanting a tighter budget set
+``timeout_s`` on the provider entry, which still overrides this."""
 
 DEFAULT_MAX_TOKENS = 4096
 """Anthropic Messages requires ``max_tokens``. When the OpenAI-format
@@ -313,6 +320,15 @@ class AnthropicAdapter(ProviderAdapter):
                 json=anthropic_body,
                 headers=self._auth_headers(),
             )
+        except httpx.TimeoutException as exc:
+            # Our own timeout elapsed — not an upstream failure. Raise the
+            # distinct subclass so the routing log can tell a too-tight
+            # timeout_s from an Anthropic outage.
+            raise ProviderTimeoutError(
+                f"timed out after {self._timeout:g}s waiting for Anthropic "
+                "(client-side timeout; raise timeout_s for long generations)",
+                details={"provider": self.name, "timeout_s": self._timeout},
+            ) from exc
         except httpx.HTTPError as exc:
             raise ProviderNetworkError(
                 f"failed to reach Anthropic: {type(exc).__name__}",
@@ -662,6 +678,14 @@ async def _anthropic_stream_iter(
                     continue
 
                 # ping / unknown -> ignore
+    except httpx.TimeoutException as exc:
+        # Our own timeout elapsed mid-stream — not an upstream failure.
+        # See the unary path for the rationale behind the distinct class.
+        raise ProviderTimeoutError(
+            "timed out waiting for Anthropic stream "
+            "(client-side timeout; raise timeout_s for long generations)",
+            details={"provider": provider_name},
+        ) from exc
     except httpx.HTTPError as exc:
         raise ProviderNetworkError(
             f"failed to stream from Anthropic: {type(exc).__name__}",

--- a/gateway/app/providers/anthropic.py
+++ b/gateway/app/providers/anthropic.py
@@ -74,15 +74,24 @@ ANTHROPIC_API_VERSION = "2023-06-01"
 """Pinned Anthropic API version. Update deliberately; bump in lockstep
 with changes to the request/response translation below."""
 
-DEFAULT_TIMEOUT_SECONDS = 300.0
+DEFAULT_TIMEOUT_SECONDS = 600.0
 """Default per-request timeout. PRD §4.4 / gateway.yaml.example exposes
 ``timeout_s`` on each provider; if absent we use this default.
 
-300s rather than the earlier 60s: frontier drafting responses of
+600s rather than the earlier 60s: frontier drafting responses of
 4-16K output tokens routinely exceed 60s of generation time, and a
 client-side timeout mid-generation surfaced as a provider outage even
-though Anthropic was healthy. Operators wanting a tighter budget set
-``timeout_s`` on the provider entry, which still overrides this."""
+though Anthropic was healthy (#318). A measured document-production
+turn over a ~47k-token case file took 370s (#503), so 300s would still
+have cut real work off. Operators wanting a tighter budget set
+``timeout_s`` on the provider entry, which still overrides this.
+
+Deliberate consequence: the router treats a client timeout as
+fallback-eligible (:func:`app.router.is_fallback_eligible`), so a hung
+connection now waits the full budget before the next provider is
+tried. The api's own gateway-client timeout must stay looser than this
+(``LQ_AI_GATEWAY_TIMEOUT_SECONDS``, default 900s) or it fires first and
+this adapter's label never appears."""
 
 DEFAULT_MAX_TOKENS = 4096
 """Anthropic Messages requires ``max_tokens``. When the OpenAI-format

--- a/gateway/app/providers/base.py
+++ b/gateway/app/providers/base.py
@@ -118,6 +118,21 @@ class ProviderNetworkError(ProviderAdapterError):
     code = "provider_unavailable"
 
 
+class ProviderTimeoutError(ProviderNetworkError):
+    """The *gateway's own* request timeout elapsed (``httpx.TimeoutException``).
+
+    Distinct from an upstream 5xx: the provider may be perfectly healthy
+    and mid-generation — we gave up waiting. Inherits ``code``
+    (``provider_unavailable``) so the wire contract and HTTP mapping are
+    unchanged (503, same as any network failure); the routing-log
+    ``refusal_reason`` builder reads ``isinstance(..., ProviderTimeoutError)``
+    to label these rows ``client_timeout:...`` so operators can tell a
+    too-tight ``timeout_s`` from a genuine provider outage. Mirrors the
+    :class:`app.providers.ollama.ProviderModelNotFound` approach of a
+    distinct class rather than a new error-code enum entry.
+    """
+
+
 class ProviderUnsupportedError(ProviderAdapterError):
     """The adapter does not support this operation.
 

--- a/gateway/app/providers/ollama.py
+++ b/gateway/app/providers/ollama.py
@@ -88,6 +88,7 @@ from app.providers.base import (
     ProviderHealth,
     ProviderHTTPError,
     ProviderNetworkError,
+    ProviderTimeoutError,
     ProviderUnsupportedError,
 )
 from app.providers.openai_schema import (
@@ -108,11 +109,14 @@ from app.secrets import ProviderKeyResolver
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_TIMEOUT_SECONDS = 120.0
+DEFAULT_TIMEOUT_SECONDS = 600.0
 """Default per-request timeout. Ollama generation latency is bounded by
 local hardware — slow CPUs or large models can take well over a minute
-on the first generation after a model load. The default is generous;
-``timeout_s`` on each provider entry overrides per-deployment."""
+on the first generation after a model load, and a single long
+generation on modest hardware can run for many minutes (#535). The
+default matches the other adapters' 600s so the whole request path
+shares one budget; ``timeout_s`` on each provider entry overrides
+per-deployment."""
 
 
 DONE_REASON_MAP: dict[str, FinishReason] = {
@@ -357,6 +361,15 @@ class OllamaAdapter(ProviderAdapter):
                 json=ollama_body,
                 headers=self._auth_headers(),
             )
+        except httpx.TimeoutException as exc:
+            # Our own timeout elapsed — not an upstream failure. Same
+            # distinct class as the Anthropic adapter so the routing log
+            # labels it ``client_timeout:`` rather than ``upstream_error:``.
+            raise ProviderTimeoutError(
+                f"timed out after {self._timeout:g}s waiting for Ollama "
+                "(client-side timeout; raise timeout_s for long generations)",
+                details={"provider": self.name, "timeout_s": self._timeout},
+            ) from exc
         except httpx.HTTPError as exc:
             raise ProviderNetworkError(
                 f"failed to reach Ollama: {type(exc).__name__}",
@@ -658,6 +671,13 @@ async def _ollama_stream_iter(
                     # naturally on EOF. Breaking would skip any
                     # trailing whitespace lines that aiter_lines might
                     # surface.
+    except httpx.TimeoutException as exc:
+        # Our own timeout elapsed mid-stream — see the unary path.
+        raise ProviderTimeoutError(
+            "timed out waiting for Ollama stream "
+            "(client-side timeout; raise timeout_s for long generations)",
+            details={"provider": provider_name},
+        ) from exc
     except httpx.HTTPError as exc:
         raise ProviderNetworkError(
             f"failed to stream from Ollama: {type(exc).__name__}",

--- a/gateway/app/providers/openai.py
+++ b/gateway/app/providers/openai.py
@@ -67,6 +67,7 @@ from app.providers.base import (
     ProviderHealth,
     ProviderHTTPError,
     ProviderNetworkError,
+    ProviderTimeoutError,
 )
 from app.providers.openai_schema import (
     ChatCompletionChunk,
@@ -113,9 +114,15 @@ _LQ_AI_MESSAGE_EXTENSION_KEYS = frozenset({"lq_ai_skip_anonymization"})
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_TIMEOUT_SECONDS = 600.0
 """Default per-request timeout. ``timeout_s`` on each provider entry
-overrides; if absent we use this default."""
+overrides; if absent we use this default.
+
+600s rather than the earlier 60s, matching the Anthropic adapter: long
+drafting and document-production turns run for minutes, and a 60s
+client-side cut-off surfaced as a provider outage (#318, #503). Shared
+by the Azure OpenAI adapter. The api's gateway-client timeout
+(``LQ_AI_GATEWAY_TIMEOUT_SECONDS``, default 900s) must stay looser."""
 
 
 class OpenAIAdapter(ProviderAdapter):
@@ -268,6 +275,15 @@ class OpenAIAdapter(ProviderAdapter):
                 json=body,
                 headers=self._auth_headers(),
             )
+        except httpx.TimeoutException as exc:
+            # Our own timeout elapsed — not an upstream failure. Same
+            # distinct class as the Anthropic adapter so the routing log
+            # labels it ``client_timeout:`` rather than ``upstream_error:``.
+            raise ProviderTimeoutError(
+                f"timed out after {self._timeout:g}s waiting for OpenAI "
+                "(client-side timeout; raise timeout_s for long generations)",
+                details={"provider": self.name, "timeout_s": self._timeout},
+            ) from exc
         except httpx.HTTPError as exc:
             raise ProviderNetworkError(
                 f"failed to reach OpenAI: {type(exc).__name__}",
@@ -324,6 +340,15 @@ class OpenAIAdapter(ProviderAdapter):
                 json=body,
                 headers=self._auth_headers(),
             )
+        except httpx.TimeoutException as exc:
+            # Our own timeout elapsed — not an upstream failure. Same
+            # distinct class as the Anthropic adapter so the routing log
+            # labels it ``client_timeout:`` rather than ``upstream_error:``.
+            raise ProviderTimeoutError(
+                f"timed out after {self._timeout:g}s waiting for OpenAI "
+                "(client-side timeout; raise timeout_s for long generations)",
+                details={"provider": self.name, "timeout_s": self._timeout},
+            ) from exc
         except httpx.HTTPError as exc:
             raise ProviderNetworkError(
                 f"failed to reach OpenAI: {type(exc).__name__}",
@@ -611,6 +636,13 @@ async def _openai_stream_iter(
                     # the whole stream. The route handler still emits
                     # [DONE] when the iterator finishes.
                     continue
+    except httpx.TimeoutException as exc:
+        # Our own timeout elapsed mid-stream — see the unary path.
+        raise ProviderTimeoutError(
+            "timed out waiting for OpenAI stream "
+            "(client-side timeout; raise timeout_s for long generations)",
+            details={"provider": provider_name},
+        ) from exc
     except httpx.HTTPError as exc:
         raise ProviderNetworkError(
             f"failed to stream from OpenAI: {type(exc).__name__}",

--- a/gateway/tests/test_anthropic_adapter.py
+++ b/gateway/tests/test_anthropic_adapter.py
@@ -37,10 +37,12 @@ from app.providers import (
     ProviderAuthError,
     ProviderHTTPError,
     ProviderNetworkError,
+    ProviderTimeoutError,
     ProviderUnsupportedError,
 )
 from app.providers.anthropic import (
     DEFAULT_MAX_TOKENS,
+    DEFAULT_TIMEOUT_SECONDS,
     _to_anthropic_request,
 )
 
@@ -437,6 +439,61 @@ async def test_network_error_raises_provider_network_error() -> None:
             await adapter.chat_completion(_basic_request(), model="claude-sonnet-4-6", stream=False)
     finally:
         await adapter.aclose()
+
+
+@pytest.mark.unit
+def test_default_timeout_accommodates_long_generations() -> None:
+    """The default per-request timeout is 300s (#15a): frontier drafting
+    responses of 4-16K output tokens routinely exceed 60s of generation
+    time, and a client-side timeout mid-generation surfaced as a provider
+    outage. Per-provider ``timeout_s`` still overrides."""
+
+    assert DEFAULT_TIMEOUT_SECONDS == 300.0
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_client_timeout_raises_provider_timeout_error() -> None:
+    """A client-side timeout raises :class:`ProviderTimeoutError` — a
+    :class:`ProviderNetworkError` subclass (wire code unchanged) that the
+    routing log labels distinctly from an upstream 5xx outage."""
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        side_effect=httpx.ReadTimeout("read timed out")
+    )
+    adapter = _make_adapter()
+    try:
+        with pytest.raises(ProviderTimeoutError) as excinfo:
+            await adapter.chat_completion(_basic_request(), model="claude-sonnet-4-6", stream=False)
+    finally:
+        await adapter.aclose()
+    exc = excinfo.value
+    # Wire contract unchanged: same code (and 503 mapping) as any network error.
+    assert isinstance(exc, ProviderNetworkError)
+    assert exc.code == "provider_unavailable"
+    # But the message and details say "we gave up", not "Anthropic is down".
+    assert "client-side timeout" in exc.message
+    assert exc.details["timeout_s"] == DEFAULT_TIMEOUT_SECONDS
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_streaming_client_timeout_raises_provider_timeout_error() -> None:
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        side_effect=httpx.ReadTimeout("read timed out")
+    )
+    adapter = _make_adapter()
+    try:
+        stream = await adapter.chat_completion(
+            _basic_request(), model="claude-sonnet-4-6", stream=True
+        )
+        assert not isinstance(stream, ChatCompletionResponse)
+        with pytest.raises(ProviderTimeoutError) as excinfo:
+            async for _chunk in stream:
+                pass
+    finally:
+        await adapter.aclose()
+    assert "client-side timeout" in excinfo.value.message
 
 
 @pytest.mark.unit

--- a/gateway/tests/test_anthropic_adapter.py
+++ b/gateway/tests/test_anthropic_adapter.py
@@ -443,12 +443,13 @@ async def test_network_error_raises_provider_network_error() -> None:
 
 @pytest.mark.unit
 def test_default_timeout_accommodates_long_generations() -> None:
-    """The default per-request timeout is 300s (#15a): frontier drafting
+    """The default per-request timeout is 600s: frontier drafting
     responses of 4-16K output tokens routinely exceed 60s of generation
-    time, and a client-side timeout mid-generation surfaced as a provider
+    time (#318), and a measured document-production turn took 370s
+    (#503). A client-side timeout mid-generation surfaced as a provider
     outage. Per-provider ``timeout_s`` still overrides."""
 
-    assert DEFAULT_TIMEOUT_SECONDS == 300.0
+    assert DEFAULT_TIMEOUT_SECONDS == 600.0
 
 
 @pytest.mark.unit

--- a/gateway/tests/test_ollama_adapter.py
+++ b/gateway/tests/test_ollama_adapter.py
@@ -49,6 +49,7 @@ from app.providers import (
     ProviderHTTPError,
     ProviderModelNotFound,
     ProviderNetworkError,
+    ProviderTimeoutError,
     ProviderUnsupportedError,
 )
 from app.providers.ollama import (
@@ -799,3 +800,47 @@ async def test_health_check_reports_unreachable_on_network_error() -> None:
         await adapter.aclose()
     assert health.reachable is False
     assert health.error is not None
+
+
+# --- #318 follow-through: client timeouts are labelled, not "upstream" -------
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_client_timeout_raises_provider_timeout_error() -> None:
+    """A client-side timeout (slow local model) raises
+    :class:`ProviderTimeoutError` — a :class:`ProviderNetworkError` subclass
+    (wire code unchanged) the routing log labels ``client_timeout:`` so an
+    operator can tell a too-tight ``timeout_s`` from Ollama being down."""
+
+    respx.post(f"{OLLAMA_BASE}/api/chat").mock(side_effect=httpx.ReadTimeout("read timed out"))
+    adapter = _make_adapter()
+    try:
+        with pytest.raises(ProviderTimeoutError) as excinfo:
+            await adapter.chat_completion(_basic_request(), model="llama3.1", stream=False)
+    finally:
+        await adapter.aclose()
+    exc = excinfo.value
+    assert isinstance(exc, ProviderNetworkError)
+    assert exc.code == "provider_unavailable"
+    assert "client-side timeout" in exc.message
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_streaming_client_timeout_raises_provider_timeout_error() -> None:
+    """The streaming path labels a client-side timeout the same way."""
+
+    respx.post(f"{OLLAMA_BASE}/api/chat").mock(side_effect=httpx.ReadTimeout("read timed out"))
+    adapter = _make_adapter()
+    try:
+        stream = await adapter.chat_completion(
+            _basic_request(stream=True), model="llama3.1", stream=True
+        )
+        assert not isinstance(stream, ChatCompletionResponse)
+        with pytest.raises(ProviderTimeoutError) as excinfo:
+            async for _chunk in stream:
+                pass
+    finally:
+        await adapter.aclose()
+    assert "client-side timeout" in excinfo.value.message

--- a/gateway/tests/test_openai_adapter.py
+++ b/gateway/tests/test_openai_adapter.py
@@ -21,6 +21,7 @@ from app.providers import (
     ProviderAuthError,
     ProviderHTTPError,
     ProviderNetworkError,
+    ProviderTimeoutError,
 )
 from app.providers.openai_schema import (
     ChatCompletionMessage,
@@ -894,3 +895,60 @@ async def test_chat_completion_forwards_tools_and_tool_choice_to_openai() -> Non
     # Regression pin: tools/tool_choice must appear in the upstream body.
     assert "tools" in sent and sent["tools"][0]["function"]["name"] == "get_time"
     assert sent["tool_choice"] == "auto"
+
+
+# --- #318 follow-through: client timeouts are labelled, not "upstream" -------
+
+
+@pytest.mark.unit
+async def test_chat_completion_client_timeout_raises_provider_timeout_error() -> None:
+    """A client-side timeout raises :class:`ProviderTimeoutError` — a
+    :class:`ProviderNetworkError` subclass (wire code unchanged) that the
+    routing log labels ``client_timeout:`` rather than ``upstream_error:``,
+    exactly as the Anthropic adapter does."""
+
+    with respx.mock(base_url="https://api.openai.com/v1") as router:
+        router.post("/chat/completions").mock(side_effect=httpx.ReadTimeout("read timed out"))
+        client = httpx.AsyncClient(base_url="https://api.openai.com/v1")
+        try:
+            adapter = OpenAIAdapter(
+                name="openai-prod",
+                base_url="https://api.openai.com/v1",
+                api_key="sk-test",
+                client=client,
+            )
+            with pytest.raises(ProviderTimeoutError) as excinfo:
+                await adapter.chat_completion(_basic_chat_request(), model="gpt-4o", stream=False)
+        finally:
+            await client.aclose()
+    exc = excinfo.value
+    assert isinstance(exc, ProviderNetworkError)
+    assert exc.code == "provider_unavailable"
+    assert "client-side timeout" in exc.message
+    assert exc.details["timeout_s"] == adapter._timeout
+
+
+@pytest.mark.unit
+async def test_streaming_client_timeout_raises_provider_timeout_error() -> None:
+    """The streaming path labels a client-side timeout the same way."""
+
+    with respx.mock(base_url="https://api.openai.com/v1") as router:
+        router.post("/chat/completions").mock(side_effect=httpx.ReadTimeout("read timed out"))
+        client = httpx.AsyncClient(base_url="https://api.openai.com/v1")
+        try:
+            adapter = OpenAIAdapter(
+                name="openai-prod",
+                base_url="https://api.openai.com/v1",
+                api_key="sk-test",
+                client=client,
+            )
+            stream = await adapter.chat_completion(
+                _basic_chat_request(stream=True), model="gpt-4o", stream=True
+            )
+            assert not isinstance(stream, ChatCompletionResponse)
+            with pytest.raises(ProviderTimeoutError) as excinfo:
+                async for _chunk in stream:
+                    pass
+        finally:
+            await client.aclose()
+    assert "client-side timeout" in excinfo.value.message

--- a/gateway/tests/test_provider_error_mapping.py
+++ b/gateway/tests/test_provider_error_mapping.py
@@ -31,6 +31,7 @@ from app.providers.base import (
     ProviderAuthError,
     ProviderHTTPError,
     ProviderNetworkError,
+    ProviderTimeoutError,
     ProviderUnsupportedError,
 )
 
@@ -126,3 +127,18 @@ def test_failure_reason_records_classified_code_and_upstream_status() -> None:
 
     network = _failure_reason(ProviderNetworkError("dns"))
     assert network == "upstream_error:provider_unavailable"
+
+
+@pytest.mark.unit
+def test_failure_reason_labels_client_timeout_distinctly() -> None:
+    """A gateway-side timeout (ProviderTimeoutError) reads
+    ``client_timeout:...`` in the routing log — distinguishable from an
+    upstream 5xx outage, which reads ``upstream_error:...:status=5xx``.
+    The wire code and HTTP mapping stay identical to any network error."""
+
+    timeout = ProviderTimeoutError("timed out after 300s waiting for Anthropic")
+    assert _failure_reason(timeout) == "client_timeout:provider_unavailable"
+    assert _classify_provider_error(timeout) == ("provider_unavailable", 503)
+
+    outage = _failure_reason(ProviderHTTPError("down", upstream_status=500))
+    assert outage == "upstream_error:provider_unavailable:status=500"


### PR DESCRIPTION
## What this PR does

Two related fixes to the Anthropic adapter's client-timeout behavior:

1. Raises `DEFAULT_TIMEOUT_SECONDS` from 60.0 to 300.0. The per-provider `timeout_s` field still overrides for operators who want a tighter budget.
2. Client-side httpx timeouts (unary and streaming) now raise a `ProviderTimeoutError` subclass instead of the generic `ProviderNetworkError` (wire code and 503 mapping unchanged, mirroring the `ProviderModelNotFound` precedent), and the routing-log refusal-reason builder labels those rows `client_timeout:provider_unavailable` instead of `upstream_error:provider_unavailable`.

## Why

Frontier drafting responses of 4-16K output tokens routinely exceed 60s of generation time, so the old default aborted healthy long generations mid-flight. Worse, the abort was logged as `upstream_error:provider_unavailable` — indistinguishable from a genuine Anthropic outage. In production this looked exactly like a flaky provider: every large request (~12K tokens in / 4K out) died at 60-63s while small probes always passed; one successful run clocked 60,123 ms — a photo finish. On a typical single-BYOK self-host, the fallback chain has no other adapters, so each "blip" surfaced as a hard 503.

Found operating a production self-hosted legal deployment (a law firm running Donna v0.6.2 fully local, BYOK Anthropic through this gateway). Findings 15/15a in that deployment's defect log.

## What this PR does *not* do

- Add retry-with-backoff on the primary for retryable upstream statuses before walking fallbacks (finding 15's other half — a separate, larger change).
- Scale the timeout with `max_tokens`.
- Change the external error contract: wire code and HTTP 503 mapping are untouched; only the exception type and the routing-log label are more precise.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Skill contribution (see attestation below)
- [ ] Refactor (no behavioral change)
- [ ] Test / CI / tooling

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] Manually tested against a real deployment (describe scenario below)
- [ ] Acceptance test plan updated (if changing skill behavior)

<details>
<summary>Manual testing notes (if applicable)</summary>

Diagnosed on a live deployment by correlating routing-log `provider_unavailable` rows with request sizes: all failures at 60-63s on large requests, none on small ones; raising the provider `timeout_s` eliminated every occurrence. Unit tests pin the new 300s default, assert unary + streaming httpx timeouts raise `ProviderTimeoutError` with the client-timeout message, and assert the routing-log label is distinct from an upstream 5xx.

</details>

## Documentation

- [ ] PRD updated (if user-facing behavior changes)
- [ ] README updated (if quickstart or capability list changes)
- [ ] Skill-authoring guide updated (if skill conventions change)
- [ ] Deployment cookbook updated (if deployment changes)
- [ ] Compliance documentation updated (if compliance posture changes)
- [ ] OpenAPI schema regenerated (if API endpoints change)

No listed doc surface covers adapter timeout defaults; `timeout_s` was already documented in `gateway.yaml.example`.

## Transparency & governance invariants

- [x] **Egress (P1):** n/a — no new outbound call; existing gateway adapter paths only.
- [x] **No raw payloads (P3):** the new routing-log label is a fixed string; no message content, args, or keys are logged.
- [x] **Closed set (P2):** n/a — no new capability.
- [x] **Fail restrictive (P4):** timeouts still fail the request with the same 503/wire code; the failure path (unary and streaming) is what the new tests exercise.
- [x] **Atomic audit (P5):** n/a — no state changes.
- [x] **One governance path (P6):** reuses the existing provider-error hierarchy and refusal-reason builder; `ProviderTimeoutError` subclasses the existing error exactly as `ProviderModelNotFound` does.
- [x] **Human gate (P7):** n/a — nothing destructive.
- [x] **Operator control (P8):** the per-provider `timeout_s` override is unchanged and still wins over the new default.
- [x] **User owns data (P9):** n/a — no matter context or residency impact.
- [x] **Contract is truth (P10):** wire codes and HTTP mappings unchanged, so no OpenAPI/schema update needed; the routing-log label change is documented here and in the commit message.

## DCO sign-off

- [x] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

## Related issues

None filed upstream; findings 15/15a in the reporting deployment's defect log. Related: the `default_max_tokens` PR from the same log (finding 18) submitted separately.

## Reviewer notes

The 300s figure is a judgment call: large enough for 16K-token generations on current frontier models, small enough to still catch genuinely hung connections. If you would rather keep 60s and instead scale with `max_tokens`, happy to rework — the label fix (part 2) is valuable independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update 2026-09-13 (maintainer).** Scope widened per the review: `ProviderTimeoutError` is now raised by the OpenAI (incl. Azure) and Ollama adapters too, so the `client_timeout:` label is provider-independent. Adapter defaults are **600s** (Anthropic 300 → 600, OpenAI 60 → 600, Ollama 120 → 600): the 300s figure covered the 4–16K-token drafting turns measured here; #503's 370s document-production turn (@SaifAlYounan) needed more. The api's own gateway-client timeout is raised to 900s in #535 so it stays the loosest hop. Decision recorded in ADR 0027 (closes #489). Refs #503.