### PR TITLE
feat(web): send chat-attached file_ids + poll ingestion status

### DIFF
--- a/web/src/lib/lq-ai/__tests__/attachedFiles.test.ts
+++ b/web/src/lib/lq-ai/__tests__/attachedFiles.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the chat-attached-files helpers (PR #316 review follow-ups
+ * F-3/F-9): the client-side 16 cap and the file_ids payload selection.
+ *
+ * Convention note: pure-function tests, no component mount (per the
+ * ChatPanel-slash-detect.test.ts header). ChatPanel wires these into the
+ * attach affordance and the send payload.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	MAX_CHAT_ATTACHED_FILES,
+	canAttachChatFile,
+	selectFileIdsForSend
+} from '../chat/attachedFiles';
+import type { FileMeta, IngestionStatus } from '../types';
+
+function meta(id: string, status?: IngestionStatus): FileMeta {
+	return {
+		id,
+		owner_id: 'u1',
+		filename: `${id}.pdf`,
+		mime_type: 'application/pdf',
+		size_bytes: 2048,
+		ingestion_status: status,
+		created_at: '2026-01-01T00:00:00Z'
+	};
+}
+
+describe('MAX_CHAT_ATTACHED_FILES', () => {
+	it('mirrors the backend MESSAGE_FILE_IDS_MAX_LEN cap', () => {
+		expect(MAX_CHAT_ATTACHED_FILES).toBe(16);
+	});
+});
+
+describe('canAttachChatFile', () => {
+	it('allows attaching below the cap', () => {
+		expect(canAttachChatFile(0)).toBe(true);
+		expect(canAttachChatFile(MAX_CHAT_ATTACHED_FILES - 1)).toBe(true);
+	});
+
+	it('blocks the 17th attach at and above the cap', () => {
+		expect(canAttachChatFile(MAX_CHAT_ATTACHED_FILES)).toBe(false);
+		expect(canAttachChatFile(MAX_CHAT_ATTACHED_FILES + 1)).toBe(false);
+	});
+});
+
+describe('selectFileIdsForSend', () => {
+	it('returns undefined for an empty panel', () => {
+		expect(selectFileIdsForSend([])).toBeUndefined();
+	});
+
+	it("excludes 'failed' files", () => {
+		const files = [meta('a', 'ready'), meta('b', 'failed'), meta('c', 'ready')];
+		expect(selectFileIdsForSend(files)).toEqual(['a', 'c']);
+	});
+
+	it("keeps 'pending' and 'processing' files (backend skips not-yet-ready gracefully)", () => {
+		const files = [meta('a', 'pending'), meta('b', 'processing'), meta('c', 'ready')];
+		expect(selectFileIdsForSend(files)).toEqual(['a', 'b', 'c']);
+	});
+
+	it('keeps files with no status yet (just-uploaded)', () => {
+		expect(selectFileIdsForSend([meta('a', undefined)])).toEqual(['a']);
+	});
+
+	it('returns undefined when every file failed', () => {
+		const files = [meta('a', 'failed'), meta('b', 'failed')];
+		expect(selectFileIdsForSend(files)).toBeUndefined();
+	});
+
+	it('defensively slices to the 16 cap', () => {
+		const files = Array.from({ length: 20 }, (_, i) => meta(`f${i}`, 'ready'));
+		const ids = selectFileIdsForSend(files);
+		expect(ids).toHaveLength(MAX_CHAT_ATTACHED_FILES);
+		expect(ids?.[0]).toBe('f0');
+		expect(ids?.[MAX_CHAT_ATTACHED_FILES - 1]).toBe('f15');
+	});
+
+	it('drops failed files before applying the cap', () => {
+		// 17 files where one failed → the 16 non-failed all fit.
+		const files = [
+			meta('bad', 'failed'),
+			...Array.from({ length: 16 }, (_, i) => meta(`f${i}`, 'ready'))
+		];
+		const ids = selectFileIdsForSend(files);
+		expect(ids).toHaveLength(16);
+		expect(ids).not.toContain('bad');
+	});
+});

