### PR TITLE
DE-322: validate playbook/KB FK ownership on schedule, watch, and run-now

### DIFF
--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -198,12 +198,18 @@ async def _load_owned_project(
     existence disclosure — same idiom as the autonomous loaders. The
     autonomous layer never reveals another user's Projects.
 
+    ``archived_at IS NULL`` matches :func:`app.api.projects._load_visible_project`,
+    which excludes archived rows by default: a matter the caller has deleted is
+    gone from their UI and must not be re-attachable as an autonomous target.
+
     Raises:
-        HTTPException: 404 if the row is absent or owned by a different user.
+        HTTPException: 404 if the row is absent, archived, or owned by a
+        different user.
     """
     stmt = select(Project).where(
         Project.id == project_id,
         Project.owner_id == user_id,
+        Project.archived_at.is_(None),
     )
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
@@ -227,12 +233,20 @@ async def _load_owned_kb(
     Conservative per-user isolation: KB-sharing is out of scope for the
     autonomous layer, so only the KB's owner may target it.
 
+    ``archived_at IS NULL`` matches :func:`app.api.knowledge_bases._load_visible_kb`.
+    ``DELETE /kb/{id}`` sets ``archived_at``, after which the KB 404s on its own
+    endpoint and disappears from the owner's UI; without this predicate it could
+    still be attached as a schedule/watch/run-now target and silently resurrected
+    as a live recurring retrieval source.
+
     Raises:
-        HTTPException: 404 if the row is absent or owned by a different user.
+        HTTPException: 404 if the row is absent, archived, or owned by a
+        different user.
     """
     stmt = select(KnowledgeBase).where(
         KnowledgeBase.id == kb_id,
         KnowledgeBase.owner_id == user_id,
+        KnowledgeBase.archived_at.is_(None),
     )
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:

--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -72,6 +72,7 @@ from app.models.autonomous import (
 from app.models.chat import Chat
 from app.models.document import Document
 from app.models.knowledge import KnowledgeBase
+from app.models.playbook import Playbook
 from app.models.project import Project
 from app.models.user import User
 from app.schemas.autonomous import (
@@ -211,6 +212,71 @@ async def _load_owned_project(
             detail="project not found",
         )
     return row
+
+
+async def _load_owned_kb(
+    db: AsyncSession,
+    *,
+    kb_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> KnowledgeBase:
+    """Fetch a KnowledgeBase by id; 404 if missing OR not owned by the caller.
+
+    Conflates "doesn't exist" and "belongs to someone else" to avoid
+    existence disclosure — same idiom as :func:`_load_owned_project`.
+    Conservative per-user isolation: KB-sharing is out of scope for the
+    autonomous layer, so only the KB's owner may target it.
+
+    Raises:
+        HTTPException: 404 if the row is absent or owned by a different user.
+    """
+    stmt = select(KnowledgeBase).where(
+        KnowledgeBase.id == kb_id,
+        KnowledgeBase.owner_id == user_id,
+    )
+    row = (await db.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="knowledge base not found",
+        )
+    return row
+
+
+async def _load_visible_playbook(
+    db: AsyncSession,
+    *,
+    playbook_id: uuid.UUID,
+    user: User,
+) -> Playbook:
+    """Fetch a playbook by id, applying the read-visibility predicate.
+
+    Mirrors :func:`app.api.playbooks._load_visible_playbook` exactly —
+    the rule the execute endpoint applies:
+
+    * Admins see every non-deleted playbook.
+    * Non-admins see playbooks they authored OR built-ins
+      (``created_by IS NULL``).
+    * Soft-deleted rows (``deleted_at IS NOT NULL``) are invisible to
+      everyone, including admins.
+
+    Raises:
+        HTTPException: 404 if the row is absent, soft-deleted, or
+            authored by a different non-admin user (collapsed into 404 —
+            not 403 — to avoid existence disclosure via id-probing).
+    """
+    playbook = await db.get(Playbook, playbook_id)
+    if playbook is None or playbook.deleted_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="playbook not found",
+        )
+    if not user.is_admin and playbook.created_by is not None and playbook.created_by != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="playbook not found",
+        )
+    return playbook
 
 
 async def _load_owned_proposal(
@@ -1298,7 +1364,7 @@ async def reject_project_context_proposal(
     responses={
         201: {"description": "Schedule created"},
         422: {"description": "Invalid cron expression"},
-        404: {"description": "Referenced project not found"},
+        404: {"description": "Referenced project, playbook, or knowledge base not found"},
         401: {"description": "Not authenticated"},
     },
 )
@@ -1313,7 +1379,10 @@ async def create_schedule(
     Validates ``cron_expr`` via :func:`~app.autonomous.cron.validate_cron_expr`
     (invalid → 422), creates the schedule row, and seeds
     ``next_run_at = next_run_after(cron_expr, now(UTC))`` so the
-    dispatcher's first eligible tick can pick it up.  Returns the created
+    dispatcher's first eligible tick can pick it up.  Non-null FK targets
+    are validated (DE-322): ``project_id`` and ``target_kb_id`` must be
+    owned by the caller; ``playbook_id`` must be visible to the caller
+    (own or built-in) — otherwise 404.  Returns the created
     :class:`~app.schemas.autonomous.AutonomousScheduleRead` (201).
 
     Audited.
@@ -1330,6 +1399,13 @@ async def create_schedule(
     # is rejected 404 (id-probing-safe). NULL = no matter; no check needed.
     if body.project_id is not None:
         await _load_owned_project(db, project_id=body.project_id, user_id=user.id)
+
+    # Validate target FKs (DE-322) — a playbook the caller cannot see or a
+    # KB the caller doesn't own is rejected 404 (id-probing-safe).
+    if body.playbook_id is not None:
+        await _load_visible_playbook(db, playbook_id=body.playbook_id, user=user)
+    if body.target_kb_id is not None:
+        await _load_owned_kb(db, kb_id=body.target_kb_id, user_id=user.id)
 
     now = datetime.now(UTC)
     schedule = AutonomousSchedule(
@@ -1365,7 +1441,7 @@ async def create_schedule(
 async def _spawn_manual_session(
     db: AsyncSession,
     *,
-    user_id: uuid.UUID,
+    user: User,
     body: AutonomousManualRunRequest,
     enqueue: Callable[[uuid.UUID], Awaitable[bool]] | None = None,
 ) -> AutonomousSession:
@@ -1387,7 +1463,14 @@ async def _spawn_manual_session(
     # Validate matter ownership — a non-null project_id the caller doesn't own
     # is rejected 404 (id-probing-safe). NULL = no matter; no check needed.
     if body.project_id is not None:
-        await _load_owned_project(db, project_id=body.project_id, user_id=user_id)
+        await _load_owned_project(db, project_id=body.project_id, user_id=user.id)
+
+    # Validate target FKs (DE-322) — a playbook the caller cannot see or a
+    # KB the caller doesn't own is rejected 404 (id-probing-safe).
+    if body.playbook_id is not None:
+        await _load_visible_playbook(db, playbook_id=body.playbook_id, user=user)
+    if body.target_kb_id is not None:
+        await _load_owned_kb(db, kb_id=body.target_kb_id, user_id=user.id)
 
     params: dict[str, object] = {"since": None}
     if body.target_kb_id is not None:
@@ -1402,7 +1485,7 @@ async def _spawn_manual_session(
         params["emit_artifacts"] = True
 
     session = AutonomousSession(
-        user_id=user_id,
+        user_id=user.id,
         project_id=body.project_id,
         trigger_kind="manual",
         trigger_ref=None,
@@ -1428,7 +1511,7 @@ async def _spawn_manual_session(
         201: {"description": "Session spawned"},
         403: {"description": "Autonomous layer not enabled for this user"},
         422: {"description": "Invalid target (need exactly one of playbook_id/skill_ref)"},
-        404: {"description": "Referenced project not found"},
+        404: {"description": "Referenced project, playbook, or knowledge base not found"},
         401: {"description": "Not authenticated"},
     },
 )
@@ -1446,7 +1529,7 @@ async def run_now(
     session runs under the same R4/R5/R6 brakes as every other session.
     Audited.
     """
-    session = await _spawn_manual_session(db, user_id=user.id, body=body)
+    session = await _spawn_manual_session(db, user=user, body=body)
     await audit_action(
         db,
         user_id=user.id,
@@ -1517,7 +1600,7 @@ async def list_schedules(
     response_model=AutonomousScheduleRead,
     summary="Partially update an autonomous schedule (edit / enable / disable)",
     responses={
-        404: {"description": "Schedule or referenced project not found"},
+        404: {"description": "Schedule, referenced project, playbook, or knowledge base not found"},
         422: {"description": "Invalid cron expression"},
         401: {"description": "Not authenticated"},
     },
@@ -1563,11 +1646,19 @@ async def update_schedule(
         # explicit null is a no-op rather than a constraint violation.
         schedule.emit_artifacts = fields["emit_artifacts"]
     if "playbook_id" in fields:
-        schedule.playbook_id = fields["playbook_id"]
+        new_playbook_id = fields["playbook_id"]
+        if new_playbook_id is not None:
+            # DE-322: a playbook the caller cannot see → 404 (id-probing-safe).
+            await _load_visible_playbook(db, playbook_id=new_playbook_id, user=user)
+        schedule.playbook_id = new_playbook_id  # explicit null clears the target
     if "skill_ref" in fields:
         schedule.skill_ref = fields["skill_ref"]
     if "target_kb_id" in fields:
-        schedule.target_kb_id = fields["target_kb_id"]
+        new_target_kb_id = fields["target_kb_id"]
+        if new_target_kb_id is not None:
+            # DE-322: a KB the caller doesn't own → 404 (id-probing-safe).
+            await _load_owned_kb(db, kb_id=new_target_kb_id, user_id=user.id)
+        schedule.target_kb_id = new_target_kb_id  # explicit null clears the target
     if "project_id" in fields:
         new_project_id = fields["project_id"]
         if new_project_id is not None:
@@ -1653,7 +1744,7 @@ async def delete_schedule(
     summary="Create an autonomous watch (KB-arrival-triggered run definition)",
     responses={
         201: {"description": "Watch created"},
-        404: {"description": "Target knowledge base or referenced project not found"},
+        404: {"description": "Target knowledge base, referenced project, or playbook not found"},
         401: {"description": "Not authenticated"},
     },
 )
@@ -1668,28 +1759,26 @@ async def create_watch(
     Validates the caller **owns** the target ``knowledge_base_id``
     (``KnowledgeBase.owner_id == user.id``) — a KB the caller cannot see
     returns 404 (conservative per-user isolation; KB-sharing is out of
-    scope). Creates the watch row. Returns the created
+    scope). A non-null ``playbook_id`` must be visible to the caller
+    (own or built-in; DE-322) — otherwise 404. Creates the watch row.
+    Returns the created
     :class:`~app.schemas.autonomous.AutonomousWatchRead` (201).
 
     Audited.
     """
     # Validate KB ownership — 404 (not 403) on a KB the caller doesn't own,
     # same existence-disclosure posture as the autonomous loaders.
-    kb_stmt = select(KnowledgeBase).where(
-        KnowledgeBase.id == body.knowledge_base_id,
-        KnowledgeBase.owner_id == user.id,
-    )
-    kb = (await db.execute(kb_stmt)).scalar_one_or_none()
-    if kb is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="knowledge base not found",
-        )
+    await _load_owned_kb(db, kb_id=body.knowledge_base_id, user_id=user.id)
 
     # Validate matter ownership — a non-null project_id the caller doesn't own
     # is rejected 404 (id-probing-safe). NULL = no matter; no check needed.
     if body.project_id is not None:
         await _load_owned_project(db, project_id=body.project_id, user_id=user.id)
+
+    # Validate the target playbook (DE-322) — a playbook the caller cannot
+    # see is rejected 404 (id-probing-safe).
+    if body.playbook_id is not None:
+        await _load_visible_playbook(db, playbook_id=body.playbook_id, user=user)
 
     watch = AutonomousWatch(
         user_id=user.id,
@@ -1779,7 +1868,7 @@ async def list_watches(
     response_model=AutonomousWatchRead,
     summary="Partially update an autonomous watch (enable / disable / retarget)",
     responses={
-        404: {"description": "Watch or referenced project not found"},
+        404: {"description": "Watch, referenced project, or playbook not found"},
         401: {"description": "Not authenticated"},
     },
 )
@@ -1811,7 +1900,11 @@ async def update_watch(
         # explicit null is a no-op rather than a constraint violation.
         watch.emit_artifacts = fields["emit_artifacts"]
     if "playbook_id" in fields:
-        watch.playbook_id = fields["playbook_id"]
+        new_playbook_id = fields["playbook_id"]
+        if new_playbook_id is not None:
+            # DE-322: a playbook the caller cannot see → 404 (id-probing-safe).
+            await _load_visible_playbook(db, playbook_id=new_playbook_id, user=user)
+        watch.playbook_id = new_playbook_id  # explicit null clears the target
     if "skill_ref" in fields:
         watch.skill_ref = fields["skill_ref"]
     if "project_id" in fields:

--- a/api/tests/autonomous/test_playbook_kb_fk_ownership.py
+++ b/api/tests/autonomous/test_playbook_kb_fk_ownership.py
@@ -43,6 +43,7 @@ from app.main import app
 from app.models.autonomous import AutonomousSchedule, AutonomousSession, AutonomousWatch
 from app.models.knowledge import KnowledgeBase
 from app.models.playbook import Playbook
+from app.models.project import Project
 from app.models.user import User
 from app.security import create_access_token, hash_password
 
@@ -689,6 +690,108 @@ async def test_run_now_foreign_kb_returns_404_no_session(
         (
             await db_session.execute(
                 select(AutonomousSession).where(AutonomousSession.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Archive predicate (DE-322 follow-up): a soft-deleted KB / project must not be
+# re-attachable as an autonomous target. `_load_owned_kb` and `_load_owned_project`
+# scoped by owner but not by `archived_at`, diverging from the house helpers
+# `_load_visible_kb` / `_load_visible_project`. Invisible to CI until now because
+# no fixture ever built an archived row.
+# ---------------------------------------------------------------------------
+
+
+async def _make_archived_kb(db: AsyncSession, *, owner: User) -> KnowledgeBase:
+    """An owned KB that the owner has since deleted (DELETE /kb sets archived_at)."""
+    kb = await _make_kb(db, owner=owner)
+    kb.archived_at = datetime.now(UTC)
+    await db.flush()
+    return kb
+
+
+async def _make_archived_project(db: AsyncSession, *, owner: User) -> Project:
+    project = Project(owner_id=owner.id, name="archived matter", slug=f"m-{uuid.uuid4().hex[:8]}")
+    db.add(project)
+    await db.flush()
+    project.archived_at = datetime.now(UTC)
+    await db.flush()
+    return project
+
+
+@pytest.mark.integration
+async def test_create_schedule_archived_kb_returns_404(
+    client: AsyncClient, db_session: AsyncSession, user_a: User
+) -> None:
+    """The owner's OWN archived KB is not a valid target — 404, no row.
+
+    Without `archived_at IS NULL` the row still matches on id+owner, so a KB the
+    user deleted would be silently resurrected as a recurring retrieval source.
+    """
+    archived = await _make_archived_kb(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "target_kb_id": str(archived.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousSchedule).where(AutonomousSchedule.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.integration
+async def test_create_watch_archived_kb_returns_404(
+    client: AsyncClient, db_session: AsyncSession, user_a: User
+) -> None:
+    """Same on the watch surface — the highest-frequency trigger path."""
+    archived = await _make_archived_kb(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(archived.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousWatch).where(AutonomousWatch.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.integration
+async def test_create_schedule_archived_project_returns_404(
+    client: AsyncClient, db_session: AsyncSession, user_a: User
+) -> None:
+    """`_load_owned_project` had the same omission — an archived matter must 404."""
+    archived = await _make_archived_project(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "project_id": str(archived.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousSchedule).where(AutonomousSchedule.user_id == user_a.id)
             )
         )
         .scalars()

--- a/api/tests/autonomous/test_playbook_kb_fk_ownership.py
+++ b/api/tests/autonomous/test_playbook_kb_fk_ownership.py
@@ -1,0 +1,697 @@
+"""Playbook + target-KB FK ownership validation across the autonomous
+schedule / watch / run-now surfaces (DE-322).
+
+Post-#133, ``project_id`` is validated on every assignment site, but
+``playbook_id`` and ``target_kb_id`` were still assigned unchecked. This
+file exercises the closed gap:
+
+* **Playbook** — a non-null ``playbook_id`` must be *visible* to the
+  caller under the execute endpoint's rule
+  (:func:`app.api.playbooks._load_visible_playbook`): own playbooks and
+  built-ins (``created_by IS NULL``) are accepted; another user's or a
+  soft-deleted playbook is rejected **404** (id-probing-safe) on
+  create_schedule, update_schedule, create_watch, update_watch, and the
+  run-now ``_spawn_manual_session``.
+* **Target KB** — a non-null ``target_kb_id`` must be *owned* by the
+  caller (same rule the watch's ``knowledge_base_id`` always had) on
+  create_schedule, update_schedule, and run-now.
+* On the update sites, the row MUST NOT be mutated when the foreign FK
+  is rejected; an explicit ``null`` still clears the target.
+
+Fixtures mirror ``test_project_reassign_ownership.py``: a per-file
+``client`` fixture overriding ``get_db`` onto the SAVEPOINT session,
+locally-built ``autonomous_enabled`` users, ``_bearer()`` headers, and a
+stubbed enqueue so run-now never touches Redis.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.api.autonomous as autonomous_api
+from app.db.session import get_db
+from app.main import app
+from app.models.autonomous import AutonomousSchedule, AutonomousSession, AutonomousWatch
+from app.models.knowledge import KnowledgeBase
+from app.models.playbook import Playbook
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture(autouse=True)
+def _stub_enqueue(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run-now enqueues onto arq; stub to an async no-op so missing Redis never errors."""
+    monkeypatch.setattr(
+        autonomous_api, "enqueue_autonomous_session_job", AsyncMock(return_value=True)
+    )
+
+
+async def _make_user(db: AsyncSession, *, suffix: str = "") -> User:
+    user = User(
+        email=f"fk-own-{suffix or uuid.uuid4().hex[:8]}@example.com",
+        display_name=f"FK Ownership User {suffix}".strip(),
+        hashed_password=hash_password("correct-horse-battery-staple"),
+        is_admin=False,
+        mfa_enabled=False,
+        must_change_password=False,
+        autonomous_enabled=True,  # mutate endpoints require opt-in
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def user_a(db_session: AsyncSession) -> User:
+    return await _make_user(db_session, suffix="a")
+
+
+@pytest_asyncio.fixture
+async def user_b(db_session: AsyncSession) -> User:
+    return await _make_user(db_session, suffix="b")
+
+
+def _bearer(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_playbook(
+    db: AsyncSession,
+    *,
+    created_by: uuid.UUID | None,
+    deleted_at: datetime | None = None,
+) -> Playbook:
+    """created_by=None mints a built-in (seed-style) playbook."""
+    playbook = Playbook(
+        name=f"FK Ownership Playbook {uuid.uuid4().hex[:8]}",
+        contract_type="NDA",
+        created_by=created_by,
+        deleted_at=deleted_at,
+    )
+    db.add(playbook)
+    await db.flush()
+    await db.refresh(playbook)
+    return playbook
+
+
+async def _make_kb(db: AsyncSession, *, owner: User) -> KnowledgeBase:
+    kb = KnowledgeBase(owner_id=owner.id, name="fk-own-kb")
+    db.add(kb)
+    await db.flush()
+    await db.refresh(kb)
+    return kb
+
+
+async def _make_schedule(
+    db: AsyncSession,
+    *,
+    user: User,
+    playbook_id: uuid.UUID | None = None,
+    target_kb_id: uuid.UUID | None = None,
+    cron_expr: str = "*/5 * * * *",
+) -> AutonomousSchedule:
+    sched = AutonomousSchedule(
+        user_id=user.id,
+        cron_expr=cron_expr,
+        enabled=True,
+        playbook_id=playbook_id,
+        target_kb_id=target_kb_id,
+    )
+    db.add(sched)
+    await db.flush()
+    await db.refresh(sched)
+    return sched
+
+
+async def _make_watch(
+    db: AsyncSession,
+    *,
+    user: User,
+    kb: KnowledgeBase,
+    playbook_id: uuid.UUID | None = None,
+) -> AutonomousWatch:
+    watch = AutonomousWatch(
+        user_id=user.id,
+        knowledge_base_id=kb.id,
+        enabled=True,
+        playbook_id=playbook_id,
+        deleted_at=None,
+    )
+    db.add(watch)
+    await db.flush()
+    await db.refresh(watch)
+    return watch
+
+
+# ===========================================================================
+# Schedule — create (playbook visibility + target-KB ownership)
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_create_schedule_owned_playbook_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    playbook = await _make_playbook(db_session, created_by=user_a.id)
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "playbook_id": str(playbook.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["playbook_id"] == str(playbook.id)
+
+
+@pytest.mark.integration
+async def test_create_schedule_builtin_playbook_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """Built-ins (created_by IS NULL) are visible to everyone."""
+    builtin = await _make_playbook(db_session, created_by=None)
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "playbook_id": str(builtin.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["playbook_id"] == str(builtin.id)
+
+
+@pytest.mark.integration
+async def test_create_schedule_foreign_playbook_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    """The closed gap: another user's playbook_id → 404, no row created."""
+    foreign = await _make_playbook(db_session, created_by=user_b.id)
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "playbook_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousSchedule).where(AutonomousSchedule.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.integration
+async def test_create_schedule_soft_deleted_playbook_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """Soft-deleted playbooks are invisible to everyone — even their author."""
+    tombstoned = await _make_playbook(
+        db_session, created_by=user_a.id, deleted_at=datetime.now(UTC)
+    )
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "playbook_id": str(tombstoned.id)},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.integration
+async def test_create_schedule_nonexistent_playbook_returns_404(
+    client: AsyncClient,
+    user_a: User,
+) -> None:
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "playbook_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.integration
+async def test_create_schedule_owned_kb_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "target_kb_id": str(kb.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["target_kb_id"] == str(kb.id)
+
+
+@pytest.mark.integration
+async def test_create_schedule_foreign_kb_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    """The closed gap: another user's target_kb_id → 404, no row created."""
+    foreign_kb = await _make_kb(db_session, owner=user_b)
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "target_kb_id": str(foreign_kb.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousSchedule).where(AutonomousSchedule.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.integration
+async def test_create_schedule_nonexistent_kb_returns_404(
+    client: AsyncClient,
+    user_a: User,
+) -> None:
+    resp = await client.post(
+        "/api/v1/autonomous/schedules",
+        headers=_bearer(user_a),
+        json={"cron_expr": "*/5 * * * *", "target_kb_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+# ===========================================================================
+# Schedule — update (retarget / builtin / foreign-404 / null clears)
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_patch_schedule_owned_playbook_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    playbook = await _make_playbook(db_session, created_by=user_a.id)
+    sched = await _make_schedule(db_session, user=user_a)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"playbook_id": str(playbook.id)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["playbook_id"] == str(playbook.id)
+
+    await db_session.refresh(sched)
+    assert sched.playbook_id == playbook.id
+
+
+@pytest.mark.integration
+async def test_patch_schedule_builtin_playbook_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    builtin = await _make_playbook(db_session, created_by=None)
+    sched = await _make_schedule(db_session, user=user_a)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"playbook_id": str(builtin.id)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["playbook_id"] == str(builtin.id)
+
+
+@pytest.mark.integration
+async def test_patch_schedule_foreign_playbook_returns_404_no_mutation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    original = await _make_playbook(db_session, created_by=user_a.id)
+    foreign = await _make_playbook(db_session, created_by=user_b.id)
+    sched = await _make_schedule(db_session, user=user_a, playbook_id=original.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"playbook_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+
+    # The row's target is unchanged — the foreign assignment was rejected.
+    await db_session.refresh(sched)
+    assert sched.playbook_id == original.id
+
+
+@pytest.mark.integration
+async def test_patch_schedule_owned_kb_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    sched = await _make_schedule(db_session, user=user_a)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"target_kb_id": str(kb.id)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["target_kb_id"] == str(kb.id)
+
+    await db_session.refresh(sched)
+    assert sched.target_kb_id == kb.id
+
+
+@pytest.mark.integration
+async def test_patch_schedule_foreign_kb_returns_404_no_mutation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    original_kb = await _make_kb(db_session, owner=user_a)
+    foreign_kb = await _make_kb(db_session, owner=user_b)
+    sched = await _make_schedule(db_session, user=user_a, target_kb_id=original_kb.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"target_kb_id": str(foreign_kb.id)},
+    )
+    assert resp.status_code == 404, resp.text
+
+    await db_session.refresh(sched)
+    assert sched.target_kb_id == original_kb.id
+
+
+@pytest.mark.integration
+async def test_patch_schedule_explicit_null_clears_targets(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    """Regression guard: an explicit null still clears playbook_id/target_kb_id."""
+    playbook = await _make_playbook(db_session, created_by=user_a.id)
+    kb = await _make_kb(db_session, owner=user_a)
+    sched = await _make_schedule(
+        db_session, user=user_a, playbook_id=playbook.id, target_kb_id=kb.id
+    )
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/schedules/{sched.id}",
+        headers=_bearer(user_a),
+        json={"playbook_id": None, "target_kb_id": None},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["playbook_id"] is None
+    assert resp.json()["target_kb_id"] is None
+
+    await db_session.refresh(sched)
+    assert sched.playbook_id is None
+    assert sched.target_kb_id is None
+
+
+# ===========================================================================
+# Watch — create (playbook visibility)
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_create_watch_owned_playbook_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    playbook = await _make_playbook(db_session, created_by=user_a.id)
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(kb.id), "playbook_id": str(playbook.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["playbook_id"] == str(playbook.id)
+
+
+@pytest.mark.integration
+async def test_create_watch_builtin_playbook_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    builtin = await _make_playbook(db_session, created_by=None)
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(kb.id), "playbook_id": str(builtin.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["playbook_id"] == str(builtin.id)
+
+
+@pytest.mark.integration
+async def test_create_watch_foreign_playbook_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    """The closed gap: another user's playbook_id → 404, no row created."""
+    kb = await _make_kb(db_session, owner=user_a)
+    foreign = await _make_playbook(db_session, created_by=user_b.id)
+    resp = await client.post(
+        "/api/v1/autonomous/watches",
+        headers=_bearer(user_a),
+        json={"knowledge_base_id": str(kb.id), "playbook_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousWatch).where(AutonomousWatch.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+# ===========================================================================
+# Watch — update (retarget / builtin / foreign-404)
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_patch_watch_builtin_playbook_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    builtin = await _make_playbook(db_session, created_by=None)
+    watch = await _make_watch(db_session, user=user_a, kb=kb)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/watches/{watch.id}",
+        headers=_bearer(user_a),
+        json={"playbook_id": str(builtin.id)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["playbook_id"] == str(builtin.id)
+
+    await db_session.refresh(watch)
+    assert watch.playbook_id == builtin.id
+
+
+@pytest.mark.integration
+async def test_patch_watch_foreign_playbook_returns_404_no_mutation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    original = await _make_playbook(db_session, created_by=user_a.id)
+    foreign = await _make_playbook(db_session, created_by=user_b.id)
+    watch = await _make_watch(db_session, user=user_a, kb=kb, playbook_id=original.id)
+
+    resp = await client.patch(
+        f"/api/v1/autonomous/watches/{watch.id}",
+        headers=_bearer(user_a),
+        json={"playbook_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+
+    await db_session.refresh(watch)
+    assert watch.playbook_id == original.id
+
+
+# ===========================================================================
+# Run-now — playbook visibility + target-KB ownership
+# ===========================================================================
+
+
+@pytest.mark.integration
+async def test_run_now_owned_playbook_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    playbook = await _make_playbook(db_session, created_by=user_a.id)
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        headers=_bearer(user_a),
+        json={"playbook_id": str(playbook.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = uuid.UUID(resp.json()["id"])
+    row = (
+        await db_session.execute(
+            select(AutonomousSession).where(AutonomousSession.id == session_id)
+        )
+    ).scalar_one()
+    assert row.params.get("playbook_id") == str(playbook.id)
+
+
+@pytest.mark.integration
+async def test_run_now_builtin_playbook_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    builtin = await _make_playbook(db_session, created_by=None)
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        headers=_bearer(user_a),
+        json={"playbook_id": str(builtin.id)},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.integration
+async def test_run_now_foreign_playbook_returns_404_no_session(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    """The closed gap: another user's playbook_id → 404, no session spawned."""
+    foreign = await _make_playbook(db_session, created_by=user_b.id)
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        headers=_bearer(user_a),
+        json={"playbook_id": str(foreign.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousSession).where(AutonomousSession.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.integration
+async def test_run_now_owned_kb_succeeds(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+) -> None:
+    kb = await _make_kb(db_session, owner=user_a)
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        headers=_bearer(user_a),
+        json={"skill_ref": "nda-review", "target_kb_id": str(kb.id)},
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = uuid.UUID(resp.json()["id"])
+    row = (
+        await db_session.execute(
+            select(AutonomousSession).where(AutonomousSession.id == session_id)
+        )
+    ).scalar_one()
+    assert row.params.get("kb_id") == str(kb.id)
+
+
+@pytest.mark.integration
+async def test_run_now_foreign_kb_returns_404_no_session(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    user_a: User,
+    user_b: User,
+) -> None:
+    """The closed gap: another user's target_kb_id → 404, no session spawned."""
+    foreign_kb = await _make_kb(db_session, owner=user_b)
+    resp = await client.post(
+        "/api/v1/autonomous/run-now",
+        headers=_bearer(user_a),
+        json={"skill_ref": "nda-review", "target_kb_id": str(foreign_kb.id)},
+    )
+    assert resp.status_code == 404, resp.text
+    rows = (
+        (
+            await db_session.execute(
+                select(AutonomousSession).where(AutonomousSession.user_id == user_a.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []

--- a/docs/api/backend-openapi.generated.yaml
+++ b/docs/api/backend-openapi.generated.yaml
@@ -8807,7 +8807,7 @@ paths:
         '403':
           description: Autonomous layer not enabled for this user
         '404':
-          description: Referenced project not found
+          description: Referenced project, playbook, or knowledge base not found
         '422':
           description: Invalid target (need exactly one of playbook_id/skill_ref)
       security:
@@ -8881,7 +8881,13 @@ paths:
 
         ``next_run_at = next_run_after(cron_expr, now(UTC))`` so the
 
-        dispatcher''s first eligible tick can pick it up.  Returns the created
+        dispatcher''s first eligible tick can pick it up.  Non-null FK targets
+
+        are validated (DE-322): ``project_id`` and ``target_kb_id`` must be
+
+        owned by the caller; ``playbook_id`` must be visible to the caller
+
+        (own or built-in) — otherwise 404.  Returns the created
 
         :class:`~app.schemas.autonomous.AutonomousScheduleRead` (201).
 
@@ -8904,7 +8910,7 @@ paths:
         '401':
           description: Not authenticated
         '404':
-          description: Referenced project not found
+          description: Referenced project, playbook, or knowledge base not found
         '422':
           description: Invalid cron expression
       security:
@@ -9004,7 +9010,8 @@ paths:
         '401':
           description: Not authenticated
         '404':
-          description: Schedule or referenced project not found
+          description: Schedule, referenced project, playbook, or knowledge base not
+            found
         '422':
           description: Invalid cron expression
       security:
@@ -9476,7 +9483,11 @@ paths:
 
         returns 404 (conservative per-user isolation; KB-sharing is out of
 
-        scope). Creates the watch row. Returns the created
+        scope). A non-null ``playbook_id`` must be visible to the caller
+
+        (own or built-in; DE-322) — otherwise 404. Creates the watch row.
+
+        Returns the created
 
         :class:`~app.schemas.autonomous.AutonomousWatchRead` (201).
 
@@ -9499,7 +9510,8 @@ paths:
         '401':
           description: Not authenticated
         '404':
-          description: Target knowledge base or referenced project not found
+          description: Target knowledge base, referenced project, or playbook not
+            found
         '422':
           content:
             application/json:
@@ -9605,7 +9617,7 @@ paths:
         '401':
           description: Not authenticated
         '404':
-          description: Watch or referenced project not found
+          description: Watch, referenced project, or playbook not found
         '422':
           content:
             application/json:


### PR DESCRIPTION
## What / why

DE-322 (PRD §9): post-#133, `project_id` is ownership-validated on the autonomous handlers, but `playbook_id` and `target_kb_id` were assigned straight from the request body. Premise verified against current main — five sites were genuinely unchecked:

- `create_schedule`: `playbook_id`, `target_kb_id`
- `update_schedule` (PATCH): `playbook_id`, `target_kb_id`
- `create_watch`: `playbook_id` (its `knowledge_base_id` was already validated)
- `update_watch` (PATCH): `playbook_id`
- `_spawn_manual_session` (run-now): `playbook_id`, `target_kb_id`

Defense-in-depth: the executor applies its own visibility checks downstream, but the write path should not persist references the caller can't see.

Part of the coordinated roadmap sweep (umbrella issue #321).

## Approach

- `_load_visible_playbook`: exact mirror of the execute endpoint's rule (`app.api.playbooks._load_visible_playbook`) — admins see every non-deleted playbook; non-admins see own + built-ins (`created_by IS NULL`); soft-deleted invisible to everyone. Cross-user access collapses into **404**, not 403 (id-probing-safe, same idiom as `_load_owned_project`).
- `_load_owned_kb`: faithful lift of the watch handler's inline KB owner-select (the watch handler now uses the helper).
- Wired into all five sites. Explicit-null PATCH semantics (clear the target) unchanged.
- One non-additive change for reviewers: `_spawn_manual_session` takes `user: User` instead of `user_id` (needed for the admin branch; single caller, same module).
- Deliberate: an **admin** can target another user's playbook — parity with the execute endpoint, not a hole.

No migration, no route changes, no schema changes (404 description strings only; generated OpenAPI artifact refreshed for the drift guard).

## Acceptance evidence

New file `api/tests/autonomous/test_playbook_kb_fk_ownership.py` — 22 tests covering every site: owned/built-in accepted, foreign/soft-deleted/nonexistent → 404, PATCH no-mutation on 404, run-now no-session-created on 404, explicit-null clears. Existing #133 project-ownership tests unchanged and green.

Gates run locally (api): ruff format/check clean, mypy clean, full suite **2647 passed, 1 skipped, 0 failed** (throwaway pgvector:pg16). Route pins untouched.

## Notes for reviewers

- Touches authorization → security review expected per CODEOWNERS routing.
- KB rule is owner-only (KB-sharing out of scope for the autonomous layer, matching the existing watch-create rule).

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #335** — same head commit (`e150fe1031aa`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
