### PR TITLE
DE-298: built-ins browser polish on /skills

### DIFF
--- a/api/app/api/tabular.py
+++ b/api/app/api/tabular.py
@@ -29,12 +29,16 @@ information leakage), matching the M3-A6 Easy Playbook posture.
 Column-spec resolution
 ----------------------
 
-Either ``skill_name`` (resolved at execution start from the live
-:class:`SkillRegistry` by reading the skill's
-``lq_ai.columns``) OR ``columns`` (ad-hoc spec) is required. The
-resolved column list is snapshotted onto the row at request time
-(Decision C-1 snapshotting posture: re-rendering the grid a week
-later must be honest about what was actually run).
+Either ``skill_name`` OR ``columns`` (ad-hoc spec) is required. A
+``skill_name`` resolves through the D8.1b stack (DE-297): the caller's
+user-scope shadow first, then the newest team-scope shadow, then the
+live :class:`SkillRegistry` built-in. User/team rows carry their column
+spec in ``frontmatter_extra`` (validated at create/PATCH time against
+the same ``LQAIFrontmatter`` schema built-ins parse with); built-ins
+carry it in ``lq_ai.columns``. The resolved column list is snapshotted
+onto the row at request time (Decision C-1 snapshotting posture:
+re-rendering the grid a week later must be honest about what was
+actually run).
 
 Cost-preview shape
 ------------------
@@ -57,6 +61,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from pydantic import ValidationError
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -66,6 +71,8 @@ from app.clients.gateway import GatewayClient, get_gateway_client
 from app.db.session import get_db
 from app.models.document import Document, DocumentChunk
 from app.models.tabular import TabularExecution
+from app.models.user import User
+from app.models.user_skill import UserSkill
 from app.schemas.tabular import (
     Citation,
     ColumnSpec,
@@ -77,6 +84,7 @@ from app.schemas.tabular import (
     TabularResults,
 )
 from app.skills.registry import MutableSkillRegistry
+from app.skills.schema import LQAIFrontmatter
 from app.tabular.cost import estimate_tabular_execution_cost
 from app.workers.queue import enqueue_tabular_execution_job
 
@@ -111,17 +119,72 @@ def _registry(request: Request) -> MutableSkillRegistry:
     return holder
 
 
-def _resolve_columns(
+def _bake_skill_ensemble(
+    columns: list[ColumnSpec], skill_ensemble: bool | None
+) -> list[ColumnSpec]:
+    """Bake the skill-level ``ensemble_verification`` fallback into each
+    column at the single resolution point (Decision C-1 snapshotting
+    posture) so both preview-cost and execute see a consistent snapshot.
+
+    A column that didn't declare its own value (None) inherits the
+    skill-level value; an explicit True/False per column is left
+    untouched.
+    """
+
+    if skill_ensemble is not None:
+        for col in columns:
+            if col.ensemble_verification is None:
+                col.ensemble_verification = skill_ensemble
+    return columns
+
+
+def _columns_from_user_skill_row(row: UserSkill, *, skill_name: str) -> list[ColumnSpec]:
+    """Resolve a user/team-scope row's ``frontmatter_extra`` to columns.
+
+    DE-297 — the user-skill half of table-mode hydration. Parses the
+    extension keys through the same :class:`LQAIFrontmatter` model the
+    built-in loader uses, so both sources apply identical validation
+    (tier bounds, non-empty name/query). Create/PATCH already reject
+    invalid shapes; the re-parse here guards legacy rows written before
+    that validation landed — those surface as a 400, never a 500.
+    """
+
+    extra = dict(row.frontmatter_extra or {})
+    try:
+        lq = LQAIFrontmatter.model_validate(extra)
+    except ValidationError:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"skill {skill_name!r} has an invalid column spec; re-save it "
+                "from the skill editor before running a tabular review"
+            ),
+        ) from None
+    if not lq.columns:
+        raise HTTPException(
+            status_code=400,
+            detail=f"skill {skill_name!r} has no columns (not a table-mode skill)",
+        )
+    resolved = [ColumnSpec.model_validate(col.model_dump()) for col in lq.columns]
+    return _bake_skill_ensemble(resolved, lq.ensemble_verification)
+
+
+async def _resolve_columns(
     request: Request,
+    db: AsyncSession,
     *,
+    user: User,
     skill_name: str | None,
     ad_hoc: list[ColumnSpec] | None,
 ) -> tuple[str | None, list[ColumnSpec]]:
     """Resolve the request's column spec to (skill_name, columns).
 
     Either ``skill_name`` OR ``ad_hoc`` must be supplied. When
-    ``skill_name`` is given, look up the registered skill's
-    ``lq_ai.columns`` and snapshot the list. When ``ad_hoc`` is
+    ``skill_name`` is given, resolve it through the D8.1b stack —
+    the caller's user-scope shadow, then the newest accessible
+    team-scope shadow, then the registered built-in (DE-297: user/team
+    rows carry their spec in ``frontmatter_extra``; built-ins in
+    ``lq_ai.columns``) — and snapshot the list. When ``ad_hoc`` is
     given, use it directly. Both-or-neither is a 400.
 
     Returns the resolved skill_name (None for ad-hoc) + a non-empty
@@ -142,6 +205,17 @@ def _resolve_columns(
         )
 
     if skill_name:
+        # Local import (matches app/api/internal.py) — the shadow
+        # loaders + resolution order live in skills.py; importing here
+        # keeps the tabular → skills edge one-way and explicit.
+        from app.api.skills import _load_team_shadow, _load_user_shadow
+
+        shadow = await _load_user_shadow(db, user_id=user.id, slug=skill_name)
+        if shadow is None:
+            shadow = await _load_team_shadow(db, user_id=user.id, slug=skill_name)
+        if shadow is not None:
+            return skill_name, _columns_from_user_skill_row(shadow, skill_name=skill_name)
+
         record = _registry(request).current().get(skill_name)
         if record is None:
             raise HTTPException(status_code=404, detail=f"skill {skill_name!r} not found")
@@ -155,18 +229,9 @@ def _resolve_columns(
         # skill-side fields the wire schema doesn't honor are
         # stripped consistently.
         resolved = [ColumnSpec.model_validate(col.model_dump()) for col in skill_columns]
-        # Bake the skill-level ensemble_verification fallback into each
-        # column at this single resolution point (Decision C-1
-        # snapshotting posture) so both preview-cost and execute see a
-        # consistent snapshot. A column that didn't declare its own
-        # value (None) inherits the skill-level value; an explicit
-        # True/False per column is left untouched.
-        skill_ensemble = record.frontmatter.lq_ai.ensemble_verification
-        if skill_ensemble is not None:
-            for col in resolved:
-                if col.ensemble_verification is None:
-                    col.ensemble_verification = skill_ensemble
-        return skill_name, resolved
+        return skill_name, _bake_skill_ensemble(
+            resolved, record.frontmatter.lq_ai.ensemble_verification
+        )
 
     # ad_hoc branch — the request-validation min_length=1 on columns
     # in TabularExecutionCreate already covers the empty case.
@@ -242,13 +307,15 @@ async def preview_tabular_cost(
     Authorization is the router-level ``get_active_user`` gate — any
     authenticated caller may preview costs against their own document
     selection. The document-ownership check is enforced at execute
-    time; preview doesn't load the documents.
+    time; preview doesn't load the documents. ``user`` also drives the
+    DE-297 skill-name resolution (the caller's user/team shadows take
+    precedence over a built-in at the same slug).
     """
 