--- a/web/src/lib/lq-ai/__tests__/files-api.test.ts
+++ b/web/src/lib/lq-ai/__tests__/files-api.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for the shared file ingestion-status poll helper (PR #316
+ * review follow-ups F-5/F-6/F-8).
+ *
+ * Convention note: pure-function tests, no component mount (per the
+ * ChatPanel-slash-detect.test.ts header). The fetcher is injected via the
+ * `getFile` option so no fetch/auth mocking is needed; timers are faked so
+ * the 2 s poll interval costs nothing.
+ *
+ * Coverage:
+ *   - resolves with 'ready' / 'failed' outcomes on terminal states
+ *   - abort stops the loop promptly, mid-sleep, without another fetch
+ *   - a transient fetch rejection does not kill the loop
+ *   - exhausting maxAttempts resolves 'timeout' (never pretends success)
+ *   - an undefined ingestion_status is never reported over a known one
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { pollFileStatus } from '../api/files';
+import type { FileMeta, IngestionStatus } from '../types';
+
+function meta(status?: IngestionStatus): FileMeta {
+	return {
+		id: 'f1',
+		owner_id: 'u1',
+		filename: 'nda.pdf',
+		mime_type: 'application/pdf',
+		size_bytes: 2048,
+		ingestion_status: status,
+		created_at: '2026-01-01T00:00:00Z'
+	};
+}
+
+/** Fetcher that yields the given results in order (an Error entry rejects). */
+function fetcherOf(...results: Array<FileMeta | Error>) {
+	let i = 0;
+	return vi.fn(async (): Promise<FileMeta> => {
+		const next = results[Math.min(i, results.length - 1)];
+		i++;
+		if (next instanceof Error) throw next;
+		return next;
+	});
+}
+
+const INTERVAL = 2000;
+
+async function tick(times = 1): Promise<void> {
+	for (let i = 0; i < times; i++) {
+		await vi.advanceTimersByTimeAsync(INTERVAL);
+	}
+}
+
+describe('pollFileStatus', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.spyOn(console, 'error').mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("resolves 'ready' once the file reaches ready", async () => {
+		const getFile = fetcherOf(meta('pending'), meta('processing'), meta('ready'));
+		const promise = pollFileStatus('f1', { getFile, intervalMs: INTERVAL });
+		await tick(3);
+		const result = await promise;
+		expect(result.outcome).toBe('ready');
+		expect(result.file?.ingestion_status).toBe('ready');
+		expect(getFile).toHaveBeenCalledTimes(3);
+	});
+
+	it("resolves 'failed' once the file reaches failed", async () => {
+		const getFile = fetcherOf(meta('pending'), meta('failed'));
+		const promise = pollFileStatus('f1', { getFile, intervalMs: INTERVAL });
+		await tick(2);
+		const result = await promise;
+		expect(result.outcome).toBe('failed');
+		expect(result.file?.ingestion_status).toBe('failed');
+	});
+
+	it('reports intermediate statuses via onStatus', async () => {
+		const getFile = fetcherOf(meta('processing'), meta('ready'));
+		const onStatus = vi.fn();
+		const promise = pollFileStatus('f1', { getFile, intervalMs: INTERVAL, onStatus });
+		await tick(2);
+		await promise;
+		expect(onStatus.mock.calls.map(([f]) => f.ingestion_status)).toEqual(['processing', 'ready']);
+	});
+
+	it('aborts promptly mid-sleep without another fetch', async () => {
+		const getFile = fetcherOf(meta('pending'));
+		const controller = new AbortController();
+		const promise = pollFileStatus('f1', {
+			getFile,
+			intervalMs: INTERVAL,
+			signal: controller.signal
+		});
+		// Abort during the first sleep — the loop must resolve with NO timer
+		// advance at all (i.e. it does not wait out the 2 s interval).
+		controller.abort();
+		const result = await promise;
+		expect(result).toEqual({ outcome: 'aborted', file: undefined });
+		expect(getFile).not.toHaveBeenCalled();
+	});
+
+	it('keeps the last known file when aborted after a successful fetch', async () => {
+		const getFile = fetcherOf(meta('processing'));
+		const controller = new AbortController();
+		const promise = pollFileStatus('f1', {
+			getFile,
+			intervalMs: INTERVAL,
+			signal: controller.signal
+		});
+		await tick(1); // one successful 'processing' fetch, now in second sleep
+		controller.abort();
+		const result = await promise;
+		expect(result.outcome).toBe('aborted');
+		expect(result.file?.ingestion_status).toBe('processing');
+	});
+
+	it('survives a transient fetch rejection and keeps polling', async () => {
+		const getFile = fetcherOf(new Error('network blip'), meta('ready'));
+		const promise = pollFileStatus('f1', { getFile, intervalMs: INTERVAL });
+		await tick(2);
+		const result = await promise;
+		expect(result.outcome).toBe('ready');
+		expect(getFile).toHaveBeenCalledTimes(2);
+	});
+
+	it("resolves 'timeout' after maxAttempts instead of pretending success", async () => {
+		const getFile = fetcherOf(meta('pending'));
+		const promise = pollFileStatus('f1', { getFile, intervalMs: INTERVAL, maxAttempts: 3 });
+		await tick(3);
+		const result = await promise;
+		expect(result.outcome).toBe('timeout');
+		// Last known (non-terminal) status is preserved, not fabricated.
+		expect(result.file?.ingestion_status).toBe('pending');
+		expect(getFile).toHaveBeenCalledTimes(3);
+	});
+
+	it('never reports an undefined status over a previously known one', async () => {
+		const getFile = fetcherOf(meta('processing'), meta(undefined), meta('ready'));
+		const onStatus = vi.fn();
+		const promise = pollFileStatus('f1', { getFile, intervalMs: INTERVAL, onStatus });
+		await tick(3);
+		const result = await promise;
+		expect(result.outcome).toBe('ready');
+		// The undefined-status response was skipped entirely.
+		expect(onStatus.mock.calls.map(([f]) => f.ingestion_status)).toEqual(['processing', 'ready']);
+	});
+
+	it('keeps the last defined status when timing out through undefined responses', async () => {
+		const getFile = fetcherOf(meta('processing'), meta(undefined));
+		const promise = pollFileStatus('f1', { getFile, intervalMs: INTERVAL, maxAttempts: 2 });
+		await tick(2);
+		const result = await promise;
+		expect(result.outcome).toBe('timeout');
+		expect(result.file?.ingestion_status).toBe('processing');
+	});
+});

