### PR TITLE
DE-324: global-chrome notification bell for autonomous users

### DIFF
--- a/web/src/lib/lq-ai/autonomous/__tests__/notification-bell.test.ts
+++ b/web/src/lib/lq-ai/autonomous/__tests__/notification-bell.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Pure-helper tests for the global-chrome notification bell (DE-324).
+ *
+ * Mirrors the pattern from cron.test.ts / receipt-timeline.test.ts in this
+ * directory: exercise the extracted helpers without the Svelte runtime.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+	afterMarkAllRead,
+	afterMarkRead,
+	badgeText,
+	shouldShowBell,
+	snippet,
+	type BellState
+} from '../notification-bell';
+import type { AutonomousNotificationRead } from '$lib/lq-ai/api/autonomous';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeNotification(
+	id: string,
+	overrides: Partial<AutonomousNotificationRead> = {}
+): AutonomousNotificationRead {
+	return {
+		id,
+		user_id: 'user-1',
+		session_id: `session-${id}`,
+		channel: 'in_app',
+		title: `Notification ${id}`,
+		body: `Body for ${id}`,
+		payload: null,
+		read_at: null,
+		created_at: '2026-07-01T12:00:00Z',
+		updated_at: '2026-07-01T12:00:00Z',
+		...overrides
+	};
+}
+
+function makeState(ids: string[], unreadCount = ids.length): BellState {
+	return { items: ids.map((id) => makeNotification(id)), unreadCount };
+}
+
+// ---------------------------------------------------------------------------
+// shouldShowBell — the opt-in gating decision
+// ---------------------------------------------------------------------------
+
+describe('shouldShowBell', () => {
+	it('hides the bell when the user has NOT opted in to autonomous mode', () => {
+		expect(shouldShowBell(false)).toBe(false);
+	});
+
+	it('shows the bell when the user HAS opted in', () => {
+		expect(shouldShowBell(true)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// badgeText
+// ---------------------------------------------------------------------------
+
+describe('badgeText', () => {
+	it('returns null for zero unread (no badge rendered)', () => {
+		expect(badgeText(0)).toBeNull();
+	});
+
+	it('returns null for negative counts (defensive)', () => {
+		expect(badgeText(-1)).toBeNull();
+	});
+
+	it('returns the count as a string for 1..99', () => {
+		expect(badgeText(1)).toBe('1');
+		expect(badgeText(42)).toBe('42');
+		expect(badgeText(99)).toBe('99');
+	});
+
+	it('caps at "99+" above 99 (mirrors the autonomous rail badge)', () => {
+		expect(badgeText(100)).toBe('99+');
+		expect(badgeText(1234)).toBe('99+');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// afterMarkRead — single-item transition
+// ---------------------------------------------------------------------------
+
+describe('afterMarkRead', () => {
+	it('removes the marked item and decrements the unread count', () => {
+		const next = afterMarkRead(makeState(['a', 'b', 'c']), 'b');
+		expect(next.items.map((n) => n.id)).toEqual(['a', 'c']);
+		expect(next.unreadCount).toBe(2);
+	});
+
+	it('is a no-op (same state) for an unknown id', () => {
+		const state = makeState(['a', 'b']);
+		expect(afterMarkRead(state, 'nope')).toBe(state);
+	});
+
+	it('never decrements the count below zero', () => {
+		const next = afterMarkRead(makeState(['a'], 0), 'a');
+		expect(next.items).toEqual([]);
+		expect(next.unreadCount).toBe(0);
+	});
+
+	it('does not mutate the input state', () => {
+		const state = makeState(['a', 'b']);
+		afterMarkRead(state, 'a');
+		expect(state.items.map((n) => n.id)).toEqual(['a', 'b']);
+		expect(state.unreadCount).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// afterMarkAllRead — bulk transition
+// ---------------------------------------------------------------------------
+
+describe('afterMarkAllRead', () => {
+	it('removes all succeeded ids and decrements the count by that many', () => {
+		const next = afterMarkAllRead(makeState(['a', 'b', 'c']), ['a', 'b', 'c']);
+		expect(next.items).toEqual([]);
+		expect(next.unreadCount).toBe(0);
+	});
+
+	it('keeps failed items visible on partial failure', () => {
+		const next = afterMarkAllRead(makeState(['a', 'b', 'c']), ['a', 'c']);
+		expect(next.items.map((n) => n.id)).toEqual(['b']);
+		expect(next.unreadCount).toBe(1);
+	});
+
+	it('preserves the off-page unread remainder (count > visible items)', () => {
+		// 10 visible, 25 unread total: marking the visible page leaves 15.
+		const ids = Array.from({ length: 10 }, (_, i) => `n${i}`);
+		const next = afterMarkAllRead(makeState(ids, 25), ids);
+		expect(next.items).toEqual([]);
+		expect(next.unreadCount).toBe(15);
+	});
+
+	it('ignores succeeded ids not present in the visible items', () => {
+		const next = afterMarkAllRead(makeState(['a', 'b']), ['zzz']);
+		expect(next.items.map((n) => n.id)).toEqual(['a', 'b']);
+		expect(next.unreadCount).toBe(2);
+	});
+
+	it('never decrements the count below zero', () => {
+		const next = afterMarkAllRead(makeState(['a', 'b'], 1), ['a', 'b']);
+		expect(next.unreadCount).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// snippet
+// ---------------------------------------------------------------------------
+
+describe('snippet', () => {
+	it('returns short bodies unchanged', () => {
+		expect(snippet('Review completed.')).toBe('Review completed.');
+	});
+
+	it('returns a body exactly at the cap unchanged', () => {
+		const body = 'x'.repeat(140);
+		expect(snippet(body)).toBe(body);
+	});
+
+	it('truncates long bodies to the cap with a trailing ellipsis', () => {
+		const body = 'x'.repeat(200);
+		const out = snippet(body);
+		expect(out.length).toBe(140);
+		expect(out.endsWith('…')).toBe(true);
+	});
+
+	it('trims trailing whitespace before the ellipsis', () => {
+		const body = `${'x'.repeat(130)}         tail`;
+		const out = snippet(body);
+		expect(out.endsWith(' …')).toBe(false);
+		expect(out.endsWith('…')).toBe(true);
+	});
+
+	it('honors a custom maxChars', () => {
+		expect(snippet('hello world', 6)).toBe('hello…');
+	});
+});

--- a/web/src/lib/lq-ai/autonomous/notification-bell.ts
+++ b/web/src/lib/lq-ai/autonomous/notification-bell.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure helpers for the global-chrome notification bell (DE-324).
+ *
+ * Extracted from `NotificationBell.svelte` so vitest can exercise the
+ * gating / badge / mark-read state transitions without the Svelte runtime.
+ * Mirrors the lib pattern of `cron.ts` / `receipt-timeline.ts` in this
+ * directory. No side-effects; all functions are referentially transparent.
+ */
+
+import type { AutonomousNotificationRead } from '$lib/lq-ai/api/autonomous';
+
+/**
+ * Whether the bell renders at all. The bell is autonomous-layer chrome:
+ * users who have not opted in (preferences.autonomous_enabled === false)
+ * see NO chrome change — zero DOM emitted.
+ */
+export function shouldShowBell(autonomousEnabled: boolean): boolean {
+	return autonomousEnabled;
+}
+
+/**
+ * Badge label for an unread count.
+ *
+ *   0 (or negative) → null (no badge rendered)
+ *   1..99           → String(count)
+ *   >99             → '99+'  (cap mirrors the autonomous rail badge)
+ */
+export function badgeText(unreadCount: number): string | null {
+	if (unreadCount <= 0) return null;
+	return unreadCount > 99 ? '99+' : String(unreadCount);
+}
+
+/** Bell dropdown state: the visible unread items + the true unread total. */
+export interface BellState {
+	/** Unread items shown in the dropdown (a page of the newest unread). */
+	items: AutonomousNotificationRead[];
+	/** Total unread count server-side — may exceed items.length. */
+	unreadCount: number;
+}
+
+/**
+ * State transition after a single notification is marked read: the item
+ * leaves the dropdown list and the badge decrements (floored at 0 — the
+ * server count may have drifted since the last fetch).
+ */
+export function afterMarkRead(state: BellState, id: string): BellState {
+	if (!state.items.some((n) => n.id === id)) return state;
+	return {
+		items: state.items.filter((n) => n.id !== id),
+		unreadCount: Math.max(0, state.unreadCount - 1)
+	};
+}
+
+/**
+ * State transition after mark-all-read: `succeededIds` are removed from the
+ * dropdown and subtracted from the badge. With a partial failure the
+ * remaining items / count stay visible so the user can retry.
+ */
+export function afterMarkAllRead(state: BellState, succeededIds: string[]): BellState {
+	const succeeded = new Set(succeededIds);
+	const removed = state.items.filter((n) => succeeded.has(n.id)).length;
+	return {
+		items: state.items.filter((n) => !succeeded.has(n.id)),
+		unreadCount: Math.max(0, state.unreadCount - removed)
+	};
+}
+
+/**
+ * Truncate a notification body for the dropdown snippet. Whole-string cap
+ * (not word-aware — dropdown rows are single-line ellipsised anyway; this
+ * just bounds the DOM text length).
+ */
+export function snippet(body: string, maxChars = 140): string {
+	if (body.length <= maxChars) return body;
+	return `${body.slice(0, maxChars - 1).trimEnd()}…`;
+}

--- a/web/src/lib/lq-ai/components/NotificationBell.svelte
+++ b/web/src/lib/lq-ai/components/NotificationBell.svelte
@@ -1,0 +1,433 @@
+<script lang="ts">
+	/**
+	 * NotificationBell — global-chrome bell for autonomous notifications (DE-324).
+	 *
+	 * Mounted in the /lq-ai shell topbar, gated by the parent layout on
+	 * `$preferences.autonomous_enabled` — this component assumes the caller has
+	 * verified opt-in (non-opted-in users get zero DOM because the layout never
+	 * mounts it). The gating decision itself is `shouldShowBell` in
+	 * `$lib/lq-ai/autonomous/notification-bell` (unit-tested there).
+	 *
+	 * Behavior:
+	 *   - Fetches unread notifications (newest first) via
+	 *     `GET /autonomous/notifications?unread=true` on mount and after every
+	 *     client-side navigation (afterNavigate — no polling loop).
+	 *   - Badge shows the server-side unread total (`total_count`), capped at
+	 *     99+ to mirror the autonomous rail badge.
+	 *   - Click → dropdown listing the newest unread items with per-item
+	 *     "Mark read" and a "Mark all read" bulk action (Promise.allSettled,
+	 *     mirroring the notifications page), plus a "View all" link to
+	 *     /lq-ai/autonomous/notifications.
+	 *
+	 * Dropdown idiom mirrors `MessageOverflowMenu.svelte` (disclosure widget,
+	 * not a WAI-ARIA menu): aria-expanded trigger, Escape-to-close via
+	 * svelte:window, close-on-focusout with a tick + requestAnimationFrame
+	 * defer so clicks on items register before the focusout teardown.
+	 * Fetch errors are swallowed (best-effort chrome badge — same posture as
+	 * the autonomous rail badge in autonomous/+layout.svelte).
+	 */
+	import { tick } from 'svelte';
+	import { afterNavigate } from '$app/navigation';
+
+	import { autonomousApi } from '$lib/lq-ai/api';
+	import {
+		afterMarkAllRead,
+		afterMarkRead,
+		badgeText,
+		snippet,
+		type BellState
+	} from '$lib/lq-ai/autonomous/notification-bell';
+
+	const VIEW_ALL_HREF = '/lq-ai/autonomous/notifications';
+	/** How many unread items the dropdown shows; the badge uses the full total. */
+	const DROPDOWN_LIMIT = 10;
+
+	let state: BellState = { items: [], unreadCount: 0 };
+	let open = false;
+	let rootEl: HTMLDivElement;
+	let triggerEl: HTMLButtonElement;
+
+	/** Ids with an in-flight mark-read call. */
+	let pendingIds: Set<string> = new Set();
+	let markingAll = false;
+
+	$: badge = badgeText(state.unreadCount);
+	$: triggerLabel =
+		state.unreadCount > 0
+			? `Notifications, ${state.unreadCount} unread`
+			: 'Notifications';
+
+	async function refresh(): Promise<void> {
+		try {
+			const resp = await autonomousApi.listNotifications(true, DROPDOWN_LIMIT);
+			state = { items: resp.notifications, unreadCount: resp.total_count };
+		} catch {
+			// Best-effort badge — do not surface errors in global chrome.
+		}
+	}
+
+	// Runs on initial mount AND after every client-side navigation.
+	afterNavigate(() => {
+		open = false;
+		refresh();
+	});
+
+	function toggle(): void {
+		open = !open;
+	}
+
+	/**
+	 * Defer a frame on focusout: clicking an item briefly nulls focus before
+	 * the new target registers, so an immediate `relatedTarget` check would
+	 * close the dropdown and swallow the click. (Mirrors MessageOverflowMenu.)
+	 */
+	async function handleFocusout(): Promise<void> {
+		await tick();
+		requestAnimationFrame(() => {
+			if (!rootEl) return;
+			if (!rootEl.contains(document.activeElement)) {
+				open = false;
+			}
+		});
+	}
+
+	function handleKeydown(e: KeyboardEvent): void {
+		if (open && e.key === 'Escape') {
+			open = false;
+			triggerEl?.focus();
+		}
+	}
+
+	async function handleMarkRead(id: string): Promise<void> {
+		if (pendingIds.has(id)) return;
+		pendingIds = new Set(pendingIds).add(id);
+		try {
+			await autonomousApi.readNotification(id);
+			state = afterMarkRead(state, id);
+		} catch {
+			// Keep the item visible so the user can retry; page surface has full errors.
+		} finally {
+			const next = new Set(pendingIds);
+			next.delete(id);
+			pendingIds = next;
+		}
+	}
+
+	async function handleMarkAllRead(): Promise<void> {
+		const ids = state.items.map((n) => n.id);
+		if (ids.length === 0 || markingAll) return;
+		markingAll = true;
+		try {
+			const results = await Promise.allSettled(
+				ids.map((id) => autonomousApi.readNotification(id))
+			);
+			const succeeded = ids.filter((_, i) => results[i].status === 'fulfilled');
+			state = afterMarkAllRead(state, succeeded);
+			// The unread total may exceed the visible page — resync with the server.
+			await refresh();
+		} finally {
+			markingAll = false;
+		}
+	}
+
+	function formatDate(iso: string): string {
+		try {
+			return new Intl.DateTimeFormat(undefined, {
+				month: 'short',
+				day: 'numeric',
+				hour: '2-digit',
+				minute: '2-digit'
+			}).format(new Date(iso));
+		} catch {
+			return iso;
+		}
+	}
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+<div class="bell" bind:this={rootEl} on:focusout={handleFocusout} data-testid="lq-ai-notification-bell">
+	<button
+		type="button"
+		class="trigger"
+		aria-label={triggerLabel}
+		aria-expanded={open}
+		data-testid="lq-ai-notification-bell-trigger"
+		bind:this={triggerEl}
+		on:click={toggle}
+	>
+		<span class="bell-icon" aria-hidden="true">🔔</span>
+		{#if badge !== null}
+			<span class="unread-badge" aria-hidden="true" data-testid="lq-ai-notification-bell-badge">
+				{badge}
+			</span>
+		{/if}
+	</button>
+
+	{#if open}
+		<div class="dropdown" data-testid="lq-ai-notification-bell-dropdown">
+			<div class="dropdown-header">
+				<span class="dropdown-title">Notifications</span>
+				{#if state.items.length > 0}
+					<button
+						type="button"
+						class="mark-all"
+						on:click={handleMarkAllRead}
+						disabled={markingAll}
+						aria-label="Mark all notifications as read"
+					>
+						{markingAll ? 'Marking…' : 'Mark all read'}
+					</button>
+				{/if}
+			</div>
+
+			{#if state.items.length === 0}
+				<p class="empty">No unread notifications.</p>
+			{:else}
+				<ul class="items" aria-label="Unread notifications">
+					{#each state.items as notification (notification.id)}
+						<li class="item">
+							<div class="item-body">
+								<div class="item-header-row">
+									<span class="item-title">{notification.title}</span>
+									<time
+										class="item-date"
+										datetime={notification.created_at}
+										title={notification.created_at}
+									>
+										{formatDate(notification.created_at)}
+									</time>
+								</div>
+								<p class="item-text">{snippet(notification.body)}</p>
+							</div>
+							<button
+								type="button"
+								class="mark-read"
+								on:click={() => handleMarkRead(notification.id)}
+								disabled={pendingIds.has(notification.id) || markingAll}
+								aria-label={`Mark "${notification.title}" as read`}
+							>
+								{pendingIds.has(notification.id) ? 'Marking…' : 'Mark read'}
+							</button>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+
+			<div class="dropdown-footer">
+				<a class="view-all" href={VIEW_ALL_HREF} on:click={() => (open = false)}>
+					View all notifications
+				</a>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.bell {
+		position: relative;
+		display: inline-block;
+	}
+
+	/* Trigger mirrors the topbar's ⚙ settings affordance + MessageOverflowMenu trigger. */
+	.trigger {
+		position: relative;
+		background: transparent;
+		border: 0;
+		padding: var(--lq-space-1) var(--lq-space-2);
+		cursor: pointer;
+		color: var(--lq-text-secondary);
+		font-size: 16px;
+		line-height: 1;
+		border-radius: var(--lq-radius-sm, 4px);
+	}
+
+	.trigger:hover {
+		background: var(--lq-inset, #fafbfa);
+		color: var(--lq-text);
+	}
+
+	.trigger:focus-visible {
+		outline: 2px solid var(--lq-accent);
+		outline-offset: 2px;
+	}
+
+	/* Badge mirrors .nav-unread-badge in autonomous/+layout.svelte. */
+	.unread-badge {
+		position: absolute;
+		top: -4px;
+		right: -6px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 18px;
+		height: 18px;
+		padding: 0 5px;
+		border-radius: 9px;
+		font-size: 11px;
+		font-weight: 600;
+		line-height: 1;
+		background: var(--lq-accent);
+		color: white;
+	}
+
+	/* Dropdown surface mirrors MessageOverflowMenu's .menu. */
+	.dropdown {
+		position: absolute;
+		right: 0;
+		top: 100%;
+		margin-top: var(--lq-space-1);
+		width: 340px;
+		max-width: 90vw;
+		background: var(--lq-canvas, #ffffff);
+		border: 1px solid var(--lq-border, #e5e7eb);
+		border-radius: var(--lq-radius, 6px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+		z-index: 10;
+	}
+
+	.dropdown-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--lq-space-3);
+		padding: var(--lq-space-2) var(--lq-space-3);
+		border-bottom: 1px solid var(--lq-border);
+	}
+
+	.dropdown-title {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--lq-text);
+	}
+
+	.mark-all {
+		background: transparent;
+		border: 0;
+		padding: 2px 4px;
+		font-size: 12px;
+		font-weight: 500;
+		color: var(--lq-accent);
+		cursor: pointer;
+		border-radius: var(--lq-radius-sm, 4px);
+		white-space: nowrap;
+	}
+
+	.mark-all:hover:not(:disabled) {
+		background: var(--lq-inset, #fafbfa);
+	}
+
+	.mark-all:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.empty {
+		margin: 0;
+		padding: var(--lq-space-4) var(--lq-space-3);
+		font-size: 13px;
+		font-style: italic;
+		color: var(--lq-text-secondary);
+	}
+
+	.items {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		max-height: 320px;
+		overflow-y: auto;
+	}
+
+	.item {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--lq-space-2);
+		padding: var(--lq-space-3);
+		border-bottom: 1px solid var(--lq-border);
+	}
+
+	.item:last-child {
+		border-bottom: none;
+	}
+
+	.item-body {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.item-header-row {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: var(--lq-space-2);
+	}
+
+	.item-title {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--lq-text);
+		word-break: break-word;
+	}
+
+	.item-date {
+		font-size: 11px;
+		color: var(--lq-text-tertiary);
+		white-space: nowrap;
+	}
+
+	.item-text {
+		margin: 0;
+		font-size: 12px;
+		line-height: 1.4;
+		color: var(--lq-text-secondary);
+		word-break: break-word;
+	}
+
+	.mark-read {
+		flex-shrink: 0;
+		padding: 2px 8px;
+		border-radius: var(--lq-radius-sm, 4px);
+		font-size: 12px;
+		cursor: pointer;
+		border: 1px solid var(--lq-border);
+		background: transparent;
+		color: var(--lq-text);
+		white-space: nowrap;
+		transition: background 0.1s;
+	}
+
+	.mark-read:hover:not(:disabled) {
+		background: var(--lq-surface-hover, rgba(0, 0, 0, 0.04));
+	}
+
+	.mark-read:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.dropdown-footer {
+		border-top: 1px solid var(--lq-border);
+		padding: var(--lq-space-2) var(--lq-space-3);
+		text-align: center;
+	}
+
+	.view-all {
+		font-size: 13px;
+		font-weight: 500;
+		color: var(--lq-accent);
+		text-decoration: none;
+	}
+
+	.view-all:hover {
+		text-decoration: underline;
+	}
+
+	.view-all:focus-visible {
+		outline: 2px solid var(--lq-accent);
+		outline-offset: 2px;
+		border-radius: var(--lq-radius-sm, 4px);
+	}
+</style>

--- a/web/src/routes/lq-ai/+layout.svelte
+++ b/web/src/routes/lq-ai/+layout.svelte
@@ -18,7 +18,10 @@
 	import DualBrandingFooter from '$lib/lq-ai/components/DualBrandingFooter.svelte';
 	import TopTabBar from '$lib/lq-ai/components/TopTabBar.svelte';
 	import AmbientTrustChrome from '$lib/lq-ai/components/AmbientTrustChrome.svelte';
+	import NotificationBell from '$lib/lq-ai/components/NotificationBell.svelte';
 	import SessionTimeoutWarning from '$lib/lq-ai/components/SessionTimeoutWarning.svelte';
+	import { preferences, initPreferences } from '$lib/lq-ai/stores/preferences';
+	import { shouldShowBell } from '$lib/lq-ai/autonomous/notification-bell';
 	import { startTracker, stopTracker, noteActivity } from '$lib/lq-ai/stores/sessionActivity';
 	import '$lib/lq-ai/styles/practice.css';
 	import '$lib/lq-ai/styles/typography.css';
@@ -58,6 +61,12 @@
 			}
 			console.error('lq-ai: failed to refresh user', e);
 		}
+		// Sync preferences so autonomous-gated chrome (notification bell)
+		// renders for opted-in users. Non-opted-in users keep the default
+		// (autonomous_enabled: false) and see NO chrome change. Not awaited:
+		// the localStorage cache applies synchronously and the fresh server
+		// value lands reactively — don't delay shell boot on it.
+		void initPreferences();
 		booted = true;
 	}
 
@@ -94,6 +103,9 @@
 				</a>
 				<div style="display: inline-flex; align-items: center; gap: var(--lq-space-3);">
 					<AmbientTrustChrome />
+					{#if shouldShowBell($preferences.autonomous_enabled)}
+						<NotificationBell />
+					{/if}
 					<a href="/lq-ai/settings/appearance" aria-label="Settings" title="Settings" style="color: var(--lq-text-secondary); text-decoration: none; padding: var(--lq-space-1) var(--lq-space-2); border-radius: var(--lq-radius-sm);">⚙</a>
 				</div>
 			</header>


### PR DESCRIPTION
## What / why

DE-324 (PRD §9): autonomous notifications were only visible on the notifications page itself. This adds a bell with an unread badge to the `/lq-ai` shell chrome so opted-in users see arrivals anywhere in the app. Gating is strict: non-opted-in users get **zero DOM change**.

Part of the coordinated roadmap sweep (umbrella issue #321).

## Approach

- `NotificationBell.svelte`: unread badge (99+ cap) from the unread-filtered list's `total_count` (accurate past the 10-item dropdown page, unlike a length count); disclosure dropdown mirroring the `MessageOverflowMenu` widget pattern (aria-expanded, Escape, focusout-with-defer, same token vocabulary); per-item mark-read, mark-all over the visible page (`Promise.allSettled` — no bulk endpoint exists; the notifications page remains the full-bulk surface), "View all" link. Refetch on `afterNavigate`, no polling loop. Fetch errors swallowed (best-effort chrome, same posture as the autonomous rail badge).
- Layout mount wrapped in `{#if shouldShowBell($preferences.autonomous_enabled)}`; the shell layout now fire-and-forgets `initPreferences()` (previously only the autonomous sub-layout synced it) — idempotent, un-awaited, cache-synchronous. Worth a reviewer glance since it now runs on every authed shell boot.
- Pure logic in `notification-bell.ts`: `shouldShowBell`, `badgeText`, `afterMarkRead`, `afterMarkAllRead` (partial-failure-safe, preserves off-page remainder), `snippet`.

Frontend-only; no api changes; no new dependencies.

## Acceptance evidence

- 20 vitest cases in `autonomous/__tests__/notification-bell.test.ts`: gating hidden/visible, badge text incl. 99+ cap and zero/negative, mark-read decrement + unknown-id no-op + floor-at-0, mark-all full/partial/off-page, snippet truncation.
- Gates: `npm run check:lq-ai` **0 errors** (7 pre-existing warnings, none in touched files); vitest **756 passed (81 files)**; eslint clean on touched files.

## Maintainer verification steps

- Rebuild the `web` container (static bundle). With a non-opted-in user, confirm no chrome change; with an opted-in user and unread notifications, confirm badge count, mark-read, and the View-all link.

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #339** — same head commit (`3b848480bb4e`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
