### PR TITLE
Validate project ownership on chat creation (API-01 IDOR, Refs #288)

### DIFF
--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -353,6 +353,36 @@ async def _load_visible_chat(
     return row
 
 
+async def _load_visible_project_for_chat(
+    db: AsyncSession,
+    project_id: uuid.UUID,
+    owner_id: uuid.UUID,
+) -> Project:
+    """Validate that ``project_id`` is owned by the caller before accepting it
+    as a chat's project association; 404 on miss / cross-user / archived.
+
+    Mirrors :func:`app.api.knowledge_bases._load_visible_project_for_kb`.
+    Inlined here rather than imported to keep the chat surface free of a
+    reverse dependency on the projects router module — it is a one-statement
+    SELECT. Without this guard a caller can bind a chat to another user's
+    project id and, on ``send_message``, pull that project's attached
+    knowledge-base content into the response and out to the LLM provider.
+    """
+
+    stmt = select(Project).where(
+        Project.id == project_id,
+        Project.owner_id == owner_id,
+        Project.archived_at.is_(None),
+    )
+    row = (await db.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        raise NotFound(
+            f"Project {project_id} not found.",
+            details={"project_id": str(project_id)},
+        )
+    return row
+
+
 async def _load_chat_for_reader(
     db: AsyncSession,
     chat_id: uuid.UUID,
@@ -587,6 +617,9 @@ async def create_chat(
     user: ActiveUser,
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ChatResponse:
+    if payload.project_id is not None:
+        await _load_visible_project_for_chat(db, payload.project_id, user.id)
+
     chat = Chat(
         owner_id=user.id,
         project_id=payload.project_id,
@@ -1035,7 +1068,13 @@ async def _retrieve_kb_context_for_chat(
         return [], []
 
     # Load KB rows (for hybrid_alpha per KB). One SELECT for the set.
-    kb_stmt = select(KnowledgeBase).where(KnowledgeBase.id.in_(kb_ids))
+    # Defense-in-depth: scope to the chat owner so a stale or foreign
+    # ``project_id`` (see _load_visible_project_for_chat) can never surface
+    # another user's KB content, even if one slipped past chat creation.
+    kb_stmt = select(KnowledgeBase).where(
+        KnowledgeBase.id.in_(kb_ids),
+        KnowledgeBase.owner_id == chat.owner_id,
+    )
     kb_rows = (await db.execute(kb_stmt)).scalars().all()
 
     # Embed the query once (reused across every KB). Mirrors the

--- a/api/tests/test_chats_endpoints.py
+++ b/api/tests/test_chats_endpoints.py
@@ -26,6 +26,7 @@ from app.clients.gateway import GatewayClient, set_gateway_client
 from app.db.session import get_db
 from app.main import app
 from app.models.chat import Chat, Message
+from app.models.project import Project
 from app.models.user import User
 from app.security import create_access_token, hash_password
 
@@ -176,6 +177,67 @@ async def test_create_chat_with_explicit_title_and_project_id(
     assert body["project_id"] is None
     # Confirm we can omit project_id without 422.
     _ = project_id
+
+
+@pytest.mark.integration
+async def test_create_chat_with_own_project_id_201(
+    client: AsyncClient,
+    db_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """A caller may bind a new chat to a project they own."""
+    project = Project(
+        owner_id=db_user.id,
+        name="My Matter",
+        slug=f"mine-{uuid.uuid4().hex[:6]}",
+    )
+    db_session.add(project)
+    await db_session.flush()
+    token = _bearer_for(db_user)
+
+    response = await client.post(
+        "/api/v1/chats",
+        json={"project_id": str(project.id)},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["project_id"] == str(project.id)
+
+
+@pytest.mark.integration
+async def test_create_chat_with_foreign_project_id_404(
+    client: AsyncClient,
+    db_user: User,
+    other_user: User,
+    db_session: AsyncSession,
+) -> None:
+    """IDOR regression (GW/API-01, #288): a caller cannot bind a chat to
+    another user's project. Without the ownership guard the foreign
+    project's attached KB content would be pulled into the chat's
+    responses and forwarded to the LLM provider.
+    """
+    foreign_project = Project(
+        owner_id=other_user.id,
+        name="Someone Else's Matter",
+        slug=f"theirs-{uuid.uuid4().hex[:6]}",
+    )
+    db_session.add(foreign_project)
+    await db_session.flush()
+    token = _bearer_for(db_user)
+
+    response = await client.post(
+        "/api/v1/chats",
+        json={"project_id": str(foreign_project.id)},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 404
+    # No chat row should have been created for the caller.
+    rows = (
+        (await db_session.execute(select(Chat).where(Chat.owner_id == db_user.id))).scalars().all()
+    )
+    assert rows == []
 
 
 @pytest.mark.integration

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -919,6 +919,11 @@ paths:
           content:
             application/json:
               schema: {$ref: '#/components/schemas/Chat'}
+        '404':
+          description: Project (if `project_id` was provided) not found.
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Error'}
 
   /api/v1/chats/{chat_id}:
     parameters:


### PR DESCRIPTION
## What this PR does

Adds an ownership check to `create_chat`: when a request supplies `project_id`, the project must be owned by the caller or the request returns 404. Also scopes the chat's knowledge-base load to the chat owner as defense-in-depth.

## Why

`Refs #288` — finding **API-01 (High, IDOR)**. `create_chat` (`api/app/api/chats.py`) persisted `payload.project_id` onto the new `Chat` with **no** check that the project belongs to the caller — the one cross-aggregate reference not run through an ownership guard. On `send_message`, the chat's `project_id` pulls the attached knowledge bases (`_retrieve_kb_context_for_chat` → `_load_attached_kb_ids_for_chat` → the KB `in_()` load), whose content is (a) returned to the caller as citations and (b) forwarded to the LLM provider as a system message flagged `lq_ai_skip_anonymization`. So an authenticated user could bind a chat to **another user's** project id and read back / exfiltrate that project's KB content — a cross-tenant breach of the platform's data-sovereignty guarantee. `update_chat` doesn't accept `project_id`, so `create_chat` is the sole injection point.

## How

- New local helper `_load_visible_project_for_chat` (mirrors the existing `knowledge_bases._load_visible_project_for_kb` that `create_kb` already uses) — a one-statement `SELECT ... WHERE id == project_id AND owner_id == caller AND archived_at IS NULL`, 404 on miss. Called in `create_chat` only when `payload.project_id is not None`, before the `Chat` row is built.
- Defense-in-depth: the KB load in `_retrieve_kb_context_for_chat` now also filters `KnowledgeBase.owner_id == chat.owner_id`, so a stale/foreign `project_id` can never surface another user's KBs even if one slipped past creation.

## What this PR does *not* do

Doesn't change the no-`project_id` path (still 201, project stays null). Doesn't alter `update_chat` (it already can't set `project_id`). `project_id` is a random UUID, so this was not trivially enumerable — but the guard removes the class of bug regardless.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests added/updated

<details>
<summary>Gates run locally</summary>

- `ruff check api/app/api/chats.py api/tests/test_chats_endpoints.py` → clean.
- `ruff format --check` → clean.
- `mypy app` (from `api/`) → `Success: no issues found in 190 source files`.
- New tests: `test_create_chat_with_own_project_id_201` (own project → 201) and `test_create_chat_with_foreign_project_id_404` (foreign project → 404, no chat row created). **pytest was not run locally** (the api suite needs a pgvector Postgres and Docker wasn't available in this sandbox) — the DB-backed tests run in CI (`api-checks`).

</details>

## Transparency & governance invariants

- [x] **Fail restrictive (P4):** an unowned/unknown `project_id` now fails closed (404); the regression test exercises that path.
- [x] **User owns data (P9):** closes a cross-tenant read/exfiltration of another user's KB content.
- [x] **One governance path (P6):** reuses the established `_load_visible_project*` ownership-guard pattern rather than a new mechanism.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (API-01).

> `api/**` authz change — routes to maintainer review per `.github/CODEOWNERS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #290** — same head commit (`afb9f73ebb65`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