--- a/web/src/lib/lq-ai/api/files.ts
+++ b/web/src/lib/lq-ai/api/files.ts
@@ -1,9 +1,11 @@
 /**
- * /api/v1/files — multipart upload + metadata + soft-delete.
+ * /api/v1/files — multipart upload + metadata + soft-delete, plus the shared
+ * ingestion-status poll helper.
  *
  * Project-scoped attach uses /api/v1/projects/{id}/files (per backend
- * OpenAPI sketch C7); chat-scoped attach is wired client-side in M1 — the
- * backend endpoint shape for chat-attached files is TBD post-M1.
+ * OpenAPI sketch C7); chat-scoped attach is client-side panel state whose
+ * file ids are sent as `file_ids` on POST /chats/{id}/messages (ChatPanel /
+ * selectFileIdsForSend).
  */
 import { apiRequest } from './client';
 import type { FileMeta } from '../types';
@@ -42,6 +44,95 @@ export async function attachFileToProject(
 		method: 'POST',
 		body: { file_id: fileId }
 	});
+}
+
+// ---- ingestion-status polling ----
+
+export type FileStatusPollOutcome = 'ready' | 'failed' | 'timeout' | 'aborted';
+
+export interface FileStatusPollResult {
+	outcome: FileStatusPollOutcome;
+	/** Last metadata fetched with a defined ingestion_status, if any. */
+	file?: FileMeta;
+}
+
+export interface PollFileStatusOptions {
+	/** Stop condition; defaults to the terminal ingestion states (ready/failed). */
+	until?: (file: FileMeta) => boolean;
+	intervalMs?: number;
+	maxAttempts?: number;
+	/** Stops the loop promptly, including mid-sleep. */
+	signal?: AbortSignal;
+	/** Fetcher override (tests inject a fake here). */
+	getFile?: (id: string) => Promise<FileMeta>;
+	/** Called on each fetch that carried a defined status, so callers can patch UI state. */
+	onStatus?: (file: FileMeta) => void;
+}
+
+// Resolves (never rejects) either after `ms` or as soon as `signal` aborts.
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		if (signal?.aborted) {
+			resolve();
+			return;
+		}
+		const timer = setTimeout(done, ms);
+		function done(): void {
+			clearTimeout(timer);
+			signal?.removeEventListener('abort', done);
+			resolve();
+		}
+		signal?.addEventListener('abort', done, { once: true });
+	});
+}
+
+const isTerminal = (f: FileMeta): boolean =>
+	f.ingestion_status === 'ready' || f.ingestion_status === 'failed';
+
+/**
+ * Poll a file's ingestion status until `until` is satisfied (default: a
+ * terminal 'ready'/'failed' state), the signal aborts, or `maxAttempts` is
+ * exhausted — the last resolves with a distinct 'timeout' outcome rather
+ * than pretending success. A transient fetch error does not kill the loop,
+ * and a response with an undefined ingestion_status is skipped so it never
+ * overwrites a previously known status.
+ */
+export async function pollFileStatus(
+	id: string,
+	opts: PollFileStatusOptions = {}
+): Promise<FileStatusPollResult> {
+	const {
+		until = isTerminal,
+		intervalMs = 2000,
+		maxAttempts = 40,
+		signal,
+		getFile: fetchFile = getFile,
+		onStatus
+	} = opts;
+	let lastKnown: FileMeta | undefined;
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		await abortableSleep(intervalMs, signal);
+		if (signal?.aborted) return { outcome: 'aborted', file: lastKnown };
+		let latest: FileMeta;
+		try {
+			latest = await fetchFile(id);
+		} catch (e) {
+			if (signal?.aborted) return { outcome: 'aborted', file: lastKnown };
+			console.error('lq-ai: file status poll failed', e);
+			continue; // transient — keep polling
+		}
+		if (signal?.aborted) return { outcome: 'aborted', file: lastKnown };
+		if (latest.ingestion_status === undefined) continue; // never patch over a known status
+		lastKnown = latest;
+		onStatus?.(latest);
+		if (until(latest)) {
+			return {
+				outcome: latest.ingestion_status === 'failed' ? 'failed' : 'ready',
+				file: latest
+			};
+		}
+	}
+	return { outcome: 'timeout', file: lastKnown };
 }
 
 /**

--- a/web/src/lib/lq-ai/chat/attachedFiles.ts
+++ b/web/src/lib/lq-ai/chat/attachedFiles.ts
@@ -1,0 +1,33 @@
+/** Pure helpers for chat-attached files (PR #316 review follow-ups). No Svelte, no network. */
+
+import type { FileMeta } from '../types';
+
+/**
+ * Maximum chat-attached files per message send. Mirrors
+ * MESSAGE_FILE_IDS_MAX_LEN in api/app/schemas/chats.py — the backend rejects
+ * the whole send with a 422 when `file_ids` exceeds this, so the attach path
+ * enforces it client-side instead of failing at send time.
+ */
+export const MAX_CHAT_ATTACHED_FILES = 16;
+
+/** Attach guard: false once the panel already holds the cap. */
+export function canAttachChatFile(attachedCount: number): boolean {
+	return attachedCount < MAX_CHAT_ATTACHED_FILES;
+}
+
+/**
+ * Build the `file_ids` payload from the panel's attached files.
+ *
+ * Excludes 'failed' files — they can never contribute text. Keeps
+ * pending/processing files: the backend skips not-yet-ready files gracefully,
+ * and dropping them would silently ignore a just-attached document.
+ * Defensively slices to the cap, and returns undefined when the result is
+ * empty so the field is omitted from the payload.
+ */
+export function selectFileIdsForSend(files: FileMeta[]): string[] | undefined {
+	const ids = files
+		.filter((f) => f.ingestion_status !== 'failed')
+		.slice(0, MAX_CHAT_ATTACHED_FILES)
+		.map((f) => f.id);
+	return ids.length > 0 ? ids : undefined;
+}

