### PR TITLE
3.7: reverse-proxy + TLS recipes (Caddy / Traefik / nginx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ For security disclosures, see [`SECURITY.md`](SECURITY.md). The disclosure proce
 - [`docs/contribute/EASIEST-CONTRIBUTIONS.md`](docs/contribute/EASIEST-CONTRIBUTIONS.md) — curated short-cycle contributions with mini-PRDs.
 - [`docs/skill-authoring-guide.md`](docs/skill-authoring-guide.md) — how to write a high-quality skill.
 - [`docs/playbooks.md`](docs/playbooks.md) — how Playbooks work and how to write one.
-- [`deploy/`](deploy/) — deployment recipes (Helm chart, Caddy/Tailscale, observability stack); see also [`docs/INSTALL-MAC.md`](docs/INSTALL-MAC.md) for a from-scratch macOS install.
+- [`deploy/`](deploy/) — deployment recipes (Helm chart, [reverse-proxy + TLS recipes](deploy/reverse-proxy/) for Caddy/Traefik/nginx, Caddy/Tailscale, observability stack); see also [`docs/INSTALL-MAC.md`](docs/INSTALL-MAC.md) for a from-scratch macOS install.
 - [`docs/compliance/`](docs/compliance/) — Compliance Alignment Pack.
 - [`docs/security/`](docs/security/) — security artifacts (SBOM, threat model, supply-chain transparency).
 - [`docs/procurement/`](docs/procurement/) — procurement-readiness templates (SIG Lite, CAIQ).

--- a/deploy/reverse-proxy/README.md
+++ b/deploy/reverse-proxy/README.md
@@ -1,0 +1,133 @@
+# Reverse-proxy + TLS recipes (DE-031 / DE-234)
+
+Three compose overlays that put a TLS-terminating reverse proxy in front of the
+LQ.AI stack, so the deployment is reachable at `https://<your-fqdn>/` instead
+of plain HTTP on the Docker host's loopback. Pick **one** recipe:
+
+| Recipe | Certificates | Config style | Choose it when |
+| --- | --- | --- | --- |
+| [`caddy/`](caddy/) | Let's Encrypt, automatic (issuance **and** renewal) | One short Caddyfile | You want TLS with the least configuration. Recommended default. |
+| [`traefik/`](traefik/) | Let's Encrypt, automatic | Docker labels on the services | You already run Traefik, or you plan to migrate to Kubernetes later (the label-based routing ports naturally to an Ingress). |
+| [`nginx/`](nginx/) | **Operator-provided** (corporate/internal CA, wildcard cert, certbot on the host) | Classic nginx server block | Your organization already standardizes on nginx, or you are **air-gapped / cannot reach Let's Encrypt** and must bring your own certificates. |
+
+> **Tailnet-private alternative:** if you don't want a public URL at all, use
+> [`deploy/caddy-tailscale/`](../caddy-tailscale/) instead — it serves the UI
+> only over your Tailscale tailnet, with the certificate handled by Tailscale.
+> The recipes here are for a **publicly resolvable FQDN** (Caddy/Traefik) or an
+> internally resolvable one with operator-supplied certs (nginx).
+
+## What all three recipes share
+
+### Upstream topology
+
+Each proxy serves a **single origin** and routes by path:
+
+| Path | Destination | Notes |
+| --- | --- | --- |
+| `/lq-ai-api/v1/*` | `api:8000` | LQ.AI backend. The proxy rewrites the prefix to `/api/v1` before forwarding. |
+| everything else | `web:8080` | OpenWebUI shell, its own `/api/v1` and `/api/config`, WebSockets (`/ws/socket.io`), static assets. |
+
+Why the prefix: the web container serves OpenWebUI, which is full-stack and
+mounts its **own** `/api/v1` (and `/api/config`, fetched at first paint). The
+LQ.AI backend *also* mounts `/api/v1`. On one origin those namespaces collide,
+so the LQ.AI backend gets its own public prefix, `/lq-ai-api/v1`, rewritten
+back to `/api/v1` at the proxy. This matches the routing shape used by
+[`deploy/caddy-tailscale/`](../caddy-tailscale/README.md#routing) and (with a
+different prefix) the release stack's bundled proxy.
+
+The **gateway is deliberately not routed** through any of these proxies. Per
+PRD §4 it is the security boundary holding privileged provider keys; its admin
+surface stays on the Docker host at `127.0.0.1:${GATEWAY_HOST_PORT}`.
+
+### The base stack stays private
+
+The base `docker-compose.yml` binds every published port to `127.0.0.1` by
+default (`*_BIND_ADDR` vars), so adding a proxy overlay makes the proxy's
+80/443 the **only** ports reachable from other machines. Do not set any
+`*_BIND_ADDR` to `0.0.0.0` when running behind one of these proxies.
+
+### Using the LQ.AI shell (`/lq-ai`) from other devices
+
+The web image bakes `PUBLIC_LQ_AI_API_BASE_URL` into its static bundle at
+**build** time. The dev default (`/api/v1`, or `http://localhost:8000/api/v1`
+from `.env`) breaks LQ.AI-shell API calls from any browser that is not the
+Docker host. To use the LQ.AI shell through a proxy, set in your root `.env`:
+
+```
+PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1
+```
+
+then rebuild `web` so Vite re-bakes the prefix:
+
+```bash
+docker compose -f docker-compose.yml -f deploy/reverse-proxy/<recipe>/docker-compose.proxy.yml build web
+docker compose -f docker-compose.yml -f deploy/reverse-proxy/<recipe>/docker-compose.proxy.yml up -d
+```
+
+If you only use the OpenWebUI shell at `/`, you can skip this — its API is
+same-origin relative and works unmodified behind all three proxies.
+
+### Streaming, WebSockets, and timeouts
+
+Chat responses are **streamed** (SSE over HTTP plus a socket.io WebSocket), and
+a long generation or an autonomous-session run can legitimately hold a
+connection open for many minutes with output trickling out token by token. A
+default-configured proxy breaks this in two ways: response **buffering** (the
+user sees nothing until the full answer is done, or the buffer flushes at 4 kB
+boundaries) and short **read timeouts** (the connection is cut mid-answer).
+Each recipe therefore:
+
+- disables (or auto-detects around) response buffering for proxied responses;
+- allows long-lived upstream reads (Caddy: no timeout by default; Traefik and
+  nginx: explicitly configured — see each README);
+- forwards WebSocket `Upgrade`/`Connection` handshakes (automatic in Caddy and
+  Traefik; explicit headers in the nginx config);
+- allows large request bodies for document upload (nginx sets
+  `client_max_body_size`; Caddy and Traefik impose no body-size limit by
+  default).
+
+If a chat stream stalls at the start and then "arrives all at once", or dies
+after exactly N seconds, suspect a second proxy/CDN in front of this one.
+
+### HSTS (read before enabling)
+
+Each config ships with a **commented-out** `Strict-Transport-Security` header.
+Once served, HSTS makes browsers refuse plain-HTTP access to the domain until
+`max-age` expires — there is no quick rollback if your certificate pipeline
+breaks. Enable it only after HTTPS has been stable for a while, starting with a
+small `max-age`. Treat `includeSubDomains` and especially `preload` as one-way
+doors: preload submission bakes your domain into browser binaries and can take
+months to undo. For an internal legal-ops deployment, plain
+`max-age=31536000` with **no** `preload` is the sensible ceiling.
+
+### Smoke checks (all recipes)
+
+```bash
+# TLS terminates and the web shell answers (expect 200; drop -k once using a
+# publicly trusted or locally trusted cert):
+curl -skI https://<fqdn>/health
+
+# Path routing to the LQ.AI backend works (expect HTTP 401 with a JSON
+# {"detail":"Not authenticated"} body — proof the rewrite reached api:8000):
+curl -sk -o /dev/null -w '%{http_code}\n' https://<fqdn>/lq-ai-api/v1/skills
+
+# WebSocket endpoint answers through the proxy (engine.io responds; any
+# HTTP answer here — not a proxy 502/504 — means the route works):
+curl -sk -o /dev/null -w '%{http_code}\n' "https://<fqdn>/ws/socket.io/?EIO=4&transport=polling"
+
+# Streaming: open the UI, send a chat message, and confirm tokens render
+# incrementally rather than appearing in one block at the end.
+
+# Full TLS posture scan (protocol versions, ciphers, HSTS, cert chain):
+docker run --rm drwetter/testssl.sh https://<fqdn>
+```
+
+## Files
+
+```
+deploy/reverse-proxy/
+├── README.md                # this file — pick a recipe
+├── caddy/                   # Let's Encrypt, automatic; simplest
+├── traefik/                 # Let's Encrypt, automatic; label-based routing
+└── nginx/                   # operator-provided certs; internal-CA / air-gap path
+```

--- a/deploy/reverse-proxy/caddy/.env.example
+++ b/deploy/reverse-proxy/caddy/.env.example
@@ -1,0 +1,13 @@
+# Caddy reverse-proxy recipe — append these lines to the ROOT .env
+# (docker compose reads only the project-root .env, not this file).
+
+# Public DNS name of this host (A/AAAA record must already resolve here).
+LQ_AI_FQDN=lq.example.com
+
+# ACME account email for Let's Encrypt (receives expiry notices).
+LQ_AI_ACME_EMAIL=ops@example.com
+
+# Bake the proxy's API path prefix into the LQ.AI web client, then rebuild
+# the web image (`... build web`). Only needed if you use the LQ.AI shell
+# at /lq-ai; see ../README.md ("Using the LQ.AI shell from other devices").
+PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1

--- a/deploy/reverse-proxy/caddy/Caddyfile
+++ b/deploy/reverse-proxy/caddy/Caddyfile
@@ -1,0 +1,42 @@
+# LQ.AI public reverse proxy — Caddy, automatic HTTPS via Let's Encrypt.
+#
+# LQ_AI_FQDN and LQ_AI_ACME_EMAIL come from the container environment
+# (set in the root .env; see .env.example in this directory).
+{
+	# ACME account contact (expiry notices).
+	email {$LQ_AI_ACME_EMAIL}
+
+	# While iterating, uncomment to use the Let's Encrypt STAGING CA so
+	# failed attempts don't burn production rate limits. Staging certs are
+	# NOT browser-trusted; comment this back out (and delete the caddy-data
+	# volume's staged cert) once the recipe works end to end.
+	# acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+}
+
+{$LQ_AI_FQDN} {
+	encode gzip zstd
+
+	# HSTS — uncomment ONLY after HTTPS has been stable for a while.
+	# Do not add `preload` casually; see ../README.md ("HSTS").
+	# header Strict-Transport-Security "max-age=31536000"
+
+	# LQ.AI backend: the web client calls /lq-ai-api/v1/*; strip the
+	# public prefix so the api (which mounts /api/v1) sees /api/v1/*.
+	handle /lq-ai-api/v1/* {
+		uri replace /lq-ai-api/v1 /api/v1
+		reverse_proxy api:8000 {
+			# Chat responses stream (SSE); flush every write so tokens
+			# reach the browser as they are generated, never buffered.
+			flush_interval -1
+		}
+	}
+
+	# Everything else — the OpenWebUI shell, /api/config, its own
+	# /api/v1/*, websockets (/ws/socket.io), static bundle — goes to the
+	# web container. WebSocket upgrades are handled automatically.
+	handle {
+		reverse_proxy web:8080 {
+			flush_interval -1
+		}
+	}
+}

--- a/deploy/reverse-proxy/caddy/README.md
+++ b/deploy/reverse-proxy/caddy/README.md
@@ -1,0 +1,92 @@
+# Caddy recipe — automatic HTTPS with Let's Encrypt
+
+The simplest TLS front door for LQ.AI: Caddy obtains and **renews**
+certificates automatically, and the whole proxy config fits in one short
+[`Caddyfile`](Caddyfile). If you have no existing proxy preference, use this
+recipe.
+
+Shared context — upstream topology, the `/lq-ai-api/v1` prefix, streaming and
+HSTS guidance — is in [`../README.md`](../README.md).
+
+## Prerequisites
+
+- The base stack checked out and configured (root `.env` with the required
+  secrets — see the repo README quick start).
+- A **public DNS A/AAAA record** for your FQDN pointing at this host.
+- Inbound **ports 80 and 443** reachable from the internet (80 is required for
+  the ACME HTTP-01 challenge and the HTTP→HTTPS redirect).
+- Nothing else on the host already bound to 80/443.
+
+## Run it
+
+1. Append the variables from [`.env.example`](.env.example) to the **root**
+   `.env` and set your real FQDN and email.
+2. From the repo root:
+
+   ```bash
+   docker compose \
+     -f docker-compose.yml \
+     -f deploy/reverse-proxy/caddy/docker-compose.proxy.yml \
+     up -d
+   ```
+
+3. If you use the LQ.AI shell at `/lq-ai`, also rebuild `web` with
+   `PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1` (see
+   [`../README.md`](../README.md#using-the-lqai-shell-lq-ai-from-other-devices)).
+
+First start-up: Caddy solves the HTTP-01 challenge and obtains the certificate
+within seconds of the stack coming up; watch it with
+`docker compose logs -f caddy` (look for `certificate obtained successfully`).
+
+**While iterating**, uncomment the staging `acme_ca` line in the
+[`Caddyfile`](Caddyfile) so repeated failed attempts don't hit Let's Encrypt's
+production rate limits (5 duplicate certs/week). Switch back and restart Caddy
+once the recipe works.
+
+## Verify
+
+```bash
+curl -fI https://<fqdn>/health          # 200, no -k needed — publicly trusted cert
+curl -s -o /dev/null -w '%{http_code}\n' https://<fqdn>/lq-ai-api/v1/skills   # 401 = api routing works
+curl -sI http://<fqdn>/ | head -1       # 308 redirect to https
+docker run --rm drwetter/testssl.sh https://<fqdn>   # full TLS scan
+```
+
+Then open `https://<fqdn>/`, log in, send a chat message, and confirm the
+response streams token-by-token (the Caddyfile sets `flush_interval -1` so
+SSE is never buffered).
+
+## Renewal and rotation
+
+- Caddy renews automatically in the background (at ~2/3 of cert lifetime).
+  There is **no cron job to add** and nothing to reload.
+- State lives in the `caddy-data` volume: the ACME account key and all issued
+  certificates. Include it in backups; deleting it forces re-issuance, which
+  is rate-limited.
+- If renewal fails (port 80 blocked after setup, DNS moved), Caddy logs errors
+  and keeps serving the old cert until it expires — alert on
+  `docker compose logs caddy | grep -i 'error'` or scrape cert expiry
+  externally.
+
+## Variations
+
+- **Port 80 can't be opened:** HTTP-01 is off the table; Caddy supports the
+  DNS-01 challenge instead, but it requires a Caddy build with your DNS
+  provider's module — out of scope here. Either use a custom Caddy image with
+  the relevant `caddy-dns/*` plugin, or use the [nginx recipe](../nginx/) with
+  certs issued out-of-band.
+- **Air-gapped / no route to Let's Encrypt:** ACME cannot work. Use the
+  [nginx recipe](../nginx/) with internal-CA certs, or point `acme_ca` at an
+  internal ACME endpoint if your organization runs one (e.g. smallstep CA).
+- **HSTS:** commented out in the Caddyfile; read
+  [`../README.md`](../README.md#hsts-read-before-enabling) before enabling.
+
+## Files
+
+```
+deploy/reverse-proxy/caddy/
+├── README.md                 # this file
+├── docker-compose.proxy.yml  # Caddy service overlaid onto the base stack
+├── Caddyfile                 # site config: auto-HTTPS, path routing, streaming
+└── .env.example              # LQ_AI_FQDN, LQ_AI_ACME_EMAIL (append to root .env)
+```

--- a/deploy/reverse-proxy/caddy/docker-compose.proxy.yml
+++ b/deploy/reverse-proxy/caddy/docker-compose.proxy.yml
@@ -1,0 +1,54 @@
+# LQ.AI reverse-proxy overlay — Caddy with automatic Let's Encrypt TLS.
+#
+# Compose onto the base stack from the REPO ROOT:
+#
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f deploy/reverse-proxy/caddy/docker-compose.proxy.yml \
+#     up -d
+#
+# Requires LQ_AI_FQDN and LQ_AI_ACME_EMAIL in the root .env (see
+# .env.example in this directory). Ports 80 and 443 must be reachable
+# from the internet: 80 for the ACME HTTP-01 challenge and the
+# HTTP→HTTPS redirect, 443 for the site itself.
+
+name: lq-ai
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      # web's first boot can take minutes (model/asset warm-up); don't hold
+      # the front door down on it. `service_started` gives Caddy DNS
+      # resolution; until web actually listens, Caddy answers 502, which
+      # recovers on its own. Same rationale as deploy/caddy-tailscale.
+      web:
+        condition: service_started
+      api:
+        condition: service_healthy
+    environment:
+      LQ_AI_FQDN: ${LQ_AI_FQDN:?LQ_AI_FQDN is required — public DNS name of this host}
+      LQ_AI_ACME_EMAIL: ${LQ_AI_ACME_EMAIL:?LQ_AI_ACME_EMAIL is required — ACME account email}
+    configs:
+      - source: caddyfile
+        target: /etc/caddy/Caddyfile
+    volumes:
+      # /data holds the ACME account key and issued certificates. Losing it
+      # forces re-issuance (rate-limited!) — keep this volume.
+      - caddy-data:/data
+      - caddy-config:/config
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp" # HTTP/3
+
+volumes:
+  caddy-data:
+  caddy-config:
+
+configs:
+  caddyfile:
+    # Relative to the FIRST -f file's directory (the repo root), matching
+    # the convention in deploy/caddy-tailscale/docker-compose.proxy.yml.
+    file: ./deploy/reverse-proxy/caddy/Caddyfile

--- a/deploy/reverse-proxy/nginx/.env.example
+++ b/deploy/reverse-proxy/nginx/.env.example
@@ -1,0 +1,12 @@
+# nginx reverse-proxy recipe — append these lines to the ROOT .env
+# (docker compose reads only the project-root .env, not this file).
+
+# Directory containing fullchain.pem + privkey.pem (see certs/README.md).
+# Defaults to deploy/reverse-proxy/nginx/certs; point it at a host path
+# (e.g. /etc/letsencrypt/live/lq.example.com) to use host-managed certs.
+#LQ_AI_TLS_CERT_DIR=./deploy/reverse-proxy/nginx/certs
+
+# Bake the proxy's API path prefix into the LQ.AI web client, then rebuild
+# the web image (`... build web`). Only needed if you use the LQ.AI shell
+# at /lq-ai; see ../README.md ("Using the LQ.AI shell from other devices").
+PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1

--- a/deploy/reverse-proxy/nginx/README.md
+++ b/deploy/reverse-proxy/nginx/README.md
@@ -1,0 +1,125 @@
+# nginx recipe — operator-provided certificates (internal CA / air-gap path)
+
+nginx in front of LQ.AI, terminating TLS with certificates **you supply** —
+from a corporate/internal CA, a wildcard-cert program, or host-side certbot.
+This is the recipe for organizations that already standardize on nginx, and
+the **only** workable recipe for air-gapped or egress-restricted sites, where
+ACME/Let's Encrypt is unreachable by definition.
+
+Shared context — upstream topology, the `/lq-ai-api/v1` prefix, streaming and
+HSTS guidance — is in [`../README.md`](../README.md).
+
+## Prerequisites
+
+- The base stack checked out and configured (root `.env` with the required
+  secrets — see the repo README quick start).
+- A DNS name for the host that your **clients** can resolve (public DNS or
+  internal DNS — nothing here requires public resolution).
+- A certificate + key pair for that name, placed per
+  [`certs/README.md`](certs/README.md) (`fullchain.pem` + `privkey.pem`).
+- Inbound ports 80 and 443 reachable from your clients; nothing else on the
+  host bound to them.
+
+## Run it
+
+1. Place `fullchain.pem` and `privkey.pem` in
+   [`certs/`](certs/) (or set `LQ_AI_TLS_CERT_DIR` in the root `.env` to the
+   directory that holds them — see [`.env.example`](.env.example)).
+2. From the repo root:
+
+   ```bash
+   docker compose \
+     -f docker-compose.yml \
+     -f deploy/reverse-proxy/nginx/docker-compose.proxy.yml \
+     up -d
+   ```
+
+3. If you use the LQ.AI shell at `/lq-ai`, also rebuild `web` with
+   `PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1` (see
+   [`../README.md`](../README.md#using-the-lqai-shell-lq-ai-from-other-devices)).
+
+## Verify
+
+```bash
+# Config syntax check (runs inside the stack's network so the upstream
+# hostnames api/web resolve):
+docker compose -f docker-compose.yml -f deploy/reverse-proxy/nginx/docker-compose.proxy.yml \
+  exec nginx nginx -t
+
+# TLS terminates and the web shell answers. With an internal-CA cert, point
+# curl at your CA bundle instead of using -k:
+curl -kI https://<fqdn>/health                       # HTTP/2 200
+curl --cacert /path/to/internal-ca.pem -fI https://<fqdn>/health
+
+# Path routing to the LQ.AI backend (401 JSON = the /lq-ai-api/v1 → /api/v1
+# rewrite reached api:8000):
+curl -sk -o /dev/null -w '%{http_code}\n' https://<fqdn>/lq-ai-api/v1/skills
+
+# HTTP→HTTPS redirect:
+curl -sI http://<fqdn>/ | head -1                    # 301
+
+# Full TLS posture scan:
+docker run --rm drwetter/testssl.sh https://<fqdn>
+```
+
+Then open `https://<fqdn>/`, log in, send a chat message, and confirm the
+response streams token-by-token — [`nginx.conf`](nginx.conf) sets
+`proxy_buffering off` for exactly this reason.
+
+## Internal CA guidance (air-gapped sites)
+
+Air-gapped deployments cannot reach any public ACME endpoint, so certificate
+issuance is an out-of-band, organization-level process. What this recipe
+needs from that process:
+
+- **Issue a server certificate** for the FQDN from your internal CA (follow
+  your CA's documentation — a Windows AD CS "Web Server" template, a
+  smallstep/step-ca instance, or an offline OpenSSL CA all work). Make sure
+  the FQDN is in the **subjectAltName**; modern clients ignore the CN.
+- **Build `fullchain.pem` correctly:** leaf certificate first, then each
+  intermediate, root omitted. A missing intermediate is the most common
+  "works in one browser, fails in another / fails in curl" symptom.
+- **Distribute the CA root** to every client that will use the UI (browsers,
+  and the OS trust store for CLI tools). This is your organization's existing
+  managed-device trust-store process; LQ.AI needs nothing special.
+- **Plan rotation manually.** There is no auto-renewal in this recipe:
+  calendar the expiry, re-issue, replace the two files, and
+  `nginx -s reload` (zero downtime — see [`certs/README.md`](certs/README.md)).
+  Internal CAs often default to short lifetimes; 90 days–1 year is typical.
+- **Scope note:** this covers *inbound* TLS to the proxy. The gateway's
+  *outbound* TLS to LLM providers doesn't exist in a fully air-gapped
+  deployment (Mode 2, local inference only); if you run a TLS-intercepting
+  egress proxy in a partially connected environment, the gateway container —
+  not nginx — needs your CA bundle in its trust store.
+
+If your organization runs an **internal ACME service** (e.g. smallstep CA),
+consider the [Caddy recipe](../caddy/) pointed at it via `acme_ca` instead —
+you get automatic rotation back.
+
+## Operational notes
+
+- **Timeouts and streaming:** `proxy_read_timeout` is 3600 s on both routes so
+  long generations and idle-but-alive WebSockets survive;
+  `proxy_buffering off` keeps SSE tokens flowing. If you tighten these, test
+  a long chat response before rolling out.
+- **Upload size:** `client_max_body_size 200m`. Raise it if your document
+  sets are larger; the symptom of hitting it is HTTP 413 on upload.
+- **Logs:** the container logs to stdout/stderr (`docker compose logs nginx`);
+  Docker's log driver handles rotation.
+- **HSTS:** commented out in [`nginx.conf`](nginx.conf); read
+  [`../README.md`](../README.md#hsts-read-before-enabling) before enabling.
+- **cert-manager:** if you later move to Kubernetes (DE-030 Helm chart),
+  cert-manager takes over the issuance role this recipe leaves manual; the
+  nginx routing translates to an Ingress with the same two path rules.
+
+## Files
+
+```
+deploy/reverse-proxy/nginx/
+├── README.md                 # this file
+├── docker-compose.proxy.yml  # nginx service overlaid onto the base stack
+├── nginx.conf                # server blocks: TLS, path routing, streaming, websockets
+├── .env.example              # optional LQ_AI_TLS_CERT_DIR (append to root .env)
+└── certs/                    # place fullchain.pem + privkey.pem here (git-ignored)
+    └── README.md             # filenames, rotation, self-signed smoke pair
+```

--- a/deploy/reverse-proxy/nginx/certs/README.md
+++ b/deploy/reverse-proxy/nginx/certs/README.md
@@ -1,0 +1,43 @@
+# Certificates directory
+
+The nginx overlay mounts this directory (or `LQ_AI_TLS_CERT_DIR`, if set)
+read-only at `/etc/nginx/certs/`. Place exactly two PEM files here:
+
+| File | Contents |
+| --- | --- |
+| `fullchain.pem` | Server (leaf) certificate first, then any intermediate CA certificates, concatenated. Do **not** include the root. |
+| `privkey.pem` | The unencrypted private key for the leaf certificate. |
+
+Never commit real certificates or keys — this directory is intentionally
+empty in source control (`.gitkeep` only), and the repo-wide `*.pem` rule in
+`.gitignore` keeps `fullchain.pem` / `privkey.pem` out of git.
+
+## Rotation
+
+nginx reads certificates once at startup. After replacing the files, apply
+them with a zero-downtime reload:
+
+```bash
+docker compose -f docker-compose.yml -f deploy/reverse-proxy/nginx/docker-compose.proxy.yml \
+  exec nginx nginx -s reload
+```
+
+Set a calendar/monitoring reminder keyed to your CA's cert lifetime — nginx
+serves an expired certificate without complaint. A quick expiry check:
+
+```bash
+openssl x509 -in fullchain.pem -noout -enddate
+```
+
+## Generating a quick self-signed pair (smoke-testing only)
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
+  -keyout privkey.pem -out fullchain.pem \
+  -subj "/CN=lq.example.internal" \
+  -addext "subjectAltName=DNS:lq.example.internal"
+```
+
+Browsers and `curl` will warn (use `curl -k`) — fine for verifying the
+recipe, not for real use. For production, see the internal-CA section in
+[`../README.md`](../README.md).

--- a/deploy/reverse-proxy/nginx/docker-compose.proxy.yml
+++ b/deploy/reverse-proxy/nginx/docker-compose.proxy.yml
@@ -1,0 +1,39 @@
+# LQ.AI reverse-proxy overlay — nginx with OPERATOR-PROVIDED certificates.
+#
+# No ACME: certificates are issued out-of-band (corporate/internal CA,
+# wildcard cert program, or host-side certbot) and dropped into the certs
+# directory — see certs/README.md. This is the recipe for air-gapped or
+# egress-restricted sites where Let's Encrypt is unreachable.
+#
+# Compose onto the base stack from the REPO ROOT:
+#
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f deploy/reverse-proxy/nginx/docker-compose.proxy.yml \
+#     up -d
+
+name: lq-ai
+
+services:
+  nginx:
+    # nginx >= 1.25.1 required (the config uses the `http2 on;` directive).
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    depends_on:
+      # web's first boot can take minutes (model/asset warm-up); don't hold
+      # the front door down on it — nginx answers 502 until web listens,
+      # which recovers on its own. Same rationale as deploy/caddy-tailscale.
+      web:
+        condition: service_started
+      api:
+        condition: service_healthy
+    volumes:
+      # Server config (replaces the stock image's default server).
+      - ./deploy/reverse-proxy/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      # Certificates: fullchain.pem + privkey.pem. Default is the certs/
+      # directory next to this file; point LQ_AI_TLS_CERT_DIR somewhere
+      # else (e.g. /etc/letsencrypt/live/<fqdn>) to use host-managed certs.
+      - ${LQ_AI_TLS_CERT_DIR:-./deploy/reverse-proxy/nginx/certs}:/etc/nginx/certs:ro
+    ports:
+      - "80:80"
+      - "443:443"

--- a/deploy/reverse-proxy/nginx/nginx.conf
+++ b/deploy/reverse-proxy/nginx/nginx.conf
@@ -1,0 +1,96 @@
+# LQ.AI public reverse proxy — nginx with OPERATOR-PROVIDED certificates.
+#
+# Mounted at /etc/nginx/conf.d/default.conf (replacing the stock image's
+# default server). Certificates are mounted at /etc/nginx/certs/ — see
+# certs/README.md for the expected filenames and the rotation procedure.
+#
+# The server_name is a catch-all on purpose: this proxy serves exactly one
+# site, and the certificate — not this file — carries the hostname, so no
+# env-substitution machinery is needed.
+
+# WebSocket upgrade pass-through (chat surface uses socket.io at
+# /ws/socket.io). Falls back to a normal keep-alive connection when the
+# client did not ask for an upgrade.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ""      close;
+}
+
+# Port 80: redirect everything to HTTPS. (No ACME here — certificates are
+# issued out-of-band; see the README's internal-CA section.)
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name _;
+
+    # --- TLS (operator-provided; see certs/README.md) -----------------
+    ssl_certificate     /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache   shared:lq_ssl:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    # HSTS — uncomment ONLY after HTTPS has been stable for a while.
+    # Do not add `preload` casually; see ../README.md ("HSTS").
+    # add_header Strict-Transport-Security "max-age=31536000" always;
+
+    # Document upload (contracts, scanned PDFs). nginx's 1m default
+    # rejects almost any real document with 413.
+    client_max_body_size 200m;
+
+    # --- LQ.AI backend ------------------------------------------------
+    # The web client calls /lq-ai-api/v1/*; the trailing-slash proxy_pass
+    # swaps the public prefix for the api's real /api/v1/ mount.
+    location /lq-ai-api/v1/ {
+        proxy_pass http://api:8000/api/v1/;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Streaming LLM responses (SSE): without these, nginx buffers the
+        # whole response and the user sees nothing until generation ends.
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_set_header Connection "";
+
+        # A long generation or autonomous-session run can idle between
+        # token writes; nginx's 60s default cuts the stream mid-answer.
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 300s;
+    }
+
+    # --- Everything else: web container -------------------------------
+    # OpenWebUI shell, /api/config, its own /api/v1/*, websockets
+    # (/ws/socket.io), static bundle.
+    location / {
+        proxy_pass http://web:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket upgrade (see the map above).
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        # The web container's own chat API streams SSE too, and idle
+        # WebSockets must not be reaped mid-session.
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 300s;
+    }
+}

--- a/deploy/reverse-proxy/traefik/.env.example
+++ b/deploy/reverse-proxy/traefik/.env.example
@@ -1,0 +1,13 @@
+# Traefik reverse-proxy recipe — append these lines to the ROOT .env
+# (docker compose reads only the project-root .env, not this file).
+
+# Public DNS name of this host (A/AAAA record must already resolve here).
+LQ_AI_FQDN=lq.example.com
+
+# ACME account email for Let's Encrypt (receives expiry notices).
+LQ_AI_ACME_EMAIL=ops@example.com
+
+# Bake the proxy's API path prefix into the LQ.AI web client, then rebuild
+# the web image (`... build web`). Only needed if you use the LQ.AI shell
+# at /lq-ai; see ../README.md ("Using the LQ.AI shell from other devices").
+PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1

--- a/deploy/reverse-proxy/traefik/README.md
+++ b/deploy/reverse-proxy/traefik/README.md
@@ -1,0 +1,112 @@
+# Traefik recipe — automatic HTTPS with Let's Encrypt, label-based routing
+
+Traefik v3 in front of LQ.AI with automatic certificate issuance and renewal.
+Routing rules are **Docker labels** on the `web` and `api` services (added by
+the overlay), which is the natural fit if you already operate Traefik or plan
+to move to Kubernetes later — the label rules port directly to Ingress
+annotations when the Helm chart (DE-030) lands.
+
+Shared context — upstream topology, the `/lq-ai-api/v1` prefix, streaming and
+HSTS guidance — is in [`../README.md`](../README.md).
+
+## Prerequisites
+
+- The base stack checked out and configured (root `.env` with the required
+  secrets — see the repo README quick start).
+- A **public DNS A/AAAA record** for your FQDN pointing at this host.
+- Inbound **ports 80 and 443** reachable from the internet (80 is required for
+  the ACME HTTP-01 challenge and the HTTP→HTTPS redirect).
+- Nothing else on the host already bound to 80/443.
+
+## Run it
+
+1. Append the variables from [`.env.example`](.env.example) to the **root**
+   `.env` and set your real FQDN and email.
+2. From the repo root:
+
+   ```bash
+   docker compose \
+     -f docker-compose.yml \
+     -f deploy/reverse-proxy/traefik/docker-compose.proxy.yml \
+     up -d
+   ```
+
+3. If you use the LQ.AI shell at `/lq-ai`, also rebuild `web` with
+   `PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1` (see
+   [`../README.md`](../README.md#using-the-lqai-shell-lq-ai-from-other-devices)).
+
+Watch issuance with `docker compose logs -f traefik`; the first certificate
+lands within seconds of the entrypoints coming up.
+
+**While iterating**, uncomment the staging `caserver` flag in
+[`docker-compose.proxy.yml`](docker-compose.proxy.yml) so repeated failed
+attempts don't hit Let's Encrypt's production rate limits. When switching back
+to production, also clear the staged state:
+`docker compose down traefik && docker volume rm lq-ai_traefik-letsencrypt`.
+
+## Verify
+
+```bash
+curl -fI https://<fqdn>/health          # 200, no -k needed — publicly trusted cert
+curl -s -o /dev/null -w '%{http_code}\n' https://<fqdn>/lq-ai-api/v1/skills   # 401 = api routing works
+curl -sI http://<fqdn>/ | head -1       # 30x redirect to https
+docker run --rm drwetter/testssl.sh https://<fqdn>   # full TLS scan
+```
+
+Then open `https://<fqdn>/`, log in, send a chat message, and confirm the
+response streams token-by-token (`responseforwarding.flushinterval=-1` on both
+services disables write batching; Traefik also auto-detects
+`text/event-stream` and never buffers SSE bodies).
+
+## How the routing works
+
+| Router | Rule | Target |
+| --- | --- | --- |
+| `lq-api` | ``Host(`FQDN`) && PathPrefix(`/lq-ai-api/v1`)`` | `api:8000`, after `stripprefix` + `addprefix` middlewares rewrite the path to `/api/v1/*` |
+| `lq-web` | ``Host(`FQDN`)`` | `web:8080` (catch-all; longer rules win automatically, so `lq-api` takes precedence) |
+
+The gateway is **not** routed (see [`../README.md`](../README.md)). Traefik's
+own dashboard/API is left disabled — don't enable `--api.insecure` on an
+internet-facing host.
+
+## Renewal, rotation, and operational notes
+
+- Traefik renews automatically (~30 days before expiry); nothing to cron and
+  nothing to reload.
+- All ACME state (account key + certs) lives in `acme.json` inside the
+  `traefik-letsencrypt` volume. Back it up; deleting it forces rate-limited
+  re-issuance.
+- Renewal failures (port 80 closed, DNS moved) appear in the Traefik logs
+  while the old cert keeps serving until expiry — watch
+  `docker compose logs traefik | grep -i acme` or monitor expiry externally.
+- **Docker socket:** Traefik mounts `/var/run/docker.sock` read-only for label
+  discovery. That is privileged access to the Docker API; on hosts running
+  anything besides this stack, front it with a socket proxy.
+
+## Variations
+
+- **Port 80 can't be opened:** switch the resolver to the DNS-01 challenge
+  (`--certificatesresolvers.letsencrypt.acme.dnschallenge=true` plus your DNS
+  provider's flags and credential env vars — Traefik supports most providers
+  natively, no plugin build needed). Out of scope here; see Traefik's ACME
+  docs.
+- **Air-gapped / no route to Let's Encrypt:** ACME cannot work. Use the
+  [nginx recipe](../nginx/) with internal-CA certs, or point `caserver` at an
+  internal ACME endpoint if your organization runs one.
+- **HSTS:** a commented `lq-hsts` headers middleware ships in the overlay;
+  read [`../README.md`](../README.md#hsts-read-before-enabling) before
+  attaching it to the routers.
+
+## Files
+
+```
+deploy/reverse-proxy/traefik/
+├── README.md                 # this file
+├── docker-compose.proxy.yml  # Traefik service (static config as flags) + routing labels on web/api
+└── .env.example              # LQ_AI_FQDN, LQ_AI_ACME_EMAIL (append to root .env)
+```
+
+*Why no `traefik.yml`?* Traefik loads its static configuration from exactly
+one source (file, flags, or env), and a static-config **file** cannot
+interpolate the operator's `.env` values. Flags in the overlay keep the whole
+recipe parameterized by the same root `.env` as the rest of the stack.

--- a/deploy/reverse-proxy/traefik/docker-compose.proxy.yml
+++ b/deploy/reverse-proxy/traefik/docker-compose.proxy.yml
@@ -1,0 +1,104 @@
+# LQ.AI reverse-proxy overlay — Traefik v3 with automatic Let's Encrypt TLS.
+#
+# Compose onto the base stack from the REPO ROOT:
+#
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f deploy/reverse-proxy/traefik/docker-compose.proxy.yml \
+#     up -d
+#
+# Requires LQ_AI_FQDN and LQ_AI_ACME_EMAIL in the root .env (see
+# .env.example in this directory). Ports 80 and 443 must be reachable
+# from the internet: 80 for the ACME HTTP-01 challenge and the
+# HTTP→HTTPS redirect, 443 for the site itself.
+#
+# Config style: Traefik's static configuration is passed as command-line
+# flags below (Traefik loads static config from exactly ONE source, and
+# flags are the only source that composes with .env interpolation for the
+# ACME email); the routing rules live as Docker labels on the `web` and
+# `api` services, which this overlay extends.
+
+name: lq-ai
+
+services:
+  traefik:
+    image: traefik:v3
+    restart: unless-stopped
+    depends_on:
+      web:
+        condition: service_started
+      api:
+        condition: service_healthy
+    command:
+      # --- providers: discover routes from container labels only ---
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      # --- entrypoints: 80 redirects to 443 ---
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.websecure.address=:443"
+      # Traefik v3 defaults readTimeout to 60s, which cuts off large
+      # document uploads on slow links; allow up to 10 minutes to read a
+      # client request. (writeTimeout stays 0 = unlimited, so long
+      # streamed LLM generations are never cut off by Traefik.)
+      - "--entrypoints.websecure.transport.respondingTimeouts.readTimeout=600s"
+      # --- ACME (Let's Encrypt), HTTP-01 on port 80 ---
+      - "--certificatesresolvers.letsencrypt.acme.email=${LQ_AI_ACME_EMAIL:?LQ_AI_ACME_EMAIL is required — ACME account email}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+      # While iterating, uncomment to use the Let's Encrypt STAGING CA so
+      # failed attempts don't burn production rate limits (staging certs
+      # are not browser-trusted):
+      # - "--certificatesresolvers.letsencrypt.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+    volumes:
+      # Read-only Docker socket: required for label-based route discovery.
+      # This is privileged access to the Docker API — acceptable on a
+      # single-purpose host; on shared hosts consider a socket proxy.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # acme.json holds the ACME account key and issued certificates.
+      # Losing it forces re-issuance (rate-limited!) — keep this volume.
+      - traefik-letsencrypt:/letsencrypt
+    ports:
+      - "80:80"
+      - "443:443"
+
+  # --- routing labels on the upstream services -------------------------
+  # Rule lengths give the api router higher priority than the web
+  # catch-all automatically; no explicit priorities needed.
+
+  api:
+    labels:
+      - "traefik.enable=true"
+      # LQ.AI backend: /lq-ai-api/v1/* → strip the public prefix, restore
+      # the real /api/v1 mount, forward to api:8000.
+      - "traefik.http.routers.lq-api.rule=Host(`${LQ_AI_FQDN:?LQ_AI_FQDN is required — public DNS name of this host}`) && PathPrefix(`/lq-ai-api/v1`)"
+      - "traefik.http.routers.lq-api.entrypoints=websecure"
+      - "traefik.http.routers.lq-api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.lq-api.middlewares=lq-api-strip,lq-api-restore"
+      - "traefik.http.middlewares.lq-api-strip.stripprefix.prefixes=/lq-ai-api/v1"
+      - "traefik.http.middlewares.lq-api-restore.addprefix.prefix=/api/v1"
+      - "traefik.http.services.lq-api.loadbalancer.server.port=8000"
+      # Chat responses stream (SSE); flush every write so tokens reach the
+      # browser as generated instead of in 100ms batches.
+      - "traefik.http.services.lq-api.loadbalancer.responseforwarding.flushinterval=-1"
+      # HSTS — enable ONLY after HTTPS has been stable for a while; see
+      # ../README.md ("HSTS"). Attach `lq-hsts` to both routers' middleware
+      # chains when you do.
+      # - "traefik.http.middlewares.lq-hsts.headers.stsSeconds=31536000"
+
+  web:
+    labels:
+      - "traefik.enable=true"
+      # Everything else — OpenWebUI shell, /api/config, its own /api/v1/*,
+      # websockets (upgrades are handled automatically), static bundle.
+      - "traefik.http.routers.lq-web.rule=Host(`${LQ_AI_FQDN:?LQ_AI_FQDN is required — public DNS name of this host}`)"
+      - "traefik.http.routers.lq-web.entrypoints=websecure"
+      - "traefik.http.routers.lq-web.tls.certresolver=letsencrypt"
+      - "traefik.http.services.lq-web.loadbalancer.server.port=8080"
+      # SSE through the web container's own chat API streams too.
+      - "traefik.http.services.lq-web.loadbalancer.responseforwarding.flushinterval=-1"
+
+volumes:
+  traefik-letsencrypt:


### PR DESCRIPTION
## What / why

Roadmap 3.7 (DE-031 + DE-234): production TLS termination recipes for the compose stack. Built per the air-gap research memo's reverse-proxy verdicts (streaming gotchas, internal-CA guidance, HSTS-with-preload-warning; all prose authored fresh — surveyed sources are CC BY-SA/AGPL).

Part of the coordinated roadmap sweep (umbrella issue #321).

## Topology (the load-bearing discovery)

The OpenWebUI `web` container serves its **own** `/api/v1` + `/api/config`, so a blanket `/api` route to the LQ.AI api breaks the shell at first paint. The recipes follow the established `deploy/caddy-tailscale` shape: `/lq-ai-api/v1/*` → `api:8000` (prefix rewrite), everything else → `web:8080`, gateway never exposed; operators rebuild `web` with `PUBLIC_LQ_AI_API_BASE_URL=/lq-ai-api/v1` (documented). Base stack keeps loopback binds.

## Recipes

- **Caddy** — Let's Encrypt HTTP-01 auto-HTTPS, staging-CA iteration advice, DNS-01/internal-ACME variations, `flush_interval -1`.
- **Traefik v3** — static config as flags + label routing; deliberately **no `traefik.yml`** (static config loads from exactly one source and can't interpolate `.env` — one parameterization path; rationale in README, flagged for sign-off); flush `-1`; `readTimeout` raised over v3's 60s default; docker-socket security note.
- **nginx** — operator certs with the **internal-CA/air-gap section** (SAN, chain order, root distribution, rotation); `proxy_buffering off` + `proxy_read_timeout 3600s` (long generations), websocket upgrade map, 200m body size, 80→443.
- HSTS commented-out everywhere with the preload one-way-door warning. Shared README: chooser table, smoke checks incl. `testssl.sh`.

## Verification (honest split)

**Verified locally** (ephemeral container joined to the live dev stack's network — dev stack untouched, temp certs deleted): all three overlays render via `compose config -q`; nginx end-to-end with self-signed certs — `nginx -t` ok with real upstream resolution, `HTTP/2 200` through TLS to web, prefix rewrite proven (`/lq-ai-api/v1/skills` returns the identical 401 body as a direct api probe), 301 http→https, websocket endpoint reachable through the proxy, served cert confirmed.

**Maintainer steps** (need a real FQDN + open 80/443 — not claimed here): Caddy/Traefik Let's Encrypt issuance end-to-end and an authenticated browser streaming session; exact commands in each recipe README.

No code changes. Pre-existing nit spotted, not fixed: `deploy/caddy-tailscale/README.md` references a `.env.example` that doesn't exist in that directory.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)