### PR TITLE
DE-376: EUR-Lex human-readable subtitle + partial-payload test

### DIFF
--- a/api/app/chat/tool_schemas.py
+++ b/api/app/chat/tool_schemas.py
@@ -89,7 +89,8 @@ RESEARCH_OPS: frozenset[str] = frozenset(RESEARCH_TOOL_SCHEMAS)
 # authority source via a `source` argument — NOT one schema per source.
 # Property names are the union across the registered adapters' real gateway
 # contracts (GovInfo: collection/query, package_id; EDGAR: query/forms,
-# external_ref); each provider's gateway tool ignores properties it doesn't
+# external_ref; EUR-Lex: query, external_ref [CELEX id] — DE-374); each
+# provider's gateway tool ignores properties it doesn't
 # recognise, so the model picks the properties relevant to the `source` it
 # chose. These templates carry the *shared* description/parameters shape;
 # `build_authority_tool_schemas` injects the per-turn `source` enum (the
@@ -99,10 +100,12 @@ AUTHORITY_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "search_authority": {
         "description": (
             "Full-text search an authoritative source: govinfo (U.S. Code / "
-            "CFR — set 'collection' to 'USCODE' or 'CFR') or edgar (SEC "
-            "company filings — optional 'forms' filter, e.g. '10-K,8-K'). "
-            "Returns matching items with an external_ref; call get_authority "
-            "to fetch an item's full text before quoting it."
+            "CFR — set 'collection' to 'USCODE' or 'CFR'), edgar (SEC "
+            "company filings — optional 'forms' filter, e.g. '10-K,8-K'), or "
+            "eurlex (EU legislation & CJEU case law — title keyword search; "
+            "returns CELEX ids). Returns matching items with an "
+            "external_ref; call get_authority to fetch an item's full text "
+            "before quoting it."
         ),
         "parameters": {
             "type": "object",
@@ -139,7 +142,11 @@ AUTHORITY_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
                 },
                 "external_ref": {
                     "type": "string",
-                    "description": "EDGAR only: external_ref returned by search_authority.",
+                    "description": (
+                        "EDGAR or EUR-Lex: external_ref returned by "
+                        "search_authority (EDGAR filing ref, or EUR-Lex CELEX "
+                        "id, e.g. 32016R0679)."
+                    ),
                 },
             },
             "required": [],

--- a/api/app/citation/authority.py
+++ b/api/app/citation/authority.py
@@ -68,6 +68,57 @@ def _validate_storage_key_component(param_name: str, value: str) -> None:
         )
 
 
+# Reversible storage-key encoding for external_refs whose canonical form
+# contains chars outside the safe key charset (DE-375).  EUR-Lex treaty and
+# corrigendum CELEX ids carry '/' and '()' (12016E/TXT, 32016R0679R(01));
+# these map to dotted triples that (a) land inside [A-Za-z0-9._-]+ and
+# (b) never occur in a raw ref of any supported source (CELEX, GovInfo
+# package ids, EDGAR accession numbers) — enforced fail-closed below, which
+# makes the encoding injective on its accepted domain.  Identity for refs
+# already in the safe charset, so pre-DE-375 cache rows keep their keys.
+_KEY_ENCODINGS: tuple[tuple[str, str], ...] = (
+    ("/", ".SL."),
+    ("(", ".OP."),
+    (")", ".CP."),
+)
+
+
+def encode_external_ref_key(external_ref: str) -> str:
+    """Encode an external_ref into its object-storage key form (reversible).
+
+    Maps ``/`` -> ``.SL.``, ``(`` -> ``.OP.``, ``)`` -> ``.CP.``; every other
+    char passes through unchanged, so the encoding is the identity for refs
+    already inside the safe key charset.  Raises ValueError (fail-closed,
+    before any encoding) if the raw ref contains a path-traversal sequence
+    (``..``) or one of the encoding triples themselves — neither occurs in a
+    legitimate ref, and rejecting them keeps the encoding reversible and the
+    traversal guard intact.  The result must still pass
+    :func:`_validate_storage_key_component`; callers validate after encoding.
+    """
+    if ".." in external_ref:
+        raise ValueError(
+            f"Invalid external_ref {external_ref!r}: path-traversal sequence '..' detected"
+        )
+    for _raw, token in _KEY_ENCODINGS:
+        if token in external_ref:
+            raise ValueError(
+                f"Invalid external_ref {external_ref!r}: reserved encoding "
+                f"sequence {token!r} detected"
+            )
+    encoded = external_ref
+    for raw, token in _KEY_ENCODINGS:
+        encoded = encoded.replace(raw, token)
+    return encoded
+
+
+def decode_external_ref_key(encoded: str) -> str:
+    """Invert :func:`encode_external_ref_key` (storage key -> raw external_ref)."""
+    decoded = encoded
+    for raw, token in _KEY_ENCODINGS:
+        decoded = decoded.replace(token, raw)
+    return decoded
+
+
 # TTL for cached authority source text: 30 days.
 AUTHORITY_TEXT_TTL = timedelta(days=30)
 
