### PR TITLE
DE-358 item 1: accumulate streamed Anthropic tool_use into tool_calls deltas

### DIFF
--- a/gateway/app/providers/anthropic.py
+++ b/gateway/app/providers/anthropic.py
@@ -575,6 +575,9 @@ async def _anthropic_stream_iter(
 
     * One initial chunk with ``delta.role = "assistant"``.
     * One chunk per text delta with ``delta.content = "<text piece>"``.
+    * One chunk per completed ``tool_use`` block with
+      ``delta.tool_calls`` (DE-358 item 1: accumulated from
+      ``input_json_delta`` fragments, emitted at ``content_block_stop``).
     * One final chunk with ``finish_reason`` set, ``delta`` empty, and
       a ``usage`` block.
 
@@ -590,6 +593,14 @@ async def _anthropic_stream_iter(
     prompt_tokens = 0
     completion_tokens = 0
     role_emitted = False
+    # DE-358 item 1: accumulate streamed ``tool_use`` blocks. Anthropic
+    # streams a tool call as ``content_block_start`` (id + name), then
+    # ``input_json_delta`` fragments of the arguments JSON, closed by
+    # ``content_block_stop`` — at which point we emit one OpenAI-shaped
+    # ``tool_calls`` delta, mirroring the non-streaming bridge in
+    # :func:`_from_anthropic_response`. Keyed by Anthropic block index.
+    tool_blocks: dict[int, dict[str, Any]] = {}
+    next_tool_index = 0
 
     try:
         async with client.stream("POST", "/v1/messages", json=body, headers=headers) as response:
@@ -632,6 +643,19 @@ async def _anthropic_stream_iter(
                         )
                     continue
 
+                if kind == "content_block_start":
+                    block = parsed.get("content_block") or {}
+                    block_index = parsed.get("index")
+                    if block.get("type") == "tool_use" and isinstance(block_index, int):
+                        tool_blocks[block_index] = {
+                            "openai_index": next_tool_index,
+                            "id": str(block.get("id", "")),
+                            "name": str(block.get("name", "")),
+                            "parts": [],
+                        }
+                        next_tool_index += 1
+                    continue
+
                 if kind == "content_block_delta":
                     delta_block = parsed.get("delta") or {}
                     if delta_block.get("type") == "text_delta":
@@ -643,6 +667,43 @@ async def _anthropic_stream_iter(
                                 model=response_model,
                                 delta=ChatCompletionDelta(content=text),
                             )
+                    elif delta_block.get("type") == "input_json_delta":
+                        block_index = parsed.get("index")
+                        state = (
+                            tool_blocks.get(block_index) if isinstance(block_index, int) else None
+                        )
+                        if state is not None:
+                            state["parts"].append(str(delta_block.get("partial_json", "")))
+                    continue
+
+                if kind == "content_block_stop":
+                    block_index = parsed.get("index")
+                    state = (
+                        tool_blocks.pop(block_index, None) if isinstance(block_index, int) else None
+                    )
+                    if state is not None:
+                        yield _make_chunk(
+                            response_id=response_id,
+                            created=created,
+                            model=response_model,
+                            delta=ChatCompletionDelta(
+                                tool_calls=[
+                                    {
+                                        "index": state["openai_index"],
+                                        "id": state["id"],
+                                        "type": "function",
+                                        "function": {
+                                            "name": state["name"],
+                                            # OpenAI streams arguments as a
+                                            # JSON string; empty input maps
+                                            # to "{}" like the non-streaming
+                                            # bridge's json.dumps(input or {}).
+                                            "arguments": "".join(state["parts"]) or "{}",
+                                        },
+                                    }
+                                ]
+                            ),
+                        )
                     continue
 
                 if kind == "message_delta":

--- a/gateway/tests/test_anthropic_adapter.py
+++ b/gateway/tests/test_anthropic_adapter.py
@@ -745,3 +745,141 @@ async def test_anthropic_round_trips_assistant_tool_use_for_follow_up() -> None:
     assert resp2.choices[0].finish_reason == "stop"
     assert resp2.choices[0].message.content == "Confirmed."
     assert call_count == 2
+
+
+# --- DE-358 item 1: streaming tool_use accumulation ---------------------------
+
+
+SSE_TOOL_USE_FIXTURE_BODY = (
+    "event: message_start\n"
+    'data: {"type":"message_start","message":{"id":"msg_tool_stream","model":"claude-sonnet-4-6",'
+    '"usage":{"input_tokens":11,"output_tokens":0}}}\n\n'
+    "event: content_block_start\n"
+    'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n'
+    "event: content_block_delta\n"
+    'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Checking."}}\n\n'
+    "event: content_block_stop\n"
+    'data: {"type":"content_block_stop","index":0}\n\n'
+    "event: content_block_start\n"
+    'data: {"type":"content_block_start","index":1,"content_block":'
+    '{"type":"tool_use","id":"toolu_s1","name":"verify_citations","input":{}}}\n\n'
+    "event: content_block_delta\n"
+    'data: {"type":"content_block_delta","index":1,"delta":'
+    '{"type":"input_json_delta","partial_json":"{\\"text\\": \\"Brown"}}\n\n'
+    "event: content_block_delta\n"
+    'data: {"type":"content_block_delta","index":1,"delta":'
+    '{"type":"input_json_delta","partial_json":" v. Board\\"}"}}\n\n'
+    "event: content_block_stop\n"
+    'data: {"type":"content_block_stop","index":1}\n\n'
+    "event: message_delta\n"
+    'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}\n\n'
+    "event: message_stop\n"
+    'data: {"type":"message_stop"}\n\n'
+)
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_streaming_accumulates_tool_use_into_tool_calls_delta() -> None:
+    """DE-358 item 1: a streamed ``tool_use`` block (``content_block_start``
+    + ``input_json_delta`` fragments) is accumulated and emitted as one
+    OpenAI ``tool_calls`` delta at ``content_block_stop``, with
+    ``finish_reason="tool_calls"`` on the final chunk. Before this change
+    the streaming adapter silently dropped tool calls (latent — the chat
+    tool-loop is non-streaming — but a future streaming-with-tools
+    consumer would have lost them)."""
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            text=SSE_TOOL_USE_FIXTURE_BODY,
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    adapter = _make_adapter()
+    try:
+        result = await adapter.chat_completion(
+            _basic_request(stream=True),
+            model="claude-sonnet-4-6",
+            stream=True,
+        )
+        assert not isinstance(result, ChatCompletionResponse)
+        chunks: list[ChatCompletionChunk] = []
+        async for chunk in result:
+            chunks.append(chunk)
+    finally:
+        await adapter.aclose()
+
+    # role chunk + text delta + tool_calls delta + final chunk.
+    assert len(chunks) == 4
+    assert chunks[0].choices[0].delta.role == "assistant"
+    assert chunks[1].choices[0].delta.content == "Checking."
+
+    tool_delta = chunks[2].choices[0].delta
+    assert tool_delta.tool_calls is not None and len(tool_delta.tool_calls) == 1
+    call = tool_delta.tool_calls[0]
+    assert call["index"] == 0
+    assert call["id"] == "toolu_s1"
+    assert call["type"] == "function"
+    assert call["function"]["name"] == "verify_citations"
+    # Fragments join into the exact arguments JSON string.
+    assert json.loads(call["function"]["arguments"]) == {"text": "Brown v. Board"}
+
+    final = chunks[-1]
+    assert final.choices[0].finish_reason == "tool_calls"
+    assert final.usage is not None
+    assert final.usage.prompt_tokens == 11
+    assert final.usage.completion_tokens == 9
+
+
+SSE_TOOL_USE_EMPTY_INPUT_FIXTURE_BODY = (
+    "event: message_start\n"
+    'data: {"type":"message_start","message":{"id":"msg_tool_empty","model":"claude-sonnet-4-6",'
+    '"usage":{"input_tokens":4,"output_tokens":0}}}\n\n'
+    "event: content_block_start\n"
+    'data: {"type":"content_block_start","index":0,"content_block":'
+    '{"type":"tool_use","id":"toolu_e1","name":"list_sources","input":{}}}\n\n'
+    "event: content_block_stop\n"
+    'data: {"type":"content_block_stop","index":0}\n\n'
+    "event: message_delta\n"
+    'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":3}}\n\n'
+    "event: message_stop\n"
+    'data: {"type":"message_stop"}\n\n'
+)
+
+
+@pytest.mark.unit
+@respx.mock
+async def test_streaming_tool_use_with_no_input_deltas_emits_empty_args() -> None:
+    """DE-358 item 1: a no-argument tool call (no ``input_json_delta``
+    events at all) emits ``arguments="{}"``, mirroring the non-streaming
+    bridge's ``json.dumps(input or {})``. A plain-text ``content_block_stop``
+    (no tool state) emits nothing — unchanged behavior."""
+
+    respx.post(f"{ANTHROPIC_BASE}/v1/messages").mock(
+        return_value=httpx.Response(
+            200,
+            text=SSE_TOOL_USE_EMPTY_INPUT_FIXTURE_BODY,
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    adapter = _make_adapter()
+    try:
+        result = await adapter.chat_completion(
+            _basic_request(stream=True),
+            model="claude-sonnet-4-6",
+            stream=True,
+        )
+        assert not isinstance(result, ChatCompletionResponse)
+        chunks = [chunk async for chunk in result]
+    finally:
+        await adapter.aclose()
+
+    # role chunk + tool_calls delta + final chunk (no text deltas).
+    assert len(chunks) == 3
+    tool_delta = chunks[1].choices[0].delta
+    assert tool_delta.tool_calls is not None
+    assert tool_delta.tool_calls[0]["function"]["arguments"] == "{}"
+    assert chunks[-1].choices[0].finish_reason == "tool_calls"


### PR DESCRIPTION
Part of DE-358 (PRD §9 tool-use hardening backlog), refs #275. Rebuilt against current main.

**Reachability verified before fixing, per the DE entry:** the gap is latent, not an active bug. The chat tool-loop drives non-streaming gateway calls (`run_chat_tool_loop` sends `stream: False`), and no consumer in `api/`, `web/`, or `tests/` combines `stream=true` with `tools`. This PR is forward-hardening so the first streaming-with-tools consumer does not silently lose tool calls.

`_anthropic_stream_iter` previously translated only `text_delta` blocks; a streamed `tool_use` block produced no `tool_calls` delta and no error. Now: `content_block_start` (type `tool_use`) opens an accumulator keyed by block index, `input_json_delta` fragments append, and one OpenAI-shaped `tool_calls` delta is emitted at `content_block_stop` — mirroring the non-streaming bridge in `_from_anthropic_response` (arguments as a JSON string; empty input becomes `"{}"`). The existing `tool_use → tool_calls` finish-reason mapping now fires on a populated stream.

Adds the suite's first streaming-tool tests: multi-fragment accumulation and the no-argument tool call. Text-only streams are byte-identical (the existing streaming test is untouched and green).

**Contributor checklist:** no new egress; no payload logged; tests in this PR; no new dependency. `gateway/**` routes to security review per CODEOWNERS.

Gates run locally: `ruff format` + `ruff check` clean, `mypy --strict` gateway clean, adapter test file 26/26 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #285** — same head commit (`7280661e67c5`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
