### PR TITLE
DE-304: tabular bulk operations — redline-per-row + summarize-column (ADR 0026 in-PR)

### DIFF
--- a/api/alembic/versions/0066_tabular_bulk_ops.py
+++ b/api/alembic/versions/0066_tabular_bulk_ops.py
@@ -1,0 +1,134 @@
+"""create tabular_bulk_ops table — DE-304 / ADR 0026
+
+Bulk operations over a completed tabular execution (redline-per-row
+report + summarize-column memo). Per ADR 0026 D1 these land in a
+dedicated table rather than the Decision C-9 sibling-execution rows —
+the outputs are not grids, so they don't fit ``tabular_executions.results``.
+
+Schema
+------
+
+* ``id`` — UUID PK.
+* ``execution_id`` — FK → ``tabular_executions.id`` ``ON DELETE CASCADE``.
+  The causal-linkage column: an op cannot exist without its parent
+  execution (ADR 0026 D1).
+* ``user_id`` — caller; nullable + ``ON DELETE SET NULL`` so historical
+  ops survive operator deletion (matches ``tabular_executions.user_id``).
+* ``kind`` — ``'redline_rows' | 'summarize_column'``; CHECK-constrained.
+* ``status`` — ``pending → running → completed | failed``;
+  CHECK-constrained. ``completed`` includes batches with per-item
+  failures (ADR 0026 D4); ``failed`` is whole-batch crashes only.
+* ``params`` — JSONB; op parameters snapshotted at request time
+  (e.g. ``{"column_name": "Term"}``) per the C-1 posture.
+* ``results`` — JSONB nullable; ``{schema_version, items: [...],
+  summary: {total_items, failed_items}}`` once terminal.
+* ``confirmed_cost_usd`` — the operator-confirmed preview echo
+  (Decision C-5 idiom, mirrors ``tabular_executions.cost_estimate_usd``).
+* ``cost_actual_usd`` — summed per-item cost once terminal.
+* ``error_text`` — populated on ``status='failed'``.
+* ``created_at`` / ``started_at`` / ``completed_at`` — lifecycle
+  timestamps. No soft delete: ops live and die with their parent
+  execution (cascade), which itself soft-deletes.
+
+Indexes
+-------
+
+* ``(execution_id, created_at DESC)`` — the detail read-side lists an
+  execution's ops recent-first.
+
+Revision ID: 0066
+Revises: 0065
+Create Date: 2026-07-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0066"
+down_revision = "0065"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tabular_bulk_ops",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "execution_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "tabular_executions.id",
+                ondelete="CASCADE",
+                name="fk_tabular_bulk_ops_execution_id",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "users.id",
+                ondelete="SET NULL",
+                name="fk_tabular_bulk_ops_user_id",
+            ),
+            nullable=True,
+        ),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "params",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "results",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("confirmed_cost_usd", sa.Numeric(10, 4), nullable=True),
+        sa.Column("cost_actual_usd", sa.Numeric(10, 4), nullable=True),
+        sa.Column("error_text", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "kind IN ('redline_rows','summarize_column')",
+            name="chk_tabular_bulk_ops_kind",
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending','running','completed','failed')",
+            name="chk_tabular_bulk_ops_status",
+        ),
+    )
+
+    op.execute(
+        """
+        CREATE INDEX idx_tabular_bulk_ops_execution_recent
+            ON tabular_bulk_ops (execution_id, created_at DESC)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_tabular_bulk_ops_execution_recent")
+    op.drop_table("tabular_bulk_ops")

--- a/api/app/api/tabular.py
+++ b/api/app/api/tabular.py
@@ -65,10 +65,14 @@ from app.audit import audit_action
 from app.clients.gateway import GatewayClient, get_gateway_client
 from app.db.session import get_db
 from app.models.document import Document, DocumentChunk