--- a/web/src/lib/lq-ai/components/AttachedFilesPanel.svelte
+++ b/web/src/lib/lq-ai/components/AttachedFilesPanel.svelte
@@ -15,10 +15,15 @@
 	 * nothing for empty citation arrays — see MessageBubble's docstring).
 	 */
 	import type { FileMeta } from '../types';
+	import { MAX_CHAT_ATTACHED_FILES } from '../chat/attachedFiles';
 
 	export let chatFiles: FileMeta[] = [];
 	export let projectFiles: FileMeta[] = [];
 	export let uploading: boolean = false;
+	// True when the chat already holds MAX_CHAT_ATTACHED_FILES files — the
+	// backend rejects sends above the cap, so the attach affordance is
+	// disabled with an inline notice instead of failing at send time.
+	export let attachLimitReached: boolean = false;
 	export let onUpload: (file: File) => void = () => undefined;
 	export let onDetach: (file: FileMeta) => void = () => undefined;
 
@@ -62,11 +67,16 @@
 		type="button"
 		class="lq-btn-secondary text-sm font-medium disabled:opacity-50"
 		on:click={() => fileInput?.click()}
-		disabled={uploading}
+		disabled={uploading || attachLimitReached}
 		data-testid="lq-ai-upload-btn"
 	>
 		{uploading ? 'Uploading…' : '+ Files'}
 	</button>
