### PR TITLE
DE-229: nightly scoped mutation testing (mutmut)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,128 @@
+name: Mutation testing (nightly)
+
+# DE-229 — nightly mutation-testing run over the critical-module allowlists
+# configured in api/pyproject.toml and gateway/pyproject.toml ([tool.mutmut]).
+#
+# Design (per the DE-229 survey verdict and docs/quality/mutation-scores.md):
+#   - Nightly + manual dispatch ONLY — never a PR gate. Mutation runs are
+#     too slow and score deltas too refactor-sensitive to block merges.
+#   - The score is a *tracked artifact*, not a threshold: surviving mutants
+#     do NOT fail the job (mutmut exits 0 when mutants survive). The job
+#     fails only on tool errors — broken config, failing clean tests,
+#     stats-collection failure — which are real problems someone must fix.
+#   - Web/Stryker is deferred (inherited TS-error backlog); see the doc.
+#
+# Scores land as per-run artifacts (mutation-score.json + survivor list)
+# and in the run's step summary. The release procedure records the most
+# recent nightly score in docs/quality/mutation-scores.md — see
+# docs/BUILD-AND-RELEASE.md.
+
+on:
+  schedule:
+    # 03:47 UTC — off the busy top-of-hour cron slots.
+    - cron: "47 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never run two nightly sweeps concurrently; a queued run supersedes nothing
+# (each night's score stands alone), so don't cancel an in-flight one either.
+concurrency:
+  group: mutation-nightly
+  cancel-in-progress: false
+
+jobs:
+  mutmut:
+    name: mutmut (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    # Local full-allowlist runs finish in seconds; CI gets a generous
+    # ceiling so a pathological hang is killed rather than billed for 6h.
+    timeout-minutes: 90
+    strategy:
+      # One package's failure must not hide the other package's score.
+      fail-fast: false
+      matrix:
+        package: [api, gateway]
+    defaults:
+      run:
+        working-directory: ${{ matrix.package }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: ${{ matrix.package }}/pyproject.toml
+
+      # mutmut is pinned exactly (same philosophy as the ruff pin in the
+      # dev extras: nightly output must be comparable run-to-run, and
+      # local == CI). It is deliberately NOT in the packages' dev extras —
+      # that would drag its dependency tree (libcst, textual, rich) into
+      # every PR's CI install for a tool only this workflow and occasional
+      # local runs use.
+      - name: Install package + dev extras + mutmut
+        run: pip install -e ".[dev]" mutmut==3.6.0
+
+      # mutmut run exits non-zero on tool errors (config problems, clean
+      # tests failing inside its mutants/ sandbox, stats collection
+      # failure) and zero when mutants survive — exactly the failure
+      # semantics this workflow wants, so no exit-code juggling here.
+      - name: Run mutation testing over the allowlist
+        run: mutmut run
+
+      - name: Export machine-readable stats
+        run: mutmut export-cicd-stats
+
+      - name: List surviving mutants
+        run: mutmut results | tee mutation-survivors.txt
+
+      - name: Compute score summary
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          python - <<'EOF'
+          import datetime
+          import json
+          import os
+
+          with open("mutants/mutmut-cicd-stats.json") as f:
+              stats = json.load(f)
+
+          # Score definition (documented in docs/quality/mutation-scores.md):
+          # killed / (total - skipped). Mutants with no covering test count
+          # against the score — untested critical code is a real gap, not
+          # a denominator adjustment.
+          denominator = stats["total"] - stats["skipped"]
+          score = round(100 * stats["killed"] / denominator, 2) if denominator else None
+
+          summary = {
+              "package": os.environ["PACKAGE"],
+              "commit": os.environ["GITHUB_SHA"],
+              "run_utc": datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds"),
+              "mutation_score_percent": score,
+              **stats,
+          }
+          with open("mutation-score.json", "w") as f:
+              json.dump(summary, f, indent=2)
+          print(json.dumps(summary, indent=2))
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write(f"## Mutation score — {summary['package']}\n\n")
+              f.write(f"**{score}%** killed ({stats['killed']}/{denominator} mutants; ")
+              f.write(f"{stats['survived']} survived, {stats['no_tests']} without covering tests)\n")
+          EOF
+
+      - name: Upload results artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: mutation-${{ matrix.package }}-${{ github.run_id }}
+          path: |
+            ${{ matrix.package }}/mutation-score.json
+            ${{ matrix.package }}/mutation-survivors.txt
+            ${{ matrix.package }}/mutants/mutmut-cicd-stats.json
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ coverage.xml
 *.py,cover
 .hypothesis/
 htmlcov/
+# mutmut (DE-229) working copy — created by `mutmut run` in api/ and gateway/
+mutants/
 
 # Type checking
 .mypy_cache/

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -196,6 +196,62 @@ markers = [
     "e2e: end-to-end tests via Playwright",
 ]
 
+# DE-229 — mutation testing (mutmut 3.x reads this section from pyproject.toml).
+#
+# Scope is a deliberate critical-module allowlist, not the whole package:
+# full-package mutation over a 237-file suite is hours-to-days, and the
+# value concentrates in the security/citation code whose test suites must
+# catch real defects, not just execute lines. Rationale, the score history,
+# and the local-run recipe live in docs/quality/mutation-scores.md.
+#
+# The allowlist is further restricted to modules whose covering tests are
+# DB-free. mutmut executes tests from a mutants/ sandbox copy, and the
+# Alembic seed migrations (0032/0033) resolve skills/ four parents above
+# the migration file — a layout that doesn't hold inside the sandbox, so
+# any Postgres-backed suite fails at session setup there. Consequence:
+# app/audit.py and the DB-tested citation modules (treatment*, cost,
+# ledger, authority) are OUT of scope for now; see the doc for the
+# follow-up. Do not add DB-bound suites to the test selection below.
+#
+# Runs nightly in .github/workflows/mutation.yml (never as a PR gate).
+# Local run: `mutmut run` from api/ — no DATABASE_URL needed.
+[tool.mutmut]
+source_paths = ["app"]
+only_mutate = [
+    # Fernet encryption helpers for provider keys / MCP tokens (ADR 0011).
+    "app/security/encryption.py",
+    # Citation Engine deterministic core (PRD §3.3): extraction →
+    # verification cascade (exact/tolerant/ensemble) + normalization,
+    # caselaw matching, and the judge prompt assembly.
+    "app/citation/normalization.py",
+    "app/citation/extraction.py",
+    "app/citation/verification.py",
+    "app/citation/caselaw.py",
+    "app/citation/judge_prompts.py",
+    "app/citation/authority_content_judge.py",
+]
+# Restrict the stats/clean runs to the DB-free suites that exercise the
+# allowlist — collecting all 237 test files per run would dominate the
+# runtime, and DB-bound suites break inside the sandbox (see above).
+pytest_add_cli_args_test_selection = [
+    "tests/citation/test_normalization.py",
+    "tests/citation/test_extraction.py",
+    "tests/citation/test_exact_match.py",
+    "tests/citation/test_tolerant_match.py",
+    "tests/citation/test_verify_cascade.py",
+    "tests/citation/test_verification_spans.py",
+    "tests/citation/test_ensemble.py",
+    "tests/citation/test_chunk_boundary.py",
+    "tests/citation/test_paraphrase_judge.py",
+    "tests/citation/test_caselaw_extraction.py",
+    "tests/citation/test_caselaw_matching.py",
+    "tests/citation/test_caselaw_verify.py",
+    "tests/citation/test_judge_prompts.py",
+    "tests/citation/test_authority_content_judge.py",
+    "tests/test_encryption.py",
+    "tests/test_mcp_encryption.py",
+]
+
 [tool.mypy]
 strict_optional = true
 warn_unused_ignores = true

--- a/docs/BUILD-AND-RELEASE.md
+++ b/docs/BUILD-AND-RELEASE.md
@@ -114,6 +114,29 @@ git tag desktop-vX.Y.Z && git push origin desktop-vX.Y.Z
 > the *image* tag separately (`-f tag=vX.Y.Z`) and point `ref` at `main`. Pushing a `vX.Y.Z` tag from
 > `main` does this for you.
 
+### 4. Record the mutation score (DE-229)
+
+Every release records the most recent nightly mutation-testing scores — the proof that the test
+suite catches real defects, not just that lines execute (PRD §5.8). The nightly workflow is
+non-blocking; this step is where its output becomes a published, per-release number.
+
+```bash
+# (a) Find the latest successful nightly run and pull its per-package score artifacts:
+gh run list -R LegalQuants/lq-ai --workflow=mutation.yml --status=success -L 1
+gh run download <run-id> -R LegalQuants/lq-ai -n mutation-api-<run-id> -n mutation-gateway-<run-id>
+cat mutation-score.json   # one per package: mutation_score_percent + raw counts + commit
+
+# (b) Append a row to the score-history table in docs/quality/mutation-scores.md
+#     (date, release tag, commit, api %, gateway %, source run URL) and land it with the
+#     release PR. NEVER hand-edit a score that didn't come from a nightly artifact.
+
+# (c) Copy the same two percentages into the GitHub release notes for vX.Y.Z.
+```
+
+If no nightly run has succeeded since the last config change, say so in the release notes
+("mutation score: no valid nightly run") rather than reusing a stale number — conservative-posture
+rule: don't overclaim.
+
 ---
 
 ## Image ↔ launcher relationship
@@ -204,6 +227,8 @@ xcrun stapler validate /tmp/LQ.AI-*.dmg     # "The validate action worked!"
 
 ## See also
 
+- [`docs/quality/mutation-scores.md`](quality/mutation-scores.md) — the per-release mutation-score
+  record (step 4 above).
 - [`docs/INSTALL-MAC.md`](INSTALL-MAC.md) — the end-user install guide.
 - [`desktop/VERIFICATION.md`](../desktop/VERIFICATION.md) — the release-time verification protocol.
 - [`docs/lq-ai-macos-launcher-playbook.md`](lq-ai-macos-launcher-playbook.md) — the full playbook this

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -5014,6 +5014,14 @@ The gateway `Router`'s `_tool_rate_limiter` (`gateway/app/router.py`) is a singl
 
 ## 10. Appendices
 
+#### DE-388 — Seed migrations resolve `skills/` relative to file layout, breaking sandboxed test runs
+
+**Priority:** P3 · **Effort:** S · **Status (2026-07-25): filed (found during DE-229 mutation-testing rollout).**
+
+Seed migrations `0032`/`0033` locate the built-in skills corpus by walking four parents up from the migration file — a layout assumption that holds in the repo but breaks in any sandboxed copy (mutmut's `mutants/` copy resolves it to a nonexistent `api/skills/`), which makes every Postgres-backed api suite fail at session setup under mutation testing and forced the DE-229 api allowlist down to DB-free-tested modules (excluding `app/audit.py`, `app/security/{passwords,jwt,totp}.py`, and the DB-tested citation modules from wave 1). Fix: resolve the corpus via an env override (e.g. `LQ_AI_SKILLS_DIR`) falling back to the current walk, set it in conftest; then widen the mutation allowlist to the excluded modules and re-baseline. Cheap, unblocks meaningful mutation coverage of the auth/audit surface.
+
+---
+
 ### Appendix A — Glossary
 
 - **agentskills.io format** — open standard for portable AI skills, compatible with Anthropic Claude Skills and Hermes Agent.

--- a/docs/quality/mutation-scores.md
+++ b/docs/quality/mutation-scores.md
@@ -1,0 +1,168 @@
+# Mutation testing (DE-229)
+
+> **Status:** nightly runs configured; **no baseline recorded yet** — the first
+> nightly run of `.github/workflows/mutation.yml` populates the score table below.
+
+Mutation testing answers the criticism that coverage percentages can be gamed:
+it makes small changes ("mutants") to the source — flipping a comparison,
+deleting a call, changing a constant — and re-runs the tests that cover the
+mutated function. A test suite that catches real defects *kills* the mutant
+(some test fails); a suite that merely executes lines lets it *survive*. The
+mutation score is the proportion of mutants killed (PRD §5.8 / DE-229).
+
+## Tooling and configuration
+
+- **Tool:** [mutmut](https://github.com/boxed/mutmut) (BSD-3-Clause), pinned to
+  **3.6.0** in the workflow. Chosen over cosmic-ray per the DE-229 survey —
+  cosmic-ray's distributed-execution machinery is unjustified at this scale.
+- **Configuration:** the `[tool.mutmut]` section of
+  [`api/pyproject.toml`](../../api/pyproject.toml) and
+  [`gateway/pyproject.toml`](../../gateway/pyproject.toml). mutmut 3.x reads
+  `source_paths`, the `only_mutate` allowlist, and the pytest test-selection
+  arguments from there.
+- **Where it runs:** [`mutation.yml`](../../.github/workflows/mutation.yml) —
+  nightly cron + manual dispatch. **Never a PR gate**: full runs are too slow
+  for PR latency, and absolute score thresholds flake with unrelated refactors.
+  Surviving mutants do **not** fail the job; the job fails only on tool errors
+  (broken config, clean tests failing, stats collection failing).
+- mutmut is intentionally **not** in either package's dev extras — it would add
+  its dependency tree (libcst, textual, rich) to every PR's CI install for a
+  tool only the nightly workflow and occasional local runs use. Install it
+  ad hoc (see "Running locally").
+
+**Score definition:** `killed / (total − skipped)`. Mutants with **no covering
+test** count *against* the score — untested critical code is a real gap, not a
+denominator adjustment. The raw counts (killed / survived / no-test / timeout /
+suspicious) are preserved in every run artifact so the score can be recomputed
+under any other definition.
+
+## The allowlist and its rationale
+
+Mutating a whole package against a 237-file suite is an hours-to-days run for
+little marginal signal. Scope is instead a named critical-module allowlist —
+the code that enforces security policy or produces the artifacts the product's
+trust story rests on:
+
+### gateway (`gateway/pyproject.toml`)
+
+| Modules | Why |
+|---|---|
+| `app/router.py`, `app/tier_floor.py` | Tier-Derivation + routing policy enforcement (PRD §3.13, §4.4) — the fail-closed security decisions. |
+| `app/routing_log.py` | The per-request audit choke point (PRD §1.5.2). |
+| `app/anonymization/**` | The Anonymization Layer (PRD §4.7), including the custom legal recognizers. |
+
+Covering suites: `tests/test_tier_floor.py`, `tests/test_router.py`,
+`tests/test_route_tool_call.py`, `tests/test_routing_log.py`,
+`tests/anonymization/`.
+
+### api (`api/pyproject.toml`)
+
+| Modules | Why |
+|---|---|
+| `app/security/encryption.py` | Fernet encryption for provider keys / MCP tokens (ADR 0011). |
+| `app/citation/{normalization,extraction,verification,caselaw,judge_prompts,authority_content_judge}.py` | The Citation Engine's deterministic core (PRD §3.3) — the exact/tolerant/ensemble verification cascade and its inputs. |
+
+Covering suites: the DB-free files under `tests/citation/` plus
+`tests/test_encryption.py` and `tests/test_mcp_encryption.py` (enumerated in
+`[tool.mutmut] pytest_add_cli_args_test_selection`).
+
+### Known scope limitations (honest state)
+
+- **api DB-backed modules are out of the first wave** — `app/audit.py`,
+  `app/security/{passwords,jwt,totp}.py`, and the DB-tested citation modules
+  (`treatment*`, `cost.py`, `ledger.py`, `authority.py`). Cause: mutmut
+  executes tests from a `mutants/` sandbox copy of the package, and the
+  Alembic seed migrations `0032`/`0033` resolve the built-in playbook YAML at
+  *four parents above the migration file* (`<repo>/skills/…`). Inside the
+  sandbox that path resolves to `api/skills/…`, which doesn't exist, so any
+  Postgres-backed suite fails at session setup (verified locally 2026-07-25).
+  Bringing these modules in requires either making those migrations
+  layout-independent or teaching the conftest a skills-path override —
+  a candidate deferred enhancement, not a quiet hack in this change.
+- **The gateway config-integration suites are excluded from mutmut's test
+  selection** (e.g. `tests/test_inference_tier_floor.py`) because they resolve
+  `gateway.yaml.example` via the repo root, which the sandbox layout breaks.
+  The mutants those suites would additionally kill show up as `survived` or
+  `no_tests` instead — the score is therefore a *floor*, not a ceiling.
+- **No per-PR diff-based gate.** The survey pattern ("zero surviving mutants in
+  changed lines") was evaluated and **scoped out** for mutmut 3.x: unlike the
+  2.x line, 3.x has no supported line- or diff-based mutant selection — scoping
+  is by module allowlist in config or by *dotted function-name* patterns on the
+  CLI. A PR gate would need a hand-rolled `git diff` → function-name mapper,
+  and the sandbox requirement that every selected suite passes cleanly makes
+  PR-time behavior depend on which suites a PR touches. That is exactly the
+  flaky-gate failure mode the survey warned against, so the PR half of DE-229
+  is deferred until the tooling supports it robustly.
+- **web/ (Stryker) is deferred.** The OpenWebUI fork carries a large inherited
+  TypeScript-error backlog (9,362 errors at capture, tracked in
+  `docs/SVELTE-CHECK-BACKLOG.md`); mutation testing on top of that gives noise,
+  not signal. Revisit once the backlog burn-down reaches the LQ.AI-owned code.
+- **No README badge yet.** DE-229's acceptance criteria include a score badge;
+  that needs a stable published score endpoint, which needs a recorded
+  baseline first. Sequence: first nightly → record scores here → badge.
+
+## Where scores land
+
+Each nightly run uploads, per package, a `mutation-<package>-<run_id>`
+artifact (90-day retention) containing:
+
+- `mutation-score.json` — score + raw counts + commit + timestamp,
+- `mutation-survivors.txt` — the surviving-mutant list (`mutmut results`),
+- `mutants/mutmut-cicd-stats.json` — mutmut's raw CI/CD stats.
+
+The score also renders in the run's step summary. At release time the release
+runner records the latest nightly scores in the table below and in the release
+notes — the step is part of [`docs/BUILD-AND-RELEASE.md`](../BUILD-AND-RELEASE.md).
+
+## Score history
+
+| Date (UTC) | Release | Commit | api score | gateway score | Source |
+|---|---|---|---|---|---|
+| — | — | — | *no baseline recorded yet — the first nightly run populates this row* | — | — |
+
+Scores in this table come **only** from CI nightly-run artifacts. Do not enter
+hand-run numbers here.
+
+### Local validation evidence (2026-07-25 — smoke only, NOT a baseline)
+
+Recorded from the pre-merge validation of this configuration on a developer
+machine (Apple Silicon, macOS). These prove the config works end-to-end; they
+are not comparable to CI-runner numbers and are not the recorded baseline.
+
+- **gateway smoke** (`mutmut run "app.tier_floor*"`): 43 mutants in
+  `app/tier_floor.py` — 39 killed, 4 survived; ~6 s wall including mutant
+  generation for the full allowlist (1,043 mutants generated).
+- **api smoke** (`mutmut run "app.citation.normalization*"`): 29 mutants in
+  `app/citation/normalization.py` — 28 killed, 1 survived; ~3 s wall
+  (1,107 mutants generated across the allowlist).
+- **Full-allowlist local runs** (same day, same machine): gateway
+  542 killed / 307 survived / 194 no-test of 1,043 (~15 s wall); api
+  571 killed / 178 survived / 358 no-test of 1,107 (~7 s wall). The high
+  no-test counts are the excluded-suite effect described above.
+
+## Running locally
+
+From `api/` or `gateway/` (the package venv must have the dev extras):
+
+```bash
+pip install mutmut==3.6.0     # or: uv pip install --python .venv/bin/python mutmut==3.6.0
+
+mutmut run                    # full allowlist for this package (fast — seconds locally)
+mutmut run "app.tier_floor*"  # restrict to one module's mutants (dotted-name pattern)
+
+mutmut results                # list surviving mutants
+mutmut show <mutant-name>     # diff of one mutant — what change survived
+mutmut browse                 # interactive TUI
+mutmut export-cicd-stats      # write mutants/mutmut-cicd-stats.json
+```
+
+Notes:
+
+- mutmut works in a `mutants/` copy of the package (git-ignored). `rm -rf
+  mutants` for a from-scratch run; leaving it in place makes reruns
+  incremental.
+- No `DATABASE_URL` is needed — the configured test selections are DB-free by
+  design (see scope limitations).
+- A surviving mutant is a *lead*, not automatically a bug: kill it by adding
+  the missing assertion, or conclude the mutation is semantically neutral
+  (e.g. logging detail) and leave it documented in the nightly survivor list.

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -107,6 +107,37 @@ markers = [
     "slow: tests that take longer than 5s",
 ]
 
+# DE-229 — mutation testing (mutmut 3.x reads this section from pyproject.toml).
+#
+# Scope is a deliberate critical-module allowlist: the routing/policy
+# choke points and the Anonymization Layer — the gateway code whose test
+# suites must catch real defects (PRD §5.8). Rationale and score history:
+# docs/quality/mutation-scores.md.
+#
+# Runs nightly in .github/workflows/mutation.yml (never as a PR gate).
+# Local run: `mutmut run` from gateway/. The test selection below excludes
+# suites that resolve gateway.yaml.example via the repo root (e.g.
+# tests/test_inference_tier_floor.py): mutmut executes tests from its
+# mutants/ sandbox copy, where that repo-root-relative path breaks.
+[tool.mutmut]
+source_paths = ["app"]
+only_mutate = [
+    # Tier-Derivation + routing policy enforcement (PRD §3.13 / §4.4).
+    "app/router.py",
+    "app/tier_floor.py",
+    # Routing-log writer — the per-request audit choke point (PRD §1.5.2).
+    "app/routing_log.py",
+    # Anonymization Layer (PRD §4.7), incl. recognizers/.
+    "app/anonymization/*",
+]
+pytest_add_cli_args_test_selection = [
+    "tests/test_tier_floor.py",
+    "tests/test_router.py",
+    "tests/test_route_tool_call.py",
+    "tests/test_routing_log.py",
+    "tests/anonymization",
+]
+
 [tool.mypy]
 strict = true
 warn_unused_ignores = true


### PR DESCRIPTION
## What / why

DE-229 (PRD §9): mutation testing for the critical paths, nightly-tracked, never a PR gate. Built per the testing-cluster memo's verdicts (mutmut BSD-3 adapted; cosmic-ray and repo-wide score gates rejected).

Part of the coordinated roadmap sweep (umbrella issue #321).

## Design

- **`mutation.yml`**: nightly + dispatch; matrix `[api, gateway]`, fail-fast off, 90-min timeout; `mutmut==3.6.0` pinned at install (kept out of dev extras — an SBOM/CI-weight call, easy to reverse). Failure semantics distinguish tool errors (job fails) from surviving mutants (reported in `mutation-score.json` + survivors artifact + step summary, 90-day retention).
- **Allowlists** (`[tool.mutmut]`, rationale commented): gateway `router.py`/`tier_floor.py`/`routing_log.py`/`anonymization/**`; api `security/encryption.py` + the deterministic citation core.
- **Smoke-proven locally** (explicitly non-baseline): gateway `tier_floor` 39/43 killed (~6s); api `citation/normalization` 28/29 killed (~3s); full-allowlist local runs recorded in the doc. The scores table ships honest-empty — **the first nightly populates the baseline; no badge until then.**
- `docs/quality/mutation-scores.md` + a release-procedure step recording the score (stale-score prohibition).

## Findings + scoping decisions (review focus)

1. **DE-388 filed**: seed migrations `0032`/`0033` resolve `skills/` by walking four parents up from the migration file — nonexistent inside mutmut's sandbox copy, so every Postgres-backed api suite fails at session setup (root-caused + reproduced). Wave 1 therefore excludes `audit.py`/`security/{passwords,jwt,totp}.py`/DB-tested citation modules; the DE row records the env-override fix that unblocks wave 2.
2. **Diff-based PR gating scoped out**: mutmut 3.x has no line/diff-based selection — a hand-rolled diff→function mapper would be fragile; the memo's escape hatch applies. Documented.
3. Stryker/web deferred (inherited svelte-check backlog); PRD's badge acceptance deferred until a real baseline exists — no fabricated numbers.

## Gates

ruff format/check + mypy clean in both packages after the pyproject edits; pytest sanity green per package (config unbroken); workflow YAML parses. Full suites not re-run (no test-code changes).

`.github/workflows/**` = security-review routed.

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)