### PR TITLE
DE-323: context-proposal inbox banner on the Matter detail page

### DIFF
--- a/web/src/routes/lq-ai/matters/[id]/+page.svelte
+++ b/web/src/routes/lq-ai/matters/[id]/+page.svelte
@@ -2,17 +2,39 @@
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { projectsApi } from '$lib/lq-ai/api';
+  import { projectsApi, autonomousApi } from '$lib/lq-ai/api';
+  import { LQAIApiError } from '$lib/lq-ai/api/client';
+  import type { ProjectContextProposalRead } from '$lib/lq-ai/api/autonomous';
   import type { Project } from '$lib/lq-ai/types';
+  import { preferences, initPreferences } from '$lib/lq-ai/stores/preferences';
   import MatterRail from '$lib/lq-ai/components/MatterRail.svelte';
   import ChatPanel from '$lib/lq-ai/components/ChatPanel.svelte';
+  import { pendingProposalsFor, removeProposal, bannerVisible } from './proposal-helpers';
 
   let matter: Project | null = null;
   let loading = true;
   let error: string | null = null;
   let activeChatId: string | undefined = undefined;
 
+  // -------------------------------------------------------------------------
+  // DE-323 — context-proposal inbox banner (autonomous opt-in users only).
+  // The matter-local surface of /lq-ai/autonomous/proposals: pending
+  // proposals targeting THIS project, with inline Accept/Reject. Accept is
+  // the user-authorized context_md write (ADR 0013 D5) — the agent never
+  // writes Project context directly.
+  // -------------------------------------------------------------------------
+  let proposals: ProjectContextProposalRead[] = [];
+  let proposalError: string | null = null;
+  let proposalSuccess: string | null = null;
+  /** proposal id → 'accepting' | 'rejecting'; drives per-row disabled state. */
+  let proposalPendingIds: Map<string, string> = new Map();
+
   $: matterId = $page.params.id;
+  $: showProposalBanner = bannerVisible(
+    $preferences.autonomous_enabled,
+    proposals.length,
+    proposalError !== null || proposalSuccess !== null
+  );
 
   async function loadMatter() {
     if (!matterId) return;
@@ -27,6 +49,84 @@
     }
   }
 
+  /**
+   * Re-fetch the matter WITHOUT toggling the page-level loading flag, so the
+   * workspace (and the proposal banner's success message) stays mounted.
+   * Used after an accepted proposal appends to the matter's context_md.
+   */
+  async function refreshMatter() {
+    if (!matterId) return;
+    try {
+      matter = await projectsApi.getProject(matterId);
+    } catch (e) {
+      // Keep the stale matter on refresh failure — the accept itself succeeded.
+      console.error('lq-ai: failed to refresh matter after proposal accept', e);
+    }
+  }
+
+  async function loadProposals() {
+    if (!matterId) return;
+    try {
+      const resp = await autonomousApi.listProposals('proposed', matterId);
+      proposals = pendingProposalsFor(resp.proposals, matterId);
+    } catch (e) {
+      if (e instanceof LQAIApiError && e.status === 403) {
+        // Not opted in server-side — keep the banner hidden, no error.
+        return;
+      }
+      // Best-effort: a proposals fetch failure must not degrade the matter page.
+      console.error('lq-ai: failed to load context proposals', e);
+    }
+  }
+
+  async function handleAcceptProposal(proposal: ProjectContextProposalRead) {
+    proposalPendingIds = new Map(proposalPendingIds).set(proposal.id, 'accepting');
+    proposalError = null;
+    proposalSuccess = null;
+    try {
+      await autonomousApi.acceptProposal(proposal.id);
+      proposals = removeProposal(proposals, proposal.id);
+      proposalSuccess = 'Added to matter context.';
+      await refreshMatter();
+    } catch (e) {
+      if (e instanceof LQAIApiError) {
+        proposalError = `Accept failed (${e.status}): ${e.message}`;
+      } else {
+        proposalError = e instanceof Error ? e.message : String(e);
+      }
+    } finally {
+      const next = new Map(proposalPendingIds);
+      next.delete(proposal.id);
+      proposalPendingIds = next;
+    }
+  }
+
+  async function handleRejectProposal(proposal: ProjectContextProposalRead) {
+    const confirmed = confirm(
+      'Reject this proposal? The suggested context will be discarded.'
+    );
+    if (!confirmed) return;
+
+    proposalPendingIds = new Map(proposalPendingIds).set(proposal.id, 'rejecting');
+    proposalError = null;
+    proposalSuccess = null;
+    try {
+      await autonomousApi.rejectProposal(proposal.id);
+      proposals = removeProposal(proposals, proposal.id);
+      proposalSuccess = 'Proposal rejected.';
+    } catch (e) {
+      if (e instanceof LQAIApiError) {
+        proposalError = `Reject failed (${e.status}): ${e.message}`;
+      } else {
+        proposalError = e instanceof Error ? e.message : String(e);
+      }
+    } finally {
+      const next = new Map(proposalPendingIds);
+      next.delete(proposal.id);
+      proposalPendingIds = next;
+    }
+  }
+
   function handleMatterUpdate(next: Project) {
     matter = next;
   }
