### PR TITLE
Scope autonomous retrieve_chunks to the session owner (AG-01, Refs #288)

### DIFF
--- a/api/app/autonomous/guard.py
+++ b/api/app/autonomous/guard.py
@@ -82,6 +82,7 @@ from decimal import Decimal
 from typing import Any
 
 import sqlalchemy as sa
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -98,6 +99,8 @@ from app.models.autonomous import (
     AutonomousSession,
     PrecedentEntry,
 )
+from app.models.file import File as FileModel
+from app.models.knowledge import KnowledgeBase
 from app.models.user import User
 from app.observability_helpers import get_tracer, record_attributes
 
@@ -1159,16 +1162,19 @@ async def _assert_kb_owned(db: AsyncSession, kb_id: uuid.UUID, owner_id: uuid.UU
     happen here or an injected document could steer retrieval at another
     tenant's KB (#288, AG-01). 404-shaped (not-found) message so cross-user
     probing can't tell "exists, not yours" from "doesn't exist".
+
+    Predicates mirror :func:`app.api.knowledge_bases._load_visible_kb` — owner
+    scope **and** ``archived_at IS NULL`` — so the autonomous path cannot reach
+    a KB the HTTP surface would treat as gone. ``ValueError`` rather than that
+    helper's HTTP ``NotFound``: a chokepoint failure becomes ``session.error``
+    text, not a response.
     """
-    from sqlalchemy import select
-
-    from app.models.knowledge import KnowledgeBase
-
     owned = (
         await db.execute(
             select(KnowledgeBase.id).where(
                 KnowledgeBase.id == kb_id,
                 KnowledgeBase.owner_id == owner_id,
+                KnowledgeBase.archived_at.is_(None),
             )
         )
     ).scalar_one_or_none()
@@ -1178,16 +1184,18 @@ async def _assert_kb_owned(db: AsyncSession, kb_id: uuid.UUID, owner_id: uuid.UU
 
 async def _assert_file_owned(db: AsyncSession, file_id: uuid.UUID, owner_id: uuid.UUID) -> None:
     """Reject a model-supplied ``file_id`` the session owner does not own
-    (#288, AG-01). See :func:`_assert_kb_owned` for the rationale."""
-    from sqlalchemy import select
+    (#288, AG-01). See :func:`_assert_kb_owned` for the rationale.
 
-    from app.models.file import File as FileModel
-
+    Predicates mirror :func:`app.api.files._load_visible_file` — owner scope
+    **and** ``deleted_at IS NULL``, so a soft-deleted (tombstoned) file is
+    unreachable here just as it is over HTTP.
+    """
     owned = (
         await db.execute(
             select(FileModel.id).where(
                 FileModel.id == file_id,
                 FileModel.owner_id == owner_id,
+                FileModel.deleted_at.is_(None),
             )
         )
     ).scalar_one_or_none()
@@ -1270,10 +1278,17 @@ async def _handle_retrieve_chunks(
             "`file_id` (file-scoped fetch), or `since` + `kb_id` "
             "(KB-scoped fetch of files attached after a cutoff)."
         )
-    # Mode 1 requires kb_id; verify ownership before searching. If kb_id is
-    # absent the downstream handler raises as before (malformed request).
-    if kb_id_raw is not None:
-        await _assert_kb_owned(db, uuid.UUID(str(kb_id_raw)), owner_id)
+    # Mode 1 requires kb_id. Fail CLOSED on a missing one rather than falling
+    # through to the downstream handler: a model-supplied params dict that
+    # omits kb_id must never reach retrieval with no ownership check applied
+    # (#288, AG-01). The downstream handler would also reject it, but the
+    # ownership gate has to be the thing that refuses, not a later accident.
+    if kb_id_raw is None:
+        raise ValueError(
+            "_handle_retrieve_chunks: `query` mode requires `kb_id` so the "
+            "search can be scoped to a knowledge base this session owns."
+        )
+    await _assert_kb_owned(db, uuid.UUID(str(kb_id_raw)), owner_id)
     return await _handle_retrieve_chunks_query(params, db=db)
 
 

--- a/api/app/autonomous/guard.py
+++ b/api/app/autonomous/guard.py
@@ -574,7 +574,7 @@ async def _dispatch(
         return ToolResult(cost_usd=Decimal("0"), data={"notification_id": str(note.id)})
 
     if intent == ToolIntent.retrieve_chunks:
-        return await _handle_retrieve_chunks(params, db=db)
+        return await _handle_retrieve_chunks(params, db=db, owner_id=session.user_id)
 
     if intent in (ToolIntent.run_skill, ToolIntent.run_playbook, ToolIntent.plan):
         return await _handle_gateway_inference(
@@ -1149,13 +1149,64 @@ async def _handle_emit_artifact(
     return ToolResult(cost_usd=Decimal("0"), data=data)
 
 
+async def _assert_kb_owned(db: AsyncSession, kb_id: uuid.UUID, owner_id: uuid.UUID) -> None:
+    """Reject a model-supplied ``kb_id`` the session owner does not own.
+
+    :func:`hybrid_search` and the since-fetch scope only by ``kb_id`` and rely
+    on the *handler* having verified ownership upstream (per the retrieval
+    module's contract). In the autonomous loop the planner's ``kb_id`` is
+    model-controlled and therefore prompt-injectable, so the check has to
+    happen here or an injected document could steer retrieval at another
+    tenant's KB (#288, AG-01). 404-shaped (not-found) message so cross-user
+    probing can't tell "exists, not yours" from "doesn't exist".
+    """
+    from sqlalchemy import select
+
+    from app.models.knowledge import KnowledgeBase
+
+    owned = (
+        await db.execute(
+            select(KnowledgeBase.id).where(
+                KnowledgeBase.id == kb_id,
+                KnowledgeBase.owner_id == owner_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if owned is None:
+        raise ValueError(f"knowledge base {kb_id} is not accessible to this session")
+
+
+async def _assert_file_owned(db: AsyncSession, file_id: uuid.UUID, owner_id: uuid.UUID) -> None:
+    """Reject a model-supplied ``file_id`` the session owner does not own
+    (#288, AG-01). See :func:`_assert_kb_owned` for the rationale."""
+    from sqlalchemy import select
+
+    from app.models.file import File as FileModel
+
+    owned = (
+        await db.execute(
+            select(FileModel.id).where(
+                FileModel.id == file_id,
+                FileModel.owner_id == owner_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if owned is None:
+        raise ValueError(f"file {file_id} is not accessible to this session")
+
+
 async def _handle_retrieve_chunks(
     params: dict[str, Any],
     *,
     db: AsyncSession,
+    owner_id: uuid.UUID,
 ) -> ToolResult:
     """Handle ``retrieve_chunks`` — hybrid KB search OR file-scoped OR
     since-scoped fetch.  Zero cost (local retrieval).
+
+    ``owner_id`` is the owning session's ``user_id``; every model-supplied
+    ``kb_id``/``file_id`` is checked against it before retrieval so a
+    prompt-injected document cannot reach another tenant's data (#288, AG-01).
 
     Three modes (mutually exclusive at the top level):
 
@@ -1204,10 +1255,12 @@ async def _handle_retrieve_chunks(
 
     # Mode 2: file-scoped fetch.
     if file_id_raw is not None:
+        await _assert_file_owned(db, uuid.UUID(str(file_id_raw)), owner_id)
         return await _handle_retrieve_chunks_by_file(file_id_raw, db=db)
 
     # Mode 3: since + kb_id scoped fetch.
     if since_raw is not None and kb_id_raw is not None:
+        await _assert_kb_owned(db, uuid.UUID(str(kb_id_raw)), owner_id)
         return await _handle_retrieve_chunks_since(since_raw, kb_id_raw, db=db)
 
     # Mode 1: query-based hybrid search (existing path — unchanged).
@@ -1217,6 +1270,10 @@ async def _handle_retrieve_chunks(
             "`file_id` (file-scoped fetch), or `since` + `kb_id` "
             "(KB-scoped fetch of files attached after a cutoff)."
         )
+    # Mode 1 requires kb_id; verify ownership before searching. If kb_id is
+    # absent the downstream handler raises as before (malformed request).
+    if kb_id_raw is not None:
+        await _assert_kb_owned(db, uuid.UUID(str(kb_id_raw)), owner_id)
     return await _handle_retrieve_chunks_query(params, db=db)
 
 

--- a/api/tests/autonomous/conftest.py
+++ b/api/tests/autonomous/conftest.py
@@ -102,6 +102,15 @@ _CHUNK_TEXT_DEFAULT = (
 
 
 async def _make_owner(db: AsyncSession) -> User:
+    """Create the owner of a KB/file fixture.
+
+    ``autonomous_enabled=True`` because the session fixtures below run their
+    autonomous session **as this owner** — retrieve_chunks is scoped to the
+    session owner (#288, AG-01), so a session whose user differs from the
+    KB/file owner is a state production cannot produce (``create_watch``
+    requires ``KnowledgeBase.owner_id == user.id``). ``fire_watches_for_kb``
+    additionally joins on ``User.autonomous_enabled``.
+    """
     user = User(
         email=f"u-retr-{uuid.uuid4().hex[:8]}@example.com",
         hashed_password=hash_password("pw"),
@@ -109,9 +118,17 @@ async def _make_owner(db: AsyncSession) -> User:
         role="member",
         mfa_enabled=False,
         must_change_password=False,
+        autonomous_enabled=True,
     )
     db.add(user)
     await db.flush()
+    return user
+
+
+async def _owner_of(db: AsyncSession, owner_id: uuid.UUID) -> User:
+    """Load the ``User`` that owns a KB/file fixture, to run a session as them."""
+    user = await db.get(User, owner_id)
+    assert user is not None, f"fixture owner {owner_id} not found"
     return user
 
 
@@ -489,7 +506,7 @@ async def running_watch_session(
     the mode 2 path end-to-end through the chokepoint rather than
     asserting against an empty list.
     """
-    user = await _make_optedin_user(db_session)
+    user = await _owner_of(db_session, kb_with_one_indexed_file.owner_id)
     return await _make_running_session(
         db_session,
         user=user,
@@ -513,7 +530,7 @@ async def running_schedule_session_with_since(
     therefore exercises the mode-3 cutoff: only ``new_file``'s chunks
     should come back.
     """
-    user = await _make_optedin_user(db_session)
+    user = await _owner_of(db_session, kb_with_old_and_new_files.owner_id)
     since_iso = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
     return await _make_running_session(
         db_session,
@@ -587,7 +604,7 @@ async def running_watch_session_at_analysis(
     ``alpha-test-skill`` is loaded into ``app.state.skill_registry`` and
     the prompt assembly path resolves without an explicit ``registry=``.
     """
-    user = await _make_optedin_user(db_session)
+    user = await _owner_of(db_session, kb_with_one_indexed_file.owner_id)
     return await _make_running_session(
         db_session,
         user=user,

--- a/api/tests/autonomous/conftest.py
+++ b/api/tests/autonomous/conftest.py
@@ -77,6 +77,7 @@ class KbOneFile:
     file_id: uuid.UUID
     document_id: uuid.UUID
     chunk_id: uuid.UUID
+    owner_id: uuid.UUID
 
 
 @dataclass
@@ -91,6 +92,7 @@ class KbTwoFiles:
     kb_id: uuid.UUID
     old_file_id: uuid.UUID
     new_file_id: uuid.UUID
+    owner_id: uuid.UUID
 
 
 _CHUNK_TEXT_DEFAULT = (
@@ -199,7 +201,9 @@ async def kb_with_one_indexed_file(db_session: AsyncSession) -> KbOneFile:
     # Force Postgres to compute the generated content_tsv column so FTS works.
     await db_session.execute(text("UPDATE document_chunks SET chunk_index = chunk_index"))
     await db_session.flush()
-    return KbOneFile(kb_id=kb.id, file_id=f.id, document_id=doc.id, chunk_id=chunk.id)
+    return KbOneFile(
+        kb_id=kb.id, file_id=f.id, document_id=doc.id, chunk_id=chunk.id, owner_id=owner.id
+    )
 
 
 @pytest_asyncio.fixture
@@ -231,7 +235,7 @@ async def kb_with_old_and_new_files(db_session: AsyncSession) -> KbTwoFiles:
     await db_session.execute(text("UPDATE document_chunks SET chunk_index = chunk_index"))
     await db_session.flush()
 
-    return KbTwoFiles(kb_id=kb.id, old_file_id=old_f.id, new_file_id=new_f.id)
+    return KbTwoFiles(kb_id=kb.id, old_file_id=old_f.id, new_file_id=new_f.id, owner_id=owner.id)
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/autonomous/test_agentic_loop.py
+++ b/api/tests/autonomous/test_agentic_loop.py
@@ -20,6 +20,7 @@ from app.autonomous.nodes import make_analysis_node
 from app.autonomous.state import AutonomousSessionState
 from app.models.audit import AuditLog
 from app.models.autonomous import AutonomousSession
+from tests.autonomous.conftest import _CHUNK_TEXT_DEFAULT, KbOneFile
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
@@ -59,12 +60,14 @@ class _ScriptedGateway:
 
     def __init__(self, planner_script: list[Any]) -> None:
         self.planner_script = list(planner_script)
+        self.captured_requests: list[Any] = []
 
     async def list_tool_providers(self) -> list[dict[str, Any]]:
         """No providers configured in the agentic-loop unit tests."""
         return []
 
     async def chat_completion(self, request: Any, *, request_id: object = None) -> SimpleNamespace:
+        self.captured_requests.append(request)
         system = request.messages[0].content
         if "research planner" in system:
             return _resp(json.dumps(self.planner_script.pop(0)))
@@ -329,6 +332,76 @@ async def test_action_error_is_nonfatal_observation(
     assert len(action_decisions) == 1
 
     # The ``started`` audit row for the action was written before the error
+    rows = await _audit_rows(db_session, str(seeded_matter_session.id))
+    assert _tool_started_calls(rows, "retrieve_chunks") >= 1
+
+
+# ---------------------------------------------------------------------------
+# AG-01 — ownership denial through the loop is a non-fatal observation
+# ---------------------------------------------------------------------------
+
+
+async def test_foreign_kb_denial_is_nonfatal_loop_observation(
+    db_session: AsyncSession,
+    seeded_matter_session: AutonomousSession,
+    kb_with_one_indexed_file: KbOneFile,
+) -> None:
+    """AG-01 through the executor loop: a foreign-KB denial degrades, not crashes.
+
+    The scope tests in ``test_retrieve_chunks_scope.py`` call the handler
+    directly; this test pins the run-level behaviour on the planner path.
+    The session user and the fixture KB's owner are different users, so the
+    ownership gate raises ``ValueError`` inside ``guarded_tool_call``.  The
+    loop must catch it as a non-fatal failed observation (nodes.py, invariant
+    #5): the run continues, the observation reads
+    ``retrieve_chunks → failed (ValueError)``, and no chunk data reaches
+    state or any model prompt.
+    """
+    kb = kb_with_one_indexed_file
+    assert seeded_matter_session.user_id != kb.owner_id  # the premise: cross-owner
+
+    gw = _ScriptedGateway(
+        [
+            {
+                "next_intent": "retrieve_chunks",
+                "args": {"kb_id": str(kb.kb_id), "query": "confidential"},
+                "rationale": "x",
+            },
+            {"done": True, "rationale": "enough evidence"},
+        ]
+    )
+    node = make_analysis_node(db_session, gw)
+    state: AutonomousSessionState = {
+        "session_id": str(seeded_matter_session.id),
+        "query": "Is the assignment clause enforceable?",
+        "retrieved_chunks": [],
+    }
+    # Must not raise — the denial is non-fatal on the loop path
+    result = await node(state)
+
+    # 1. The run continues: synthesis ran, the failed step is counted, planner finished
+    assert result.get("analysis_content") is not None
+    trace = result.get("analysis_plan_trace")
+    assert trace is not None
+    assert trace["steps"] == 1
+    assert trace["halt_reason"] == "planner_done"
+
+    # 2. The observation is the exact non-fatal failure line (observations live
+    #    only in the prompts, not in returned state — hence the captured requests)
+    all_prompt_text = "\n".join(
+        m.content
+        for req in gw.captured_requests
+        for m in req.messages
+        if isinstance(m.content, str)
+    )
+    assert "retrieve_chunks → failed (ValueError)" in all_prompt_text
+
+    # 3. No chunk data escaped the denial: nothing in evidence, and the foreign
+    #    chunk's text never reached any model prompt
+    assert not result.get("analysis_evidence")
+    assert _CHUNK_TEXT_DEFAULT not in all_prompt_text
+
+    # The ``started`` audit row was written before the gate refused
     rows = await _audit_rows(db_session, str(seeded_matter_session.id))
     assert _tool_started_calls(rows, "retrieve_chunks") >= 1
 

--- a/api/tests/autonomous/test_emit_artifact.py
+++ b/api/tests/autonomous/test_emit_artifact.py
@@ -516,7 +516,9 @@ async def test_retrieve_chunks_since_excludes_artifact_files(
     await db_session.flush()
 
     since = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
-    result = await _handle_retrieve_chunks({"since": since, "kb_id": str(kb.id)}, db=db_session)
+    result = await _handle_retrieve_chunks(
+        {"since": since, "kb_id": str(kb.id)}, db=db_session, owner_id=user.id
+    )
 
     returned_file_ids = {c["file_id"] for c in result.data["chunks"]}
     assert str(ordinary_file.id) in returned_file_ids

--- a/api/tests/autonomous/test_r4_per_trigger_cap.py
+++ b/api/tests/autonomous/test_r4_per_trigger_cap.py
@@ -25,7 +25,6 @@ asserts exactly that.
 
 from __future__ import annotations
 
-import uuid
 from decimal import Decimal
 from unittest.mock import AsyncMock
 
@@ -37,7 +36,6 @@ from app.autonomous.executor import run_autonomous_session
 from app.autonomous.watch_trigger import fire_watches_for_kb
 from app.models.autonomous import AutonomousSession, AutonomousWatch
 from app.models.user import User
-from app.security import hash_password
 from tests.autonomous.conftest import KbOneFile
 
 # ``alpha-test-skill`` is the fixture skill installed into
@@ -48,24 +46,18 @@ from tests.autonomous.conftest import KbOneFile
 _FIXTURE_SKILL_REF = "alpha-test-skill"
 
 
-async def _make_opted_in_user(db: AsyncSession) -> User:
-    """Create a user with ``autonomous_enabled=True``.
+async def _kb_owner(db: AsyncSession, kb: KbOneFile) -> User:
+    """Return the KB's owner, to run the watch as them.
 
-    ``fire_watches_for_kb`` joins on ``User.autonomous_enabled.is_(True)``
-    — a non-opted-in user's watch never fires.  Mirrors the proven helper
-    in ``test_spawn_max_cost_usd.py``.
+    The watch must belong to the user who owns the KB and its files:
+    ``retrieve_chunks`` is scoped to the session owner (#288, AG-01), and a
+    watch on someone else's KB is a state production cannot produce —
+    ``create_watch`` requires ``KnowledgeBase.owner_id == user.id``. The
+    conftest fixture owner is created with ``autonomous_enabled=True``, which
+    ``fire_watches_for_kb`` joins on, so the watch still fires.
     """
-    user = User(
-        email=f"r4-cap-test-{uuid.uuid4().hex[:8]}@example.com",
-        display_name="R4 Per-Trigger Cap Test User",
-        hashed_password=hash_password("correct-horse-battery-staple"),
-        is_admin=False,
-        mfa_enabled=False,
-        must_change_password=False,
-        autonomous_enabled=True,
-    )
-    db.add(user)
-    await db.flush()
+    user = await db.get(User, kb.owner_id)
+    assert user is not None, f"fixture KB owner {kb.owner_id} not found"
     return user
 
 
@@ -83,7 +75,7 @@ async def test_r4_trips_on_low_per_trigger_max_cost_usd(
     pre-call brake that trips on the estimate, before dispatch.
     """
     kb = kb_with_one_indexed_file
-    opted_in_user = await _make_opted_in_user(db_session)
+    opted_in_user = await _kb_owner(db_session, kb)
 
     watch = AutonomousWatch(
         user_id=opted_in_user.id,
@@ -152,7 +144,7 @@ async def test_r4_halt_populates_receipt_terminal_reason(
     brake-halted receipt behavior. The gap documented at Task 16 is now closed.
     """
     kb = kb_with_one_indexed_file
-    opted_in_user = await _make_opted_in_user(db_session)
+    opted_in_user = await _kb_owner(db_session, kb)
 
     watch = AutonomousWatch(
         user_id=opted_in_user.id,

--- a/api/tests/autonomous/test_retrieve_chunks_scope.py
+++ b/api/tests/autonomous/test_retrieve_chunks_scope.py
@@ -235,3 +235,80 @@ async def test_retrieve_chunks_rejects_foreign_kb_id(
             db=db_session,
             owner_id=intruder,
         )
+
+
+async def test_query_mode_without_kb_id_fails_closed(
+    db_session: AsyncSession,
+) -> None:
+    """A ``query``-mode call with no ``kb_id`` is refused BY THE OWNERSHIP GATE.
+
+    Regression pin (#288, AG-01): the first cut skipped ``_assert_kb_owned``
+    when ``kb_id`` was absent and let the downstream handler complain instead.
+    That made the ownership check conditional on the model supplying the very
+    field being checked. The gate must be the thing that refuses.
+    """
+    with pytest.raises(ValueError, match="requires `kb_id`"):
+        await _handle_retrieve_chunks(
+            {"query": "confidential", "alpha": 1.0},
+            db=db_session,
+            owner_id=uuid.uuid4(),
+        )
+
+
+async def test_retrieve_chunks_rejects_soft_deleted_file(
+    db_session: AsyncSession, kb_with_one_indexed_file: KbOneFile
+) -> None:
+    """A tombstoned file is unreachable even for its own owner.
+
+    Mirrors ``app.api.files._load_visible_file``, which filters
+    ``deleted_at IS NULL``: the autonomous path must not resurrect content the
+    HTTP surface treats as deleted.
+    """
+    from sqlalchemy import update
+
+    from app.models.file import File as FileModel
+
+    await db_session.execute(
+        update(FileModel)
+        .where(FileModel.id == kb_with_one_indexed_file.file_id)
+        .values(deleted_at=datetime.now(UTC))
+    )
+    await db_session.flush()
+
+    with pytest.raises(ValueError, match="not accessible"):
+        await _handle_retrieve_chunks(
+            {"file_id": str(kb_with_one_indexed_file.file_id)},
+            db=db_session,
+            owner_id=kb_with_one_indexed_file.owner_id,
+        )
+
+
+async def test_retrieve_chunks_rejects_archived_kb(
+    db_session: AsyncSession, kb_with_one_indexed_file: KbOneFile
+) -> None:
+    """An archived KB is unreachable even for its owner.
+
+    Mirrors ``app.api.knowledge_bases._load_visible_kb``, which filters
+    ``archived_at IS NULL`` unless archived rows are explicitly requested.
+    """
+    from sqlalchemy import update
+
+    from app.models.knowledge import KnowledgeBase
+
+    await db_session.execute(
+        update(KnowledgeBase)
+        .where(KnowledgeBase.id == kb_with_one_indexed_file.kb_id)
+        .values(archived_at=datetime.now(UTC))
+    )
+    await db_session.flush()
+
+    with pytest.raises(ValueError, match="not accessible"):
+        await _handle_retrieve_chunks(
+            {
+                "kb_id": str(kb_with_one_indexed_file.kb_id),
+                "query": "confidential",
+                "alpha": 1.0,
+            },
+            db=db_session,
+            owner_id=kb_with_one_indexed_file.owner_id,
+        )

--- a/api/tests/autonomous/test_retrieve_chunks_scope.py
+++ b/api/tests/autonomous/test_retrieve_chunks_scope.py
@@ -20,6 +20,7 @@ options, so an invocation bug surfaces with an actionable failure.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -46,6 +47,7 @@ async def test_retrieve_chunks_query_path_unchanged(
             "top_k": 4,
         },
         db=db_session,
+        owner_id=kb_with_one_indexed_file.owner_id,
     )
     assert "summary" in result.data
     assert "chunks" in result.data
@@ -83,6 +85,7 @@ async def test_retrieve_chunks_by_file_id(
             "file_id": str(kb_with_one_indexed_file.file_id),
         },
         db=db_session,
+        owner_id=kb_with_one_indexed_file.owner_id,
     )
     assert result.data["summary"]["chunk_count"] > 0
     for chunk in result.data["chunks"]:
@@ -111,6 +114,7 @@ async def test_retrieve_chunks_since_scope(
             "since": cutoff.isoformat(),
         },
         db=db_session,
+        owner_id=kb_with_old_and_new_files.owner_id,
     )
     returned_file_ids = {c["file_id"] for c in result.data["chunks"]}
     assert str(kb_with_old_and_new_files.new_file_id) in returned_file_ids
@@ -135,6 +139,7 @@ async def test_retrieve_chunks_since_accepts_aware_datetime(
             "since": cutoff,
         },
         db=db_session,
+        owner_id=kb_with_old_and_new_files.owner_id,
     )
     returned_file_ids = {c["file_id"] for c in result.data["chunks"]}
     assert str(kb_with_old_and_new_files.new_file_id) in returned_file_ids
@@ -152,7 +157,7 @@ async def test_retrieve_chunks_no_mode_raises_actionable_error(
     empty result, not a generic KeyError.
     """
     with pytest.raises(ValueError) as excinfo:
-        await _handle_retrieve_chunks({}, db=db_session)
+        await _handle_retrieve_chunks({}, db=db_session, owner_id=uuid.uuid4())
     message = str(excinfo.value)
     assert "query" in message
     assert "file_id" in message
@@ -174,6 +179,7 @@ async def test_retrieve_chunks_since_rejects_naive_datetime(
                 "since": naive_dt,
             },
             db=db_session,
+            owner_id=kb_with_old_and_new_files.owner_id,
         )
     with pytest.raises(ValueError, match="timezone-aware"):
         await _handle_retrieve_chunks(
@@ -182,4 +188,50 @@ async def test_retrieve_chunks_since_rejects_naive_datetime(
                 "since": "2026-05-27T12:00:00",  # naive ISO string (no offset)
             },
             db=db_session,
+            owner_id=kb_with_old_and_new_files.owner_id,
+        )
+
+
+async def test_retrieve_chunks_rejects_foreign_kb_id(
+    db_session: AsyncSession, kb_with_one_indexed_file: KbOneFile
+) -> None:
+    """IDOR regression (#288, AG-01): a session whose owner does not own the
+    model-supplied ``kb_id`` cannot retrieve its chunks, in any mode.
+
+    The autonomous planner's args are model-controlled and prompt-injectable,
+    so a foreign ``kb_id``/``file_id`` must be rejected before ``hybrid_search``
+    (which scopes only by id and trusts the handler for ownership).
+    """
+    intruder = uuid.uuid4()  # not the KB's owner
+
+    # Mode 1 (query)
+    with pytest.raises(ValueError, match="not accessible"):
+        await _handle_retrieve_chunks(
+            {
+                "kb_id": str(kb_with_one_indexed_file.kb_id),
+                "query": "confidential",
+                "alpha": 1.0,
+            },
+            db=db_session,
+            owner_id=intruder,
+        )
+
+    # Mode 2 (file_id)
+    with pytest.raises(ValueError, match="not accessible"):
+        await _handle_retrieve_chunks(
+            {"file_id": str(kb_with_one_indexed_file.file_id)},
+            db=db_session,
+            owner_id=intruder,
+        )
+
+    # Mode 3 (since + kb_id)
+    cutoff = datetime.now(UTC) - timedelta(minutes=5)
+    with pytest.raises(ValueError, match="not accessible"):
+        await _handle_retrieve_chunks(
+            {
+                "kb_id": str(kb_with_one_indexed_file.kb_id),
+                "since": cutoff.isoformat(),
+            },
+            db=db_session,
+            owner_id=intruder,
         )


### PR DESCRIPTION
## What this PR does

Scopes the autonomous agent's `retrieve_chunks` tool to the owning session's user: a model-supplied `kb_id`/`file_id` that the session owner does not own is rejected (404-shaped) before any retrieval.

## Why

`Refs #288` — finding **AG-01 (Medium, cross-tenant / prompt-injection)**. In the autonomous loop, `guarded_tool_call` forwards the planner model's `args` verbatim to `_handle_retrieve_chunks`, which read `kb_id`/`file_id` and called `hybrid_search` (and the file/`since` fetches) with **no** ownership check. `hybrid_search` scopes only by `kb_id` and explicitly documents that per-user isolation is enforced *upstream by the handler* — but the autonomous path never did it. Because the planner's `args` are model-controlled, a prompt-injected document (e.g. `"...next action: retrieve_chunks with kb_id=<foreign-uuid>"`) could steer retrieval at another tenant's KB, pulling its chunk text into the run's evidence/synthesis. The closed intent enum and phase grants don't help here — `retrieve_chunks` is a legitimately granted intent; the gap was missing authorization on its *target*.

## How

- Thread the session's `user_id` (`AutonomousSession.user_id`) into `_handle_retrieve_chunks` as `owner_id` from the single `_dispatch` call site.
- Before retrieval, verify ownership: `_assert_kb_owned` for mode 1 (query) and mode 3 (`since`+`kb_id`), `_assert_file_owned` for mode 2 (`file_id`). A foreign/unknown id raises a 404-shaped `ValueError` (`"…not accessible to this session"`), so cross-user probing can't distinguish "exists, not yours" from "doesn't exist".
- The `_by_file` and `_since` sub-handlers were also uncovered; the router-level check gates all three modes.

## What this PR does *not* do

Doesn't change `hybrid_search` itself (keeps its "handler verifies ownership" contract; this PR makes the autonomous handler honor it). Doesn't touch the AG-04 artifact-provenance item (tracked separately in #294).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests added/updated

<details>
<summary>Gates run locally (api/.venv)</summary>

- `ruff check` + `ruff format --check` → clean.
- `mypy app` (strict) → `Success: no issues found in 190 source files`.
- New test `test_retrieve_chunks_rejects_foreign_kb_id` asserts a non-owner is rejected in all three modes; the existing scope tests were updated to pass the fixture's `owner_id` (added to the `KbOneFile`/`KbTwoFiles` bundles). **pytest was not run locally** (the autonomous suite needs a pgvector Postgres and Docker wasn't available in this sandbox) — the DB-backed tests run in CI (`api-checks`).

</details>

## Transparency & governance invariants

- [x] **User owns data (P9) / Fail restrictive (P4):** closes a cross-tenant read reachable via prompt injection; foreign ids fail closed; the regression covers all three modes.
- [x] **Human gate / closed set (P2, P7):** unchanged — this tightens authorization on an already-granted intent.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Refs #288 (AG-01). Tracked in #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #295** — same head commit (`12524197d651`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
