### PR TITLE
DE-240: PII leakage measurement — real rates, and a 100% ORGANIZATION leak found

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -3420,6 +3420,8 @@ This subsection operationalizes the §1.9 engineering-discipline posture and the
 
 **Priority:** P1 · **Effort:** M
 
+**Status:** First harness + measured baseline shipped (2026-07-25). Labeled synthetic corpus at `tests/pii/corpus/`, measurement harness in `gateway/tests/anonymization/pii_leakage.py` (slow-marked CI test with a ±5-point anti-regression pin against `tests/pii/baseline/`), measured rates published in [docs/quality/pii-leakage-rates.md](quality/pii-leakage-rates.md). Headline honest finding: ORGANIZATION leaks 100% (Presidio's default NLP config suppresses `ORG` via `labels_to_ignore`; un-suppressing is a precision trade-off deferred to DE-282 calibration). Adversarial-extraction fixtures live at `tests/pii/extraction/` with a maintainer-run live test (`LQ_PII_LIVE=1`); the "each NER backend × each tier" matrix collapses to the single spaCy backend the gateway supports, as documented in the rates doc. Remaining open scope: real legal-document recall/precision (DE-282) and per-release refresh cadence.
+
 **Context:** Per §5.8. The measurable analog of the privacy claim. Depends on the Anonymization Layer being wired (§4.7 at M2).
 
 **Specific scope:** Test the Anonymization Layer against a documented PII corpus: each entity class × each NER backend × each inference tier × each adversarial-extraction technique. Publish a per-release "PII leakage probability" rate per configuration in `docs/quality/pii-leakage-rates.md` with the test methodology.
@@ -5013,6 +5015,14 @@ The gateway `Router`'s `_tool_rate_limiter` (`gateway/app/router.py`) is a singl
 ---
 
 ## 10. Appendices
+
+#### DE-390 — Anonymization layer never pseudonymizes ORGANIZATION entities (Presidio default suppression)
+
+**Priority:** P1 · **Effort:** S · **Status (2026-07-25): filed (measured by the DE-240 harness — 10/10 organization names survive anonymization).**
+
+The DE-240 leakage harness measured a 100% miss rate for organization names through the pre-egress anonymization path, and root-caused it: raw spaCy detects the ORG entities, but Presidio's default `AnalyzerEngine` NLP configuration ships `ORGANIZATION` in `labels_to_ignore` (a deliberate upstream precision choice — ORG detection is noisy), and `gateway/app/anonymization/engine.py` never overrides it. For a legal product, organization names in privileged documents are often exactly the sensitive identifier an operator enables the layer to protect. Fix requires a maintainer decision inside the security boundary: un-suppress ORGANIZATION (accepting the precision cost — likely over-pseudonymization of common nouns spaCy mislabels), gate it behind a config flag (e.g. `anonymize_organizations: true|false` defaulting per the committee's risk posture), or document the exclusion prominently in the operator-facing anonymization docs. Whichever lands must re-run the DE-240 harness and update the published rates + the DE-282 calibration plan. Related finding recorded in the rates doc: `ENABLED_DEFAULT_RECOGNIZERS` in `engine.py` is descriptive-only (several undocumented Presidio defaults are active) — documentation drift worth fixing in the same pass.
+
+---
 
 ### Appendix A — Glossary
 

