### PR TITLE
DE-333: aggregate multi-artifact storage-failure warn findings

### DIFF
--- a/api/app/autonomous/nodes.py
+++ b/api/app/autonomous/nodes.py
@@ -452,7 +452,9 @@ def make_drafting_node(
        opted in to artifacts (``params["emit_artifacts"]`` truthy — Donna
        ask #8), each parsed artifact is additionally dispatched via
        :attr:`~app.autonomous.enums.ToolIntent.emit_artifact`; skip /
-       storage-error outcomes surface as honest explanatory findings.
+       storage-error outcomes surface as honest explanatory findings
+       (two or more storage failures aggregate into ONE warn finding
+       naming every failed artifact — DE-333).
 
     Every return path emits ``findings`` (the list of dispatched finding
     dicts), ``findings_count`` (its length), and ``artifacts_count`` (the
@@ -600,6 +602,12 @@ def make_drafting_node(
         # and no finding is emitted about it either).
         artifacts_count = 0
         if (session.params or {}).get("emit_artifacts") and parsed.artifacts:
+            # (name, error_text) per storage failure — findings are emitted
+            # AFTER the loop so N>=2 failures aggregate into ONE warn
+            # finding instead of one per artifact (DE-333). Audit rows for
+            # every emit_artifact attempt are unaffected: the chokepoint
+            # writes them at dispatch time.
+            storage_failures: list[tuple[str, str]] = []
             for artifact in parsed.artifacts:
                 result = await guarded_tool_call(
                     session,
@@ -655,27 +663,45 @@ def make_drafting_node(
                     continue
                 if result.outcome == "storage_error":
                     # Storage failures are per-artifact (and possibly
-                    # transient) — emit ONE ``warn`` finding for THIS
-                    # artifact and continue with the remaining ones.
+                    # transient) — record the failure and continue with the
+                    # remaining artifacts; the warn finding(s) are emitted
+                    # after the loop (aggregated when N>=2, DE-333).
                     error_text = str(data.get("error") or "")[:500]
                     artifact_name = str(artifact.get("name") or "(unnamed)")[:255]
-                    finding = {
-                        "title": "Artifact persistence failed at storage",
-                        "summary": (
-                            f"The artifact {artifact_name!r} "
-                            f"could not be uploaded to object storage: {error_text}"
-                        ),
-                        "severity": "warn",
-                    }
-                    await guarded_tool_call(
-                        session,
-                        ToolIntent.emit_finding,
-                        {"finding": finding},
-                        db,
-                        gateway,
-                    )
-                    findings.append(finding)
+                    storage_failures.append((artifact_name, error_text))
                     continue
+
+            if storage_failures:
+                if len(storage_failures) == 1:
+                    # A single failure keeps the per-artifact message: the
+                    # name AND the error text stay actionable.
+                    artifact_name, error_text = storage_failures[0]
+                    summary = (
+                        f"The artifact {artifact_name!r} "
+                        f"could not be uploaded to object storage: {error_text}"
+                    )
+                else:
+                    # N>=2 failures almost always share one cause (object
+                    # storage down) — ONE aggregated warn finding naming
+                    # every failed artifact, not one per artifact (DE-333).
+                    names = ", ".join(name for name, _ in storage_failures)
+                    summary = (
+                        f"{len(storage_failures)} artifacts could not be "
+                        f"stored — object storage unavailable: {names}"
+                    )
+                finding = {
+                    "title": "Artifact persistence failed at storage",
+                    "summary": summary,
+                    "severity": "warn",
+                }
+                await guarded_tool_call(
+                    session,
+                    ToolIntent.emit_finding,
+                    {"finding": finding},
+                    db,
+                    gateway,
+                )
+                findings.append(finding)
 
         # ``findings_count`` counts findings ONLY — memories, precedents,
         # and artifacts are deliberately excluded (the artifact-explanatory

--- a/api/tests/autonomous/test_executor_real_work.py
+++ b/api/tests/autonomous/test_executor_real_work.py
@@ -563,6 +563,49 @@ async def test_drafting_storage_error_emits_warn_and_continues(
     assert "RuntimeError" in finding["summary"]
 
 
+@pytest.mark.integration
+async def test_drafting_multiple_storage_errors_emit_one_aggregated_warn(
+    db_session: AsyncSession,
+    mock_gateway: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Storage failures on BOTH artifacts → exactly ONE aggregated warn
+    finding naming both artifacts (DE-333), while every emit_artifact
+    attempt is still audited so receipts show each attempt."""
+    _stub_embed(monkeypatch)
+
+    async def _down_upload(*, storage_path: str, body: bytes, content_type: str) -> None:
+        raise RuntimeError("minio is down")
+
+    monkeypatch.setattr("app.storage.upload_bytes", _down_upload)
+    session = await _make_drafting_session_with_kb(db_session, emit_artifacts=True)
+
+    state: AutonomousSessionState = {
+        "session_id": str(session.id),
+        "analysis_content": _structured_content(_TWO_ARTIFACTS),
+        "analysis_outcome": "success",
+    }
+    node = make_drafting_node(db_session, mock_gateway)
+    result = await node(state)
+
+    rows = await _autonomous_audit_rows(db_session, str(session.id))
+    # BOTH artifacts were still attempted — the audit trail is unchanged
+    # by the aggregation (one started tool_call row per attempt).
+    assert _tool_started_calls(rows, "emit_artifact") == 2
+    assert result["artifacts_count"] == 0
+    # Exactly ONE warn finding total, dispatched through ONE emit_finding —
+    # not one finding per failed artifact.
+    assert _tool_started_calls(rows, "emit_finding") == 1
+    assert result["findings_count"] == 1
+    finding = result["findings"][0]
+    assert finding["title"] == "Artifact persistence failed at storage"
+    assert finding["severity"] == "warn"
+    assert "2 artifacts could not be stored" in finding["summary"]
+    assert "object storage unavailable" in finding["summary"]
+    assert "review-memo.md" in finding["summary"]
+    assert "summary.md" in finding["summary"]
+
+
 # ---------------------------------------------------------------------------
 # Donna ask #8 — delivery_node artifact_count in notify payload + audit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What / why

DE-333 (PRD §9): premise verified — the drafting node emitted one warn finding per `storage_error` artifact, so a storage outage during a multi-artifact session flooded the findings list with near-identical rows.

Part of the coordinated roadmap sweep (umbrella issue #321).

## Approach

- The `storage_error` branch now records `(artifact_name, error_text)` and continues; emission happens once after the loop.
- Exactly 1 failure → the original per-artifact message, verbatim (name + error text stay actionable). ≥2 failures → one aggregated warn finding: `"N artifacts could not be stored — object storage unavailable: <names>"`. Same title and severity either way.
- Audit `tool_call` rows untouched: the chokepoint writes them per `emit_artifact` attempt at dispatch time, so receipts still show every attempt. Individual error strings for the aggregated case remain visible in those per-attempt audit rows.
- Behavior note for review: the single-failure finding is now emitted after the loop instead of mid-loop — message, counts, and audit rows are identical; only relative audit-row ordering vs later artifact attempts shifts (no test depended on it). Failures recorded before a `no_target_kb` break still surface.

## Acceptance evidence

- New test `test_drafting_multiple_storage_errors_emit_one_aggregated_warn` (`test_executor_real_work.py`): both artifacts fail → 2 `emit_artifact` attempt audit rows (unchanged), exactly 1 finding, summary names both artifacts.
- Existing single-failure test `test_drafting_storage_error_emits_warn_and_continues` unchanged and green.

Gates run locally (api): ruff format/check clean, mypy clean, full suite **2624 passed, 1 skipped, 0 failed** (throwaway pgvector:pg16).

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)