@@ -139,11 +190,18 @@ async def store_authority_text(
     The body is stored raw (not normalized) so that ``load_authority_text``
     can return it verbatim for use with ``authority_target``; the verifier
     normalizes the content internally when needed.
+
+    The storage key uses the encoded external_ref
+    (:func:`encode_external_ref_key`, DE-375) so treaty/corrigendum CELEX
+    ids (``/``, ``()``) become storable; the DB row and every user-visible
+    surface keep the raw external_ref.  Encoding is the identity for refs
+    already in the safe charset, so pre-existing cache rows are unaffected.
     """
     _validate_storage_key_component("source_type", source_type)
-    _validate_storage_key_component("external_ref", external_ref)
+    encoded_ref = encode_external_ref_key(external_ref)
+    _validate_storage_key_component("external_ref", encoded_ref)
 
-    storage_path = f"authority/{source_type}/{external_ref}"
+    storage_path = f"authority/{source_type}/{encoded_ref}"
     await upload_bytes(
         storage_path=storage_path,
         body=text.encode("utf-8"),
@@ -210,9 +268,14 @@ async def load_authority_text(
 
     Reads the body from object storage via the same ``stream_download``
     helper that :mod:`app.research.service` uses for opinion bodies.
+
+    ``external_ref`` is the raw ref (the DB row stores it raw); it is
+    encode-validated here (:func:`encode_external_ref_key`, DE-375) so a
+    hostile ref is rejected before any DB/storage access — the same
+    fail-closed gate as ``store_authority_text``.
     """
     _validate_storage_key_component("source_type", source_type)
-    _validate_storage_key_component("external_ref", external_ref)
+    _validate_storage_key_component("external_ref", encode_external_ref_key(external_ref))
 
     row = (
         await db.execute(
@@ -264,7 +327,9 @@ async def verify_and_persist_authority_citations(
     # Only get_authority-sourced refs carry a cached body; filter to authority
     # content kinds with an external_ref.  EDGAR's "sec_filing" is covered as
     # of WS-E PR2a (DE-371); EUR-Lex's eu_* kinds are covered as of WS-E PR2b
-    # (DE-374) — treaty/corrigendum CELEX handling is still pending (DE-375).
+    # (DE-374), including treaty/corrigendum CELEX ids (DE-375 — they land as
+    # "eu_legislation"/"eu_regulation" and their cache keys are encoded by
+    # encode_external_ref_key).
     # A content kind outside this set is silently not verified (a
     # conservative drop, never a false claim, but it means no ledger row).
     _VERIFIABLE_CONTENT_KINDS = {

--- a/api/app/research/adapters.py
+++ b/api/app/research/adapters.py
@@ -12,7 +12,7 @@ because the gateway payloads are already structured for direct use.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, ClassVar, Protocol, runtime_checkable
 
 
 @dataclass
@@ -235,6 +235,17 @@ class EurLexAdapter:
             return self._from_search_authority(payload)
         raise ValueError(f"EurLexAdapter: unsupported op {op!r}")
 
+    # Human-readable subtitle labels per machine content_kind (DE-376).
+    # subtitle is a display heading, never load-bearing for verification;
+    # content_kind itself stays machine-form everywhere.
+    _KIND_LABELS: ClassVar[dict[str, str]] = {
+        "eu_regulation": "EU Regulation",
+        "eu_directive": "EU Directive",
+        "eu_decision": "EU Decision",
+        "eu_caselaw": "CJEU Case Law",
+        "eu_legislation": "EU Legislation",
+    }
+
     def _from_get_authority(self, payload: dict[str, Any]) -> FetchedAuthority:
         title: str = payload.get("title") or ""
         url: str = payload.get("url") or ""
@@ -244,7 +255,7 @@ class EurLexAdapter:
         return FetchedAuthority(
             citable_text=text,
             label=title,
-            subtitle=content_kind,
+            subtitle=self._KIND_LABELS.get(content_kind, content_kind),
             url=url,
             external_ref=external_ref,
             content_kind=content_kind,

--- a/api/app/research/adapters.py
+++ b/api/app/research/adapters.py
@@ -206,23 +206,33 @@ class EdgarAdapter:
 class EurLexAdapter:
     """Normalises EUR-Lex gateway payloads into ``FetchedAuthority`` objects.
 
-    Handles the single EUR-Lex tool operation exposed by the gateway:
+    Handles the two EUR-Lex tool operations exposed by the gateway:
 
     ``get_authority``
         Payload: ``{external_ref, title, url, text, content_kind?}``
         Returns a fully-hydrated ``FetchedAuthority`` with the retrieved
         EU legislation or CJEU case-law text.
 
-    EUR-Lex has no full-text search endpoint wired through the gateway —
-    retrieval is by CELEX id only, so this adapter is a thin carry-through:
-    the gateway adapter already derives ``content_kind`` from the CELEX
-    descriptor (sector digit) and passes it through in the payload; this
-    adapter just reads it, falling back to ``"eu_legislation"`` if absent.
+    ``search_authority`` (DE-374)
+        Payload: ``{results: [{external_ref, title, url}], count}``
+        Returns a ``FetchedAuthority`` from the *first* result. EUR-Lex
+        search results carry no document body (same contract as GovInfo/
+        EDGAR search) — ``citable_text`` is the title only and is NOT
+        quotable as document text; call ``get_authority`` with the CELEX
+        ``external_ref`` to fetch the body.
+
+    ``content_kind``: the gateway adapter derives it from the CELEX
+    descriptor (sector digit) on ``get_authority`` and passes it through in
+    the payload; this adapter just reads it, falling back to
+    ``"eu_legislation"`` if absent (search results carry no kind field, so
+    they always fall back).
     """
 
     def from_response(self, op: str, payload: dict[str, Any]) -> FetchedAuthority:
         if op == "get_authority":
             return self._from_get_authority(payload)
+        if op == "search_authority":
+            return self._from_search_authority(payload)
         raise ValueError(f"EurLexAdapter: unsupported op {op!r}")
 
     def _from_get_authority(self, payload: dict[str, Any]) -> FetchedAuthority:
@@ -238,4 +248,21 @@ class EurLexAdapter:
             url=url,
             external_ref=external_ref,
             content_kind=content_kind,
+        )
+
+    def _from_search_authority(self, payload: dict[str, Any]) -> FetchedAuthority:
+        results: list[dict[str, Any]] = payload.get("results") or []
+        if not results:
+            raise ValueError("EurLexAdapter: search_authority payload has no results")
+        first = results[0]
+        title: str = first.get("title") or ""
+        url: str = first.get("url") or ""
+        external_ref: str = first.get("external_ref") or ""
+        return FetchedAuthority(
+            citable_text=title,  # search has no quotable body; only get_authority does
+            label=title,
+            subtitle="",
+            url=url,
+            external_ref=external_ref,
+            content_kind="eu_legislation",
         )

--- a/api/app/research/registry.py
+++ b/api/app/research/registry.py
@@ -83,7 +83,10 @@ SOURCE_REGISTRY: dict[str, SourceSpec] = {
     "eurlex": SourceSpec(
         type="eurlex",
         jurisdiction="eu",
-        coverage="EU legislation & CJEU case law via EUR-Lex/Cellar — retrieve by CELEX id",
+        coverage=(
+            "EU legislation & CJEU case law via EUR-Lex/Cellar — title keyword "
+            "search + retrieve by CELEX id"
+        ),
         content_kinds=(
             "eu_regulation",
             "eu_directive",
@@ -91,7 +94,7 @@ SOURCE_REGISTRY: dict[str, SourceSpec] = {
             "eu_caselaw",
             "eu_legislation",
         ),
-        ops=("get_authority",),
+        ops=("search_authority", "get_authority"),
         adapter=EurLexAdapter(),
     ),
 }

--- a/api/tests/chat/test_tool_loop.py
+++ b/api/tests/chat/test_tool_loop.py
@@ -1191,3 +1191,91 @@ async def test_dispatch_authority_unknown_source_does_not_raise(db):
     assert result.outcome == "success"
     assert result.data["authority"]["error"] == "source not available"
     assert gw.calls == []  # never reached the gateway for an unknown source
+
+
+# ---------------------------------------------------------------------------
+# EUR-Lex search → get chaining (DE-374)
+# ---------------------------------------------------------------------------
+
+
+class _FakeGatewayByOp:
+    """Gateway double returning a distinct payload per op — lets one test
+    exercise the search → get chain the model performs across two calls."""
+
+    def __init__(self, payloads_by_op):
+        self._payloads = payloads_by_op
+        self.calls = []
+
+    async def call_tool(self, provider, op, args):
+        self.calls.append((provider, op, args))
+        return {"payload": self._payloads[op]}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_authority_eurlex_search_then_get_chains(
+    db, fake_authority_storage: dict[str, bytes]
+):
+    """DE-374: an eurlex search_authority call yields a CELEX external_ref
+    with NO body; feeding that ref to get_authority fetches the quotable text
+    and writes the durable authority cache under source_type='eurlex'. Only
+    the get step may produce citable content (fail-closed search contract)."""
+    celex = "32016R0679"
+    page_url = f"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:{celex}"
+    gw = _FakeGatewayByOp(
+        {
+            "search_authority": {
+                "results": [
+                    {
+                        "external_ref": celex,
+                        "title": "General Data Protection Regulation",
+                        "url": page_url,
+                    }
+                ],
+                "count": 1,
+            },
+            "get_authority": {
+                "external_ref": celex,
+                "title": celex,
+                "url": page_url,
+                "text": "Article 6 Lawfulness of processing ...",
+                "content_kind": "eu_regulation",
+            },
+        }
+    )
+
+    search_result = await _dispatch_authority(
+        db,
+        spec=_shared_authority_spec("search_authority"),
+        args={"source": "eurlex", "query": "data protection"},
+        gateway=gw,
+        request_id="r1",
+    )
+    search_auth = search_result.data["authority"]
+    assert search_auth["source"] == "eurlex"
+    assert search_auth["external_ref"] == celex
+    # Search carries no quotable body — only the title label — and must not
+    # populate the durable authority cache.
+    assert search_auth["citable_text"] == "General Data Protection Regulation"
+    from app.citation.authority import load_authority_text
+
+    assert await load_authority_text(db, source_type="eurlex", external_ref=celex) is None
+
+    get_result = await _dispatch_authority(
+        db,
+        spec=_shared_authority_spec("get_authority"),
+        args={"source": "eurlex", "external_ref": search_auth["external_ref"]},
+        gateway=gw,
+        request_id="r1",
+    )
+    get_auth = get_result.data["authority"]
+    assert get_auth["source"] == "eurlex"
+    assert get_auth["content_kind"] == "eu_regulation"
+    assert "Article 6" in get_auth["citable_text"]
+    # get_authority persisted the body for the finalize verify hook.
+    body = await load_authority_text(db, source_type="eurlex", external_ref=celex)
+    assert body is not None and "Article 6" in body
+    # Both calls were routed under the eurlex source, chained on the same ref.
+    assert gw.calls == [
+        ("eurlex", "search_authority", {"query": "data protection"}),
+        ("eurlex", "get_authority", {"external_ref": celex}),
+    ]

--- a/api/tests/chat/test_tool_schemas.py
+++ b/api/tests/chat/test_tool_schemas.py
@@ -240,22 +240,49 @@ async def test_assemble_allowlist_adds_both_sources_when_both_available(db, monk
     assert set(search_spec.parameters["properties"]["source"]["enum"]) == {"govinfo", "edgar"}
 
 
-def test_authority_source_enum_is_per_op():
-    # govinfo+edgar support both ops; eurlex supports only get_authority.
-    schemas = build_authority_tool_schemas(enabled_sources=["govinfo", "edgar", "eurlex"])
+def _get_only_spec():
+    """Synthetic get-only SourceSpec — every real registry source now supports
+    search (eurlex gained search_authority in DE-374), so per-op enum scoping
+    is exercised via a registry double."""
+    from app.research.registry import SourceSpec
+
+    return SourceSpec(
+        type="getonly",
+        jurisdiction="test",
+        coverage="synthetic get-only source",
+        content_kinds=("test",),
+        ops=("get_authority",),
+        adapter=None,
+    )
+
+
+def test_authority_source_enum_is_per_op(monkeypatch):
+    # govinfo/edgar/eurlex all support both ops (eurlex search: DE-374); a
+    # synthetic get-only source preserves coverage of per-op enum scoping.
+    from app.chat.tool_schemas import SOURCE_REGISTRY
+
+    monkeypatch.setitem(SOURCE_REGISTRY, "getonly", _get_only_spec())
+    schemas = build_authority_tool_schemas(
+        enabled_sources=["govinfo", "edgar", "eurlex", "getonly"]
+    )
     by_name = {s["name"]: s for s in schemas}
     assert set(by_name["get_authority"]["parameters"]["properties"]["source"]["enum"]) == {
         "govinfo",
         "edgar",
         "eurlex",
+        "getonly",
     }
     assert set(by_name["search_authority"]["parameters"]["properties"]["source"]["enum"]) == {
         "govinfo",
         "edgar",
+        "eurlex",
     }
 
 
-def test_authority_search_omitted_when_no_search_source():
+def test_authority_search_omitted_when_no_search_source(monkeypatch):
     # only a get-only source enabled → no search_authority tool at all
-    schemas = build_authority_tool_schemas(enabled_sources=["eurlex"])
+    from app.chat.tool_schemas import SOURCE_REGISTRY
+
+    monkeypatch.setitem(SOURCE_REGISTRY, "getonly", _get_only_spec())
+    schemas = build_authority_tool_schemas(enabled_sources=["getonly"])
     assert [s["name"] for s in schemas] == ["get_authority"]

--- a/api/tests/test_authority_substrate.py
+++ b/api/tests/test_authority_substrate.py
@@ -6,6 +6,10 @@ Covers:
 - load returns None when absent.
 - load returns None when the cached row is stale (past AUTHORITY_TEXT_TTL).
 - _AuthorityCandidate duck-types _CandidateProtocol; verify() passes stage 1/2.
+- encode_external_ref_key/decode_external_ref_key (DE-375): reversible key
+  encoding for treaty/corrigendum CELEX refs, identity for safe refs,
+  fail-closed on traversal/reserved sequences; store/load round-trip for
+  '/' and '()' shapes under the encoded storage key.
 
 Object-storage is backed by the same in-memory fake fixture pattern used in
 tests/test_research_service.py, patching upload_bytes/stream_download at the
@@ -21,9 +25,12 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from app.citation.authority import (
+    _SAFE_KEY_RE,
     AUTHORITY_TEXT_TTL,
     _AuthorityCandidate,
     authority_target,
+    decode_external_ref_key,
+    encode_external_ref_key,
     load_authority_text,
     store_authority_text,
 )
@@ -121,6 +128,89 @@ async def test_load_returns_none_when_stale(db_session, fake_storage) -> None:
         await load_authority_text(db_session, source_type="govinfo", external_ref="USCODE-old")
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# Storage-key encoding for treaty/corrigendum external_refs (DE-375)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "12016E/TXT",  # treaty full text
+        "12012P/TXT",  # Charter full text
+        "32016R0679R(01)",  # corrigendum
+        "12016M/PRO/02",  # multiple slashes stay reversible
+        "32016R0679",  # already-safe id (identity)
+    ],
+)
+def test_encode_decode_external_ref_round_trips(raw: str) -> None:
+    encoded = encode_external_ref_key(raw)
+    assert decode_external_ref_key(encoded) == raw
+    # Encoded form always lands in the safe key charset — no '/' survives.
+    assert _SAFE_KEY_RE.fullmatch(encoded)
+    assert "/" not in encoded
+
+
+@pytest.mark.parametrize(
+    "safe_ref",
+    [
+        "32016R0679",  # CELEX regulation
+        "USCODE-2022-title15",  # GovInfo package id
+        "0001193125-15-118890",  # EDGAR accession number
+        "CFR-2023-title40",
+    ],
+)
+def test_encode_is_identity_for_safe_refs(safe_ref: str) -> None:
+    """Pre-DE-375 cache rows keep their storage keys: encoding must be the
+    identity for every ref already inside the safe charset."""
+    assert encode_external_ref_key(safe_ref) == safe_ref
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "../../etc/passwd",  # traversal — must never become storable via encoding
+        "a..b",  # bare traversal sequence
+        "a.SL.b",  # reserved encoding triple — would break reversibility
+        "a.OP.b",
+        "a.CP.b",
+    ],
+)
+def test_encode_rejects_traversal_and_reserved_sequences(hostile: str) -> None:
+    with pytest.raises(ValueError, match="external_ref"):
+        encode_external_ref_key(hostile)
+
+
+@pytest.mark.asyncio
+async def test_store_then_load_round_trips_treaty_celex(db_session, fake_storage) -> None:
+    """A treaty CELEX ('/' shape, DE-375) stores under the encoded key and
+    loads back by its raw external_ref; the object-store key stays inside
+    authority/<source_type>/ with no extra path segment."""
+    body = "The Union shall be founded on the present Treaty."
+    await store_authority_text(
+        db_session, source_type="eurlex-prod", external_ref="12016E/TXT", text=body
+    )
+    assert list(fake_storage) == ["authority/eurlex-prod/12016E.SL.TXT"]
+    got = await load_authority_text(
+        db_session, source_type="eurlex-prod", external_ref="12016E/TXT"
+    )
+    assert got == body
+
+
+@pytest.mark.asyncio
+async def test_store_then_load_round_trips_corrigendum_celex(db_session, fake_storage) -> None:
+    """A corrigendum CELEX ('()' shape, DE-375) round-trips the same way."""
+    body = "Corrigendum to Regulation (EU) 2016/679."
+    await store_authority_text(
+        db_session, source_type="eurlex-prod", external_ref="32016R0679R(01)", text=body
+    )
+    assert list(fake_storage) == ["authority/eurlex-prod/32016R0679R.OP.01.CP."]
+    got = await load_authority_text(
+        db_session, source_type="eurlex-prod", external_ref="32016R0679R(01)"
+    )
+    assert got == body
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_source_registry.py
+++ b/api/tests/test_source_registry.py
@@ -221,9 +221,40 @@ def test_eurlex_get_authority_maps_to_fetched_authority():
     assert "CELEX:32016R0679" in fa.url
 
 
+def test_eurlex_search_authority_first_result_no_body():
+    """DE-374: search results carry no document body — citable_text is the
+    title only (same fail-closed contract as GovInfo/EDGAR search)."""
+    payload = {
+        "results": [
+            {
+                "external_ref": "32016R0679",
+                "title": "General Data Protection Regulation",
+                "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679",
+            },
+            {
+                "external_ref": "32011L0083",
+                "title": "Consumer Rights Directive",
+                "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32011L0083",
+            },
+        ],
+        "count": 2,
+    }
+    fa = EurLexAdapter().from_response("search_authority", payload)
+    assert fa.external_ref == "32016R0679"  # first result
+    assert fa.citable_text == "General Data Protection Regulation"  # title only, NOT body text
+    assert fa.label == "General Data Protection Regulation"
+    assert "CELEX:32016R0679" in fa.url
+    assert fa.content_kind == "eu_legislation"
+
+
+def test_eurlex_search_authority_empty_results_raises():
+    with pytest.raises(ValueError):
+        EurLexAdapter().from_response("search_authority", {"results": [], "count": 0})
+
+
 def test_eurlex_unsupported_op_raises() -> None:
     with pytest.raises(ValueError):
-        EurLexAdapter().from_response("search_authority", {})
+        EurLexAdapter().from_response("bogus_op", {})
 
 
 # ---------------------------------------------------------------------------
@@ -231,9 +262,9 @@ def test_eurlex_unsupported_op_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_eurlex_registered_get_only():
+def test_eurlex_registered_with_search_and_get():
     spec = SOURCE_REGISTRY["eurlex"]
     assert spec.type == "eurlex"
-    assert spec.ops == ("get_authority",)
+    assert spec.ops == ("search_authority", "get_authority")
     assert "eu_regulation" in spec.content_kinds
     assert spec.adapter is not None

--- a/api/tests/test_source_registry.py
+++ b/api/tests/test_source_registry.py
@@ -221,6 +221,61 @@ def test_eurlex_get_authority_maps_to_fetched_authority():
     assert "CELEX:32016R0679" in fa.url
 
 
+def test_eurlex_get_authority_subtitle_is_human_readable():
+    """DE-376: subtitle is a display heading — machine kinds map to labels,
+    content_kind itself stays machine-form."""
+    for kind, label in [
+        ("eu_regulation", "EU Regulation"),
+        ("eu_directive", "EU Directive"),
+        ("eu_decision", "EU Decision"),
+        ("eu_caselaw", "CJEU Case Law"),
+        ("eu_legislation", "EU Legislation"),
+    ]:
+        fa = EurLexAdapter().from_response(
+            "get_authority",
+            {
+                "external_ref": "32016R0679",
+                "title": "t",
+                "url": "u",
+                "text": "x",
+                "content_kind": kind,
+            },
+        )
+        assert fa.subtitle == label
+        assert fa.content_kind == kind
+    # An unknown future kind passes through unchanged rather than erroring.
+    fa = EurLexAdapter().from_response(
+        "get_authority",
+        {
+            "external_ref": "32016R0679",
+            "title": "t",
+            "url": "u",
+            "text": "x",
+            "content_kind": "eu_other",
+        },
+    )
+    assert fa.subtitle == "eu_other"
+
+
+def test_eurlex_get_authority_partial_payload_fallbacks():
+    """DE-376: every field the adapter reads via payload.get(...) falls back
+    safely on a partial payload — empty strings and the eu_legislation kind."""
+    fa = EurLexAdapter().from_response("get_authority", {})
+    assert fa.citable_text == ""
+    assert fa.label == ""
+    assert fa.url == ""
+    assert fa.external_ref == ""
+    assert fa.content_kind == "eu_legislation"
+    assert fa.subtitle == "EU Legislation"
+    # Explicit None values fall back the same way as missing keys.
+    fa = EurLexAdapter().from_response(
+        "get_authority",
+        {"external_ref": None, "title": None, "url": None, "text": None, "content_kind": None},
+    )
+    assert fa.content_kind == "eu_legislation"
+    assert fa.subtitle == "EU Legislation"
+
+
 def test_eurlex_search_authority_first_result_no_body():
     """DE-374: search results carry no document body — citable_text is the
     title only (same fail-closed contract as GovInfo/EDGAR search)."""

--- a/gateway.yaml.example
+++ b/gateway.yaml.example
@@ -249,7 +249,7 @@ providers:
 #
 #   - name: eurlex-prod
 #     type: eurlex                 # shipped in WS-E PR2b; uncomment to enable
-#     base_url: https://publications.europa.eu    # EU Cellar (content-negotiation by CELEX)
+#     base_url: https://publications.europa.eu    # EU Cellar (CELEX retrieval + /webapi/rdf/sparql title search)
 #     user_agent: "YourOrg legal-ops@yourorg.example"   # descriptive UA — REQUIRED, no API key
 #     egress_tier: 4               # public EU legal text (ADR 0014 D4)
 #     allowlist:

--- a/gateway/app/providers/tool/eurlex.py
+++ b/gateway/app/providers/tool/eurlex.py
@@ -29,15 +29,23 @@ content until ``get_authority`` fetches it. The user keyword is escaped as a
 SPARQL string literal (never interpolated raw) so it cannot break out of the
 ``FILTER`` clause.
 
-CELEX ids containing ``/`` or ``()`` (treaty texts, corrigenda) are rejected
-by ``get_authority`` before any egress is attempted (DE-375); search hits
-whose CELEX would be rejected are dropped rather than surfaced with an
+``get_authority`` validates the CELEX id against a full-CELEX shape regex
+(``_VALID_CELEX_RE``) before any egress is attempted (DE-375): sector digit +
+4-digit year + document-type letters, then either a treaty full-text suffix
+(``12016E/TXT``), or a document number with optional consolidation date
+(``02016R0679-20160504``) and optional corrigendum suffix (``32016R0679R(01)``).
+Anything else — traversal sequences, lowercase, stray specials — is rejected
+fail-closed with a 400. The id is URL-quoted (``quote(..., safe="")``) when
+building the Cellar path so ``/`` and ``()`` never reach the URL raw; the
+user-visible ``external_ref``/page URL keep the raw CELEX form. Search hits
+whose CELEX the same regex rejects are dropped rather than surfaced with an
 unfetchable ref (mirrors EDGAR's drop invariant)."""
 
 from __future__ import annotations
 
 import re
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -73,7 +81,14 @@ _SPARQL_ESCAPES = {
     "\f": "\\f",
 }
 
-_SAFE_CELEX_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+# Full-CELEX validation (DE-375): sector digit, 4-digit year, 1-2 letter
+# document-type descriptor, then EITHER a treaty full-text suffix (/TXT, e.g.
+# 12016E/TXT, 12012P/TXT) OR a document number ([0-9A-Z]*, possibly empty for
+# bare treaty ids like 12016E) with an optional consolidation-date suffix
+# (-YYYYMMDD, e.g. 02016R0679-20160504) and an optional corrigendum suffix
+# (R(NN), e.g. 32016R0679R(01)). Anchored and conservative: no lowercase, no
+# whitespace, no '..', no path segments beyond the single literal '/TXT'.
+_VALID_CELEX_RE = re.compile(r"^\d\d{4}[A-Z]{1,2}(?:/TXT|[0-9A-Z]*(?:-\d{8})?(?:R\(\d{2}\))?)$")
 _CELEX_RE = re.compile(r"^(?P<sector>\d)(?P<year>\d{4})(?P<type>[A-Z]{1,2})")
 _TAG_RE = re.compile(r"<[^>]+>")
 _WHITESPACE_RE = re.compile(r"\s+")
@@ -248,9 +263,11 @@ class EurLexToolAdapter(ToolProviderAdapter):
         title contains the keyword string (case-insensitive). The keyword is
         embedded only as an escaped SPARQL string literal — no injection path
         out of the ``FILTER`` clause. Hits whose CELEX id would be rejected by
-        ``get_authority`` (``/`` or ``()`` shapes, DE-375) are dropped rather
-        than surfaced with an unfetchable ref. Results carry NO body — same
-        fail-closed contract as the GovInfo/EDGAR search ops."""
+        ``get_authority``'s full-CELEX validation (``_VALID_CELEX_RE``,
+        DE-375) are dropped rather than surfaced with an unfetchable ref;
+        treaty (``12016E/TXT``) and corrigendum (``32016R0679R(01)``) shapes
+        are valid and survive. Results carry NO body — same fail-closed
+        contract as the GovInfo/EDGAR search ops."""
         query = args.get("query")
         if not isinstance(query, str) or not query.strip():
             raise ToolProviderInvalidRequestError(
@@ -288,7 +305,7 @@ class EurLexToolAdapter(ToolProviderAdapter):
         for binding in bindings:
             celex = str((binding.get("celex") or {}).get("value") or "").strip()
             title = str((binding.get("title") or {}).get("value") or "").strip()
-            if not celex or not _SAFE_CELEX_RE.match(celex):
+            if not celex or not _VALID_CELEX_RE.fullmatch(celex):
                 # get_authority would refuse this ref (DE-375) — drop the hit
                 # rather than hand back an unfetchable external_ref.
                 continue
@@ -306,22 +323,26 @@ class EurLexToolAdapter(ToolProviderAdapter):
     async def _get_authority(self, args: dict[str, Any]) -> ToolResult:
         """GET the Cellar manifestation for a CELEX id; strip HTML to plaintext.
 
-        Rejects CELEX ids containing ``/`` or ``()`` (treaty texts,
-        corrigenda — DE-375) before any egress is attempted."""
+        Validates the id against the full-CELEX shape (``_VALID_CELEX_RE`` —
+        including treaty ``12016E/TXT`` and corrigendum ``32016R0679R(01)``
+        forms, DE-375) before any egress is attempted; an id that fails is
+        rejected with a 400, never mangled. The validated id is URL-quoted
+        into the Cellar path (``/`` and ``()`` never reach the URL raw);
+        the payload's ``external_ref``/``url`` keep the raw CELEX form."""
         celex = args.get("external_ref")
         if not isinstance(celex, str) or not celex.strip():
             raise ToolProviderInvalidRequestError(
                 "get_authority requires non-empty 'external_ref' (a CELEX id)",
                 upstream_status=400,
             )
-        if not _SAFE_CELEX_RE.match(celex):
+        if not _VALID_CELEX_RE.fullmatch(celex):
             raise ToolProviderInvalidRequestError(
-                f"unsupported CELEX {celex!r}: treaty/corrigendum ids with '/' or "
-                "'()' are not yet supported (DE-375)",
+                f"invalid CELEX {celex!r}: expected sector+year+type(+number) with "
+                "optional /TXT (treaty) or R(NN) (corrigendum) suffix (DE-375)",
                 upstream_status=400,
             )
 
-        start_url = f"{self._base_url}/resource/celex/{celex}"
+        start_url = f"{self._base_url}/resource/celex/{quote(celex, safe='')}"
         resp = await self._fetch_following_redirects(start_url)
         text = _TAG_RE.sub(" ", resp.text)
         text = _WHITESPACE_RE.sub(" ", text).strip()

--- a/gateway/app/providers/tool/eurlex.py
+++ b/gateway/app/providers/tool/eurlex.py
@@ -1,4 +1,4 @@
-"""``eurlex`` tool provider — EU legal document retrieval by CELEX id (WS-E PR2b).
+"""``eurlex`` tool provider — EU legal document search + retrieval (WS-E PR2b, DE-374).
 
 Auth model mirrors EDGAR: the EU Publications Office's Cellar service has no
 API-key scheme, so a descriptive ``User-Agent`` header is the only auth
@@ -20,9 +20,19 @@ EUR-Lex document text is public, so results are marked
 ``skip_anonymization=True`` for verbatim verifier delivery (ADR 0014 D5),
 mirroring the GovInfo/EDGAR adapters.
 
-``get_authority`` only — there is no keyword search endpoint wired up yet
-(DE-374). CELEX ids containing ``/`` or ``()`` (treaty texts, corrigenda) are
-rejected before any egress is attempted (DE-375)."""
+``search_authority`` (DE-374) queries the Cellar SPARQL endpoint
+(``/webapi/rdf/sparql`` on the same host, so the allowlist is unchanged) for
+English expression titles containing the keyword string, returning CELEX ids
+with title and EUR-Lex page URL but NO document body — same fail-closed
+contract as the GovInfo/EDGAR search ops: a search hit is never verified
+content until ``get_authority`` fetches it. The user keyword is escaped as a
+SPARQL string literal (never interpolated raw) so it cannot break out of the
+``FILTER`` clause.
+
+CELEX ids containing ``/`` or ``()`` (treaty texts, corrigenda) are rejected
+by ``get_authority`` before any egress is attempted (DE-375); search hits
+whose CELEX would be rejected are dropped rather than surfaced with an
+unfetchable ref (mirrors EDGAR's drop invariant)."""
 
 from __future__ import annotations
 
@@ -47,6 +57,21 @@ from app.providers.tool.egress import EgressRefused, validate_egress_target
 
 DEFAULT_TIMEOUT_SECONDS = 30.0
 MAX_REDIRECTS = 5
+DEFAULT_SEARCH_PAGE_SIZE = 10
+
+_SPARQL_ACCEPT = "application/sparql-results+json"
+# SPARQL string-literal escapes (SPARQL 1.1 grammar ECHAR) — the user keyword
+# is only ever embedded through _sparql_string_literal, never raw.
+_SPARQL_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "'": "\\'",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+    "\b": "\\b",
+    "\f": "\\f",
+}
 
 _SAFE_CELEX_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _CELEX_RE = re.compile(r"^(?P<sector>\d)(?P<year>\d{4})(?P<type>[A-Z]{1,2})")
@@ -77,6 +102,20 @@ def _content_kind_from_celex(celex: str) -> str:
     return "eu_legislation"
 
 
+def _sparql_string_literal(value: str) -> str:
+    """Render ``value`` as a double-quoted SPARQL string literal.
+
+    Escapes every SPARQL ECHAR (backslash, both quote kinds, control
+    characters) so a user keyword can never terminate the literal and inject
+    SPARQL syntax into the query."""
+    return '"' + "".join(_SPARQL_ESCAPES.get(ch, ch) for ch in value) + '"'
+
+
+def _eurlex_page_url(celex: str) -> str:
+    """Canonical EUR-Lex page URL for a CELEX id (same form get_authority emits)."""
+    return f"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:{celex}"
+
+
 def _force_https(url: str) -> str:
     """Upgrade an ``http`` URL to ``https``; leave other schemes untouched.
 
@@ -93,9 +132,11 @@ def _force_https(url: str) -> str:
 class EurLexToolAdapter(ToolProviderAdapter):
     """Tool adapter for the EU Publications Office Cellar service.
 
-    Auth: a descriptive ``User-Agent`` header (no API key). Supports one
-    read-only operation: ``get_authority`` for fetching an EU legal
-    document's plaintext by CELEX id.
+    Auth: a descriptive ``User-Agent`` header (no API key). Supports two
+    read-only operations: ``search_authority`` for keyword search of EU
+    legal document titles via the Cellar SPARQL endpoint (DE-374), and
+    ``get_authority`` for fetching an EU legal document's plaintext by
+    CELEX id.
     """
 
     def __init__(
@@ -146,12 +187,36 @@ class EurLexToolAdapter(ToolProviderAdapter):
     async def list_tools(self, *, user_token: str | None = None) -> list[ToolSpec]:
         return [
             ToolSpec(
+                name="search_authority",
+                description=(
+                    "Keyword search of EU legal documents (regulations, "
+                    "directives, decisions, CJEU judgments) by title via the "
+                    "EUR-Lex/Cellar SPARQL endpoint. Returns matching CELEX "
+                    "ids usable by get_authority; results carry no document "
+                    "body."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Keyword(s) to match against document titles.",
+                        },
+                        "page_size": {
+                            "type": "integer",
+                            "description": "Maximum results to return (default 10).",
+                        },
+                    },
+                    "required": ["query"],
+                },
+                read_only=True,
+            ),
+            ToolSpec(
                 name="get_authority",
                 description=(
                     "Retrieve the full text of an EU legal document (regulation, "
                     "directive, decision, or CJEU judgment) from EUR-Lex by its "
-                    "CELEX id (e.g. 32016R0679 = GDPR). No keyword search — "
-                    "provide a CELEX id."
+                    "CELEX id (e.g. 32016R0679 = GDPR)."
                 ),
                 parameters={
                     "type": "object",
@@ -164,15 +229,79 @@ class EurLexToolAdapter(ToolProviderAdapter):
                     "required": ["external_ref"],
                 },
                 read_only=True,
-            )
+            ),
         ]
 
     async def invoke_tool(
         self, tool: str, args: dict[str, Any], *, request_id: str, user_token: str | None = None
     ) -> ToolResult:
+        if tool == "search_authority":
+            return await self._search_authority(args)
         if tool == "get_authority":
             return await self._get_authority(args)
         raise ToolProviderError(f"unknown tool {tool!r} for eurlex provider")
+
+    async def _search_authority(self, args: dict[str, Any]) -> ToolResult:
+        """GET the Cellar SPARQL endpoint for title/keyword matches (DE-374).
+
+        Selects distinct CELEX id + English expression title for works whose
+        title contains the keyword string (case-insensitive). The keyword is
+        embedded only as an escaped SPARQL string literal — no injection path
+        out of the ``FILTER`` clause. Hits whose CELEX id would be rejected by
+        ``get_authority`` (``/`` or ``()`` shapes, DE-375) are dropped rather
+        than surfaced with an unfetchable ref. Results carry NO body — same
+        fail-closed contract as the GovInfo/EDGAR search ops."""
+        query = args.get("query")
+        if not isinstance(query, str) or not query.strip():
+            raise ToolProviderInvalidRequestError(
+                "search_authority requires non-empty 'query'", upstream_status=400
+            )
+        raw_page_size = args.get("page_size", DEFAULT_SEARCH_PAGE_SIZE)
+        page_size: int = (
+            raw_page_size
+            if isinstance(raw_page_size, int)
+            and not isinstance(raw_page_size, bool)
+            and raw_page_size >= 1
+            else DEFAULT_SEARCH_PAGE_SIZE
+        )
+
+        literal = _sparql_string_literal(query.strip())
+        sparql = (
+            "PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>\n"
+            "SELECT DISTINCT ?celex ?title\n"
+            "WHERE {\n"
+            "  ?work cdm:resource_legal_id_celex ?celex .\n"
+            "  ?expression cdm:expression_belongs_to_work ?work .\n"
+            "  ?expression cdm:expression_uses_language "
+            "<http://publications.europa.eu/resource/authority/language/ENG> .\n"
+            "  ?expression cdm:expression_title ?title .\n"
+            f"  FILTER(CONTAINS(LCASE(STR(?title)), LCASE({literal})))\n"
+            "}\n"
+            f"LIMIT {page_size}"
+        )
+        url = str(httpx.URL(f"{self._base_url}/webapi/rdf/sparql", params={"query": sparql}))
+        resp = await self._fetch_following_redirects(url, accept=_SPARQL_ACCEPT)
+
+        data: dict[str, Any] = resp.json()
+        bindings: list[dict[str, Any]] = data.get("results", {}).get("bindings", [])
+        results: list[dict[str, Any]] = []
+        for binding in bindings:
+            celex = str((binding.get("celex") or {}).get("value") or "").strip()
+            title = str((binding.get("title") or {}).get("value") or "").strip()
+            if not celex or not _SAFE_CELEX_RE.match(celex):
+                # get_authority would refuse this ref (DE-375) — drop the hit
+                # rather than hand back an unfetchable external_ref.
+                continue
+            results.append(
+                {
+                    "external_ref": celex,
+                    "title": title or celex,
+                    "url": _eurlex_page_url(celex),
+                }
+            )
+
+        payload = {"results": results, "count": len(results)}
+        return self._result("search_authority", payload, resp)
 
     async def _get_authority(self, args: dict[str, Any]) -> ToolResult:
         """GET the Cellar manifestation for a CELEX id; strip HTML to plaintext.
@@ -200,13 +329,15 @@ class EurLexToolAdapter(ToolProviderAdapter):
         payload = {
             "external_ref": celex,
             "title": celex,
-            "url": f"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:{celex}",
+            "url": _eurlex_page_url(celex),
             "text": text,
             "content_kind": _content_kind_from_celex(celex),
         }
         return self._result("get_authority", payload, resp)
 
-    async def _fetch_following_redirects(self, url: str) -> httpx.Response:
+    async def _fetch_following_redirects(
+        self, url: str, *, accept: str = "application/xhtml+xml"
+    ) -> httpx.Response:
         """Fetch ``url``, following redirects manually.
 
         Each hop is https-upgraded (Cellar's 303 ``Location`` is plain http)
@@ -215,7 +346,7 @@ class EurLexToolAdapter(ToolProviderAdapter):
         unvalidated hop can never be dispatched."""
         headers = {
             "User-Agent": self._user_agent,
-            "Accept": "application/xhtml+xml",
+            "Accept": accept,
             "Accept-Language": "eng",
         }
         current = url

--- a/gateway/tests/test_eurlex_adapter.py
+++ b/gateway/tests/test_eurlex_adapter.py
@@ -1,13 +1,14 @@
-"""Tests for the EUR-Lex tool-provider adapter (WS-E PR2b Task 1).
+"""Tests for the EUR-Lex tool-provider adapter (WS-E PR2b Task 1; search DE-374).
 
 Auth model mirrors EDGAR: a descriptive User-Agent header, no API key
 (EU Publications Office Cellar service has no fair-access key scheme).
-get_authority only (search lands as DE-374). The Cellar
-``/resource/celex/{CELEX}`` URL 303-redirects to a concrete manifestation
-whose ``Location`` is http; egress is https-only, so the adapter upgrades
-the redirect target to https and re-validates every hop against the
-allowlist before following it (never lets httpx auto-follow an
-unvalidated/http hop)."""
+search_authority (DE-374) queries the Cellar SPARQL endpoint for title
+matches and returns CELEX refs with no body; get_authority fetches the
+document text by CELEX id. The Cellar ``/resource/celex/{CELEX}`` URL
+303-redirects to a concrete manifestation whose ``Location`` is http;
+egress is https-only, so the adapter upgrades the redirect target to https
+and re-validates every hop against the allowlist before following it
+(never lets httpx auto-follow an unvalidated/http hop)."""
 
 import httpx
 import pytest
@@ -86,16 +87,164 @@ def test_content_kind_from_celex(celex: str, kind: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# list_tools: get_authority only
+# list_tools: search_authority + get_authority
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-async def test_list_tools_only_get_authority(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_list_tools_search_and_get_authority(monkeypatch: pytest.MonkeyPatch) -> None:
     adapter = _adapter(monkeypatch)
     tools = await adapter.list_tools()
-    assert [t.name for t in tools] == ["get_authority"]
+    assert [t.name for t in tools] == ["search_authority", "get_authority"]
     assert all(t.read_only for t in tools)
+
+
+# ---------------------------------------------------------------------------
+# search_authority — SPARQL query construction, escaping, parsing (DE-374)
+# ---------------------------------------------------------------------------
+
+_SPARQL_URL = "https://publications.europa.eu/webapi/rdf/sparql"
+
+
+def _sparql_body(*rows: tuple[str, str]) -> dict:
+    return {
+        "head": {"vars": ["celex", "title"]},
+        "results": {
+            "bindings": [
+                {
+                    "celex": {"type": "literal", "value": celex},
+                    "title": {"type": "literal", "value": title},
+                }
+                for celex, title in rows
+            ]
+        },
+    }
+
+
+@pytest.mark.unit
+async def test_search_authority_builds_sparql_and_parses_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter(monkeypatch)
+    body = _sparql_body(
+        ("32016R0679", "General Data Protection Regulation"),
+        ("32011L0083", "Consumer Rights Directive"),
+    )
+    with respx.mock:
+        route = respx.get(_SPARQL_URL).mock(return_value=httpx.Response(200, json=body))
+        out = await adapter.invoke_tool(
+            "search_authority", {"query": "data protection"}, request_id="r1"
+        )
+        req = route.calls.last.request
+        sparql = req.url.params["query"]
+        assert 'CONTAINS(LCASE(STR(?title)), LCASE("data protection"))' in sparql
+        assert "cdm:resource_legal_id_celex" in sparql
+        assert sparql.endswith("LIMIT 10")
+        assert req.headers["accept"] == "application/sparql-results+json"
+        assert req.headers["user-agent"] == "LQ.AI test ops@lq.ai"
+    assert out.payload["count"] == 2
+    r0 = out.payload["results"][0]
+    assert r0["external_ref"] == "32016R0679"
+    assert r0["title"] == "General Data Protection Regulation"
+    assert r0["url"] == "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679"
+    assert "text" not in r0  # search results carry NO body (fail-closed contract)
+    assert out.skip_anonymization is True
+
+
+@pytest.mark.unit
+async def test_search_authority_escapes_sparql_string_literal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hostile keyword must be embedded as an escaped literal — it can never
+    terminate the string and inject SPARQL syntax into the FILTER clause."""
+    adapter = _adapter(monkeypatch)
+    hostile = "x\") } LIMIT 1 # \\ 'quote'\nnewline"
+    with respx.mock:
+        route = respx.get(_SPARQL_URL).mock(return_value=httpx.Response(200, json=_sparql_body()))
+        await adapter.invoke_tool("search_authority", {"query": hostile}, request_id="r1")
+        sparql = route.calls.last.request.url.params["query"]
+    expected_literal = '"x\\") } LIMIT 1 # \\\\ \\\'quote\\\'\\nnewline"'
+    assert f"LCASE({expected_literal})" in sparql
+    # No raw double-quote inside the literal and no raw newline anywhere in it.
+    assert 'LCASE("x") } LIMIT 1' not in sparql
+
+
+@pytest.mark.unit
+async def test_search_authority_respects_page_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _adapter(monkeypatch)
+    with respx.mock:
+        route = respx.get(_SPARQL_URL).mock(return_value=httpx.Response(200, json=_sparql_body()))
+        await adapter.invoke_tool(
+            "search_authority", {"query": "gdpr", "page_size": 3}, request_id="r1"
+        )
+        assert route.calls.last.request.url.params["query"].endswith("LIMIT 3")
+        # Bad page_size falls back to the default.
+        await adapter.invoke_tool(
+            "search_authority", {"query": "gdpr", "page_size": True}, request_id="r2"
+        )
+        assert route.calls.last.request.url.params["query"].endswith("LIMIT 10")
+
+
+@pytest.mark.unit
+async def test_search_authority_empty_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _adapter(monkeypatch)
+    with respx.mock:
+        respx.get(_SPARQL_URL).mock(return_value=httpx.Response(200, json=_sparql_body()))
+        out = await adapter.invoke_tool(
+            "search_authority", {"query": "no such instrument"}, request_id="r1"
+        )
+    assert out.payload == {"results": [], "count": 0}
+
+
+@pytest.mark.unit
+async def test_search_authority_empty_query_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.providers.tool.base import ToolProviderInvalidRequestError
+
+    adapter = _adapter(monkeypatch)
+    for bad in ("", "   ", None):
+        with pytest.raises(ToolProviderInvalidRequestError):
+            await adapter.invoke_tool("search_authority", {"query": bad}, request_id="r1")
+
+
+@pytest.mark.unit
+async def test_search_authority_drops_unfetchable_celex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hits whose CELEX get_authority would reject (DE-375 shapes) are dropped
+    rather than surfaced with an unfetchable external_ref."""
+    adapter = _adapter(monkeypatch)
+    body = _sparql_body(
+        ("32016R0679R(01)", "GDPR corrigendum"),  # '()' — get_authority rejects
+        ("12016E/TXT", "TFEU"),  # '/' — get_authority rejects
+        ("", "no celex at all"),
+        ("32016R0679", "General Data Protection Regulation"),
+    )
+    with respx.mock:
+        respx.get(_SPARQL_URL).mock(return_value=httpx.Response(200, json=body))
+        out = await adapter.invoke_tool("search_authority", {"query": "gdpr"}, request_id="r1")
+    assert [r["external_ref"] for r in out.payload["results"]] == ["32016R0679"]
+    assert out.payload["count"] == 1
+
+
+@pytest.mark.unit
+async def test_search_authority_redirect_hop_outside_allowlist_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SPARQL-endpoint redirect to a non-allowlisted host must be refused
+    before any egress to that host (every hop re-runs validate_egress_target)."""
+    from app.providers.tool.egress import EgressRefused
+
+    adapter = _adapter(monkeypatch)
+    with respx.mock:
+        respx.get(_SPARQL_URL).mock(
+            return_value=httpx.Response(303, headers={"location": "http://evil.test/steal"})
+        )
+        evil = respx.get("https://evil.test/steal").mock(
+            return_value=httpx.Response(200, json=_sparql_body())
+        )
+        with pytest.raises(EgressRefused):
+            await adapter.invoke_tool("search_authority", {"query": "gdpr"}, request_id="r1")
+        assert not evil.called  # refused before any egress to the rogue host
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/tests/test_eurlex_adapter.py
+++ b/gateway/tests/test_eurlex_adapter.py
@@ -210,20 +210,28 @@ async def test_search_authority_empty_query_raises(monkeypatch: pytest.MonkeyPat
 async def test_search_authority_drops_unfetchable_celex(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Hits whose CELEX get_authority would reject (DE-375 shapes) are dropped
-    rather than surfaced with an unfetchable external_ref."""
+    """Hits whose CELEX get_authority would reject are dropped rather than
+    surfaced with an unfetchable external_ref; treaty (12016E/TXT) and
+    corrigendum (32016R0679R(01)) shapes are now fetchable (DE-375) and
+    SURVIVE."""
     adapter = _adapter(monkeypatch)
     body = _sparql_body(
-        ("32016R0679R(01)", "GDPR corrigendum"),  # '()' — get_authority rejects
-        ("12016E/TXT", "TFEU"),  # '/' — get_authority rejects
-        ("", "no celex at all"),
+        ("32016R0679R(01)", "GDPR corrigendum"),  # corrigendum — now fetchable (DE-375)
+        ("12016E/TXT", "TFEU"),  # treaty — now fetchable (DE-375)
+        ("", "no celex at all"),  # dropped
+        ("12016E/../etc", "traversal-shaped"),  # dropped — fails _VALID_CELEX_RE
+        ("not a celex", "garbage"),  # dropped — fails _VALID_CELEX_RE
         ("32016R0679", "General Data Protection Regulation"),
     )
     with respx.mock:
         respx.get(_SPARQL_URL).mock(return_value=httpx.Response(200, json=body))
         out = await adapter.invoke_tool("search_authority", {"query": "gdpr"}, request_id="r1")
-    assert [r["external_ref"] for r in out.payload["results"]] == ["32016R0679"]
-    assert out.payload["count"] == 1
+    assert [r["external_ref"] for r in out.payload["results"]] == [
+        "32016R0679R(01)",
+        "12016E/TXT",
+        "32016R0679",
+    ]
+    assert out.payload["count"] == 3
 
 
 @pytest.mark.unit
@@ -282,15 +290,106 @@ async def test_get_authority_follows_redirect_upgrades_https_strips_html(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "celex,valid",
+    [
+        ("32016R0679", True),  # regulation
+        ("62014CJ0362", True),  # CJEU judgment (2-letter descriptor)
+        ("12016E", True),  # bare treaty id (no number)
+        ("12016E101", True),  # treaty article
+        ("12016E/TXT", True),  # treaty full text (DE-375)
+        ("12012P/TXT", True),  # Charter full text (DE-375)
+        ("32016R0679R(01)", True),  # corrigendum (DE-375)
+        ("02016R0679-20160504", True),  # consolidated version
+        ("", False),
+        ("garbage", False),
+        ("12016E/PDF", False),  # only /TXT is a valid segment
+        ("12016E/TXT/TXT", False),
+        ("12016E/../TXT", False),
+        ("12016e/txt", False),  # lowercase
+        ("32016R0679R(001)", False),  # corrigendum needs exactly two digits
+        ("32016R0679R()", False),
+        ("32016R0679 ", False),  # whitespace
+        ("2016R0679", False),  # missing sector digit
+    ],
+)
+def test_valid_celex_re_shapes(celex: str, valid: bool) -> None:
+    from app.providers.tool.eurlex import _VALID_CELEX_RE
+
+    assert bool(_VALID_CELEX_RE.fullmatch(celex)) is valid
+
+
+@pytest.mark.unit
+async def test_get_authority_treaty_celex_url_quoted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A treaty CELEX (12016E/TXT, DE-375) is fetchable; the '/' is URL-quoted
+    in the Cellar path while external_ref/url stay raw CELEX."""
+    adapter = _adapter(monkeypatch)
+    quoted_url = "https://publications.europa.eu/resource/celex/12016E%2FTXT"
+    with respx.mock:
+        route = respx.get(quoted_url).mock(
+            return_value=httpx.Response(200, text="<html><body>Treaty  text</body></html>")
+        )
+        out = await adapter.invoke_tool(
+            "get_authority", {"external_ref": "12016E/TXT"}, request_id="r1"
+        )
+        assert route.called
+        # The '/' must be percent-encoded in the raw request path — never a
+        # path segment of its own.
+        assert b"12016E%2FTXT" in route.calls.last.request.url.raw_path
+    assert out.payload["external_ref"] == "12016E/TXT"  # raw CELEX, user-visible
+    assert out.payload["url"] == (
+        "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:12016E/TXT"
+    )
+    assert out.payload["text"] == "Treaty text"
+    assert out.payload["content_kind"] == "eu_legislation"  # sector 1 fallback
+
+
+@pytest.mark.unit
+async def test_get_authority_corrigendum_celex_url_quoted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corrigendum CELEX (32016R0679R(01), DE-375) is fetchable; the parens
+    are URL-quoted in the Cellar path while external_ref stays raw CELEX."""
+    adapter = _adapter(monkeypatch)
+    quoted_url = "https://publications.europa.eu/resource/celex/32016R0679R%2801%29"
+    with respx.mock:
+        route = respx.get(quoted_url).mock(
+            return_value=httpx.Response(200, text="<html><body>Corrigendum</body></html>")
+        )
+        out = await adapter.invoke_tool(
+            "get_authority", {"external_ref": "32016R0679R(01)"}, request_id="r1"
+        )
+        assert route.called
+        assert b"32016R0679R%2801%29" in route.calls.last.request.url.raw_path
+    assert out.payload["external_ref"] == "32016R0679R(01)"  # raw CELEX, user-visible
+    assert out.payload["text"] == "Corrigendum"
+    assert out.payload["content_kind"] == "eu_regulation"  # sector 3, type R
+
+
+@pytest.mark.unit
 async def test_get_authority_rejects_unsafe_celex_before_egress(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Ids failing full-CELEX validation (traversal, lowercase, stray
+    segments, malformed suffixes) are 400ed before any egress (DE-375)."""
     from app.providers.tool.base import ToolProviderInvalidRequestError
 
     adapter = _adapter(monkeypatch)
     with respx.mock:
         route = respx.get(url__regex=r".*").mock(return_value=httpx.Response(200, text="x"))
-        for bad in ("12016E/TXT", "32016R0679R(01)"):
+        for bad in (
+            "../../etc/passwd",  # path traversal
+            "12016E/../TXT",  # traversal hidden in a treaty-looking id
+            "12016E/PDF",  # only the literal /TXT segment is allowed
+            "12016E/TXT/TXT",  # extra segment
+            "12016e/txt",  # lowercase
+            "32016R0679R(1)",  # corrigendum suffix must be two digits
+            "32016R0679R(01",  # unbalanced paren
+            "garbage",  # not CELEX-shaped at all
+            "32016R0679 ",  # trailing whitespace
+        ):
             with pytest.raises(ToolProviderInvalidRequestError):
                 await adapter.invoke_tool("get_authority", {"external_ref": bad}, request_id="r1")
         assert not route.called  # rejected before any egress


### PR DESCRIPTION
> **Stacked on #329 (DE-375) → #327 (DE-374)** — same adapter file. Review only the last commit here; merge the stack bottom-up and this PR reduces to that commit.

## What / why

DE-376 (PRD §9): `EurLexAdapter._from_get_authority` set `subtitle=content_kind`, leaking the machine kind (`eu_regulation`) into a human-heading display field. Cosmetic only — subtitle is never load-bearing for verification.

Part of the coordinated roadmap sweep (umbrella issue #321).

## Approach

- `_KIND_LABELS` map on the adapter: `eu_regulation`→"EU Regulation", `eu_directive`→"EU Directive", `eu_decision`→"EU Decision", `eu_caselaw`→"CJEU Case Law", `eu_legislation`→"EU Legislation"; unknown kinds pass through unchanged rather than erroring. `content_kind` itself stays machine-form everywhere.
- Added the missing partial-payload unit test exercising every `payload.get(...)` fallback (missing keys and explicit `None`s → empty strings + `eu_legislation` kind).

No verification-path change; no route/schema/migration changes.

## Acceptance evidence

New tests in `api/tests/test_source_registry.py`: `test_eurlex_get_authority_subtitle_is_human_readable`, `test_eurlex_get_authority_partial_payload_fallbacks`.

Gates run locally (api): ruff format/check clean, mypy clean, full suite **2644 passed, 1 skipped, 0 failed** (throwaway pgvector:pg16).

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)