-from app.models.tabular import TabularExecution
+from app.models.tabular import TabularBulkOp, TabularExecution
 from app.schemas.tabular import (
     Citation,
     ColumnSpec,
+    TabularBulkOpPreviewRequest,
+    TabularBulkOpPreviewResponse,
+    TabularBulkOpRequest,
+    TabularBulkOpResponse,
     TabularExecutionCreate,
     TabularExecutionResponse,
     TabularExecutionSummary,
@@ -77,8 +81,9 @@ from app.schemas.tabular import (
     TabularResults,
 )
 from app.skills.registry import MutableSkillRegistry
+from app.tabular.bulk_ops import estimate_bulk_op_cost
 from app.tabular.cost import estimate_tabular_execution_cost
-from app.workers.queue import enqueue_tabular_execution_job
+from app.workers.queue import enqueue_tabular_bulk_op_job, enqueue_tabular_execution_job
 
 logger = logging.getLogger(__name__)
 
@@ -481,6 +486,183 @@ async def cancel_tabular_execution(
 
 
 # ---------------------------------------------------------------------------
+# Bulk operations (DE-304 / ADR 0026)
+# ---------------------------------------------------------------------------
+
+
+def _bulk_op_grid_row_count(row: TabularExecution) -> int:
+    """Number of grid rows in the execution's persisted results."""
+
+    rows = (row.results or {}).get("rows")
+    return len(rows) if isinstance(rows, list) else 0
+
+
+async def _load_bulk_op_target(
+    db: AsyncSession,
+    *,
+    execution_id: uuid.UUID,
+    user: ActiveUser,
+) -> TabularExecution:
+    """Load + validate the parent execution for a bulk op.
+
+    Ownership follows :func:`_load_caller_execution` (missing /
+    cross-user / soft-deleted collapse into 404). The execution must be
+    ``status='completed'`` — bulk-operating a partial grid would
+    mislead (same 409 posture as export; ADR 0026 D2).
+    """
+
+    row = await _load_caller_execution(db, execution_id=execution_id, user=user)
+    if row.status != "completed":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"execution must be in status='completed' for bulk operations "
+                f"(current status: {row.status!r})"
+            ),
+        )
+    return row
+
+
+def _validate_bulk_op_params(
+    row: TabularExecution,
+    *,
+    kind: str,
+    column_name: str | None,
+) -> dict[str, str | None]:
+    """Validate op parameters against the execution's snapshotted spec.
+
+    ``summarize_column`` requires ``column_name`` to name a column of
+    the *snapshotted* spec (Decision C-1: the op targets what was
+    actually run, not what the skill currently says). Returns the
+    ``params`` payload to snapshot onto the bulk-op row.
+    """
+
+    if kind != "summarize_column":
+        return {}
+    known = {str(col.get("name")) for col in row.columns}
+    if not column_name or column_name not in known:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"summarize_column requires column_name to be one of the "
+                f"execution's columns (got {column_name!r})"
+            ),
+        )
+    return {"column_name": column_name}
+
+
+@router.post(
+    "/tabular/executions/{execution_id}/bulk-ops/preview-cost",
+    response_model=TabularBulkOpPreviewResponse,
+    summary="Preview the cost of a proposed bulk operation.",
+)
+async def preview_tabular_bulk_op_cost(
+    execution_id: uuid.UUID,
+    body: TabularBulkOpPreviewRequest,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TabularBulkOpPreviewResponse:
+    """Synchronous cost preview — no bulk-op row is created.
+
+    Mirrors ``POST /tabular/preview-cost`` (Decision C-5): the UI calls
+    this before arming the confirmation gate. Calls count is one per
+    grid row for ``redline_rows``, one total for ``summarize_column``;
+    per-call cost is the rolling average over recent
+    ``purpose='tabular_bulk_op'`` routing-log rows (conservative
+    cold-start default before calibration; ADR 0026 D3).
+    """
+
+    row = await _load_bulk_op_target(db, execution_id=execution_id, user=user)
+    _validate_bulk_op_params(row, kind=body.kind, column_name=body.column_name)
+    return await estimate_bulk_op_cost(
+        db,
+        kind=body.kind,
+        n_rows=_bulk_op_grid_row_count(row),
+    )
+
+
+@router.post(
+    "/tabular/executions/{execution_id}/bulk-ops",
+    response_model=TabularBulkOpResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Start a bulk operation over a completed tabular execution.",
+)
+async def create_tabular_bulk_op(
+    execution_id: uuid.UUID,
+    body: TabularBulkOpRequest,
+    user: ActiveUser,
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TabularBulkOpResponse:
+    """Create a ``tabular_bulk_ops`` row at ``pending`` and enqueue the
+    ARQ job on the shared playbook queue (Decision C-3). Returns 202;
+    the detail view polls ``GET /tabular/executions/{id}`` — the
+    ``bulk_ops`` array embedded there is the read-side (ADR 0026 D2).
+
+    ``confirmed_cost_usd`` is the echo of the preview response —
+    persisted for audit; the $1.00 confirmation gate stays UI-side,
+    exactly like ``POST /tabular/execute`` (Decision C-5).
+
+    Per ADR 0026 D4, batch "completed" does NOT mean every item
+    succeeded — failed items are persisted per-row and rendered as
+    failures in the report.
+    """
+
+    row = await _load_bulk_op_target(db, execution_id=execution_id, user=user)
+    params = _validate_bulk_op_params(row, kind=body.kind, column_name=body.column_name)
+    if _bulk_op_grid_row_count(row) == 0:
+        raise HTTPException(
+            status_code=400,
+            detail="execution has no results grid rows to bulk-operate on",
+        )
+
+    bulk_op = TabularBulkOp(
+        execution_id=row.id,
+        user_id=user.id,
+        kind=body.kind,
+        status="pending",
+        params=params,
+        confirmed_cost_usd=body.confirmed_cost_usd,
+    )
+    db.add(bulk_op)
+    await db.flush()
+
+    await audit_action(
+        db,
+        user_id=user.id,
+        action="tabular.bulk_op_started",
+        resource_type="tabular_bulk_op",
+        resource_id=str(bulk_op.id),
+        request=request,
+        details={
+            "execution_id": str(row.id),
+            "kind": body.kind,
+            "column_name": body.column_name,
+            "confirmed_cost_usd": (
+                str(body.confirmed_cost_usd) if body.confirmed_cost_usd is not None else None
+            ),
+        },
+    )
+    await db.commit()
+    await db.refresh(bulk_op)
+
+    enqueued = await enqueue_tabular_bulk_op_job(bulk_op.id)
+    logger.info(
+        "tabular_bulk_op_started",
+        extra={
+            "event": "tabular_bulk_op_started",
+            "user_id": str(user.id),
+            "execution_id": str(row.id),
+            "bulk_op_id": str(bulk_op.id),
+            "kind": body.kind,
+            "enqueued": enqueued,
+        },
+    )
+
+    return TabularBulkOpResponse.model_validate(bulk_op)
+
+
+# ---------------------------------------------------------------------------
 # Export (M3-C4a — XLSX + CSV)
 # ---------------------------------------------------------------------------
 
@@ -742,17 +924,32 @@ async def _load_document_names(
     return {row.id: row.filename for row in rows}
 
 
+async def _load_bulk_ops(db: AsyncSession, execution_id: uuid.UUID) -> list[TabularBulkOpResponse]:
+    """Load an execution's bulk ops, recent-first (DE-304 / ADR 0026 D2)."""
+
+    stmt = (
+        select(TabularBulkOp)
+        .where(TabularBulkOp.execution_id == execution_id)
+        .order_by(TabularBulkOp.created_at.desc())
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    return [TabularBulkOpResponse.model_validate(op) for op in rows]
+
+
 async def _to_response(db: AsyncSession, row: TabularExecution) -> TabularExecutionResponse:
     """Convert the ORM row to the response wire shape.
 
     Async because the response includes a ``document_names`` field
     that requires a join on ``files`` — keeping the join inside the
     response builder means every endpoint that returns a single
-    execution gets the names without duplicating the query."""
+    execution gets the names without duplicating the query. The
+    ``bulk_ops`` array (DE-304) is loaded here for the same reason —
+    the detail endpoint the UI polls is the bulk-op read-side."""
 
     document_ids = list(row.document_ids)
     name_by_id = await _load_document_names(db, document_ids)
     document_names = [name_by_id.get(did, "") for did in document_ids]
+    bulk_ops = await _load_bulk_ops(db, row.id)
     return TabularExecutionResponse.model_validate(
         {
             "id": row.id,
@@ -770,6 +967,7 @@ async def _to_response(db: AsyncSession, row: TabularExecution) -> TabularExecut
             "created_at": row.created_at,
             "started_at": row.started_at,
             "completed_at": row.completed_at,
+            "bulk_ops": bulk_ops,
         }
     )
 

--- a/api/app/models/tabular.py
+++ b/api/app/models/tabular.py
@@ -145,3 +145,103 @@ class TabularExecution(Base):
             f"status={self.status!r} docs={len(self.document_ids)} "
             f"cols={len(self.columns)}>"
         )
+
+
+class TabularBulkOp(Base):
+    """One bulk operation over a completed tabular execution — DE-304 / ADR 0026.
+
+    Two kinds in v1 (CHECK-constrained per migration 0066):
+
+    * ``redline_rows`` — one redline-style review memo per parent grid
+      row; the items combine into a redline report on the execution
+      detail page.
+    * ``summarize_column`` — one memo synthesizing a single column
+      across all rows (``params['column_name']`` names the column);
+      results carry one item with ``document_id = null``.
+
+    Lifecycle: ``pending → running → completed | failed``. Per ADR 0026
+    D4, ``completed`` includes batches with per-item failures — item
+    failures are persisted inside ``results.items[*].error`` and never
+    block the batch. ``failed`` is reserved for whole-batch
+    orchestration crashes (``error_text`` populated).
+
+    ``execution_id`` is the causal-linkage column (ADR 0026 D1): the op
+    cannot exist without its parent execution, so the FK cascades on
+    delete. ``params`` is snapshotted at request time (C-1 posture).
+
+    ``results`` JSONB shape::
+
+        {
+            "schema_version": "de304-v1",
+            "items": [
+                {"document_id", "document_name", "status", "output_text", "error", "cost_usd"}
+            ],
+            "summary": {"total_items": N, "failed_items": M},
+        }
+    """
+
+    __tablename__ = "tabular_bulk_ops"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    execution_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "tabular_executions.id",
+            ondelete="CASCADE",
+            name="fk_tabular_bulk_ops_execution_id",
+        ),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "users.id",
+            ondelete="SET NULL",
+            name="fk_tabular_bulk_ops_user_id",
+        ),
+        nullable=True,
+    )
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default=text("'pending'"),
+    )
+    params: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    results: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    confirmed_cost_usd: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 4),
+        nullable=True,
+    )
+    cost_actual_usd: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 4),
+        nullable=True,
+    )
+    error_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<TabularBulkOp id={self.id} execution_id={self.execution_id} "
+            f"kind={self.kind!r} status={self.status!r}>"
+        )

--- a/api/app/schemas/tabular.py
+++ b/api/app/schemas/tabular.py
@@ -305,6 +305,121 @@ class TabularPreviewCostResponse(BaseModel):
     no cell is ensemble-verified."""
 
 
+# --- Bulk operations (DE-304 / ADR 0026) -----------------------------------
+
+
+TabularBulkOpKind = Literal["redline_rows", "summarize_column"]
+"""The two v1 bulk operations (ADR 0026 D2). Matches the CHECK
+constraint on ``tabular_bulk_ops.kind`` (migration 0066)."""
+
+TabularBulkOpStatus = Literal["pending", "running", "completed", "failed"]
+"""Lifecycle states for a :class:`TabularBulkOp`. ``completed``
+includes batches with per-item failures (ADR 0026 D4); ``failed`` is
+reserved for whole-batch orchestration crashes."""
+
+
+class TabularBulkOpRequest(BaseModel):
+    """Request body for
+    ``POST /api/v1/tabular/executions/{id}/bulk-ops`` (DE-304 / ADR 0026).
+
+    Replaces the never-wired M3-C4 stub of the same name (which
+    anticipated Decision C-9 sibling rows; ADR 0026 D1 stores bulk-op
+    output in a dedicated ``tabular_bulk_ops`` table instead because
+    the outputs are not grids).
+
+    ``column_name`` is required for ``summarize_column`` (validated
+    against the execution's snapshotted column spec) and ignored for
+    ``redline_rows``. ``confirmed_cost_usd`` is the echo of the
+    ``.../bulk-ops/preview-cost`` response value — persisted for audit,
+    same idiom as :class:`TabularExecutionCreate.confirmed_cost_usd`."""
+
+    kind: TabularBulkOpKind
+    column_name: str | None = None
+    confirmed_cost_usd: Decimal | None = None
+
+
+class TabularBulkOpPreviewRequest(BaseModel):
+    """Request body for
+    ``POST /api/v1/tabular/executions/{id}/bulk-ops/preview-cost``.
+
+    Same shape as :class:`TabularBulkOpRequest` minus the
+    ``confirmed_cost_usd`` echo — preview produces the cost;
+    confirmation echoes it back on the subsequent create call."""
+
+    kind: TabularBulkOpKind
+    column_name: str | None = None
+
+
+class TabularBulkOpPreviewResponse(BaseModel):
+    """Response from the bulk-op cost preview.
+
+    ``calls_count`` is the number of gateway calls the op will make
+    (one per grid row for ``redline_rows``; one for
+    ``summarize_column``). ``estimated_cost_usd`` = ``calls_count`` x
+    the rolling-average per-call cost over recent
+    ``purpose='tabular_bulk_op'`` routing-log rows (conservative
+    cold-start default before calibration; ADR 0026 D3)."""
+
+    kind: TabularBulkOpKind
+    calls_count: int
+    per_call_cost_usd: Decimal
+    estimated_cost_usd: Decimal
+
+
+class TabularBulkOpItem(BaseModel):
+    """One item in a bulk op's results.
+
+    ``redline_rows`` produces one item per parent grid row (in grid-row
+    order); ``summarize_column`` produces a single item with
+    ``document_id = None`` (the memo spans the whole grid). Failed
+    items carry ``status='failed'`` + ``error`` and are rendered as
+    failures — the report never silently omits failed rows (C-10)."""
+
+    document_id: uuid.UUID | None = None
+    document_name: str | None = None
+    status: Literal["completed", "failed"]
+    output_text: str | None = None
+    error: str | None = None
+    cost_usd: Decimal | None = None
+
+
+class TabularBulkOpSummary(BaseModel):
+    """Honesty counters for a bulk op's results panel."""
+
+    total_items: int
+    failed_items: int
+
+
+class TabularBulkOpResults(BaseModel):
+    """Shape persisted in ``tabular_bulk_ops.results`` once terminal."""
+
+    schema_version: str
+    items: list[TabularBulkOpItem]
+    summary: TabularBulkOpSummary
+
+
+class TabularBulkOpResponse(BaseModel):
+    """Wire shape for one bulk op — embedded in
+    :class:`TabularExecutionResponse.bulk_ops` (ADR 0026 D2: the detail
+    endpoint the UI already polls is the read-side; no dedicated GET)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    execution_id: uuid.UUID
+    user_id: uuid.UUID | None
+    kind: TabularBulkOpKind
+    status: TabularBulkOpStatus
+    params: dict[str, str | None]
+    results: TabularBulkOpResults | None = None
+    confirmed_cost_usd: Decimal | None = None
+    cost_actual_usd: Decimal | None = None
+    error_text: str | None = None
+    created_at: datetime
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
 class TabularExecutionResponse(BaseModel):
     """Wire shape returned by every tabular execution endpoint
     (``POST /execute``, ``GET /executions/{id}``, etc.)."""
@@ -335,6 +450,12 @@ class TabularExecutionResponse(BaseModel):
     started_at: datetime | None = None
     completed_at: datetime | None = None
 
+    bulk_ops: list[TabularBulkOpResponse] = Field(default_factory=list)
+    """Bulk operations run over this execution, recent-first (DE-304 /
+    ADR 0026 D2). Embedded here — rather than behind a dedicated GET —
+    because the detail endpoint is what the UI already polls, so the
+    results panel gets live progress for free."""
+
 
 class TabularExecutionSummary(BaseModel):
     """Compact wire shape for the list endpoint
@@ -358,29 +479,20 @@ class TabularExecutionSummary(BaseModel):
     completed_at: datetime | None = None
 
 
-class TabularBulkOpRequest(BaseModel):
-    """Request body for
-    ``POST /api/v1/tabular/executions/{id}/bulk-op`` (M3-C4).
-
-    Per Decision C-9, bulk ops spawn sibling execution rows rather
-    than mutating the original grid. The sibling carries
-    ``parent_execution_id`` set to this execution's ID."""
-
-    op: Literal["redline", "summarize"]
-    column_name: str
-    skill_name_override: str | None = None
-    """Override the default skill used for the operation. Default for
-    ``redline`` is ``nda-review`` (or skill matched to the parent
-    execution's skill family); default for ``summarize`` is the
-    deployment-configured summary skill."""
-
-
 __all__ = [
     "CellConfidence",
     "CellResult",
     "Citation",
     "ColumnSpec",
+    "TabularBulkOpItem",
+    "TabularBulkOpKind",
+    "TabularBulkOpPreviewRequest",
+    "TabularBulkOpPreviewResponse",
     "TabularBulkOpRequest",
+    "TabularBulkOpResponse",
+    "TabularBulkOpResults",
+    "TabularBulkOpStatus",
+    "TabularBulkOpSummary",
     "TabularExecutionCreate",
     "TabularExecutionResponse",
     "TabularExecutionStatus",

--- a/api/app/tabular/bulk_ops.py
+++ b/api/app/tabular/bulk_ops.py
@@ -1,0 +1,708 @@
+"""Tabular bulk operations — DE-304 / ADR 0026.
+
+Two operations over a *completed* tabular execution:
+
+* ``redline_rows`` — one redline-style review memo per parent grid row
+  (document), grounded in the row's extracted cell values plus leading
+  document text; items combine into a redline report on the execution
+  detail page.
+* ``summarize_column`` — one memo synthesizing a single column across
+  all rows (an execution-attached memo artifact).
+
+This module carries the whole vertical for the feature:
+
+* the cost estimator the preview endpoint calls (rolling average over
+  ``purpose='tabular_bulk_op'`` routing-log rows, mirroring the
+  M2-E2 / M3-C2 pattern in :mod:`app.tabular.cost`);
+* the ARQ job (``tabular_bulk_op_job``) registered on the shared
+  playbook queue (``arq:m3a6`` per Decision C-3) — one job walks the
+  parent grid sequentially, one gateway call per item, each wrapped in
+  try/except so a failed item never blocks the batch (ADR 0026 D4);
+* the prompt builders (pure functions, unit-testable without a DB).
+
+All inference goes through the same :class:`GatewayClient` surface the
+tabular cell node uses (ADR 0014 — no new egress path), tagged
+``lq_ai_purpose='tabular_bulk_op'`` so the estimator's rolling average
+calibrates off real spend.
+
+Per the M3-C2 quality bar: both outputs are drafts for attorney
+review. "Batch completed" means every item reached a terminal
+per-item state — not that any redline or memo is correct or fit for
+use without review.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.inference import InferenceRoutingLog
+from app.models.tabular import TabularBulkOp, TabularExecution
+from app.schemas.gateway import ChatCompletionMessage, ChatCompletionRequest
+from app.schemas.tabular import TabularBulkOpKind, TabularBulkOpPreviewResponse
+
+if TYPE_CHECKING:
+    from app.clients.gateway import GatewayClient
+
+logger = logging.getLogger(__name__)
+
+
+TABULAR_BULK_OP_PURPOSE = "tabular_bulk_op"
+"""``lq_ai_purpose`` tag on every bulk-op gateway call. The gateway
+writes it through to ``inference_routing_log.purpose`` (M2-E2); the
+cost estimator filters on it so bulk-op calibration is not polluted by
+extraction / chat / judge traffic."""
+
+DEFAULT_PER_CALL_USD: Decimal = Decimal("0.01")
+"""Cold-start per-call cost fallback — 2x the tabular per-cell default
+(:data:`app.tabular.cost.DEFAULT_PER_CELL_USD`) because bulk-op calls
+generate long-form prose (redline memos) rather than short extractions
+(ADR 0026 D3). Conservative on purpose: a 200-row redline op previews
+at $2.00 cold, which arms the UI-side $1.00 confirmation gate
+(Decision C-5)."""
+
+BULK_OP_RESULTS_SCHEMA_VERSION = "de304-v1"
+"""Schema-version stamp on ``tabular_bulk_ops.results``. Bumped on any
+shape-breaking change so the results panel can refuse to render
+unknown versions instead of crashing."""
+
+BULK_OP_MAX_TOKENS = 1500
+"""Max tokens per bulk-op call. Redline memos and column memos are
+prose (unlike the 500-token cell extraction); 1500 keeps a 200-row
+batch bounded while leaving room for a usable draft."""
+
+BULK_OP_CHUNKS_PER_ROW = 4
+"""Leading document chunks included per redline call. Matches the cell
+node's ``RETRIEVAL_TOP_K`` context budget."""
+
+# Job-function name registered on the worker — must match the constant
+# in :mod:`app.workers.queue` so the api-side enqueue helper targets
+# the right function on the shared playbook queue.
+TABULAR_BULK_OP_JOB_NAME = "tabular_bulk_op_job"
+
+_MIN_SAMPLES = 5
+_WINDOW_SAMPLES = 100
+_WINDOW_DAYS = 30
+_CACHE_TTL_SECONDS = 300.0
+
+# Single-slot in-process cache: (cached_at_monotonic, per_call_cost).
+_cache: dict[str, tuple[float, Decimal]] = {}
+_CACHE_KEY = "per_call_cost"
+
+
+# ---------------------------------------------------------------------------
+# Cost preview (ADR 0026 D3)
+# ---------------------------------------------------------------------------
+
+
+def invalidate_cache() -> None:
+    """Reset the in-process cache. Tests call this between assertions."""
+
+    _cache.clear()
+
+
+def bulk_op_calls_count(kind: TabularBulkOpKind, *, n_rows: int) -> int:
+    """Gateway calls the op will make: one per row for ``redline_rows``,
+    one total for ``summarize_column`` (zero either way on an empty grid)."""
+
+    if n_rows <= 0:
+        return 0
+    return n_rows if kind == "redline_rows" else 1
+
+
+async def estimate_per_call_cost_usd(db: AsyncSession | None) -> Decimal:
+    """Rolling-average per-call cost over recent bulk-op routing-log rows.
+
+    Mirrors :func:`app.tabular.cost._estimate_per_cell_metrics`: last
+    :data:`_WINDOW_SAMPLES` rows where ``purpose = 'tabular_bulk_op'``
+    within :data:`_WINDOW_DAYS`; falls back to
+    :data:`DEFAULT_PER_CALL_USD` below :data:`_MIN_SAMPLES` samples,
+    on ``db=None``, or on any query error (the pre-flight must never
+    break the endpoint). Cached in-process per
+    :data:`_CACHE_TTL_SECONDS`.
+    """
+
+    if db is None:
+        return DEFAULT_PER_CALL_USD
+
+    now = time.monotonic()
+    cached = _cache.get(_CACHE_KEY)
+    if cached is not None:
+        cached_at, cached_value = cached
+        if now - cached_at < _CACHE_TTL_SECONDS:
+            return cached_value
+
+    cutoff = datetime.now(UTC) - timedelta(days=_WINDOW_DAYS)
+    recent = (
+        select(InferenceRoutingLog.cost_estimate)
+        .where(
+            InferenceRoutingLog.purpose == TABULAR_BULK_OP_PURPOSE,
+            InferenceRoutingLog.cost_estimate.is_not(None),
+            InferenceRoutingLog.timestamp >= cutoff,
+        )
+        .order_by(InferenceRoutingLog.timestamp.desc())
+        .limit(_WINDOW_SAMPLES)
+        .subquery()
+    )
+    stmt = select(func.avg(recent.c.cost_estimate), func.count(recent.c.cost_estimate))
+
+    try:
+        avg_cost_raw, count = (await db.execute(stmt)).one()
+    except Exception as exc:
+        logger.warning(
+            "bulk-op cost calibration query failed: %s",
+            exc,
+            extra={
+                "event": "tabular_bulk_op_cost_query_error",
+                "error_type": type(exc).__name__,
+            },
+        )
+        return DEFAULT_PER_CALL_USD
+
+    if count is None or count < _MIN_SAMPLES or avg_cost_raw is None:
+        _cache[_CACHE_KEY] = (now, DEFAULT_PER_CALL_USD)
+        return DEFAULT_PER_CALL_USD
+
+    per_call = Decimal(str(avg_cost_raw))
+    _cache[_CACHE_KEY] = (now, per_call)
+    return per_call
+
+
+async def estimate_bulk_op_cost(
+    db: AsyncSession | None,
+    *,
+    kind: TabularBulkOpKind,
+    n_rows: int,
+) -> TabularBulkOpPreviewResponse:
+    """Compute the full preview payload for one proposed bulk op."""
+
+    calls_count = bulk_op_calls_count(kind, n_rows=n_rows)
+    per_call = await estimate_per_call_cost_usd(db)
+    return TabularBulkOpPreviewResponse(
+        kind=kind,
+        calls_count=calls_count,
+        per_call_cost_usd=per_call,
+        estimated_cost_usd=per_call * Decimal(calls_count),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt builders (pure — unit-testable without a DB)
+# ---------------------------------------------------------------------------
+
+
+_REDLINE_SYSTEM_PROMPT = """\
+You are a legal review assistant for an in-house legal team, drafting a
+FIRST-PASS redline memo for one document out of a multi-document review.
+
+You will be given:
+* The DOCUMENT NAME.
+* EXTRACTED TERMS — key values a prior extraction pass pulled from this
+  document, with per-term confidence. Terms marked "(extraction failed)"
+  could not be extracted; do not invent values for them.
+* DOCUMENT EXCERPTS — leading text of the document for context.
+
+Write a concise redline-style review memo in Markdown with these sections:
+
+## Issues
+Numbered list of problematic or unusual terms, each with (a) what the
+document says, (b) why it is a concern, (c) a suggested revised wording.
+
+## Missing or unextracted
+Terms that are absent or failed extraction and should be checked by hand.
+
+## Overall posture
+Two or three sentences on negotiation posture.
+
+Ground every point in the EXTRACTED TERMS or the EXCERPTS. If the
+provided material does not support a conclusion, say so plainly rather
+than speculating. This memo is a draft for attorney review, not final
+work product.
+"""
+
+_MEMO_SYSTEM_PROMPT = """\
+You are a legal review assistant for an in-house legal team, drafting a
+comparative memo about ONE extracted column across a multi-document
+review grid.
+
+You will be given the COLUMN name, the extraction QUERY that produced
+it, and one line per document with that document's extracted value.
+Lines marked "(no value — extraction failed)" are documents where
+extraction failed; you MUST list those documents explicitly in the memo
+rather than omitting them.
+
+Write a concise memo in Markdown with these sections:
+
+## Summary
+The distribution of values across documents (counts, ranges, outliers).
+
+## Outliers and concerns
+Documents whose value deviates from the pack, and why that matters.
+
+## Not covered
+Every document with no extracted value, listed by name, so a human
+reviews them by hand.
+
+Use only the provided values; do not invent data. This memo is a draft
+for attorney review, not final work product.
+"""
+
+
+def build_redline_messages(
+    *,
+    document_name: str,
+    cells: dict[str, dict[str, Any]],
+    chunks: list[dict[str, Any]],
+) -> list[ChatCompletionMessage]:
+    """Render the redline-memo messages for one grid row.
+
+    ``cells`` is the persisted grid-row cell map (column name →
+    CellResult-shaped dict). Failed cells are surfaced to the model as
+    ``(extraction failed)`` — the honesty marker the system prompt
+    keys off — never silently dropped.
+    """
+
+    term_lines: list[str] = []
+    for column_name, cell in cells.items():
+        confidence = cell.get("confidence")
+        value = cell.get("value")
+        if confidence == "failed" or value is None:
+            term_lines.append(f"- {column_name}: (extraction failed)")
+        else:
+            term_lines.append(f"- {column_name}: {value} [confidence: {confidence}]")
+
+    chunk_blocks = [f"[EXCERPT {i}]\n{chunk['content']}" for i, chunk in enumerate(chunks)]
+    user_content = (
+        f"DOCUMENT NAME: {document_name}\n\n"
+        f"EXTRACTED TERMS:\n" + ("\n".join(term_lines) if term_lines else "(none)") + "\n\n"
+        "DOCUMENT EXCERPTS:\n" + ("\n\n".join(chunk_blocks) if chunk_blocks else "(none)")
+    )
+    return [
+        ChatCompletionMessage(role="system", content=_REDLINE_SYSTEM_PROMPT),
+        ChatCompletionMessage(role="user", content=user_content),
+    ]
+
+
+def build_memo_messages(
+    *,
+    column_name: str,
+    column_query: str,
+    row_values: list[tuple[str, str | None]],
+) -> list[ChatCompletionMessage]:
+    """Render the column-memo messages.
+
+    ``row_values`` is ``(document_name, value-or-None)`` per grid row,
+    in grid-row order. ``None`` values (failed / missing extraction)
+    are rendered as ``(no value — extraction failed)`` so the memo
+    accounts for every row (ADR 0026 D5).
+    """
+
+    lines = [
+        f"- {name}: {value if value is not None else '(no value — extraction failed)'}"
+        for name, value in row_values
+    ]
+    user_content = f"COLUMN: {column_name}\nQUERY: {column_query}\n\nVALUES PER DOCUMENT:\n" + (
+        "\n".join(lines) if lines else "(no rows)"
+    )
+    return [
+        ChatCompletionMessage(role="system", content=_MEMO_SYSTEM_PROMPT),
+        ChatCompletionMessage(role="user", content=user_content),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Per-item dispatch
+# ---------------------------------------------------------------------------
+
+
+async def _dispatch(
+    gateway: GatewayClient,
+    *,
+    judge_model: str,
+    messages: list[ChatCompletionMessage],
+) -> str:
+    """One bulk-op gateway call; returns the response text.
+
+    Raises on any transport / shape problem — the caller's per-item
+    try/except converts that into a failed item.
+    """
+
+    request = ChatCompletionRequest(
+        model=judge_model,
+        messages=messages,
+        max_tokens=BULK_OP_MAX_TOKENS,
+        anonymize=False,
+        lq_ai_purpose=TABULAR_BULK_OP_PURPOSE,
+    )
+    response = await gateway.chat_completion(request)
+    choices = getattr(response, "choices", None)
+    if not choices:
+        raise ValueError("empty response from gateway")
+    content = choices[0].message.content
+    if not content or not content.strip():
+        raise ValueError("empty response content")
+    return content.strip()
+
+
+def _failed_item(
+    *,
+    document_id: str | None,
+    document_name: str | None,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "document_id": document_id,
+        "document_name": document_name,
+        "status": "failed",
+        "output_text": None,
+        "error": reason[:2000],
+        "cost_usd": "0",
+    }
+
+
+def _completed_item(
+    *,
+    document_id: str | None,
+    document_name: str | None,
+    output_text: str,
+) -> dict[str, Any]:
+    return {
+        "document_id": document_id,
+        "document_name": document_name,
+        "status": "completed",
+        "output_text": output_text,
+        "error": None,
+        # Per-call cost reconciles off the routing log (same v0.3.0
+        # posture as the cell node's cost_usd).
+        "cost_usd": "0",
+    }
+
+
+def shape_bulk_op_results(items: list[dict[str, Any]]) -> dict[str, Any]:
+    """Assemble the persisted ``tabular_bulk_ops.results`` payload.
+
+    The summary counters are the fail-closed honesty surface: the UI
+    renders ``failed_items`` prominently so a partially-failed batch
+    never reads as a clean one.
+    """
+
+    return {
+        "schema_version": BULK_OP_RESULTS_SCHEMA_VERSION,
+        "items": items,
+        "summary": {
+            "total_items": len(items),
+            "failed_items": sum(1 for item in items if item.get("status") == "failed"),
+        },
+    }
+
+
+async def _run_redline_rows(
+    db: AsyncSession,
+    *,
+    gateway: GatewayClient,
+    judge_model: str,
+    rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """One redline call per grid row; per-item failures never block the batch."""
+
+    from app.tabular.nodes import _fetch_first_chunks
+
+    items: list[dict[str, Any]] = []
+    for row in rows:
+        document_id = row.get("document_id")
+        document_name = row.get("document_name") or ""
+        try:
+            chunks: list[dict[str, Any]] = []
+            if document_id:
+                chunks = await _fetch_first_chunks(
+                    db,
+                    uuid.UUID(str(document_id)),
+                    limit=BULK_OP_CHUNKS_PER_ROW,
+                )
+            messages = build_redline_messages(
+                document_name=document_name,
+                cells=row.get("cells") or {},
+                chunks=chunks,
+            )
+            output = await _dispatch(gateway, judge_model=judge_model, messages=messages)
+            items.append(
+                _completed_item(
+                    document_id=document_id,
+                    document_name=document_name,
+                    output_text=output,
+                )
+            )
+        except Exception as exc:
+            logger.warning(
+                "tabular bulk-op redline item failed: %s",
+                exc,
+                extra={
+                    "event": "tabular_bulk_op_item_error",
+                    "document_id": str(document_id),
+                    "error_type": type(exc).__name__,
+                },
+            )
+            items.append(
+                _failed_item(
+                    document_id=document_id,
+                    document_name=document_name,
+                    reason=f"{type(exc).__name__}: {exc}",
+                )
+            )
+    return items
+
+
+async def _run_summarize_column(
+    *,
+    gateway: GatewayClient,
+    judge_model: str,
+    rows: list[dict[str, Any]],
+    column_name: str,
+    column_query: str,
+) -> list[dict[str, Any]]:
+    """One memo call spanning the whole grid — a single result item."""
+
+    row_values: list[tuple[str, str | None]] = []
+    for row in rows:
+        cell = (row.get("cells") or {}).get(column_name) or {}
+        value = cell.get("value")
+        if cell.get("confidence") == "failed":
+            value = None
+        row_values.append((row.get("document_name") or "", value))
+
+    try:
+        messages = build_memo_messages(
+            column_name=column_name,
+            column_query=column_query,
+            row_values=row_values,
+        )
+        output = await _dispatch(gateway, judge_model=judge_model, messages=messages)
+        return [_completed_item(document_id=None, document_name=None, output_text=output)]
+    except Exception as exc:
+        logger.warning(
+            "tabular bulk-op memo failed: %s",
+            exc,
+            extra={
+                "event": "tabular_bulk_op_item_error",
+                "column_name": column_name,
+                "error_type": type(exc).__name__,
+            },
+        )
+        return [
+            _failed_item(
+                document_id=None,
+                document_name=None,
+                reason=f"{type(exc).__name__}: {exc}",
+            )
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Orchestration + ARQ job
+# ---------------------------------------------------------------------------
+
+
+async def run_tabular_bulk_op(
+    db: AsyncSession,
+    *,
+    bulk_op_id: uuid.UUID,
+    gateway: GatewayClient,
+    judge_model: str | None = None,
+) -> None:
+    """Run one bulk op end to end.
+
+    Lifecycle: ``pending → running`` on entry (sets ``started_at``);
+    on batch completion writes ``results`` + ``cost_actual_usd`` and
+    flips to ``completed`` — including batches with failed items (ADR
+    0026 D4). Whole-batch failures (row missing, parent execution
+    vanished, unreadable results payload, uncaught orchestration
+    error) land at ``failed`` + ``error_text``.
+    """
+
+    from app.tabular.executor import DEFAULT_JUDGE_MODEL
+
+    model = judge_model or DEFAULT_JUDGE_MODEL
+
+    bulk_op = await db.get(TabularBulkOp, bulk_op_id)
+    if bulk_op is None:
+        logger.warning(
+            "tabular bulk-op row not found; nothing to do",
+            extra={
+                "event": "tabular_bulk_op_row_missing",
+                "bulk_op_id": str(bulk_op_id),
+            },
+        )
+        return
+
+    bulk_op.status = "running"
+    bulk_op.started_at = datetime.now(UTC)
+    await db.commit()
+
+    try:
+        execution = await db.get(TabularExecution, bulk_op.execution_id)
+        if execution is None:
+            await _mark_failed(db, bulk_op, "parent execution not found")
+            return
+
+        rows_raw = (execution.results or {}).get("rows")
+        if not isinstance(rows_raw, list) or not rows_raw:
+            await _mark_failed(db, bulk_op, "parent execution has no results grid")
+            return
+        rows: list[dict[str, Any]] = [row for row in rows_raw if isinstance(row, dict)]
+
+        if bulk_op.kind == "redline_rows":
+            items = await _run_redline_rows(
+                db,
+                gateway=gateway,
+                judge_model=model,
+                rows=rows,
+            )
+        else:
+            column_name = str((bulk_op.params or {}).get("column_name") or "")
+            column_query = next(
+                (
+                    str(col.get("query") or "")
+                    for col in execution.columns
+                    if col.get("name") == column_name
+                ),
+                "",
+            )
+            if not column_name:
+                await _mark_failed(db, bulk_op, "params.column_name missing")
+                return
+            items = await _run_summarize_column(
+                gateway=gateway,
+                judge_model=model,
+                rows=rows,
+                column_name=column_name,
+                column_query=column_query,
+            )
+
+        bulk_op.results = shape_bulk_op_results(items)
+        bulk_op.cost_actual_usd = _sum_item_costs(items)
+        bulk_op.status = "completed"
+        bulk_op.completed_at = datetime.now(UTC)
+        await db.commit()
+    except Exception as exc:
+        logger.exception(
+            "tabular bulk-op crashed at orchestration layer",
+            extra={
+                "event": "tabular_bulk_op_crash",
+                "bulk_op_id": str(bulk_op_id),
+            },
+        )
+        await _mark_failed(db, bulk_op, f"{type(exc).__name__}: {exc}")
+
+
+def _sum_item_costs(items: list[dict[str, Any]]) -> Decimal:
+    total = Decimal("0")
+    for item in items:
+        raw = item.get("cost_usd")
+        if raw is None:
+            continue
+        try:
+            total += Decimal(str(raw))
+        except Exception:
+            continue
+    return total
+
+
+async def _mark_failed(db: AsyncSession, bulk_op: TabularBulkOp, error_text: str) -> None:
+    """Best-effort write of the failed terminal state."""
+
+    bulk_op.status = "failed"
+    bulk_op.error_text = error_text[:2000]
+    bulk_op.completed_at = datetime.now(UTC)
+    try:
+        await db.commit()
+    except Exception as exc:  # pragma: no cover - DB best-effort
+        logger.warning(
+            "tabular bulk-op: failed-state write failed: %s",
+            exc,
+            extra={"event": "tabular_bulk_op_persist_failed_error"},
+        )
+
+
+async def tabular_bulk_op_job(ctx: dict[str, Any], bulk_op_id_str: str) -> dict[str, Any]:
+    """ARQ job — run one bulk op on the shared playbook queue.
+
+    Mirrors :func:`app.workers.tabular_worker.tabular_execution_job`:
+    resolves a gateway client from the worker ``ctx``, opens its own
+    session via the standard factory, and delegates to
+    :func:`run_tabular_bulk_op` (which manages the lifecycle
+    internally). BaseException (ARQ ``job_timeout`` cancellation)
+    writes the failed terminal state then re-raises so arq's shutdown
+    machinery still sees the cancel.
+    """
+
+    from app.db.session import get_session_factory
+    from app.workers.tabular_worker import _gateway_from_ctx
+
+    bulk_op_id = uuid.UUID(bulk_op_id_str)
+    logger.info(
+        "tabular bulk-op job start",
+        extra={"event": "tabular_bulk_op_start", "bulk_op_id": bulk_op_id_str},
+    )
+
+    factory = get_session_factory()
+    gateway = _gateway_from_ctx(ctx)
+
+    async with factory() as session:
+        try:
+            await run_tabular_bulk_op(session, bulk_op_id=bulk_op_id, gateway=gateway)
+        except BaseException as exc:
+            # run_tabular_bulk_op catches Exception internally; only
+            # BaseException (CancelledError / SystemExit) reaches here.
+            logger.exception(
+                "tabular bulk-op job cancelled / crashed at job layer",
+                extra={
+                    "event": "tabular_bulk_op_job_error",
+                    "bulk_op_id": bulk_op_id_str,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            from sqlalchemy import update
+
+            await session.execute(
+                update(TabularBulkOp)
+                .where(TabularBulkOp.id == bulk_op_id)
+                .values(
+                    status="failed",
+                    error_text=f"{type(exc).__name__}: {exc}"[:2000],
+                    completed_at=datetime.now(UTC),
+                )
+            )
+            await session.commit()
+            raise
+
+    logger.info(
+        "tabular bulk-op job complete",
+        extra={"event": "tabular_bulk_op_complete", "bulk_op_id": bulk_op_id_str},
+    )
+    return {"bulk_op_id": bulk_op_id_str, "status": "done"}
+
+
+__all__ = [
+    "BULK_OP_CHUNKS_PER_ROW",
+    "BULK_OP_MAX_TOKENS",
+    "BULK_OP_RESULTS_SCHEMA_VERSION",
+    "DEFAULT_PER_CALL_USD",
+    "TABULAR_BULK_OP_JOB_NAME",
+    "TABULAR_BULK_OP_PURPOSE",
+    "build_memo_messages",
+    "build_redline_messages",
+    "bulk_op_calls_count",
+    "estimate_bulk_op_cost",
+    "estimate_per_call_cost_usd",
+    "invalidate_cache",
+    "run_tabular_bulk_op",
+    "shape_bulk_op_results",
+    "tabular_bulk_op_job",
+]

--- a/api/app/workers/arq_setup.py
+++ b/api/app/workers/arq_setup.py
@@ -40,6 +40,9 @@ Registered functions:
   (M3-A6) — Easy Playbook generation pipeline.
 * :func:`app.workers.tabular_worker.tabular_execution_job`
   (M3-C2) — Tabular Review execution pipeline.
+* :func:`app.tabular.bulk_ops.tabular_bulk_op_job`
+  (DE-304 / ADR 0026) — Tabular bulk operations (redline report /
+  column memo) over a completed execution.
 * :func:`app.workers.autonomous_worker.autonomous_session_job`
   (M4-A2) — Autonomous Session execution pipeline.
 
@@ -70,6 +73,7 @@ from typing import Any, ClassVar
 
 from app.config import get_settings
 from app.db.session import dispose_engine
+from app.tabular.bulk_ops import tabular_bulk_op_job
 from app.workers.autonomous_worker import (
     autonomous_idle_watchdog,
     autonomous_schedule_dispatcher,
@@ -233,6 +237,7 @@ class WorkerSettings:
         noop_job,
         easy_playbook_generation_job,
         tabular_execution_job,
+        tabular_bulk_op_job,
         autonomous_session_job,
     ]
     queue_name: ClassVar[str] = M3_PLAYBOOK_QUEUE_NAME

--- a/api/app/workers/queue.py
+++ b/api/app/workers/queue.py
@@ -70,6 +70,13 @@ worker consumes from the same shared queue as Easy Playbook (per
 Decision C-3) and walks the documents x columns grid via the
 LangGraph executor."""
 
+TABULAR_BULK_OP_JOB_NAME = "tabular_bulk_op_job"
+"""DE-304 / ADR 0026 — Tabular bulk operation (redline-per-row report /
+summarize-column memo). Triggered by the API when a user calls
+``POST /api/v1/tabular/executions/{id}/bulk-ops``; the playbook worker
+consumes from the shared queue (Decision C-3). Must match
+:data:`app.tabular.bulk_ops.TABULAR_BULK_OP_JOB_NAME`."""
+
 M3_PLAYBOOK_QUEUE_NAME = "arq:m3a6"
 """Mirror of :data:`app.workers.arq_setup.M3_PLAYBOOK_QUEUE_NAME` (kept
 here to avoid a circular import). Must stay in sync; a discrepancy
@@ -277,6 +284,40 @@ async def enqueue_tabular_execution_job(execution_id: uuid.UUID) -> bool:
             extra={
                 "event": "tabular_execution_enqueue_failed",
                 "execution_id": str(execution_id),
+                "error": str(exc),
+            },
+        )
+        return False
+
+
+async def enqueue_tabular_bulk_op_job(bulk_op_id: uuid.UUID) -> bool:
+    """Enqueue a Tabular bulk-op job onto the shared playbook queue.
+
+    Shares the queue with Easy Playbook + Tabular execution (Decision
+    C-3). Returns True on success, False on transport / import failure
+    (best-effort posture matching the other ``enqueue_*`` helpers).
+    The POST handler logs at WARNING on failure but does NOT roll back
+    the row — the detail view polls regardless, and an operator can
+    re-enqueue manually if the row is stuck at ``pending``.
+    """
+
+    try:
+        pool = await _get_m3a6_pool()
+        await pool.enqueue_job(TABULAR_BULK_OP_JOB_NAME, str(bulk_op_id))
+        log.info(
+            "enqueue_tabular_bulk_op_job: enqueued",
+            extra={
+                "event": "tabular_bulk_op_enqueue",
+                "bulk_op_id": str(bulk_op_id),
+            },
+        )
+        return True
+    except Exception as exc:
+        log.warning(
+            "enqueue_tabular_bulk_op_job: failed; row stays pending",
+            extra={
+                "event": "tabular_bulk_op_enqueue_failed",
+                "bulk_op_id": str(bulk_op_id),
                 "error": str(exc),
             },
         )

--- a/api/tests/tabular/test_bulk_ops.py
+++ b/api/tests/tabular/test_bulk_ops.py
@@ -1,0 +1,387 @@
+"""Tests for tabular bulk operations — DE-304 / ADR 0026.
+
+Covers the :mod:`app.tabular.bulk_ops` vertical:
+
+* preview math (calls count + cold-start default);
+* prompt builders' fail-closed honesty (failed cells / missing values
+  are surfaced to the model, never silently dropped);
+* results shaping (summary counters);
+* the batch runner — partial failures land as failed *items* while the
+  batch completes (ADR 0026 D4), results stay causally linked to the
+  parent execution, and a missing grid fails the whole batch;
+* queue / worker registration wiring (mirrors
+  :mod:`tests.tabular.test_worker`).
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.tabular import TabularBulkOp, TabularExecution
+from app.models.user import User
+from app.security import hash_password
+from app.tabular import bulk_ops
+from app.tabular.bulk_ops import (
+    DEFAULT_PER_CALL_USD,
+    build_memo_messages,
+    build_redline_messages,
+    bulk_op_calls_count,
+    estimate_bulk_op_cost,
+    run_tabular_bulk_op,
+    shape_bulk_op_results,
+)
+from app.workers import arq_setup, queue
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cost_cache() -> None:
+    bulk_ops.invalidate_cache()
+
+
+# ---------------------------------------------------------------------------
+# Preview math (unit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_calls_count_math() -> None:
+    """One call per row for redlines; one total for the memo; zero on
+    an empty grid either way."""
+
+    assert bulk_op_calls_count("redline_rows", n_rows=7) == 7
+    assert bulk_op_calls_count("summarize_column", n_rows=7) == 1
+    assert bulk_op_calls_count("redline_rows", n_rows=0) == 0
+    assert bulk_op_calls_count("summarize_column", n_rows=0) == 0
+
+
+@pytest.mark.unit
+async def test_estimate_cold_start_uses_default_per_call() -> None:
+    """``db=None`` previews at the conservative cold-start default
+    (ADR 0026 D3)."""
+
+    preview = await estimate_bulk_op_cost(None, kind="redline_rows", n_rows=3)
+    assert preview.calls_count == 3
+    assert preview.per_call_cost_usd == DEFAULT_PER_CALL_USD
+    assert preview.estimated_cost_usd == DEFAULT_PER_CALL_USD * 3
+
+    memo_preview = await estimate_bulk_op_cost(None, kind="summarize_column", n_rows=3)
+    assert memo_preview.calls_count == 1
+    assert memo_preview.estimated_cost_usd == DEFAULT_PER_CALL_USD
+
+
+# ---------------------------------------------------------------------------
+# Prompt builders (unit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_redline_messages_mark_failed_cells() -> None:
+    """Failed cells surface as ``(extraction failed)`` — never dropped."""
+
+    messages = build_redline_messages(
+        document_name="nda-1.pdf",
+        cells={
+            "Term": {"value": "3 years", "confidence": "high"},
+            "Survival": {"value": None, "confidence": "failed", "error": "boom"},
+        },
+        chunks=[{"content": "This Agreement lasts three years."}],
+    )
+    assert messages[0].role == "system"
+    user = messages[1].content
+    assert "nda-1.pdf" in user
+    assert "Term: 3 years [confidence: high]" in user
+    assert "Survival: (extraction failed)" in user
+    assert "This Agreement lasts three years." in user
+
+
+@pytest.mark.unit
+def test_memo_messages_list_missing_rows() -> None:
+    """Every row appears in the memo prompt; missing values are marked
+    explicitly so the memo accounts for them (ADR 0026 D5)."""
+
+    messages = build_memo_messages(
+        column_name="Term",
+        column_query="What is the term length?",
+        row_values=[("a.pdf", "3 years"), ("b.pdf", None)],
+    )
+    user = messages[1].content
+    assert "COLUMN: Term" in user
+    assert "a.pdf: 3 years" in user
+    assert "b.pdf: (no value — extraction failed)" in user
+
+
+@pytest.mark.unit
+def test_shape_results_counts_failures() -> None:
+    """The summary counters are the fail-closed honesty surface."""
+
+    items = [
+        {"status": "completed", "output_text": "memo"},
+        {"status": "failed", "error": "boom"},
+        {"status": "completed", "output_text": "memo2"},
+    ]
+    payload = shape_bulk_op_results(items)
+    assert payload["schema_version"] == bulk_ops.BULK_OP_RESULTS_SCHEMA_VERSION
+    assert payload["summary"] == {"total_items": 3, "failed_items": 1}
+    assert payload["items"] == items
+
+
+# ---------------------------------------------------------------------------
+# Queue / worker registration wiring (unit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_bulk_op_job_name_is_stable() -> None:
+    """The ARQ function name is the API↔worker contract."""
+
+    assert queue.TABULAR_BULK_OP_JOB_NAME == "tabular_bulk_op_job"
+    assert bulk_ops.TABULAR_BULK_OP_JOB_NAME == queue.TABULAR_BULK_OP_JOB_NAME
+
+
+@pytest.mark.unit
+def test_worker_registers_bulk_op_job() -> None:
+    """``WorkerSettings.functions`` must include ``tabular_bulk_op_job``
+    or the shared playbook worker would reject the job by name."""
+
+    from app.tabular.bulk_ops import tabular_bulk_op_job
+
+    assert tabular_bulk_op_job in arq_setup.WorkerSettings.functions
+
+
+@pytest.mark.unit
+def test_enqueue_helper_exists() -> None:
+    assert callable(queue.enqueue_tabular_bulk_op_job)
+
+
+# ---------------------------------------------------------------------------
+# Batch runner (integration — real DB, stub gateway)
+# ---------------------------------------------------------------------------
+
+
+class _StubGateway:
+    """Gateway stub: fails any call whose user prompt contains a marker
+    string; otherwise returns a canned completion. Captures every
+    request so tests can assert on prompt content."""
+
+    def __init__(self, *, fail_markers: set[str] | None = None, text: str = "DRAFT MEMO") -> None:
+        self.fail_markers = fail_markers or set()
+        self.text = text
+        self.requests: list[Any] = []
+
+    async def chat_completion(self, request: Any) -> Any:
+        self.requests.append(request)
+        user_content = request.messages[-1].content
+        for marker in self.fail_markers:
+            if marker in user_content:
+                raise RuntimeError("stub gateway failure")
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=self.text))]
+        )
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        email=f"bulk-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+def _grid_row(name: str, term_value: str | None, *, failed: bool = False) -> dict[str, Any]:
+    cell: dict[str, Any] = (
+        {"value": None, "confidence": "failed", "error": "no chunks"}
+        if failed
+        else {"value": term_value, "confidence": "high"}
+    )
+    return {
+        "document_id": str(uuid.uuid4()),
+        "document_name": name,
+        "cells": {"Term": cell},
+    }
+
+
+async def _make_execution(
+    db: AsyncSession,
+    *,
+    user: User,
+    rows: list[dict[str, Any]] | None,
+) -> TabularExecution:
+    execution = TabularExecution(
+        user_id=user.id,
+        status="completed",
+        document_ids=[],
+        columns=[{"name": "Term", "query": "What is the term?"}],
+        results=({"schema_version": "m3-c2-v1", "rows": rows} if rows is not None else None),
+    )
+    db.add(execution)
+    await db.flush()
+    return execution
+
+
+async def _make_bulk_op(
+    db: AsyncSession,
+    *,
+    execution: TabularExecution,
+    user: User,
+    kind: str,
+    params: dict[str, Any] | None = None,
+) -> TabularBulkOp:
+    bulk_op = TabularBulkOp(
+        execution_id=execution.id,
+        user_id=user.id,
+        kind=kind,
+        status="pending",
+        params=params or {},
+    )
+    db.add(bulk_op)
+    await db.flush()
+    return bulk_op
+
+
+@pytest.mark.integration
+async def test_redline_partial_failure_completes_batch(db_session: AsyncSession) -> None:
+    """One row's gateway call errors → that item lands failed with its
+    error persisted; the other rows complete; the BATCH completes
+    (ADR 0026 D4) and results stay linked to the parent execution."""
+
+    user = await _make_user(db_session)
+    rows = [
+        _grid_row("good-1.pdf", "3 years"),
+        _grid_row("bad.pdf", "5 years"),
+        _grid_row("good-2.pdf", "1 year"),
+    ]
+    execution = await _make_execution(db_session, user=user, rows=rows)
+    bulk_op = await _make_bulk_op(db_session, execution=execution, user=user, kind="redline_rows")
+
+    gateway = _StubGateway(fail_markers={"bad.pdf"}, text="## Issues\n1. ...")
+    await run_tabular_bulk_op(
+        db_session,
+        bulk_op_id=bulk_op.id,
+        gateway=gateway,  # type: ignore[arg-type]
+    )
+
+    refreshed = await db_session.get(TabularBulkOp, bulk_op.id)
+    assert refreshed is not None
+    # Linkage: the results row is tied to the parent execution.
+    assert refreshed.execution_id == execution.id
+    assert refreshed.status == "completed"
+    assert refreshed.started_at is not None and refreshed.completed_at is not None
+
+    results = refreshed.results
+    assert results is not None
+    items = results["items"]
+    assert [item["document_name"] for item in items] == [
+        "good-1.pdf",
+        "bad.pdf",
+        "good-2.pdf",
+    ]
+    assert [item["status"] for item in items] == ["completed", "failed", "completed"]
+    # The failed item carries its error and no output; it is never omitted.
+    assert "RuntimeError" in items[1]["error"]
+    assert items[1]["output_text"] is None
+    assert items[0]["output_text"] == "## Issues\n1. ..."
+    assert results["summary"] == {"total_items": 3, "failed_items": 1}
+    # Item document_ids echo the grid rows (per-row linkage).
+    assert items[0]["document_id"] == rows[0]["document_id"]
+    # 3 gateway calls were attempted — the failure did not short-circuit.
+    assert len(gateway.requests) == 3
+    assert all(r.lq_ai_purpose == bulk_ops.TABULAR_BULK_OP_PURPOSE for r in gateway.requests)
+
+
+@pytest.mark.integration
+async def test_summarize_column_single_memo_lists_failed_rows(
+    db_session: AsyncSession,
+) -> None:
+    """The memo op makes ONE call spanning the grid; rows whose cell
+    failed are fed to the model as explicit no-value markers."""
+
+    user = await _make_user(db_session)
+    rows = [
+        _grid_row("a.pdf", "3 years"),
+        _grid_row("b.pdf", None, failed=True),
+    ]
+    execution = await _make_execution(db_session, user=user, rows=rows)
+    bulk_op = await _make_bulk_op(
+        db_session,
+        execution=execution,
+        user=user,
+        kind="summarize_column",
+        params={"column_name": "Term"},
+    )
+
+    gateway = _StubGateway(text="## Summary\n...")
+    await run_tabular_bulk_op(
+        db_session,
+        bulk_op_id=bulk_op.id,
+        gateway=gateway,  # type: ignore[arg-type]
+    )
+
+    refreshed = await db_session.get(TabularBulkOp, bulk_op.id)
+    assert refreshed is not None
+    assert refreshed.status == "completed"
+    assert refreshed.results is not None
+    items = refreshed.results["items"]
+    assert len(items) == 1
+    assert items[0]["document_id"] is None
+    assert items[0]["status"] == "completed"
+    assert items[0]["output_text"] == "## Summary\n..."
+
+    # One call; its prompt covers every row honestly.
+    assert len(gateway.requests) == 1
+    prompt = gateway.requests[0].messages[-1].content
+    assert "a.pdf: 3 years" in prompt
+    assert "b.pdf: (no value — extraction failed)" in prompt
+
+
+@pytest.mark.integration
+async def test_missing_results_grid_fails_whole_batch(db_session: AsyncSession) -> None:
+    """A parent execution without a results grid is a whole-batch
+    failure (pre-flight), not a fabricated empty report."""
+
+    user = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=user, rows=None)
+    bulk_op = await _make_bulk_op(db_session, execution=execution, user=user, kind="redline_rows")
+
+    gateway = _StubGateway()
+    await run_tabular_bulk_op(
+        db_session,
+        bulk_op_id=bulk_op.id,
+        gateway=gateway,  # type: ignore[arg-type]
+    )
+
+    refreshed = await db_session.get(TabularBulkOp, bulk_op.id)
+    assert refreshed is not None
+    assert refreshed.status == "failed"
+    assert refreshed.error_text is not None
+    assert "no results grid" in refreshed.error_text
+    assert gateway.requests == []
+
+
+@pytest.mark.integration
+async def test_cost_actual_summed_from_items(db_session: AsyncSession) -> None:
+    """``cost_actual_usd`` is the item-cost sum (v0.3.0 posture: zero
+    until the gateway returns per-call cost; the column is wired)."""
+
+    user = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=user, rows=[_grid_row("a.pdf", "x")])
+    bulk_op = await _make_bulk_op(db_session, execution=execution, user=user, kind="redline_rows")
+    await run_tabular_bulk_op(
+        db_session,
+        bulk_op_id=bulk_op.id,
+        gateway=_StubGateway(),  # type: ignore[arg-type]
+    )
+    refreshed = await db_session.get(TabularBulkOp, bulk_op.id)
+    assert refreshed is not None
+    assert refreshed.cost_actual_usd == Decimal("0")

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -230,6 +230,9 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("POST", "/api/v1/tabular/executions/{execution_id}/cancel"),
     # M3-C4a — XLSX/CSV export.
     ("GET", "/api/v1/tabular/executions/{execution_id}/export"),
+    # DE-304 / ADR 0026 — bulk operations (preview + create).
+    ("POST", "/api/v1/tabular/executions/{execution_id}/bulk-ops/preview-cost"),
+    ("POST", "/api/v1/tabular/executions/{execution_id}/bulk-ops"),
     # M3-B1 — Word add-in admin manifest generation
     ("GET", "/api/v1/admin/word-addin/manifest"),
     # M3-B8 — Word add-in version handshake (unauthenticated)

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -156,6 +156,9 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/tabular/executions/{execution_id}/cancel",
         # M3-C4a — XLSX/CSV export.
         "/api/v1/tabular/executions/{execution_id}/export",
+        # DE-304 / ADR 0026 — bulk operations (preview + create).
+        "/api/v1/tabular/executions/{execution_id}/bulk-ops/preview-cost",
+        "/api/v1/tabular/executions/{execution_id}/bulk-ops",
         # M3-D1 — slack-bridge persistence surface (bearer-token, no user)
         "/api/v1/integrations/slack/workspaces",
         # M3-D3 — teams-bridge persistence surface (bearer-token, no user)
@@ -342,7 +345,10 @@ async def test_openapi_paths_match_sketch() -> None:
     # Donna #3 adds two new paths (137 -> 139):
     # /api/v1/admin/tool-providers
     # /api/v1/admin/tool-providers/{provider_type}
-    assert len(actual) == 139
+    # DE-304 / ADR 0026 adds two new paths (139 -> 141):
+    # /api/v1/tabular/executions/{execution_id}/bulk-ops/preview-cost
+    # /api/v1/tabular/executions/{execution_id}/bulk-ops
+    assert len(actual) == 141
 
 
 @pytest.mark.unit

--- a/api/tests/test_tabular_bulk_ops_endpoints.py
+++ b/api/tests/test_tabular_bulk_ops_endpoints.py
@@ -1,0 +1,323 @@
+"""HTTP-level tests for the tabular bulk-op endpoints — DE-304 / ADR 0026.
+
+Covers:
+
+* ``POST /api/v1/tabular/executions/{id}/bulk-ops/preview-cost`` —
+  preview math (cold-start default x calls count), Decimal-as-string
+  serialization, 400 on bad column, 404 ownership collapse, 409 on
+  non-completed executions.
+* ``POST /api/v1/tabular/executions/{id}/bulk-ops`` — 202 + row
+  persisted at ``pending`` with the confirmed-cost echo, job enqueued,
+  and the new row embedded in the execution detail response
+  (the ADR 0026 D2 read-side / linkage property).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.main import app
+from app.models.tabular import TabularExecution
+from app.models.user import User
+from app.security import create_access_token, hash_password
+from app.tabular import bulk_ops as bulk_ops_module
+from app.tabular.bulk_ops import DEFAULT_PER_CALL_USD
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cost_cache() -> None:
+    bulk_ops_module.invalidate_cache()
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+async def _make_user(db: AsyncSession) -> User:
+    user = User(
+        email=f"bulkop-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=hash_password("pw"),
+        is_admin=False,
+        role="member",
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+def _bearer(user: User) -> dict[str, str]:
+    return {
+        "Authorization": (
+            f"Bearer {create_access_token(user.id, user.email, is_admin=user.is_admin)}"
+        )
+    }
+
+
+def _rows(n: int) -> list[dict[str, Any]]:
+    return [
+        {
+            "document_id": str(uuid.uuid4()),
+            "document_name": f"doc-{i}.pdf",
+            "cells": {"Term": {"value": f"{i} years", "confidence": "high"}},
+        }
+        for i in range(n)
+    ]
+
+
+async def _make_execution(
+    db: AsyncSession,
+    *,
+    user: User,
+    status: str = "completed",
+    rows: list[dict[str, Any]] | None = None,
+) -> TabularExecution:
+    execution = TabularExecution(
+        user_id=user.id,
+        status=status,
+        document_ids=[],
+        columns=[{"name": "Term", "query": "What is the term?"}],
+        results=({"schema_version": "m3-c2-v1", "rows": rows} if rows is not None else None),
+    )
+    db.add(execution)
+    await db.flush()
+    return execution
+
+
+# ---------------------------------------------------------------------------
+# Preview
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_preview_redline_math_cold_start(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """3 grid rows → 3 calls at the cold-start default; Decimal fields
+    serialize as JSON strings."""
+
+    user = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=user, rows=_rows(3))
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{execution.id}/bulk-ops/preview-cost",
+        headers=_bearer(user),
+        json={"kind": "redline_rows"},
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["kind"] == "redline_rows"
+    assert payload["calls_count"] == 3
+    assert payload["per_call_cost_usd"] == str(DEFAULT_PER_CALL_USD)
+    assert payload["estimated_cost_usd"] == str(DEFAULT_PER_CALL_USD * 3)
+    # Decimal-as-string invariant.
+    assert isinstance(payload["estimated_cost_usd"], str)
+
+
+@pytest.mark.integration
+async def test_preview_summarize_is_one_call(client: AsyncClient, db_session: AsyncSession) -> None:
+    user = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=user, rows=_rows(5))
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{execution.id}/bulk-ops/preview-cost",
+        headers=_bearer(user),
+        json={"kind": "summarize_column", "column_name": "Term"},
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["calls_count"] == 1
+    assert payload["estimated_cost_usd"] == str(DEFAULT_PER_CALL_USD)
+
+
+@pytest.mark.integration
+async def test_preview_summarize_unknown_column_400(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The column must belong to the SNAPSHOTTED spec (C-1)."""
+
+    user = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=user, rows=_rows(2))
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{execution.id}/bulk-ops/preview-cost",
+        headers=_bearer(user),
+        json={"kind": "summarize_column", "column_name": "Nope"},
+    )
+    assert resp.status_code == 400
+    assert "column_name" in resp.json()["detail"]
+
+
+@pytest.mark.integration
+async def test_preview_cross_user_collapses_to_404(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Missing / cross-user executions collapse into 404 (no leakage)."""
+
+    owner = await _make_user(db_session)
+    other = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=owner, rows=_rows(1))
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{execution.id}/bulk-ops/preview-cost",
+        headers=_bearer(other),
+        json={"kind": "redline_rows"},
+    )
+    assert resp.status_code == 404
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{uuid.uuid4()}/bulk-ops/preview-cost",
+        headers=_bearer(other),
+        json={"kind": "redline_rows"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.integration
+async def test_preview_non_completed_execution_409(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Bulk-operating a partial grid would mislead — same posture as
+    export (ADR 0026 D2)."""
+
+    user = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=user, status="running", rows=None)
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{execution.id}/bulk-ops/preview-cost",
+        headers=_bearer(user),
+        json={"kind": "redline_rows"},
+    )
+    assert resp.status_code == 409
+    assert "completed" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_create_bulk_op_202_persists_enqueues_and_links(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """202 + row at ``pending`` with the confirmed-cost echo; the job
+    is enqueued; the new op is embedded in the execution detail
+    response (linkage / read-side per ADR 0026 D2)."""
+
+    enqueued: list[uuid.UUID] = []
+
+    async def _fake_enqueue(bulk_op_id: uuid.UUID) -> bool:
+        enqueued.append(bulk_op_id)
+        return True
+
+    monkeypatch.setattr("app.api.tabular.enqueue_tabular_bulk_op_job", _fake_enqueue)
+
+    user = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=user, rows=_rows(2))
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{execution.id}/bulk-ops",
+        headers=_bearer(user),
+        json={
+            "kind": "summarize_column",
+            "column_name": "Term",
+            "confirmed_cost_usd": "0.01",
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    payload = resp.json()
+    assert payload["execution_id"] == str(execution.id)
+    assert payload["kind"] == "summarize_column"
+    assert payload["status"] == "pending"
+    assert payload["params"] == {"column_name": "Term"}
+    assert payload["confirmed_cost_usd"] == "0.0100"
+    assert payload["results"] is None
+    assert enqueued == [uuid.UUID(payload["id"])]
+
+    # Read-side: the op is embedded in the detail response.
+    detail = await client.get(f"/api/v1/tabular/executions/{execution.id}", headers=_bearer(user))
+    assert detail.status_code == 200, detail.text
+    ops = detail.json()["bulk_ops"]
+    assert [op["id"] for op in ops] == [payload["id"]]
+    assert ops[0]["execution_id"] == str(execution.id)
+
+
+@pytest.mark.integration
+async def test_create_bulk_op_empty_grid_400(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completed execution with zero grid rows has nothing to
+    bulk-operate on — 400, no row created, nothing enqueued."""
+
+    async def _fail_enqueue(bulk_op_id: uuid.UUID) -> bool:  # pragma: no cover
+        raise AssertionError("must not enqueue")
+
+    monkeypatch.setattr("app.api.tabular.enqueue_tabular_bulk_op_job", _fail_enqueue)
+
+    user = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=user, rows=[])
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{execution.id}/bulk-ops",
+        headers=_bearer(user),
+        json={"kind": "redline_rows"},
+    )
+    assert resp.status_code == 400
+    assert "no results grid rows" in resp.json()["detail"]
+
+
+@pytest.mark.integration
+async def test_create_bulk_op_cross_user_404(client: AsyncClient, db_session: AsyncSession) -> None:
+    owner = await _make_user(db_session)
+    other = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=owner, rows=_rows(1))
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{execution.id}/bulk-ops",
+        headers=_bearer(other),
+        json={"kind": "redline_rows"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.integration
+async def test_create_bulk_op_unknown_kind_422(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Kinds outside the closed set are a validation error."""
+
+    user = await _make_user(db_session)
+    execution = await _make_execution(db_session, user=user, rows=_rows(1))
+
+    resp = await client.post(
+        f"/api/v1/tabular/executions/{execution.id}/bulk-ops",
+        headers=_bearer(user),
+        json={"kind": "translate_rows"},
+    )
+    assert resp.status_code == 422

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4141,6 +4141,8 @@ Two paths; the contributor picks one as part of the PR:
 
 #### DE-304 — Tabular Review bulk operations: redline-per-row + summarize-column (deferred from M3-C4)
 
+> **Status: SHIPPED (pending ADR review).** Built per [ADR 0026](adr/0026-tabular-bulk-operations.md) (Status: Proposed — the committee can still reject the output pattern): `POST /tabular/executions/{id}/bulk-ops` (+ `/preview-cost`) with the confirmed-cost idiom, a dedicated `tabular_bulk_ops` table (migration `0066`, execution-CASCADE causal linkage), one ARQ job walking rows with non-blocking per-item failures, and the redline-report/memo results panel on the execution detail page.
+
 **Priority:** P2 (operators get most of M3-C4's value from export today; bulk operations is the "second step" beyond a static grid) · **Effort:** M (~3–4 hr code; ~1–2 hr design conversation upfront because the output pattern is architecturally novel)
 
 **Context:** The M3-C4 spec bundled two distinct deliverables — XLSX/CSV export, and bulk operations on the grid. The export half shipped at M3-C4a (PR #75); the bulk operations half is deferred here because it surfaces architectural decisions the substrate work does not anticipate. M3-C4's M3 scope is reduced to "export only" for v0.3.0; the M3 plan's effort estimate stays 8–10 hr because the M3-C4a work landed in that range.

--- a/docs/adr/0026-tabular-bulk-operations.md
+++ b/docs/adr/0026-tabular-bulk-operations.md
@@ -1,0 +1,78 @@
+# ADR 0026 — Tabular bulk operations (redline report + column memo)
+
+**Status:** Proposed — self-authored in the DE-304 implementation PR. This ADR introduces a novel output pattern (non-grid work product attached to a tabular execution); the review committee can reject it at PR review, in which case the implementation is reverted with it. *AI-drafted, pending maintainer review.*
+
+**Relates to:** the Phase C prep doc Decisions C-1 (snapshotting), C-3 (shared playbook queue), C-5 (cost-confirmation gate), C-9 (bulk ops must not mutate the original grid), C-10 (failed cells render as failures); [PRD §3.14](../PRD.md#314-tabular--multi-document-review-m3) (Tabular / Multi-Document Review); [ADR 0014](0014-gateway-egress-boundary-for-tool-providers.md) (single egress boundary — bulk ops add no new egress path).
+
+---
+
+## Context
+
+The Tabular Review surface (M3-C2/C3/C4) produces a documents × columns grid of Citation-Engine-grounded extractions. PRD §3.14 and the Phase C prep doc anticipated *bulk operations* over a completed grid — "Redline column N", "Summarize column N" — and Decision C-9 reserved `tabular_executions.parent_execution_id` for "bulk-op sibling rows". A `TabularBulkOpRequest` wire-schema stub landed with M3-C4 but no endpoint, worker, or storage ever shipped. DE-304 ships the first two operations.
+
+The two operations chosen, and their output shapes:
+
+1. **Redline-per-row (`redline_rows`)** — for every document (row) of the parent execution, generate a redline-style review memo of that document (issues found, suggested edits, negotiation posture), grounded in the row's extracted cell values plus retrieved document text. The per-row outputs combine into a single **redline report** rendered on the execution detail page.
+2. **Summarize-column (`summarize_column`)** — for one operator-chosen column, synthesize the column's values across all rows into a comparative **memo artifact** attached to the execution (e.g., "Term lengths across the 40 NDAs: 32 are 3 years, 5 are 5 years, 3 failed extraction").
+
+Neither output is a grid. That creates the fork this ADR settles: Decision C-9's sibling-execution mechanism assumed bulk-op output would be *another grid* (a child `tabular_executions` row whose `results` is a `TabularResults` payload). A redline report and a memo do not fit `rows × cells` without abusing the schema.
+
+## Decision drivers
+
+1. **Causal linkage (C-1 spirit).** The output must remain attached to the execution that produced it. Re-opening the execution a week later must show *exactly* which grid snapshot the redlines/memo were derived from — not the skill's or documents' current state.
+2. **Cost control (C-5).** Bulk ops fan out one inference call per row; a 200-row redline op is real money. The operator must see an estimate and confirm before the run starts, with the same preview → `confirmed_cost_usd` echo idiom the tabular execute path uses.
+3. **Fail-closed honesty (C-10).** A row whose redline call fails must render as a failure in the report; the batch must complete around it; the report must never silently omit failed rows.
+4. **No new egress.** All inference goes through the same `GatewayClient.chat_completion` path as tabular cell extraction (ADR 0014); the only change is a new `lq_ai_purpose` tag.
+5. **Small API surface delta.** Prefer extending existing wire shapes over minting new paths where the UI already polls.
+
+## Decisions
+
+### D1 — Storage: a dedicated `tabular_bulk_ops` table (refines Decision C-9)
+
+Bulk-op results are stored in a new table, `tabular_bulk_ops` (migration 0066), one row per operation:
+
+- `id` UUID PK; `execution_id` UUID FK → `tabular_executions.id` `ON DELETE CASCADE` (the causal-linkage column — an op cannot exist without its parent execution); `user_id` FK → `users.id` `ON DELETE SET NULL` (audit survives operator deletion, matching `tabular_executions.user_id`).
+- `kind` text CHECK (`'redline_rows'`, `'summarize_column'`); `params` JSONB (snapshot of op parameters at request time, e.g. `{"column_name": "Term"}`).
+- `status` text CHECK `pending → running → completed | failed`. `completed` means the batch finished, *including* batches with per-item failures (see D4). `failed` is reserved for whole-batch orchestration crashes. No `cancelled` in v1 — ops are minutes, not hours; cancellation is a follow-on if operators ask.
+- `results` JSONB — `{schema_version, items: [{document_id, document_name, status: 'completed'|'failed', output_text, error, cost_usd}], summary: {total_items, failed_items}}`. `redline_rows` yields one item per parent grid row, in grid-row order; `summarize_column` yields one item with `document_id = null` (the memo spans the grid).
+- `confirmed_cost_usd` / `cost_actual_usd` Numeric(10,4); `error_text`; `created_at` / `started_at` / `completed_at`.
+
+**Why not C-9's sibling `tabular_executions` rows:** the sibling mechanism was designed for grid-shaped output. Stuffing a redline report into `TabularExecution.results` would either violate the `TabularResults` schema (breaking every consumer that validates it, including export) or force a fake one-column grid; sibling rows would also pollute the executions list endpoint with rows that are not executions. `parent_execution_id` and its index are **retained unchanged** for future grid-shaped bulk ops (e.g. "re-run column N at a higher tier"); this ADR narrows C-9's mechanism to that case rather than repealing it. This is the novel pattern the committee may reject.
+
+**Why JSONB items, not a per-item results table:** matches the established `tabular_executions.results` convention (grid cells are JSONB, not rows); items are only ever read whole-report; no per-item query pattern exists to index for.
+
+### D2 — API surface: preview + create under the execution, read-side embedded in the detail response
+
+Two new paths, mirroring the existing `preview-cost` / `execute` split exactly:
+
+- `POST /api/v1/tabular/executions/{execution_id}/bulk-ops/preview-cost` — synchronous estimate; no row created.
+- `POST /api/v1/tabular/executions/{execution_id}/bulk-ops` — creates the row at `pending`, enqueues the ARQ job, returns 202 + the row.
+
+Both require the parent execution to be caller-owned (missing / cross-user / soft-deleted collapse into 404, the M3-A6 posture) and in `status='completed'` (409 otherwise — the same posture as export: bulk-operating a partial grid would mislead). `summarize_column` additionally validates `column_name` against the execution's *snapshotted* column spec (400 on unknown — C-1: the op targets what was actually run).
+
+**Read-side:** `TabularExecutionResponse` gains a `bulk_ops` array (recent-first). No new GET path — the detail page already polls `GET /tabular/executions/{id}`, so embedding gives the results panel live progress for free and keeps the OpenAPI delta at two paths instead of three.
+
+### D3 — Cost control: same preview → confirm idiom, purpose-tagged rolling average
+
+The estimator mirrors the M2-E2 / M3-C2 rolling-average pattern: per-call cost = average `cost_estimate` over the last 100 `inference_routing_log` rows where `purpose = 'tabular_bulk_op'` (30-day cap, 5-sample minimum), falling back to a conservative cold-start default of **$0.01/call** — 2× the tabular per-cell default, because bulk-op calls generate long-form prose (redline memos) rather than short extractions. Calls count: `n_rows` for `redline_rows`, `1` for `summarize_column`.
+
+`confirmed_cost_usd` on the create body is the echo of the preview value, persisted for audit — **exactly** the existing tabular-execute idiom: the $1.00 confirmation gate is enforced UI-side (Decision C-5), and the server does not reject on estimate drift (no 402/409-on-mismatch exists anywhere in the tabular surface today; inventing one here would fork the idiom).
+
+### D4 — Execution: one ARQ job on the shared queue; per-item failures never block the batch
+
+One job (`tabular_bulk_op_job`, registered on the shared `arq:m3a6` playbook queue per Decision C-3) walks the parent grid's rows sequentially, one gateway call per item, each wrapped in try/except. A failed item is persisted as `{status: 'failed', error, output_text: null}` and the loop continues; the batch lands at `completed` with `summary.failed_items > 0`, and the UI renders failed items as failures (C-10). The whole-batch `failed` state is reserved for pre-flight errors (parent execution vanished mid-flight, results payload unreadable).
+
+Rejected: one ARQ job *per item* — queue churn for no isolation win, and it forks the established convention (the tabular executor already walks 2000 cells inside one job). Sequential dispatch matches the cell node; per-item parallelism is a follow-on if latency forces it.
+
+Inference goes through the same `GatewayClient.chat_completion` surface as cell extraction, tagged `lq_ai_purpose='tabular_bulk_op'` (feeds the D3 estimator) — no new egress path, no new provider wiring.
+
+### D5 — Grounding: cells first, document text second
+
+The redline prompt for a row carries (a) the row's extracted cell values with their confidences — including `(extraction failed)` markers for failed cells, honestly — and (b) the top document chunks retrieved via the same FTS helper the cell node uses. The memo prompt for a column carries every row's value for that column, with failed/missing rows explicitly listed as such (the memo must account for every row, not just the extractable ones). Per the M3-C2 quality bar, both outputs are drafts for attorney review, and the UI labels them as such.
+
+## Consequences
+
+- Two tables now carry tabular work product; the detail response joins them. Export (`/export`) covers the grid only — exporting bulk-op reports is a follow-on (DE candidate) rather than scope creep here.
+- The `TabularBulkOpRequest` schema stub from M3-C4 (`op`/`column_name`/`skill_name_override`) is replaced by the shapes above; it was never referenced by an endpoint, worker, or the frontend. `skill_name_override` is dropped — v1 bulk ops use fixed prompts, not skill dispatch; skill-driven bulk ops are a follow-on.
+- Deployments must rebuild `api` + `arq-worker` + `ingest-worker` together when this lands (migration 0066 + a new registered job).
+- If the committee rejects D1, the fallback is C-9 sibling rows with a new results discriminator — a larger schema change; the code isolates storage behind the model + one shaping function to keep that pivot cheap.

--- a/docs/api/backend-openapi.generated.yaml
+++ b/docs/api/backend-openapi.generated.yaml
@@ -4875,6 +4875,293 @@ components:
       - sources
       title: SourcesResponse
       type: object
+    TabularBulkOpItem:
+      description: 'One item in a bulk op''s results.
+
+
+        ``redline_rows`` produces one item per parent grid row (in grid-row
+
+        order); ``summarize_column`` produces a single item with
+
+        ``document_id = None`` (the memo spans the whole grid). Failed
+
+        items carry ``status=''failed''`` + ``error`` and are rendered as
+
+        failures — the report never silently omits failed rows (C-10).'
+      properties:
+        cost_usd:
+          anyOf:
+          - pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+            type: string
+          - type: 'null'
+          title: Cost Usd
+        document_id:
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
+          title: Document Id
+        document_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Document Name
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+        output_text:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Output Text
+        status:
+          enum:
+          - completed
+          - failed
+          title: Status
+          type: string
+      required:
+      - status
+      title: TabularBulkOpItem
+      type: object
+    TabularBulkOpPreviewRequest:
+      description: 'Request body for
+
+        ``POST /api/v1/tabular/executions/{id}/bulk-ops/preview-cost``.
+
+
+        Same shape as :class:`TabularBulkOpRequest` minus the
+
+        ``confirmed_cost_usd`` echo — preview produces the cost;
+
+        confirmation echoes it back on the subsequent create call.'
+      properties:
+        column_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Column Name
+        kind:
+          enum:
+          - redline_rows
+          - summarize_column
+          title: Kind
+          type: string
+      required:
+      - kind
+      title: TabularBulkOpPreviewRequest
+      type: object
+    TabularBulkOpPreviewResponse:
+      description: 'Response from the bulk-op cost preview.
+
+
+        ``calls_count`` is the number of gateway calls the op will make
+
+        (one per grid row for ``redline_rows``; one for
+
+        ``summarize_column``). ``estimated_cost_usd`` = ``calls_count`` x
+
+        the rolling-average per-call cost over recent
+
+        ``purpose=''tabular_bulk_op''`` routing-log rows (conservative
+
+        cold-start default before calibration; ADR 0026 D3).'
+      properties:
+        calls_count:
+          title: Calls Count
+          type: integer
+        estimated_cost_usd:
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Estimated Cost Usd
+          type: string
+        kind:
+          enum:
+          - redline_rows
+          - summarize_column
+          title: Kind
+          type: string
+        per_call_cost_usd:
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Per Call Cost Usd
+          type: string
+      required:
+      - kind
+      - calls_count
+      - per_call_cost_usd
+      - estimated_cost_usd
+      title: TabularBulkOpPreviewResponse
+      type: object
+    TabularBulkOpRequest:
+      description: 'Request body for
+
+        ``POST /api/v1/tabular/executions/{id}/bulk-ops`` (DE-304 / ADR 0026).
+
+
+        Replaces the never-wired M3-C4 stub of the same name (which
+
+        anticipated Decision C-9 sibling rows; ADR 0026 D1 stores bulk-op
+
+        output in a dedicated ``tabular_bulk_ops`` table instead because
+
+        the outputs are not grids).
+
+
+        ``column_name`` is required for ``summarize_column`` (validated
+
+        against the execution''s snapshotted column spec) and ignored for
+
+        ``redline_rows``. ``confirmed_cost_usd`` is the echo of the
+
+        ``.../bulk-ops/preview-cost`` response value — persisted for audit,
+
+        same idiom as :class:`TabularExecutionCreate.confirmed_cost_usd`.'
+      properties:
+        column_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Column Name
+        confirmed_cost_usd:
+          anyOf:
+          - type: number
+          - pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+            type: string
+          - type: 'null'
+          title: Confirmed Cost Usd
+        kind:
+          enum:
+          - redline_rows
+          - summarize_column
+          title: Kind
+          type: string
+      required:
+      - kind
+      title: TabularBulkOpRequest
+      type: object
+    TabularBulkOpResponse:
+      description: 'Wire shape for one bulk op — embedded in
+
+        :class:`TabularExecutionResponse.bulk_ops` (ADR 0026 D2: the detail
+
+        endpoint the UI already polls is the read-side; no dedicated GET).'
+      properties:
+        completed_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Completed At
+        confirmed_cost_usd:
+          anyOf:
+          - pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+            type: string
+          - type: 'null'
+          title: Confirmed Cost Usd
+        cost_actual_usd:
+          anyOf:
+          - pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+            type: string
+          - type: 'null'
+          title: Cost Actual Usd
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        error_text:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Text
+        execution_id:
+          format: uuid
+          title: Execution Id
+          type: string
+        id:
+          format: uuid
+          title: Id
+          type: string
+        kind:
+          enum:
+          - redline_rows
+          - summarize_column
+          title: Kind
+          type: string
+        params:
+          additionalProperties:
+            anyOf:
+            - type: string
+            - type: 'null'
+          title: Params
+          type: object
+        results:
+          anyOf:
+          - $ref: '#/components/schemas/TabularBulkOpResults'
+          - type: 'null'
+        started_at:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Started At
+        status:
+          enum:
+          - pending
+          - running
+          - completed
+          - failed
+          title: Status
+          type: string
+        user_id:
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
+          title: User Id
+      required:
+      - id
+      - execution_id
+      - user_id
+      - kind
+      - status
+      - params
+      - created_at
+      title: TabularBulkOpResponse
+      type: object
+    TabularBulkOpResults:
+      description: Shape persisted in ``tabular_bulk_ops.results`` once terminal.
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/TabularBulkOpItem'
+          title: Items
+          type: array
+        schema_version:
+          title: Schema Version
+          type: string
+        summary:
+          $ref: '#/components/schemas/TabularBulkOpSummary'
+      required:
+      - schema_version
+      - items
+      - summary
+      title: TabularBulkOpResults
+      type: object
+    TabularBulkOpSummary:
+      description: Honesty counters for a bulk op's results panel.
+      properties:
+        failed_items:
+          title: Failed Items
+          type: integer
+        total_items:
+          title: Total Items
+          type: integer
+      required:
+      - total_items
+      - failed_items
+      title: TabularBulkOpSummary
+      type: object
     TabularExecutionCreate:
       description: 'Request body for ``POST /api/v1/tabular/execute``.
 
@@ -4931,6 +5218,11 @@ components:
 
         (``POST /execute``, ``GET /executions/{id}``, etc.).'
       properties:
+        bulk_ops:
+          items:
+            $ref: '#/components/schemas/TabularBulkOpResponse'
+          title: Bulk Ops
+          type: array
         columns:
           items:
             $ref: '#/components/schemas/ColumnSpec'
@@ -12965,6 +13257,111 @@ paths:
       security:
       - OAuth2PasswordBearer: []
       summary: Get a tabular execution by id.
+      tags:
+      - tabular
+  /api/v1/tabular/executions/{execution_id}/bulk-ops:
+    post:
+      description: 'Create a ``tabular_bulk_ops`` row at ``pending`` and enqueue the
+
+        ARQ job on the shared playbook queue (Decision C-3). Returns 202;
+
+        the detail view polls ``GET /tabular/executions/{id}`` — the
+
+        ``bulk_ops`` array embedded there is the read-side (ADR 0026 D2).
+
+
+        ``confirmed_cost_usd`` is the echo of the preview response —
+
+        persisted for audit; the $1.00 confirmation gate stays UI-side,
+
+        exactly like ``POST /tabular/execute`` (Decision C-5).
+
+
+        Per ADR 0026 D4, batch "completed" does NOT mean every item
+
+        succeeded — failed items are persisted per-row and rendered as
+
+        failures in the report.'
+      operationId: create_tabular_bulk_op_api_v1_tabular_executions__execution_id__bulk_ops_post
+      parameters:
+      - in: path
+        name: execution_id
+        required: true
+        schema:
+          format: uuid
+          title: Execution Id
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TabularBulkOpRequest'
+        required: true
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TabularBulkOpResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: Start a bulk operation over a completed tabular execution.
+      tags:
+      - tabular
+  /api/v1/tabular/executions/{execution_id}/bulk-ops/preview-cost:
+    post:
+      description: 'Synchronous cost preview — no bulk-op row is created.
+
+
+        Mirrors ``POST /tabular/preview-cost`` (Decision C-5): the UI calls
+
+        this before arming the confirmation gate. Calls count is one per
+
+        grid row for ``redline_rows``, one total for ``summarize_column``;
+
+        per-call cost is the rolling average over recent
+
+        ``purpose=''tabular_bulk_op''`` routing-log rows (conservative
+
+        cold-start default before calibration; ADR 0026 D3).'
+      operationId: preview_tabular_bulk_op_cost_api_v1_tabular_executions__execution_id__bulk_ops_preview_cost_post
+      parameters:
+      - in: path
+        name: execution_id
+        required: true
+        schema:
+          format: uuid
+          title: Execution Id
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TabularBulkOpPreviewRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TabularBulkOpPreviewResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: Preview the cost of a proposed bulk operation.
       tags:
       - tabular
   /api/v1/tabular/executions/{execution_id}/cancel:

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -2942,6 +2942,97 @@ paths:
         '401':
           description: Not authenticated.
 
+  /api/v1/tabular/executions/{execution_id}/bulk-ops/preview-cost:
+    parameters:
+      - in: path
+        name: execution_id
+        required: true
+        schema: {type: string, format: uuid}
+    post:
+      tags: [tabular]
+      summary: Preview the cost of a proposed bulk operation (DE-304)
+      description: |
+        Synchronous cost preview — no bulk-op row is created. Mirrors
+        ``POST /tabular/preview-cost`` (Decision C-5): the UI calls this
+        before arming the confirmation gate. Calls count is one per grid
+        row for ``redline_rows``, one total for ``summarize_column``;
+        per-call cost is a rolling average over recent
+        ``purpose='tabular_bulk_op'`` routing-log rows with a
+        conservative cold-start default (ADR 0026 D3).
+
+        The parent execution must be caller-owned (404 collapse) and in
+        ``status='completed'`` (409 otherwise — same posture as export).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/TabularBulkOpPreviewRequest'}
+      responses:
+        '200':
+          description: Cost preview.
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/TabularBulkOpPreviewResponse'}
+        '400':
+          description: ``summarize_column`` without a valid ``column_name`` from the snapshotted spec.
+        '404':
+          description: Execution not found or not authorized.
+        '409':
+          description: Execution not in ``status='completed'``.
+        '422':
+          description: Validation error (unknown ``kind`` etc.).
+        '401':
+          description: Not authenticated.
+
+  /api/v1/tabular/executions/{execution_id}/bulk-ops:
+    parameters:
+      - in: path
+        name: execution_id
+        required: true
+        schema: {type: string, format: uuid}
+    post:
+      tags: [tabular]
+      summary: Start a bulk operation over a completed tabular execution (DE-304)
+      description: |
+        Creates a ``tabular_bulk_ops`` row at ``status='pending'`` and
+        enqueues the ARQ job on the shared playbook queue (Decision
+        C-3). Returns 202; the detail view polls
+        ``GET /api/v1/tabular/executions/{id}`` — the ``bulk_ops``
+        array embedded there is the read-side (ADR 0026 D2).
+
+        Two kinds (ADR 0026): ``redline_rows`` (one redline-style
+        review memo per grid row, combined into a redline report) and
+        ``summarize_column`` (one memo synthesizing a chosen column
+        across all rows). Per-item failures are persisted per-row and
+        rendered as failures — they never block the batch, and the
+        report never silently omits failed rows.
+
+        ``confirmed_cost_usd`` echoes the preview value for audit; the
+        $1.00 confirmation gate is UI-side (Decision C-5, matching
+        ``POST /tabular/execute``). Outputs are drafts for attorney
+        review, not final work product.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/TabularBulkOpRequest'}
+      responses:
+        '202':
+          description: Bulk op scheduled; row created at status `pending`.
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/TabularBulkOp'}
+        '400':
+          description: Invalid ``column_name``, or execution has no results grid rows.
+        '404':
+          description: Execution not found or not authorized.
+        '409':
+          description: Execution not in ``status='completed'``.
+        '422':
+          description: Validation error.
+        '401':
+          description: Not authenticated.
+
   /api/v1/playbooks/{playbook_id}/execute:
     parameters:
       - in: path
@@ -6328,6 +6419,14 @@ components:
         created_at: {type: string, format: date-time}
         started_at: {type: string, format: date-time, nullable: true}
         completed_at: {type: string, format: date-time, nullable: true}
+        bulk_ops:
+          type: array
+          items: {$ref: '#/components/schemas/TabularBulkOp'}
+          description: |
+            Bulk operations run over this execution, recent-first
+            (DE-304 / ADR 0026). Embedded in the detail response —
+            rather than behind a dedicated GET — because the detail
+            endpoint is what the UI already polls.
 
     TabularExecutionSummary:
       type: object
@@ -6354,6 +6453,113 @@ components:
         cost_estimate_usd: {type: string, nullable: true}
         cost_actual_usd: {type: string, nullable: true}
         created_at: {type: string, format: date-time}
+        completed_at: {type: string, format: date-time, nullable: true}
+
+    # DE-304 / ADR 0026 — Tabular bulk-operation wire shapes.
+    TabularBulkOpPreviewRequest:
+      type: object
+      required: [kind]
+      description: |
+        Request body for
+        ``POST /api/v1/tabular/executions/{id}/bulk-ops/preview-cost``.
+        ``column_name`` is required for ``summarize_column`` (validated
+        against the execution's snapshotted column spec) and ignored
+        for ``redline_rows``.
+      properties:
+        kind:
+          type: string
+          enum: [redline_rows, summarize_column]
+        column_name: {type: string, nullable: true}
+
+    TabularBulkOpPreviewResponse:
+      type: object
+      required: [kind, calls_count, per_call_cost_usd, estimated_cost_usd]
+      properties:
+        kind:
+          type: string
+          enum: [redline_rows, summarize_column]
+        calls_count:
+          type: integer
+          description: |
+            Gateway calls the op will make — one per grid row for
+            ``redline_rows``; one total for ``summarize_column``.
+        per_call_cost_usd:
+          type: string
+          description: |
+            Rolling-average cost over recent
+            ``purpose='tabular_bulk_op'`` routing-log rows (conservative
+            cold-start default before calibration), serialized as a
+            JSON string to preserve decimal precision.
+        estimated_cost_usd:
+          type: string
+          description: |
+            ``per_call_cost_usd * calls_count``, serialized as a JSON
+            string to preserve decimal precision.
+
+    TabularBulkOpRequest:
+      type: object
+      required: [kind]
+      description: |
+        Request body for
+        ``POST /api/v1/tabular/executions/{id}/bulk-ops``.
+        ``confirmed_cost_usd`` echoes the preview value — persisted for
+        audit (Decision C-5 idiom; the $1.00 confirmation gate is
+        UI-side, matching ``POST /tabular/execute``).
+      properties:
+        kind:
+          type: string
+          enum: [redline_rows, summarize_column]
+        column_name: {type: string, nullable: true}
+        confirmed_cost_usd: {type: string, nullable: true}
+
+    TabularBulkOp:
+      type: object
+      required: [id, execution_id, kind, status, params, created_at]
+      description: |
+        One row from the ``tabular_bulk_ops`` table (migration 0066).
+        Lifecycle: ``pending → running → completed | failed``. Per ADR
+        0026 D4, ``completed`` includes batches with per-item failures
+        — failed items are persisted in ``results.items[*]`` with
+        ``status='failed'`` + ``error`` and rendered as failures;
+        ``failed`` is reserved for whole-batch orchestration crashes
+        (``error_text`` populated).
+      properties:
+        id: {type: string, format: uuid}
+        execution_id:
+          type: string
+          format: uuid
+          description: The parent execution (causal linkage; ADR 0026 D1).
+        user_id: {type: string, format: uuid, nullable: true}
+        kind:
+          type: string
+          enum: [redline_rows, summarize_column]
+        status:
+          type: string
+          enum: [pending, running, completed, failed]
+        params:
+          type: object
+          additionalProperties: {type: string, nullable: true}
+          description: |
+            Op parameters snapshotted at request time (C-1 posture) —
+            ``{"column_name": ...}`` for ``summarize_column``; empty
+            for ``redline_rows``.
+        results:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: |
+            ``{schema_version, items, summary}`` once terminal
+            (currently ``de304-v1``). Each item:
+            ``{document_id (uuid, null for the summarize memo),
+            document_name, status ('completed'|'failed'),
+            output_text (Markdown draft, null on failure),
+            error (null on success), cost_usd (string)}``.
+            ``summary`` carries ``total_items`` + ``failed_items``.
+        confirmed_cost_usd: {type: string, nullable: true}
+        cost_actual_usd: {type: string, nullable: true}
+        error_text: {type: string, nullable: true}
+        created_at: {type: string, format: date-time}
+        started_at: {type: string, format: date-time, nullable: true}
         completed_at: {type: string, format: date-time, nullable: true}
 
     AdminUserRow:

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1518,11 +1518,15 @@ Substrate for the Tabular / Multi-Document Review surface
 execution walks a `documents × columns` grid and produces a
 row-per-document by column-per-spec result, run as a LangGraph workflow
 on the existing `arq:m3a6` queue (Decision C-3 from the Phase C prep
-doc: reuse the queue rather than add a second worker container). One
-table, introduced by migration `0036_tabular_executions.py`:
+doc: reuse the queue rather than add a second worker container). Two
+tables (migrations `0036_tabular_executions.py` and
+`0066_tabular_bulk_ops.py`):
 
 * `tabular_executions` — one row per execution; persists the inputs +
   status + assembled grid so the result view can re-render a week later.
+* `tabular_bulk_ops` — one row per bulk operation over a completed
+  execution (DE-304 / ADR 0026); persists the op params + per-item
+  results causally linked to the parent execution.
 
 ### `tabular_executions` (M3)
 
@@ -1600,6 +1604,66 @@ populated once status is `completed` (may carry partial output on
 
 Soft delete via `deleted_at` matches the `playbooks.deleted_at` posture
 from M3-A6's migration 0034.
+
+### `tabular_bulk_ops` (DE-304 / [ADR 0026](adr/0026-tabular-bulk-operations.md))
+
+One row per bulk operation over a *completed* tabular execution —
+`redline_rows` (one redline-style review memo per grid row, combined
+into a redline report) or `summarize_column` (one memo synthesizing a
+chosen column across all rows). Introduced by migration
+`0066_tabular_bulk_ops.py`. Per ADR 0026 D1 these land in a dedicated
+table rather than Decision C-9's sibling-execution rows: the outputs
+are not grids, so they don't fit `tabular_executions.results`
+(`parent_execution_id` is retained unchanged for future grid-shaped
+bulk ops).
+
+```sql
+CREATE TABLE tabular_bulk_ops (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    execution_id        UUID NOT NULL REFERENCES tabular_executions(id) ON DELETE CASCADE,
+    user_id             UUID REFERENCES users(id) ON DELETE SET NULL,
+    kind                TEXT NOT NULL,                       -- 'redline_rows' | 'summarize_column'
+    status              TEXT NOT NULL DEFAULT 'pending',
+    params              JSONB NOT NULL DEFAULT '{}'::jsonb,  -- op params snapshotted at request time (e.g. column_name)
+    results             JSONB,                               -- {schema_version, items, summary} once terminal
+    confirmed_cost_usd  NUMERIC(10,4),                       -- operator-confirmed preview echo (Decision C-5 idiom)
+    cost_actual_usd     NUMERIC(10,4),
+    error_text          TEXT,                                -- populated when status='failed'
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    started_at          TIMESTAMPTZ,
+    completed_at        TIMESTAMPTZ,
+
+    CONSTRAINT chk_tabular_bulk_ops_kind
+        CHECK (kind IN ('redline_rows','summarize_column')),
+    CONSTRAINT chk_tabular_bulk_ops_status
+        CHECK (status IN ('pending','running','completed','failed')),
+    CONSTRAINT fk_tabular_bulk_ops_execution_id
+        FOREIGN KEY (execution_id) REFERENCES tabular_executions(id) ON DELETE CASCADE,
+    CONSTRAINT fk_tabular_bulk_ops_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- The execution detail read-side lists an execution's ops recent-first.
+CREATE INDEX idx_tabular_bulk_ops_execution_recent
+    ON tabular_bulk_ops (execution_id, created_at DESC);
+```
+
+`execution_id` is the causal-linkage column (ADR 0026 D1): an op
+cannot exist without its parent execution, so the FK cascades on
+delete. No soft delete of its own — ops live and die with their
+parent, which itself soft-deletes.
+
+Status lifecycle: `pending → running → completed | failed`. Per ADR
+0026 D4, `completed` includes batches with per-item failures — failed
+items are persisted inside `results.items[*]` (`status='failed'` +
+`error`) and rendered as failures; `failed` is reserved for
+whole-batch orchestration crashes.
+
+`results` shape (`schema_version` currently `de304-v1`):
+`{items: [{document_id, document_name, status, output_text, error,
+cost_usd}], summary: {total_items, failed_items}}`. `redline_rows`
+yields one item per parent grid row in grid-row order;
+`summarize_column` yields a single item with `document_id = NULL`.
 
 ---
 

--- a/web/cypress/e2e/m3-c-tabular-review.cy.ts
+++ b/web/cypress/e2e/m3-c-tabular-review.cy.ts
@@ -337,4 +337,116 @@ describe('M3-C3 — Tabular Review happy path', () => {
 		cy.get('[data-testid="lq-tabcm-close"]').click();
 		cy.get('[data-testid="lq-tabcm"]').should('not.exist');
 	});
+
+	// DE-304 / ADR 0026 — bulk operations over a completed grid.
+	it('completed grid → preview bulk-op cost → run redline report → results panel renders per-row failures honestly', () => {
+		const BULK_OP_ID = 'bop-1';
+		const mockBulkOpPending = {
+			id: BULK_OP_ID,
+			execution_id: EXECUTION_ID,
+			user_id: 'u1',
+			kind: 'redline_rows' as const,
+			status: 'pending' as const,
+			params: {},
+			results: null,
+			confirmed_cost_usd: '0.0500',
+			cost_actual_usd: null,
+			error_text: null,
+			created_at: '2026-05-22T16:00:00Z',
+			started_at: null,
+			completed_at: null
+		};
+		// One row of the 5 fails — the panel must say so (fail-closed
+		// honesty; the report never silently omits failed rows).
+		const mockBulkOpCompleted = {
+			...mockBulkOpPending,
+			status: 'completed' as const,
+			started_at: '2026-05-22T16:00:02Z',
+			completed_at: '2026-05-22T16:01:00Z',
+			cost_actual_usd: '0',
+			results: {
+				schema_version: 'de304-v1',
+				items: DOC_IDS.map((docId, i) => ({
+					document_id: docId,
+					document_name: `sample-nda-${i + 1}.pdf`,
+					status: i === 1 ? ('failed' as const) : ('completed' as const),
+					output_text: i === 1 ? null : `## Issues\n1. Draft point for doc ${i + 1}`,
+					error: i === 1 ? 'RuntimeError: gateway unavailable' : null,
+					cost_usd: '0'
+				})),
+				summary: { total_items: 5, failed_items: 1 }
+			}
+		};
+
+		cy.intercept('POST', `**/api/v1/tabular/executions/${EXECUTION_ID}/bulk-ops/preview-cost`, {
+			statusCode: 200,
+			body: {
+				kind: 'redline_rows',
+				calls_count: 5,
+				per_call_cost_usd: '0.0100',
+				estimated_cost_usd: '0.0500'
+			}
+		}).as('bulkOpPreview');
+
+		cy.intercept('POST', `**/api/v1/tabular/executions/${EXECUTION_ID}/bulk-ops`, {
+			statusCode: 202,
+			body: mockBulkOpPending
+		}).as('bulkOpCreate');
+
+		// Detail polls: completed grid throughout; the bulk op appears
+		// pending right after create, then completed on the next poll.
+		let detailCount = 0;
+		cy.intercept('GET', `**/api/v1/tabular/executions/${EXECUTION_ID}`, (req) => {
+			detailCount += 1;
+			const bulkOps =
+				detailCount === 1 ? [] : detailCount === 2 ? [mockBulkOpPending] : [mockBulkOpCompleted];
+			req.reply({
+				statusCode: 200,
+				body: { ...mockExecutionCompleted, bulk_ops: bulkOps }
+			});
+		}).as('pollDetail');
+
+		// Login and land directly on the completed execution.
+		cy.visit('/lq-ai/login');
+		cy.get('[data-testid="lq-ai-login-email"]').type('admin@lq.ai');
+		cy.get('[data-testid="lq-ai-login-password"]').type('password');
+		cy.get('[data-testid="lq-ai-login-submit"]').click();
+		cy.wait('@login');
+		cy.url({ timeout: 15000 }).should('not.include', '/login');
+
+		cy.visit(`/lq-ai/tabular/${EXECUTION_ID}`);
+		cy.wait('@pollDetail');
+		cy.get('[data-testid="lq-tabres-status"]', { timeout: 10000 }).should('contain', 'Completed');
+
+		// Bulk-ops affordance is visible on a completed grid.
+		cy.get('[data-testid="lq-bulkops"]').should('be.visible');
+		cy.get('[data-testid="lq-bulkops-kind-redline"]').check();
+
+		// Preview: 5 calls at $0.01 → $0.05; below $1 so no confirm gate.
+		cy.get('[data-testid="lq-bulkops-preview"]').click();
+		cy.wait('@bulkOpPreview');
+		cy.get('[data-testid="lq-bulkops-preview-result"]').should('contain', '5 call(s)');
+		cy.get('[data-testid="lq-bulkops-preview-result"]').should('contain', '$0.05');
+		cy.get('[data-testid="lq-bulkops-confirm"]').should('not.exist');
+
+		// Run → create fires with the confirmed-cost echo; pending row shows.
+		cy.get('[data-testid="lq-bulkops-run"]').should('not.be.disabled').click();
+		cy.wait('@bulkOpCreate')
+			.its('request.body')
+			.should('deep.include', { kind: 'redline_rows', confirmed_cost_usd: '0.0500' });
+		cy.wait('@pollDetail');
+		cy.get('[data-testid="lq-bulkops-op-status"]', { timeout: 10000 }).should(
+			'contain',
+			'Queued'
+		);
+
+		// Next poll (op non-terminal keeps polling alive) → completed with
+		// the honest partial-failure banner.
+		cy.wait('@pollDetail');
+		cy.get('[data-testid="lq-bulkops-op-status"]', { timeout: 10000 }).should(
+			'contain',
+			'1 of 5 item(s) FAILED'
+		);
+		cy.get('[data-testid="lq-bulkops-item-failed"]').should('have.length', 1);
+	});
 });

--- a/web/src/lib/lq-ai/api/tabular.ts
+++ b/web/src/lib/lq-ai/api/tabular.ts
@@ -10,6 +10,10 @@
 import { getAccessToken } from '../auth/store';
 import { apiRequest, LQ_AI_API_BASE_URL, LQAIApiError } from './client';
 import type {
+	TabularBulkOp,
+	TabularBulkOpCreateRequest,
+	TabularBulkOpPreviewRequest,
+	TabularBulkOpPreviewResponse,
 	TabularExecution,
 	TabularExecutionCreate,
 	TabularExecutionSummary,
@@ -86,6 +90,45 @@ export async function cancelTabularExecution(
 	return apiRequest<TabularExecution>(
 		`/tabular/executions/${encodeURIComponent(executionId)}/cancel`,
 		{ method: 'POST' }
+	);
+}
+
+/**
+ * POST /api/v1/tabular/executions/{id}/bulk-ops/preview-cost —
+ * DE-304 / ADR 0026. Synchronous cost preview for a proposed bulk op;
+ * no row is created. Mirrors {@link previewTabularCost} (Decision
+ * C-5): call before arming the confirmation gate.
+ */
+export async function previewTabularBulkOpCost(
+	executionId: string,
+	body: TabularBulkOpPreviewRequest
+): Promise<TabularBulkOpPreviewResponse> {
+	return apiRequest<TabularBulkOpPreviewResponse>(
+		`/tabular/executions/${encodeURIComponent(executionId)}/bulk-ops/preview-cost`,
+		{
+			method: 'POST',
+			body: body as unknown as Record<string, unknown>
+		}
+	);
+}
+
+/**
+ * POST /api/v1/tabular/executions/{id}/bulk-ops — DE-304 / ADR 0026.
+ * Creates the bulk-op row at `status='pending'` and enqueues the
+ * worker job. Returns 202 + the row; poll
+ * {@link getTabularExecution} — the op appears in its `bulk_ops`
+ * array (the read-side).
+ */
+export async function createTabularBulkOp(
+	executionId: string,
+	body: TabularBulkOpCreateRequest
+): Promise<TabularBulkOp> {
+	return apiRequest<TabularBulkOp>(
+		`/tabular/executions/${encodeURIComponent(executionId)}/bulk-ops`,
+		{
+			method: 'POST',
+			body: body as unknown as Record<string, unknown>
+		}
 	);
 }
 

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -1198,6 +1198,12 @@ export interface TabularExecution {
 	created_at: string;
 	started_at: string | null;
 	completed_at: string | null;
+	/**
+	 * Bulk operations run over this execution, recent-first (DE-304 /
+	 * ADR 0026). Optional so responses predating the field parse
+	 * unchanged.
+	 */
+	bulk_ops?: TabularBulkOp[];
 }
 
 /**
@@ -1259,6 +1265,96 @@ export interface TabularPreviewCostResponse {
 	estimated_tokens: number;
 	estimated_cost_usd: string;
 	per_tier_breakdown: Record<string, number>;
+}
+
+// ----- Tabular bulk operations (DE-304 / ADR 0026) -----
+
+/**
+ * The two v1 bulk operations over a completed execution:
+ * `redline_rows` (one redline-style review memo per grid row,
+ * combined into a redline report) and `summarize_column` (one memo
+ * synthesizing a chosen column across all rows).
+ */
+export type TabularBulkOpKind = 'redline_rows' | 'summarize_column';
+
+/**
+ * Lifecycle of a bulk op. `completed` includes batches with per-item
+ * failures (ADR 0026 D4) — failed items live inside `results.items`
+ * and MUST render as failures; `failed` is whole-batch crashes only
+ * (`error_text` populated).
+ */
+export type TabularBulkOpStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+/**
+ * One item of a bulk op's results. `document_id`/`document_name` are
+ * null on the summarize-column memo (it spans the whole grid).
+ * Decimal-typed `cost_usd` comes over the wire as a JSON string.
+ */
+export interface TabularBulkOpItem {
+	document_id: string | null;
+	document_name: string | null;
+	status: 'completed' | 'failed';
+	output_text: string | null;
+	error: string | null;
+	cost_usd: string | null;
+}
+
+export interface TabularBulkOpResults {
+	schema_version: string;
+	items: TabularBulkOpItem[];
+	summary: {
+		total_items: number;
+		failed_items: number;
+	};
+}
+
+/**
+ * One row from `tabular_bulk_ops`, embedded in
+ * `TabularExecution.bulk_ops` (the detail endpoint the page already
+ * polls is the read-side — ADR 0026 D2).
+ */
+export interface TabularBulkOp {
+	id: string;
+	execution_id: string;
+	user_id: string | null;
+	kind: TabularBulkOpKind;
+	status: TabularBulkOpStatus;
+	params: Record<string, string | null>;
+	results: TabularBulkOpResults | null;
+	confirmed_cost_usd: string | null;
+	cost_actual_usd: string | null;
+	error_text: string | null;
+	created_at: string;
+	started_at: string | null;
+	completed_at: string | null;
+}
+
+/**
+ * Request body for
+ * `POST /api/v1/tabular/executions/{id}/bulk-ops/preview-cost`.
+ * `column_name` is required for `summarize_column`.
+ */
+export interface TabularBulkOpPreviewRequest {
+	kind: TabularBulkOpKind;
+	column_name?: string | null;
+}
+
+export interface TabularBulkOpPreviewResponse {
+	kind: TabularBulkOpKind;
+	calls_count: number;
+	per_call_cost_usd: string;
+	estimated_cost_usd: string;
+}
+
+/**
+ * Request body for `POST /api/v1/tabular/executions/{id}/bulk-ops`.
+ * `confirmed_cost_usd` echoes the preview value (audit trail; the
+ * $1.00 confirmation gate is UI-side, per Decision C-5).
+ */
+export interface TabularBulkOpCreateRequest {
+	kind: TabularBulkOpKind;
+	column_name?: string | null;
+	confirmed_cost_usd?: string | null;
 }
 
 // ----- Citation Ledger (P1-A3 / P1-C1) -----

--- a/web/src/routes/lq-ai/tabular/[id]/+page.svelte
+++ b/web/src/routes/lq-ai/tabular/[id]/+page.svelte
@@ -6,12 +6,16 @@
 	import {
 		getTabularExecution,
 		cancelTabularExecution,
-		exportTabularExecution
+		exportTabularExecution,
+		previewTabularBulkOpCost,
+		createTabularBulkOp
 	} from '$lib/lq-ai/api/tabular';
 	import { LQAIApiError } from '$lib/lq-ai/api/client';
 	import TabularGrid from '$lib/lq-ai/components/TabularGrid.svelte';
 	import TabularCitationModal from '$lib/lq-ai/components/TabularCitationModal.svelte';
 	import type {
+		TabularBulkOpKind,
+		TabularBulkOpPreviewResponse,
 		TabularCellResult,
 		TabularExecution
 	} from '$lib/lq-ai/types';
@@ -20,9 +24,14 @@
 		isTerminalStatus,
 		progressFraction,
 		formatProgress,
+		bulkOpKindLabel,
+		bulkOpStatusSummary,
+		bulkOpItemHeading,
+		hasActiveBulkOp,
 		TABULAR_POLL_INTERVAL_MS
 	} from './page-helpers';
 	import { formatTabularStatus, formatCostUsd, skillNameDisplay } from '../page-helpers';
+	import { requiresCostConfirmation } from '../new/page-helpers';
 
 	let execution: TabularExecution | null = null;
 	let loading = true;
@@ -82,7 +91,10 @@
 
 	function scheduleNextPoll(): void {
 		if (!execution) return;
-		if (isTerminalStatus(execution.status)) {
+		// Keep polling while the execution runs OR any bulk op is
+		// non-terminal — the detail response's `bulk_ops` array is the
+		// bulk-op read-side (DE-304 / ADR 0026 D2).
+		if (isTerminalStatus(execution.status) && !hasActiveBulkOp(execution.bulk_ops)) {
 			if (pollTimer) {
 				clearTimeout(pollTimer);
 				pollTimer = null;
@@ -142,6 +154,67 @@
 			exportError = err instanceof LQAIApiError ? err.message : 'Export failed.';
 		} finally {
 			exportingFormat = null;
+		}
+	}
+
+	// DE-304 / ADR 0026 — bulk operations.
+	let bulkOpKind: TabularBulkOpKind = 'redline_rows';
+	let bulkOpColumn = '';
+	let bulkOpPreview: TabularBulkOpPreviewResponse | null = null;
+	let bulkOpPreviewing = false;
+	let bulkOpStarting = false;
+	let bulkOpConfirmed = false;
+	let bulkOpError: string | null = null;
+
+	$: columnNames = execution?.columns.map((c) => c.name) ?? [];
+	$: if (!bulkOpColumn && columnNames.length > 0) bulkOpColumn = columnNames[0];
+	$: bulkOpNeedsConfirm = bulkOpPreview
+		? requiresCostConfirmation(bulkOpPreview.estimated_cost_usd)
+		: false;
+	$: bulkOpRunnable =
+		bulkOpPreview !== null && !bulkOpStarting && (!bulkOpNeedsConfirm || bulkOpConfirmed);
+
+	function resetBulkOpPreview(): void {
+		bulkOpPreview = null;
+		bulkOpConfirmed = false;
+		bulkOpError = null;
+	}
+
+	async function previewBulkOp(): Promise<void> {
+		if (!executionId || bulkOpPreviewing) return;
+		bulkOpPreviewing = true;
+		bulkOpError = null;
+		try {
+			bulkOpPreview = await previewTabularBulkOpCost(executionId, {
+				kind: bulkOpKind,
+				column_name: bulkOpKind === 'summarize_column' ? bulkOpColumn : null
+			});
+			bulkOpConfirmed = false;
+		} catch (err) {
+			bulkOpError = err instanceof LQAIApiError ? err.message : 'Cost preview failed.';
+		} finally {
+			bulkOpPreviewing = false;
+		}
+	}
+
+	async function startBulkOp(): Promise<void> {
+		if (!executionId || !bulkOpRunnable || !bulkOpPreview) return;
+		bulkOpStarting = true;
+		bulkOpError = null;
+		try {
+			await createTabularBulkOp(executionId, {
+				kind: bulkOpKind,
+				column_name: bulkOpKind === 'summarize_column' ? bulkOpColumn : null,
+				confirmed_cost_usd: bulkOpPreview.estimated_cost_usd
+			});
+			resetBulkOpPreview();
+			// Re-fetch immediately so the new pending op appears and the
+			// poll loop re-arms off its non-terminal status.
+			await loadOnce();
+		} catch (err) {
+			bulkOpError = err instanceof LQAIApiError ? err.message : 'Failed to start bulk operation.';
+		} finally {
+			bulkOpStarting = false;
 		}
 	}
 
@@ -267,6 +340,136 @@
 			/>
 		{:else}
 			<div class="lq-tabres__state">No grid to render (empty execution).</div>
+		{/if}
+
+		<!-- Bulk operations (DE-304 / ADR 0026) — completed grids only. -->
+		{#if execution.status === 'completed'}
+			<section class="lq-bulkops" data-testid="lq-bulkops">
+				<h2>Bulk operations</h2>
+				<p class="lq-bulkops__hint">
+					Run a follow-on operation over this grid. Outputs are drafts for attorney review, not
+					final work product.
+				</p>
+				<div class="lq-bulkops__form">
+					<label class="lq-bulkops__radio">
+						<input
+							type="radio"
+							name="bulk-op-kind"
+							value="redline_rows"
+							bind:group={bulkOpKind}
+							on:change={resetBulkOpPreview}
+							data-testid="lq-bulkops-kind-redline"
+						/>
+						Redline per row
+					</label>
+					<label class="lq-bulkops__radio">
+						<input
+							type="radio"
+							name="bulk-op-kind"
+							value="summarize_column"
+							bind:group={bulkOpKind}
+							on:change={resetBulkOpPreview}
+							data-testid="lq-bulkops-kind-summarize"
+						/>
+						Summarize a column
+					</label>
+					{#if bulkOpKind === 'summarize_column'}
+						<select
+							bind:value={bulkOpColumn}
+							on:change={resetBulkOpPreview}
+							data-testid="lq-bulkops-column"
+							aria-label="Column to summarize"
+						>
+							{#each columnNames as name}
+								<option value={name}>{name}</option>
+							{/each}
+						</select>
+					{/if}
+					<button
+						type="button"
+						class="lq-bulkops__btn"
+						data-testid="lq-bulkops-preview"
+						on:click={previewBulkOp}
+						disabled={bulkOpPreviewing}
+					>
+						{bulkOpPreviewing ? 'Estimating…' : 'Preview cost'}
+					</button>
+				</div>
+				{#if bulkOpPreview}
+					<div class="lq-bulkops__preview" data-testid="lq-bulkops-preview-result">
+						<span>
+							{bulkOpPreview.calls_count} call(s) · est.
+							{formatCostUsd(bulkOpPreview.estimated_cost_usd)}
+						</span>
+						{#if bulkOpNeedsConfirm}
+							<label class="lq-bulkops__confirm">
+								<input
+									type="checkbox"
+									bind:checked={bulkOpConfirmed}
+									data-testid="lq-bulkops-confirm"
+								/>
+								I confirm this estimated cost.
+							</label>
+						{/if}
+						<button
+							type="button"
+							class="lq-bulkops__btn lq-bulkops__btn--run"
+							data-testid="lq-bulkops-run"
+							on:click={startBulkOp}
+							disabled={!bulkOpRunnable}
+						>
+							{bulkOpStarting ? 'Starting…' : `Run ${bulkOpKindLabel(bulkOpKind)}`}
+						</button>
+					</div>
+				{/if}
+				{#if bulkOpError}
+					<div class="lq-tabres__error" role="alert" data-testid="lq-bulkops-error">
+						{bulkOpError}
+					</div>
+				{/if}
+
+				{#if (execution.bulk_ops ?? []).length > 0}
+					<ul class="lq-bulkops__list" data-testid="lq-bulkops-list">
+						{#each execution.bulk_ops ?? [] as op (op.id)}
+							<li class="lq-bulkops__op" data-status={op.status}>
+								<div class="lq-bulkops__op-head">
+									<strong>{bulkOpKindLabel(op.kind)}</strong>
+									<span
+										class="lq-bulkops__op-status"
+										data-failed={op.status === 'failed' ||
+											(op.results?.summary.failed_items ?? 0) > 0}
+										data-testid="lq-bulkops-op-status"
+									>
+										{bulkOpStatusSummary(op)}
+									</span>
+								</div>
+								{#if op.status === 'failed' && op.error_text}
+									<pre class="lq-tabres__banner-error">{op.error_text}</pre>
+								{/if}
+								{#if op.results}
+									{#each op.results.items as item, i (i)}
+										<details class="lq-bulkops__item" data-status={item.status}>
+											<summary>
+												{bulkOpItemHeading(op, item)}
+												{#if item.status === 'failed'}
+													<span class="lq-bulkops__item-failed" data-testid="lq-bulkops-item-failed"
+														>failed</span
+													>
+												{/if}
+											</summary>
+											{#if item.status === 'failed'}
+												<pre class="lq-tabres__banner-error">{item.error ?? 'unknown error'}</pre>
+											{:else}
+												<div class="lq-bulkops__output">{item.output_text}</div>
+											{/if}
+										</details>
+									{/each}
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</section>
 		{/if}
 	{/if}
 
@@ -420,5 +623,115 @@
 		border: 1px solid var(--lq-error-border, var(--lq-border));
 		border-radius: 0.375rem;
 		color: var(--lq-error, inherit);
+	}
+
+	/* Bulk operations (DE-304) */
+	.lq-bulkops {
+		padding: 1rem;
+		background: var(--lq-inset);
+		border: 1px solid var(--lq-border);
+		border-radius: 0.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.lq-bulkops h2 {
+		margin: 0;
+		font-size: 1.125rem;
+	}
+	.lq-bulkops__hint {
+		margin: 0;
+		font-size: 0.8125rem;
+		color: var(--lq-text-secondary);
+	}
+	.lq-bulkops__form {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+	.lq-bulkops__radio {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		font-size: 0.875rem;
+	}
+	.lq-bulkops__btn {
+		padding: 0.375rem 0.75rem;
+		border: 1px solid var(--lq-border);
+		border-radius: 0.375rem;
+		background: var(--lq-surface);
+		font-size: 0.8125rem;
+		cursor: pointer;
+	}
+	.lq-bulkops__btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.lq-bulkops__btn--run {
+		font-weight: 600;
+	}
+	.lq-bulkops__preview {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+		font-size: 0.875rem;
+	}
+	.lq-bulkops__confirm {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		font-size: 0.8125rem;
+	}
+	.lq-bulkops__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.lq-bulkops__op {
+		padding: 0.75rem;
+		background: var(--lq-surface);
+		border: 1px solid var(--lq-border);
+		border-radius: 0.375rem;
+	}
+	.lq-bulkops__op-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+	.lq-bulkops__op-status {
+		font-size: 0.8125rem;
+		color: var(--lq-text-secondary);
+	}
+	.lq-bulkops__op-status[data-failed='true'] {
+		color: var(--lq-error, #b91c1c);
+		font-weight: 600;
+	}
+	.lq-bulkops__item {
+		margin-top: 0.5rem;
+		border-top: 1px solid var(--lq-border);
+		padding-top: 0.5rem;
+		font-size: 0.875rem;
+	}
+	.lq-bulkops__item summary {
+		cursor: pointer;
+	}
+	.lq-bulkops__item-failed {
+		margin-left: 0.5rem;
+		color: var(--lq-error, #b91c1c);
+		font-weight: 600;
+		font-size: 0.75rem;
+		text-transform: uppercase;
+	}
+	.lq-bulkops__output {
+		margin-top: 0.5rem;
+		white-space: pre-wrap;
+		font-size: 0.8125rem;
+		line-height: 1.5;
 	}
 </style>

--- a/web/src/routes/lq-ai/tabular/[id]/__tests__/page-helpers.test.ts
+++ b/web/src/routes/lq-ai/tabular/[id]/__tests__/page-helpers.test.ts
@@ -14,9 +14,14 @@ import {
 	formatProgress,
 	cellRenderState,
 	confidenceChipLabel,
+	bulkOpKindLabel,
+	bulkOpStatusSummary,
+	bulkOpItemHeading,
+	hasActiveBulkOp,
+	isBulkOpActive,
 	TABULAR_POLL_INTERVAL_MS
 } from '../page-helpers';
-import type { TabularCellResult, TabularResults } from '$lib/lq-ai/types';
+import type { TabularBulkOp, TabularCellResult, TabularResults } from '$lib/lq-ai/types';
 
 function cell(over: Partial<TabularCellResult> = {}): TabularCellResult {
 	return {
@@ -130,6 +135,114 @@ describe('tabular result page-helpers', () => {
 			expect(confidenceChipLabel('medium')).toBe('Med');
 			expect(confidenceChipLabel('low')).toBe('Low');
 			expect(confidenceChipLabel('failed')).toBe('Failed');
+		});
+	});
+
+	// ----- Bulk operations (DE-304 / ADR 0026) -----
+
+	function bulkOp(over: Partial<TabularBulkOp> = {}): TabularBulkOp {
+		return {
+			id: 'op-1',
+			execution_id: 'exec-1',
+			user_id: 'u-1',
+			kind: 'redline_rows',
+			status: 'completed',
+			params: {},
+			results: {
+				schema_version: 'de304-v1',
+				items: [],
+				summary: { total_items: 0, failed_items: 0 }
+			},
+			confirmed_cost_usd: null,
+			cost_actual_usd: null,
+			error_text: null,
+			created_at: '2026-07-25T00:00:00Z',
+			started_at: null,
+			completed_at: null,
+			...over
+		};
+	}
+
+	describe('bulkOpKindLabel', () => {
+		it('labels the two v1 kinds', () => {
+			expect(bulkOpKindLabel('redline_rows')).toBe('Redline report');
+			expect(bulkOpKindLabel('summarize_column')).toBe('Column memo');
+		});
+	});
+
+	describe('isBulkOpActive / hasActiveBulkOp', () => {
+		it('pending and running are active; completed/failed are not', () => {
+			expect(isBulkOpActive(bulkOp({ status: 'pending' }))).toBe(true);
+			expect(isBulkOpActive(bulkOp({ status: 'running' }))).toBe(true);
+			expect(isBulkOpActive(bulkOp({ status: 'completed' }))).toBe(false);
+			expect(isBulkOpActive(bulkOp({ status: 'failed' }))).toBe(false);
+		});
+
+		it('hasActiveBulkOp drives continued polling and tolerates undefined', () => {
+			expect(hasActiveBulkOp(undefined)).toBe(false);
+			expect(hasActiveBulkOp([])).toBe(false);
+			expect(hasActiveBulkOp([bulkOp({ status: 'completed' })])).toBe(false);
+			expect(hasActiveBulkOp([bulkOp({ status: 'completed' }), bulkOp({ status: 'running' })])).toBe(
+				true
+			);
+		});
+	});
+
+	describe('bulkOpStatusSummary', () => {
+		it('reports pending / running / failed states', () => {
+			expect(bulkOpStatusSummary(bulkOp({ status: 'pending' }))).toBe('Queued…');
+			expect(bulkOpStatusSummary(bulkOp({ status: 'running' }))).toBe('Running…');
+			expect(bulkOpStatusSummary(bulkOp({ status: 'failed' }))).toBe('Failed');
+		});
+
+		it('NEVER reads a partially-failed batch as clean (fail-closed honesty)', () => {
+			const partial = bulkOp({
+				results: {
+					schema_version: 'de304-v1',
+					items: [],
+					summary: { total_items: 3, failed_items: 1 }
+				}
+			});
+			expect(bulkOpStatusSummary(partial)).toBe('Completed — 1 of 3 item(s) FAILED');
+		});
+
+		it('reports clean completion with counts', () => {
+			const clean = bulkOp({
+				results: {
+					schema_version: 'de304-v1',
+					items: [],
+					summary: { total_items: 3, failed_items: 0 }
+				}
+			});
+			expect(bulkOpStatusSummary(clean)).toBe('Completed — 3 item(s)');
+			expect(bulkOpStatusSummary(bulkOp({ results: null }))).toBe('Completed');
+		});
+	});
+
+	describe('bulkOpItemHeading', () => {
+		const item = {
+			document_id: null,
+			document_name: null,
+			status: 'completed' as const,
+			output_text: 'memo',
+			error: null,
+			cost_usd: null
+		};
+
+		it('uses the document name for redline items', () => {
+			expect(bulkOpItemHeading(bulkOp(), { ...item, document_name: 'nda.pdf' })).toBe('nda.pdf');
+		});
+
+		it('labels the summarize memo by its column', () => {
+			const op = bulkOp({ kind: 'summarize_column', params: { column_name: 'Term' } });
+			expect(bulkOpItemHeading(op, item)).toBe('Memo — Term');
+		});
+
+		it('falls back honestly when metadata is missing', () => {
+			expect(bulkOpItemHeading(bulkOp({ kind: 'summarize_column', params: {} }), item)).toBe(
+				'Memo'
+			);
+			expect(bulkOpItemHeading(bulkOp(), item)).toBe('(unknown document)');
 		});
 	});
 });

--- a/web/src/routes/lq-ai/tabular/[id]/page-helpers.ts
+++ b/web/src/routes/lq-ai/tabular/[id]/page-helpers.ts
@@ -13,6 +13,9 @@
  *   freshness; 3s is the existing accepted default.
  */
 import type {
+	TabularBulkOp,
+	TabularBulkOpItem,
+	TabularBulkOpKind,
 	TabularCellConfidence,
 	TabularCellResult,
 	TabularExecutionStatus,
@@ -80,4 +83,67 @@ export function confidenceChipLabel(confidence: TabularCellConfidence): string {
 		case 'failed':
 			return 'Failed';
 	}
+}
+
+// ----- Bulk operations (DE-304 / ADR 0026) -----
+
+/** Operator-facing label for a bulk-op kind. */
+export function bulkOpKindLabel(kind: TabularBulkOpKind): string {
+	switch (kind) {
+		case 'redline_rows':
+			return 'Redline report';
+		case 'summarize_column':
+			return 'Column memo';
+	}
+}
+
+/** A bulk op the worker is still processing (or hasn't picked up). */
+export function isBulkOpActive(op: TabularBulkOp): boolean {
+	return op.status === 'pending' || op.status === 'running';
+}
+
+/**
+ * True while any bulk op is non-terminal — the page keeps polling the
+ * detail endpoint in that window even though the execution itself is
+ * terminal (the `bulk_ops` array embedded there is the read-side).
+ */
+export function hasActiveBulkOp(ops: TabularBulkOp[] | undefined): boolean {
+	return (ops ?? []).some(isBulkOpActive);
+}
+
+/**
+ * Honest one-line status for a bulk op's results panel header.
+ * A completed batch with failed items MUST say so — the report never
+ * reads as clean when rows failed (ADR 0026 D4 / C-10).
+ */
+export function bulkOpStatusSummary(op: TabularBulkOp): string {
+	switch (op.status) {
+		case 'pending':
+			return 'Queued…';
+		case 'running':
+			return 'Running…';
+		case 'failed':
+			return 'Failed';
+		case 'completed': {
+			const summary = op.results?.summary;
+			if (!summary) return 'Completed';
+			if (summary.failed_items > 0) {
+				return `Completed — ${summary.failed_items} of ${summary.total_items} item(s) FAILED`;
+			}
+			return `Completed — ${summary.total_items} item(s)`;
+		}
+	}
+}
+
+/**
+ * Heading for one result item. Redline items are per-document; the
+ * summarize-column memo (null document) is labelled by its column.
+ */
+export function bulkOpItemHeading(op: TabularBulkOp, item: TabularBulkOpItem): string {
+	if (item.document_name) return item.document_name;
+	if (op.kind === 'summarize_column') {
+		const column = op.params['column_name'];
+		return column ? `Memo — ${column}` : 'Memo';
+	}
+	return '(unknown document)';
 }


### PR DESCRIPTION
## What / why

DE-304 (PRD §9, deferred from M3-C4): the bulk-operations half of the tabular spec, deferred because the output pattern is architecturally novel. Per the sweep's ADR-gated-item rule, **ADR 0026 is self-authored in this PR** (Status: Proposed) — the committee can reject the pattern at review and the PR falls with it.

Part of the coordinated roadmap sweep (umbrella issue #321).

## ADR 0026 key decisions

1. **Dedicated `tabular_bulk_ops` table** (execution-CASCADE FK = causal linkage), *refining* Decision C-9: redline reports and memos aren't grids, so sibling `tabular_executions` rows would abuse the grid schema. `parent_execution_id` is retained for future grid-shaped ops. Storage is isolated behind the model + one shaping function to keep a pivot cheap if the committee prefers C-9-literal.
2. **Cost-control parity**: preview + create mirror the `preview-cost`/`confirmed_cost_usd` idiom exactly (the $1 gate stays UI-side, matching the existing tabular surface — verified no server-side mismatch rejection exists to mirror).
3. **Failure semantics**: one ARQ job walks rows sequentially with per-item try/except — failed items persist their errors and never block the batch; failed cells/rows are explicitly surfaced in prompts and UI (fail-closed honesty; a partially-failed batch is never rendered as clean).

## Implementation

- `POST /tabular/executions/{id}/bulk-ops/preview-cost` + `POST .../bulk-ops` (202): ownership collapses cross-user to 404, 409 on non-completed executions, 400 on unknown column/empty grid, audited. Read-side: `bulk_ops` embedded in the polled execution detail response (smallest OpenAPI delta).
- `api/app/tabular/bulk_ops.py`: cost estimator (rolling average over `purpose='tabular_bulk_op'` with cold-start default), prompt builders that explicitly mark failed cells/missing rows, batch runner, ARQ job registered in `arq_setup` on the existing `arq:m3a6` queue. Inference through the same gateway client path as all tabular inference; Decimal-as-string costs.
- Migration `0066_tabular_bulk_ops` — reversible; **downgrade proven** on a scratch database (`lq_de304_migr` on the throwaway container; dev stack untouched): upgrade 0065→0066 verified table+index present, downgrade 0066→0065 verified table absent and version restored.
- Web: bulk-ops affordance on the execution detail page (kind picker, column select for summarize, cost confirm) + "Redline report"/"Memos" results panel with per-item errors; polling continues while any op is non-terminal.
- Route pins 139→141; OpenAPI sketch + generated spec + `docs/db-schema.md` + PRD §9 status updated. Replaced the never-wired M3-C4 `TabularBulkOpRequest` stub (dropped `skill_name_override` — v1 uses fixed prompts, not skill dispatch; documented in ADR Consequences).

## Acceptance evidence

- api: 12 unit tests (`tests/tabular/test_bulk_ops.py`: cost math, prompt honesty about failed cells, partial-failure completes batch with error persisted + linkage, job registration) + 9 endpoint tests (`test_tabular_bulk_ops_endpoints.py`: preview math, unknown column 400, cross-user 404, non-completed 409, 202 persists/enqueues/links, empty grid 400, unknown kind 422).
- web: vitest suites for the new helpers incl. "never reads a partially-failed batch as clean"; Cypress spec extended (preview → run → completed with 1-of-5-FAILED banner) — added, not run.

Gates run locally:
- api: ruff format/check clean, mypy clean, full suite **2644 passed, 1 skipped, 0 failed** (throwaway pgvector:pg16)
- web: `check:lq-ai` **0 errors**; vitest **745 passed (80 files)**

## Deployment note (maintainers)

Migration 0066 + a newly registered worker job land together — **rebuild `api` + `arq-worker` + `ingest-worker` together** (stale siblings crash-loop on revision mismatch).

## Maintainer verification steps

1. Review/accept (or reject) ADR 0026 — the build is deliberately pivot-cheap if you prefer a different storage shape.
2. On a completed execution: run redline bulk-op on a small grid → report renders per-row, failures flagged; summarize-column → memo attached to the execution.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)