+	{#if attachLimitReached}
+		<p class="text-xs lq-subtext" data-testid="lq-ai-attach-limit-notice">
+			Limit of {MAX_CHAT_ATTACHED_FILES} files per chat reached — detach one to add another.
+		</p>
+	{/if}
 	<input
 		bind:this={fileInput}
 		type="file"

--- a/web/src/lib/lq-ai/components/ChatPanel.svelte
+++ b/web/src/lib/lq-ai/components/ChatPanel.svelte
@@ -61,7 +61,7 @@
 	 * surfaced per-message.
 	 */
 	import { get } from 'svelte/store';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 
 	import {
@@ -84,6 +84,7 @@
 	} from '$lib/lq-ai/stores';
 	import { consumeMessageStream } from '$lib/lq-ai/sse/parser';
 	import { buildAuthorizeUrl, type PendingGate } from '$lib/lq-ai/chat/toolGate';
+	import { canAttachChatFile, selectFileIdsForSend } from '$lib/lq-ai/chat/attachedFiles';
 	import type { Chat, FileMeta, Message, Project, Skill } from '$lib/lq-ai/types';
 
 	import ChatSidebar from '$lib/lq-ai/components/ChatSidebar.svelte';
@@ -169,6 +170,20 @@
 	let chatFiles: FileMeta[] = [];
 	let projectFiles: FileMeta[] = [];
 	let uploading = false;
+
+	// In-flight ingestion-status polls, keyed by file id, so detach, chat
+	// switch, and teardown can stop them (files attached in chat A must not
+	// keep polling — or get sent — after switching to chat B).
+	let filePollAborts: Record<string, AbortController> = {};
+
+	function abortFilePolls(): void {
+		for (const controller of Object.values(filePollAborts)) controller.abort();
+		filePollAborts = {};
+	}
+
+	onDestroy(abortFilePolls);
+
+	$: attachLimitReached = !canAttachChatFile(chatFiles.length);
 
 	let streamingMessageId: string | null = null;
 	let streamAbort: AbortController | null = null;
@@ -330,6 +345,10 @@
 		attachedSkillNames = [];
 		attachmentSources = {};
 		skillInputs = {};
+		// Attached files are per-chat draft state too — reset them (and stop
+		// their status polls) so chat A's files are never sent from chat B.
+		abortFilePolls();
+		chatFiles = [];
 		// Load messages.
 		try {
 			const page = await messagesApi.listMessages(chat.id, { limit: 100 });
@@ -436,12 +455,19 @@
 
 	// ---- file panel handlers ----
 	async function uploadAttached(file: File) {
+		// The backend 422s the whole send when file_ids exceeds the cap
+		// (MESSAGE_FILE_IDS_MAX_LEN), so block the attach up front; the panel
+		// shows the limit notice + disables the upload button in parallel.
+		if (!canAttachChatFile(chatFiles.length)) return;
 		uploading = true;
 		try {
 			const uploaded = await filesApi.uploadFile(file, {
 				project_id: $activeChatStore?.project_id ?? undefined
 			});
 			chatFiles = [...chatFiles, uploaded];
+			// Ingestion is async; poll so the chip flips pending -> ready (or
+			// failed) instead of showing a stale "pending" forever.
+			void pollAttachedStatus(uploaded.id);
 		} catch (e) {
 			console.error('lq-ai: upload failed', e);
 		} finally {
@@ -449,9 +475,37 @@
 		}
 	}
 
+	// Poll a chat-attached file's ingestion status until it reaches a terminal
+	// state, patching the matching chatFiles entry so the panel chip updates.
+	// The per-file AbortController stops the loop on detach, chat switch, and
+	// component teardown (abortFilePolls / onDestroy).
+	async function pollAttachedStatus(id: string): Promise<void> {
+		const controller = new AbortController();
+		filePollAborts[id]?.abort();
+		filePollAborts = { ...filePollAborts, [id]: controller };
+		const result = await filesApi.pollFileStatus(id, {
+			signal: controller.signal,
+			onStatus: (latest) => {
+				chatFiles = chatFiles.map((f) =>
+					f.id === id ? { ...f, ingestion_status: latest.ingestion_status } : f
+				);
+			}
+		});
+		if (filePollAborts[id] === controller) {
+			const next = { ...filePollAborts };
+			delete next[id];
+			filePollAborts = next;
+		}
+		if (result.outcome === 'timeout') {
+			// Leave the last known status in place — don't fabricate 'failed'.
+			console.warn('lq-ai: file ingestion status poll timed out', id);
+		}
+	}
+
 	async function detachFile(file: FileMeta) {
 		// Per the spec the M1 attached-files panel manages chat-local state;
 		// the full file-row is left in place and can be re-attached later.
+		filePollAborts[file.id]?.abort();
 		chatFiles = chatFiles.filter((f) => f.id !== file.id);
 	}
 
@@ -641,6 +695,11 @@
 					// Issue #207 finding 4 — only send set_sticky on a real toggle
 					// change; otherwise leave the chat's sticky set unchanged.
 					set_sticky: stickyDirty ? stickyEnabled : undefined,
+					// Chat-scoped attached files — the backend injects each ready
+					// file's canonical text as a system block (chats.py). Ownership
+					// is validated server-side; files with no text are skipped.
+					// selectFileIdsForSend drops 'failed' files and caps at 16.
+					file_ids: selectFileIdsForSend(chatFiles),
 					stream: true
 				},
 				streamAbort.signal
@@ -1164,6 +1223,7 @@
 			{chatFiles}
 			{projectFiles}
 			{uploading}
+			{attachLimitReached}
 			onUpload={uploadAttached}
 			onDetach={detachFile}
 		/>

--- a/web/src/lib/lq-ai/components/ChatPanel.svelte
+++ b/web/src/lib/lq-ai/components/ChatPanel.svelte
@@ -459,11 +459,18 @@
 		// (MESSAGE_FILE_IDS_MAX_LEN), so block the attach up front; the panel
 		// shows the limit notice + disables the upload button in parallel.
 		if (!canAttachChatFile(chatFiles.length)) return;
+		// The active chat can change while the upload is in flight; capture the
+		// target so chat A's file is never appended to (or sent from) chat B.
+		const targetChatId = $activeChatStore?.id ?? null;
 		uploading = true;
 		try {
 			const uploaded = await filesApi.uploadFile(file, {
 				project_id: $activeChatStore?.project_id ?? undefined
 			});
+			// Re-check after the await: the chat may have changed, and a
+			// parallel upload may have taken the last slot under the cap.
+			if (($activeChatStore?.id ?? null) !== targetChatId) return;
+			if (!canAttachChatFile(chatFiles.length)) return;
 			chatFiles = [...chatFiles, uploaded];
 			// Ingestion is async; poll so the chip flips pending -> ready (or
 			// failed) instead of showing a stale "pending" forever.
@@ -472,6 +479,8 @@
 			console.error('lq-ai: upload failed', e);
 		} finally {
 			uploading = false;
+		}
+	}
 		}
 	}
 