@@ -36,7 +136,17 @@
     await goto('/lq-ai/matters');
   }
 
-  onMount(loadMatter);
+  onMount(() => {
+    loadMatter();
+    // Proposals are gated on the autonomous opt-in preference; resolve it
+    // first (server-synced with localStorage cache), then fetch best-effort.
+    void (async () => {
+      await initPreferences();
+      if ($preferences.autonomous_enabled) {
+        await loadProposals();
+      }
+    })();
+  });
 </script>
 
 {#if loading}
@@ -44,27 +154,90 @@
 {:else if error || !matter}
   <p class="lq-text-body" style="padding: var(--lq-space-6); color: var(--lq-error, #b91c1c);">{error ?? 'Matter not found'}</p>
 {:else}
-  <div class="matter-workspace">
-    <MatterRail
-      {matter}
-      bind:activeChatId
-      onMatterUpdate={handleMatterUpdate}
-      onMatterArchived={handleMatterArchived}
-    />
-    <div class="matter-chat-pane">
-      <ChatPanel
-        projectIdFilter={matter.id}
-        initialChatId={activeChatId}
-        on:kbsAttached={loadMatter}
+  <div class="matter-page">
+    {#if showProposalBanner}
+      <section class="proposal-banner" aria-label="Context proposals">
+        <header class="proposal-banner-header">
+          <h2 class="lq-text-panel-h proposal-banner-title">Context proposals</h2>
+          {#if proposals.length > 0}
+            <span class="lq-text-caption proposal-banner-count">
+              {proposals.length} pending — accept to append to this matter's context, or reject to discard.
+            </span>
+          {/if}
+        </header>
+
+        {#if proposalError}
+          <div class="proposal-message proposal-message--error" role="alert">{proposalError}</div>
+        {/if}
+        {#if proposalSuccess}
+          <div class="proposal-message proposal-message--success" role="status">{proposalSuccess}</div>
+        {/if}
+
+        {#if proposals.length > 0}
+          <ul class="proposal-list" aria-label="Pending context proposals">
+            {#each proposals as proposal (proposal.id)}
+              {@const pending = proposalPendingIds.get(proposal.id)}
+              <li class="proposal-row">
+                <div class="proposal-body">
+                  <p class="proposal-text">{proposal.suggested_md}</p>
+                  <span class="lq-text-caption proposal-date">
+                    Proposed {new Date(proposal.created_at).toLocaleDateString()}
+                  </span>
+                </div>
+                <div class="proposal-actions">
+                  <button
+                    type="button"
+                    class="proposal-button proposal-button--primary"
+                    on:click={() => handleAcceptProposal(proposal)}
+                    disabled={!!pending}
+                  >
+                    {pending === 'accepting' ? 'Accepting…' : 'Accept'}
+                  </button>
+                  <button
+                    type="button"
+                    class="proposal-button proposal-button--danger"
+                    on:click={() => handleRejectProposal(proposal)}
+                    disabled={!!pending}
+                  >
+                    {pending === 'rejecting' ? 'Rejecting…' : 'Reject'}
+                  </button>
+                </div>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </section>
+    {/if}
+
+    <div class="matter-workspace">
+      <MatterRail
+        {matter}
+        bind:activeChatId
+        onMatterUpdate={handleMatterUpdate}
+        onMatterArchived={handleMatterArchived}
       />
+      <div class="matter-chat-pane">
+        <ChatPanel
+          projectIdFilter={matter.id}
+          initialChatId={activeChatId}
+          on:kbsAttached={loadMatter}
+        />
+      </div>
     </div>
   </div>
 {/if}
 
 <style>
+  .matter-page {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+
   .matter-workspace {
     display: flex;
-    height: 100%;
+    flex: 1;
     min-height: 0;
   }
 
@@ -78,4 +251,135 @@
   /* Match the outer layout's overflow-y: auto on main — the rail scrolls
      within itself if it overflows; the chat panel manages its own scroll
      internally. */
+
+  /* ------------------------------------------------------------------ */
+  /* DE-323 — context-proposal inbox banner                             */
+  /* ------------------------------------------------------------------ */
+
+  .proposal-banner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--lq-space-2);
+    padding: var(--lq-space-3) var(--lq-space-4);
+    border-bottom: 1px solid var(--lq-border);
+    background: var(--lq-surface);
+    flex-shrink: 0;
+  }
+
+  .proposal-banner-header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--lq-space-3);
+    flex-wrap: wrap;
+  }
+
+  .proposal-banner-title {
+    margin: 0;
+  }
+
+  .proposal-banner-count {
+    color: var(--lq-text-secondary);
+  }
+
+  .proposal-message {
+    padding: var(--lq-space-2) var(--lq-space-3);
+    border-radius: 6px;
+    font-size: 13px;
+  }
+
+  .proposal-message--error {
+    background: var(--lq-error-bg, #fee);
+    color: var(--lq-error-text, #800);
+    border: 1px solid var(--lq-error-border, #fbb);
+  }
+
+  .proposal-message--success {
+    background: var(--lq-success-bg, #efe);
+    color: var(--lq-success-text, #060);
+    border: 1px solid var(--lq-success-border, #bfb);
+  }
+
+  .proposal-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--lq-space-2);
+  }
+
+  .proposal-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--lq-space-3);
+    padding: var(--lq-space-2) var(--lq-space-3);
+    border: 1px solid var(--lq-border);
+    border-left: 3px solid var(--lq-accent);
+    border-radius: 6px;
+    background: var(--lq-surface-hover, rgba(0, 0, 0, 0.03));
+  }
+
+  .proposal-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--lq-space-1);
+  }
+
+  .proposal-text {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--lq-text);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .proposal-date {
+    color: var(--lq-text-secondary);
+  }
+
+  .proposal-actions {
+    display: flex;
+    gap: var(--lq-space-2);
+    flex-shrink: 0;
+  }
+
+  .proposal-button {
+    padding: var(--lq-space-1) var(--lq-space-3);
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+    border: 1px solid var(--lq-border);
+    background: transparent;
+    color: var(--lq-text);
+    transition: background 0.1s;
+    white-space: nowrap;
+  }
+
+  .proposal-button:hover:not(:disabled) {
+    background: var(--lq-surface-hover, rgba(0, 0, 0, 0.04));
+  }
+
+  .proposal-button--primary {
+    background: var(--lq-accent);
+    color: white;
+    border-color: var(--lq-accent);
+  }
+
+  .proposal-button--primary:hover:not(:disabled) {
+    opacity: 0.9;
+    background: var(--lq-accent);
+  }
+
+  .proposal-button--danger {
+    color: var(--lq-error-text, #b00);
+    border-color: var(--lq-error-border, #fbb);
+  }
+
+  .proposal-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 </style>

--- a/web/src/routes/lq-ai/matters/[id]/__tests__/proposal-helpers.test.ts
+++ b/web/src/routes/lq-ai/matters/[id]/__tests__/proposal-helpers.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Pure-helper tests for the DE-323 context-proposal inbox banner on the
+ * Matter detail page.
+ *
+ * Mirrors the pattern from:
+ *   web/src/routes/lq-ai/autonomous/__tests__/page-helpers.test.ts
+ */
+import { describe, expect, it } from 'vitest';
+
+import { bannerVisible, pendingProposalsFor, removeProposal } from '../proposal-helpers';
+import type { ProjectContextProposalRead, ProposalState } from '$lib/lq-ai/api/autonomous';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_PROJECT_ID = '22222222-2222-2222-2222-222222222222';
+
+function makeProposal(
+	overrides: Partial<ProjectContextProposalRead> = {}
+): ProjectContextProposalRead {
+	return {
+		id: 'prop-1',
+		user_id: 'user-1',
+		precedent_id: 'prec-1',
+		project_id: PROJECT_ID,
+		suggested_md: '- Counterparty prefers NY governing law.',
+		state: 'proposed',
+		accepted_at: null,
+		rejected_at: null,
+		created_at: '2026-07-01T00:00:00Z',
+		updated_at: '2026-07-01T00:00:00Z',
+		...overrides
+	};
+}
+
+// ---------------------------------------------------------------------------
+// pendingProposalsFor
+// ---------------------------------------------------------------------------
+
+describe('pendingProposalsFor', () => {
+	it('keeps only proposed-state proposals for the given project', () => {
+		const list = [
+			makeProposal({ id: 'a' }),
+			makeProposal({ id: 'b', state: 'accepted' }),
+			makeProposal({ id: 'c', state: 'rejected' }),
+			makeProposal({ id: 'd', project_id: OTHER_PROJECT_ID })
+		];
+		const result = pendingProposalsFor(list, PROJECT_ID);
+		expect(result.map((p) => p.id)).toEqual(['a']);
+	});
+
+	it('filters out every non-proposed state', () => {
+		const states: ProposalState[] = ['accepted', 'rejected'];
+		for (const state of states) {
+			expect(pendingProposalsFor([makeProposal({ state })], PROJECT_ID)).toEqual([]);
+		}
+	});
+
+	it('returns an empty list when nothing targets the project', () => {
+		const list = [makeProposal({ project_id: OTHER_PROJECT_ID })];
+		expect(pendingProposalsFor(list, PROJECT_ID)).toEqual([]);
+	});
+
+	it('returns an empty list for an empty input', () => {
+		expect(pendingProposalsFor([], PROJECT_ID)).toEqual([]);
+	});
+
+	it('preserves input order for multiple pending proposals', () => {
+		const list = [makeProposal({ id: 'a' }), makeProposal({ id: 'b' }), makeProposal({ id: 'c' })];
+		expect(pendingProposalsFor(list, PROJECT_ID).map((p) => p.id)).toEqual(['a', 'b', 'c']);
+	});
+
+	it('does not mutate the input list', () => {
+		const list = [makeProposal({ id: 'a' }), makeProposal({ id: 'b', state: 'accepted' })];
+		pendingProposalsFor(list, PROJECT_ID);
+		expect(list).toHaveLength(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// removeProposal — the accept/reject state transition
+// ---------------------------------------------------------------------------
+
+describe('removeProposal', () => {
+	it('removes the accepted proposal and keeps the rest (accept transition)', () => {
+		const list = [makeProposal({ id: 'a' }), makeProposal({ id: 'b' })];
+		const result = removeProposal(list, 'a');
+		expect(result.map((p) => p.id)).toEqual(['b']);
+	});
+
+	it('removes the rejected proposal and keeps the rest (reject transition)', () => {
+		const list = [makeProposal({ id: 'a' }), makeProposal({ id: 'b' })];
+		const result = removeProposal(list, 'b');
+		expect(result.map((p) => p.id)).toEqual(['a']);
+	});
+
+	it('removing the last proposal yields an empty list (banner then hides)', () => {
+		const list = [makeProposal({ id: 'a' })];
+		const result = removeProposal(list, 'a');
+		expect(result).toEqual([]);
+		expect(bannerVisible(true, result.length)).toBe(false);
+	});
+
+	it('is a no-op for an unknown id', () => {
+		const list = [makeProposal({ id: 'a' })];
+		expect(removeProposal(list, 'nope')).toHaveLength(1);
+	});
+
+	it('returns a new array and does not mutate the input', () => {
+		const list = [makeProposal({ id: 'a' }), makeProposal({ id: 'b' })];
+		const result = removeProposal(list, 'a');
+		expect(result).not.toBe(list);
+		expect(list).toHaveLength(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// bannerVisible — banner show/hide states
+// ---------------------------------------------------------------------------
+
+describe('bannerVisible', () => {
+	it('is hidden when the user has not opted in, regardless of pending count', () => {
+		expect(bannerVisible(false, 0)).toBe(false);
+		expect(bannerVisible(false, 3)).toBe(false);
+		expect(bannerVisible(false, 3, true)).toBe(false);
+	});
+
+	it('is hidden when opted in but zero pending and no message', () => {
+		expect(bannerVisible(true, 0)).toBe(false);
+		expect(bannerVisible(true, 0, false)).toBe(false);
+	});
+
+	it('is visible when opted in with pending proposals', () => {
+		expect(bannerVisible(true, 1)).toBe(true);
+		expect(bannerVisible(true, 5)).toBe(true);
+	});
+
+	it('stays visible with zero pending while an action message is showing', () => {
+		// e.g. right after accepting/rejecting the last pending proposal.
+		expect(bannerVisible(true, 0, true)).toBe(true);
+	});
+
+	it('hasMessage defaults to false', () => {
+		expect(bannerVisible(true, 0)).toBe(false);
+	});
+});

--- a/web/src/routes/lq-ai/matters/[id]/proposal-helpers.ts
+++ b/web/src/routes/lq-ai/matters/[id]/proposal-helpers.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure helpers for the DE-323 context-proposal inbox banner on the Matter
+ * detail page.
+ *
+ * Extracted from `+page.svelte` so vitest can exercise the banner state
+ * logic without the SvelteKit / Svelte runtime. Mirrors the pattern from:
+ *   web/src/routes/lq-ai/autonomous/__tests__/page-helpers.test.ts
+ *
+ * The banner is the matter-local surface of the proposal review loop that
+ * lives at /lq-ai/autonomous/proposals (M4-C2 Task 14). ADR 0013 D5 still
+ * holds: accepting here is the same user-authorized write path — the agent
+ * never writes Project context directly.
+ */
+
+import type { ProjectContextProposalRead } from '$lib/lq-ai/api/autonomous';
+
+/**
+ * Narrow a proposal list to the pending ('proposed') proposals that target
+ * the given project.
+ *
+ * The server already filters by state + project_id when asked, but the
+ * banner re-filters defensively so a stale or over-broad response can never
+ * surface another matter's proposals (or already-resolved ones) here.
+ */
+export function pendingProposalsFor(
+	proposals: ProjectContextProposalRead[],
+	projectId: string
+): ProjectContextProposalRead[] {
+	return proposals.filter((p) => p.state === 'proposed' && p.project_id === projectId);
+}
+
+/**
+ * Return a new list without the proposal `id` (used after accept/reject).
+ * Unknown ids are a no-op; the input list is never mutated.
+ */
+export function removeProposal(
+	proposals: ProjectContextProposalRead[],
+	id: string
+): ProjectContextProposalRead[] {
+	return proposals.filter((p) => p.id !== id);
+}
+
+/**
+ * Whether the proposal banner region should render at all.
+ *
+ * Hidden when the user has not opted in to autonomous mode, and hidden when
+ * there is nothing to show: zero pending proposals AND no lingering
+ * action message (`hasMessage` keeps a success/error visible right after
+ * the last pending proposal was resolved).
+ */
+export function bannerVisible(
+	optedIn: boolean,
+	pendingCount: number,
+	hasMessage = false
+): boolean {
+	return optedIn && (pendingCount > 0 || hasMessage);
+}


### PR DESCRIPTION
## What / why

DE-323 (PRD §9): context proposals could only be reviewed on the global `/lq-ai/autonomous/proposals` page. This surfaces the matter-scoped pending proposals right where the matter is being worked, with inline Accept/Reject. Frontend-only — the api client (`listProposals`/`acceptProposal`/`rejectProposal`) already existed.

Part of the coordinated roadmap sweep (umbrella issue #321).

## Approach

- Banner on `matters/[id]` (above the workspace): pending proposals for this project, suggested-context preview + date, per-row Accept/Reject with pending-state guards and `confirm()` before reject; error/success surfacing mirrors the proposals page idioms.
- Accept → `refreshMatter()` re-fetch without toggling the page loading flag, so the workspace stays mounted and `context_md` consumers see the appended context. Reject → row removed.
- Gating: `$preferences.autonomous_enabled` (same server-synced store the autonomous section gates on; `initPreferences()` called on mount since this route has no initializing layout). Defense in depth: a server-side 403 from the proposals list keeps the banner hidden silently. Hidden at zero pending (with a brief message-lingering state so the last action's feedback isn't cut off).
- Deliberate softening: a proposals *fetch* outage is logged, not surfaced — it must not degrade the matter page; *action* failures are surfaced in the banner.
- Pure logic (`pendingProposalsFor` defensive state+project re-filter, `removeProposal`, `bannerVisible`) in `proposal-helpers.ts` for vitest.
- ADR 0013 D5 preserved: accept is the same user-authorized context write path; the agent never writes Project context directly.

`/lq-ai/autonomous/proposals` is untouched.

## Acceptance evidence

- 16 vitest tests in `matters/[id]/__tests__/proposal-helpers.test.ts` (banner visibility incl. not-opted-in and message-lingering, defensive filtering, accept/reject transitions, immutability).
- Gates: `npm run check:lq-ai` **0 errors** (7 pre-existing warnings in untouched files); vitest **752 passed (81 files)**; eslint clean on touched files.

## Maintainer verification steps

- Rebuild the `web` container (static bundle) to see the banner; with an opted-in user and a pending proposal on a matter, verify accept appends to the matter context and reject discards.

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)