-    _ = user  # gate-only; no per-user logic on preview
-
-    _, columns = _resolve_columns(
+    _, columns = await _resolve_columns(
         request,
+        db,
+        user=user,
         skill_name=body.skill_name,
         ad_hoc=body.columns,
     )
@@ -306,8 +373,10 @@ async def create_tabular_execution(
     if len(documents) != len(body.document_ids):
         raise HTTPException(status_code=404, detail="one or more documents not found")
 
-    resolved_skill_name, columns = _resolve_columns(
+    resolved_skill_name, columns = await _resolve_columns(
         request,
+        db,
+        user=user,
         skill_name=body.skill_name,
         ad_hoc=body.columns,
     )

--- a/api/app/api/user_skills.py
+++ b/api/app/api/user_skills.py
@@ -32,7 +32,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -44,6 +44,7 @@ from app.models.audit import AuditLog
 from app.models.team import Team, TeamMember
 from app.models.user import User
 from app.models.user_skill import UserSkill
+from app.skills.schema import LQAIFrontmatter
 
 router = APIRouter(prefix="/user-skills", tags=["user-skills"])
 
@@ -247,13 +248,35 @@ def _validate_tags(tags: list[str]) -> list[str]:
     return out
 
 
-def _validate_frontmatter_extra(extra: dict[str, Any]) -> dict[str, Any]:
-    """Reject pathologically large extension blobs.
+# The ``lq_ai:`` keys that participate in table-mode authoring (DE-297).
+# When any of them appear in ``frontmatter_extra``, that subset is
+# re-validated through :class:`app.skills.schema.LQAIFrontmatter` — the
+# SAME model the built-in loader parses SKILL.md frontmatter with — so a
+# user-authored table skill can never persist a shape the built-in path
+# would reject (zero columns, blank query, tier outside 1-5, …).
+# Restricted to this subset (rather than validating the whole dict) so
+# unrelated free-form extension keys keep their documented
+# "arbitrary JSON" contract.
+_TABLE_MODE_EXTRA_KEYS = frozenset(
+    {"output_format", "columns", "minimum_inference_tier", "ensemble_verification"}
+)
 
-    Keys/values are arbitrary JSON; the only guard at this layer is a
-    serialized-size ceiling so a runaway client can't burn a JSONB
-    page on a single row. The Pydantic ``dict[str, Any]`` typing
-    already rejects non-dict bodies.
+
+def _validate_frontmatter_extra(extra: dict[str, Any]) -> dict[str, Any]:
+    """Reject pathologically large extension blobs and invalid table specs.
+
+    Keys/values are arbitrary JSON; the guards at this layer are:
+
+    * a serialized-size ceiling so a runaway client can't burn a JSONB
+      page on a single row (the Pydantic ``dict[str, Any]`` typing
+      already rejects non-dict bodies); and
+    * DE-297 table-mode parity — when the extra block carries any of
+      the ``lq_ai`` authoring keys (``output_format`` / ``columns`` /
+      ``minimum_inference_tier`` / ``ensemble_verification``), that
+      subset must validate through the same ``LQAIFrontmatter`` schema
+      the filesystem loader applies to built-ins. This is what makes a
+      user-authored ``output_format: table`` skill runnable by the
+      Tabular workflow instead of a stored-but-broken row.
     """
 
     import json  # local — only this validator needs it
@@ -267,6 +290,20 @@ def _validate_frontmatter_extra(extra: dict[str, Any]) -> dict[str, Any]:
                 "serialized ceiling for a single user skill"
             ),
         )
+
+    table_subset = {k: v for k, v in extra.items() if k in _TABLE_MODE_EXTRA_KEYS}
+    if table_subset:
+        try:
+            LQAIFrontmatter.model_validate(table_subset)
+        except ValidationError as exc:
+            problems = "; ".join(
+                f"{'.'.join(str(part) for part in err['loc']) or 'frontmatter_extra'}: {err['msg']}"
+                for err in exc.errors()
+            )
+            raise HTTPException(
+                status_code=422,
+                detail=f"frontmatter_extra is not a valid skill spec: {problems}",
+            ) from None
     return extra
 
 

--- a/api/app/skills/schema.py
+++ b/api/app/skills/schema.py
@@ -56,12 +56,17 @@ class ColumnSpec(BaseModel):
     walkthrough surfaces the need.
     """
 
-    name: str
-    """The grid column header. Required."""
+    name: str = Field(min_length=1)
+    """The grid column header. Required and non-empty (DE-297: the
+    table-mode authoring UI rejects blank names inline; the schema
+    enforces the same floor so no authoring surface can persist a
+    column the Tabular workflow cannot label)."""
 
-    query: str
+    query: str = Field(min_length=1)
     """The per-row extraction prompt instantiated against each document.
-    Required."""
+    Required and non-empty (DE-297: a blank query would dispatch an
+    empty extraction prompt per cell — rejected at the schema layer for
+    parity with the authoring UI's inline validation)."""
 
     ensemble_verification: bool | None = None
     """When ``True``, this column's cells route through Stage 4 of the

--- a/api/tests/test_tabular_user_skill_columns.py
+++ b/api/tests/test_tabular_user_skill_columns.py
@@ -1,0 +1,512 @@
+"""DE-297 — table-mode user skills: authoring validation + tabular hydration.
+
+Two halves of the same contract:
+
+* **Persisted shape** — ``POST /api/v1/user-skills`` / ``PATCH`` validate
+  ``frontmatter_extra`` table-mode keys through the SAME
+  :class:`app.skills.schema.LQAIFrontmatter` model the built-in loader
+  uses, so a user-authored ``output_format: table`` skill can never be
+  stored in a shape the built-in path would reject (zero columns, blank
+  query, tier outside 1-5). The stored extra round-trips verbatim and
+  the merged ``GET /skills`` summary surfaces ``output_format: table``
+  — which is what makes the skill pickable in the Tabular wizard.
+
+* **Hydration** — ``POST /api/v1/tabular/execute`` (and preview-cost)
+  resolve a ``skill_name`` through the D8.1b stack: the caller's
+  user-scope shadow first, then team shadow, then the built-in
+  registry. A user table skill therefore RUNS with its own columns —
+  including when it shadows a built-in at the same slug — and the
+  resolved spec (with the skill-level ``ensemble_verification``
+  fallback baked in) is snapshotted onto the execution row.
+
+Fixture pattern mirrors ``test_user_skills.py`` (fixture-skills registry
+injected via ``app.state.skill_registry``) plus the document seeding
+helper from ``test_tabular_endpoints.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.clients.gateway import get_gateway_client
+from app.db.session import get_db
+from app.main import app
+from app.models.document import Document, DocumentChunk
+from app.models.file import File as FileModel
+from app.models.tabular import TabularExecution
+from app.models.user import User
+from app.models.user_skill import UserSkill
+from app.security import create_access_token, hash_password
+from app.skills import load_registry
+from app.skills.registry import MutableSkillRegistry
+from app.skills.schema import ColumnSpec
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "skills"
+
+TABLE_COLUMNS = [
+    {"name": "Term", "query": "What is the term of this agreement?"},
+    {
+        "name": "Governing law",
+        "query": "Which law governs this agreement?",
+        "ensemble_verification": True,
+        "minimum_inference_tier": 4,
+    },
+]
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    """In-process AsyncClient with the fixture-skills registry installed."""
+
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    holder = MutableSkillRegistry(load_registry(FIXTURES_DIR))
+    prior_holder = getattr(app.state, "skill_registry", None)
+    app.state.skill_registry = holder
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    if prior_holder is None:
+        delattr(app.state, "skill_registry")
+    else:
+        app.state.skill_registry = prior_holder
+    app.dependency_overrides.pop(get_db, None)
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        email=f"table-skill-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def user_a(db_session: AsyncSession) -> User:
+    return await _make_user(db_session)
+
+
+def _bearer(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _table_skill_body(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "slug": "contract-grid",
+        "display_name": "Contract Grid",
+        "description": "Row-per-document contract comparison grid.",
+        "body": "Extract the configured columns from each document.",
+        "frontmatter_extra": {
+            "output_format": "table",
+            "columns": TABLE_COLUMNS,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+async def _make_document(db: AsyncSession, *, owner: User) -> Document:
+    """Seed a File + Document + one chunk so execute/preview can run."""
+
+    f = FileModel(
+        owner_id=owner.id,
+        filename=f"doc-{uuid.uuid4().hex[:6]}.pdf",
+        mime_type="application/pdf",
+        size_bytes=1024,
+        hash_sha256=uuid.uuid4().hex + uuid.uuid4().hex,
+        storage_path=f"table-skill-fixture/{uuid.uuid4()}",
+        ingestion_status="ready",
+    )
+    db.add(f)
+    await db.flush()
+    doc = Document(
+        file_id=f.id,
+        parser="pymupdf-only",
+        parser_version="pymupdf=1.27",
+        page_count=1,
+        character_count=64,
+        normalized_content="This agreement runs for two years under Delaware law.",
+        was_ocrd=False,
+    )
+    db.add(doc)
+    await db.flush()
+    chunk = DocumentChunk(
+        document_id=doc.id,
+        chunk_index=0,
+        content="This agreement runs for two years under Delaware law.",
+        page_start=1,
+        page_end=1,
+        char_offset_start=0,
+        char_offset_end=53,
+    )
+    db.add(chunk)
+    await db.flush()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Schema parity — ColumnSpec floors shared by built-ins and user skills
+# ---------------------------------------------------------------------------
+
+
+def test_column_spec_rejects_empty_query() -> None:
+    with pytest.raises(ValidationError):
+        ColumnSpec.model_validate({"name": "Term", "query": ""})
+
+
+def test_column_spec_rejects_empty_name() -> None:
+    with pytest.raises(ValidationError):
+        ColumnSpec.model_validate({"name": "", "query": "What is the term?"})
+
+
+# ---------------------------------------------------------------------------
+# Persisted shape — create / patch validation + round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_create_table_mode_skill_persists_and_is_wizard_pickable(
+    client: AsyncClient, user_a: User
+) -> None:
+    resp = await client.post(
+        "/api/v1/user-skills", headers=_bearer(user_a), json=_table_skill_body()
+    )
+    assert resp.status_code == 201, resp.text
+    created = resp.json()
+    assert created["frontmatter_extra"] == {
+        "output_format": "table",
+        "columns": TABLE_COLUMNS,
+    }
+
+    # Round-trip through the management GET — the edit page reloads from here.
+    detail = await client.get(f"/api/v1/user-skills/{created['id']}", headers=_bearer(user_a))
+    assert detail.status_code == 200
+    assert detail.json()["frontmatter_extra"]["columns"] == TABLE_COLUMNS
+
+    # Merged picker summary carries output_format=table — the Tabular
+    # wizard filters on exactly this field.
+    merged = await client.get("/api/v1/skills", headers=_bearer(user_a))
+    assert merged.status_code == 200
+    mine = [s for s in merged.json() if s["name"] == "contract-grid"]
+    assert len(mine) == 1
+    assert mine[0]["output_format"] == "table"
+    assert mine[0]["scope"] == "user"
+
+
+@pytest.mark.integration
+async def test_create_table_mode_without_columns_returns_422(
+    client: AsyncClient, user_a: User
+) -> None:
+    resp = await client.post(
+        "/api/v1/user-skills",
+        headers=_bearer(user_a),
+        json=_table_skill_body(frontmatter_extra={"output_format": "table"}),
+    )
+    assert resp.status_code == 422, resp.text
+    assert "columns" in resp.json()["detail"]
+
+
+@pytest.mark.integration
+async def test_create_table_mode_with_empty_columns_returns_422(
+    client: AsyncClient, user_a: User
+) -> None:
+    resp = await client.post(
+        "/api/v1/user-skills",
+        headers=_bearer(user_a),
+        json=_table_skill_body(frontmatter_extra={"output_format": "table", "columns": []}),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.integration
+async def test_create_column_with_empty_query_returns_422(
+    client: AsyncClient, user_a: User
+) -> None:
+    resp = await client.post(
+        "/api/v1/user-skills",
+        headers=_bearer(user_a),
+        json=_table_skill_body(
+            frontmatter_extra={
+                "output_format": "table",
+                "columns": [{"name": "Term", "query": ""}],
+            }
+        ),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("tier", [0, 6])
+async def test_create_column_with_out_of_range_tier_returns_422(
+    client: AsyncClient, user_a: User, tier: int
+) -> None:
+    resp = await client.post(
+        "/api/v1/user-skills",
+        headers=_bearer(user_a),
+        json=_table_skill_body(
+            frontmatter_extra={
+                "output_format": "table",
+                "columns": [
+                    {"name": "Term", "query": "What is the term?", "minimum_inference_tier": tier}
+                ],
+            }
+        ),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.integration
+async def test_create_column_missing_name_returns_422(client: AsyncClient, user_a: User) -> None:
+    resp = await client.post(
+        "/api/v1/user-skills",
+        headers=_bearer(user_a),
+        json=_table_skill_body(
+            frontmatter_extra={
+                "output_format": "table",
+                "columns": [{"query": "What is the term?"}],
+            }
+        ),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.integration
+async def test_non_table_output_format_needs_no_columns(client: AsyncClient, user_a: User) -> None:
+    """Parity with the loader: ``output_format`` other than ``table``
+    carries no columns requirement."""
+
+    resp = await client.post(
+        "/api/v1/user-skills",
+        headers=_bearer(user_a),
+        json=_table_skill_body(frontmatter_extra={"output_format": "report"}),
+    )
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.integration
+async def test_patch_validates_table_mode_and_persists_valid_spec(
+    client: AsyncClient, user_a: User
+) -> None:
+    created = (
+        await client.post("/api/v1/user-skills", headers=_bearer(user_a), json=_table_skill_body())
+    ).json()
+
+    # Invalid PATCH (table without columns) is rejected...
+    bad = await client.patch(
+        f"/api/v1/user-skills/{created['id']}",
+        headers=_bearer(user_a),
+        json={"frontmatter_extra": {"output_format": "table", "columns": []}},
+    )
+    assert bad.status_code == 422, bad.text
+
+    # ...and the stored spec is untouched.
+    detail = await client.get(f"/api/v1/user-skills/{created['id']}", headers=_bearer(user_a))
+    assert detail.json()["frontmatter_extra"]["columns"] == TABLE_COLUMNS
+
+    # A valid PATCH moves the columns.
+    new_columns = [{"name": "Renewal", "query": "Does the agreement auto-renew?"}]
+    good = await client.patch(
+        f"/api/v1/user-skills/{created['id']}",
+        headers=_bearer(user_a),
+        json={"frontmatter_extra": {"output_format": "table", "columns": new_columns}},
+    )
+    assert good.status_code == 200, good.text
+    assert good.json()["frontmatter_extra"]["columns"] == new_columns
+
+
+# ---------------------------------------------------------------------------
+# Hydration — tabular execute / preview resolve user-skill columns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_execute_resolves_user_skill_columns_and_snapshots_them(
+    client: AsyncClient, db_session: AsyncSession, user_a: User
+) -> None:
+    created = (
+        await client.post("/api/v1/user-skills", headers=_bearer(user_a), json=_table_skill_body())
+    ).json()
+    doc = await _make_document(db_session, owner=user_a)
+
+    resp = await client.post(
+        "/api/v1/tabular/execute",
+        headers=_bearer(user_a),
+        json={"document_ids": [str(doc.id)], "skill_name": created["slug"]},
+    )
+    assert resp.status_code == 202, resp.text
+    payload = resp.json()
+    assert payload["skill_name"] == "contract-grid"
+    assert [c["name"] for c in payload["columns"]] == ["Term", "Governing law"]
+
+    # Snapshot invariant (Decision C-1): the resolved spec is persisted
+    # on the execution row, not re-read from the skill at render time.
+    row = await db_session.get(TabularExecution, uuid.UUID(payload["id"]))
+    assert row is not None
+    assert [c["name"] for c in row.columns] == ["Term", "Governing law"]
+    assert row.columns[1]["minimum_inference_tier"] == 4
+    assert row.columns[1]["ensemble_verification"] is True
+
+
+@pytest.mark.integration
+async def test_execute_user_shadow_wins_over_builtin_at_same_slug(
+    client: AsyncClient, db_session: AsyncSession, user_a: User
+) -> None:
+    """A user-scope table skill at a built-in's slug resolves to the
+    USER columns. Before DE-297 this request failed with 400 — the
+    resolver only consulted the registry, and the fixture built-in
+    ``alpha-test-skill`` has no columns."""
+
+    body = _table_skill_body(slug="alpha-test-skill", display_name="Alpha (mine)")
+    created = await client.post("/api/v1/user-skills", headers=_bearer(user_a), json=body)
+    assert created.status_code == 201, created.text
+    doc = await _make_document(db_session, owner=user_a)
+
+    resp = await client.post(
+        "/api/v1/tabular/execute",
+        headers=_bearer(user_a),
+        json={"document_ids": [str(doc.id)], "skill_name": "alpha-test-skill"},
+    )
+    assert resp.status_code == 202, resp.text
+    assert [c["name"] for c in resp.json()["columns"]] == ["Term", "Governing law"]
+
+
+@pytest.mark.integration
+async def test_execute_non_table_user_skill_returns_400(
+    client: AsyncClient, db_session: AsyncSession, user_a: User
+) -> None:
+    body = _table_skill_body(slug="prose-skill", frontmatter_extra={"output_format": "report"})
+    created = await client.post("/api/v1/user-skills", headers=_bearer(user_a), json=body)
+    assert created.status_code == 201, created.text
+    doc = await _make_document(db_session, owner=user_a)
+
+    resp = await client.post(
+        "/api/v1/tabular/execute",
+        headers=_bearer(user_a),
+        json={"document_ids": [str(doc.id)], "skill_name": "prose-skill"},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "no columns" in resp.json()["detail"]
+
+
+@pytest.mark.integration
+async def test_execute_legacy_malformed_columns_returns_400_not_500(
+    client: AsyncClient, db_session: AsyncSession, user_a: User
+) -> None:
+    """Rows written before DE-297 validation could hold invalid shapes;
+    hydration surfaces them as a 400 with a re-save hint."""
+
+    row = UserSkill(
+        scope="user",
+        owner_user_id=user_a.id,
+        slug="legacy-broken-grid",
+        display_name="Legacy Broken Grid",
+        description="Pre-DE-297 row with a malformed column spec.",
+        version="1.0.0",
+        tags=[],
+        frontmatter_extra={
+            "output_format": "table",
+            "columns": [{"name": "Term", "query": "", "minimum_inference_tier": 9}],
+        },
+        body="legacy",
+    )
+    db_session.add(row)
+    await db_session.flush()
+    doc = await _make_document(db_session, owner=user_a)
+
+    resp = await client.post(
+        "/api/v1/tabular/execute",
+        headers=_bearer(user_a),
+        json={"document_ids": [str(doc.id)], "skill_name": "legacy-broken-grid"},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "invalid column spec" in resp.json()["detail"]
+
+
+@pytest.mark.integration
+async def test_skill_level_ensemble_fallback_bakes_into_user_columns(
+    client: AsyncClient, db_session: AsyncSession, user_a: User
+) -> None:
+    """A skill-level ``ensemble_verification: true`` in the extra block
+    fills columns that declared no per-column value — mirroring the
+    built-in resolution path."""
+
+    body = _table_skill_body(
+        slug="ensemble-grid",
+        frontmatter_extra={
+            "output_format": "table",
+            "ensemble_verification": True,
+            "columns": [
+                {"name": "Term", "query": "What is the term?"},
+                {"name": "Venue", "query": "What is the venue?", "ensemble_verification": False},
+            ],
+        },
+    )
+    created = await client.post("/api/v1/user-skills", headers=_bearer(user_a), json=body)
+    assert created.status_code == 201, created.text
+    doc = await _make_document(db_session, owner=user_a)
+
+    resp = await client.post(
+        "/api/v1/tabular/execute",
+        headers=_bearer(user_a),
+        json={"document_ids": [str(doc.id)], "skill_name": "ensemble-grid"},
+    )
+    assert resp.status_code == 202, resp.text
+    columns = resp.json()["columns"]
+    assert columns[0]["ensemble_verification"] is True  # inherited
+    assert columns[1]["ensemble_verification"] is False  # explicit override kept
+
+
+class _StubGateway:
+    """preview-cost only touches the ensemble-config accessor."""
+
+    async def get_citation_engine_ensemble_config(self) -> None:
+        return None
+
+
+@pytest.mark.integration
+async def test_preview_cost_resolves_user_skill_columns(
+    client: AsyncClient, db_session: AsyncSession, user_a: User
+) -> None:
+    created = (
+        await client.post("/api/v1/user-skills", headers=_bearer(user_a), json=_table_skill_body())
+    ).json()
+    docs = [await _make_document(db_session, owner=user_a) for _ in range(2)]
+
+    app.dependency_overrides[get_gateway_client] = lambda: _StubGateway()
+    try:
+        resp = await client.post(
+            "/api/v1/tabular/preview-cost",
+            headers=_bearer(user_a),
+            json={
+                "document_ids": [str(d.id) for d in docs],
+                "skill_name": created["slug"],
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_gateway_client, None)
+
+    assert resp.status_code == 200, resp.text
+    # 2 documents x 2 user-skill columns = 4 cells.
+    assert resp.json()["cells_count"] == 4

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -3983,7 +3983,9 @@ Rationale for scoping down: (a) the existing `PlaybookExecuteModal` already prov
 
 **When to ship:** Bundle into the v0.3.1 quickstart-corpus-expansion patch alongside the DPA / MSA-Commercial-Purchase sample corpora (already DE-tracked per [`project_lq_ai_status.md`](#) memory). Project source on its own is a 30-min lift and may justify its own micro-PR if a Tabular operator surfaces the need before v0.3.1.
 
-#### DE-297 — Table-mode skill authoring UI in `/skills/new` (column editor) (deferred from M3-C3)
+#### DE-297 — Table-mode skill authoring UI in `/skills/new` (column editor) (deferred from M3-C3) — ✓ Shipped
+
+**Shipped (v0.4 cycle):** mode selector (`Prose | Table`) in the Skill Creator wizard and on `/skills/[id]/edit`; `ColumnEditor.svelte` column list (name, query textarea, `ensemble_verification` as an Inherit/On/Off select — tri-state rather than the sketched checkbox, to preserve the backend's `None` = inherit semantics — `minimum_inference_tier` 1–5 dropdown, up/down reorder buttons in place of the sketched drag-handle, add/remove, min-one-column + inline empty-query validation). Persisted as `frontmatter_extra.output_format='table'` + `columns`; `POST/PATCH /user-skills` now validates that subset through the same `LQAIFrontmatter` schema built-ins parse with, and the tabular resolver (`/tabular/preview-cost`, `/tabular/execute`) resolves `skill_name` through the D8.1b stack (user shadow > team shadow > built-in) so user-authored table skills run with their own columns. Cypress walkthrough added to `wave-d2-skill-creator.cy.ts`.
 
 **Priority:** P2 (operators can fork built-in reference skills via filesystem; in-app authoring is convenience, not capability) · **Effort:** M (a structured column editor with per-column query / `ensemble_verification` / `minimum_inference_tier` fields, save-back-to-user-scope flow)
 

--- a/docs/api/backend-openapi.generated.yaml
+++ b/docs/api/backend-openapi.generated.yaml
@@ -13112,7 +13112,11 @@ paths:
 
         selection. The document-ownership check is enforced at execute
 
-        time; preview doesn''t load the documents.'
+        time; preview doesn''t load the documents. ``user`` also drives the
+
+        DE-297 skill-name resolution (the caller''s user/team shadows take
+
+        precedence over a built-in at the same slug).'
       operationId: preview_tabular_cost_api_v1_tabular_preview_cost_post
       requestBody:
         content:

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -2737,6 +2737,10 @@ paths:
         breakdown (Phase C prep doc Decision C-5).
 
         Either ``skill_name`` or ``columns`` is required (not both).
+        ``skill_name`` resolves through the D8.1b stack (DE-297): the
+        caller's user-scope shadow first, then the newest accessible
+        team-scope shadow (columns read from ``frontmatter_extra``),
+        then the live skill registry built-in (``lq_ai.columns``).
         The estimator uses a rolling-average over recent
         ``purpose='tabular_extraction'`` routing-log rows; cold-start
         deployments see the conservative default per-cell cost until
@@ -2753,9 +2757,9 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/TabularPreviewCostResponse'}
         '400':
-          description: Both ``skill_name`` and ``columns`` provided, or skill has no columns.
+          description: Both ``skill_name`` and ``columns`` provided, or skill has no columns / an invalid stored column spec.
         '404':
-          description: ``skill_name`` not found in the live skill registry.
+          description: ``skill_name`` matches neither a user/team shadow nor a registry built-in.
         '422':
           description: Validation error (empty ``document_ids``, malformed column spec, etc.).
         '401':
@@ -2778,6 +2782,11 @@ paths:
         ``document_ids`` (admins bypass). Cross-user / missing /
         soft-deleted documents collapse into 404.
 
+        ``skill_name`` resolves through the D8.1b stack (DE-297):
+        user shadow > team shadow > registry built-in — so a
+        user-authored table-mode skill runs with its own columns,
+        including when it shadows a built-in at the same slug.
+
         Execution completion does NOT mean every cell is correct —
         the result view's per-cell citation drawer is where the
         user-attorney validates extractions before relying on them.
@@ -2793,7 +2802,7 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/TabularExecution'}
         '400':
-          description: Both ``skill_name`` and ``columns`` provided, or skill has no columns.
+          description: Both ``skill_name`` and ``columns`` provided, or skill has no columns / an invalid stored column spec.
         '404':
           description: One or more documents not found / not authorized, or skill not found.
         '422':
@@ -8181,7 +8190,21 @@ components:
         body: {type: string, minLength: 1, maxLength: 200000}
         version: {type: string, default: '1.0.0', maxLength: 50}
         tags: {type: array, items: {type: string}, maxItems: 20}
-        frontmatter_extra: {type: object, additionalProperties: true}
+        frontmatter_extra:
+          type: object
+          additionalProperties: true
+          description: |
+            Arbitrary ``lq_ai:`` extension keys, EXCEPT the table-mode
+            authoring subset (DE-297): when ``output_format`` /
+            ``columns`` / ``minimum_inference_tier`` /
+            ``ensemble_verification`` are present they are validated
+            against the same schema built-in SKILL.md frontmatter
+            parses with — ``output_format: 'table'`` requires a
+            non-empty ``columns`` list, each column needs a non-empty
+            ``name`` + ``query``, and per-column
+            ``minimum_inference_tier`` must be 1–5. 422 with a
+            ``frontmatter_extra is not a valid skill spec: ...`` detail
+            on violation.
         scope:
           type: string
           enum: [user, team]
@@ -8220,7 +8243,14 @@ components:
         body: {type: string, minLength: 1, maxLength: 200000}
         version: {type: string, maxLength: 50}
         tags: {type: array, items: {type: string}, maxItems: 20}
-        frontmatter_extra: {type: object, additionalProperties: true}
+        frontmatter_extra:
+          type: object
+          additionalProperties: true
+          description: |
+            Same table-mode validation as on create (DE-297): the
+            ``output_format`` / ``columns`` / ``minimum_inference_tier``
+            / ``ensemble_verification`` subset must parse as a valid
+            skill spec; 422 otherwise.
         slash_alias:
           type: string
           nullable: true

--- a/web/cypress/e2e/wave-d2-skill-creator.cy.ts
+++ b/web/cypress/e2e/wave-d2-skill-creator.cy.ts
@@ -113,6 +113,54 @@ describe('Wave D.2 — Skill Creator', () => {
 		cy.contains(/use it/i, { timeout: 10000 }).should('exist');
 	});
 
+	it('2b. Table-mode wizard (DE-297): pick Table → column list → save → frontmatter_extra persisted', () => {
+		const ts = Date.now();
+		const displayName = `Table Grid Skill ${ts}`;
+		const expectedSlug = `table-grid-skill-${ts}`;
+
+		cy.visit('/lq-ai/skills/new');
+
+		// Sections 1-2.
+		cy.get('[data-testid="lq-ai-wizard-display-name"]').type(displayName);
+		cy.get('[data-testid="lq-ai-wizard-description"]').type(
+			'DE-297 Cypress fixture: table-mode skill.'
+		);
+
+		// Section 3 — switch to table mode; the body editor is swapped for
+		// the column list (one blank column row is pre-seeded).
+		cy.get('[data-testid="lq-ai-wizard-mode-table"]').check();
+		cy.get('[data-testid="lq-ai-wizard-body"]').should('not.exist');
+		cy.get('[data-testid="lq-ai-column-row"]').should('have.length', 1);
+
+		// Inline empty-query validation: blur the empty query field.
+		cy.get('[data-testid="lq-ai-column-query"]').first().focus();
+		cy.get('[data-testid="lq-ai-column-query"]').first().blur();
+		cy.get('[data-testid="lq-ai-column-query-error"]').should('exist');
+
+		// Fill the first column and add a second.
+		cy.get('[data-testid="lq-ai-column-name"]').first().type('Term');
+		cy.get('[data-testid="lq-ai-column-query"]').first().type('What is the term?');
+		cy.get('[data-testid="lq-ai-column-query-error"]').should('not.exist');
+		cy.get('[data-testid="lq-ai-column-add"]').click();
+		cy.get('[data-testid="lq-ai-column-row"]').should('have.length', 2);
+		cy.get('[data-testid="lq-ai-column-name"]').eq(1).type('Governing law');
+		cy.get('[data-testid="lq-ai-column-query"]').eq(1).type('Which law governs?');
+
+		// Save; the POST body must carry output_format=table + both columns.
+		cy.intercept('POST', '/api/v1/user-skills').as('createTableSkill');
+		cy.get('[data-testid="lq-ai-wizard-save"]').click();
+		cy.wait('@createTableSkill').then((interception) => {
+			expect(interception.response?.statusCode).to.eq(201);
+			const extra = interception.request.body.frontmatter_extra;
+			expect(extra.output_format).to.eq('table');
+			expect(extra.columns.map((c: { name: string }) => c.name)).to.deep.eq([
+				'Term',
+				'Governing law'
+			]);
+		});
+		cy.url({ timeout: 10000 }).should('include', `/lq-ai/skills/${expectedSlug}`);
+	});
+
 	it('3. Fork flow: detail page → fork → wizard pre-populated → save', () => {
 		// Timestamp suffix makes the forked slug unique across reruns so the
 		// uniqueSlug dedup in skills/new/+page.svelte doesn't silently append -2.

--- a/web/src/lib/lq-ai/__tests__/SkillWizard.test.ts
+++ b/web/src/lib/lq-ai/__tests__/SkillWizard.test.ts
@@ -26,9 +26,21 @@ import {
 	buildPayload,
 	serializeDraft,
 	loadDraft,
+	DEFAULT_TABLE_BODY,
 	type WizardFormState
 } from '../components/SkillWizard.svelte';
+import type { EditableColumn } from '../skills/tableColumns';
 import { kebab } from '../util/slug';
+
+function makeColumn(overrides: Partial<EditableColumn> = {}): EditableColumn {
+	return {
+		name: 'Term',
+		query: 'What is the term of this agreement?',
+		ensemble_verification: null,
+		minimum_inference_tier: null,
+		...overrides
+	};
+}
 
 function makeState(overrides: Partial<WizardFormState> = {}): WizardFormState {
 	return {
@@ -41,6 +53,8 @@ function makeState(overrides: Partial<WizardFormState> = {}): WizardFormState {
 		version: '1.0.0',
 		scope: 'user',
 		ownerTeamId: '',
+		outputMode: 'prose',
+		columns: [makeColumn()],
 		saving: false,
 		...overrides
 	};
@@ -204,6 +218,37 @@ describe('SkillWizard.canSave', () => {
 	it('is false while saving is in flight', () => {
 		expect(canSave(makeState({ saving: true }))).toBe(false);
 	});
+
+	// --- DE-297 table mode -------------------------------------------------
+
+	it('table mode: valid columns satisfy the gate even with an empty body', () => {
+		expect(canSave(makeState({ outputMode: 'table', body: '' }))).toBe(true);
+	});
+
+	it('table mode: false with zero columns (backend min-one-column parity)', () => {
+		expect(canSave(makeState({ outputMode: 'table', columns: [] }))).toBe(false);
+	});
+
+	it('table mode: false when a column query is empty', () => {
+		expect(
+			canSave(makeState({ outputMode: 'table', columns: [makeColumn({ query: '  ' })] }))
+		).toBe(false);
+	});
+
+	it('table mode: false when a column tier is out of range', () => {
+		expect(
+			canSave(
+				makeState({
+					outputMode: 'table',
+					columns: [makeColumn({ minimum_inference_tier: 6 })]
+				})
+			)
+		).toBe(false);
+	});
+
+	it('prose mode ignores invalid columns state entirely', () => {
+		expect(canSave(makeState({ outputMode: 'prose', columns: [] }))).toBe(true);
+	});
 });
 
 describe('SkillWizard.buildPayload', () => {
@@ -288,6 +333,55 @@ describe('SkillWizard.buildPayload', () => {
 		const payload = buildPayload(makeState({ version: '2.1.0' }), null);
 		expect(payload.version).toBe('2.1.0');
 	});
+
+	// --- DE-297 table mode -------------------------------------------------
+
+	it('prose mode sends no frontmatter_extra', () => {
+		expect(buildPayload(makeState(), null).frontmatter_extra).toBeUndefined();
+	});
+
+	it('table mode persists frontmatter_extra.output_format=table + serialized columns', () => {
+		const payload = buildPayload(
+			makeState({
+				outputMode: 'table',
+				columns: [
+					makeColumn(),
+					makeColumn({
+						name: 'Governing law',
+						query: 'Which law governs?',
+						ensemble_verification: true,
+						minimum_inference_tier: 4
+					})
+				]
+			}),
+			null
+		);
+		expect(payload.frontmatter_extra).toEqual({
+			output_format: 'table',
+			columns: [
+				{ name: 'Term', query: 'What is the term of this agreement?' },
+				{
+					name: 'Governing law',
+					query: 'Which law governs?',
+					ensemble_verification: true,
+					minimum_inference_tier: 4
+				}
+			]
+		});
+	});
+
+	it('table mode falls back to the documented placeholder body when body is blank', () => {
+		const payload = buildPayload(makeState({ outputMode: 'table', body: '   ' }), null);
+		expect(payload.body).toBe(DEFAULT_TABLE_BODY);
+	});
+
+	it('table mode keeps an author-written body verbatim', () => {
+		const payload = buildPayload(
+			makeState({ outputMode: 'table', body: '# My grid notes' }),
+			null
+		);
+		expect(payload.body).toBe('# My grid notes');
+	});
 });
 
 describe('SkillWizard.serializeDraft / loadDraft (round-trip)', () => {
@@ -323,6 +417,18 @@ describe('SkillWizard.serializeDraft / loadDraft (round-trip)', () => {
 			version: '1.0.0',
 			scope: 'user',
 			ownerTeamId: ''
+		});
+	});
+
+	it('round-trips the DE-297 table-mode state (outputMode + columns)', () => {
+		const state = makeState({
+			outputMode: 'table',
+			columns: [makeColumn({ minimum_inference_tier: 3 })]
+		});
+		const restored = loadDraft(JSON.stringify(serializeDraft(state)));
+		expect(restored).toMatchObject({
+			outputMode: 'table',
+			columns: [makeColumn({ minimum_inference_tier: 3 })]
 		});
 	});
 

--- a/web/src/lib/lq-ai/__tests__/builtinsBrowser.test.ts
+++ b/web/src/lib/lq-ai/__tests__/builtinsBrowser.test.ts
@@ -1,0 +1,196 @@
+/**
+ * DE-298 — pure-helper tests for the /lq-ai/skills built-ins browser:
+ * output-format chip filter (+ URL-param round-trip), recently-used
+ * sort with never-used alphabetical fallback, and fork-seed column
+ * extraction from a source skill's `content_yaml`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	FORMAT_ALL,
+	FORMAT_PROSE,
+	columnsFromContentYaml,
+	forkTableSeed,
+	formatChips,
+	formatFilterFromParam,
+	matchesFormat,
+	normalizeFormat,
+	sortFromParam,
+	sortSkillRows
+} from '../skills/builtinsBrowser';
+
+describe('builtinsBrowser helpers (DE-298)', () => {
+	describe('normalizeFormat', () => {
+		it('buckets absent / blank formats as prose', () => {
+			expect(normalizeFormat(undefined)).toBe(FORMAT_PROSE);
+			expect(normalizeFormat(null)).toBe(FORMAT_PROSE);
+			expect(normalizeFormat('   ')).toBe(FORMAT_PROSE);
+		});
+
+		it('lowercases and trims declared formats', () => {
+			expect(normalizeFormat(' Table ')).toBe('table');
+			expect(normalizeFormat('report')).toBe('report');
+		});
+	});
+
+	describe('formatChips', () => {
+		it('derives distinct chips from the rows present, "all" first then alphabetical', () => {
+			expect(formatChips(['table', undefined, 'report', 'table', null])).toEqual([
+				FORMAT_ALL,
+				FORMAT_PROSE,
+				'report',
+				'table'
+			]);
+		});
+
+		it('empty catalog yields only the "all" chip', () => {
+			expect(formatChips([])).toEqual([FORMAT_ALL]);
+		});
+	});
+
+	describe('formatFilterFromParam (URL round-trip)', () => {
+		const chips = [FORMAT_ALL, FORMAT_PROSE, 'table'];
+
+		it('absent param means no filter', () => {
+			expect(formatFilterFromParam(null, chips)).toBe(FORMAT_ALL);
+		});
+
+		it('a known chip value round-trips (case-insensitively)', () => {
+			expect(formatFilterFromParam('table', chips)).toBe('table');
+			expect(formatFilterFromParam(' TABLE ', chips)).toBe('table');
+		});
+
+		it('a stale / unknown param degrades to "all", never an empty page', () => {
+			expect(formatFilterFromParam('report', chips)).toBe(FORMAT_ALL);
+			expect(formatFilterFromParam('nonsense', chips)).toBe(FORMAT_ALL);
+		});
+	});
+
+	describe('matchesFormat', () => {
+		it('"all" passes everything', () => {
+			expect(matchesFormat('table', FORMAT_ALL)).toBe(true);
+			expect(matchesFormat(undefined, FORMAT_ALL)).toBe(true);
+		});
+
+		it('a specific chip matches only its bucket, with prose catching undeclared', () => {
+			expect(matchesFormat('table', 'table')).toBe(true);
+			expect(matchesFormat('report', 'table')).toBe(false);
+			expect(matchesFormat(undefined, FORMAT_PROSE)).toBe(true);
+			expect(matchesFormat('table', FORMAT_PROSE)).toBe(false);
+		});
+	});
+
+	describe('sortFromParam', () => {
+		it('recognises "name"; everything else defaults to "recent"', () => {
+			expect(sortFromParam('name')).toBe('name');
+			expect(sortFromParam('recent')).toBe('recent');
+			expect(sortFromParam(null)).toBe('recent');
+			expect(sortFromParam('garbage')).toBe('recent');
+		});
+	});
+
+	describe('sortSkillRows', () => {
+		const rows = [
+			{ slug: 'zeta', title: 'Zeta' },
+			{ slug: 'alpha', title: 'Alpha' },
+			{ slug: 'mid', title: 'Mid' }
+		];
+		const slugOf = (r: { slug: string }) => r.slug;
+		const titleOf = (r: { title: string }) => r.title;
+
+		it('recent sort orders by recents position, never-used fall back alphabetical', () => {
+			const sorted = sortSkillRows(rows, 'recent', ['mid', 'zeta'], slugOf, titleOf);
+			expect(sorted.map(slugOf)).toEqual(['mid', 'zeta', 'alpha']);
+		});
+
+		it('with no recents, recent sort degrades to alphabetical-by-title', () => {
+			const sorted = sortSkillRows(rows, 'recent', [], slugOf, titleOf);
+			expect(sorted.map(slugOf)).toEqual(['alpha', 'mid', 'zeta']);
+		});
+
+		it('name sort is alphabetical regardless of recents', () => {
+			const sorted = sortSkillRows(rows, 'name', ['zeta'], slugOf, titleOf);
+			expect(sorted.map(slugOf)).toEqual(['alpha', 'mid', 'zeta']);
+		});
+
+		it('does not mutate the input array', () => {
+			const input = [...rows];
+			sortSkillRows(input, 'recent', ['zeta'], slugOf, titleOf);
+			expect(input).toEqual(rows);
+		});
+	});
+
+	// The shape a built-in table skill actually carries on the wire —
+	// lq_ai.columns with block-scalar queries and per-column overrides
+	// (mirrors skills/contract-snapshot/SKILL.md).
+	const BUILTIN_YAML = [
+		'name: contract-snapshot',
+		'description: Compare terms across contracts.',
+		'lq_ai:',
+		'  title: Contract Snapshot',
+		'  version: 1.0.0',
+		'  output_format: table',
+		'  columns:',
+		'    - name: Term',
+		'      query: |',
+		'        What is the term length of this agreement?',
+		'    - name: Survival',
+		'      query: What survives termination?',
+		'      ensemble_verification: true',
+		'    - name: Governing Law',
+		'      query: What law governs?',
+		'      minimum_inference_tier: 3',
+		''
+	].join('\n');
+
+	describe('columnsFromContentYaml', () => {
+		it('extracts lq_ai.columns with overrides normalized to EditableColumn rows', () => {
+			const cols = columnsFromContentYaml(BUILTIN_YAML);
+			expect(cols).not.toBeNull();
+			expect(cols).toHaveLength(3);
+			expect(cols?.[0]).toEqual({
+				name: 'Term',
+				query: 'What is the term length of this agreement?\n',
+				ensemble_verification: null,
+				minimum_inference_tier: null
+			});
+			expect(cols?.[1].ensemble_verification).toBe(true);
+			expect(cols?.[2].minimum_inference_tier).toBe(3);
+		});
+
+		it('accepts a top-level columns key as fallback', () => {
+			const cols = columnsFromContentYaml(
+				'name: x\ncolumns:\n  - name: A\n    query: Q\n'
+			);
+			expect(cols).toEqual([
+				{ name: 'A', query: 'Q', ensemble_verification: null, minimum_inference_tier: null }
+			]);
+		});
+
+		it('returns null for absent input, unparseable YAML, and column-less frontmatter', () => {
+			expect(columnsFromContentYaml(null)).toBeNull();
+			expect(columnsFromContentYaml('')).toBeNull();
+			expect(columnsFromContentYaml(': not: valid: [yaml')).toBeNull();
+			expect(columnsFromContentYaml('name: x\nlq_ai:\n  title: X\n')).toBeNull();
+			expect(columnsFromContentYaml('name: x\nlq_ai:\n  columns: []\n')).toBeNull();
+		});
+	});
+
+	describe('forkTableSeed', () => {
+		it('seeds table mode + columns for a table-mode source', () => {
+			const seed = forkTableSeed({ output_format: 'table', content_yaml: BUILTIN_YAML });
+			expect(seed).not.toBeNull();
+			expect(seed?.outputMode).toBe('table');
+			expect(seed?.columns.map((c) => c.name)).toEqual(['Term', 'Survival', 'Governing Law']);
+		});
+
+		it('returns null for prose sources (fork opens in prose mode unchanged)', () => {
+			expect(forkTableSeed({ output_format: undefined, content_yaml: BUILTIN_YAML })).toBeNull();
+			expect(forkTableSeed({ output_format: 'report', content_yaml: BUILTIN_YAML })).toBeNull();
+		});
+
+		it('returns null when a table source has no recoverable columns', () => {
+			expect(forkTableSeed({ output_format: 'table', content_yaml: 'name: x\n' })).toBeNull();
+		});
+	});
+});

--- a/web/src/lib/lq-ai/__tests__/tableColumns.test.ts
+++ b/web/src/lib/lq-ai/__tests__/tableColumns.test.ts
@@ -1,0 +1,203 @@
+/**
+ * DE-297 — unit tests for the table-mode column helpers.
+ *
+ * These helpers carry the backend-parity contract for skill authoring:
+ * validation mirrors `app.skills.schema.LQAIFrontmatter` /
+ * `ColumnSpec` (min one column for table mode, non-empty name + query,
+ * tier 1-5), and serialization produces exactly the
+ * `frontmatter_extra.{output_format, columns}` shape
+ * `POST /api/v1/user-skills` validates and the tabular resolver
+ * hydrates.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	EMPTY_NAME_ERROR,
+	EMPTY_QUERY_ERROR,
+	MIN_ONE_COLUMN_ERROR,
+	TIER_RANGE_ERROR,
+	buildFrontmatterExtra,
+	columnsFromRaw,
+	modeFromExtra,
+	moveColumn,
+	newEditableColumn,
+	serializeColumns,
+	validateColumns,
+	type EditableColumn
+} from '../skills/tableColumns';
+
+function col(overrides: Partial<EditableColumn> = {}): EditableColumn {
+	return {
+		name: 'Term',
+		query: 'What is the term of this agreement?',
+		ensemble_verification: null,
+		minimum_inference_tier: null,
+		...overrides
+	};
+}
+
+describe('validateColumns', () => {
+	it('accepts a well-formed single column', () => {
+		const v = validateColumns([col()]);
+		expect(v.valid).toBe(true);
+		expect(v.listError).toBeNull();
+		expect(v.columnErrors).toEqual([{}]);
+	});
+
+	it('rejects an empty list (backend _table_mode_requires_columns parity)', () => {
+		const v = validateColumns([]);
+		expect(v.valid).toBe(false);
+		expect(v.listError).toBe(MIN_ONE_COLUMN_ERROR);
+	});
+
+	it('flags an empty query inline on the offending column only', () => {
+		const v = validateColumns([col(), col({ query: '   ' })]);
+		expect(v.valid).toBe(false);
+		expect(v.columnErrors[0]).toEqual({});
+		expect(v.columnErrors[1].query).toBe(EMPTY_QUERY_ERROR);
+	});
+
+	it('flags an empty name', () => {
+		const v = validateColumns([col({ name: '' })]);
+		expect(v.valid).toBe(false);
+		expect(v.columnErrors[0].name).toBe(EMPTY_NAME_ERROR);
+	});
+
+	it('rejects tiers outside 1-5 and non-integer tiers', () => {
+		for (const tier of [0, 6, 2.5]) {
+			const v = validateColumns([col({ minimum_inference_tier: tier })]);
+			expect(v.valid).toBe(false);
+			expect(v.columnErrors[0].tier).toBe(TIER_RANGE_ERROR);
+		}
+	});
+
+	it('accepts every in-range tier and null (inherit)', () => {
+		for (const tier of [1, 2, 3, 4, 5, null]) {
+			expect(validateColumns([col({ minimum_inference_tier: tier })]).valid).toBe(true);
+		}
+	});
+});
+
+describe('serializeColumns', () => {
+	it('trims name and query', () => {
+		const [c] = serializeColumns([col({ name: '  Term  ', query: '  q  ' })]);
+		expect(c).toEqual({ name: 'Term', query: 'q' });
+	});
+
+	it('drops null overrides (absent key = inherit, matching SKILL.md frontmatter)', () => {
+		const [c] = serializeColumns([col()]);
+		expect('ensemble_verification' in c).toBe(false);
+		expect('minimum_inference_tier' in c).toBe(false);
+	});
+
+	it('keeps explicit overrides, including false', () => {
+		const [c] = serializeColumns([
+			col({ ensemble_verification: false, minimum_inference_tier: 4 })
+		]);
+		expect(c.ensemble_verification).toBe(false);
+		expect(c.minimum_inference_tier).toBe(4);
+	});
+});
+
+describe('moveColumn', () => {
+	const three = [col({ name: 'A' }), col({ name: 'B' }), col({ name: 'C' })];
+
+	it('moves a column up', () => {
+		expect(moveColumn(three, 1, -1).map((c) => c.name)).toEqual(['B', 'A', 'C']);
+	});
+
+	it('moves a column down', () => {
+		expect(moveColumn(three, 1, 1).map((c) => c.name)).toEqual(['A', 'C', 'B']);
+	});
+
+	it('returns the same reference on boundary moves (no-op)', () => {
+		expect(moveColumn(three, 0, -1)).toBe(three);
+		expect(moveColumn(three, 2, 1)).toBe(three);
+	});
+
+	it('does not mutate the input array', () => {
+		const before = three.map((c) => c.name);
+		moveColumn(three, 0, 1);
+		expect(three.map((c) => c.name)).toEqual(before);
+	});
+});
+
+describe('modeFromExtra', () => {
+	it('reads table mode', () => {
+		expect(modeFromExtra({ output_format: 'table' })).toBe('table');
+	});
+
+	it('treats anything else as prose', () => {
+		expect(modeFromExtra({ output_format: 'report' })).toBe('prose');
+		expect(modeFromExtra({})).toBe('prose');
+		expect(modeFromExtra(null)).toBe('prose');
+		expect(modeFromExtra(undefined)).toBe('prose');
+	});
+});
+
+describe('columnsFromRaw', () => {
+	it('parses a persisted columns array, normalizing missing overrides to null', () => {
+		const parsed = columnsFromRaw([
+			{ name: 'Term', query: 'q' },
+			{ name: 'Law', query: 'q2', ensemble_verification: true, minimum_inference_tier: 4 }
+		]);
+		expect(parsed).toEqual([
+			{ name: 'Term', query: 'q', ensemble_verification: null, minimum_inference_tier: null },
+			{ name: 'Law', query: 'q2', ensemble_verification: true, minimum_inference_tier: 4 }
+		]);
+	});
+
+	it('returns null for non-array input', () => {
+		expect(columnsFromRaw(undefined)).toBeNull();
+		expect(columnsFromRaw('columns')).toBeNull();
+		expect(columnsFromRaw({ name: 'x' })).toBeNull();
+	});
+
+	it('skips non-object rows and tolerates wrong-typed fields', () => {
+		const parsed = columnsFromRaw([
+			'junk',
+			null,
+			{ name: 42, query: ['not a string'], minimum_inference_tier: 'four' }
+		]);
+		expect(parsed).toEqual([
+			{ name: '', query: '', ensemble_verification: null, minimum_inference_tier: null }
+		]);
+	});
+
+	it('round-trips serializeColumns output', () => {
+		const original = [col({ ensemble_verification: true, minimum_inference_tier: 2 })];
+		expect(columnsFromRaw(serializeColumns(original))).toEqual(original);
+	});
+});
+
+describe('buildFrontmatterExtra', () => {
+	it('sets output_format + columns for table mode, preserving unrelated keys', () => {
+		const extra = buildFrontmatterExtra({ jurisdiction: 'us' }, 'table', [col()]);
+		expect(extra.jurisdiction).toBe('us');
+		expect(extra.output_format).toBe('table');
+		expect(extra.columns).toEqual(serializeColumns([col()]));
+	});
+
+	it('strips table keys when switching back to prose', () => {
+		const prev = { output_format: 'table', columns: [{ name: 'x', query: 'y' }], icon: 'i' };
+		expect(buildFrontmatterExtra(prev, 'prose', [])).toEqual({ icon: 'i' });
+	});
+
+	it('leaves a hand-set non-table output_format alone in prose mode', () => {
+		const prev = { output_format: 'report' };
+		expect(buildFrontmatterExtra(prev, 'prose', [])).toEqual({ output_format: 'report' });
+	});
+
+	it('does not mutate the previous extra object', () => {
+		const prev: Record<string, unknown> = { output_format: 'table', columns: [] };
+		buildFrontmatterExtra(prev, 'prose', []);
+		expect(prev).toEqual({ output_format: 'table', columns: [] });
+	});
+
+	it('is idempotent for an unchanged prose skill (no spurious PATCH diff)', () => {
+		const prev = { jurisdiction: 'us' };
+		expect(JSON.stringify(buildFrontmatterExtra(prev, 'prose', [newEditableColumn()]))).toBe(
+			JSON.stringify(prev)
+		);
+	});
+});

--- a/web/src/lib/lq-ai/components/ColumnEditor.svelte
+++ b/web/src/lib/lq-ai/components/ColumnEditor.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+	/**
+	 * ColumnEditor — DE-297 table-mode column list for skill authoring.
+	 *
+	 * Used by `SkillWizard.svelte` (/lq-ai/skills/new) and the user-skill
+	 * edit page when the author picks `output_format: table`. Each row is
+	 * one backend `ColumnSpec`: name, per-document extraction query, and
+	 * the two optional overrides (`ensemble_verification`,
+	 * `minimum_inference_tier` 1-5, both defaulting to "inherit" = the
+	 * backend's `None`).
+	 *
+	 * Contract with the parent:
+	 * - `bind:columns` — the parent owns the array; every edit reassigns
+	 *   it so Svelte reactivity (and the parent's validation gate)
+	 *   re-runs.
+	 * - `showErrors` — when true, all inline errors render regardless of
+	 *   touch state (the parent flips it on a save attempt). Before
+	 *   that, a field's error shows only after the user leaves the field
+	 *   (matches the SkillWizard slash-alias validate-on-blur idiom).
+	 *
+	 * Validation mirrors — never widens — the backend schema; see the
+	 * header of `../skills/tableColumns.ts`.
+	 */
+	import {
+		newEditableColumn,
+		moveColumn,
+		validateColumns,
+		type EditableColumn
+	} from '../skills/tableColumns';
+
+	export let columns: EditableColumn[] = [];
+	export let showErrors = false;
+
+	/** Per-row-index touch state; reset on structural changes because
+	 * indices shift when rows move or vanish. */
+	let touched: Record<number, { name?: boolean; query?: boolean }> = {};
+
+	$: validation = validateColumns(columns);
+
+	function addColumn(): void {
+		columns = [...columns, newEditableColumn()];
+	}
+
+	function removeColumn(index: number): void {
+		columns = columns.filter((_, i) => i !== index);
+		touched = {};
+	}
+
+	function move(index: number, delta: -1 | 1): void {
+		const next = moveColumn(columns, index, delta);
+		if (next !== columns) {
+			columns = next;
+			touched = {};
+		}
+	}
+
+	function setField(index: number, patch: Partial<EditableColumn>): void {
+		columns = columns.map((col, i) => (i === index ? { ...col, ...patch } : col));
+	}
+
+	function markTouched(index: number, field: 'name' | 'query'): void {
+		touched = { ...touched, [index]: { ...touched[index], [field]: true } };
+	}
+
+	function errorFor(index: number, field: 'name' | 'query'): string | null {
+		if (!showErrors && !touched[index]?.[field]) return null;
+		return validation.columnErrors[index]?.[field] ?? null;
+	}
+</script>
+
+<div class="lq-column-editor" data-testid="lq-ai-column-editor">
+	<!-- The min-one-column rule is structural, not field-level — surface it
+	     immediately (there is no field to blur), matching the backend's
+	     _table_mode_requires_columns rejection. -->
+	{#if validation.listError}
+		<p class="error list-error" data-testid="lq-ai-column-list-error">
+			{validation.listError}
+		</p>
+	{/if}
+
+	{#each columns as col, i (i)}
+		<fieldset class="column-row" data-testid="lq-ai-column-row">
+			<div class="row-head">
+				<span class="row-index">Column {i + 1}</span>
+				<span class="row-actions">
+					<button
+						type="button"
+						class="ghost"
+						disabled={i === 0}
+						aria-label="move column {i + 1} up"
+						data-testid="lq-ai-column-up"
+						on:click={() => move(i, -1)}
+					>
+						↑
+					</button>
+					<button
+						type="button"
+						class="ghost"
+						disabled={i === columns.length - 1}
+						aria-label="move column {i + 1} down"
+						data-testid="lq-ai-column-down"
+						on:click={() => move(i, 1)}
+					>
+						↓
+					</button>
+					<button
+						type="button"
+						class="ghost danger"
+						aria-label="remove column {i + 1}"
+						data-testid="lq-ai-column-remove"
+						on:click={() => removeColumn(i)}
+					>
+						Remove
+					</button>
+				</span>
+			</div>
+
+			<label>
+				<span>Name <em class="required">*</em></span>
+				<input
+					type="text"
+					value={col.name}
+					placeholder="Governing law"
+					aria-label="column {i + 1} name"
+					data-testid="lq-ai-column-name"
+					on:input={(e) => setField(i, { name: e.currentTarget.value })}
+					on:blur={() => markTouched(i, 'name')}
+				/>
+				{#if errorFor(i, 'name')}
+					<span class="error inline-error" data-testid="lq-ai-column-name-error">
+						{errorFor(i, 'name')}
+					</span>
+				{/if}
+			</label>
+
+			<label>
+				<span>Extraction query <em class="required">*</em></span>
+				<textarea
+					value={col.query}
+					rows="3"
+					placeholder="Which law governs this agreement? Quote the operative clause."
+					aria-label="column {i + 1} query"
+					data-testid="lq-ai-column-query"
+					on:input={(e) => setField(i, { query: e.currentTarget.value })}
+					on:blur={() => markTouched(i, 'query')}
+				></textarea>
+				{#if errorFor(i, 'query')}
+					<span class="error inline-error" data-testid="lq-ai-column-query-error">
+						{errorFor(i, 'query')}
+					</span>
+				{/if}
+			</label>
+
+			<div class="overrides">
+				<label>
+					<span>Ensemble verification</span>
+					<select
+						value={col.ensemble_verification === null
+							? ''
+							: String(col.ensemble_verification)}
+						aria-label="column {i + 1} ensemble verification"
+						data-testid="lq-ai-column-ensemble"
+						on:change={(e) =>
+							setField(i, {
+								ensemble_verification:
+									e.currentTarget.value === '' ? null : e.currentTarget.value === 'true'
+							})}
+					>
+						<option value="">Inherit (default)</option>
+						<option value="true">On</option>
+						<option value="false">Off</option>
+					</select>
+				</label>
+				<label>
+					<span>Minimum inference tier</span>
+					<select
+						value={col.minimum_inference_tier === null
+							? ''
+							: String(col.minimum_inference_tier)}
+						aria-label="column {i + 1} minimum inference tier"
+						data-testid="lq-ai-column-tier"
+						on:change={(e) =>
+							setField(i, {
+								minimum_inference_tier:
+									e.currentTarget.value === '' ? null : Number(e.currentTarget.value)
+							})}
+					>
+						<option value="">Inherit (default)</option>
+						{#each [1, 2, 3, 4, 5] as tier}
+							<option value={String(tier)}>Tier {tier}</option>
+						{/each}
+					</select>
+				</label>
+			</div>
+		</fieldset>
+	{/each}
+
+	<button
+		type="button"
+		class="ghost add-column"
+		data-testid="lq-ai-column-add"
+		on:click={addColumn}
+	>
+		+ Add column
+	</button>
+</div>
+
+<style>
+	.lq-column-editor {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+	.column-row {
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: 6px;
+		padding: 12px;
+		margin: 0;
+	}
+	.row-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 8px;
+	}
+	.row-index {
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--lq-text-tertiary, #9ca3af);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+	.row-actions {
+		display: flex;
+		gap: 4px;
+	}
+	label {
+		display: block;
+		margin-bottom: 8px;
+	}
+	label > span {
+		display: block;
+		font-size: 13px;
+		font-weight: 600;
+		margin-bottom: 4px;
+	}
+	.required {
+		color: var(--lq-error, #b54848);
+		font-style: normal;
+	}
+	input,
+	textarea,
+	select {
+		width: 100%;
+		padding: 8px;
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: 6px;
+		font-size: 14px;
+		font-family: inherit;
+		box-sizing: border-box;
+	}
+	.overrides {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 8px;
+	}
+	.error {
+		color: var(--lq-error, #b54848);
+		font-size: 12px;
+	}
+	.inline-error {
+		display: block;
+		margin-top: 4px;
+	}
+	.list-error {
+		margin: 0;
+	}
+	.ghost {
+		background: transparent;
+		border: 1px solid var(--lq-border, #e5e7eb);
+		padding: 4px 10px;
+		border-radius: 6px;
+		cursor: pointer;
+		font-size: 13px;
+	}
+	.ghost:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+	.ghost.danger {
+		color: var(--lq-error, #b54848);
+		border-color: var(--lq-error, #b54848);
+	}
+	.add-column {
+		align-self: flex-start;
+	}
+</style>

--- a/web/src/lib/lq-ai/components/SkillWizard.svelte
+++ b/web/src/lib/lq-ai/components/SkillWizard.svelte
@@ -38,6 +38,24 @@
 	 */
 	import type { UserSkillCreate } from '../types';
 	import { kebab } from '../util/slug';
+	import {
+		buildFrontmatterExtra,
+		columnsFromRaw,
+		newEditableColumn,
+		validateColumns,
+		type EditableColumn,
+		type SkillOutputMode
+	} from '../skills/tableColumns';
+
+	/**
+	 * DE-297 — fallback body persisted for a table-mode skill when the
+	 * author leaves the (hidden) prose body empty. The backend requires a
+	 * non-empty ``body``; for table mode the columns are the work product,
+	 * so a documented placeholder satisfies the contract honestly.
+	 */
+	export const DEFAULT_TABLE_BODY =
+		'Table-mode skill: each column in the frontmatter `columns` list defines a ' +
+		'per-document extraction query. Run it from the Tabular Review wizard.';
 
 	/** Mutable form state — every input bound in the template, plus ``saving``. */
 	export interface WizardFormState {
@@ -50,6 +68,10 @@
 		version: string;
 		scope: 'user' | 'team';
 		ownerTeamId: string;
+		/** DE-297 — 'prose' keeps the body editor; 'table' swaps in the column list. */
+		outputMode: SkillOutputMode;
+		/** DE-297 — table-mode column rows; ignored in prose mode. */
+		columns: EditableColumn[];
 		saving: boolean;
 	}
 
@@ -64,6 +86,8 @@
 		version: string;
 		scope: 'user' | 'team';
 		ownerTeamId: string;
+		outputMode: SkillOutputMode;
+		columns: EditableColumn[];
 	}
 
 	const SLUG_RE = /^[a-z0-9]([a-z0-9-]{0,78}[a-z0-9])?$|^[a-z0-9]$/;
@@ -96,7 +120,14 @@
 		if (!state.slug || !isSlugValid(state.slug)) return false;
 		if (!state.displayName.trim()) return false;
 		if (!state.description.trim()) return false;
-		if (!state.body.trim()) return false;
+		if (state.outputMode === 'table') {
+			// DE-297 — the column list replaces the body as the work
+			// product; it must mirror the backend's table-mode rules
+			// (min one column, non-empty name + query, tier 1-5).
+			if (!validateColumns(state.columns).valid) return false;
+		} else if (!state.body.trim()) {
+			return false;
+		}
 		if (!isSlashAliasValid(state.slashAlias)) return false;
 		if (state.scope === 'team' && !state.ownerTeamId) return false;
 		return true;
@@ -117,11 +148,15 @@
 			.map((t) => t.trim())
 			.filter(Boolean);
 		const slashAlias = state.slashAlias.trim();
-		return {
+		const isTable = state.outputMode === 'table';
+		const payload: UserSkillCreate = {
 			slug: state.slug,
 			display_name: state.displayName.trim(),
 			description: state.description.trim(),
-			body: state.body,
+			// Table mode hides the body editor; the backend still requires
+			// a non-empty body, so fall back to the documented placeholder
+			// when the author never wrote one (DE-297).
+			body: isTable && !state.body.trim() ? DEFAULT_TABLE_BODY : state.body,
 			version: state.version,
 			tags,
 			slash_alias: slashAlias === '' ? null : slashAlias,
@@ -129,6 +164,10 @@
 			owner_team_id: state.scope === 'team' ? state.ownerTeamId : null,
 			forked_from: forkedFrom
 		};
+		if (isTable) {
+			payload.frontmatter_extra = buildFrontmatterExtra({}, 'table', state.columns);
+		}
+		return payload;
 	}
 
 	/** Snapshot the persistable subset of the form state. */
@@ -142,7 +181,9 @@
 			slashAlias: state.slashAlias,
 			version: state.version,
 			scope: state.scope,
-			ownerTeamId: state.ownerTeamId
+			ownerTeamId: state.ownerTeamId,
+			outputMode: state.outputMode,
+			columns: state.columns
 		};
 	}
 
@@ -174,6 +215,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import SkillWizardSection from './SkillWizardSection.svelte';
 	import SkillTryItPane from './SkillTryItPane.svelte';
+	import ColumnEditor from './ColumnEditor.svelte';
 	import { LQAIApiError } from '$lib/lq-ai/api/client';
 
 	export let initial: {
@@ -205,6 +247,10 @@
 	let version = initial.version ?? '1.0.0';
 	let scope: 'user' | 'team' = initial.scope ?? 'user';
 	let ownerTeamId = initial.ownerTeamId ?? '';
+	// DE-297 — output mode + table columns. New drafts start in prose;
+	// choosing 'table' swaps the body editor for the column list.
+	let outputMode: SkillOutputMode = 'prose';
+	let columns: EditableColumn[] = [newEditableColumn()];
 	// `forked_from` is write-once at create time per ADR 0012; we capture
 	// it from `initial` and pass it through buildPayload verbatim.
 	const forkedFrom: string | null = initial.forkedFrom ?? null;
@@ -234,6 +280,8 @@
 		version,
 		scope,
 		ownerTeamId,
+		outputMode,
+		columns,
 		saving
 	} as WizardFormState;
 	$: saveable = canSave(formState);
@@ -290,6 +338,10 @@
 		scope;
 		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		ownerTeamId;
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+		outputMode;
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+		columns;
 		scheduleAutosave();
 	}
 
@@ -320,6 +372,9 @@
 				if (typeof d.version === 'string') version = d.version;
 				if (d.scope === 'user' || d.scope === 'team') scope = d.scope;
 				if (typeof d.ownerTeamId === 'string') ownerTeamId = d.ownerTeamId;
+				if (d.outputMode === 'prose' || d.outputMode === 'table') outputMode = d.outputMode;
+				const restoredColumns = columnsFromRaw(d.columns);
+				if (restoredColumns && restoredColumns.length > 0) columns = restoredColumns;
 			}
 		}
 		restored = true;
@@ -505,16 +560,45 @@
 	<SkillWizardSection
 		index={3}
 		title="What does it produce?"
-		hint="The skill body — instructions the model follows."
+		hint={outputMode === 'table'
+			? 'A row-per-document grid — each column defines one extraction query.'
+			: 'The skill body — instructions the model follows.'}
 	>
-		<textarea
-			class="body-textarea"
-			bind:value={body}
-			aria-label="body"
-			data-testid="lq-ai-wizard-body"
-			rows="14"
-			placeholder={'# NDA Review\nApply this skill when the user shares an NDA…'}
-		></textarea>
+		<div class="mode-selector" role="radiogroup" aria-label="output mode">
+			<label class="mode-option">
+				<input
+					type="radio"
+					name="lq-ai-wizard-output-mode"
+					value="prose"
+					bind:group={outputMode}
+					data-testid="lq-ai-wizard-mode-prose"
+				/>
+				<span>Prose (default)</span>
+			</label>
+			<label class="mode-option">
+				<input
+					type="radio"
+					name="lq-ai-wizard-output-mode"
+					value="table"
+					bind:group={outputMode}
+					data-testid="lq-ai-wizard-mode-table"
+				/>
+				<span>Table</span>
+			</label>
+		</div>
+
+		{#if outputMode === 'table'}
+			<ColumnEditor bind:columns />
+		{:else}
+			<textarea
+				class="body-textarea"
+				bind:value={body}
+				aria-label="body"
+				data-testid="lq-ai-wizard-body"
+				rows="14"
+				placeholder={'# NDA Review\nApply this skill when the user shares an NDA…'}
+			></textarea>
+		{/if}
 	</SkillWizardSection>
 
 	<SkillWizardSection
@@ -522,7 +606,12 @@
 		title="Try it out"
 		hint="Test against the sandbox. This conversation is non-billable."
 	>
-		{#if body.trim()}
+		{#if outputMode === 'table'}
+			<p class="hint" data-testid="lq-ai-wizard-tryout-table-hint">
+				Table-mode skills run from the Tabular Review wizard against a document
+				set — save the skill, then pick it at /lq-ai/tabular/new.
+			</p>
+		{:else if body.trim()}
 			<SkillTryItPane
 				draftBody={body}
 				draftSlug={slug || 'draft'}
@@ -623,6 +712,27 @@
 	}
 	.body-textarea {
 		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	}
+	.mode-selector {
+		display: flex;
+		gap: 16px;
+		margin-bottom: 12px;
+	}
+	.mode-option {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		margin-bottom: 0;
+		cursor: pointer;
+	}
+	.mode-option > input {
+		width: auto;
+	}
+	.mode-option > span {
+		display: inline;
+		font-size: 14px;
+		font-weight: 400;
+		margin-bottom: 0;
 	}
 	.error {
 		color: var(--lq-error, #b54848);

--- a/web/src/lib/lq-ai/components/SkillWizard.svelte
+++ b/web/src/lib/lq-ai/components/SkillWizard.svelte
@@ -229,6 +229,10 @@
 		scope?: 'user' | 'team';
 		ownerTeamId?: string;
 		forkedFrom?: string | null;
+		/** DE-298 — fork-seeded output mode (table forks open in table mode). */
+		outputMode?: SkillOutputMode;
+		/** DE-298 — fork-seeded column rows for a table-mode source. */
+		columns?: EditableColumn[];
 	} = {};
 	export let draftKey: string | null = null;
 	export let onSave: (payload: UserSkillCreate) => Promise<string>;
@@ -248,9 +252,11 @@
 	let scope: 'user' | 'team' = initial.scope ?? 'user';
 	let ownerTeamId = initial.ownerTeamId ?? '';
 	// DE-297 — output mode + table columns. New drafts start in prose;
-	// choosing 'table' swaps the body editor for the column list.
-	let outputMode: SkillOutputMode = 'prose';
-	let columns: EditableColumn[] = [newEditableColumn()];
+	// choosing 'table' swaps the body editor for the column list. A fork
+	// of a table-mode source seeds both via `initial` (DE-298).
+	let outputMode: SkillOutputMode = initial.outputMode ?? 'prose';
+	let columns: EditableColumn[] =
+		initial.columns && initial.columns.length > 0 ? initial.columns : [newEditableColumn()];
 	// `forked_from` is write-once at create time per ADR 0012; we capture
 	// it from `initial` and pass it through buildPayload verbatim.
 	const forkedFrom: string | null = initial.forkedFrom ?? null;

--- a/web/src/lib/lq-ai/skills/builtinsBrowser.ts
+++ b/web/src/lib/lq-ai/skills/builtinsBrowser.ts
@@ -1,0 +1,174 @@
+/**
+ * DE-298 — built-ins browser polish on /lq-ai/skills: pure helpers.
+ *
+ * Three concerns, all deterministic so vitest can cover them without the
+ * svelte transformer (repo page-helpers pattern):
+ *
+ * 1. Output-format chip filter — normalize a row's format ("prose" when
+ *    the frontmatter declares none), derive the chip set from the rows
+ *    actually present, and round-trip the active chip through the
+ *    ``?format=`` URL param.
+ * 2. Recently-used sort — order rows by the caller's per-user recents
+ *    (``GET /skills/autocomplete`` with empty ``q`` returns the
+ *    ``messages.applied_skills`` recents block first, then an
+ *    alphabetical fill). Rows absent from that response fall back to
+ *    alphabetical-by-title, so never-used skills stay stably ordered.
+ * 3. Fork seeding for table-mode skills — extract ``lq_ai.columns``
+ *    from a source skill's ``content_yaml`` (the only place built-ins
+ *    carry their column spec on the wire) into `EditableColumn` rows so
+ *    "Fork to my skills" pre-populates the wizard's column editor
+ *    (DE-297 pairing).
+ */
+
+import { parse } from 'yaml';
+
+import type { Skill } from '../types';
+import { columnsFromRaw, type EditableColumn, type SkillOutputMode } from './tableColumns';
+
+// ---------------------------------------------------------------------------
+// 1. Output-format chip filter
+// ---------------------------------------------------------------------------
+
+/** Chip value meaning "no filter". */
+export const FORMAT_ALL = 'all';
+
+/** Format bucket for rows whose frontmatter declares no output_format. */
+export const FORMAT_PROSE = 'prose';
+
+/**
+ * Normalize a raw ``output_format`` value into a chip bucket. Absent /
+ * blank formats read as "prose" — the skill produces conversational
+ * output, which is what an undeclared format means in practice.
+ */
+export function normalizeFormat(outputFormat: string | null | undefined): string {
+	const v = (outputFormat ?? '').trim().toLowerCase();
+	return v === '' ? FORMAT_PROSE : v;
+}
+
+/**
+ * Distinct chip values for the rows on screen, "all" first, the rest
+ * alphabetical. Derived from the data rather than hardcoded so corpus
+ * formats beyond prose/table (``report``, ``markdown``, …) surface a
+ * chip without a code change.
+ */
+export function formatChips(formats: Array<string | null | undefined>): string[] {
+	const distinct = new Set(formats.map(normalizeFormat));
+	return [FORMAT_ALL, ...[...distinct].sort((a, b) => a.localeCompare(b))];
+}
+
+/**
+ * Resolve the ``?format=`` URL param to an active chip. Unknown /
+ * absent values fall back to "all" so a stale deep-link (a format that
+ * no longer exists in the catalog) degrades to the unfiltered view
+ * rather than an empty page.
+ */
+export function formatFilterFromParam(param: string | null, chips: string[]): string {
+	if (param === null) return FORMAT_ALL;
+	const normalized = param.trim().toLowerCase();
+	return chips.includes(normalized) ? normalized : FORMAT_ALL;
+}
+
+/** Does a row with (raw) ``outputFormat`` pass the active chip? */
+export function matchesFormat(outputFormat: string | null | undefined, filter: string): boolean {
+	return filter === FORMAT_ALL || normalizeFormat(outputFormat) === filter;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Recently-used sort
+// ---------------------------------------------------------------------------
+
+export type SkillSort = 'recent' | 'name';
+
+/** Resolve the ``?sort=`` URL param; anything unrecognised = 'recent'. */
+export function sortFromParam(param: string | null): SkillSort {
+	return param === 'name' ? 'name' : 'recent';
+}
+
+/**
+ * Sort rows for the browser. ``sort === 'name'`` is plain
+ * alphabetical-by-title. ``sort === 'recent'`` orders by position in
+ * ``recentSlugs`` (the autocomplete recents response — most recent
+ * first); rows not in that list come after, alphabetical by title, so
+ * a brand-new user with no chat activity sees a stable A–Z list.
+ *
+ * Pure: returns a new array, never mutates the input.
+ */
+export function sortSkillRows<T>(
+	rows: T[],
+	sort: SkillSort,
+	recentSlugs: string[],
+	slugOf: (row: T) => string,
+	titleOf: (row: T) => string
+): T[] {
+	const byTitle = (a: T, b: T) =>
+		titleOf(a).toLowerCase().localeCompare(titleOf(b).toLowerCase());
+	if (sort === 'name') {
+		return [...rows].sort(byTitle);
+	}
+	const rank = new Map(recentSlugs.map((slug, idx) => [slug, idx]));
+	return [...rows].sort((a, b) => {
+		const ra = rank.get(slugOf(a)) ?? Number.POSITIVE_INFINITY;
+		const rb = rank.get(slugOf(b)) ?? Number.POSITIVE_INFINITY;
+		if (ra !== rb) return ra - rb;
+		return byTitle(a, b);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// 3. Fork seeding — table-mode columns from content_yaml
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the column spec from a skill's frontmatter YAML. Built-ins
+ * carry columns at ``lq_ai.columns`` (authoring-guide shape); the
+ * synthesized user/team-skill frontmatter re-emits ``frontmatter_extra``
+ * under ``lq_ai:`` too, so one path covers both sources. A top-level
+ * ``columns:`` key is accepted as a fallback for hand-authored
+ * frontmatter that skipped the namespace.
+ *
+ * Returns ``null`` when the YAML is unparseable or carries no
+ * recognisable column list — callers treat that as "no columns to
+ * seed", never an error.
+ */
+export function columnsFromContentYaml(
+	contentYaml: string | null | undefined
+): EditableColumn[] | null {
+	if (!contentYaml) return null;
+	let doc: unknown;
+	try {
+		doc = parse(contentYaml);
+	} catch {
+		return null;
+	}
+	if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) return null;
+	const root = doc as Record<string, unknown>;
+	const lqAi = root['lq_ai'];
+	if (lqAi !== null && typeof lqAi === 'object' && !Array.isArray(lqAi)) {
+		const nested = columnsFromRaw((lqAi as Record<string, unknown>)['columns']);
+		if (nested && nested.length > 0) return nested;
+	}
+	const topLevel = columnsFromRaw(root['columns']);
+	return topLevel && topLevel.length > 0 ? topLevel : null;
+}
+
+/** Wizard seed for a fork source's output mode + columns. */
+export interface ForkTableSeed {
+	outputMode: SkillOutputMode;
+	columns: EditableColumn[];
+}
+
+/**
+ * Build the DE-297 wizard seed from a fork source. Non-table sources
+ * (or table sources whose columns can't be recovered from the
+ * frontmatter) return ``null`` — the wizard then opens in prose mode
+ * exactly as before, so the fork path never regresses on a parse
+ * hiccup.
+ */
+export function forkTableSeed(
+	source: Pick<Skill, 'output_format' | 'content_yaml'>
+): ForkTableSeed | null {
+	if (normalizeFormat(source.output_format) !== 'table') return null;
+	const columns = columnsFromContentYaml(source.content_yaml);
+	if (!columns) return null;
+	return { outputMode: 'table', columns };
+}

--- a/web/src/lib/lq-ai/skills/tableColumns.ts
+++ b/web/src/lib/lq-ai/skills/tableColumns.ts
@@ -1,0 +1,189 @@
+/**
+ * DE-297 — table-mode skill authoring: pure column-spec helpers.
+ *
+ * Shared by the Skill Creator wizard (`/lq-ai/skills/new` via
+ * `SkillWizard.svelte`), the user-skill edit page
+ * (`/lq-ai/skills/[id]/edit`), and `ColumnEditor.svelte`. Extracted
+ * into a plain `.ts` module (repo convention: page-helpers pattern) so
+ * vitest can exercise validation / serialization / reorder without the
+ * svelte transformer.
+ *
+ * Backend parity contract: the backend validates
+ * `frontmatter_extra.{output_format, columns}` through
+ * `app.skills.schema.LQAIFrontmatter` (see
+ * `api/app/api/user_skills.py::_validate_frontmatter_extra`). The
+ * validation here mirrors — and never widens — that schema:
+ *
+ * - `output_format: table` requires >= 1 column
+ *   (`_table_mode_requires_columns`);
+ * - each column needs a non-empty `name` and `query`
+ *   (`ColumnSpec` `min_length=1`);
+ * - `minimum_inference_tier` is an integer 1-5 or unset (`ge=1, le=5`);
+ * - `ensemble_verification` is boolean or unset (null = inherit the
+ *   skill / deployment default).
+ */
+
+import type { TabularColumnSpec } from '../types';
+
+export type SkillOutputMode = 'prose' | 'table';
+
+/**
+ * One column row as the editor holds it. `null` on the two override
+ * fields means "inherit" (the backend's `None`) — distinct from an
+ * explicit `false` / tier value, which overrides the skill level.
+ */
+export interface EditableColumn {
+	name: string;
+	query: string;
+	ensemble_verification: boolean | null;
+	minimum_inference_tier: number | null;
+}
+
+/** Per-column inline error slots. Absent key = field is valid. */
+export interface ColumnFieldErrors {
+	name?: string;
+	query?: string;
+	tier?: string;
+}
+
+export interface ColumnsValidation {
+	valid: boolean;
+	/**
+	 * List-level error (currently only the min-one-column rule,
+	 * mirroring the backend's `_table_mode_requires_columns`).
+	 */
+	listError: string | null;
+	/** Index-aligned with the input columns. */
+	columnErrors: ColumnFieldErrors[];
+}
+
+export const MIN_ONE_COLUMN_ERROR =
+	'A table-mode skill needs at least one column.';
+export const EMPTY_NAME_ERROR = 'Column name is required.';
+export const EMPTY_QUERY_ERROR = 'Extraction query is required.';
+export const TIER_RANGE_ERROR = 'Tier must be between 1 and 5.';
+
+export function newEditableColumn(): EditableColumn {
+	return {
+		name: '',
+		query: '',
+		ensemble_verification: null,
+		minimum_inference_tier: null
+	};
+}
+
+/**
+ * Validate the column list against the backend schema rules. Always
+ * returns an index-aligned `columnErrors` array so the editor can
+ * render inline errors next to the offending field.
+ */
+export function validateColumns(columns: EditableColumn[]): ColumnsValidation {
+	const columnErrors: ColumnFieldErrors[] = columns.map((col) => {
+		const errs: ColumnFieldErrors = {};
+		if (!col.name.trim()) errs.name = EMPTY_NAME_ERROR;
+		if (!col.query.trim()) errs.query = EMPTY_QUERY_ERROR;
+		const tier = col.minimum_inference_tier;
+		if (tier !== null && (!Number.isInteger(tier) || tier < 1 || tier > 5)) {
+			errs.tier = TIER_RANGE_ERROR;
+		}
+		return errs;
+	});
+	const listError = columns.length === 0 ? MIN_ONE_COLUMN_ERROR : null;
+	const valid =
+		listError === null && columnErrors.every((e) => Object.keys(e).length === 0);
+	return { valid, listError, columnErrors };
+}
+
+/**
+ * Serialize editor rows to the backend `ColumnSpec` wire shape.
+ * Trims name/query; drops `null` overrides entirely so the persisted
+ * spec reads "inherit" the same way built-in SKILL.md frontmatter
+ * does (absent key, not `null`).
+ */
+export function serializeColumns(columns: EditableColumn[]): TabularColumnSpec[] {
+	return columns.map((col) => {
+		const out: TabularColumnSpec = { name: col.name.trim(), query: col.query.trim() };
+		if (col.ensemble_verification !== null) {
+			out.ensemble_verification = col.ensemble_verification;
+		}
+		if (col.minimum_inference_tier !== null) {
+			out.minimum_inference_tier = col.minimum_inference_tier;
+		}
+		return out;
+	});
+}
+
+/**
+ * Move the column at `index` by `delta` (-1 = up, +1 = down).
+ * Out-of-range moves return the input array unchanged (same
+ * reference), so callers can no-op cheaply on boundary clicks.
+ */
+export function moveColumn(
+	columns: EditableColumn[],
+	index: number,
+	delta: -1 | 1
+): EditableColumn[] {
+	const target = index + delta;
+	if (index < 0 || index >= columns.length) return columns;
+	if (target < 0 || target >= columns.length) return columns;
+	const next = [...columns];
+	const [moved] = next.splice(index, 1);
+	next.splice(target, 0, moved);
+	return next;
+}
+
+/** Read the authoring mode off a stored `frontmatter_extra` block. */
+export function modeFromExtra(extra: Record<string, unknown> | null | undefined): SkillOutputMode {
+	return extra && extra['output_format'] === 'table' ? 'table' : 'prose';
+}
+
+/**
+ * Defensively parse a raw `columns` value (from `frontmatter_extra` or
+ * a localStorage draft) into editor rows. Non-array input or rows that
+ * are not plain objects yield `null` / get skipped; missing overrides
+ * normalize to `null` ("inherit"); non-integer tiers are kept only when
+ * they are numbers so validation can flag them rather than silently
+ * dropping user data.
+ */
+export function columnsFromRaw(raw: unknown): EditableColumn[] | null {
+	if (!Array.isArray(raw)) return null;
+	const out: EditableColumn[] = [];
+	for (const entry of raw) {
+		if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) continue;
+		const rec = entry as Record<string, unknown>;
+		out.push({
+			name: typeof rec.name === 'string' ? rec.name : '',
+			query: typeof rec.query === 'string' ? rec.query : '',
+			ensemble_verification:
+				typeof rec.ensemble_verification === 'boolean' ? rec.ensemble_verification : null,
+			minimum_inference_tier:
+				typeof rec.minimum_inference_tier === 'number' ? rec.minimum_inference_tier : null
+		});
+	}
+	return out;
+}
+
+/**
+ * Build the next `frontmatter_extra` for the chosen mode, preserving
+ * unrelated extension keys (jurisdiction, icon, inputs, …).
+ *
+ * - `table` → sets `output_format: 'table'` + the serialized columns.
+ * - `prose` → strips `columns`, and strips `output_format` only when
+ *   it was `'table'` (a hand-set `output_format: 'report'` etc. is not
+ *   this surface's key to remove).
+ */
+export function buildFrontmatterExtra(
+	prev: Record<string, unknown> | null | undefined,
+	mode: SkillOutputMode,
+	columns: EditableColumn[]
+): Record<string, unknown> {
+	const base: Record<string, unknown> = { ...(prev ?? {}) };
+	if (mode === 'table') {
+		base['output_format'] = 'table';
+		base['columns'] = serializeColumns(columns);
+		return base;
+	}
+	delete base['columns'];
+	if (base['output_format'] === 'table') delete base['output_format'];
+	return base;
+}

--- a/web/src/routes/lq-ai/skills/+page.svelte
+++ b/web/src/routes/lq-ai/skills/+page.svelte
@@ -13,15 +13,28 @@
 	 */
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 
 	import { userSkillsApi, skillsApi, teamsApi } from '$lib/lq-ai/api';
 	import { LQAIApiError } from '$lib/lq-ai/api/client';
 	import type { UserSkill, SkillSummary, TeamSummary } from '$lib/lq-ai/types';
 	import TrustPill from '$lib/lq-ai/components/TrustPill.svelte';
+	import {
+		FORMAT_ALL,
+		FORMAT_PROSE,
+		formatChips,
+		formatFilterFromParam,
+		matchesFormat,
+		normalizeFormat,
+		sortFromParam,
+		sortSkillRows,
+		type SkillSort
+	} from '$lib/lq-ai/skills/builtinsBrowser';
 
 	let rows: UserSkill[] = [];
 	let builtinSlugs = new Set<string>();
-	let builtinTableSkills: SkillSummary[] = [];
+	let builtins: SkillSummary[] = [];
+	let recentSlugs: string[] = [];
 	let teamNamesById = new Map<string, string>();
 	let loading = false;
 	let listError: string | null = null;
@@ -31,19 +44,25 @@
 		loading = true;
 		listError = null;
 		try {
-			const [mine, builtins, myTeams] = await Promise.all([
+			const [mine, builtinList, myTeams, recents] = await Promise.all([
 				userSkillsApi.listUserSkills('all'),
 				skillsApi.listSkills('builtin'),
-				teamsApi.listMyTeams()
+				teamsApi.listMyTeams(),
+				// DE-298 — per-user recents (messages.applied_skills ordering)
+				// via the autocomplete endpoint's empty-query mode. Tolerant:
+				// a recents failure degrades to alphabetical, never blocks the page.
+				skillsApi
+					.autocompleteSkills('', 25)
+					.then((r) => r.results.map((item) => item.slug))
+					.catch((e) => {
+						console.warn('user-skills: recents load failed', e);
+						return [] as string[];
+					})
 			]);
 			rows = mine;
-			builtinSlugs = new Set(builtins.map((s: SkillSummary) => s.name));
-			// Surface built-in table-mode reference skills (M3-C3) so
-			// operators can discover them; /skills only shows user-scope
-			// skills by default and otherwise these would be invisible.
-			builtinTableSkills = builtins
-				.filter((s: SkillSummary) => s.output_format === 'table')
-				.sort((a: SkillSummary, b: SkillSummary) => a.name.localeCompare(b.name));
+			builtins = builtinList;
+			builtinSlugs = new Set(builtinList.map((s: SkillSummary) => s.name));
+			recentSlugs = recents;
 			teamNamesById = new Map(
 				(myTeams as TeamSummary[]).map((t) => [t.id, t.name])
 			);
@@ -81,6 +100,65 @@
 		} catch {
 			return iso;
 		}
+	}
+
+	// DE-298 — output-format chip filter + recently-used sort, both
+	// persisted in the URL (?format= / ?sort=) so a filtered view
+	// survives refresh and is deep-linkable.
+	function userSkillFormat(row: UserSkill): string | undefined {
+		const v = row.frontmatter_extra?.['output_format'];
+		return typeof v === 'string' ? v : undefined;
+	}
+
+	$: chips = formatChips([
+		...builtins.map((b) => b.output_format),
+		...rows.map((r) => userSkillFormat(r))
+	]);
+	$: activeFormat = formatFilterFromParam($page.url.searchParams.get('format'), chips);
+	$: activeSort = sortFromParam($page.url.searchParams.get('sort'));
+	$: visibleBuiltins = sortSkillRows(
+		builtins.filter((b) => matchesFormat(b.output_format, activeFormat)),
+		activeSort,
+		recentSlugs,
+		(b) => b.name,
+		(b) => b.title ?? b.name
+	);
+	$: visibleRows = sortSkillRows(
+		rows.filter((r) => matchesFormat(userSkillFormat(r), activeFormat)),
+		activeSort,
+		recentSlugs,
+		(r) => r.slug,
+		(r) => r.display_name
+	);
+
+	function setParam(key: string, value: string | null): void {
+		const url = new URL($page.url);
+		if (value === null) {
+			url.searchParams.delete(key);
+		} else {
+			url.searchParams.set(key, value);
+		}
+		// replaceState: filter/sort tweaks shouldn't pollute history the
+		// way the detail page's tab navigation deliberately does.
+		void goto(url.pathname + url.search, {
+			replaceState: true,
+			keepFocus: true,
+			noScroll: true
+		});
+	}
+
+	function setFormat(f: string): void {
+		setParam('format', f === FORMAT_ALL ? null : f);
+	}
+
+	function setSort(s: SkillSort): void {
+		setParam('sort', s === 'recent' ? null : s);
+	}
+
+	function chipLabel(chip: string): string {
+		if (chip === FORMAT_ALL) return 'All';
+		if (chip === FORMAT_PROSE) return 'Prose';
+		return chip.charAt(0).toUpperCase() + chip.slice(1);
 	}
 
 	onMount(() => {
@@ -131,35 +209,93 @@
 		</div>
 	{/if}
 
-	{#if !loading && builtinTableSkills.length > 0}
-		<section class="mb-6" data-testid="lq-ai-builtin-table-skills">
-			<h2 class="lq-text-h4 mb-2">Reference table-mode skills</h2>
-			<p class="lq-text-caption mb-3" style="color: var(--lq-text-secondary);">
-				Built-in skills with <code>output_format: table</code> — usable from the
-				<a href="/lq-ai/tabular/new" class="lq-link">Tabular Review wizard</a>'s
-				skill picker. Paired with the synthetic corpus in
-				<code>docs/quickstart/</code> for first-run exploration.
-			</p>
-			<ul class="lq-table-skill-list">
-				{#each builtinTableSkills as s (s.name)}
-					<li class="lq-table-skill-card" data-testid="lq-ai-builtin-table-skill">
-						<div class="flex items-start justify-between gap-3">
-							<div class="min-w-0">
-								<div class="flex items-center gap-2 flex-wrap">
-									<span class="font-medium lq-text-body">{s.title ?? s.name}</span>
-									<span data-testid="lq-ai-table-badge">
-										<TrustPill variant="tier" label="Table" />
-									</span>
-								</div>
-								<code class="lq-text-caption font-mono" style="color: var(--lq-text-secondary);">{s.name}</code>
-								{#if s.description}
-									<p class="lq-text-caption mt-1 line-clamp-2" style="color: var(--lq-text-tertiary);">{s.description}</p>
-								{/if}
-							</div>
-						</div>
-					</li>
+	{#if !loading && (builtins.length > 0 || rows.length > 0)}
+		<!-- DE-298 — output-format chips + sort toggle, URL-param persisted. -->
+		<div class="lq-browser-toolbar mb-4" data-testid="lq-ai-skills-toolbar">
+			<div class="lq-chip-row" role="group" aria-label="Filter by output format">
+				{#each chips as chip (chip)}
+					<button
+						type="button"
+						class="lq-chip"
+						data-active={chip === activeFormat}
+						data-testid="lq-ai-format-chip"
+						data-format={chip}
+						aria-pressed={chip === activeFormat}
+						on:click={() => setFormat(chip)}
+					>
+						{chipLabel(chip)}
+					</button>
 				{/each}
-			</ul>
+			</div>
+			<div class="lq-chip-row" role="group" aria-label="Sort skills">
+				<span class="lq-text-caption" style="color: var(--lq-text-tertiary);">Sort:</span>
+				<button
+					type="button"
+					class="lq-chip"
+					data-active={activeSort === 'recent'}
+					data-testid="lq-ai-sort-recent"
+					aria-pressed={activeSort === 'recent'}
+					on:click={() => setSort('recent')}
+				>
+					Recently used
+				</button>
+				<button
+					type="button"
+					class="lq-chip"
+					data-active={activeSort === 'name'}
+					data-testid="lq-ai-sort-name"
+					aria-pressed={activeSort === 'name'}
+					on:click={() => setSort('name')}
+				>
+					A–Z
+				</button>
+			</div>
+		</div>
+	{/if}
+
+	{#if !loading && builtins.length > 0}
+		<section class="mb-6" data-testid="lq-ai-builtin-table-skills">
+			<h2 class="lq-text-h4 mb-2">Built-in skills</h2>
+			<p class="lq-text-caption mb-3" style="color: var(--lq-text-secondary);">
+				Read-only skills that ship with LQ.AI. Open one to read its description
+				(and column spec for table-mode skills), run it from the
+				<a href="/lq-ai/tabular/new" class="lq-link">Tabular Review wizard</a>,
+				or fork it into an editable copy of your own.
+			</p>
+			{#if visibleBuiltins.length === 0}
+				<p class="lq-text-caption" style="color: var(--lq-text-tertiary);" data-testid="lq-ai-builtin-empty-filtered">
+					No built-in skills match the "{chipLabel(activeFormat)}" filter.
+				</p>
+			{:else}
+				<ul class="lq-table-skill-list">
+					{#each visibleBuiltins as s (s.name)}
+						<li class="lq-table-skill-card" data-testid="lq-ai-builtin-table-skill">
+							<div class="flex items-start justify-between gap-3">
+								<div class="min-w-0">
+									<div class="flex items-center gap-2 flex-wrap">
+										<a
+											href={`/lq-ai/skills/${encodeURIComponent(s.name)}`}
+											class="font-medium lq-text-body lq-link"
+											data-testid="lq-ai-builtin-skill-link"
+										>
+											{s.title ?? s.name}
+										</a>
+										{#if normalizeFormat(s.output_format) !== FORMAT_PROSE}
+											<span data-testid="lq-ai-table-badge">
+												<TrustPill variant="tier" label={chipLabel(normalizeFormat(s.output_format))} />
+											</span>
+										{/if}
+									</div>
+									<code class="lq-text-caption font-mono" style="color: var(--lq-text-secondary);">{s.name}</code>
+									{#if s.description}
+										<p class="lq-text-caption mt-1 line-clamp-2" style="color: var(--lq-text-tertiary);">{s.description}</p>
+									{/if}
+								</div>
+							</div>
+						</li>
+					{/each}
+				</ul>
+			{/if}
 		</section>
 	{/if}
 
@@ -177,6 +313,14 @@
 				, or fork a built-in from the picker.
 			</p>
 		</div>
+	{:else if visibleRows.length === 0}
+		<p
+			class="lq-text-caption"
+			style="color: var(--lq-text-tertiary);"
+			data-testid="lq-ai-user-skills-empty-filtered"
+		>
+			None of your skills match the "{chipLabel(activeFormat)}" filter.
+		</p>
 	{:else}
 		<div class="lq-table-wrap overflow-x-auto">
 			<table class="min-w-full lq-text-body-sm">
@@ -191,7 +335,7 @@
 					</tr>
 				</thead>
 				<tbody class="lq-tbody">
-					{#each rows as row (row.id)}
+					{#each visibleRows as row (row.id)}
 						<tr data-testid="lq-ai-user-skill-row" data-scope={row.scope}>
 							<td class="px-3 py-2" style="color: var(--lq-text);">
 								<a
@@ -256,6 +400,39 @@
 </div>
 
 <style>
+	/* DE-298 — filter / sort toolbar */
+	.lq-browser-toolbar {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem 1rem;
+	}
+	.lq-chip-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.375rem;
+	}
+	.lq-chip {
+		padding: 2px 10px;
+		border-radius: var(--lq-radius-pill);
+		border: 1px solid var(--lq-border);
+		background: var(--lq-surface);
+		color: var(--lq-text-secondary);
+		font-size: 12px;
+		font-weight: 500;
+		cursor: pointer;
+	}
+	.lq-chip:hover {
+		background: var(--lq-inset);
+	}
+	.lq-chip[data-active='true'] {
+		background: var(--lq-accent-soft, var(--lq-inset));
+		border-color: var(--lq-accent, var(--lq-border));
+		color: var(--lq-text);
+	}
+
 	.lq-table-skill-list {
 		list-style: none;
 		padding: 0;

--- a/web/src/routes/lq-ai/skills/[id]/+page.svelte
+++ b/web/src/routes/lq-ai/skills/[id]/+page.svelte
@@ -5,6 +5,7 @@
 	import { skillsApi } from '$lib/lq-ai/api';
 	import type { Skill } from '$lib/lq-ai/types';
 	import { toolUsageNote } from '$lib/lq-ai/skills/toolUsageNote';
+	import { columnsFromContentYaml, normalizeFormat } from '$lib/lq-ai/skills/builtinsBrowser';
 	import SkillDetailTabs from '$lib/lq-ai/components/SkillDetailTabs.svelte';
 	import SkillSourceView from '$lib/lq-ai/components/SkillSourceView.svelte';
 	import SkillTryItTab from '$lib/lq-ai/components/SkillTryItTab.svelte';
@@ -26,6 +27,11 @@
 	) as Tab;
 	// C5 (PR6d) — derive tool-usage note reactively; never blocks UI.
 	$: usageNote = toolUsageNote(skill?.tool_usage, skill?.unavailable_tool_usage);
+	// DE-298 — table-mode skills surface their column spec (parsed from
+	// the frontmatter, where both built-ins and user rows carry it) plus
+	// a CTA into the Tabular Review wizard with this skill preselected.
+	$: isTableSkill = skill !== null && normalizeFormat(skill.output_format) === 'table';
+	$: tableColumns = isTableSkill && skill ? columnsFromContentYaml(skill.content_yaml) : null;
 
 	onMount(async () => {
 		if (!skillName) return;
@@ -57,9 +63,17 @@
 				</p>
 			</div>
 			<div style="display: flex; gap: 8px;">
+				{#if isTableSkill}
+					<a
+						href={`/lq-ai/tabular/new?skill=${encodeURIComponent(skill.name)}`}
+						class="lq-btn-primary"
+						data-testid="lq-ai-skill-use-in-tabular"
+					>Use in Tabular Review</a>
+				{/if}
 				<a
 					href={`/lq-ai/skills/new?fork=${encodeURIComponent(skill.name)}`}
 					class="lq-btn-ghost"
+					data-testid="lq-ai-skill-fork-link"
 					aria-label={`Fork ${skill.title ?? skill.name} as my own`}
 				>🔱 Fork as my own</a>
 				{#if skill.scope !== 'builtin'}
@@ -75,6 +89,34 @@
 				<article class="lq-text-body" style="white-space: pre-wrap;">
 					{skill.description ?? '(no description)'}
 				</article>
+				{#if isTableSkill && tableColumns && tableColumns.length > 0}
+					<!-- DE-298 — read-only column spec for table-mode skills. -->
+					<section class="lq-columns" data-testid="lq-ai-skill-columns">
+						<h2 class="lq-columns-title">Columns ({tableColumns.length})</h2>
+						<p class="lq-columns-hint">
+							Each column runs as a per-document extraction query in a Tabular
+							Review — one grid cell per document per column.
+						</p>
+						<dl class="lq-columns-list">
+							{#each tableColumns as col (col.name)}
+								<div class="lq-columns-row" data-testid="lq-ai-skill-column">
+									<dt>
+										{col.name}
+										{#if col.ensemble_verification !== null}
+											<span class="lq-columns-flag">
+												ensemble: {col.ensemble_verification ? 'on' : 'off'}
+											</span>
+										{/if}
+										{#if col.minimum_inference_tier !== null}
+											<span class="lq-columns-flag">tier ≥ {col.minimum_inference_tier}</span>
+										{/if}
+									</dt>
+									<dd>{col.query}</dd>
+								</div>
+							{/each}
+						</dl>
+					</section>
+				{/if}
 				{#if usageNote.uses.length > 0}
 					<div class="lq-tool-usage" data-testid="skill-tool-usage">
 						<span class="lq-tool-usage-label">Uses:</span> {usageNote.uses.join(', ')}
@@ -132,6 +174,54 @@
 	.lq-btn-ghost:hover {
 		background: var(--lq-accent-soft, #e8f4ec);
 	}
+	/* DE-298 — read-only column spec */
+	.lq-columns {
+		margin-top: var(--lq-space-4, 16px);
+		padding: var(--lq-space-4, 16px);
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius, 6px);
+		background: var(--lq-surface, transparent);
+	}
+	.lq-columns-title {
+		margin: 0;
+		font-size: 15px;
+		font-weight: 600;
+	}
+	.lq-columns-hint {
+		margin: var(--lq-space-1, 4px) 0 0;
+		font-size: 13px;
+		color: var(--lq-text-secondary, #6b7280);
+	}
+	.lq-columns-list {
+		margin: var(--lq-space-3, 12px) 0 0;
+	}
+	.lq-columns-row {
+		padding: var(--lq-space-2, 8px) 0;
+		border-top: 1px solid var(--lq-border, #e5e7eb);
+	}
+	.lq-columns-row dt {
+		font-weight: 600;
+		font-size: 14px;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-wrap: wrap;
+	}
+	.lq-columns-row dd {
+		margin: var(--lq-space-1, 4px) 0 0;
+		font-size: 13px;
+		color: var(--lq-text-secondary, #6b7280);
+		white-space: pre-wrap;
+	}
+	.lq-columns-flag {
+		font-size: 11px;
+		font-weight: 500;
+		padding: 1px 8px;
+		border-radius: 999px;
+		border: 1px solid var(--lq-border, #e5e7eb);
+		color: var(--lq-text-secondary, #6b7280);
+	}
+
 	/* C5 (PR6d) — tool-usage metadata row */
 	.lq-tool-usage {
 		margin-top: var(--lq-space-3, 12px);

--- a/web/src/routes/lq-ai/skills/[id]/edit/+page.svelte
+++ b/web/src/routes/lq-ai/skills/[id]/edit/+page.svelte
@@ -17,6 +17,16 @@
 
 	import { userSkillsApi, skillsApi, teamsApi } from '$lib/lq-ai/api';
 	import { LQAIApiError } from '$lib/lq-ai/api/client';
+	import ColumnEditor from '$lib/lq-ai/components/ColumnEditor.svelte';
+	import {
+		buildFrontmatterExtra,
+		columnsFromRaw,
+		modeFromExtra,
+		newEditableColumn,
+		validateColumns,
+		type EditableColumn,
+		type SkillOutputMode
+	} from '$lib/lq-ai/skills/tableColumns';
 	import type { UserSkill, SkillSummary, TeamSummary } from '$lib/lq-ai/types';
 
 	let row: UserSkill | null = null;
@@ -30,6 +40,10 @@
 	let version = '';
 	let tagsInput = '';
 	let body = '';
+	// DE-297 — table-mode authoring state, seeded from frontmatter_extra.
+	let outputMode: SkillOutputMode = 'prose';
+	let columns: EditableColumn[] = [newEditableColumn()];
+	let showColumnErrors = false;
 
 	let submitting = false;
 	let submitError: string | null = null;
@@ -59,6 +73,11 @@
 			version = skill.version;
 			tagsInput = (skill.tags ?? []).join(', ');
 			body = skill.body;
+			outputMode = modeFromExtra(skill.frontmatter_extra);
+			const loadedColumns = columnsFromRaw(skill.frontmatter_extra?.['columns']);
+			columns =
+				loadedColumns && loadedColumns.length > 0 ? loadedColumns : [newEditableColumn()];
+			showColumnErrors = false;
 		} catch (e) {
 			console.error('user-skills/edit: load failed', e);
 			if (e instanceof LQAIApiError && e.status === 404) {
@@ -84,6 +103,7 @@
 		body: string;
 		version: string;
 		tags: string[];
+		frontmatter_extra: Record<string, unknown>;
 	}> {
 		if (!row) return {};
 		const diff: ReturnType<typeof changeSet> = {};
@@ -102,11 +122,26 @@
 		) {
 			diff.tags = newTags;
 		}
+		// DE-297 — table-mode: rebuild the extra block (preserving
+		// unrelated keys) and send it only when it actually moved, so an
+		// idempotent re-save still writes no audit row.
+		const prevExtra = row.frontmatter_extra ?? {};
+		const newExtra = buildFrontmatterExtra(prevExtra, outputMode, columns);
+		if (JSON.stringify(newExtra) !== JSON.stringify(prevExtra)) {
+			diff.frontmatter_extra = newExtra;
+		}
 		return diff;
 	}
 
 	async function save(): Promise<void> {
 		if (!row) return;
+		// Mirror — never widen — the backend's table-mode validation: a
+		// spec the server would 422 never leaves the page (DE-297).
+		if (outputMode === 'table' && !validateColumns(columns).valid) {
+			showColumnErrors = true;
+			submitError = 'Fix the column errors before saving.';
+			return;
+		}
 		const diff = changeSet();
 		if (Object.keys(diff).length === 0) {
 			saveOk = 'Nothing to save — no changes.';
@@ -123,6 +158,10 @@
 			version = updated.version;
 			body = updated.body;
 			tagsInput = (updated.tags ?? []).join(', ');
+			outputMode = modeFromExtra(updated.frontmatter_extra);
+			const savedColumns = columnsFromRaw(updated.frontmatter_extra?.['columns']);
+			columns = savedColumns && savedColumns.length > 0 ? savedColumns : [newEditableColumn()];
+			showColumnErrors = false;
 			saveOk = 'Saved.';
 		} catch (e) {
 			console.error('user-skills/edit: save failed', e);
@@ -307,16 +346,54 @@
 				</label>
 			</div>
 
-			<label class="block">
-				<span class="lq-text-label">Body (Markdown system prompt)</span>
-				<textarea
-					bind:value={body}
-					rows="16"
-					required
-					maxlength="200000"
-					class="mt-1 w-full rounded border-gray-300 dark:border-gray-700 dark:bg-gray-900 text-sm font-mono"
-				></textarea>
-			</label>
+			<div class="block">
+				<span class="lq-text-label">Output</span>
+				<div
+					class="mt-1 flex items-center gap-4"
+					role="radiogroup"
+					aria-label="output mode"
+				>
+					<label class="flex items-center gap-1.5 text-sm cursor-pointer">
+						<input
+							type="radio"
+							name="lq-ai-user-skill-edit-output-mode"
+							value="prose"
+							bind:group={outputMode}
+							data-testid="lq-ai-user-skill-edit-mode-prose"
+						/>
+						Prose (default)
+					</label>
+					<label class="flex items-center gap-1.5 text-sm cursor-pointer">
+						<input
+							type="radio"
+							name="lq-ai-user-skill-edit-output-mode"
+							value="table"
+							bind:group={outputMode}
+							data-testid="lq-ai-user-skill-edit-mode-table"
+						/>
+						Table
+					</label>
+				</div>
+				<p class="lq-text-caption mt-1" style="color: var(--lq-text-tertiary);">
+					Table-mode skills produce a row-per-document grid in the Tabular Review
+					wizard; each column defines one extraction query.
+				</p>
+			</div>
+
+			{#if outputMode === 'table'}
+				<ColumnEditor bind:columns showErrors={showColumnErrors} />
+			{:else}
+				<label class="block">
+					<span class="lq-text-label">Body (Markdown system prompt)</span>
+					<textarea
+						bind:value={body}
+						rows="16"
+						required
+						maxlength="200000"
+						class="mt-1 w-full rounded border-gray-300 dark:border-gray-700 dark:bg-gray-900 text-sm font-mono"
+					></textarea>
+				</label>
+			{/if}
 
 			<div class="flex items-center justify-between pt-2">
 				<button

--- a/web/src/routes/lq-ai/skills/new/+page.svelte
+++ b/web/src/routes/lq-ai/skills/new/+page.svelte
@@ -51,6 +51,8 @@
 	import { listUserSkills, createUserSkill } from '$lib/lq-ai/api/userSkills';
 	import SkillWizard from '$lib/lq-ai/components/SkillWizard.svelte';
 	import { stashStorageKey } from '$lib/lq-ai/components/CaptureSkillModal.svelte';
+	import { forkTableSeed } from '$lib/lq-ai/skills/builtinsBrowser';
+	import type { EditableColumn, SkillOutputMode } from '$lib/lq-ai/skills/tableColumns';
 	import type { UserSkillCreate } from '$lib/lq-ai/types';
 
 	interface WizardInitial {
@@ -64,6 +66,9 @@
 		scope?: 'user' | 'team';
 		ownerTeamId?: string;
 		forkedFrom?: string | null;
+		/** DE-298 — table-mode fork seed (mode + columns from the source). */
+		outputMode?: SkillOutputMode;
+		columns?: EditableColumn[];
 	}
 
 	let initial: WizardInitial = {};
@@ -120,6 +125,12 @@
 				// "name" but holds the slug — see types.ts:354). We use it
 				// for both the slug seed and the `forked_from` audit field.
 				const baseSlug = await uniqueSlug(`${source.name}-fork`);
+				// DE-298 — a table-mode source seeds the wizard's column
+				// editor from the source's `lq_ai.columns` frontmatter (the
+				// only wire surface where built-ins carry their column spec).
+				// Prose sources — and table sources whose columns can't be
+				// parsed — yield null and the wizard opens in prose mode.
+				const tableSeed = forkTableSeed(source);
 				initial = {
 					slug: baseSlug,
 					displayName: `${source.title ?? source.name} (fork)`,
@@ -129,7 +140,8 @@
 					slashAlias: null,
 					version: '1.0.0',
 					scope: 'user',
-					forkedFrom: source.name
+					forkedFrom: source.name,
+					...(tableSeed ?? {})
 				};
 				// Intentionally NOT seeding `jurisdiction` from the source —
 				// the wizard doesn't surface that field today (see header

--- a/web/src/routes/lq-ai/tabular/new/+page.svelte
+++ b/web/src/routes/lq-ai/tabular/new/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 
 	import { LQAIApiError } from '$lib/lq-ai/api/client';
 	import {
@@ -26,6 +27,7 @@
 		isLastStep,
 		validateDocumentsStep,
 		validateColumnsStep,
+		resolvePreselectedSkill,
 		requiresCostConfirmation,
 		buildPreviewRequest,
 		buildExecuteRequest,
@@ -263,6 +265,17 @@
 
 	onMount(async () => {
 		await Promise.all([loadKBs(), loadTableSkills()]);
+		// DE-298 — the skill detail page's "Use in Tabular Review" CTA
+		// deep-links here with ?skill=<slug>; preselect it when it names a
+		// loaded table-mode skill.
+		const preselect = resolvePreselectedSkill(
+			$page.url.searchParams.get('skill'),
+			allTableSkills
+		);
+		if (preselect) {
+			columnsMode = 'skill';
+			selectedSkillName = preselect;
+		}
 	});
 </script>
 
@@ -407,6 +420,14 @@
 						{#if s?.description}
 							<p class="lq-tabwiz__skill-desc">{s.description}</p>
 						{/if}
+						<!-- DE-298 — read-only detail page shows the full column spec. -->
+						<a
+							class="lq-tabwiz__view-columns"
+							data-testid="lq-tabwiz-view-columns"
+							href={`/lq-ai/skills/${encodeURIComponent(selectedSkillName)}`}
+						>
+							View columns
+						</a>
 					{/if}
 				{/if}
 			{:else}
@@ -696,6 +717,12 @@
 		margin: 0.25rem 0 0;
 		color: var(--lq-text-secondary);
 		font-size: 0.875rem;
+	}
+	.lq-tabwiz__view-columns {
+		align-self: flex-start;
+		font-size: 0.875rem;
+		color: var(--lq-accent, #4f46e5);
+		text-decoration: underline;
 	}
 	.lq-tabwiz__adhoc {
 		width: 100%;

--- a/web/src/routes/lq-ai/tabular/new/__tests__/page-helpers.test.ts
+++ b/web/src/routes/lq-ai/tabular/new/__tests__/page-helpers.test.ts
@@ -18,6 +18,7 @@ import {
 	isLastStep,
 	validateDocumentsStep,
 	validateColumnsStep,
+	resolvePreselectedSkill,
 	requiresCostConfirmation,
 	buildPreviewRequest,
 	buildExecuteRequest,
@@ -210,6 +211,24 @@ describe('tabular wizard page-helpers', () => {
 				columns: cols,
 				confirmed_cost_usd: '0.0100'
 			});
+		});
+	});
+
+	describe('resolvePreselectedSkill (DE-298 ?skill= deep link)', () => {
+		const skills = [{ name: 'contract-snapshot' }, { name: 'nda-snapshot' }];
+
+		it('returns the slug when it names a loaded table-mode skill', () => {
+			expect(resolvePreselectedSkill('nda-snapshot', skills)).toBe('nda-snapshot');
+		});
+
+		it('returns null for absent params', () => {
+			expect(resolvePreselectedSkill(null, skills)).toBeNull();
+			expect(resolvePreselectedSkill('', skills)).toBeNull();
+		});
+
+		it('returns null for slugs not in the loaded list (stale deep link)', () => {
+			expect(resolvePreselectedSkill('archived-skill', skills)).toBeNull();
+			expect(resolvePreselectedSkill('contract-snapshot', [])).toBeNull();
 		});
 	});
 });

--- a/web/src/routes/lq-ai/tabular/new/page-helpers.ts
+++ b/web/src/routes/lq-ai/tabular/new/page-helpers.ts
@@ -113,6 +113,21 @@ export function requiresCostConfirmation(estimatedCostUsd: string): boolean {
 	return n >= COST_CONFIRMATION_THRESHOLD_USD;
 }
 
+/**
+ * DE-298 — resolve the wizard's ``?skill=`` preselect param against the
+ * loaded table-mode skill list. Returns the slug only when it names a
+ * loaded skill; unknown / absent params return null so a stale deep
+ * link degrades to the normal "Choose…" picker rather than an
+ * invisible selection the select can't render.
+ */
+export function resolvePreselectedSkill(
+	param: string | null,
+	skills: Array<{ name: string }>
+): string | null {
+	if (!param) return null;
+	return skills.some((s) => s.name === param) ? param : null;
+}
+
 interface RequestBuilderInput {
 	documentIds: string[];
 	skillName: string | null;


### PR DESCRIPTION
> **Stacked on #345 (DE-297)** — fork-seeding and the column-spec view build on the table-mode authoring PR. Review only the last commit here; merge #345 first.

## What / why

DE-298 (PRD §9): the /skills page listed built-ins minimally (table-mode references only), with no filtering, no recency ordering, no read-only detail affordances, and forking a table-mode built-in lost its columns. Frontend-only polish pass; **zero api changes**.

Part of the coordinated roadmap sweep (umbrella issue #321).

## Approach

- **Chip filter + sort, URL-persisted**: `?format=` chips derived from the catalog (unknown values degrade to All; undeclared formats bucket as Prose), `?sort=` Recently-used (default) | A–Z; both apply to built-ins and user rows; `replaceState` navigation, defaults omitted from the URL.
- **Recents**: existing per-user `applied_skills` ordering via `GET /skills/autocomplete` (alphabetical fill past the cap keeps combined ordering stable). Fault-tolerant load.
- **Read-only detail**: table-mode skills show the column spec (name, query, ensemble/tier flags parsed from `content_yaml`) + "Use in Tabular Review" CTA (`/lq-ai/tabular/new?skill=<slug>` — preselects only when the slug is actually loaded; stale links degrade gracefully). No edit affordance on built-ins (unchanged).
- **Fork-seeding (DE-297 pairing)**: `?fork=` of a table skill parses `lq_ai.columns` from the source YAML (one path covers built-in and user/team sources) and opens the wizard in table mode with columns in the editor; prose/unparseable sources open in prose as before. Fresh fork draft keys prevent localStorage clobbering the seed.
- **Wizard picker**: "View columns" link to the read-only detail.

Flag for reviewers: the "Use in Tabular Review" CTA shows for any table-mode skill (user/team included), not just built-ins — user table skills are equally runnable; say the word if you want it built-in-only.

## Acceptance evidence

- 23 new vitest cases (`builtinsBrowser.test.ts` 20, `page-helpers.test.ts` +3): chip derivation, URL-param round-trip incl. stale-param degradation, recents sort with never-used alphabetical fallback + immutability, fork-seed extraction (overrides, fallbacks, unparseable → null), deep-link resolution.
- Gates: `check:lq-ai` **0 errors** (7 pre-existing warnings); vitest **793 passed (82 files)**; eslint clean on touched files except two pre-existing issues reproduced byte-identical on HEAD copies (`globalThis no-undef` in skills/new, plugin crash on SkillWizard).

## Maintainer verification steps

- Rebuild `web`; on /skills: chip filter + sort persist across reload via URL; open a table built-in → column spec renders, no edit affordance; Fork → wizard opens in table mode with columns; Use-in-Tabular → wizard preselects the skill; picker's View-columns links back.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)