--- a/web/src/lib/lq-ai/components/ChatPanel.svelte
+++ b/web/src/lib/lq-ai/components/ChatPanel.svelte
@@ -481,8 +481,6 @@
 			uploading = false;
 		}
 	}
-		}
-	}
 
 	// Poll a chat-attached file's ingestion status until it reaches a terminal
 	// state, patching the matching chatFiles entry so the panel chip updates.

--- a/web/src/lib/lq-ai/types.ts
+++ b/web/src/lib/lq-ai/types.ts
@@ -370,6 +370,13 @@ export interface MessageCreate {
 	 * `false` clears the set; omitted leaves it unchanged. Off by default.
 	 */
 	set_sticky?: boolean | null;
+	/**
+	 * Chat-scoped attached file ids (owner's file UUIDs). The backend
+	 * (chats.py `_load_attached_file_contexts`) loads each file's
+	 * `Document.normalized_content` and injects it as a system message so
+	 * the model can review the full document. Capped at 16 server-side.
+	 */
+	file_ids?: string[];
 }
 
 export interface MessagePostResponse {


### PR DESCRIPTION
## Summary

Wires the chat **Attached files** panel into the send path so an attached document actually reaches the model. The backend already fully supports this — `MessageCreateRequest.file_ids` is validated (`_validate_owned_file_ids`), loads each file's `Document.normalized_content`, and injects it as a system message (`chats.py` `_load_attached_file_contexts` → `_format_attached_files_block`). But the web composer never sent `file_ids` and never polled the upload status, so:

- the per-file status chip stayed on **`pending`** forever (set once from the upload response, never re-fetched), and
- **Send never included `file_ids`**, so attached documents never reached the model (the composer payload carried only `content/model/attached_skills/skill_inputs/set_sticky/stream`).

**Anchor:** PRD §3.1 — the per-message `file_ids` contract (docs/PRD.md, "Chat" capability: per-message `file_ids`, 16-file cap, server-side ownership validation) and the §3.1 user story for attaching documents in chat; the backend half is listed implemented in HONEST-STATE. This PR wires the already-contracted client half. Also completes the documented M1 TODO in `web/src/lib/lq-ai/api/files.ts`. **Frontend-only; no backend, schema, or migration changes.**

## Changes

- `web/src/lib/lq-ai/types.ts` — add `file_ids?: string[]` to `MessageCreate`.
- `web/src/lib/lq-ai/chat/attachedFiles.ts` (new) — pure helpers: `MAX_CHAT_ATTACHED_FILES = 16` (mirrors `MESSAGE_FILE_IDS_MAX_LEN` in `api/app/schemas/chats.py`), `canAttachChatFile()`, and `selectFileIdsForSend()` (drops `failed` files, keeps pending ones, slices to the cap, omits the field when empty).
- `web/src/lib/lq-ai/api/files.ts` — shared, abortable `pollFileStatus(id, { until, intervalMs, maxAttempts, signal, getFile, onStatus })` helper with a distinct `timeout` outcome; a transient fetch error keeps polling; an undefined status never overwrites a known one. Stale M1 header comment updated.
- `web/src/lib/lq-ai/components/ChatPanel.svelte`
  - include `file_ids: selectFileIdsForSend(chatFiles)` in the `sendMessageStream` payload;
  - after `uploadAttached()`, poll via `pollFileStatus` so the chip flips `pending → ready`/`failed`; polls are keyed by file id with `AbortController`s aborted on detach, on chat switch, and in `onDestroy`;
  - `selectChat()` now resets `chatFiles` (and aborts in-flight polls) alongside the other per-chat draft state, so files attached in one chat are never sent from another;
  - attach path short-circuits at the 16-file cap.
- `web/src/lib/lq-ai/components/AttachedFilesPanel.svelte` — disables the upload button at the cap and renders an inline notice, instead of a silent 422 dead send.

## Testing

- New vitest coverage (19 tests, no-component-mount pattern per `ChatPanel-slash-detect.test.ts`): `pollFileStatus` under fake timers (ready/failed resolution, prompt mid-sleep abort, transient-error survival, timeout outcome, undefined-status skipping) and `selectFileIdsForSend`/cap helpers (undefined-when-empty, failed excluded, pending kept, slice at 16).
- Gates: `npm run check:lq-ai` → 665 files, 0 errors; `npx vitest run src/lib/lq-ai` → 73 files / 625 tests passed.
- Earlier revision verified end-to-end against a local stack: upload a PDF → chip flips `pending → ready` → send → response echoes `applied_file_ids` and the answer reflects the document contents. Maintainer smoke-test of the current revision is welcome (see review follow-up comment).

## Out of scope

Persisting chat-attached files across a page reload (`chatFiles` re-initialises to `[]` on load with no reload path) — a separate follow-up. Migrating the two pre-existing route-level poll loops (`playbooks/easy`, `knowledge/[id]`) onto `pollFileStatus` — follow-up refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #316** — same head commit (`bf8ea38973f1`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
