### PR TITLE
Roadmap 1.6: matter-intake UI for governed matter sessions

### DIFF
--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -1376,7 +1376,8 @@ async def _spawn_manual_session(
     ``params`` carrying only the non-null target keys (plus
     ``emit_artifacts`` — set to ``True`` only when the request body opted
     in; Donna ask #8 — a manual run has no schedule/watch row, so the
-    body carries the flag), sets a non-null ``max_cost_usd`` (per-run cap
+    body carries the flag; plus ``query`` — the optional matter
+    description, item 1.6), sets a non-null ``max_cost_usd`` (per-run cap
     or the config default so R4 always arms), flushes to obtain the id,
     then best-effort enqueues. The five-phase executor + R4/R5/R6 brakes
     + receipt are unchanged.
@@ -1400,6 +1401,13 @@ async def _spawn_manual_session(
         # Opt-in (Donna ask #8) — non-null-subset convention: the key is
         # present iff the caller opted in.
         params["emit_artifacts"] = True
+    if body.query is not None:
+        # Matter intake (item 1.6) — the free-text matter description the
+        # executor reads via ``session.params.get("query")`` into the
+        # ADR-0020 matter loop. Non-null-subset convention: key present
+        # iff the caller supplied a description; absent keeps the
+        # query-less path unchanged.
+        params["query"] = body.query
 
     session = AutonomousSession(
         user_id=user_id,

--- a/api/app/schemas/autonomous.py
+++ b/api/app/schemas/autonomous.py
@@ -23,9 +23,9 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, StringConstraints, model_validator
 
 
 class TriggerKind(StrEnum):
@@ -214,6 +214,14 @@ class AutonomousManualRunRequest(BaseModel):
     (Donna ask #8) — a manual run has no schedule/watch row to inherit the
     flag from, so the request body IS the opt-in source; defaults off,
     matching the schedule/watch column default.
+
+    ``query`` (item 1.6 — matter intake) is an optional free-text matter
+    description. When present it lands in ``session.params["query"]`` and
+    the executor routes the session through the ADR-0020 matter loop
+    (planner goal = the description); when omitted the session stays on
+    the existing query-less path — no behavior change for current
+    callers. Length bounds mirror ``KnowledgeSearchRequest.query``
+    (1 to 10,000 chars).
     """
 
     playbook_id: uuid.UUID | None = None
@@ -222,6 +230,7 @@ class AutonomousManualRunRequest(BaseModel):
     project_id: uuid.UUID | None = None
     max_cost_usd: Decimal | None = None
     emit_artifacts: bool = False
+    query: Annotated[str, StringConstraints(min_length=1, max_length=10_000)] | None = None
 
     @model_validator(mode="after")
     def _exactly_one_target(self) -> AutonomousManualRunRequest:

--- a/api/tests/autonomous/test_run_now.py
+++ b/api/tests/autonomous/test_run_now.py
@@ -182,6 +182,71 @@ async def test_run_now_defaults_cost_cap_when_omitted(
 
 
 @pytest.mark.asyncio
+async def test_run_now_copies_query_into_params(
+    client: AsyncClient,
+    opted_in_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """A matter description in the body lands in session.params["query"]
+    (item 1.6 — the executor reads it via ``session.params.get("query")``
+    into the ADR-0020 matter loop)."""
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        json={
+            "skill_ref": "nda-review",
+            "query": "Review the Acme NDA for a mutual confidentiality carve-out.",
+        },
+        headers=_bearer(opted_in_user),
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = uuid.UUID(resp.json()["id"])
+    row = (
+        await db_session.execute(
+            select(AutonomousSession).where(AutonomousSession.id == session_id)
+        )
+    ).scalar_one()
+    assert row.params["query"] == "Review the Acme NDA for a mutual confidentiality carve-out."
+
+
+@pytest.mark.asyncio
+async def test_run_now_omitted_query_keeps_params_key_absent(
+    client: AsyncClient,
+    opted_in_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """Omitting query keeps current behavior: no "query" key in params
+    (non-null-subset convention; the executor's ``params.get("query")``
+    then yields None → query-less path)."""
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        json={"skill_ref": "nda-review"},
+        headers=_bearer(opted_in_user),
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = uuid.UUID(resp.json()["id"])
+    row = (
+        await db_session.execute(
+            select(AutonomousSession).where(AutonomousSession.id == session_id)
+        )
+    ).scalar_one()
+    assert "query" not in row.params
+
+
+@pytest.mark.asyncio
+async def test_run_now_rejects_empty_query(
+    client: AsyncClient,
+    opted_in_user: User,
+) -> None:
+    """An empty-string query violates min_length=1 → 422."""
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        json={"skill_ref": "nda-review", "query": ""},
+        headers=_bearer(opted_in_user),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
 async def test_run_now_requires_exactly_one_target(
     client: AsyncClient,
     opted_in_user: User,

--- a/docs/api/backend-openapi.generated.yaml
+++ b/docs/api/backend-openapi.generated.yaml
@@ -458,7 +458,22 @@ components:
 
         flag from, so the request body IS the opt-in source; defaults off,
 
-        matching the schedule/watch column default.'
+        matching the schedule/watch column default.
+
+
+        ``query`` (item 1.6 — matter intake) is an optional free-text matter
+
+        description. When present it lands in ``session.params["query"]`` and
+
+        the executor routes the session through the ADR-0020 matter loop
+
+        (planner goal = the description); when omitted the session stays on
+
+        the existing query-less path — no behavior change for current
+
+        callers. Length bounds mirror ``KnowledgeSearchRequest.query``
+
+        (1 to 10,000 chars).'
       properties:
         emit_artifacts:
           default: false
@@ -483,6 +498,13 @@ components:
             type: string
           - type: 'null'
           title: Project Id
+        query:
+          anyOf:
+          - maxLength: 10000
+            minLength: 1
+            type: string
+          - type: 'null'
+          title: Query
         skill_ref:
           anyOf:
           - type: string

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -6703,7 +6703,11 @@ components:
         / ``project_id`` are optional scope.  ``max_cost_usd`` is the
         per-run cap (NULL → fall back to the config default).  A manual
         run has no schedule/watch row to inherit ``emit_artifacts`` from,
-        so this body IS the opt-in source.
+        so this body IS the opt-in source.  ``query`` (item 1.6 — matter
+        intake) is an optional free-text matter description; when present
+        it lands in ``session.params["query"]`` and the executor routes
+        the run through the ADR-0020 matter loop, when omitted the
+        query-less path is unchanged.
       properties:
         playbook_id: {type: string, format: uuid, nullable: true}
         skill_ref: {type: string, nullable: true}
@@ -6716,6 +6720,16 @@ components:
           description: |
             Opt-in document-grade artifact emission (Donna #8) for this
             one-off run; default off so existing callers are unchanged.
+        query:
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 10000
+          description: |
+            Optional free-text matter description (item 1.6). Copied into
+            ``session.params["query"]`` so the executor runs the ADR-0020
+            matter loop with this as the goal. Omitted → key absent →
+            existing query-less behavior.
 
     AutonomousScheduleListResponse:
       type: object

--- a/web/cypress/e2e/matter-intake.cy.ts
+++ b/web/cypress/e2e/matter-intake.cy.ts
@@ -1,0 +1,209 @@
+/**
+ * Item 1.6 — Matter-intake E2E: describe → session → receipt.
+ *
+ * Intercept-based (deterministic; no real seed data), mirroring
+ * m4-autonomous.cy.ts. Two scenarios:
+ *
+ *   1. Describe → session → receipt — fill the matter description, pick a
+ *      skill, submit; POST /autonomous/run-now carries `query`; the app
+ *      navigates to the session receipt page.
+ *   2. Validation — submitting without a description surfaces the inline
+ *      field error and does NOT fire the run-now endpoint.
+ *
+ * Auth strategy: lq_ai_auth in localStorage + intercepted /users/me and
+ * preferences, exactly as in m4-autonomous.cy.ts.
+ *
+ * Run:
+ *   docker compose up -d
+ *   cd web && npx cypress run --spec 'cypress/e2e/matter-intake.cy.ts'
+ */
+
+/// <reference types="cypress" />
+
+const SESSION_ID = 'sess-0016-aaaa-bbbb-cccc-dddddddddddd';
+const MATTER_QUERY =
+	'Review the Acme NDA for a mutual confidentiality carve-out and flag survival terms longer than 3 years.';
+
+const mockUser = {
+	id: 'u1',
+	email: 'admin@lq.ai',
+	display_name: 'Admin',
+	is_admin: true,
+	role: 'admin' as const,
+	mfa_enabled: false,
+	must_change_password: false,
+	created_at: '2026-01-01T00:00:00Z'
+};
+
+const mockSession = {
+	id: SESSION_ID,
+	user_id: 'u1',
+	project_id: null,
+	trigger_kind: 'manual' as const,
+	trigger_ref: null,
+	current_phase: 'intake' as const,
+	halt_state: 'running' as const,
+	max_cost_usd: '5.00',
+	cost_total_usd: '0.00',
+	cost_cap_reached: false,
+	idle_halt_minutes: 30,
+	last_activity_at: '2026-07-25T10:00:00Z',
+	status: 'running' as const,
+	params: { skill_ref: 'nda-review', query: MATTER_QUERY },
+	result: null,
+	error: null,
+	created_at: '2026-07-25T09:55:00Z',
+	updated_at: '2026-07-25T10:00:00Z',
+	completed_at: null
+};
+
+const mockReceipt = {
+	session_id: SESSION_ID,
+	trigger_kind: 'manual',
+	status: 'running',
+	halt_state: 'running',
+	current_phase: 'intake',
+	cost_total_usd: 0.0,
+	max_cost_usd: 5.0,
+	cost_cap_reached: false,
+	created_at: '2026-07-25T09:55:00Z',
+	completed_at: null,
+	phase_transitions: [{ to_phase: 'intake', timestamp: '2026-07-25T09:55:01Z' }],
+	tool_calls: [],
+	terminal_reason: null
+};
+
+function setAuthStorage(win: Window): void {
+	win.localStorage.setItem(
+		'lq_ai_auth',
+		JSON.stringify({
+			access_token: 'fake-token-1-6',
+			refresh_token: null,
+			expires_at: Date.now() + 3600 * 1000,
+			user: mockUser
+		})
+	);
+	win.localStorage.setItem(
+		'lq-ai:preferences-cache',
+		JSON.stringify({
+			reasoning_visibility: 'disclosure',
+			featured_tools: 'prominent',
+			workspace_layout: 'three_pane',
+			trust_pills: 'labels',
+			provenance_pills: 'always',
+			autonomous_enabled: true
+		})
+	);
+}
+
+function interceptBaseRequests(): void {
+	cy.intercept('GET', '**/api/v1/users/me', { statusCode: 200, body: mockUser }).as('getMe');
+	cy.intercept('GET', '**/api/v1/admin/bootstrap-status', {
+		statusCode: 200,
+		body: { default_password_active: false, logs_hint: '' }
+	}).as('bootstrapStatus');
+	cy.intercept('GET', '**/api/v1/users/me/preferences', {
+		statusCode: 200,
+		body: {
+			reasoning_visibility: 'disclosure',
+			featured_tools: 'prominent',
+			workspace_layout: 'three_pane',
+			trust_pills: 'labels',
+			provenance_pills: 'always',
+			autonomous_enabled: true
+		}
+	}).as('getPreferences');
+	// Incidental calls the shell/layout may trigger.
+	cy.intercept('GET', '**/api/v1/chats**', {
+		statusCode: 200,
+		body: { items: [], next_cursor: null }
+	}).as('listChats');
+	cy.intercept('GET', '**/api/v1/user-skills**', { statusCode: 200, body: [] }).as(
+		'listUserSkills'
+	);
+	cy.intercept('GET', '**/api/v1/saved-prompts**', { statusCode: 200, body: [] }).as(
+		'listSavedPrompts'
+	);
+	cy.intercept('GET', '**/api/v1/teams**', { statusCode: 200, body: [] }).as('listTeams');
+	cy.intercept('GET', '**/api/v1/autonomous/notifications**', {
+		statusCode: 200,
+		body: { notifications: [], total_count: 0, limit: 50, offset: 0 }
+	}).as('listNotifications');
+	// Intake-page picker lists.
+	cy.intercept('GET', '**/api/v1/skills**', {
+		statusCode: 200,
+		body: [{ name: 'nda-review', title: 'NDA Review', description: 'Review an NDA' }]
+	}).as('listSkills');
+	cy.intercept('GET', '**/api/v1/playbooks**', { statusCode: 200, body: [] }).as('listPlaybooks');
+	cy.intercept('GET', '**/api/v1/knowledge-bases**', { statusCode: 200, body: [] }).as('listKbs');
+	cy.intercept('GET', '**/api/v1/projects**', { statusCode: 200, body: [] }).as('listProjects');
+}
+
+describe('Item 1.6 — Matter intake: describe → session → receipt', () => {
+	beforeEach(() => {
+		interceptBaseRequests();
+	});
+
+	it('1: Fill the description, pick a skill, submit → run-now carries query → receipt page', () => {
+		cy.intercept('POST', '**/api/v1/autonomous/run-now', {
+			statusCode: 201,
+			body: mockSession
+		}).as('runNow');
+
+		// The receipt page the intake navigates to issues a GET for the session.
+		cy.intercept('GET', `**/api/v1/autonomous/sessions/${SESSION_ID}`, {
+			statusCode: 200,
+			body: { session: mockSession, receipt: mockReceipt }
+		}).as('getSession');
+
+		cy.visit('/lq-ai/autonomous/matters', {
+			onBeforeLoad: (win) => setAuthStorage(win)
+		});
+
+		// The intake page heading.
+		cy.contains('h1', 'Describe your matter', { timeout: 10000 }).should('exist');
+
+		// Describe the matter.
+		cy.get('#matter-query').type(MATTER_QUERY, { delay: 0 });
+
+		// Skill is the default target — pick the seeded skill.
+		cy.get('select[aria-label="Select skill"]', { timeout: 10000 }).select('nda-review');
+
+		// Submit.
+		cy.contains('button', 'Run on this matter').click();
+
+		// The run-now body carries the matter description as `query`.
+		cy.wait('@runNow').its('request.body').should('deep.include', {
+			query: MATTER_QUERY,
+			skill_ref: 'nda-review'
+		});
+
+		// On 201 the app navigates to the new session's receipt (plan trace).
+		cy.url({ timeout: 10000 }).should('include', `/lq-ai/autonomous/sessions/${SESSION_ID}`);
+		cy.contains('h1', 'Session receipt').should('exist');
+	});
+
+	it('2: Submitting without a description shows the inline error and does not call run-now', () => {
+		let runNowCalled = false;
+		cy.intercept('POST', '**/api/v1/autonomous/run-now', () => {
+			runNowCalled = true;
+		}).as('runNowGuard');
+
+		cy.visit('/lq-ai/autonomous/matters', {
+			onBeforeLoad: (win) => setAuthStorage(win)
+		});
+
+		cy.contains('h1', 'Describe your matter', { timeout: 10000 }).should('exist');
+
+		// Pick a skill but leave the description blank.
+		cy.get('select[aria-label="Select skill"]', { timeout: 10000 }).select('nda-review');
+		cy.contains('button', 'Run on this matter').click();
+
+		// Inline field error on the description; endpoint never fired.
+		cy.get('[role="alert"]').should('contain', 'Describe the matter');
+		cy.url().should('include', '/lq-ai/autonomous/matters');
+		cy.then(() => {
+			expect(runNowCalled).to.equal(false);
+		});
+	});
+});

--- a/web/src/lib/lq-ai/api/autonomous.ts
+++ b/web/src/lib/lq-ai/api/autonomous.ts
@@ -296,6 +296,9 @@ export interface PromotePrecedentRequest {
  * POST /autonomous/run-now — manual-trigger body. All fields optional.
  * Mirrors app/schemas/autonomous.py ManualRunRequest. `max_cost_usd` is a
  * Decimal serialized as a string, matching AutonomousScheduleCreate.
+ * `query` (item 1.6 — matter intake) is a free-text matter description
+ * (1–10,000 chars); when present the session runs the matter loop with
+ * it as the goal, when omitted behavior is unchanged.
  */
 export interface ManualRunRequest {
 	playbook_id?: string;
@@ -303,6 +306,7 @@ export interface ManualRunRequest {
 	target_kb_id?: string;
 	project_id?: string;
 	max_cost_usd?: string;
+	query?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/routes/lq-ai/autonomous/+layout.svelte
+++ b/web/src/routes/lq-ai/autonomous/+layout.svelte
@@ -12,6 +12,7 @@
 	const navLinks = [
 		{ href: '/lq-ai/autonomous/configure',      label: 'Configure',     exact: false },
 		{ href: '/lq-ai/autonomous',               label: 'Sessions',      exact: true  },
+		{ href: '/lq-ai/autonomous/matters',        label: 'Matter intake', exact: false },
 		{ href: '/lq-ai/autonomous/memory',         label: 'Memory',        exact: false },
 		{ href: '/lq-ai/autonomous/precedents',     label: 'Precedents',    exact: false },
 		{ href: '/lq-ai/autonomous/proposals',      label: 'Proposals',     exact: false },

--- a/web/src/routes/lq-ai/autonomous/matters/+page.svelte
+++ b/web/src/routes/lq-ai/autonomous/matters/+page.svelte
@@ -1,0 +1,485 @@
+<script lang="ts">
+	/**
+	 * /lq-ai/autonomous/matters — matter-intake page (item 1.6).
+	 *
+	 * "Describe your matter": a full-page intake form that spawns a one-off
+	 * governed autonomous session via POST /autonomous/run-now with the new
+	 * optional `query` field. The description lands in
+	 * session.params["query"], which the executor reads into the ADR-0020
+	 * matter loop as the planner goal. On 201 we redirect to the session
+	 * detail page, which already renders the plan trace and live receipt.
+	 *
+	 * Structure mirrors the run-now modal on ../+page.svelte (picker
+	 * Promise.allSettled load, LQAIApiError handling, goto on success);
+	 * gating is inherited from ../+layout.svelte, which redirects users
+	 * without autonomous_enabled to the opt-in settings page.
+	 *
+	 * Pure form logic (validation + request building) lives in
+	 * ./intake-helpers.ts so vitest can cover it without the Svelte runtime.
+	 */
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+
+	import { autonomousApi, skillsApi, knowledgeBasesApi, projectsApi } from '$lib/lq-ai/api';
+	import * as playbooksApi from '$lib/lq-ai/api/playbooks';
+	import { LQAIApiError } from '$lib/lq-ai/api/client';
+	import type { Playbook } from '$lib/lq-ai/types';
+	import type { SkillSummary } from '$lib/lq-ai/types';
+	import type { KnowledgeBase, Project } from '$lib/lq-ai/types';
+	import {
+		QUERY_MAX_LENGTH,
+		buildIntakeRunRequest,
+		isIntakeFormValid,
+		validateIntakeForm,
+		type IntakeFormState
+	} from './intake-helpers';
+
+	// ---------------------------------------------------------------------------
+	// Form state
+	// ---------------------------------------------------------------------------
+
+	let formQuery = '';
+	let formTargetKind: 'skill' | 'playbook' = 'skill';
+	let formSkillRef = '';
+	let formPlaybookId = '';
+	let formKbId = '';
+	let formProjectId = '';
+	let formMaxCostUsd = '';
+
+	let submitting = false;
+	let queryError: string | null = null;
+	let targetError: string | null = null;
+	let submitError: string | null = null;
+
+	// Picker lists (loaded on mount)
+	let playbooks: Playbook[] = [];
+	let skillSummaries: SkillSummary[] = [];
+	let kbs: KnowledgeBase[] = [];
+	let projects: Project[] = [];
+	let pickerLoading = false;
+	let pickerError: string | null = null;
+
+	onMount(() => {
+		loadPickerData();
+	});
+
+	async function loadPickerData(): Promise<void> {
+		pickerLoading = true;
+		pickerError = null;
+		try {
+			const [pb, sk, kb, pr] = await Promise.allSettled([
+				playbooksApi.listPlaybooks(),
+				skillsApi.listSkills(),
+				knowledgeBasesApi.listKnowledgeBases(),
+				projectsApi.listProjects()
+			]);
+			if (pb.status === 'fulfilled') playbooks = pb.value;
+			if (sk.status === 'fulfilled') skillSummaries = sk.value;
+			if (kb.status === 'fulfilled') kbs = kb.value;
+			if (pr.status === 'fulfilled') projects = pr.value;
+			// If all failed, surface a brief error; partial failure is silently degraded.
+			if ([pb, sk, kb, pr].every((r) => r.status === 'rejected')) {
+				pickerError = 'Could not load picker data. Check your connection.';
+			}
+		} finally {
+			pickerLoading = false;
+		}
+	}
+
+	function currentFormState(): IntakeFormState {
+		return {
+			query: formQuery,
+			targetKind: formTargetKind,
+			skillRef: formSkillRef,
+			playbookId: formPlaybookId,
+			kbId: formKbId,
+			projectId: formProjectId,
+			maxCostUsd: formMaxCostUsd
+		};
+	}
+
+	async function handleSubmit(): Promise<void> {
+		submitError = null;
+
+		const form = currentFormState();
+		const errors = validateIntakeForm(form);
+		queryError = errors.query;
+		targetError = errors.target;
+		if (!isIntakeFormValid(errors)) return;
+
+		submitting = true;
+		try {
+			const session = await autonomousApi.runNow(buildIntakeRunRequest(form));
+			await goto(`/lq-ai/autonomous/sessions/${session.id}`);
+		} catch (err) {
+			if (err instanceof LQAIApiError && err.status === 422) {
+				submitError = `The server rejected this request (422): ${err.message}`;
+			} else if (err instanceof LQAIApiError) {
+				submitError = `Run failed (${err.status}): ${err.message}`;
+			} else {
+				submitError = err instanceof Error ? err.message : String(err);
+			}
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<div class="matters-page">
+	<header class="page-header">
+		<h1 class="lq-text-page-h">Describe your matter</h1>
+		<p class="page-intro">
+			Describe what you need done and pick the skill or playbook to run. LQVern runs once, plans
+			against your description, and stops at the cost cap (R4). You are redirected to the session's
+			receipt — review the plan trace and findings there; nothing is applied anywhere on your
+			behalf.
+		</p>
+	</header>
+
+	<form on:submit|preventDefault={handleSubmit} class="intake-form" novalidate>
+		<!-- Matter description (required → ManualRunRequest.query) -->
+		<div class="intake-field">
+			<label class="intake-label" for="matter-query">
+				Matter description <span class="intake-required" aria-hidden="true">*</span>
+			</label>
+			<textarea
+				id="matter-query"
+				class="intake-textarea"
+				class:intake-input--error={!!queryError}
+				bind:value={formQuery}
+				rows="6"
+				maxlength={QUERY_MAX_LENGTH}
+				placeholder="e.g. Review the Acme NDA for a mutual confidentiality carve-out and flag any survival terms longer than 3 years."
+				disabled={submitting}
+				aria-invalid={queryError ? 'true' : undefined}
+			></textarea>
+			<p class="intake-hint">
+				This becomes the run's goal. Be specific — the agent only sees what you write here plus the
+				selected knowledge base.
+			</p>
+			{#if queryError}
+				<p class="intake-field-error" role="alert">{queryError}</p>
+			{/if}
+		</div>
+
+		<!-- Target kind radio -->
+		<div class="intake-field">
+			<span class="intake-label">
+				Target <span class="intake-required" aria-hidden="true">*</span>
+			</span>
+			<div class="radio-group">
+				<label class="radio-label">
+					<input
+						type="radio"
+						name="matter-target-kind"
+						value="skill"
+						bind:group={formTargetKind}
+						disabled={submitting}
+					/>
+					Skill
+				</label>
+				<label class="radio-label">
+					<input
+						type="radio"
+						name="matter-target-kind"
+						value="playbook"
+						bind:group={formTargetKind}
+						disabled={submitting}
+					/>
+					Playbook
+				</label>
+			</div>
+
+			{#if formTargetKind === 'skill'}
+				{#if pickerLoading}
+					<p class="picker-loading">Loading skills…</p>
+				{:else}
+					<select
+						class="intake-select"
+						class:intake-input--error={!!targetError}
+						bind:value={formSkillRef}
+						disabled={submitting}
+						aria-label="Select skill"
+					>
+						<option value="">— Select a skill —</option>
+						{#each skillSummaries as sk (sk.name)}
+							<option value={sk.name}>{sk.title || sk.name}</option>
+						{/each}
+					</select>
+				{/if}
+			{:else if pickerLoading}
+				<p class="picker-loading">Loading playbooks…</p>
+			{:else}
+				<select
+					class="intake-select"
+					class:intake-input--error={!!targetError}
+					bind:value={formPlaybookId}
+					disabled={submitting}
+					aria-label="Select playbook"
+				>
+					<option value="">— Select a playbook —</option>
+					{#each playbooks as pb (pb.id)}
+						<option value={pb.id}>{pb.name}</option>
+					{/each}
+				</select>
+			{/if}
+
+			{#if targetError}
+				<p class="intake-field-error" role="alert">{targetError}</p>
+			{/if}
+		</div>
+
+		<!-- Optional matter / project -->
+		<div class="intake-field">
+			<label class="intake-label" for="matter-project">
+				Matter / project <span class="intake-optional">(optional)</span>
+			</label>
+			{#if pickerLoading}
+				<p class="picker-loading">Loading projects…</p>
+			{:else}
+				<select
+					id="matter-project"
+					class="intake-select"
+					bind:value={formProjectId}
+					disabled={submitting}
+				>
+					<option value="">— None —</option>
+					{#each projects as proj (proj.id)}
+						<option value={proj.id}>{proj.name}</option>
+					{/each}
+				</select>
+			{/if}
+		</div>
+
+		<!-- Optional KB scope -->
+		<div class="intake-field">
+			<label class="intake-label" for="matter-kb">
+				Knowledge base <span class="intake-optional">(optional)</span>
+			</label>
+			{#if pickerLoading}
+				<p class="picker-loading">Loading knowledge bases…</p>
+			{:else}
+				<select id="matter-kb" class="intake-select" bind:value={formKbId} disabled={submitting}>
+					<option value="">— None —</option>
+					{#each kbs as kb (kb.id)}
+						<option value={kb.id}>{kb.name}</option>
+					{/each}
+				</select>
+			{/if}
+			<p class="intake-hint">
+				The documents the run retrieves from. Without one, the run has only your description to work
+				with.
+			</p>
+		</div>
+
+		<!-- Cost cap (optional) -->
+		<div class="intake-field">
+			<label class="intake-label" for="matter-cost-cap">
+				Cost cap (USD) <span class="intake-optional">(optional)</span>
+			</label>
+			<input
+				id="matter-cost-cap"
+				type="number"
+				min="0"
+				step="0.01"
+				class="intake-input"
+				bind:value={formMaxCostUsd}
+				placeholder="e.g. 1.00 — defaults to the system cap if blank"
+				disabled={submitting}
+			/>
+			<p class="intake-hint">
+				The most this run may spend before it halts (R4). Blank uses the system default.
+			</p>
+		</div>
+
+		{#if pickerError}
+			<p class="picker-error" role="alert">{pickerError}</p>
+		{/if}
+
+		{#if submitError}
+			<p class="submit-error" role="alert">{submitError}</p>
+		{/if}
+
+		<div class="intake-actions">
+			<button type="submit" class="intake-btn-primary" disabled={submitting}>
+				{submitting ? 'Starting run…' : 'Run on this matter'}
+			</button>
+		</div>
+	</form>
+</div>
+
+<style>
+	.matters-page {
+		padding: var(--lq-space-5);
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-5);
+		max-width: 44rem;
+	}
+
+	.page-header {
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-2);
+	}
+
+	.page-intro {
+		color: var(--lq-text-secondary);
+		max-width: 60rem;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	.intake-form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-4);
+	}
+
+	.intake-field {
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-1);
+	}
+
+	.intake-label {
+		font-size: 13px;
+		font-weight: 500;
+		color: var(--lq-text-primary);
+	}
+
+	.intake-required {
+		color: var(--lq-error);
+		margin-left: 2px;
+	}
+
+	.intake-optional {
+		font-weight: 400;
+		color: var(--lq-text-tertiary);
+		font-size: 12px;
+	}
+
+	.intake-hint {
+		font-size: 12px;
+		color: var(--lq-text-tertiary);
+		margin: 0;
+		line-height: 1.4;
+	}
+
+	.intake-input,
+	.intake-select,
+	.intake-textarea {
+		background: var(--lq-inset);
+		border: 1px solid var(--lq-border);
+		border-radius: var(--lq-radius);
+		padding: var(--lq-space-2) var(--lq-space-3);
+		font-size: 14px;
+		color: var(--lq-text-primary);
+		width: 100%;
+		box-sizing: border-box;
+		transition: border-color 0.15s ease;
+	}
+
+	.intake-textarea {
+		resize: vertical;
+		font-family: inherit;
+		line-height: 1.5;
+	}
+
+	.intake-input:focus,
+	.intake-select:focus,
+	.intake-textarea:focus {
+		outline: none;
+		border-color: var(--lq-accent);
+		box-shadow: 0 0 0 2px var(--lq-accent-soft);
+	}
+
+	.intake-input:disabled,
+	.intake-select:disabled,
+	.intake-textarea:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.intake-input--error {
+		border-color: var(--lq-error);
+	}
+
+	.intake-field-error {
+		font-size: 12px;
+		color: var(--lq-error);
+		margin: 0;
+	}
+
+	.radio-group {
+		display: flex;
+		gap: var(--lq-space-4);
+		padding: var(--lq-space-1) 0;
+	}
+
+	.radio-label {
+		display: flex;
+		align-items: center;
+		gap: var(--lq-space-1);
+		font-size: 14px;
+		cursor: pointer;
+		color: var(--lq-text);
+	}
+
+	.picker-loading {
+		font-size: 13px;
+		color: var(--lq-text-tertiary);
+		font-style: italic;
+		margin: 0;
+	}
+
+	.picker-error {
+		font-size: 13px;
+		color: var(--lq-error);
+		margin: 0;
+	}
+
+	.submit-error {
+		font-size: 13px;
+		color: var(--lq-error);
+		background: var(--lq-error-soft, rgba(176, 0, 0, 0.06));
+		border: 1px solid var(--lq-error-border, var(--lq-error));
+		border-radius: var(--lq-radius);
+		padding: var(--lq-space-2) var(--lq-space-3);
+		margin: 0;
+	}
+
+	.intake-actions {
+		display: flex;
+		justify-content: flex-start;
+		gap: var(--lq-space-3);
+		padding-top: var(--lq-space-2);
+		border-top: 1px solid var(--lq-border);
+		margin-top: var(--lq-space-2);
+	}
+
+	.intake-btn-primary {
+		background: var(--lq-accent);
+		color: white;
+		border: 0;
+		border-radius: var(--lq-radius);
+		padding: var(--lq-space-2) var(--lq-space-4);
+		font-weight: 500;
+		font-size: 14px;
+		cursor: pointer;
+	}
+
+	.intake-btn-primary:hover:not(:disabled) {
+		filter: brightness(0.95);
+	}
+
+	.intake-btn-primary:focus-visible {
+		outline: 2px solid var(--lq-accent);
+		outline-offset: 2px;
+	}
+
+	.intake-btn-primary:disabled {
+		opacity: 0.65;
+		cursor: not-allowed;
+	}
+</style>

--- a/web/src/routes/lq-ai/autonomous/matters/__tests__/intake-helpers.test.ts
+++ b/web/src/routes/lq-ai/autonomous/matters/__tests__/intake-helpers.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure-helper tests for the matter-intake page (item 1.6).
+ *
+ * Mirrors the pattern from ../../__tests__/page-helpers.test.ts.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	QUERY_MAX_LENGTH,
+	buildIntakeRunRequest,
+	isIntakeFormValid,
+	validateIntakeForm,
+	type IntakeFormState
+} from '../intake-helpers';
+
+function baseForm(overrides: Partial<IntakeFormState> = {}): IntakeFormState {
+	return {
+		query: 'Review the Acme NDA for a mutual confidentiality carve-out.',
+		targetKind: 'skill',
+		skillRef: 'nda-review',
+		playbookId: '',
+		kbId: '',
+		projectId: '',
+		maxCostUsd: '',
+		...overrides
+	};
+}
+
+// ---------------------------------------------------------------------------
+// validateIntakeForm / isIntakeFormValid
+// ---------------------------------------------------------------------------
+
+describe('validateIntakeForm', () => {
+	it('accepts a description + skill target', () => {
+		const errors = validateIntakeForm(baseForm());
+		expect(errors).toEqual({ query: null, target: null });
+		expect(isIntakeFormValid(errors)).toBe(true);
+	});
+
+	it('requires a non-blank description (empty and whitespace-only)', () => {
+		for (const query of ['', '   ', '\n\t ']) {
+			const errors = validateIntakeForm(baseForm({ query }));
+			expect(errors.query).toBeTruthy();
+			expect(isIntakeFormValid(errors)).toBe(false);
+		}
+	});
+
+	it('rejects a description longer than QUERY_MAX_LENGTH after trimming', () => {
+		const atLimit = validateIntakeForm(baseForm({ query: 'a'.repeat(QUERY_MAX_LENGTH) }));
+		expect(atLimit.query).toBeNull();
+
+		const overLimit = validateIntakeForm(baseForm({ query: 'a'.repeat(QUERY_MAX_LENGTH + 1) }));
+		expect(overLimit.query).toBeTruthy();
+	});
+
+	it('requires a skill when targetKind=skill', () => {
+		const errors = validateIntakeForm(baseForm({ skillRef: '' }));
+		expect(errors.target).toBeTruthy();
+		expect(isIntakeFormValid(errors)).toBe(false);
+	});
+
+	it('requires a playbook when targetKind=playbook', () => {
+		const missing = validateIntakeForm(baseForm({ targetKind: 'playbook', playbookId: '' }));
+		expect(missing.target).toBeTruthy();
+
+		const chosen = validateIntakeForm(
+			baseForm({ targetKind: 'playbook', playbookId: 'pb-1', skillRef: '' })
+		);
+		expect(chosen.target).toBeNull();
+	});
+
+	it('reports both errors independently', () => {
+		const errors = validateIntakeForm(baseForm({ query: '', skillRef: '' }));
+		expect(errors.query).toBeTruthy();
+		expect(errors.target).toBeTruthy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildIntakeRunRequest
+// ---------------------------------------------------------------------------
+
+describe('buildIntakeRunRequest', () => {
+	it('builds a minimal skill-targeted body: trimmed query + skill_ref only', () => {
+		const body = buildIntakeRunRequest(baseForm({ query: '  Review the NDA.  ' }));
+		expect(body).toEqual({ query: 'Review the NDA.', skill_ref: 'nda-review' });
+	});
+
+	it('uses playbook_id (not skill_ref) when targetKind=playbook', () => {
+		const body = buildIntakeRunRequest(
+			baseForm({ targetKind: 'playbook', playbookId: 'pb-1', skillRef: 'nda-review' })
+		);
+		expect(body.playbook_id).toBe('pb-1');
+		expect(body).not.toHaveProperty('skill_ref');
+	});
+
+	it('includes optional scope fields only when set', () => {
+		const body = buildIntakeRunRequest(
+			baseForm({ kbId: 'kb-1', projectId: 'proj-1', maxCostUsd: ' 1.50 ' })
+		);
+		expect(body.target_kb_id).toBe('kb-1');
+		expect(body.project_id).toBe('proj-1');
+		// Decimal-as-string on the wire — never coerced to number.
+		expect(body.max_cost_usd).toBe('1.50');
+	});
+
+	it('omits blank optional fields entirely (non-null-subset convention)', () => {
+		const body = buildIntakeRunRequest(baseForm());
+		expect(body).not.toHaveProperty('target_kb_id');
+		expect(body).not.toHaveProperty('project_id');
+		expect(body).not.toHaveProperty('max_cost_usd');
+	});
+});

--- a/web/src/routes/lq-ai/autonomous/matters/intake-helpers.ts
+++ b/web/src/routes/lq-ai/autonomous/matters/intake-helpers.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure helpers for the matter-intake page (item 1.6).
+ *
+ * Extracted from `+page.svelte` so vitest can exercise them without the
+ * SvelteKit / Svelte runtime (mirrors ../page-helpers.ts). No side-effects.
+ */
+
+import type { ManualRunRequest } from '$lib/lq-ai/api/autonomous';
+
+/** Mirrors the backend bound (StringConstraints max_length=10_000). */
+export const QUERY_MAX_LENGTH = 10_000;
+
+/** The intake form's raw field state, as bound in the page. */
+export interface IntakeFormState {
+	/** Free-text matter description → ManualRunRequest.query. */
+	query: string;
+	targetKind: 'skill' | 'playbook';
+	skillRef: string;
+	playbookId: string;
+	kbId: string;
+	projectId: string;
+	maxCostUsd: string;
+}
+
+/** Per-field validation errors; null = field is valid. */
+export interface IntakeFormErrors {
+	query: string | null;
+	target: string | null;
+}
+
+/**
+ * Validate the intake form. Returns per-field errors; both null ⇔ valid
+ * (see isIntakeFormValid). The description is required on THIS page —
+ * the API keeps `query` optional, but a matter-intake submission without
+ * a description would silently fall back to the query-less path, which
+ * is not what the user asked for.
+ */
+export function validateIntakeForm(form: IntakeFormState): IntakeFormErrors {
+	const errors: IntakeFormErrors = { query: null, target: null };
+
+	const trimmed = form.query.trim();
+	if (!trimmed) {
+		errors.query = 'Describe the matter — this is what the run works on.';
+	} else if (trimmed.length > QUERY_MAX_LENGTH) {
+		errors.query = `The description is too long (max ${QUERY_MAX_LENGTH.toLocaleString()} characters).`;
+	}
+
+	if (form.targetKind === 'skill' && !form.skillRef) {
+		errors.target = 'Select a skill, or switch to the Playbook target.';
+	} else if (form.targetKind === 'playbook' && !form.playbookId) {
+		errors.target = 'Select a playbook, or switch to the Skill target.';
+	}
+
+	return errors;
+}
+
+/** True when validateIntakeForm produced no field errors. */
+export function isIntakeFormValid(errors: IntakeFormErrors): boolean {
+	return errors.query === null && errors.target === null;
+}
+
+/**
+ * Build the POST /autonomous/run-now body from a validated form.
+ *
+ * Optional fields are OMITTED when blank (the API's non-null-subset
+ * convention); the description is trimmed. `max_cost_usd` stays a string
+ * (Decimal-as-string on the wire, matching the schedules form).
+ */
+export function buildIntakeRunRequest(form: IntakeFormState): ManualRunRequest {
+	return {
+		query: form.query.trim(),
+		...(form.targetKind === 'skill'
+			? { skill_ref: form.skillRef }
+			: { playbook_id: form.playbookId }),
+		...(form.kbId ? { target_kb_id: form.kbId } : {}),
+		...(form.projectId ? { project_id: form.projectId } : {}),
+		...(form.maxCostUsd.trim() !== '' ? { max_cost_usd: form.maxCostUsd.trim() } : {})
+	};
+}


### PR DESCRIPTION
## What / why

Roadmap item 1.6: the autonomous executor already reads `session.params["query"]` into the ADR-0020 matter loop, but nothing ever set it — `AutonomousManualRunRequest` had no `query` field, so described-matter sessions were unreachable from the UI. This wires the field end-to-end and adds the "Describe your matter" intake page.

Part of the coordinated roadmap sweep (umbrella issue #321).

## Approach

**API** (no new routes, no migration):
- `AutonomousManualRunRequest.query`: optional, 1–10,000 chars (bounds mirror `KnowledgeSearchRequest.query`).
- `_spawn_manual_session` threads it into `session.params["query"]` under the existing non-null-subset convention (key present iff supplied) — existing run-now callers are byte-identical in behavior (tested).
- OpenAPI sketch + generated spec updated (drift guard `test_openapi_export.py` enforces the latter).

**Web** (Svelte, design-system primitives, TypeScript):
- New page `/lq-ai/autonomous/matters`: description textarea → `query`, skill/playbook target, optional project picker, optional KB, per-run cost cap; on 201 redirects to `sessions/[id]` (existing plan-trace + receipt view). Structure mirrors the run-now modal (Promise.allSettled picker load, `LQAIApiError` surfacing); `autonomous_enabled` gating is inherited from the section layout's opt-in redirect.
- Pure validation/request-building logic in `intake-helpers.ts` for vitest coverage.
- One nav entry in the autonomous tab bar.

Deliberate choices: the description is required in the UI but optional in the API (an intake submission without one would silently take the query-less path); KB picker included because the executor's retrieval consumes `kb_id` alongside `query` and every neighboring run form offers it; `emit_artifacts` left off the form (schedule/watch-parity opt-in, out of 1.6 scope).

## Acceptance evidence

- API tests (`api/tests/autonomous/test_run_now.py`): `test_run_now_copies_query_into_params`, `test_run_now_omitted_query_keeps_params_key_absent`, `test_run_now_rejects_empty_query`
- Web vitest: 10 tests in `matters/__tests__/intake-helpers.test.ts`
- E2E: `web/cypress/e2e/matter-intake.cy.ts` (describe→session→receipt + validation spec), following `m4-autonomous.cy.ts` conventions. Note: the repo's E2E suite is Cypress — CLAUDE.md's "Playwright" reference is stale.

Gates run locally:
- API: ruff format/check clean, mypy clean, full suite **2626 passed, 1 skipped, 0 failed** (throwaway pgvector:pg16); route pins untouched.
- Web: `npm run check:lq-ai` **0 errors** (7 pre-existing warnings in untouched files); vitest **746 passed (81 files)**; eslint clean on touched files.

## Maintainer verification steps

- The dev `web` container serves a pre-built static bundle — rebuild `web` to see the new page.
- Cypress spec not run here (needs a deployed stack): `cd web && npx cypress run --spec cypress/e2e/matter-intake.cy.ts` against the compose stack.

## Flaky-test observation (pre-existing, not this PR)

`tests/autonomous/test_sessions_api.py::test_receipt_assembles_phase_transitions_and_tool_calls` failed once in a mid-run full-suite pass (passed on re-run and in isolation) — it writes 4 audit rows in the same instant and asserts timestamp ordering; tie-ordering flake worth a DE row.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)