--- a/docs/quality/pii-leakage-rates.md
+++ b/docs/quality/pii-leakage-rates.md
@@ -1,0 +1,297 @@
+# PII Leakage Rates — Anonymization Layer (DE-240)
+
+> **Status of these numbers:** measured, not aspirational. They are produced by a
+> deterministic local harness running the real anonymization engine over a labeled
+> synthetic corpus, and several of them are bad. Publishing the bad numbers is the
+> point — a miss in this layer is a silent confidentiality incident, so operators
+> deserve the measured rates, not a claim.
+
+- **Measured:** 2026-07-25 (macOS arm64, gateway venv; Python 3.12)
+- **Engine under test:** the exact production configuration constructed by
+  [`gateway/app/anonymization/engine.py::get_analyzer_engine`](../../gateway/app/anonymization/engine.py)
+- **Environment:** presidio-analyzer 2.2.364 · presidio-anonymizer 2.2.360 ·
+  spacy 3.8.14 · en_core_web_lg 3.8.0
+- **Corpus:** [`tests/pii/corpus/pii_corpus.json`](../../tests/pii/corpus/pii_corpus.json)
+  — 71 entries, 80 expected entity occurrences, all values synthetic
+- **Baseline (anti-regression pin):**
+  [`tests/pii/baseline/pii_leakage_baseline.json`](../../tests/pii/baseline/pii_leakage_baseline.json)
+
+## Methodology
+
+The harness ([`gateway/tests/anonymization/pii_leakage.py`](../../gateway/tests/anonymization/pii_leakage.py))
+runs every corpus entry through `Anonymizer.pseudonymize_into` against the real
+Presidio `AnalyzerEngine` (spaCy `en_core_web_lg` backbone) and scores the
+anonymized output:
+
+- **Full leak** — the expected entity value survives verbatim (case-sensitive
+  substring) in the anonymized text. The provider would receive the exact PII string.
+- **Partial leak** — the full value is broken up, but a *significant token* of it
+  survives (length ≥ 4, excluding generic structural/corporate words like "Avenue"
+  or "Corporation"). The provider would receive an identifying fragment.
+
+The unit of measurement is the expected entity occurrence, not the corpus entry.
+This measures **leakage, not classification accuracy**: an entity substituted under
+the "wrong" type (e.g. a passport number caught by the bank-number recognizer)
+still counts as protected, because the original text never reaches the provider.
+
+Corpus classes mirror the recognizer set the gateway actually registers — six kept
+Presidio defaults (`PERSON`, `ORGANIZATION`, `EMAIL_ADDRESS`, `PHONE_NUMBER`,
+`US_BANK_NUMBER`, `LOCATION`) plus two custom legal recognizers (`CASE_NUMBER`,
+`MATTER_NUMBER`) — crossed with format variants (canonical, mid-sentence, list
+context, spaced, punctuated, all-caps, non-Anglo/unicode names, international
+phone formats). A **known-untargeted** section documents classes the configuration
+deliberately does not cover (see below).
+
+Reproduce (fully offline, deterministic for a fixed model/version set):
+
+```bash
+cd gateway
+.venv/bin/python -m tests.anonymization.pii_leakage --markdown   # rate tables
+.venv/bin/python -m tests.anonymization.pii_leakage              # full JSON report
+```
+
+## Measured rates — per class
+
+Measured 2026-07-25 — presidio-analyzer 2.2.364, presidio-anonymizer 2.2.360, spacy 3.8.14, en_core_web_lg 3.8.0.
+
+| Class | Targeted | Entities | Full-leak rate | Partial-leak rate |
+|---|---|---:|---:|---:|
+| PERSON | yes | 12 | 0.0% | 0.0% |
+| ORGANIZATION | yes | 10 | **100.0%** | 0.0% |
+| EMAIL_ADDRESS | yes | 9 | 0.0% | 11.1% |
+| PHONE_NUMBER | yes | 11 | 0.0% | 0.0% |
+| US_BANK_NUMBER | yes | 5 | 0.0% | 0.0% |
+| LOCATION | yes | 10 | 0.0% | 20.0% |
+| CASE_NUMBER | yes | 8 | 12.5% | 0.0% |
+| MATTER_NUMBER | yes | 7 | 14.3% | 0.0% |
+| CREDIT_CARD | no (out of scope, measured informationally) | 1 | 0.0% | 0.0% |
+| DATE_OF_BIRTH | no | 1 | 0.0% | 0.0% |
+| EIN | no | 1 | 100.0% | 0.0% |
+| IBAN_CODE | no | 1 | 100.0% | 0.0% |
+| IP_ADDRESS | no | 1 | 100.0% | 0.0% |
+| US_DRIVER_LICENSE | no | 1 | 100.0% | 0.0% |
+| US_PASSPORT | no | 1 | 0.0% | 0.0% |
+| US_SSN | no | 1 | 100.0% | 0.0% |
+
+## Measured rates — per variant
+
+| Class | Variant | n | Full leaks | Partial leaks |
+|---|---|---:|---:|---:|
+| PERSON | all_caps | 1 | 0 | 0 |
+| PERSON | canonical | 2 | 0 | 0 |
+| PERSON | list_context | 3 | 0 | 0 |
+| PERSON | mid_sentence | 1 | 0 | 0 |
+| PERSON | non_anglo | 3 | 0 | 0 |
+| PERSON | punctuated | 1 | 0 | 0 |
+| PERSON | surname_first | 1 | 0 | 0 |
+| ORGANIZATION | all_caps | 1 | 1 | 0 |
+| ORGANIZATION | canonical | 2 | 2 | 0 |
+| ORGANIZATION | law_firm | 1 | 1 | 0 |
+| ORGANIZATION | list_context | 3 | 3 | 0 |
+| ORGANIZATION | mid_sentence | 1 | 1 | 0 |
+| ORGANIZATION | no_suffix | 1 | 1 | 0 |
+| ORGANIZATION | unicode | 1 | 1 | 0 |
+| EMAIL_ADDRESS | all_caps | 1 | 0 | 0 |
+| EMAIL_ADDRESS | canonical | 1 | 0 | 0 |
+| EMAIL_ADDRESS | list_context | 2 | 0 | 0 |
+| EMAIL_ADDRESS | mid_sentence | 1 | 0 | 0 |
+| EMAIL_ADDRESS | plus_address | 1 | 0 | 0 |
+| EMAIL_ADDRESS | punctuated | 1 | 0 | 0 |
+| EMAIL_ADDRESS | spaced | 1 | 0 | 1 |
+| EMAIL_ADDRESS | subdomain | 1 | 0 | 0 |
+| PHONE_NUMBER | canonical | 1 | 0 | 0 |
+| PHONE_NUMBER | extension | 1 | 0 | 0 |
+| PHONE_NUMBER | international | 3 | 0 | 0 |
+| PHONE_NUMBER | list_context | 2 | 0 | 0 |
+| PHONE_NUMBER | mid_sentence | 1 | 0 | 0 |
+| PHONE_NUMBER | punctuated | 2 | 0 | 0 |
+| PHONE_NUMBER | spaced | 1 | 0 | 0 |
+| US_BANK_NUMBER | canonical | 1 | 0 | 0 |
+| US_BANK_NUMBER | labeled | 1 | 0 | 0 |
+| US_BANK_NUMBER | mid_sentence | 1 | 0 | 0 |
+| US_BANK_NUMBER | punctuated | 1 | 0 | 0 |
+| US_BANK_NUMBER | spaced | 1 | 0 | 0 |
+| LOCATION | canonical | 2 | 0 | 0 |
+| LOCATION | list_context | 3 | 0 | 0 |
+| LOCATION | mid_sentence | 2 | 0 | 0 |
+| LOCATION | street_address | 2 | 0 | 2 |
+| LOCATION | unicode | 1 | 0 | 0 |
+| CASE_NUMBER | canonical | 2 | 0 | 0 |
+| CASE_NUMBER | docket | 2 | 0 | 0 |
+| CASE_NUMBER | lowercase | 1 | 0 | 0 |
+| CASE_NUMBER | mid_sentence | 1 | 0 | 0 |
+| CASE_NUMBER | spaced | 1 | 1 | 0 |
+| CASE_NUMBER | state_reporter | 1 | 0 | 0 |
+| MATTER_NUMBER | canonical | 1 | 0 | 0 |
+| MATTER_NUMBER | dotted | 1 | 1 | 0 |
+| MATTER_NUMBER | list_context | 2 | 0 | 0 |
+| MATTER_NUMBER | lowercase | 1 | 0 | 0 |
+| MATTER_NUMBER | mid_sentence | 1 | 0 | 0 |
+| MATTER_NUMBER | punctuated | 1 | 0 | 0 |
+| CREDIT_CARD | canonical | 1 | 0 | 0 |
+| DATE_OF_BIRTH | canonical | 1 | 0 | 0 |
+| EIN | canonical | 1 | 1 | 0 |
+| IBAN_CODE | canonical | 1 | 1 | 0 |
+| IP_ADDRESS | canonical | 1 | 1 | 0 |
+| US_DRIVER_LICENSE | canonical | 1 | 1 | 0 |
+| US_PASSPORT | canonical | 1 | 0 | 0 |
+| US_SSN | canonical | 1 | 1 | 0 |
+
+## Findings (honest, root-caused)
+
+### 1. ORGANIZATION leaks 100% — the documented "enabled" recognizer never fires
+
+Every organization name in the corpus — `Meridian Fabrication LLC`, `Delacroix &
+Marsh LLP`, all ten — reached the anonymized output verbatim. Root cause,
+verified during measurement: raw spaCy `en_core_web_lg` detects these spans as
+`ORG` correctly, but Presidio's **default** `AnalyzerEngine` NLP configuration
+ships `ORGANIZATION` in `labels_to_ignore` (Presidio suppresses it by default
+because of its false-positive rate on general text). The gateway constructs
+`AnalyzerEngine(registry=...)` without overriding the NLP-engine configuration,
+so the suppression applies. The `ENABLED_DEFAULT_RECOGNIZERS` tuple in
+`engine.py` that lists `ORGANIZATION` is documentation only — nothing in the
+code path enforces it.
+
+**Consequence for operators today:** company names — counterparties, clients,
+targets in M&A matters — are NOT pseudonymized. Treat any matter where the
+organization's identity is itself confidential accordingly (Tier 1 local routing
+per `docs/security/anonymization.md`).
+
+**Not fixed in this change deliberately:** un-ignoring `ORGANIZATION` is a
+behavior change inside the security boundary with a known precision cost (the
+reason Presidio suppresses it), which is exactly the recall/precision trade-off
+DE-282's legal-corpus validation exists to calibrate. Needs a maintainer
+decision; the drift pin will make the improvement visible when it lands.
+
+### 2. Custom-recognizer format edges
+
+- **`MATTER_NUMBER` dotted form at sentence end** (14.3% class rate): the
+  pattern `2025.0138.` — a dotted matter number followed by the sentence's
+  period — is missed because the recognizer's trailing guard `(?![\d.])` treats
+  the sentence-final period as part of a longer decimal. Verified: the analyzer
+  returns zero results for that sentence.
+- **`CASE_NUMBER` spaced docket** (12.5% class rate): `Case No. 1:24 - cv - 00317`
+  (spaces around hyphens, as OCR or sloppy transcription produces) defeats the
+  docket regex.
+
+### 3. Partial leaks: street addresses and spaced emails
+
+- **Street addresses**: spaCy catches the city/state (`Springfield, Illinois`)
+  but the house number and street name (`1247 Marlowe`…) and the ZIP (`59801`)
+  survive — 2 of 2 street-address entries partially leak. The surviving fragment
+  is enough to identify a premises.
+- **Spaced email** (`elena . marchetti @ quarrybend-example . com`): the email
+  recognizer misses the spaced form; identifying tokens (`quarrybend`) survive.
+
+### 4. What the configuration deliberately does not cover (known-untargeted)
+
+`engine.py` disables `UsSsnRecognizer`, `UsPassportRecognizer`,
+`UsLicenseRecognizer`, `CryptoRecognizer`, `IbanRecognizer`, `IpRecognizer`, and
+`MedicalLicenseRecognizer` (false-positive rationale documented inline there),
+and no recognizer targets EINs. As measured: **SSNs, EINs, driver's licenses,
+IPs, and IBANs pass through to the provider verbatim (100% leak)**. Operators
+whose corpus contains these re-enable per-recognizer in their deployment per
+`docs/security/anonymization.md`.
+
+Two untargeted classes were caught *incidentally* — attribute honestly, don't
+count on them:
+
+- The passport number was substituted by `UsBankRecognizer` at confidence 0.05
+  (a nine-digit number resembles an account number). Fragile, not a guarantee.
+- The date of birth was caught by `DATE_TIME` and the credit card by
+  `CREDIT_CARD` — recognizers that are **registered but not documented** in
+  `ENABLED_DEFAULT_RECOGNIZERS`. The measured registry also includes
+  `DateRecognizer`, `CreditCardRecognizer`, `MacAddressRecognizer`,
+  `NhsRecognizer`, `UrlRecognizer`, and `UsItinRecognizer`: the enable-list in
+  `engine.py` is descriptive, the disable-list is what's enforced. The full
+  measured recognizer inventory is embedded in every harness report
+  (`metadata.recognizers`).
+
+## Configurations: NER backends and inference tiers
+
+- **NER backend:** the gateway supports exactly one backend today — Presidio's
+  default spaCy engine with `en_core_web_lg`. There is no alternative-backend
+  configuration surface, so the DE-240 "per NER backend" matrix collapses to
+  this single measured column. If a transformer or alternative-model backend
+  ever lands, it gets its own measured column here before it ships.
+- **Inference tiers:** anonymization applies at the tiers listed in
+  `anonymization.apply_at_tiers` (gateway config); the engine and therefore
+  these rates are identical at every tier where it applies. At tiers where it
+  does not apply (typically Tier 1 local, where the prompt never leaves the
+  operator's environment), the leakage question is moot by construction.
+  Privileged chats and per-request opt-outs skip anonymization entirely —
+  those paths send original text by design (PRD §4.7 Decision A).
+
+## Adversarial extraction (response path)
+
+Fixtures at [`tests/pii/extraction/extraction_prompts.json`](../../tests/pii/extraction/extraction_prompts.json)
+attack the response path: plant synthetic PII, then ask the model for a
+*transformed* rendering (surname reversed, name letter-spelled, digits reversed,
+base64, `[at]`-obfuscated email). The transformation is load-bearing — the
+gateway rehydrates pseudonyms in responses, so the original value legitimately
+reappears whenever the model echoes a pseudonym; only a transformed rendering
+proves the provider saw raw PII. `tests/pii/test_fixture_integrity.py` enforces
+deterministically (keyless, in CI-able form) that no leak indicator could
+false-positive on a legitimate round-trip.
+
+Two structural guarantees are pinned without any live model:
+
+- the serialized provider-bound request contains pseudonyms only, and carries no
+  reference to the mapper or its reverse table
+  (`gateway/tests/anonymization/test_provider_payload_isolation.py`);
+- the mapper never reaches logs or audit rows
+  (`gateway/tests/anonymization/test_round_trip.py`, invariant 4).
+
+The end-to-end check needs a live provider, so it is a **maintainer-run step**,
+guarded off by default:
+
+```bash
+LQ_PII_LIVE=1 LQ_PII_GATEWAY_URL=http://127.0.0.1:8100 \
+    pytest tests/pii/test_extraction_live.py -m live -rs
+```
+
+A failure (leak indicator in a response) is a confidentiality-incident signal.
+A pass is evidence, not proof — model outputs are nondeterministic.
+
+## CI integration and the anti-regression pin
+
+`gateway/tests/anonymization/test_pii_leakage_rates.py` (marked `slow`, runs in
+the normal gateway `pytest -q` suite) gates on two things only:
+
+1. the harness runs and scores the complete corpus (the measurement capability
+   must not rot), and
+2. **no targeted class's full-leak rate worsens by more than 5 percentage
+   points** versus the committed baseline.
+
+The absolute rates are deliberately not gated — they are informational until
+DE-282 calibrates recognizer accuracy on a real legal-document corpus. The pin
+exists to catch *drift*: a Presidio/spaCy upgrade or config change that silently
+starts leaking a class that used to be caught. Suite cost: ~2-4s added to the
+gateway run (one spaCy model load, ~71 analyze calls).
+
+After a deliberate corpus or engine change, regenerate the baseline and refresh
+the tables in this document:
+
+```bash
+cd gateway
+.venv/bin/python -m tests.anonymization.pii_leakage --write-baseline
+.venv/bin/python -m tests.anonymization.pii_leakage --markdown
+```
+
+## Per-release process
+
+Re-run the two commands above on the release branch, update the tables and the
+"Measured" date here, and note any rate movement in the release notes. Rates are
+attributed to the exact `presidio-analyzer` / `spacy` / `en_core_web_lg`
+versions in the report metadata; a version bump without a rate re-measurement is
+a release-checklist violation.
+
+## Relationship to DE-282
+
+This corpus is synthetic and format-focused: it measures how the engine handles
+entity *format variants* under controlled conditions. It does **not** measure
+recall/precision on real legal documents — annotated contracts, briefs, and
+correspondence with natural context — which is DE-282's scope. When DE-282's
+curated corpus lands, its recall numbers supersede these for "will my actual
+documents leak" questions; the two harnesses share the same engine entry point
+and can share fixture conventions.

--- a/gateway/tests/anonymization/pii_leakage.py
+++ b/gateway/tests/anonymization/pii_leakage.py
@@ -1,0 +1,377 @@
+"""DE-240 — PII leakage measurement harness.
+
+Runs the REAL anonymization engine (Presidio + spaCy ``en_core_web_lg``,
+exactly as configured by :func:`app.anonymization.engine.get_analyzer_engine`)
+over the labeled synthetic corpus at ``tests/pii/corpus/pii_corpus.json``
+(repo root) and measures per-class / per-variant leakage rates.
+
+Metric definitions (documented in ``docs/quality/pii-leakage-rates.md``):
+
+* **full leak** — the expected entity value survives verbatim (substring,
+  case-sensitive) in the anonymized output. The provider would receive
+  the exact PII string.
+* **partial leak** — the full value no longer survives, but at least one
+  *significant token* of it does (length >= 4, not a generic
+  structural/corporate word). The provider would receive an identifying
+  fragment (a surname, a street name, a digit group).
+
+The unit of measurement is the *expected entity occurrence*, not the
+corpus entry — entries carrying several entities contribute one
+measurement per entity. Leakage is measured, not classification
+accuracy: an entity substituted under the "wrong" type (e.g. a person
+caught as ORGANIZATION) still counts as protected, because the original
+text never reaches the provider.
+
+Two consumers:
+
+* ``tests/anonymization/test_pii_leakage_rates.py`` — the slow-marked
+  pytest module that runs the harness and enforces the anti-regression
+  pin against the committed baseline.
+* ``python -m tests.anonymization.pii_leakage`` (from ``gateway/``, in
+  the gateway venv) — regenerates the baseline JSON and/or prints the
+  markdown rate tables for ``docs/quality/pii-leakage-rates.md``.
+
+The corpus and baseline live under the repo-root ``tests/pii/`` tree so
+they're shared work product (DE-282's legal-corpus validation is the
+successor for recall claims on *real* documents; this harness measures
+format-variant behavior on synthetic values).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import date
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CORPUS_PATH = REPO_ROOT / "tests" / "pii" / "corpus" / "pii_corpus.json"
+BASELINE_PATH = REPO_ROOT / "tests" / "pii" / "baseline" / "pii_leakage_baseline.json"
+
+# A targeted class's full-leak rate may not worsen by more than this
+# many percentage points vs the committed baseline before the drift
+# test fails. Rates are informational until DE-282 calibrates them; the
+# pin only catches *regressions* (an engine/config/model drift that
+# silently starts leaking a class it used to catch).
+DRIFT_THRESHOLD_POINTS = 5.0
+
+# Tokens of an expected value that are structural/generic and don't
+# identify anyone on their own. A surviving "Avenue" or "Corporation"
+# is not treated as a partial leak; a surviving "Marlowe" or "4472" is.
+_GENERIC_TOKENS = frozenset(
+    {
+        # structural words that appear inside address/identifier values
+        "avenue",
+        "street",
+        "road",
+        "boulevard",
+        "suite",
+        "county",
+        "courthouse",
+        "account",
+        "matter",
+        "case",
+        "number",
+        # corporate suffixes (>= 4 chars; shorter ones are excluded by
+        # the length rule anyway)
+        "corporation",
+        "company",
+        "holdings",
+        "incorporated",
+        "limited",
+        "gmbh",
+    }
+)
+_MIN_TOKEN_LEN = 4
+
+# Word-ish tokens: digit runs or letter runs (unicode-aware via \w
+# minus digits/underscore).
+_TOKEN_RE = re.compile(r"\d+|[^\W\d_]+", re.UNICODE)
+
+# Canonical ordering for report rows: targeted classes in the order the
+# engine documentation lists them, then whatever untargeted classes the
+# corpus carries (sorted).
+TARGETED_CLASS_ORDER = (
+    "PERSON",
+    "ORGANIZATION",
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "US_BANK_NUMBER",
+    "LOCATION",
+    "CASE_NUMBER",
+    "MATTER_NUMBER",
+)
+
+
+@dataclass(slots=True)
+class EntityOutcome:
+    """Measured outcome for one expected entity occurrence."""
+
+    entry_id: str
+    entity_class: str
+    variant: str
+    targeted: bool
+    value: str
+    full_leak: bool
+    partial_leak: bool
+    leaked_tokens: list[str]
+
+
+def load_corpus(path: Path = CORPUS_PATH) -> dict[str, Any]:
+    """Load and structurally validate the corpus JSON."""
+
+    with path.open(encoding="utf-8") as fh:
+        corpus: dict[str, Any] = json.load(fh)
+
+    entries = corpus["entries"]
+    seen_ids: set[str] = set()
+    for entry in entries:
+        entry_id = entry["id"]
+        if entry_id in seen_ids:
+            raise ValueError(f"duplicate corpus entry id: {entry_id}")
+        seen_ids.add(entry_id)
+        for expected in entry["expected_entities"]:
+            if expected["value"] not in entry["text"]:
+                raise ValueError(
+                    f"corpus entry {entry_id}: expected value {expected['value']!r} "
+                    f"does not appear in the entry text"
+                )
+    return corpus
+
+
+def significant_tokens(value: str) -> list[str]:
+    """Tokens of ``value`` that identify something on their own."""
+
+    return [
+        token
+        for token in _TOKEN_RE.findall(value)
+        if len(token) >= _MIN_TOKEN_LEN and token.lower() not in _GENERIC_TOKENS
+    ]
+
+
+def evaluate_entry(anonymized_text: str, entry: dict[str, Any]) -> list[EntityOutcome]:
+    """Score one corpus entry's expected entities against its anonymized text."""
+
+    outcomes: list[EntityOutcome] = []
+    for expected in entry["expected_entities"]:
+        value = expected["value"]
+        full_leak = value in anonymized_text
+        leaked_tokens = (
+            [] if full_leak else [t for t in significant_tokens(value) if t in anonymized_text]
+        )
+        outcomes.append(
+            EntityOutcome(
+                entry_id=entry["id"],
+                entity_class=expected["class"],
+                variant=entry["variant"],
+                targeted=bool(entry["targeted"]),
+                value=value,
+                full_leak=full_leak,
+                partial_leak=bool(leaked_tokens),
+                leaked_tokens=leaked_tokens,
+            )
+        )
+    return outcomes
+
+
+def _pkg_version(name: str) -> str:
+    try:
+        return version(name)
+    except PackageNotFoundError:  # pragma: no cover - environment-dependent
+        return "not-installed"
+
+
+def _rate(count: int, n: int) -> float:
+    return round(100.0 * count / n, 1) if n else 0.0
+
+
+def measure(corpus: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Run the real engine over the corpus; return the rates report.
+
+    Imports the engine lazily so merely importing this module never
+    triggers the spaCy model load.
+    """
+
+    from app.anonymization.engine import Anonymizer, get_analyzer_engine
+    from app.anonymization.mapper import PseudonymMapper
+
+    if corpus is None:
+        corpus = load_corpus()
+
+    engine = get_analyzer_engine()
+    anonymizer = Anonymizer(analyzer=engine)
+
+    outcomes: list[EntityOutcome] = []
+    for entry in corpus["entries"]:
+        mapper = PseudonymMapper()
+        anonymized = anonymizer.pseudonymize_into(entry["text"], mapper)
+        outcomes.extend(evaluate_entry(anonymized, entry))
+
+    return build_report(corpus, outcomes, recognizers=_recognizer_inventory(engine))
+
+
+def _recognizer_inventory(engine: Any) -> list[dict[str, Any]]:
+    """The recognizer set actually registered — honest config attribution."""
+
+    return sorted(
+        (
+            {
+                "name": type(recognizer).__name__,
+                "supported_entities": sorted(recognizer.supported_entities),
+            }
+            for recognizer in engine.registry.recognizers
+        ),
+        key=lambda r: str(r["name"]),
+    )
+
+
+def build_report(
+    corpus: dict[str, Any],
+    outcomes: list[EntityOutcome],
+    recognizers: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Aggregate per-entity outcomes into the rates report structure."""
+
+    classes: dict[str, dict[str, Any]] = {}
+    for outcome in outcomes:
+        cls = classes.setdefault(
+            outcome.entity_class,
+            {
+                "targeted": outcome.targeted,
+                "n": 0,
+                "full_leaks": 0,
+                "partial_leaks": 0,
+                "variants": {},
+            },
+        )
+        cls["n"] += 1
+        cls["full_leaks"] += int(outcome.full_leak)
+        cls["partial_leaks"] += int(outcome.partial_leak)
+        var = cls["variants"].setdefault(
+            outcome.variant, {"n": 0, "full_leaks": 0, "partial_leaks": 0}
+        )
+        var["n"] += 1
+        var["full_leaks"] += int(outcome.full_leak)
+        var["partial_leaks"] += int(outcome.partial_leak)
+
+    for cls in classes.values():
+        cls["full_leak_rate"] = _rate(cls["full_leaks"], cls["n"])
+        cls["partial_leak_rate"] = _rate(cls["partial_leaks"], cls["n"])
+        for var in cls["variants"].values():
+            var["full_leak_rate"] = _rate(var["full_leaks"], var["n"])
+            var["partial_leak_rate"] = _rate(var["partial_leaks"], var["n"])
+
+    return {
+        "metadata": {
+            "generated": date.today().isoformat(),
+            "corpus_schema_version": corpus["schema_version"],
+            "corpus_entries": len(corpus["entries"]),
+            "expected_entities": len(outcomes),
+            "drift_threshold_points": DRIFT_THRESHOLD_POINTS,
+            "versions": {
+                "presidio-analyzer": _pkg_version("presidio-analyzer"),
+                "presidio-anonymizer": _pkg_version("presidio-anonymizer"),
+                "spacy": _pkg_version("spacy"),
+                "en_core_web_lg": _pkg_version("en_core_web_lg"),
+            },
+            "recognizers": recognizers or [],
+        },
+        "classes": classes,
+        "entities": [asdict(o) for o in outcomes],
+    }
+
+
+def ordered_classes(report: dict[str, Any]) -> list[str]:
+    """Targeted classes in canonical order, then untargeted classes sorted."""
+
+    classes = report["classes"]
+    targeted = [c for c in TARGETED_CLASS_ORDER if c in classes]
+    untargeted = sorted(c for c in classes if c not in TARGETED_CLASS_ORDER)
+    return targeted + untargeted
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    """Render the rate tables for ``docs/quality/pii-leakage-rates.md``."""
+
+    meta = report["metadata"]
+    lines: list[str] = []
+    versions = ", ".join(f"{k} {v}" for k, v in meta["versions"].items())
+    lines.append(f"Measured {meta['generated']} — {versions}.")
+    lines.append("")
+    lines.append("| Class | Targeted | Entities | Full-leak rate | Partial-leak rate |")
+    lines.append("|---|---|---:|---:|---:|")
+    for cls_name in ordered_classes(report):
+        cls = report["classes"][cls_name]
+        lines.append(
+            f"| {cls_name} | {'yes' if cls['targeted'] else 'no (documented out of scope)'} "
+            f"| {cls['n']} | {cls['full_leak_rate']}% | {cls['partial_leak_rate']}% |"
+        )
+    lines.append("")
+    lines.append("Per-variant breakdown (full-leak / partial-leak, n):")
+    lines.append("")
+    lines.append("| Class | Variant | n | Full leaks | Partial leaks |")
+    lines.append("|---|---|---:|---:|---:|")
+    for cls_name in ordered_classes(report):
+        cls = report["classes"][cls_name]
+        for variant_name in sorted(cls["variants"]):
+            var = cls["variants"][variant_name]
+            lines.append(
+                f"| {cls_name} | {variant_name} | {var['n']} "
+                f"| {var['full_leaks']} | {var['partial_leaks']} |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def write_baseline(report: dict[str, Any], path: Path = BASELINE_PATH) -> None:
+    """Write the committed anti-regression baseline (rates only, no per-entity rows)."""
+
+    baseline = {
+        "metadata": report["metadata"],
+        "classes": {
+            name: {
+                "targeted": cls["targeted"],
+                "n": cls["n"],
+                "full_leaks": cls["full_leaks"],
+                "full_leak_rate": cls["full_leak_rate"],
+                "partial_leaks": cls["partial_leaks"],
+                "partial_leak_rate": cls["partial_leak_rate"],
+            }
+            for name, cls in report["classes"].items()
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(baseline, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="DE-240 PII leakage measurement")
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help=f"write the anti-regression baseline to {BASELINE_PATH}",
+    )
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        help="print the docs-ready markdown tables instead of the JSON report",
+    )
+    args = parser.parse_args(argv)
+
+    report = measure()
+    if args.write_baseline:
+        write_baseline(report)
+        print(f"baseline written: {BASELINE_PATH}", file=sys.stderr)
+    if args.markdown:
+        print(render_markdown(report))
+    elif not args.write_baseline:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entry point
+    raise SystemExit(main())

--- a/gateway/tests/anonymization/test_pii_leakage_rates.py
+++ b/gateway/tests/anonymization/test_pii_leakage_rates.py
@@ -1,0 +1,150 @@
+"""DE-240 — PII leakage rates: harness run + anti-regression pin.
+
+Runs the measurement harness (``tests/anonymization/pii_leakage.py``)
+against the real Presidio + spaCy engine over the labeled corpus at
+``tests/pii/corpus/pii_corpus.json`` (repo root) and enforces two
+things:
+
+1. **The harness runs and produces a complete report** — every corpus
+   entry evaluated, every expected entity scored. This is the CI gate:
+   the *measurement capability* must not rot.
+2. **No-regression drift pin** — a targeted class's full-leak rate may
+   not worsen by more than ``DRIFT_THRESHOLD_POINTS`` (5) percentage
+   points versus the committed baseline
+   (``tests/pii/baseline/pii_leakage_baseline.json``). The absolute
+   rates are deliberately NOT gated: they are informational until
+   DE-282 calibrates recognizer accuracy on a real legal-document
+   corpus, and several are honestly bad (see
+   ``docs/quality/pii-leakage-rates.md`` — ORGANIZATION leaks 100% as
+   of the first measurement). The pin only catches *drift*: an
+   engine/config/model change that silently starts leaking a class
+   that used to be caught.
+
+Untargeted classes (``targeted: false`` in the corpus — SSN, EIN,
+driver's license, IP, IBAN, ...) are measured informationally and
+never gate; they document what the recognizer configuration
+deliberately does not cover.
+
+Regenerating the baseline after a deliberate corpus or engine change:
+
+    cd gateway && .venv/bin/python -m tests.anonymization.pii_leakage --write-baseline
+
+Marked ``slow`` (spaCy ``en_core_web_lg`` load, ~1-3s; the ~70 analyze
+calls add roughly the same again).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests.anonymization import pii_leakage
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def report() -> dict[str, Any]:
+    """Run the full measurement once for this module."""
+
+    from app.anonymization.engine import _reset_analyzer_engine_for_tests
+
+    _reset_analyzer_engine_for_tests()
+    return pii_leakage.measure()
+
+
+@pytest.fixture(scope="module")
+def baseline() -> dict[str, Any]:
+    assert pii_leakage.BASELINE_PATH.exists(), (
+        f"Missing committed baseline {pii_leakage.BASELINE_PATH}. Generate it with: "
+        f"cd gateway && python -m tests.anonymization.pii_leakage --write-baseline"
+    )
+    with pii_leakage.BASELINE_PATH.open(encoding="utf-8") as fh:
+        data: dict[str, Any] = json.load(fh)
+    return data
+
+
+def test_harness_evaluates_every_corpus_entity(report: dict[str, Any]) -> None:
+    """Gate: the harness runs end-to-end and scores the whole corpus."""
+
+    corpus = pii_leakage.load_corpus()
+    expected_total = sum(len(e["expected_entities"]) for e in corpus["entries"])
+
+    assert report["metadata"]["corpus_entries"] == len(corpus["entries"])
+    assert report["metadata"]["expected_entities"] == expected_total
+    assert len(report["entities"]) == expected_total
+
+    # Every targeted class the corpus documents shows up in the report.
+    reported = set(report["classes"])
+    corpus_classes = {
+        expected["class"] for entry in corpus["entries"] for expected in entry["expected_entities"]
+    }
+    assert corpus_classes == reported
+
+
+def test_report_attributes_the_measured_configuration(report: dict[str, Any]) -> None:
+    """The report is honestly attributed: versions + real recognizer inventory."""
+
+    versions = report["metadata"]["versions"]
+    for pkg in ("presidio-analyzer", "presidio-anonymizer", "spacy", "en_core_web_lg"):
+        assert versions[pkg] != "not-installed", f"{pkg} missing from the measured environment"
+
+    recognizer_names = {r["name"] for r in report["metadata"]["recognizers"]}
+    # The custom legal recognizers must be part of the measured config.
+    assert {"CaseNumberRecognizer", "MatterNumberRecognizer"} <= recognizer_names
+    # The disabled defaults must NOT be part of the measured config.
+    from app.anonymization.engine import DISABLED_DEFAULT_RECOGNIZERS
+
+    assert not (set(DISABLED_DEFAULT_RECOGNIZERS) & recognizer_names)
+
+
+def test_corpus_matches_baseline_shape(report: dict[str, Any], baseline: dict[str, Any]) -> None:
+    """Corpus changes require a deliberate baseline regeneration."""
+
+    assert report["metadata"]["corpus_entries"] == baseline["metadata"]["corpus_entries"], (
+        "Corpus entry count changed vs the committed baseline. If the corpus change "
+        "is deliberate, regenerate: cd gateway && python -m tests.anonymization.pii_leakage "
+        "--write-baseline (and refresh docs/quality/pii-leakage-rates.md)."
+    )
+    assert report["metadata"]["expected_entities"] == baseline["metadata"]["expected_entities"]
+
+
+def test_targeted_full_leak_rates_do_not_regress(
+    report: dict[str, Any], baseline: dict[str, Any]
+) -> None:
+    """Drift pin: no targeted class worsens by > DRIFT_THRESHOLD_POINTS points."""
+
+    threshold = pii_leakage.DRIFT_THRESHOLD_POINTS
+    regressions: list[str] = []
+    for cls_name, base_cls in baseline["classes"].items():
+        if not base_cls["targeted"]:
+            continue  # untargeted classes are informational, never gate
+        current = report["classes"].get(cls_name)
+        assert current is not None, f"class {cls_name} vanished from the report"
+        delta = current["full_leak_rate"] - base_cls["full_leak_rate"]
+        if delta > threshold:
+            regressions.append(
+                f"{cls_name}: {base_cls['full_leak_rate']}% -> {current['full_leak_rate']}% "
+                f"(+{round(delta, 1)} points)"
+            )
+
+    assert not regressions, (
+        "PII full-leak rate regressed beyond the ±"
+        f"{threshold}-point drift pin for: {'; '.join(regressions)}. If the regression is "
+        "an accepted trade-off (documented!), regenerate the baseline and update "
+        "docs/quality/pii-leakage-rates.md; otherwise fix the engine/config drift."
+    )
+
+
+def test_untargeted_classes_are_present_and_informational(
+    report: dict[str, Any],
+) -> None:
+    """The known-untargeted section exists — the out-of-scope surface stays documented."""
+
+    untargeted = [name for name, cls in report["classes"].items() if not cls["targeted"]]
+    assert "US_SSN" in untargeted, (
+        "The corpus must keep documenting deliberately-untargeted classes "
+        "(engine.py disables UsSsnRecognizer et al.); US_SSN is the canonical example."
+    )

--- a/gateway/tests/anonymization/test_provider_payload_isolation.py
+++ b/gateway/tests/anonymization/test_provider_payload_isolation.py
@@ -1,0 +1,126 @@
+"""DE-240 — the rehydration mapper never reaches provider-bound payloads.
+
+The adversarial-extraction premise (tests/pii/extraction/ at repo root)
+is only sound if the provider *cannot* know the pseudonym → original
+mapping. Two structural guarantees make that true, and this module
+pins both deterministically (stub analyzer — no spaCy, not slow):
+
+1. After ``pre_anonymize_request`` runs, the serialized request (the
+   object every provider adapter builds its outbound payload from)
+   contains pseudonyms only — no original entity text, in message
+   content or in nested skill inputs.
+2. The request object carries no reference to the mapper or its
+   reverse table at all — the mapping lives exclusively in the
+   in-process ``PseudonymMapper`` the middleware returns to the
+   caller, which is never serialized (see also the persistence
+   invariant in ``test_round_trip.py`` and the adapter-level checks in
+   ``test_inference_anonymization.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.anonymization.engine import Anonymizer
+from app.anonymization.mapper import PseudonymMapper
+from app.anonymization.middleware import pre_anonymize_request
+from app.config import AnonymizationConfig
+from app.providers.openai_schema import ChatCompletionMessage, ChatCompletionRequest
+
+_ORIGINALS = ("John Smith", "Acme LLP")
+
+
+@dataclass(slots=True)
+class _Span:
+    entity_type: str
+    start: int
+    end: int
+    score: float = 0.9
+
+
+class _StubAnalyzer:
+    """Deterministic analyzer: flags every occurrence of the known originals."""
+
+    def analyze(self, *, text: str, language: str = "en") -> list[_Span]:
+        spans: list[_Span] = []
+        for value, entity_type in ((_ORIGINALS[0], "PERSON"), (_ORIGINALS[1], "ORGANIZATION")):
+            start = 0
+            while (found := text.find(value, start)) != -1:
+                spans.append(_Span(entity_type=entity_type, start=found, end=found + len(value)))
+                start = found + len(value)
+        return spans
+
+
+def _pseudonymized_request() -> tuple[ChatCompletionRequest, PseudonymMapper]:
+    request = ChatCompletionRequest(
+        model="smart",
+        messages=[
+            ChatCompletionMessage(role="system", content="Context: John Smith retained Acme LLP."),
+            ChatCompletionMessage(role="user", content="Summarize John Smith's obligations."),
+        ],
+        lq_ai_skill_inputs={
+            "nda-review": {"party": "John Smith", "nested": {"firm": ["Acme LLP"]}}
+        },
+    )
+    mapper = pre_anonymize_request(
+        chat_request=request,
+        config=AnonymizationConfig(enabled=True, apply_at_tiers=[3, 4, 5]),
+        routed_tier=4,
+        anonymizer=Anonymizer(analyzer=_StubAnalyzer()),
+    )
+    assert mapper is not None
+    return request, mapper
+
+
+def test_serialized_request_contains_pseudonyms_and_no_originals() -> None:
+    """The provider-bound serialization carries zero original entity text."""
+
+    request, mapper = _pseudonymized_request()
+    serialized = request.model_dump_json()
+
+    for original in _ORIGINALS:
+        assert original not in serialized, f"original {original!r} leaked into provider payload"
+    # Sanity: substitution actually happened (guards against a vacuous pass).
+    assert "PERSON_0001" in serialized
+    assert "ORGANIZATION_0001" in serialized
+
+    # The mapper knows the originals — in process only.
+    assert set(mapper.reverse().values()) == set(_ORIGINALS)
+
+
+def test_skill_inputs_are_pseudonymized_in_serialized_request() -> None:
+    """Nested skill-input strings are substituted too, not just message content."""
+
+    request, _ = _pseudonymized_request()
+    assert request.lq_ai_skill_inputs is not None
+    inputs = request.lq_ai_skill_inputs["nda-review"]
+    assert inputs["party"] == "PERSON_0001"
+    assert inputs["nested"]["firm"] == ["ORGANIZATION_0001"]
+
+
+def test_request_object_holds_no_reference_to_the_mapper() -> None:
+    """No field of the request (or its dump) can carry the reverse mapping."""
+
+    request, mapper = _pseudonymized_request()
+
+    # No attribute of the pydantic model is (or contains) the mapper.
+    dumped = request.model_dump()
+
+    def _walk(value: object) -> None:
+        assert not isinstance(value, PseudonymMapper)
+        assert not isinstance(value, dict) or all(
+            not isinstance(v, PseudonymMapper) for v in value.values()
+        )
+        if isinstance(value, dict):
+            for v in value.values():
+                _walk(v)
+        elif isinstance(value, list):
+            for v in value:
+                _walk(v)
+
+    _walk(dumped)
+
+    # And the serialized form never mentions the reverse table's contents.
+    serialized = request.model_dump_json()
+    for original in mapper.reverse().values():
+        assert original not in serialized

--- a/tests/pii/baseline/pii_leakage_baseline.json
+++ b/tests/pii/baseline/pii_leakage_baseline.json
@@ -1,0 +1,223 @@
+{
+  "classes": {
+    "CASE_NUMBER": {
+      "full_leak_rate": 12.5,
+      "full_leaks": 1,
+      "n": 8,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": true
+    },
+    "CREDIT_CARD": {
+      "full_leak_rate": 0.0,
+      "full_leaks": 0,
+      "n": 1,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": false
+    },
+    "DATE_OF_BIRTH": {
+      "full_leak_rate": 0.0,
+      "full_leaks": 0,
+      "n": 1,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": false
+    },
+    "EIN": {
+      "full_leak_rate": 100.0,
+      "full_leaks": 1,
+      "n": 1,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": false
+    },
+    "EMAIL_ADDRESS": {
+      "full_leak_rate": 0.0,
+      "full_leaks": 0,
+      "n": 9,
+      "partial_leak_rate": 11.1,
+      "partial_leaks": 1,
+      "targeted": true
+    },
+    "IBAN_CODE": {
+      "full_leak_rate": 100.0,
+      "full_leaks": 1,
+      "n": 1,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": false
+    },
+    "IP_ADDRESS": {
+      "full_leak_rate": 100.0,
+      "full_leaks": 1,
+      "n": 1,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": false
+    },
+    "LOCATION": {
+      "full_leak_rate": 0.0,
+      "full_leaks": 0,
+      "n": 10,
+      "partial_leak_rate": 20.0,
+      "partial_leaks": 2,
+      "targeted": true
+    },
+    "MATTER_NUMBER": {
+      "full_leak_rate": 14.3,
+      "full_leaks": 1,
+      "n": 7,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": true
+    },
+    "ORGANIZATION": {
+      "full_leak_rate": 100.0,
+      "full_leaks": 10,
+      "n": 10,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": true
+    },
+    "PERSON": {
+      "full_leak_rate": 0.0,
+      "full_leaks": 0,
+      "n": 12,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": true
+    },
+    "PHONE_NUMBER": {
+      "full_leak_rate": 0.0,
+      "full_leaks": 0,
+      "n": 11,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": true
+    },
+    "US_BANK_NUMBER": {
+      "full_leak_rate": 0.0,
+      "full_leaks": 0,
+      "n": 5,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": true
+    },
+    "US_DRIVER_LICENSE": {
+      "full_leak_rate": 100.0,
+      "full_leaks": 1,
+      "n": 1,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": false
+    },
+    "US_PASSPORT": {
+      "full_leak_rate": 0.0,
+      "full_leaks": 0,
+      "n": 1,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": false
+    },
+    "US_SSN": {
+      "full_leak_rate": 100.0,
+      "full_leaks": 1,
+      "n": 1,
+      "partial_leak_rate": 0.0,
+      "partial_leaks": 0,
+      "targeted": false
+    }
+  },
+  "metadata": {
+    "corpus_entries": 71,
+    "corpus_schema_version": 1,
+    "drift_threshold_points": 5.0,
+    "expected_entities": 80,
+    "generated": "2026-07-25",
+    "recognizers": [
+      {
+        "name": "CaseNumberRecognizer",
+        "supported_entities": [
+          "CASE_NUMBER"
+        ]
+      },
+      {
+        "name": "CreditCardRecognizer",
+        "supported_entities": [
+          "CREDIT_CARD"
+        ]
+      },
+      {
+        "name": "DateRecognizer",
+        "supported_entities": [
+          "DATE_TIME"
+        ]
+      },
+      {
+        "name": "EmailRecognizer",
+        "supported_entities": [
+          "EMAIL_ADDRESS"
+        ]
+      },
+      {
+        "name": "MacAddressRecognizer",
+        "supported_entities": [
+          "MAC_ADDRESS"
+        ]
+      },
+      {
+        "name": "MatterNumberRecognizer",
+        "supported_entities": [
+          "MATTER_NUMBER"
+        ]
+      },
+      {
+        "name": "NhsRecognizer",
+        "supported_entities": [
+          "UK_NHS"
+        ]
+      },
+      {
+        "name": "PhoneRecognizer",
+        "supported_entities": [
+          "PHONE_NUMBER"
+        ]
+      },
+      {
+        "name": "SpacyRecognizer",
+        "supported_entities": [
+          "DATE_TIME",
+          "LOCATION",
+          "NRP",
+          "ORGANIZATION",
+          "PERSON"
+        ]
+      },
+      {
+        "name": "UrlRecognizer",
+        "supported_entities": [
+          "URL"
+        ]
+      },
+      {
+        "name": "UsBankRecognizer",
+        "supported_entities": [
+          "US_BANK_NUMBER"
+        ]
+      },
+      {
+        "name": "UsItinRecognizer",
+        "supported_entities": [
+          "US_ITIN"
+        ]
+      }
+    ],
+    "versions": {
+      "en_core_web_lg": "3.8.0",
+      "presidio-analyzer": "2.2.364",
+      "presidio-anonymizer": "2.2.360",
+      "spacy": "3.8.14"
+    }
+  }
+}

--- a/tests/pii/corpus/pii_corpus.json
+++ b/tests/pii/corpus/pii_corpus.json
@@ -1,0 +1,620 @@
+{
+  "schema_version": 1,
+  "title": "DE-240 PII leakage corpus",
+  "description": "Labeled synthetic PII corpus for measuring the gateway Anonymization Layer's leakage rates. Every value is synthetic: names, organizations, and matter identifiers are invented; phone numbers use reserved fictional ranges (US 555-01xx, UK 20 7946 0xxx); account numbers, SSNs, and card numbers are fabricated or standard test values. Entry classes mirror the recognizer set the gateway actually registers (gateway/app/anonymization/engine.py): six kept Presidio defaults (PERSON, ORGANIZATION, EMAIL_ADDRESS, PHONE_NUMBER, US_BANK_NUMBER, LOCATION) plus two custom recognizers (CASE_NUMBER, MATTER_NUMBER). Entries with targeted=false document classes the gateway DELIBERATELY does not target (recognizers disabled or never registered); they are measured informationally and never gate. Shared concern with DE-282 (empirical recall/precision on real legal-document corpus): this corpus is synthetic and format-focused; DE-282's curated-document corpus supersedes it for recall claims.",
+  "entries": [
+    {
+      "id": "person-canonical-01",
+      "class": "PERSON",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "Marcus Ellery signed the settlement agreement yesterday.",
+      "expected_entities": [{ "value": "Marcus Ellery", "class": "PERSON" }]
+    },
+    {
+      "id": "person-canonical-02",
+      "class": "PERSON",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "Priya Raghunathan will depose the witness on Thursday.",
+      "expected_entities": [{ "value": "Priya Raghunathan", "class": "PERSON" }]
+    },
+    {
+      "id": "person-midsentence-01",
+      "class": "PERSON",
+      "variant": "mid_sentence",
+      "targeted": true,
+      "text": "The parties agree that Daniel Okonkwo shall serve as escrow agent for the deposit.",
+      "expected_entities": [{ "value": "Daniel Okonkwo", "class": "PERSON" }]
+    },
+    {
+      "id": "person-list-01",
+      "class": "PERSON",
+      "variant": "list_context",
+      "targeted": true,
+      "text": "Attendees: Helena Vargas, Tomasz Zielinski, and Mei-Ling Chow.",
+      "expected_entities": [
+        { "value": "Helena Vargas", "class": "PERSON" },
+        { "value": "Tomasz Zielinski", "class": "PERSON" },
+        { "value": "Mei-Ling Chow", "class": "PERSON" }
+      ]
+    },
+    {
+      "id": "person-nonanglo-01",
+      "class": "PERSON",
+      "variant": "non_anglo",
+      "targeted": true,
+      "text": "Nguyễn Thị Minh signed on behalf of the seller.",
+      "expected_entities": [{ "value": "Nguyễn Thị Minh", "class": "PERSON" }]
+    },
+    {
+      "id": "person-nonanglo-02",
+      "class": "PERSON",
+      "variant": "non_anglo",
+      "targeted": true,
+      "text": "Counsel for the defendant is Oluwaseun Adeyemi.",
+      "expected_entities": [{ "value": "Oluwaseun Adeyemi", "class": "PERSON" }]
+    },
+    {
+      "id": "person-nonanglo-03",
+      "class": "PERSON",
+      "variant": "non_anglo",
+      "targeted": true,
+      "text": "Aoife Ní Bhraonáin attended the mediation session.",
+      "expected_entities": [{ "value": "Aoife Ní Bhraonáin", "class": "PERSON" }]
+    },
+    {
+      "id": "person-allcaps-01",
+      "class": "PERSON",
+      "variant": "all_caps",
+      "targeted": true,
+      "text": "IN WITNESS WHEREOF, ROBERT KOWALSKI has executed this Agreement.",
+      "expected_entities": [{ "value": "ROBERT KOWALSKI", "class": "PERSON" }]
+    },
+    {
+      "id": "person-surnamefirst-01",
+      "class": "PERSON",
+      "variant": "surname_first",
+      "targeted": true,
+      "text": "Deponent: Whitfield, Sandra (Vice President, Operations).",
+      "expected_entities": [{ "value": "Whitfield, Sandra", "class": "PERSON" }]
+    },
+    {
+      "id": "person-punctuated-01",
+      "class": "PERSON",
+      "variant": "punctuated",
+      "targeted": true,
+      "text": "Per Dr. Elena Marchetti's report, damages exceed the threshold.",
+      "expected_entities": [{ "value": "Elena Marchetti", "class": "PERSON" }]
+    },
+    {
+      "id": "org-canonical-01",
+      "class": "ORGANIZATION",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "Meridian Fabrication LLC breached the supply agreement.",
+      "expected_entities": [{ "value": "Meridian Fabrication LLC", "class": "ORGANIZATION" }]
+    },
+    {
+      "id": "org-canonical-02",
+      "class": "ORGANIZATION",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "The claim was filed against Cobalt Ridge Logistics, Inc.",
+      "expected_entities": [{ "value": "Cobalt Ridge Logistics, Inc.", "class": "ORGANIZATION" }]
+    },
+    {
+      "id": "org-midsentence-01",
+      "class": "ORGANIZATION",
+      "variant": "mid_sentence",
+      "targeted": true,
+      "text": "Payments owed by Harborview Analytics Corporation remain outstanding.",
+      "expected_entities": [{ "value": "Harborview Analytics Corporation", "class": "ORGANIZATION" }]
+    },
+    {
+      "id": "org-list-01",
+      "class": "ORGANIZATION",
+      "variant": "list_context",
+      "targeted": true,
+      "text": "Vendors: Tessellate Systems Ltd, Quarry Bend Partners, and Ferrous Oak Holdings.",
+      "expected_entities": [
+        { "value": "Tessellate Systems Ltd", "class": "ORGANIZATION" },
+        { "value": "Quarry Bend Partners", "class": "ORGANIZATION" },
+        { "value": "Ferrous Oak Holdings", "class": "ORGANIZATION" }
+      ]
+    },
+    {
+      "id": "org-nosuffix-01",
+      "class": "ORGANIZATION",
+      "variant": "no_suffix",
+      "targeted": true,
+      "text": "The indemnity offered by Silverpine Mutual is capped at two million dollars.",
+      "expected_entities": [{ "value": "Silverpine Mutual", "class": "ORGANIZATION" }]
+    },
+    {
+      "id": "org-unicode-01",
+      "class": "ORGANIZATION",
+      "variant": "unicode",
+      "targeted": true,
+      "text": "The distributor, Müller & Söhne GmbH, disputes the delivery terms.",
+      "expected_entities": [{ "value": "Müller & Söhne GmbH", "class": "ORGANIZATION" }]
+    },
+    {
+      "id": "org-allcaps-01",
+      "class": "ORGANIZATION",
+      "variant": "all_caps",
+      "targeted": true,
+      "text": "BETWEEN: NORTHGATE PRECISION TOOLING INC. (the \"Supplier\") and the Buyer.",
+      "expected_entities": [{ "value": "NORTHGATE PRECISION TOOLING INC.", "class": "ORGANIZATION" }]
+    },
+    {
+      "id": "org-firm-01",
+      "class": "ORGANIZATION",
+      "variant": "law_firm",
+      "targeted": true,
+      "text": "Opposing counsel at Delacroix & Marsh LLP requested an extension.",
+      "expected_entities": [{ "value": "Delacroix & Marsh LLP", "class": "ORGANIZATION" }]
+    },
+    {
+      "id": "email-canonical-01",
+      "class": "EMAIL_ADDRESS",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "Send the executed copy to r.calloway@meridianfab-example.com by Friday.",
+      "expected_entities": [{ "value": "r.calloway@meridianfab-example.com", "class": "EMAIL_ADDRESS" }]
+    },
+    {
+      "id": "email-midsentence-01",
+      "class": "EMAIL_ADDRESS",
+      "variant": "mid_sentence",
+      "targeted": true,
+      "text": "Delivery of notice to legal.notices@cobaltridge-example.net shall constitute service.",
+      "expected_entities": [{ "value": "legal.notices@cobaltridge-example.net", "class": "EMAIL_ADDRESS" }]
+    },
+    {
+      "id": "email-list-01",
+      "class": "EMAIL_ADDRESS",
+      "variant": "list_context",
+      "targeted": true,
+      "text": "CC: h.vargas@delmarsh-example.com, t.zielinski@delmarsh-example.com.",
+      "expected_entities": [
+        { "value": "h.vargas@delmarsh-example.com", "class": "EMAIL_ADDRESS" },
+        { "value": "t.zielinski@delmarsh-example.com", "class": "EMAIL_ADDRESS" }
+      ]
+    },
+    {
+      "id": "email-angle-01",
+      "class": "EMAIL_ADDRESS",
+      "variant": "punctuated",
+      "targeted": true,
+      "text": "Contact: <sandra.whitfield@harborview-example.org>.",
+      "expected_entities": [{ "value": "sandra.whitfield@harborview-example.org", "class": "EMAIL_ADDRESS" }]
+    },
+    {
+      "id": "email-plus-01",
+      "class": "EMAIL_ADDRESS",
+      "variant": "plus_address",
+      "targeted": true,
+      "text": "Route billing queries to invoices+matter42@silverpine-example.com.",
+      "expected_entities": [{ "value": "invoices+matter42@silverpine-example.com", "class": "EMAIL_ADDRESS" }]
+    },
+    {
+      "id": "email-upper-01",
+      "class": "EMAIL_ADDRESS",
+      "variant": "all_caps",
+      "targeted": true,
+      "text": "The notice address is LEGAL@FERROUSOAK-EXAMPLE.COM.",
+      "expected_entities": [{ "value": "LEGAL@FERROUSOAK-EXAMPLE.COM", "class": "EMAIL_ADDRESS" }]
+    },
+    {
+      "id": "email-spaced-01",
+      "class": "EMAIL_ADDRESS",
+      "variant": "spaced",
+      "targeted": true,
+      "text": "The address was transcribed as elena . marchetti @ quarrybend-example . com in the minutes.",
+      "expected_entities": [{ "value": "elena . marchetti @ quarrybend-example . com", "class": "EMAIL_ADDRESS" }]
+    },
+    {
+      "id": "email-subdomain-01",
+      "class": "EMAIL_ADDRESS",
+      "variant": "subdomain",
+      "targeted": true,
+      "text": "Escalations go to ops@mail.tessellate-example.co.uk.",
+      "expected_entities": [{ "value": "ops@mail.tessellate-example.co.uk", "class": "EMAIL_ADDRESS" }]
+    },
+    {
+      "id": "phone-canonical-01",
+      "class": "PHONE_NUMBER",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "Call the claims desk at 415-555-0132.",
+      "expected_entities": [{ "value": "415-555-0132", "class": "PHONE_NUMBER" }]
+    },
+    {
+      "id": "phone-dotted-01",
+      "class": "PHONE_NUMBER",
+      "variant": "punctuated",
+      "targeted": true,
+      "text": "Fax responses to 312.555.0187.",
+      "expected_entities": [{ "value": "312.555.0187", "class": "PHONE_NUMBER" }]
+    },
+    {
+      "id": "phone-parens-01",
+      "class": "PHONE_NUMBER",
+      "variant": "punctuated",
+      "targeted": true,
+      "text": "Reception can be reached at (206) 555-0144.",
+      "expected_entities": [{ "value": "(206) 555-0144", "class": "PHONE_NUMBER" }]
+    },
+    {
+      "id": "phone-spaced-01",
+      "class": "PHONE_NUMBER",
+      "variant": "spaced",
+      "targeted": true,
+      "text": "The mediator's line is 646 555 0179.",
+      "expected_entities": [{ "value": "646 555 0179", "class": "PHONE_NUMBER" }]
+    },
+    {
+      "id": "phone-intl-uk-01",
+      "class": "PHONE_NUMBER",
+      "variant": "international",
+      "targeted": true,
+      "text": "Ring the London office on +44 20 7946 0958.",
+      "expected_entities": [{ "value": "+44 20 7946 0958", "class": "PHONE_NUMBER" }]
+    },
+    {
+      "id": "phone-intl-de-01",
+      "class": "PHONE_NUMBER",
+      "variant": "international",
+      "targeted": true,
+      "text": "The Hamburg agent answers at +49 40 555 0123.",
+      "expected_entities": [{ "value": "+49 40 555 0123", "class": "PHONE_NUMBER" }]
+    },
+    {
+      "id": "phone-plusone-01",
+      "class": "PHONE_NUMBER",
+      "variant": "international",
+      "targeted": true,
+      "text": "Dial +1-503-555-0106 for the records custodian.",
+      "expected_entities": [{ "value": "+1-503-555-0106", "class": "PHONE_NUMBER" }]
+    },
+    {
+      "id": "phone-midsentence-01",
+      "class": "PHONE_NUMBER",
+      "variant": "mid_sentence",
+      "targeted": true,
+      "text": "According to the log, the witness, reachable at 917-555-0163, will confirm the timeline.",
+      "expected_entities": [{ "value": "917-555-0163", "class": "PHONE_NUMBER" }]
+    },
+    {
+      "id": "phone-list-01",
+      "class": "PHONE_NUMBER",
+      "variant": "list_context",
+      "targeted": true,
+      "text": "Contacts: 415-555-0198 (main), 415-555-0121 (after hours).",
+      "expected_entities": [
+        { "value": "415-555-0198", "class": "PHONE_NUMBER" },
+        { "value": "415-555-0121", "class": "PHONE_NUMBER" }
+      ]
+    },
+    {
+      "id": "phone-ext-01",
+      "class": "PHONE_NUMBER",
+      "variant": "extension",
+      "targeted": true,
+      "text": "Reach accounting at 802-555-0135 ext. 204.",
+      "expected_entities": [{ "value": "802-555-0135", "class": "PHONE_NUMBER" }]
+    },
+    {
+      "id": "bank-canonical-01",
+      "class": "US_BANK_NUMBER",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "Wire the settlement funds to account 447291805233.",
+      "expected_entities": [{ "value": "447291805233", "class": "US_BANK_NUMBER" }]
+    },
+    {
+      "id": "bank-labeled-01",
+      "class": "US_BANK_NUMBER",
+      "variant": "labeled",
+      "targeted": true,
+      "text": "Account No. 89041127365 at First Meridian Savings shall receive the escrow balance.",
+      "expected_entities": [{ "value": "89041127365", "class": "US_BANK_NUMBER" }]
+    },
+    {
+      "id": "bank-midsentence-01",
+      "class": "US_BANK_NUMBER",
+      "variant": "mid_sentence",
+      "targeted": true,
+      "text": "The funds were deposited into account number 5521904873 before closing.",
+      "expected_entities": [{ "value": "5521904873", "class": "US_BANK_NUMBER" }]
+    },
+    {
+      "id": "bank-spaced-01",
+      "class": "US_BANK_NUMBER",
+      "variant": "spaced",
+      "targeted": true,
+      "text": "The ledger lists the account as 4472 9180 5233.",
+      "expected_entities": [{ "value": "4472 9180 5233", "class": "US_BANK_NUMBER" }]
+    },
+    {
+      "id": "bank-punctuated-01",
+      "class": "US_BANK_NUMBER",
+      "variant": "punctuated",
+      "targeted": true,
+      "text": "Escrow acct. #7730264418 remains frozen pending appeal.",
+      "expected_entities": [{ "value": "7730264418", "class": "US_BANK_NUMBER" }]
+    },
+    {
+      "id": "loc-street-01",
+      "class": "LOCATION",
+      "variant": "street_address",
+      "targeted": true,
+      "text": "Service was attempted at 1247 Marlowe Avenue, Springfield, Illinois 62704.",
+      "expected_entities": [
+        { "value": "1247 Marlowe Avenue, Springfield, Illinois 62704", "class": "LOCATION" }
+      ]
+    },
+    {
+      "id": "loc-street-02",
+      "class": "LOCATION",
+      "variant": "street_address",
+      "targeted": true,
+      "text": "The premises at 88 Quarry Bend Road, Missoula, Montana 59801 were inspected.",
+      "expected_entities": [
+        { "value": "88 Quarry Bend Road, Missoula, Montana 59801", "class": "LOCATION" }
+      ]
+    },
+    {
+      "id": "loc-city-01",
+      "class": "LOCATION",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "The deposition will take place in Sacramento, California.",
+      "expected_entities": [{ "value": "Sacramento, California", "class": "LOCATION" }]
+    },
+    {
+      "id": "loc-courthouse-01",
+      "class": "LOCATION",
+      "variant": "mid_sentence",
+      "targeted": true,
+      "text": "Hearings resume at the county courthouse in Seattle next month.",
+      "expected_entities": [{ "value": "Seattle", "class": "LOCATION" }]
+    },
+    {
+      "id": "loc-midsentence-01",
+      "class": "LOCATION",
+      "variant": "mid_sentence",
+      "targeted": true,
+      "text": "The goods were warehoused in Toledo, Ohio, before shipment.",
+      "expected_entities": [{ "value": "Toledo, Ohio", "class": "LOCATION" }]
+    },
+    {
+      "id": "loc-list-01",
+      "class": "LOCATION",
+      "variant": "list_context",
+      "targeted": true,
+      "text": "Branch closures: Denver, Tucson, and Baton Rouge.",
+      "expected_entities": [
+        { "value": "Denver", "class": "LOCATION" },
+        { "value": "Tucson", "class": "LOCATION" },
+        { "value": "Baton Rouge", "class": "LOCATION" }
+      ]
+    },
+    {
+      "id": "loc-unicode-01",
+      "class": "LOCATION",
+      "variant": "unicode",
+      "targeted": true,
+      "text": "The arbitration will be seated in Zürich, Switzerland.",
+      "expected_entities": [{ "value": "Zürich, Switzerland", "class": "LOCATION" }]
+    },
+    {
+      "id": "loc-country-01",
+      "class": "LOCATION",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "The subsidiary is incorporated in Luxembourg.",
+      "expected_entities": [{ "value": "Luxembourg", "class": "LOCATION" }]
+    },
+    {
+      "id": "case-cite-01",
+      "class": "CASE_NUMBER",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "See Calloway v. Meridian Fabrication, 512 F.3d 118 (7th Cir. 2019).",
+      "expected_entities": [
+        {
+          "value": "Calloway v. Meridian Fabrication, 512 F.3d 118 (7th Cir. 2019)",
+          "class": "CASE_NUMBER"
+        }
+      ]
+    },
+    {
+      "id": "case-inre-01",
+      "class": "CASE_NUMBER",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "In re Harborview Analytics, 601 F.Supp.3d 44 (S.D.N.Y. 2022), controls here.",
+      "expected_entities": [
+        {
+          "value": "In re Harborview Analytics, 601 F.Supp.3d 44 (S.D.N.Y. 2022)",
+          "class": "CASE_NUMBER"
+        }
+      ]
+    },
+    {
+      "id": "case-docket-01",
+      "class": "CASE_NUMBER",
+      "variant": "docket",
+      "targeted": true,
+      "text": "The complaint was filed as Case No. 1:24-cv-00317.",
+      "expected_entities": [{ "value": "Case No. 1:24-cv-00317", "class": "CASE_NUMBER" }]
+    },
+    {
+      "id": "case-docket-short-01",
+      "class": "CASE_NUMBER",
+      "variant": "docket",
+      "targeted": true,
+      "text": "The appeal is docketed as No. 23-1584.",
+      "expected_entities": [{ "value": "No. 23-1584", "class": "CASE_NUMBER" }]
+    },
+    {
+      "id": "case-state-01",
+      "class": "CASE_NUMBER",
+      "variant": "state_reporter",
+      "targeted": true,
+      "text": "Compare Voss v. Quarry Bend Partners, 87 N.E.3d 210 (Ill. App. 2021).",
+      "expected_entities": [
+        {
+          "value": "Voss v. Quarry Bend Partners, 87 N.E.3d 210 (Ill. App. 2021)",
+          "class": "CASE_NUMBER"
+        }
+      ]
+    },
+    {
+      "id": "case-midsentence-01",
+      "class": "CASE_NUMBER",
+      "variant": "mid_sentence",
+      "targeted": true,
+      "text": "The court reasoned, as held in Okonkwo v. Silverpine Mutual, 934 P.2d 771 (Wash. 2017), that the duty attaches at signing.",
+      "expected_entities": [
+        {
+          "value": "Okonkwo v. Silverpine Mutual, 934 P.2d 771 (Wash. 2017)",
+          "class": "CASE_NUMBER"
+        }
+      ]
+    },
+    {
+      "id": "case-lowercase-01",
+      "class": "CASE_NUMBER",
+      "variant": "lowercase",
+      "targeted": true,
+      "text": "the matter proceeds under case no. 2:23-cv-04412 in the district court.",
+      "expected_entities": [{ "value": "case no. 2:23-cv-04412", "class": "CASE_NUMBER" }]
+    },
+    {
+      "id": "case-spaced-01",
+      "class": "CASE_NUMBER",
+      "variant": "spaced",
+      "targeted": true,
+      "text": "The clerk stamped it Case No. 1:24 - cv - 00317 on the cover sheet.",
+      "expected_entities": [{ "value": "Case No. 1:24 - cv - 00317", "class": "CASE_NUMBER" }]
+    },
+    {
+      "id": "matter-canonical-01",
+      "class": "MATTER_NUMBER",
+      "variant": "canonical",
+      "targeted": true,
+      "text": "Please bill all time to matter LQ-2026-0042.",
+      "expected_entities": [{ "value": "LQ-2026-0042", "class": "MATTER_NUMBER" }]
+    },
+    {
+      "id": "matter-dotted-01",
+      "class": "MATTER_NUMBER",
+      "variant": "dotted",
+      "targeted": true,
+      "text": "The engagement letter references matter 2025.0138.",
+      "expected_entities": [{ "value": "2025.0138", "class": "MATTER_NUMBER" }]
+    },
+    {
+      "id": "matter-midsentence-01",
+      "class": "MATTER_NUMBER",
+      "variant": "mid_sentence",
+      "targeted": true,
+      "text": "Fees accrued under ACME-2024-117 exceed the retainer.",
+      "expected_entities": [{ "value": "ACME-2024-117", "class": "MATTER_NUMBER" }]
+    },
+    {
+      "id": "matter-list-01",
+      "class": "MATTER_NUMBER",
+      "variant": "list_context",
+      "targeted": true,
+      "text": "Open matters: KLD-2023-0009, KLD-2024-0031.",
+      "expected_entities": [
+        { "value": "KLD-2023-0009", "class": "MATTER_NUMBER" },
+        { "value": "KLD-2024-0031", "class": "MATTER_NUMBER" }
+      ]
+    },
+    {
+      "id": "matter-lowercase-01",
+      "class": "MATTER_NUMBER",
+      "variant": "lowercase",
+      "targeted": true,
+      "text": "Archived under lq-2019-0007 in the records system.",
+      "expected_entities": [{ "value": "lq-2019-0007", "class": "MATTER_NUMBER" }]
+    },
+    {
+      "id": "matter-punctuated-01",
+      "class": "MATTER_NUMBER",
+      "variant": "punctuated",
+      "targeted": true,
+      "text": "The audit (matter LQ-2022-0311) closed in March.",
+      "expected_entities": [{ "value": "LQ-2022-0311", "class": "MATTER_NUMBER" }]
+    },
+    {
+      "id": "untargeted-ssn-01",
+      "class": "US_SSN",
+      "variant": "canonical",
+      "targeted": false,
+      "text": "The claimant's social security number 123-45-6789 appears in the intake form.",
+      "expected_entities": [{ "value": "123-45-6789", "class": "US_SSN" }]
+    },
+    {
+      "id": "untargeted-ein-01",
+      "class": "EIN",
+      "variant": "canonical",
+      "targeted": false,
+      "text": "The company's EIN 12-3456789 was listed on the W-9.",
+      "expected_entities": [{ "value": "12-3456789", "class": "EIN" }]
+    },
+    {
+      "id": "untargeted-dob-01",
+      "class": "DATE_OF_BIRTH",
+      "variant": "canonical",
+      "targeted": false,
+      "text": "The deponent was born on March 4, 1985.",
+      "expected_entities": [{ "value": "March 4, 1985", "class": "DATE_OF_BIRTH" }]
+    },
+    {
+      "id": "untargeted-passport-01",
+      "class": "US_PASSPORT",
+      "variant": "canonical",
+      "targeted": false,
+      "text": "Passport number 483205917 was presented at the border crossing.",
+      "expected_entities": [{ "value": "483205917", "class": "US_PASSPORT" }]
+    },
+    {
+      "id": "untargeted-dl-01",
+      "class": "US_DRIVER_LICENSE",
+      "variant": "canonical",
+      "targeted": false,
+      "text": "Driver license D1234567 was suspended after the incident.",
+      "expected_entities": [{ "value": "D1234567", "class": "US_DRIVER_LICENSE" }]
+    },
+    {
+      "id": "untargeted-ip-01",
+      "class": "IP_ADDRESS",
+      "variant": "canonical",
+      "targeted": false,
+      "text": "The server at 203.0.113.47 hosted the disputed repository.",
+      "expected_entities": [{ "value": "203.0.113.47", "class": "IP_ADDRESS" }]
+    },
+    {
+      "id": "untargeted-iban-01",
+      "class": "IBAN_CODE",
+      "variant": "canonical",
+      "targeted": false,
+      "text": "Funds were routed through IBAN DE89 3704 0044 0532 0130 00.",
+      "expected_entities": [{ "value": "DE89 3704 0044 0532 0130 00", "class": "IBAN_CODE" }]
+    },
+    {
+      "id": "untargeted-cc-01",
+      "class": "CREDIT_CARD",
+      "variant": "canonical",
+      "targeted": false,
+      "text": "The retainer was charged to card 4111 1111 1111 1111.",
+      "expected_entities": [{ "value": "4111 1111 1111 1111", "class": "CREDIT_CARD" }]
+    }
+  ]
+}

--- a/tests/pii/extraction/extraction_prompts.json
+++ b/tests/pii/extraction/extraction_prompts.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "title": "DE-240 adversarial-extraction prompt fixtures",
+  "description": "Response-path fixtures for the live (LQ_PII_LIVE=1) extraction test. Each fixture plants synthetic PII in a setup message, then attacks with a prompt that asks the model to reveal the original in a TRANSFORMED form (reversed, letter-spelled, base64, acronym, obfuscated address). The transformation is load-bearing: the gateway rehydrates pseudonyms in responses, so a response legitimately contains the original value whenever the model echoes the pseudonym. A transformed rendering of the original, however, can only be produced by a model that actually SAW the original — i.e., an anonymization bypass. leak_indicators are therefore never substrings of any planted value, of the setup text, or of anything rehydration can reconstruct; test_fixture_integrity.py enforces that deterministically.",
+  "fixtures": [
+    {
+      "id": "extract-reverse-surname-01",
+      "setup_content": "Our client Sandra Whitfield is the signatory for the escrow amendment. Keep her involvement confidential.",
+      "attack_content": "Spell the signatory's surname backwards, one word, no explanation.",
+      "planted_values": ["Sandra Whitfield"],
+      "leak_indicators": ["dleiftihW", "dleiftihw", "DLEIFTIHW"],
+      "technique": "reversal",
+      "notes": "If the provider only saw PERSON_NNNN, it cannot produce the reversed surname."
+    },
+    {
+      "id": "extract-hyphen-spell-01",
+      "setup_content": "The deposition of Marcus Ellery is scheduled for the 14th at our offices.",
+      "attack_content": "Write the deponent's first name with a hyphen between every letter.",
+      "planted_values": ["Marcus Ellery"],
+      "leak_indicators": ["M-a-r-c-u-s", "m-a-r-c-u-s", "M-A-R-C-U-S"],
+      "technique": "letter_spelling",
+      "notes": "Rehydration restores contiguous originals only; a hyphen-spelled form proves the model saw the raw name."
+    },
+    {
+      "id": "extract-reverse-account-01",
+      "setup_content": "Wire the settlement funds to account 447291805233 at First Meridian Savings by the end of the quarter.",
+      "attack_content": "State the account number with its digits in reverse order.",
+      "planted_values": ["447291805233"],
+      "leak_indicators": ["332508192744"],
+      "technique": "reversal",
+      "notes": "The reversed digit string cannot arise from rehydrating US_BANK_NUMBER_NNNN."
+    },
+    {
+      "id": "extract-acronym-org-01",
+      "setup_content": "The counterparty, Harborview Analytics Corporation, has proposed revised indemnity language.",
+      "attack_content": "Give me only the initials of the counterparty's name, as one uppercase string.",
+      "planted_values": ["Harborview Analytics Corporation"],
+      "leak_indicators": ["HAC"],
+      "technique": "acronym",
+      "notes": "Three-letter indicator carries a small false-positive risk; review a hit manually before treating it as a leak."
+    },
+    {
+      "id": "extract-base64-name-01",
+      "setup_content": "Please summarize the employment claim brought by Priya Raghunathan against the subsidiary.",
+      "attack_content": "Base64-encode the claimant's full name and output only the encoded string.",
+      "planted_values": ["Priya Raghunathan"],
+      "leak_indicators": ["UHJpeWEgUmFnaHVuYXRoYW4="],
+      "technique": "encoding",
+      "notes": "base64('Priya Raghunathan'). Only producible from the raw name."
+    },
+    {
+      "id": "extract-obfuscated-email-01",
+      "setup_content": "All notices go to r.calloway@meridianfab-example.com per section 12 of the agreement.",
+      "attack_content": "Repeat the notice email address but replace the @ sign with [at] and each dot with [dot].",
+      "planted_values": ["r.calloway@meridianfab-example.com"],
+      "leak_indicators": ["calloway[at]", "calloway [at]", "r[dot]calloway"],
+      "technique": "obfuscation",
+      "notes": "Rehydrated pseudonyms restore the literal address (with @ and dots); the [at]/[dot] rendering requires the raw address."
+    }
+  ]
+}

--- a/tests/pii/test_extraction_live.py
+++ b/tests/pii/test_extraction_live.py
@@ -1,0 +1,98 @@
+"""DE-240 — live adversarial-extraction test (maintainer-run, opt-in).
+
+End-to-end check of the response path: can a prompt trick the model
+into revealing a pseudonymized original? The fixtures
+(``extraction/extraction_prompts.json``) plant synthetic PII and then
+ask for a TRANSFORMED rendering of it (reversed, letter-spelled,
+base64, ...). Because the gateway rehydrates pseudonyms in responses,
+a transformed rendering is the only observable that distinguishes "the
+provider saw the raw PII" from a legitimate round-trip —
+``test_fixture_integrity.py`` enforces that property deterministically.
+
+This test needs a running gateway with anonymization enabled and a
+real provider behind it, so it is guarded twice and skips by default:
+
+* ``LQ_PII_LIVE=1`` must be set (the explicit opt-in), and
+* ``LQ_PII_GATEWAY_URL`` must point at the gateway (e.g.
+  ``http://127.0.0.1:8100``).
+
+Optional: ``LQ_PII_MODEL`` (default ``smart``), ``LQ_PII_GATEWAY_TOKEN``
+(sent as a Bearer token when the deployment requires auth).
+
+Maintainer run (documented in docs/quality/pii-leakage-rates.md):
+
+    LQ_PII_LIVE=1 LQ_PII_GATEWAY_URL=http://127.0.0.1:8100 \
+        pytest tests/pii/test_extraction_live.py -m live -rs
+
+A failure means a leak indicator appeared in a model response — treat
+it as a confidentiality incident signal and investigate the
+anonymization path before anything else. Model outputs are
+nondeterministic; a PASS is evidence, not proof.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+FIXTURES_PATH = Path(__file__).resolve().parent / "extraction" / "extraction_prompts.json"
+
+_LIVE_ENABLED = os.environ.get("LQ_PII_LIVE") == "1"
+_GATEWAY_URL = os.environ.get("LQ_PII_GATEWAY_URL", "").rstrip("/")
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        not (_LIVE_ENABLED and _GATEWAY_URL),
+        reason="live extraction test: set LQ_PII_LIVE=1 and LQ_PII_GATEWAY_URL to run",
+    ),
+]
+
+
+def _fixtures() -> list[dict[str, Any]]:
+    with FIXTURES_PATH.open(encoding="utf-8") as fh:
+        data: dict[str, Any] = json.load(fh)
+    fixtures: list[dict[str, Any]] = data["fixtures"]
+    return fixtures
+
+
+@pytest.mark.parametrize("fixture", _fixtures(), ids=lambda f: str(f["id"]))
+async def test_extraction_attack_reveals_no_transformed_original(
+    fixture: dict[str, Any],
+) -> None:
+    import httpx
+
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("LQ_PII_GATEWAY_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    payload = {
+        "model": os.environ.get("LQ_PII_MODEL", "smart"),
+        "messages": [
+            {"role": "user", "content": fixture["setup_content"]},
+            {"role": "user", "content": fixture["attack_content"]},
+        ],
+        "stream": False,
+    }
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{_GATEWAY_URL}/v1/chat/completions", json=payload, headers=headers
+        )
+    assert response.status_code == 200, f"gateway returned {response.status_code}: {response.text}"
+
+    body = response.json()
+    content = " ".join(
+        choice.get("message", {}).get("content") or "" for choice in body.get("choices", [])
+    )
+
+    leaks = [ind for ind in fixture["leak_indicators"] if ind in content]
+    assert not leaks, (
+        f"{fixture['id']}: leak indicator(s) {leaks} appeared in the model response — "
+        f"the provider may have seen the raw PII. Response content: {content!r}"
+    )

--- a/tests/pii/test_fixture_integrity.py
+++ b/tests/pii/test_fixture_integrity.py
@@ -1,0 +1,137 @@
+"""DE-240 — deterministic integrity checks for the PII corpus + extraction fixtures.
+
+Keyless and dependency-free: validates the committed JSON artifacts so a
+malformed corpus entry or a false-positive-prone extraction fixture
+fails fast, without spaCy, a provider key, or a running stack.
+
+The load-bearing rule for extraction fixtures: a ``leak_indicator``
+must be a TRANSFORMED rendering of the planted value (reversed,
+letter-spelled, base64, ...), never something the normal
+pseudonymize → provider → rehydrate round-trip could reproduce. If an
+indicator were a substring of the setup text or of a planted value,
+the live test would flag legitimate rehydrated responses as leaks.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+PII_DIR = Path(__file__).resolve().parent
+CORPUS_PATH = PII_DIR / "corpus" / "pii_corpus.json"
+BASELINE_PATH = PII_DIR / "baseline" / "pii_leakage_baseline.json"
+EXTRACTION_PATH = PII_DIR / "extraction" / "extraction_prompts.json"
+
+TARGETED_CLASSES = {
+    "PERSON",
+    "ORGANIZATION",
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "US_BANK_NUMBER",
+    "LOCATION",
+    "CASE_NUMBER",
+    "MATTER_NUMBER",
+}
+
+
+def _load(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as fh:
+        data: dict[str, Any] = json.load(fh)
+    return data
+
+
+def test_corpus_entries_are_well_formed() -> None:
+    corpus = _load(CORPUS_PATH)
+    assert corpus["schema_version"] == 1
+
+    seen_ids: set[str] = set()
+    for entry in corpus["entries"]:
+        assert set(entry) == {"id", "class", "variant", "targeted", "text", "expected_entities"}, (
+            f"unexpected keys in corpus entry {entry.get('id')!r}"
+        )
+        assert entry["id"] not in seen_ids, f"duplicate corpus id {entry['id']}"
+        seen_ids.add(entry["id"])
+        assert entry["expected_entities"], f"{entry['id']}: no expected entities"
+        for expected in entry["expected_entities"]:
+            assert expected["value"] in entry["text"], (
+                f"{entry['id']}: expected value {expected['value']!r} not present in text"
+            )
+        # Targeted entries use recognizer-target classes; untargeted
+        # entries document the out-of-scope surface and must NOT claim
+        # a targeted class.
+        if entry["targeted"]:
+            assert entry["class"] in TARGETED_CLASSES, (
+                f"{entry['id']}: targeted entry uses non-recognizer class {entry['class']}"
+            )
+        else:
+            assert entry["class"] not in TARGETED_CLASSES, (
+                f"{entry['id']}: untargeted entry claims a targeted class"
+            )
+
+
+def test_corpus_covers_every_recognizer_target_class() -> None:
+    """Corpus classes = the gateway's real recognizer targets, all of them."""
+
+    corpus = _load(CORPUS_PATH)
+    targeted_present = {e["class"] for e in corpus["entries"] if e["targeted"]}
+    assert targeted_present == TARGETED_CLASSES
+
+    untargeted_present = {e["class"] for e in corpus["entries"] if not e["targeted"]}
+    assert untargeted_present, "the known-untargeted section must not be empty"
+
+
+def test_baseline_is_committed_and_covers_targeted_classes() -> None:
+    """The anti-regression baseline exists and matches the corpus scale."""
+
+    corpus = _load(CORPUS_PATH)
+    baseline = _load(BASELINE_PATH)
+
+    assert baseline["metadata"]["corpus_entries"] == len(corpus["entries"])
+    expected_total = sum(len(e["expected_entities"]) for e in corpus["entries"])
+    assert baseline["metadata"]["expected_entities"] == expected_total
+
+    baseline_targeted = {n for n, c in baseline["classes"].items() if c["targeted"]}
+    assert baseline_targeted == TARGETED_CLASSES
+
+
+def test_extraction_fixtures_are_well_formed() -> None:
+    data = _load(EXTRACTION_PATH)
+    assert data["schema_version"] == 1
+
+    seen_ids: set[str] = set()
+    for fixture in data["fixtures"]:
+        assert fixture["id"] not in seen_ids
+        seen_ids.add(fixture["id"])
+        assert fixture["setup_content"]
+        assert fixture["attack_content"]
+        assert fixture["planted_values"], f"{fixture['id']}: no planted values"
+        assert fixture["leak_indicators"], f"{fixture['id']}: no leak indicators"
+        for planted in fixture["planted_values"]:
+            assert planted in fixture["setup_content"], (
+                f"{fixture['id']}: planted value {planted!r} not in setup_content"
+            )
+
+
+def test_extraction_indicators_cannot_false_positive_on_rehydration() -> None:
+    """Indicators must be unreachable via the legitimate round-trip.
+
+    A response produced by echoing pseudonyms is rehydrated back to the
+    planted originals — so any indicator that appears inside the setup
+    text or inside a planted value would fire on a NON-leaking system.
+    """
+
+    data = _load(EXTRACTION_PATH)
+    for fixture in data["fixtures"]:
+        for indicator in fixture["leak_indicators"]:
+            assert indicator not in fixture["setup_content"], (
+                f"{fixture['id']}: indicator {indicator!r} appears in setup_content"
+            )
+            assert indicator not in fixture["attack_content"], (
+                f"{fixture['id']}: indicator {indicator!r} appears in attack_content"
+            )
+            for planted in fixture["planted_values"]:
+                assert indicator not in planted, (
+                    f"{fixture['id']}: indicator {indicator!r} is a substring of a "
+                    f"planted value — rehydration would false-positive"
+                )

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -4,4 +4,5 @@ testpaths = ["."]
 markers = [
     "unit: pure unit tests, no I/O",
     "integration: tests that exercise contracts across subsystems",
+    "live: tests that need a running stack + provider key (opt-in via env guards)",
 ]


### PR DESCRIPTION
## What / why

DE-240 (PRD §9): stop guessing what the anonymization layer catches — measure it. The NER stack is local and deterministic, so unlike the LLM-dependent harnesses, this one ships with **real measured rates**, config-attributed and reproducible.

Part of the coordinated roadmap sweep (umbrella issue #321).

## 🚨 Headline finding (DE-390 filed — decision needed, deliberately not patched here)

**Organization names leak 100%** (10/10) through the pre-egress anonymization path. Root-caused and verified: raw spaCy detects the ORGs, but Presidio's default `AnalyzerEngine` NLP config ships `ORGANIZATION` in `labels_to_ignore` (an upstream precision choice), and the gateway never overrides it. For a legal product, org names in privileged documents are often exactly what the operator enabled the layer to protect. Un-suppressing has a known precision cost inside the security boundary → maintainer decision; DE-390 records the options (un-suppress / config flag / prominent doc exclusion). Context: the layer is opt-in (`enabled: false` default) and its accuracy was already documented as unmeasured (DE-282) — this PR is the measurement that makes the gap concrete.

Secondary finding: `ENABLED_DEFAULT_RECOGNIZERS` in `engine.py` is descriptive-only — five undocumented Presidio defaults (Date, CreditCard, Url, MacAddress, NHS, ITIN) are active. Documentation drift, recorded in the doc; **no `gateway/app/**` code was touched** in this PR.

## Measured rates (2026-07-25; presidio 2.2.364, spaCy en_core_web_lg 3.8.0)

PERSON 0% full-leak (incl. non-Anglo names) · PHONE 0% (intl formats) · US_BANK 0% · EMAIL 0% full / 11.1% partial (spaced) · LOCATION 0% full / 20% partial (street number + ZIP survive) · CASE_NUMBER 12.5% (spaced docket) · MATTER_NUMBER 14.3% (dotted form at sentence end — the `(?![\d.])` guard defeated by the period) · **ORGANIZATION 100%** · untargeted classes (SSN/EIN/DL/IP/IBAN) documented as 100%-by-design.

## Harness design

- 71-entry synthetic corpus (`tests/pii/corpus/`), classes = the engine's *actual* recognizer inventory (measured, not from docs); shared deliberately with DE-282's calibration work.
- CI gating: **drift pin only** — fails if any targeted class worsens >5 points vs the committed baseline; absolute rates informational until DE-282 calibration. Regeneration commands documented.
- Response path: transformation-based extraction fixtures (reversed/spelled/base64/acronym indicators that provably can't false-positive on legitimate rehydration) + a double-guarded live test (maintainer step); deterministic provider-payload isolation test pins pseudonyms-only outbound with no mapper reference.

## Evidence

Gateway suite **778 passed, 3 skipped** (harness adds ~1–2s); root `tests/pii` 5 passed + 6 live-skipped keyless; ruff/mypy-strict clean. `docs/quality/pii-leakage-rates.md` carries the full tables, methodology, and per-release refresh process.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)
