### PR TITLE
Guard LLM provider base_url egress at build time (GW-04, Refs #288)

### DIFF
--- a/gateway.yaml.example
+++ b/gateway.yaml.example
@@ -178,6 +178,15 @@ providers:
     # local, air-gap-capable) backbone — Tier 1 by every authoritative
     # reference (PRD §1.5.2: "Local-only inference (air-gap-capable)").
     # See B6 partial in M1-PROGRESS for the adapter that wires this up.
+    #
+    # NOTE (LLM egress policy, GW-04): a plaintext ``http://`` base_url is
+    # accepted only for loopback/private/local hosts (localhost, RFC-1918
+    # ranges, host.docker.internal, in-Compose service names). A base_url
+    # that violates the policy is FATAL AT STARTUP — the gateway refuses to
+    # boot rather than silently skip the provider, because a skipped local
+    # primary would let the router fall through to a cloud fallback the
+    # operator did not choose. If startup fails naming this provider, fix
+    # the base_url (most often a mistyped OLLAMA_BASE_URL).
     base_url: ${OLLAMA_BASE_URL:-http://ollama:11434}
     api_key_env: ''  # Ollama doesn't require an API key
     tier: 1  # Fully local; no data leaves the deployment

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -74,7 +74,7 @@ from app.providers import (
     OpenAIAdapter,
     ProviderAdapter,
 )
-from app.providers.base_url_policy import validate_llm_base_url
+from app.providers.base_url_policy import ProviderEgressRefused, validate_llm_base_url
 from app.providers.tool.base import ToolProviderAdapter
 from app.providers.tool.courtlistener import CourtListenerToolAdapter
 from app.providers.tool.echo import EchoToolAdapter
@@ -267,6 +267,19 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     for provider in config.providers:
         try:
             adapter = build_adapter(provider)
+        except ProviderEgressRefused as exc:
+            # Deliberate: an egress-policy violation is fatal at startup.
+            # Skipping the provider would let the router fall through to the
+            # next candidate in the chain, silently sending prompts somewhere
+            # the operator did not choose.
+            logger.error(
+                "refusing to start: provider %r (type=%s) has a base_url that "
+                "violates LLM egress policy: %s",
+                provider.name,
+                provider.type,
+                exc.reason,
+            )
+            raise
         except ValueError as exc:
             # Missing/unresolvable key for a supported provider — non-fatal
             # at startup; the provider is skipped and chat requests routing

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -74,6 +74,7 @@ from app.providers import (
     OpenAIAdapter,
     ProviderAdapter,
 )
+from app.providers.base_url_policy import validate_llm_base_url
 from app.providers.tool.base import ToolProviderAdapter
 from app.providers.tool.courtlistener import CourtListenerToolAdapter
 from app.providers.tool.echo import EchoToolAdapter
@@ -161,6 +162,11 @@ def build_adapter(provider: ProviderConfig) -> ProviderAdapter | None:
 
     if not provider.enabled:
         return None
+    # Egress guard (#288, GW-04): the prompt-carrying LLM path must not send
+    # cleartext to a public host or use a non-http(s) scheme. Validate before
+    # building any adapter so a bad base_url fails at startup — matching the
+    # build-time validation the tool path already does.
+    validate_llm_base_url(provider.base_url)
     if provider.type == "anthropic":
         return AnthropicAdapter.from_config(provider)
     if provider.type in ("openai", "openai_compatible"):

--- a/gateway/app/provider_keys.py
+++ b/gateway/app/provider_keys.py
@@ -57,8 +57,13 @@ from typing import Protocol
 
 from app.config import GatewayConfig
 from app.config_holder import MutableConfigHolder
-from app.config_writer import delete_provider_key, upsert_provider_key
+from app.config_writer import (
+    ProviderKeyMutationError,
+    delete_provider_key,
+    upsert_provider_key,
+)
 from app.providers import ProviderAdapter
+from app.providers.base_url_policy import ProviderEgressRefused
 from app.secrets import MasterKeyMissing, ProviderKeyResolver, encrypt_value
 
 logger = logging.getLogger(__name__)
@@ -324,6 +329,15 @@ async def apply_provider_key(
     else:
         try:
             new_adapter = build_adapter(provider)
+        except ProviderEgressRefused as exc:
+            # The key was written, but this provider's base_url is refused by
+            # egress policy; report it rather than 500 after a successful
+            # write. Must sit ahead of the ValueError arm below —
+            # ProviderKeyMutationError subclasses ValueError.
+            raise ProviderKeyMutationError(
+                f"provider {provider_name!r} base_url violates egress policy: {exc.reason}",
+                http_status=409,
+            ) from exc
         except ValueError:
             # A supported, enabled provider whose key still won't resolve.
             # We just wrote the encrypted key, so this is unexpected; treat

--- a/gateway/app/providers/base_url_policy.py
+++ b/gateway/app/providers/base_url_policy.py
@@ -1,0 +1,70 @@
+"""Egress policy for LLM provider ``base_url``s (#288, GW-04).
+
+The tool path (:mod:`app.providers.tool.egress`) enforces a strict
+https-only, host-allowlisted, public-IP egress guard. The LLM provider path
+needs a slightly looser but still-safe rule: public providers (Anthropic,
+OpenAI, Azure, Vertex, Bedrock) MUST use ``https``, but local providers
+(Ollama, vLLM) legitimately speak plaintext ``http`` to a loopback address
+or a compose service name (``http://ollama:11434``, ``http://vllm:8000/v1``).
+
+Before this guard ``ProviderConfig.base_url`` was validated only as
+``min_length=1``, so a misconfiguration or config tampering could point the
+crown-jewel prompt-egress path at ``http://attacker.example`` or an internal
+address in cleartext — the asymmetry the audit flagged versus the hardened
+tool path. This guard is applied at adapter build time so a bad ``base_url``
+fails fast at startup.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse
+
+
+class ProviderEgressRefused(Exception):
+    """Raised when a provider ``base_url`` violates LLM egress policy."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _is_local_host(host: str) -> bool:
+    """True when plaintext ``http`` egress to ``host`` is acceptable.
+
+    Acceptable local targets: a loopback/private/link-local/CGNAT IP literal,
+    ``localhost``, or a single-label hostname (no dot) — i.e. a container /
+    compose service name such as ``ollama`` or ``vllm`` that is not a routable
+    public host. A dotted FQDN (``api.openai.com``) is treated as public.
+    """
+    if host.lower() == "localhost":
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        # Not an IP literal: a single-label name is a private service name;
+        # a dotted (or IPv6-bracketed) name is a public FQDN.
+        return "." not in host and ":" not in host
+    return not ip.is_global
+
+
+def validate_llm_base_url(base_url: str) -> None:
+    """Validate an LLM provider ``base_url`` against egress policy.
+
+    ``https`` is always allowed; ``http`` is allowed only to a local host
+    (Ollama/vLLM). Any other scheme, a missing host, or plaintext ``http`` to
+    a public host raises :class:`ProviderEgressRefused`.
+    """
+    parsed = urlparse(base_url)
+    if parsed.scheme not in ("http", "https"):
+        raise ProviderEgressRefused(
+            f"provider base_url must use http or https, got scheme {parsed.scheme!r}"
+        )
+    host = parsed.hostname
+    if not host:
+        raise ProviderEgressRefused("provider base_url has no host")
+    if parsed.scheme == "http" and not _is_local_host(host):
+        raise ProviderEgressRefused(
+            "plaintext http base_url is only permitted for local providers "
+            f"(loopback/private/service name); public host {host!r} must use https"
+        )

--- a/gateway/app/providers/base_url_policy.py
+++ b/gateway/app/providers/base_url_policy.py
@@ -4,8 +4,14 @@ The tool path (:mod:`app.providers.tool.egress`) enforces a strict
 https-only, host-allowlisted, public-IP egress guard. The LLM provider path
 needs a slightly looser but still-safe rule: public providers (Anthropic,
 OpenAI, Azure, Vertex, Bedrock) MUST use ``https``, but local providers
-(Ollama, vLLM) legitimately speak plaintext ``http`` to a loopback address
-or a compose service name (``http://ollama:11434``, ``http://vllm:8000/v1``).
+(Ollama, vLLM) legitimately speak plaintext ``http`` to a loopback address,
+a private network, or one of a few named local targets
+(``http://ollama:11434``, ``http://host.docker.internal:11434``).
+
+The named hosts and networks are spelled out as explicit module constants
+below rather than derived from :attr:`ipaddress.ip_address.is_global`, so an
+operator can see exactly what plaintext egress is permitted without leaving
+this file.
 
 Before this guard ``ProviderConfig.base_url`` was validated only as
 ``min_length=1``, so a misconfiguration or config tampering could point the
@@ -29,31 +35,60 @@ class ProviderEgressRefused(Exception):
         self.reason = reason
 
 
+# Hostnames permitted as plaintext ``http`` targets. Every local-inference
+# host the project documents is here: ``ollama`` is the Compose service
+# (docker-compose.yml), ``vllm`` is the disabled-by-default service in
+# gateway.yaml.example, and ``host.docker.internal`` is the host bridge that
+# .env.example ships as the default OLLAMA_BASE_URL (the release Compose file
+# has no ollama service, so that is the release path). Add a name here rather
+# than loosening the rule.
+_LOCAL_HOSTS = frozenset({"localhost", "host.docker.internal", "ollama", "vllm"})
+
+# Networks permitted as plaintext ``http`` targets: loopback, RFC1918 private
+# space, and IPv6 unique-local. Deliberately narrower than "not is_global" —
+# link-local (169.254.0.0/16, which carries the cloud metadata endpoint),
+# CGNAT (100.64.0.0/10) and 0.0.0.0 are NOT local inference targets and must
+# not receive prompts in cleartext.
+_LOCAL_NETWORKS = tuple(
+    ipaddress.ip_network(n)
+    for n in (
+        "127.0.0.0/8",
+        "::1/128",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "fc00::/7",
+    )
+)
+
+
 def _is_local_host(host: str) -> bool:
     """True when plaintext ``http`` egress to ``host`` is acceptable.
 
-    Acceptable local targets: a loopback/private/link-local/CGNAT IP literal,
-    ``localhost``, or a single-label hostname (no dot) — i.e. a container /
-    compose service name such as ``ollama`` or ``vllm`` that is not a routable
-    public host. A dotted FQDN (``api.openai.com``) is treated as public.
+    Acceptable local targets: a name in :data:`_LOCAL_HOSTS`, or an IP literal
+    inside one of :data:`_LOCAL_NETWORKS`. Anything else — a public FQDN such
+    as ``api.openai.com``, an unlisted service name, or a routable IP — is
+    treated as public and must use ``https``.
     """
-    if host.lower() == "localhost":
+    if host.lower() in _LOCAL_HOSTS:
         return True
     try:
         ip = ipaddress.ip_address(host)
     except ValueError:
-        # Not an IP literal: a single-label name is a private service name;
-        # a dotted (or IPv6-bracketed) name is a public FQDN.
-        return "." not in host and ":" not in host
-    return not ip.is_global
+        # Not an IP literal and not an allowlisted name.
+        return False
+    # A v4 address is never "in" a v6 network (and vice versa); CPython returns
+    # False on a version mismatch rather than raising, so no version guard.
+    return any(ip in network for network in _LOCAL_NETWORKS)
 
 
 def validate_llm_base_url(base_url: str) -> None:
     """Validate an LLM provider ``base_url`` against egress policy.
 
-    ``https`` is always allowed; ``http`` is allowed only to a local host
-    (Ollama/vLLM). Any other scheme, a missing host, or plaintext ``http`` to
-    a public host raises :class:`ProviderEgressRefused`.
+    ``https`` is always allowed; ``http`` is allowed only to a host in
+    :data:`_LOCAL_HOSTS` or an IP inside :data:`_LOCAL_NETWORKS`. Any other
+    scheme, a missing host, or plaintext ``http`` to a public host raises
+    :class:`ProviderEgressRefused`.
     """
     parsed = urlparse(base_url)
     if parsed.scheme not in ("http", "https"):
@@ -64,7 +99,8 @@ def validate_llm_base_url(base_url: str) -> None:
     if not host:
         raise ProviderEgressRefused("provider base_url has no host")
     if parsed.scheme == "http" and not _is_local_host(host):
+        allowed = ", ".join(sorted(_LOCAL_HOSTS))
         raise ProviderEgressRefused(
-            "plaintext http base_url is only permitted for local providers "
-            f"(loopback/private/service name); public host {host!r} must use https"
+            f"plaintext http base_url is only permitted for local providers ({allowed}, "
+            f"or a loopback/private IP); host {host!r} must use https"
         )

--- a/gateway/tests/test_llm_base_url_policy.py
+++ b/gateway/tests/test_llm_base_url_policy.py
@@ -8,11 +8,16 @@ always allowed; `http` only to an explicitly allowlisted local host
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from app.config import ProviderConfig
 from app.main import build_adapter
 from app.providers.base_url_policy import ProviderEgressRefused, validate_llm_base_url
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONFIG = REPO_ROOT / "gateway.yaml.example"
 
 
 @pytest.mark.unit
@@ -83,3 +88,31 @@ def test_build_adapter_allows_local_ollama() -> None:
     )
     adapter = build_adapter(provider)
     assert adapter is not None
+
+
+@pytest.mark.unit
+async def test_lifespan_refuses_to_start_on_refused_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An egress-policy violation is FATAL at startup, never a silent skip.
+
+    Regression guard for the deliberate design call on this PR: if
+    ``ProviderEgressRefused`` were ever swallowed by the lifespan's
+    ``except ValueError`` skip path (e.g. by a refactor re-basing the
+    exception), the router would fall through to the next candidate in the
+    chain and silently send prompts somewhere the operator did not choose.
+    This reproduces the operator story: a mistyped ``OLLAMA_BASE_URL``.
+    """
+
+    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
+    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://attacker.example/v1")
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(EXAMPLE_CONFIG))
+
+    from app.main import app
+
+    with pytest.raises(ProviderEgressRefused):
+        async with app.router.lifespan_context(app):
+            pass  # pragma: no cover — startup must raise before entry

--- a/gateway/tests/test_llm_base_url_policy.py
+++ b/gateway/tests/test_llm_base_url_policy.py
@@ -2,7 +2,8 @@
 
 The prompt-carrying LLM path must not send cleartext to a public host or use
 a non-http(s) scheme, mirroring the hardened tool-egress path. `https` is
-always allowed; `http` only to a local host (Ollama/vLLM).
+always allowed; `http` only to an explicitly allowlisted local host
+(`_LOCAL_HOSTS`) or an IP inside `_LOCAL_NETWORKS`.
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ from app.providers.base_url_policy import ProviderEgressRefused, validate_llm_ba
         "https://us-central1-aiplatform.googleapis.com",
         "http://ollama:11434",  # compose service name
         "http://vllm:8000/v1",
+        "http://host.docker.internal:11434",  # .env.example's default OLLAMA_BASE_URL
         "http://localhost:11434",
         "http://127.0.0.1:11434",
         "http://[::1]:11434",
@@ -40,6 +42,8 @@ def test_accepts_valid_targets(url: str) -> None:
         "http://api.openai.com/v1",  # plaintext to a public host
         "http://attacker.example/v1",
         "http://8.8.8.8/v1",  # plaintext to a public IP
+        "http://169.254.169.254/latest/meta-data/",  # link-local cloud metadata
+        "http://nginx:8080",  # single-label name that is not an allowlisted local provider
         "ftp://api.openai.com",  # unsupported scheme
         "file:///etc/passwd",
         "https://",  # no host

--- a/gateway/tests/test_llm_base_url_policy.py
+++ b/gateway/tests/test_llm_base_url_policy.py
@@ -1,0 +1,81 @@
+"""Tests for the LLM provider base_url egress guard (#288, GW-04).
+
+The prompt-carrying LLM path must not send cleartext to a public host or use
+a non-http(s) scheme, mirroring the hardened tool-egress path. `https` is
+always allowed; `http` only to a local host (Ollama/vLLM).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import ProviderConfig
+from app.main import build_adapter
+from app.providers.base_url_policy import ProviderEgressRefused, validate_llm_base_url
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.anthropic.com",
+        "https://api.openai.com/v1",
+        "https://us-central1-aiplatform.googleapis.com",
+        "http://ollama:11434",  # compose service name
+        "http://vllm:8000/v1",
+        "http://localhost:11434",
+        "http://127.0.0.1:11434",
+        "http://[::1]:11434",
+        "http://10.0.0.5:8000",  # private
+    ],
+)
+def test_accepts_valid_targets(url: str) -> None:
+    validate_llm_base_url(url)  # does not raise
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://api.openai.com/v1",  # plaintext to a public host
+        "http://attacker.example/v1",
+        "http://8.8.8.8/v1",  # plaintext to a public IP
+        "ftp://api.openai.com",  # unsupported scheme
+        "file:///etc/passwd",
+        "https://",  # no host
+    ],
+)
+def test_rejects_bad_targets(url: str) -> None:
+    with pytest.raises(ProviderEgressRefused):
+        validate_llm_base_url(url)
+
+
+@pytest.mark.unit
+def test_build_adapter_rejects_plaintext_public_base_url() -> None:
+    """build_adapter fails fast when a provider is configured to send prompts
+    in cleartext to a public host."""
+    provider = ProviderConfig.model_validate(
+        {
+            "name": "evil",
+            "type": "ollama",  # ollama needs no API key, so build reaches the guard
+            "base_url": "http://attacker.example/v1",
+            "tier": 1,
+        }
+    )
+    with pytest.raises(ProviderEgressRefused):
+        build_adapter(provider)
+
+
+@pytest.mark.unit
+def test_build_adapter_allows_local_ollama() -> None:
+    """A normal local Ollama config over http builds without complaint."""
+    provider = ProviderConfig.model_validate(
+        {
+            "name": "ollama-local",
+            "type": "ollama",
+            "base_url": "http://ollama:11434",
+            "tier": 1,
+        }
+    )
+    adapter = build_adapter(provider)
+    assert adapter is not None

--- a/gateway/tests/test_provider_keys.py
+++ b/gateway/tests/test_provider_keys.py
@@ -502,3 +502,50 @@ async def test_revoke_retires_live_adapter(
     )
     assert KEYLESS_PROVIDER not in state.adapters
     assert state.retired_adapters == [live]
+
+
+@pytest.mark.unit
+async def test_apply_maps_egress_refusal_to_409(
+    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+) -> None:
+    """An egress-refused base_url on the BYOK path is a structured 409.
+
+    Regression guard (GW-04 follow-up): ``apply_provider_key`` writes the
+    encrypted key BEFORE building the adapter, so an unhandled
+    ``ProviderEgressRefused`` here used to surface as a 500 after a
+    successful write. The explicit arm maps it to
+    ``ProviderKeyMutationError`` with ``http_status=409`` — and the arm must
+    sit ahead of the ``except ValueError`` skip, because
+    ``ProviderKeyMutationError`` itself subclasses ``ValueError``.
+    """
+
+    from app.config_writer import ProviderKeyMutationError
+    from app.providers.base_url_policy import ProviderEgressRefused
+
+    _set_example_env(monkeypatch, writable_config)
+    master_key = Fernet.generate_key().decode()
+    monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", master_key)
+
+    from app.config_holder import MutableConfigHolder
+    from app.config_loader import load_config
+
+    holder = MutableConfigHolder(load_config(writable_config), config_path=writable_config)
+    state = _FakeState()
+
+    def _refusing_build(provider: ProviderConfig) -> _FakeAdapter:
+        raise ProviderEgressRefused("plaintext http to a public host")
+
+    monkeypatch.setattr("app.main.build_adapter", _refusing_build)
+
+    with pytest.raises(ProviderKeyMutationError) as excinfo:
+        await apply_provider_key(
+            holder=holder,
+            app_state=state,  # type: ignore[arg-type]
+            provider_name=KEYLESS_PROVIDER,
+            plaintext=FAKE_KEY,
+            master_key=master_key,
+        )
+    assert excinfo.value.http_status == 409
+    assert "egress policy" in str(excinfo.value)
+    # The refusal must not have swapped any adapter into the live registry.
+    assert KEYLESS_PROVIDER not in state.adapters


### PR DESCRIPTION
## What this PR does

Adds a build-time egress guard on LLM provider `base_url`s: `https` is always allowed, `http` only to a local host (Ollama/vLLM). A misconfigured provider now fails fast at startup instead of silently sending prompts in cleartext to a public host.

## Why

`Refs #288` — finding **GW-04 (Medium)**. `ProviderConfig.base_url` was validated only as `Field(min_length=1)`, and `build_adapter` handed it straight to the adapter with no scheme/host check. So the **crown-jewel prompt-egress path** could use a plaintext `http://` base_url or an internal/attacker-controlled address — while the **lower-trust tool path** is hardened (`build_tool_adapter` → `validate_base_url` → `validate_egress_target`: https-only, host allowlist, public-IP/DNS-rebind check). That asymmetry means a config mistake or tampering could silently exfiltrate every prompt.

## How

- New `gateway/app/providers/base_url_policy.py::validate_llm_base_url`, called at the top of `build_adapter` (main.py) before any adapter is constructed — mirroring how `build_tool_adapter` validates each tool provider at build time, so a bad `base_url` fails at startup.
- Policy is intentionally looser than the tool path because LLM providers differ: public providers (Anthropic/OpenAI/Azure/Vertex/Bedrock) **must** use `https`, but local providers legitimately speak plaintext `http` to a loopback address or a compose service name (`http://ollama:11434`, `http://vllm:8000/v1`). So: `https` any host; `http` only when the host is loopback / a private-or-link-local IP literal / `localhost` / a single-label service name. Everything else (plaintext to a public host, non-http(s) schemes, missing host) is refused.

## What this PR does *not* do

Doesn't add a per-provider host allowlist (the finding notes it as optional; the scheme/locality guard closes the cleartext-exfil path, and an allowlist can layer on later). Doesn't change the tool-egress path.

## Type of change

- [x] Bug fix (fixes an issue)
- [x] Breaking change (a deployment whose provider `base_url` violates the egress policy — e.g. a mistyped `OLLAMA_BASE_URL` pointing at a public host over plaintext `http` — no longer starts with that provider skipped; the gateway refuses to boot, deliberately, naming the provider. The tradeoffs table in the description is the upgrade note.)

## Testing

- [x] Unit tests added/updated

<details>
<summary>Gates run locally (gateway/.venv)</summary>

- `pytest tests/test_llm_base_url_policy.py` → **17 passed** — accepts the shipped configs (anthropic/openai/vertex https, ollama/vllm/localhost/private-IP http); rejects http-to-public, http-to-public-IP, non-http schemes, and missing host; `build_adapter` raises on a plaintext-public `base_url` and still builds a normal local Ollama.
- `ruff check` + `ruff format --check` → clean.
- `mypy app` (strict) → `Success: no issues found in 57 source files`.

</details>

## Transparency & governance invariants

- [x] **Egress (P1) / Fail restrictive (P4):** the sole audited egress boundary now refuses a cleartext-to-public or non-http(s) provider target and fails closed at startup; tests cover accept + reject paths.
- [x] **One governance path (P6):** applied at the same `build_adapter` build-time hook the tool path uses.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (GW-04).

> `gateway/**` is a security-sensitive path — routes to `@legalquants/security` per `.github/CODEOWNERS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #293** — same head commit (`5acfd4dccc0a`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._


---

## Update — explicit allowlist (review feedback, 2026-07-28)

Per @houfu's review, the plaintext-`http` decision is now driven by two named constants
an operator can read in the file, instead of Python's `ip.is_global`:

```python
_LOCAL_HOSTS    = {"localhost", "host.docker.internal", "ollama", "vllm"}
_LOCAL_NETWORKS = 127.0.0.0/8, ::1/128, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7
```

**This also fixes a startup regression the first version introduced.** The single-label
heuristic treated any dotted name as a public FQDN, so it refused
`http://host.docker.internal` — the value `.env.example` ships as the default
`OLLAMA_BASE_URL`, and the only route to Ollama in `docker-compose.release.yml`, which
has no `ollama` service. `build_adapter` raises inside `lifespan`, which catches only
`ValueError`, so the gateway failed to start on the most common documented configuration.
Reproduced and confirmed fixed.

**Behaviour change worth reviewing deliberately.** The explicit network list is narrower
than `not is_global`. Plaintext `http` to these is now **refused** where it was previously
allowed:

| Range | Note |
|---|---|
| `169.254.0.0/16` | link-local — carries the cloud metadata endpoint (`169.254.169.254`) |
| `100.64.0.0/10` | CGNAT — where Tailscale addresses live |
| `0.0.0.0`, `fe80::/10` | not local inference targets |

An unlisted single-label service name (e.g. `http://nginx:8080`) is also refused now. The
intended remedy is to add the name to `_LOCAL_HOSTS` rather than loosen the rule. I took
the list exactly as proposed rather than widening it; if any operator recipe needs the
CGNAT range for a tailnet-hosted Ollama, that is a one-line addition and worth a follow-up.

Tests go 17 → 20: accept `host.docker.internal`, reject the IMDS address and an unlisted
single-label name so a later edit cannot silently restore the heuristic. Full gateway
suite green (790 passed, 3 skipped), `ruff`, `ruff format --check` and `mypy --strict` clean.

