### PR TITLE
3.8: community skill installer admin UI (ADR 0027 in-PR)

### DIFF
--- a/api/app/api/__init__.py
+++ b/api/app/api/__init__.py
@@ -31,6 +31,7 @@ from app.api import (
     bootstrap,
     chat_receipts,
     chats,
+    community_skills,
     enhance_prompt,
     files,
     inference,
@@ -114,6 +115,11 @@ api_router.include_router(admin.router, dependencies=_active)
 # AdminUser dependency; mounted under the `_active` group so the
 # bearer-token + must-change-password gates fire first.
 api_router.include_router(admin_intake_bridges.router, dependencies=_active)
+# 3.8 / DE-263: community skill installer (catalog from the local
+# submodule per ADR 0027). Admin-gated at handler level via AdminUser;
+# mounted under `_active` so the bearer + must-change-password gates
+# fire first.
+api_router.include_router(community_skills.router, dependencies=_active)
 # M4-A4-i: Autonomous sessions read/halt API — per-user isolated, bearer-auth.
 api_router.include_router(autonomous.router, dependencies=_active)
 # M3-A2: Playbook executor — two endpoints under different prefixes

--- a/api/app/api/community_skills.py
+++ b/api/app/api/community_skills.py
@@ -1,0 +1,395 @@
+"""Admin community-skill installer surface — roadmap 3.8 (DE-263, ADR 0027).
+
+Backs the SvelteKit admin page at ``/lq-ai/admin/community-skills``.
+Operators browse the community catalog served FROM THE LOCAL SUBMODULE
+checkout (``skills/community/skills/`` — never a network fetch, per
+ADR 0027 and the single-outbound-client invariant), read the full
+SKILL.md (transparency principle: the work product is reviewable before
+install), and install a skill as an editable DB-backed copy.
+
+Surface:
+
+* ``GET  /api/v1/admin/community-skills`` — catalog list. Re-scans the
+  submodule per request; an absent/empty submodule returns 200 with an
+  empty list + operator hint (ADR 0027 §3). Per-skill parse failures
+  are surfaced in ``load_errors`` so broken corpus entries are visible.
+* ``GET  /api/v1/admin/community-skills/{slug}`` — full detail incl.
+  ``content_md`` / ``content_yaml``. 404 unknown slug; 422 when the
+  folder exists but its SKILL.md is malformed (the error text says why).
+* ``POST /api/v1/admin/community-skills/{slug}/install`` — persist a
+  ``user_skills`` row (ADR 0012 semantics) owned by the installing
+  admin, validated through :class:`app.api.user_skills.UserSkillCreate`
+  so malformed content gets the same 422s a hand-authored skill would.
+  Writes ``forked_from = "lq-skills:<slug>@<sha>"`` (sha degrades to
+  ``"unknown"``) and a ``community_skill.installed`` audit row in the
+  same transaction. 409 when the caller already has a live row at the
+  slug.
+
+Auth posture: mounted under ``ActiveUser`` at the include site (bearer +
+must-change-password gates), PLUS the handler-level ``AdminUser``
+dependency — non-admin authenticated users get 403 on every endpoint.
+
+Attestation honesty: community skills are attested at their source repo
+(lq-skills PR process). ``attested_by`` surfaces only what the SKILL.md
+frontmatter declares; ``null`` renders as "none declared", never as
+attested (ADR 0027 §5).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import AdminUser
+from app.api.user_skills import UserSkillCreate, UserSkillResponse, _to_response, _validate_slug
+from app.audit import audit_action
+from app.config import Settings, get_settings
+from app.db.session import get_db
+from app.models.user_skill import UserSkill
+from app.skills.community_installer import (
+    SUBMODULE_HINT,
+    CommunityCatalog,
+    attestation_of,
+    display_title,
+    forked_from_ref,
+    install_fields_from_record,
+    resolve_catalog_dir,
+    scan_catalog,
+)
+from app.skills.loader import LoaderError, load_skill_folder
+from app.skills.registry import SkillRecord
+
+router = APIRouter(prefix="/admin/community-skills", tags=["admin-community-skills"])
+
+_BODY_PREVIEW_CHARS = 280
+
+
+# ---------------------------------------------------------------------------
+# Wire shapes
+# ---------------------------------------------------------------------------
+
+
+class CommunityCatalogSource(BaseModel):
+    """Where the catalog came from — stated so staleness is visible."""
+
+    path: str
+    """Filesystem path the scan looked at (shown even when absent)."""
+
+    sha: str | None = None
+    """Submodule HEAD commit resolved by file-reads of git plumbing;
+    ``null`` when unresolvable (surfaced as "unknown" in the UI)."""
+
+    submodule_present: bool
+    operator_hint: str | None = None
+    """Set when the catalog is absent/empty — names the
+    ``git submodule update --init`` remedy."""
+
+
+class CommunitySkillSummary(BaseModel):
+    """One catalog entry — the list view."""
+
+    slug: str
+    title: str
+    description: str
+    version: str
+    author: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    jurisdiction: str | None = None
+    attested_by: str | None = None
+    """Verbatim frontmatter declaration; ``null`` == none declared in
+    SKILL.md. Displayed, never synthesized."""
+
+    installed: bool
+    """Whether the CALLING admin already has a live user-scope row at
+    this slug (which is exactly the condition that makes install 409)."""
+
+    body_preview: str
+
+
+class CommunityCatalogResponse(BaseModel):
+    items: list[CommunitySkillSummary]
+    source: CommunityCatalogSource
+    load_errors: list[str] = Field(default_factory=list)
+    """Per-skill parse failures from the scan, verbatim — broken corpus
+    entries are visible to the operator, not silently dropped."""
+
+
+class CommunitySkillDetail(CommunitySkillSummary):
+    """Full SKILL.md view — the install-confirm surface."""
+
+    output_format: str | None = None
+    minimum_inference_tier: int | None = None
+    content_yaml: str
+    content_md: str
+    install_ref: str
+    """The ``forked_from`` provenance string an install would write now."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _catalog(settings: Annotated[Settings, Depends(get_settings)]) -> CommunityCatalog:
+    """Per-request re-scan of the community corpus (ADR 0027)."""
+
+    return scan_catalog(resolve_catalog_dir(settings))
+
+
+async def _installed_slugs(db: AsyncSession, *, user_id: Any, slugs: list[str]) -> set[str]:
+    """The caller's live user-scope slugs among ``slugs``."""
+
+    if not slugs:
+        return set()
+    stmt = select(UserSkill.slug).where(
+        UserSkill.scope == "user",
+        UserSkill.owner_user_id == user_id,
+        UserSkill.archived_at.is_(None),
+        UserSkill.slug.in_(slugs),
+    )
+    return set((await db.execute(stmt)).scalars().all())
+
+
+def _summary_from_record(record: SkillRecord, *, installed: bool) -> CommunitySkillSummary:
+    lq = record.frontmatter.lq_ai
+    body = record.body.strip()
+    return CommunitySkillSummary(
+        slug=record.name,
+        title=display_title(record),
+        description=record.frontmatter.description,
+        version=lq.version or "unversioned",
+        author=lq.author,
+        tags=list(lq.tags),
+        jurisdiction=lq.jurisdiction,
+        attested_by=attestation_of(record),
+        installed=installed,
+        body_preview=body[:_BODY_PREVIEW_CHARS],
+    )
+
+
+def _load_record_or_error(catalog: CommunityCatalog, slug: str) -> SkillRecord:
+    """Load one community skill by slug; 404 unknown, 422 malformed.
+
+    The slug is validated against the user-skill slug shape FIRST so a
+    path-shaped value (``../…``) can never reach the filesystem join.
+    A folder that exists but fails to parse gets a 422 carrying the
+    loader's error text — the admin sees *why* the skill is broken
+    instead of a bare not-found.
+    """
+
+    _validate_slug(slug)
+    folder = catalog.path / slug
+    if not (folder / "SKILL.md").is_file():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"community skill {slug!r} not found in the catalog",
+        )
+    try:
+        return load_skill_folder(folder, source="community")
+    except LoaderError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"community skill {slug!r} has a malformed SKILL.md: {exc}",
+        ) from None
+
+
+def _source_info(catalog: CommunityCatalog) -> CommunityCatalogSource:
+    empty = not catalog.dir_present or (not catalog.records and not catalog.load_errors)
+    return CommunityCatalogSource(
+        path=str(catalog.path),
+        sha=catalog.sha,
+        submodule_present=catalog.dir_present,
+        operator_hint=SUBMODULE_HINT if empty else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "",
+    response_model=CommunityCatalogResponse,
+    summary="List the community skill catalog from the local submodule (DE-263)",
+    responses={403: {"description": "Authenticated but not an admin"}},
+)
+async def list_community_skills(
+    admin: AdminUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    catalog: Annotated[CommunityCatalog, Depends(_catalog)],
+) -> CommunityCatalogResponse:
+    """GET /api/v1/admin/community-skills — the catalog list.
+
+    An absent submodule is 200-with-hint, not an error: fresh clones
+    without ``--recurse-submodules`` must not break the admin UI.
+    """
+
+    installed = await _installed_slugs(
+        db, user_id=admin.id, slugs=[r.name for r in catalog.records]
+    )
+    return CommunityCatalogResponse(
+        items=[
+            _summary_from_record(record, installed=record.name in installed)
+            for record in catalog.records
+        ],
+        source=_source_info(catalog),
+        load_errors=list(catalog.load_errors),
+    )
+
+
+@router.get(
+    "/{slug}",
+    response_model=CommunitySkillDetail,
+    summary="Full SKILL.md detail for one community skill (DE-263)",
+    responses={
+        403: {"description": "Authenticated but not an admin"},
+        404: {"description": "Unknown community skill slug"},
+        422: {"description": "SKILL.md exists but is malformed"},
+    },
+)
+async def get_community_skill(
+    slug: str,
+    admin: AdminUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    catalog: Annotated[CommunityCatalog, Depends(_catalog)],
+) -> CommunitySkillDetail:
+    """GET /api/v1/admin/community-skills/{slug} — the install-confirm view.
+
+    Returns the full body + raw frontmatter so the operator reviews the
+    actual work product before installing (transparency principle).
+    """
+
+    record = _load_record_or_error(catalog, slug)
+    installed = await _installed_slugs(db, user_id=admin.id, slugs=[record.name])
+    summary = _summary_from_record(record, installed=record.name in installed)
+    lq = record.frontmatter.lq_ai
+    return CommunitySkillDetail(
+        **summary.model_dump(),
+        output_format=lq.output_format,
+        minimum_inference_tier=lq.minimum_inference_tier,
+        content_yaml=record.raw_yaml,
+        content_md=record.body,
+        install_ref=forked_from_ref(record.name, catalog.sha),
+    )
+
+
+@router.post(
+    "/{slug}/install",
+    response_model=UserSkillResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Install a community skill as an editable user-scope copy (DE-263)",
+    responses={
+        403: {"description": "Authenticated but not an admin"},
+        404: {"description": "Unknown community skill slug"},
+        409: {"description": "Caller already has a live user skill at this slug"},
+        422: {"description": "SKILL.md malformed or violates user-skill bounds"},
+    },
+)
+async def install_community_skill(
+    slug: str,
+    request: Request,
+    admin: AdminUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    catalog: Annotated[CommunityCatalog, Depends(_catalog)],
+) -> UserSkillResponse:
+    """POST /api/v1/admin/community-skills/{slug}/install.
+
+    The installed copy is a fork (ADR 0012): a user-scope row owned by
+    the INSTALLING ADMIN, editable and archivable like any user skill;
+    it does not auto-update when the submodule moves. Provenance lives
+    in ``forked_from`` + the audit row.
+
+    409 semantics: ``user_skills`` uniqueness is per-owner among
+    non-archived rows, so "already installed" is exactly "the caller
+    has a live user-scope row at this slug" — including a hand-authored
+    one, which install must not clobber. Archiving the row frees the
+    slug for re-install (that is the honest re-install path).
+    """
+
+    record = _load_record_or_error(catalog, slug)
+
+    # Reuse the ADR 0012 validation path verbatim so a community skill
+    # whose parsed fields violate the user-skill bounds is rejected with
+    # the same 422 shape a hand-authored skill would get.
+    try:
+        payload = UserSkillCreate(
+            **install_fields_from_record(record),
+            forked_from=forked_from_ref(record.name, catalog.sha),
+        )
+    except ValidationError as exc:
+        # Surface the first error the way the loader does — a one-line
+        # "this is what's wrong" signal, not the full Pydantic dump.
+        errors = exc.errors()
+        if errors:
+            loc = ".".join(str(p) for p in errors[0].get("loc", ()))
+            msg = str(errors[0].get("msg", exc))
+        else:  # pragma: no cover — ValidationError always carries errors
+            loc, msg = "", str(exc)
+        raise HTTPException(
+            status_code=422,
+            detail=f"community skill {slug!r} violates user-skill bounds: {loc} — {msg}",
+        ) from None
+
+    if await _installed_slugs(db, user_id=admin.id, slugs=[record.name]):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"a live user skill named {record.name!r} already exists for you — "
+                "archive it first to re-install from the community catalog"
+            ),
+        )
+
+    row = UserSkill(
+        scope="user",
+        owner_user_id=admin.id,
+        slug=payload.slug,
+        display_name=payload.display_name.strip(),
+        description=payload.description.strip(),
+        version=payload.version.strip(),
+        tags=payload.tags,
+        frontmatter_extra=payload.frontmatter_extra,
+        body=payload.body,
+        forked_from=payload.forked_from,
+    )
+    db.add(row)
+    try:
+        await db.flush()
+    except IntegrityError:
+        # Backstop for a concurrent create between the pre-check and the
+        # flush — same partial unique index, same honest answer.
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"a live user skill named {record.name!r} already exists for you",
+        ) from None
+
+    audit_details: dict[str, Any] = {
+        "slug": record.name,
+        "version": payload.version,
+        "forked_from": payload.forked_from,
+        "source_sha": catalog.sha or "unknown",
+        "catalog_path": str(catalog.path),
+    }
+    attested_by = attestation_of(record)
+    if attested_by is not None:
+        audit_details["attested_by"] = attested_by
+
+    await audit_action(
+        db,
+        user_id=admin.id,
+        action="community_skill.installed",
+        resource_type="user_skill",
+        resource_id=str(row.id),
+        request=request,
+        details=audit_details,
+    )
+    await db.commit()
+    await db.refresh(row)
+
+    return _to_response(row)

--- a/api/app/skills/community_installer.py
+++ b/api/app/skills/community_installer.py
@@ -1,0 +1,287 @@
+"""Community skill catalog scan + provenance helpers — DE-263 (ADR 0027).
+
+The admin installer surface (``app/api/community_skills.py``) serves the
+community catalog FROM THE LOCAL SUBMODULE checkout at
+``skills/community/skills/`` (or the operator's
+``LQ_AI_COMMUNITY_SKILLS_DIR`` override) — never a network fetch. That
+preserves the backend single-outbound-client invariant
+(``tests/test_transparency_invariants.py``) and air-gap compatibility;
+``git submodule update --remote skills/community`` is the operator
+refresh path. See ``docs/adr/0027-community-skill-catalog-source.md``.
+
+This module is deliberately free of any ``app.api`` import so the
+router can import it without a package cycle. It owns:
+
+* :func:`resolve_catalog_dir` — where the catalog lives for this
+  deployment (mirrors the startup resolution rules).
+* :func:`scan_catalog` — a per-request re-scan of the community corpus
+  using the same parser the registry walk uses, plus honest state about
+  an absent submodule.
+* :func:`resolve_submodule_sha` — the submodule HEAD commit via PURE
+  FILE READS of git plumbing (no git subprocess at request time),
+  degrading to ``None`` (surfaced as ``"unknown"``) when the plumbing
+  is absent — e.g. an uninitialized submodule or a container image
+  built without ``.git``.
+* :func:`attestation_of` / :func:`install_fields_from_record` — read
+  frontmatter-declared attestation (display-only, never synthesized)
+  and map a parsed record onto the ``UserSkillCreate`` field set.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from app.skills.loader import scan_skills_folder
+from app.skills.registry import SkillRecord
+from app.skills.schema import _humanise
+
+if TYPE_CHECKING:
+    from app.config import Settings
+
+# The lq-skills repo name — the stable prefix of the ``forked_from``
+# provenance ref written at install time (ADR 0027 §2).
+FORKED_FROM_PREFIX = "lq-skills"
+
+# A loose or detached-HEAD object id: 40 hex chars (SHA-1) or 64 (SHA-256
+# repos). Anything else read out of the plumbing is treated as unknown.
+_OBJECT_ID_RE = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+
+# Frontmatter keys we accept as an attestation declaration, checked in
+# order at the top level and under ``lq_ai:``. Community skills are
+# attested at their source repo (lq-skills PR process); we surface what
+# the file declares and never assert more (ADR 0027 §5).
+_ATTESTATION_KEYS = ("attested_by", "attested-by", "attestation")
+
+# Operator remedy surfaced when the submodule directory is absent/empty.
+SUBMODULE_HINT = (
+    "Community catalog is empty. If this deployment was cloned without "
+    "--recurse-submodules, run `git submodule update --init skills/community` "
+    "(and `git submodule update --remote skills/community` to refresh), then "
+    "reload this page."
+)
+
+
+@dataclass(frozen=True)
+class CommunityCatalog:
+    """One re-scan of the community corpus, with honest source state."""
+
+    path: Path
+    """Where the scan looked (shown to the operator even when absent)."""
+
+    dir_present: bool
+    """Whether ``path`` exists as a directory. ``False`` == submodule
+    not checked out; the catalog is empty with an operator hint, not
+    an error (ADR 0027 §3)."""
+
+    sha: str | None
+    """Submodule HEAD commit, or ``None`` when unresolvable."""
+
+    records: list[SkillRecord] = field(default_factory=list)
+    load_errors: list[str] = field(default_factory=list)
+    """Per-skill parse failures, verbatim from the loader — surfaced to
+    the admin so broken corpus entries are visible, not hidden."""
+
+
+def resolve_catalog_dir(settings: Settings) -> Path:
+    """Return the community catalog directory for this deployment.
+
+    Mirrors :func:`app.skills.bootstrap.resolve_skill_dirs` — the
+    operator override wins; otherwise the submodule default at
+    ``<skills_dir>/community/skills``. Unlike the bootstrap helper this
+    returns the candidate path even when it does not exist, so the
+    admin UI can show the operator *where* the submodule is expected.
+    """
+
+    if settings.community_skills_dir:
+        return Path(settings.community_skills_dir).resolve()
+    return Path(settings.skills_dir).resolve() / "community" / "skills"
+
+
+def scan_catalog(catalog_dir: Path) -> CommunityCatalog:
+    """Re-scan ``catalog_dir`` and return the catalog with source state."""
+
+    dir_present = catalog_dir.is_dir()
+    records: list[SkillRecord] = []
+    load_errors: list[str] = []
+    if dir_present:
+        records, load_errors = scan_skills_folder(catalog_dir, source="community")
+    return CommunityCatalog(
+        path=catalog_dir,
+        dir_present=dir_present,
+        sha=resolve_submodule_sha(catalog_dir),
+        records=records,
+        load_errors=load_errors,
+    )
+
+
+# --- Submodule sha resolution (pure file reads) ------------------------------
+
+
+def resolve_submodule_sha(catalog_dir: Path) -> str | None:
+    """Resolve the submodule HEAD commit without invoking git.
+
+    The catalog dir is ``<submodule root>/skills``, so the ``.git``
+    entry normally lives one level up; both levels are checked so an
+    operator override pointing directly at a repo root also resolves.
+
+    Resolution chain (all plain file reads):
+
+    1. ``.git`` file → ``gitdir: <path>`` pointer (the submodule case)
+       or ``.git`` directory (a plain clone mounted as the corpus).
+    2. ``<gitdir>/HEAD`` — a detached HEAD is the sha itself (the
+       normal submodule state); a symbolic ref is followed into the
+       loose ref file, then ``packed-refs``.
+
+    Returns ``None`` when any link in the chain is missing or
+    unparseable — callers surface that as ``"unknown"`` rather than
+    guessing (ADR 0027 §2).
+    """
+
+    for root in (catalog_dir, catalog_dir.parent):
+        sha = _sha_from_git_entry(root / ".git")
+        if sha is not None:
+            return sha
+    return None
+
+
+def _sha_from_git_entry(git_entry: Path) -> str | None:
+    """Resolve HEAD for one ``.git`` file-or-directory candidate."""
+
+    try:
+        if git_entry.is_file():
+            pointer = git_entry.read_text(encoding="utf-8").strip()
+            if not pointer.startswith("gitdir:"):
+                return None
+            gitdir = (git_entry.parent / pointer.removeprefix("gitdir:").strip()).resolve()
+        elif git_entry.is_dir():
+            gitdir = git_entry
+        else:
+            return None
+
+        head_path = gitdir / "HEAD"
+        if not head_path.is_file():
+            return None
+        head = head_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+    if _OBJECT_ID_RE.match(head):
+        return head  # detached HEAD — the usual submodule state
+
+    if head.startswith("ref:"):
+        ref_name = head.removeprefix("ref:").strip()
+        return _resolve_ref(gitdir, ref_name)
+    return None
+
+
+def _resolve_ref(gitdir: Path, ref_name: str) -> str | None:
+    """Resolve a symbolic ref via the loose ref file, then packed-refs."""
+
+    loose = gitdir / ref_name
+    try:
+        if loose.is_file():
+            candidate = loose.read_text(encoding="utf-8").strip()
+            return candidate if _OBJECT_ID_RE.match(candidate) else None
+
+        packed = gitdir / "packed-refs"
+        if packed.is_file():
+            for line in packed.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line or line.startswith(("#", "^")):
+                    continue
+                parts = line.split(" ", 1)
+                if len(parts) == 2 and parts[1].strip() == ref_name:
+                    return parts[0] if _OBJECT_ID_RE.match(parts[0]) else None
+    except OSError:
+        return None
+    return None
+
+
+# --- Record → install-payload mapping ----------------------------------------
+
+
+def forked_from_ref(slug: str, sha: str | None) -> str:
+    """Provenance string written to ``user_skills.forked_from`` at install.
+
+    ``lq-skills:<slug>@<sha>`` — sha degrades to the literal
+    ``"unknown"`` when the plumbing could not be read, honestly
+    recording that the pin was unavailable rather than omitting it.
+    """
+
+    return f"{FORKED_FROM_PREFIX}:{slug}@{sha or 'unknown'}"
+
+
+def attestation_of(record: SkillRecord) -> str | None:
+    """Frontmatter-declared attestation string, or ``None``.
+
+    Checked at the frontmatter top level first, then under ``lq_ai:``
+    (both are ``extra="allow"`` models, so declarations land in
+    ``model_extra``). Only a non-empty string counts — the UI renders
+    ``None`` as "none declared in SKILL.md", never as attested.
+    """
+
+    fm = record.frontmatter
+    for container in (fm.model_extra or {}, fm.lq_ai.model_extra or {}):
+        for key in _ATTESTATION_KEYS:
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def display_title(record: SkillRecord) -> str:
+    """``lq_ai.title`` when declared; humanised slug otherwise."""
+
+    return record.frontmatter.lq_ai.title or _humanise(record.name)
+
+
+def install_fields_from_record(record: SkillRecord) -> dict[str, Any]:
+    """Map a parsed community record onto the ``UserSkillCreate`` field set.
+
+    The router feeds this dict through ``UserSkillCreate`` so a
+    community SKILL.md whose parsed fields violate the ADR 0012 bounds
+    (over-long description, empty body, …) is rejected with the same
+    422s a hand-authored user skill would get.
+
+    ``frontmatter_extra`` mirrors the fork endpoint's mapping
+    (jurisdiction / minimum_inference_tier / output_format carry
+    through) so the synthesized gateway payload after install is
+    shape-identical to the community original.
+    """
+
+    lq = record.frontmatter.lq_ai
+    frontmatter_extra: dict[str, Any] = {}
+    if lq.jurisdiction is not None:
+        frontmatter_extra["jurisdiction"] = lq.jurisdiction
+    if lq.minimum_inference_tier is not None:
+        frontmatter_extra["minimum_inference_tier"] = lq.minimum_inference_tier
+    if lq.output_format is not None:
+        frontmatter_extra["output_format"] = lq.output_format
+
+    return {
+        "slug": record.name,
+        "display_name": display_title(record),
+        "description": record.frontmatter.description,
+        "body": record.body,
+        "version": lq.version or "unversioned",
+        "tags": list(lq.tags),
+        "frontmatter_extra": frontmatter_extra,
+        "scope": "user",
+    }
+
+
+__all__ = [
+    "FORKED_FROM_PREFIX",
+    "SUBMODULE_HINT",
+    "CommunityCatalog",
+    "attestation_of",
+    "display_title",
+    "forked_from_ref",
+    "install_fields_from_record",
+    "resolve_catalog_dir",
+    "resolve_submodule_sha",
+    "scan_catalog",
+]

--- a/api/app/skills/loader.py
+++ b/api/app/skills/loader.py
@@ -323,6 +323,62 @@ def _list_subfolder_files(subfolder: Path) -> list[Path]:
     return out
 
 
+# --- Single-folder scan surface (DE-263 community catalog) -------------------
+
+
+def scan_skills_folder(
+    base: Path | str,
+    *,
+    source: SkillSource = "community",
+) -> tuple[list[SkillRecord], list[str]]:
+    """Scan ONE skills folder and return ``(records, failures)``.
+
+    Public wrapper over the same per-folder walk :func:`load_registry`
+    uses, for callers that want a raw listing of a single corpus rather
+    than the merged registry (the DE-263 community-catalog admin surface
+    scans ``skills/community/skills/`` per request through this).
+
+    Semantics match the registry walk exactly: malformed skills land in
+    ``failures`` (one human-readable string each) instead of raising;
+    frontmatter-name/folder-name mismatches are failures; within-folder
+    duplicate names keep the first occurrence. Records come back sorted
+    by name. A missing/non-directory ``base`` yields ``([], [])`` — an
+    absent community submodule is a first-class state (ADR 0027 §3),
+    not an error.
+    """
+
+    records: dict[str, SkillRecord] = {}
+    failures: list[str] = []
+    base_path = Path(base)
+    if base_path.is_dir():
+        _walk_into(base_path, source=source, records=records, failures=failures, existing=set())
+    return [records[name] for name in sorted(records)], failures
+
+
+def load_skill_folder(folder: Path | str, *, source: SkillSource = "community") -> SkillRecord:
+    """Load a single skill folder; raise :class:`LoaderError` on failure.
+
+    Public wrapper over the per-skill parse used by the registry walk.
+    Unlike :func:`scan_skills_folder` this surfaces the parse failure to
+    the caller — the DE-263 install path needs the error text so a
+    malformed community SKILL.md is rejected with a 422 naming the
+    problem rather than silently vanishing from the catalog.
+
+    Also enforces the frontmatter-name/folder-name match the registry
+    walk enforces, so a skill that would never load into the registry
+    cannot be installed either.
+    """
+
+    folder_path = Path(folder)
+    record = _load_one(folder_path, source=source)
+    if record.name != folder_path.name:
+        raise LoaderError(
+            folder_path.name,
+            f"frontmatter name {record.name!r} does not match folder name {folder_path.name!r}",
+        )
+    return record
+
+
 # --- SIGHUP wiring -----------------------------------------------------------
 
 
@@ -385,4 +441,10 @@ def install_sighup_reload(
     signal.signal(sighup, _handler)
 
 
-__all__ = ["LoaderError", "install_sighup_reload", "load_registry"]
+__all__ = [
+    "LoaderError",
+    "install_sighup_reload",
+    "load_registry",
+    "load_skill_folder",
+    "scan_skills_folder",
+]

--- a/api/tests/test_community_skills.py
+++ b/api/tests/test_community_skills.py
@@ -1,0 +1,545 @@
+"""Tests for the DE-263 admin community-skill installer (ADR 0027).
+
+Unit layer — ``app/skills/community_installer.py``:
+
+* catalog scan against a tmp fixture dir (valid + malformed + name-
+  mismatch skills; absent dir);
+* submodule sha resolution via pure file reads of git plumbing
+  (detached HEAD, symbolic ref → loose ref, packed-refs, absent →
+  ``None``);
+* provenance-ref formatting and attestation extraction (display-only,
+  never synthesized).
+
+Integration layer — ``app/api/community_skills.py``:
+
+* 403 for a non-admin authenticated user on EVERY endpoint;
+* catalog list (entries, load_errors surfaced, installed indication,
+  source sha) and the empty/absent-submodule 200-with-hint;
+* detail (full body + raw yaml + install_ref), 404 unknown slug,
+  422 malformed SKILL.md;
+* install happy path (user_skills row + ``forked_from`` provenance +
+  ``community_skill.installed`` audit row), 409 already-installed,
+  422 for bounds-violating content, 404 unknown slug.
+
+The catalog dependency is overridden with a per-test tmp fixture dir so
+the suite does not depend on the ``skills/community`` submodule being
+initialized in the checkout (ADR 0027 §3 makes absence first-class).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api import community_skills as community_skills_api
+from app.db.session import get_db
+from app.main import app
+from app.models.audit import AuditLog
+from app.models.user import User
+from app.models.user_skill import UserSkill
+from app.security import create_access_token, hash_password
+from app.skills.community_installer import (
+    attestation_of,
+    forked_from_ref,
+    resolve_catalog_dir,
+    resolve_submodule_sha,
+    scan_catalog,
+)
+
+_SHA = "abc123def4567890abc123def4567890abc123de"
+
+
+# ---------------------------------------------------------------------------
+# Fixture-corpus helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(
+    base: Path,
+    slug: str,
+    *,
+    description: str = "One-sentence trigger statement.",
+    body: str = "You are reviewing a document.\n",
+    lq_ai_block: str = '  title: "Fixture Skill"\n  version: "1.0.0"\n',
+    top_level_extra: str = "",
+    frontmatter_name: str | None = None,
+) -> Path:
+    folder = base / slug
+    folder.mkdir(parents=True)
+    name = frontmatter_name if frontmatter_name is not None else slug
+    (folder / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        f"{top_level_extra}"
+        "lq_ai:\n"
+        f"{lq_ai_block}"
+        "---\n"
+        f"{body}",
+        encoding="utf-8",
+    )
+    return folder
+
+
+def _write_malformed_skill(base: Path, slug: str) -> Path:
+    """A SKILL.md whose frontmatter is missing the required description."""
+
+    folder = base / slug
+    folder.mkdir(parents=True)
+    (folder / "SKILL.md").write_text(f"---\nname: {slug}\n---\nbody\n", encoding="utf-8")
+    return folder
+
+
+def _write_submodule_plumbing(root: Path, sha: str = _SHA) -> None:
+    """Fake the initialized-submodule git plumbing: ``.git`` file pointing
+    at a gitdir whose HEAD is a detached sha (the normal submodule state)."""
+
+    gitdir = root.parent / ".git" / "modules" / "community"
+    gitdir.mkdir(parents=True)
+    (gitdir / "HEAD").write_text(sha + "\n", encoding="utf-8")
+    (root / ".git").write_text("gitdir: ../.git/modules/community\n", encoding="utf-8")
+
+
+@pytest.fixture
+def catalog_dir(tmp_path: Path) -> Path:
+    """A populated community corpus: two valid skills, one malformed,
+    one frontmatter/folder name mismatch, plus submodule git plumbing."""
+
+    root = tmp_path / "community"
+    catalog = root / "skills"
+    catalog.mkdir(parents=True)
+    _write_skill(
+        catalog,
+        "lease-review",
+        description="First-pass review of commercial leases.",
+        lq_ai_block=(
+            '  title: "Lease Review"\n'
+            '  version: "1.2.0"\n'
+            '  author: "Jane Attorney"\n'
+            "  tags: [real-estate, review]\n"
+            "  jurisdiction: us\n"
+            "  output_format: report\n"
+        ),
+        top_level_extra='attested_by: "Jane Attorney, NY Bar #12345"\n',
+    )
+    _write_skill(
+        catalog,
+        "nda-triage",
+        description="Quick triage pass over inbound NDAs.",
+        lq_ai_block='  version: "0.9.0"\n',
+    )
+    _write_malformed_skill(catalog, "broken-skill")
+    _write_skill(catalog, "mismatched", frontmatter_name="other-name")
+    _write_submodule_plumbing(root)
+    return catalog
+
+
+# ---------------------------------------------------------------------------
+# Unit — catalog scan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_scan_catalog_lists_valid_and_surfaces_failures(catalog_dir: Path) -> None:
+    catalog = scan_catalog(catalog_dir)
+
+    assert catalog.dir_present is True
+    assert [r.name for r in catalog.records] == ["lease-review", "nda-triage"]
+    # Both broken entries are visible as failures, not silently dropped.
+    assert len(catalog.load_errors) == 2
+    assert any("broken-skill" in err for err in catalog.load_errors)
+    assert any("mismatched" in err for err in catalog.load_errors)
+    assert catalog.sha == _SHA
+
+
+@pytest.mark.unit
+def test_scan_catalog_absent_dir_is_first_class_empty(tmp_path: Path) -> None:
+    catalog = scan_catalog(tmp_path / "nope" / "skills")
+
+    assert catalog.dir_present is False
+    assert catalog.records == []
+    assert catalog.load_errors == []
+    assert catalog.sha is None
+
+
+@pytest.mark.unit
+def test_resolve_catalog_dir_prefers_operator_override(tmp_path: Path) -> None:
+    settings = SimpleNamespace(
+        community_skills_dir=str(tmp_path / "custom"), skills_dir=str(tmp_path / "skills")
+    )
+    assert resolve_catalog_dir(settings) == (tmp_path / "custom").resolve()  # type: ignore[arg-type]
+
+    settings = SimpleNamespace(community_skills_dir=None, skills_dir=str(tmp_path / "skills"))
+    expected = (tmp_path / "skills").resolve() / "community" / "skills"
+    assert resolve_catalog_dir(settings) == expected  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Unit — sha resolution (pure file reads; no git subprocess)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sha_from_detached_head_via_gitdir_pointer(tmp_path: Path) -> None:
+    root = tmp_path / "community"
+    catalog = root / "skills"
+    catalog.mkdir(parents=True)
+    _write_submodule_plumbing(root)
+
+    assert resolve_submodule_sha(catalog) == _SHA
+
+
+@pytest.mark.unit
+def test_sha_from_symbolic_ref_loose_file(tmp_path: Path) -> None:
+    root = tmp_path / "community"
+    catalog = root / "skills"
+    catalog.mkdir(parents=True)
+    gitdir = root / ".git"
+    (gitdir / "refs" / "heads").mkdir(parents=True)
+    (gitdir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (gitdir / "refs" / "heads" / "main").write_text(_SHA + "\n", encoding="utf-8")
+
+    assert resolve_submodule_sha(catalog) == _SHA
+
+
+@pytest.mark.unit
+def test_sha_from_symbolic_ref_packed_refs(tmp_path: Path) -> None:
+    root = tmp_path / "community"
+    catalog = root / "skills"
+    catalog.mkdir(parents=True)
+    gitdir = root / ".git"
+    gitdir.mkdir()
+    (gitdir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (gitdir / "packed-refs").write_text(
+        "# pack-refs with: peeled fully-peeled sorted\n"
+        f"{_SHA} refs/heads/main\n"
+        "^deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n",
+        encoding="utf-8",
+    )
+
+    assert resolve_submodule_sha(catalog) == _SHA
+
+
+@pytest.mark.unit
+def test_sha_degrades_to_none_without_plumbing(tmp_path: Path) -> None:
+    root = tmp_path / "community"
+    catalog = root / "skills"
+    catalog.mkdir(parents=True)
+
+    assert resolve_submodule_sha(catalog) is None
+    # An unparseable .git file also degrades instead of raising.
+    (root / ".git").write_text("not a gitdir pointer\n", encoding="utf-8")
+    assert resolve_submodule_sha(catalog) is None
+
+
+@pytest.mark.unit
+def test_forked_from_ref_degrades_sha_honestly() -> None:
+    assert forked_from_ref("lease-review", _SHA) == f"lq-skills:lease-review@{_SHA}"
+    assert forked_from_ref("lease-review", None) == "lq-skills:lease-review@unknown"
+
+
+@pytest.mark.unit
+def test_attestation_is_read_never_synthesized(catalog_dir: Path) -> None:
+    catalog = scan_catalog(catalog_dir)
+    by_name = {r.name: r for r in catalog.records}
+
+    assert attestation_of(by_name["lease-review"]) == "Jane Attorney, NY Bar #12345"
+    assert attestation_of(by_name["nda-triage"]) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration — endpoint fixtures
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+async def _make_user(
+    db_session: AsyncSession,
+    *,
+    email: str,
+    is_admin: bool,
+) -> tuple[User, str]:
+    user = User(
+        id=uuid.uuid4(),
+        email=email,
+        hashed_password=hash_password("test-password-123"),
+        is_admin=is_admin,
+        must_change_password=False,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    token = create_access_token(user_id=user.id, email=user.email, is_admin=user.is_admin)
+    return user, token
+
+
+def _install_catalog_override(catalog_path: Path) -> None:
+    app.dependency_overrides[community_skills_api._catalog] = lambda: scan_catalog(catalog_path)
+
+
+@pytest_asyncio.fixture
+async def admin_client(
+    db_session: AsyncSession, catalog_dir: Path
+) -> AsyncIterator[tuple[AsyncClient, str, User]]:
+    user, token = await _make_user(db_session, email="admin-community@example.com", is_admin=True)
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    _install_catalog_override(catalog_dir)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, token, user
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(community_skills_api._catalog, None)
+
+
+@pytest_asyncio.fixture
+async def member_client(
+    db_session: AsyncSession, catalog_dir: Path
+) -> AsyncIterator[tuple[AsyncClient, str]]:
+    _user, token = await _make_user(
+        db_session, email="member-community@example.com", is_admin=False
+    )
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    _install_catalog_override(catalog_dir)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, token
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(community_skills_api._catalog, None)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Integration — admin gate (403 on EVERY endpoint for non-admins)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/api/v1/admin/community-skills"),
+        ("GET", "/api/v1/admin/community-skills/lease-review"),
+        ("POST", "/api/v1/admin/community-skills/lease-review/install"),
+    ],
+)
+async def test_non_admin_gets_403_on_every_endpoint(
+    member_client: tuple[AsyncClient, str],
+    method: str,
+    path: str,
+) -> None:
+    ac, token = member_client
+    res = await ac.request(method, path, headers=_auth(token))
+    assert res.status_code == 403, res.text
+
+
+# ---------------------------------------------------------------------------
+# Integration — catalog list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_list_returns_catalog_with_source_and_load_errors(
+    admin_client: tuple[AsyncClient, str, User],
+) -> None:
+    ac, token, _user = admin_client
+    res = await ac.get("/api/v1/admin/community-skills", headers=_auth(token))
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert [item["slug"] for item in body["items"]] == ["lease-review", "nda-triage"]
+    lease = body["items"][0]
+    assert lease["title"] == "Lease Review"
+    assert lease["version"] == "1.2.0"
+    assert lease["attested_by"] == "Jane Attorney, NY Bar #12345"
+    assert lease["installed"] is False
+    assert lease["body_preview"].startswith("You are reviewing")
+    # No attestation declared → null, never synthesized.
+    assert body["items"][1]["attested_by"] is None
+
+    assert body["source"]["sha"] == _SHA
+    assert body["source"]["submodule_present"] is True
+    assert body["source"]["operator_hint"] is None
+    assert len(body["load_errors"]) == 2
+
+
+@pytest.mark.integration
+async def test_list_absent_submodule_is_200_with_operator_hint(
+    admin_client: tuple[AsyncClient, str, User],
+    tmp_path: Path,
+) -> None:
+    ac, token, _user = admin_client
+    _install_catalog_override(tmp_path / "absent" / "skills")
+
+    res = await ac.get("/api/v1/admin/community-skills", headers=_auth(token))
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["items"] == []
+    assert body["source"]["submodule_present"] is False
+    assert body["source"]["sha"] is None
+    assert "git submodule update --init" in body["source"]["operator_hint"]
+
+
+# ---------------------------------------------------------------------------
+# Integration — detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_detail_returns_full_skill_md(
+    admin_client: tuple[AsyncClient, str, User],
+) -> None:
+    ac, token, _user = admin_client
+    res = await ac.get("/api/v1/admin/community-skills/lease-review", headers=_auth(token))
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["slug"] == "lease-review"
+    assert body["content_md"].startswith("You are reviewing")
+    assert "name: lease-review" in body["content_yaml"]
+    assert body["output_format"] == "report"
+    assert body["install_ref"] == f"lq-skills:lease-review@{_SHA}"
+
+
+@pytest.mark.integration
+async def test_detail_unknown_slug_404(admin_client: tuple[AsyncClient, str, User]) -> None:
+    ac, token, _user = admin_client
+    res = await ac.get("/api/v1/admin/community-skills/no-such-skill", headers=_auth(token))
+    assert res.status_code == 404, res.text
+
+
+@pytest.mark.integration
+async def test_detail_malformed_skill_md_422_names_the_problem(
+    admin_client: tuple[AsyncClient, str, User],
+) -> None:
+    ac, token, _user = admin_client
+    res = await ac.get("/api/v1/admin/community-skills/broken-skill", headers=_auth(token))
+    assert res.status_code == 422, res.text
+    assert "malformed SKILL.md" in res.json()["detail"]
+
+
+@pytest.mark.integration
+async def test_path_shaped_slug_is_rejected_before_filesystem_join(
+    admin_client: tuple[AsyncClient, str, User],
+) -> None:
+    ac, token, _user = admin_client
+    res = await ac.get("/api/v1/admin/community-skills/Bad_Slug", headers=_auth(token))
+    assert res.status_code == 422, res.text
+
+
+# ---------------------------------------------------------------------------
+# Integration — install
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_install_persists_row_with_provenance_and_audit(
+    admin_client: tuple[AsyncClient, str, User],
+    db_session: AsyncSession,
+) -> None:
+    ac, token, user = admin_client
+    res = await ac.post("/api/v1/admin/community-skills/lease-review/install", headers=_auth(token))
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["slug"] == "lease-review"
+    assert body["scope"] == "user"
+    assert body["owner_user_id"] == str(user.id)
+    assert body["forked_from"] == f"lq-skills:lease-review@{_SHA}"
+    assert body["frontmatter_extra"] == {"jurisdiction": "us", "output_format": "report"}
+
+    row = (
+        await db_session.execute(select(UserSkill).where(UserSkill.id == uuid.UUID(body["id"])))
+    ).scalar_one()
+    assert row.forked_from == f"lq-skills:lease-review@{_SHA}"
+    assert row.owner_user_id == user.id
+    assert row.display_name == "Lease Review"
+
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(AuditLog.action == "community_skill.installed")
+        )
+    ).scalar_one()
+    assert audit.resource_type == "user_skill"
+    assert audit.resource_id == str(row.id)
+    assert audit.user_id == user.id
+    assert audit.details is not None
+    assert audit.details["forked_from"] == f"lq-skills:lease-review@{_SHA}"
+    assert audit.details["source_sha"] == _SHA
+    assert audit.details["attested_by"] == "Jane Attorney, NY Bar #12345"
+
+    # The list now reports the slug as installed for this admin.
+    res = await ac.get("/api/v1/admin/community-skills", headers=_auth(token))
+    installed = {item["slug"]: item["installed"] for item in res.json()["items"]}
+    assert installed == {"lease-review": True, "nda-triage": False}
+
+
+@pytest.mark.integration
+async def test_install_twice_409_until_archived(
+    admin_client: tuple[AsyncClient, str, User],
+) -> None:
+    ac, token, _user = admin_client
+    first = await ac.post(
+        "/api/v1/admin/community-skills/lease-review/install", headers=_auth(token)
+    )
+    assert first.status_code == 201, first.text
+
+    second = await ac.post(
+        "/api/v1/admin/community-skills/lease-review/install", headers=_auth(token)
+    )
+    assert second.status_code == 409, second.text
+    assert "archive it first" in second.json()["detail"]
+
+
+@pytest.mark.integration
+async def test_install_malformed_skill_md_422(
+    admin_client: tuple[AsyncClient, str, User],
+) -> None:
+    ac, token, _user = admin_client
+    res = await ac.post("/api/v1/admin/community-skills/broken-skill/install", headers=_auth(token))
+    assert res.status_code == 422, res.text
+    assert "malformed SKILL.md" in res.json()["detail"]
+
+
+@pytest.mark.integration
+async def test_install_bounds_violation_gets_user_skill_422(
+    admin_client: tuple[AsyncClient, str, User],
+    catalog_dir: Path,
+) -> None:
+    """A parseable SKILL.md whose fields violate the ADR 0012 bounds is
+    rejected through the reused UserSkillCreate path (description > 2000)."""
+
+    ac, token, _user = admin_client
+    _write_skill(
+        catalog_dir,
+        "too-long",
+        description="x" * 2_100,
+        lq_ai_block='  version: "1.0.0"\n',
+    )
+
+    res = await ac.post("/api/v1/admin/community-skills/too-long/install", headers=_auth(token))
+    assert res.status_code == 422, res.text
+    assert "violates user-skill bounds" in res.json()["detail"]
+
+
+@pytest.mark.integration
+async def test_install_unknown_slug_404(admin_client: tuple[AsyncClient, str, User]) -> None:
+    ac, token, _user = admin_client
+    res = await ac.post(
+        "/api/v1/admin/community-skills/no-such-skill/install", headers=_auth(token)
+    )
+    assert res.status_code == 404, res.text

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -203,6 +203,10 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("PATCH", "/api/v1/admin/tool-providers/{provider_type}"),
     ("DELETE", "/api/v1/admin/tool-providers/{provider_type}"),
     ("GET", "/api/v1/admin/config"),
+    # 3.8 / DE-263 — admin community-skill installer (ADR 0027)
+    ("GET", "/api/v1/admin/community-skills"),
+    ("GET", "/api/v1/admin/community-skills/{slug}"),
+    ("POST", "/api/v1/admin/community-skills/{slug}/install"),
     # D3 — admin audit-log read endpoint
     ("GET", "/api/v1/admin/audit-log"),
     # M3-0.3 / DE-276 — admin ingest-health aggregate

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -164,6 +164,10 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/admin/intake-bridges",
         "/api/v1/admin/intake-bridges/slack/{workspace_id}",
         "/api/v1/admin/intake-bridges/teams/{tenant_id}",
+        # 3.8 / DE-263 — admin community-skill installer (ADR 0027)
+        "/api/v1/admin/community-skills",
+        "/api/v1/admin/community-skills/{slug}",
+        "/api/v1/admin/community-skills/{slug}/install",
         # M4-A4-i — Autonomous sessions read/halt API (per-user)
         "/api/v1/autonomous/sessions",
         "/api/v1/autonomous/sessions/{session_id}",
@@ -342,7 +346,11 @@ async def test_openapi_paths_match_sketch() -> None:
     # Donna #3 adds two new paths (137 -> 139):
     # /api/v1/admin/tool-providers
     # /api/v1/admin/tool-providers/{provider_type}
-    assert len(actual) == 139
+    # 3.8 / DE-263 adds three new paths (139 -> 142):
+    # /api/v1/admin/community-skills
+    # /api/v1/admin/community-skills/{slug}
+    # /api/v1/admin/community-skills/{slug}/install
+    assert len(actual) == 142
 
 
 @pytest.mark.unit

--- a/docs/adr/0027-community-skill-catalog-source.md
+++ b/docs/adr/0027-community-skill-catalog-source.md
@@ -1,0 +1,83 @@
+# ADR 0027 — Community skill catalog served from the local submodule
+
+**Status:** Proposed (2026-07-25) — authored in-PR with roadmap item 3.8 (DE-263, community skill installer admin UI); reviewable at PR time. New admin endpoints carry **security review** per the auth-touching-surface rule in CLAUDE.md / CODEOWNERS.
+
+**Relates to:** [ADR 0004](0004-skill-loader-locus.md) (the skill loader lives in the backend; filesystem-canonical skills), [ADR 0012](0012-db-backed-user-skills.md) (DB-backed user skills, `forked_from` documentary lineage, audit-log lineage records), [ADR 0014](0014-gateway-egress-boundary-for-tool-providers.md) / [ADR 0016](0016-transparency-and-governance-invariants.md) (the gateway is the only egress path; the backend makes no outbound HTTP calls beyond its single gateway client — enforced by `tests/test_transparency_invariants.py`). Realizes **DE-263**.
+
+---
+
+## Context
+
+The `skills/community` git submodule (the `lq-skills` repo) is the distribution channel
+for community-contributed skills. The existing loader (`api/app/skills/loader.py`,
+wired via `api/app/skills/bootstrap.py`) already scans `skills/community/skills/`
+at startup and merges parseable community skills into the in-memory registry with
+`source="community"` (built-ins win on slug collision).
+
+DE-263 adds an **admin installer UI**: an operator browses the community catalog,
+reads the full SKILL.md (transparency principle — the work product is the artifact),
+and installs a skill as an editable DB-backed copy. The open question this ADR pins:
+**where does the catalog come from at request time?**
+
+## Decision
+
+**Serve the catalog from the local submodule checkout, by re-scanning
+`skills/community/skills/` (or the operator's `LQ_AI_COMMUNITY_SKILLS_DIR`
+override) from disk on each admin catalog request. The api never fetches the
+catalog over the network.**
+
+Consequences pinned with this decision:
+
+1. **Refresh path is `git submodule update --remote skills/community` (operator-run),
+   followed by SIGHUP (or restart) if the merged registry should also pick up the
+   new corpus.** The catalog endpoints re-scan the directory per request, so the
+   admin UI sees a refreshed submodule immediately; the chat-facing registry
+   refreshes on the existing SIGHUP/restart path.
+2. **Catalog provenance is recorded as `forked_from = "lq-skills:<slug>@<sha>"`** on
+   the installed `user_skills` row, where `<sha>` is the submodule's HEAD commit.
+   The sha is resolved by **pure file reads** of git plumbing (`skills/community/.git`
+   gitdir pointer → `HEAD` → loose ref or `packed-refs`); the api does **not** shell
+   out to git at request time. When the plumbing is absent (uninitialized submodule,
+   Docker image built without `.git`), the sha degrades honestly to `"unknown"`.
+3. **An absent or empty submodule is a first-class state, not an error.** The catalog
+   endpoint returns 200 with an empty list plus an operator hint naming the
+   `git submodule update --init skills/community` remedy. Fresh clones without
+   `--recurse-submodules` must not break the admin UI.
+4. **Install reuses the ADR 0012 user-skill validation path** (`UserSkillCreate`
+   bounds), so a malformed community SKILL.md is rejected with the same 422 shape a
+   hand-authored malformed skill would get, and the install writes the standard
+   `community_skill.installed` audit-log row in the same transaction as the row
+   insert.
+5. **Attestation is displayed, never asserted.** Community skills are attested at
+   their source repo (lq-skills PR process). The catalog surfaces whatever
+   attestation metadata the SKILL.md frontmatter carries and states "none declared"
+   otherwise; the installer never synthesizes attestation state.
+
+## Alternatives considered
+
+- **GitHub API fetch from the api (rejected).** Fetching the lq-skills repo listing
+  from the backend would add a second outbound HTTP surface beyond the single
+  gateway client, violating the egress invariant that
+  `tests/test_transparency_invariants.py` enforces (ADR 0014/0016), and would break
+  air-gapped deployments — a core self-hosted posture. It would also make the
+  catalog non-reproducible: what the operator reviewed and what got installed could
+  differ between requests.
+- **Web-side fetch (browser calls GitHub directly) (rejected).** Moves the
+  supply chain into the browser: CSP loosening for `github.com`/`raw.githubusercontent.com`,
+  un-audited content rendered and installed from a URL the deployment does not pin,
+  and no server-side record of what was actually reviewed at install time. The
+  install provenance would be whatever the browser happened to see — unauditable.
+- **Dedicated registry service (rejected).** A separate catalog service (or DB-synced
+  mirror of the submodule) is overkill for a corpus of dozens of skills that already
+  ships inside the repo as a submodule; it would add an SBOM/deploy surface and a
+  second source of truth that can drift from the filesystem-canonical one (ADR 0004).
+
+## Consequences
+
+- Air-gap compatible; zero new egress; zero new dependencies.
+- The catalog is exactly as fresh as the operator's submodule checkout — the UI
+  states the pinned sha (or `unknown`) so staleness is visible, not hidden.
+- Installed copies do not auto-update; they are forks (ADR 0012 semantics) whose
+  lineage lives in `forked_from` + the audit log. A future "update available"
+  surface can diff installed `forked_from` shas against the current submodule sha
+  (deferred; would be a new DE).

--- a/docs/api/backend-openapi.generated.yaml
+++ b/docs/api/backend-openapi.generated.yaml
@@ -1822,6 +1822,171 @@ components:
       - query
       title: ColumnSpec
       type: object
+    CommunityCatalogResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/CommunitySkillSummary'
+          title: Items
+          type: array
+        load_errors:
+          items:
+            type: string
+          title: Load Errors
+          type: array
+        source:
+          $ref: '#/components/schemas/CommunityCatalogSource'
+      required:
+      - items
+      - source
+      title: CommunityCatalogResponse
+      type: object
+    CommunityCatalogSource:
+      description: Where the catalog came from — stated so staleness is visible.
+      properties:
+        operator_hint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Operator Hint
+        path:
+          title: Path
+          type: string
+        sha:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Sha
+        submodule_present:
+          title: Submodule Present
+          type: boolean
+      required:
+      - path
+      - submodule_present
+      title: CommunityCatalogSource
+      type: object
+    CommunitySkillDetail:
+      description: Full SKILL.md view — the install-confirm surface.
+      properties:
+        attested_by:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Attested By
+        author:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Author
+        body_preview:
+          title: Body Preview
+          type: string
+        content_md:
+          title: Content Md
+          type: string
+        content_yaml:
+          title: Content Yaml
+          type: string
+        description:
+          title: Description
+          type: string
+        install_ref:
+          title: Install Ref
+          type: string
+        installed:
+          title: Installed
+          type: boolean
+        jurisdiction:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Jurisdiction
+        minimum_inference_tier:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Minimum Inference Tier
+        output_format:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Output Format
+        slug:
+          title: Slug
+          type: string
+        tags:
+          items:
+            type: string
+          title: Tags
+          type: array
+        title:
+          title: Title
+          type: string
+        version:
+          title: Version
+          type: string
+      required:
+      - slug
+      - title
+      - description
+      - version
+      - installed
+      - body_preview
+      - content_yaml
+      - content_md
+      - install_ref
+      title: CommunitySkillDetail
+      type: object
+    CommunitySkillSummary:
+      description: One catalog entry — the list view.
+      properties:
+        attested_by:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Attested By
+        author:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Author
+        body_preview:
+          title: Body Preview
+          type: string
+        description:
+          title: Description
+          type: string
+        installed:
+          title: Installed
+          type: boolean
+        jurisdiction:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Jurisdiction
+        slug:
+          title: Slug
+          type: string
+        tags:
+          items:
+            type: string
+          title: Tags
+          type: array
+        title:
+          title: Title
+          type: string
+        version:
+          title: Version
+          type: string
+      required:
+      - slug
+      - title
+      - description
+      - version
+      - installed
+      - body_preview
+      title: CommunitySkillSummary
+      type: object
     CurrentTierResponse:
       description: '``GET /inference/current-tier`` response.
 
@@ -6771,6 +6936,115 @@ paths:
       summary: Report whether the first-run bootstrap admin password is still active.
       tags:
       - admin
+  /api/v1/admin/community-skills:
+    get:
+      description: 'GET /api/v1/admin/community-skills — the catalog list.
+
+
+        An absent submodule is 200-with-hint, not an error: fresh clones
+
+        without ``--recurse-submodules`` must not break the admin UI.'
+      operationId: list_community_skills_api_v1_admin_community_skills_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommunityCatalogResponse'
+          description: Successful Response
+        '403':
+          description: Authenticated but not an admin
+      security:
+      - OAuth2PasswordBearer: []
+      summary: List the community skill catalog from the local submodule (DE-263)
+      tags:
+      - admin-community-skills
+  /api/v1/admin/community-skills/{slug}:
+    get:
+      description: 'GET /api/v1/admin/community-skills/{slug} — the install-confirm
+        view.
+
+
+        Returns the full body + raw frontmatter so the operator reviews the
+
+        actual work product before installing (transparency principle).'
+      operationId: get_community_skill_api_v1_admin_community_skills__slug__get
+      parameters:
+      - in: path
+        name: slug
+        required: true
+        schema:
+          title: Slug
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommunitySkillDetail'
+          description: Successful Response
+        '403':
+          description: Authenticated but not an admin
+        '404':
+          description: Unknown community skill slug
+        '422':
+          description: SKILL.md exists but is malformed
+      security:
+      - OAuth2PasswordBearer: []
+      summary: Full SKILL.md detail for one community skill (DE-263)
+      tags:
+      - admin-community-skills
+  /api/v1/admin/community-skills/{slug}/install:
+    post:
+      description: 'POST /api/v1/admin/community-skills/{slug}/install.
+
+
+        The installed copy is a fork (ADR 0012): a user-scope row owned by
+
+        the INSTALLING ADMIN, editable and archivable like any user skill;
+
+        it does not auto-update when the submodule moves. Provenance lives
+
+        in ``forked_from`` + the audit row.
+
+
+        409 semantics: ``user_skills`` uniqueness is per-owner among
+
+        non-archived rows, so "already installed" is exactly "the caller
+
+        has a live user-scope row at this slug" — including a hand-authored
+
+        one, which install must not clobber. Archiving the row frees the
+
+        slug for re-install (that is the honest re-install path).'
+      operationId: install_community_skill_api_v1_admin_community_skills__slug__install_post
+      parameters:
+      - in: path
+        name: slug
+        required: true
+        schema:
+          title: Slug
+          type: string
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSkillResponse'
+          description: Successful Response
+        '403':
+          description: Authenticated but not an admin
+        '404':
+          description: Unknown community skill slug
+        '409':
+          description: Caller already has a live user skill at this slug
+        '422':
+          description: SKILL.md malformed or violates user-skill bounds
+      security:
+      - OAuth2PasswordBearer: []
+      summary: Install a community skill as an editable user-scope copy (DE-263)
+      tags:
+      - admin-community-skills
   /api/v1/admin/config:
     get:
       description: Return the gateway's sanitized current config (D0.5).

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -60,6 +60,8 @@ tags:
     description: Per-user saved prompt fragments
   - name: user-skills
     description: Per-user DB-backed skills (D8) — owned CRUD that shadows built-ins per ADR 0012
+  - name: admin-community-skills
+    description: Admin community-skill installer — catalog from the local lq-skills submodule (DE-263, ADR 0027)
   - name: teams
     description: Operator-admin-controlled teams (D8.1a) — D8.1b will gate team-scope user-skills mutate on team-admin role
   - name: audit-log
@@ -4030,6 +4032,110 @@ paths:
           description: Tenant not found or already disconnected
 
 # ============================================================
+# 3.8 / DE-263 — Admin community-skill installer (ADR 0027)
+# ============================================================
+
+  /api/v1/admin/community-skills:
+    get:
+      tags: [admin-community-skills]
+      summary: List the community skill catalog from the local submodule (DE-263)
+      description: |
+        Serves the catalog FROM THE LOCAL `skills/community` submodule
+        checkout — never a network fetch (ADR 0027; preserves the
+        backend single-outbound-client invariant and air-gap
+        compatibility). Re-scans the directory per request; the
+        operator refresh path is `git submodule update --remote
+        skills/community`. An absent/empty submodule returns 200 with
+        an empty list plus `source.operator_hint`. Per-skill parse
+        failures surface in `load_errors`. Admin-only. Backs the
+        SvelteKit admin page at `/lq-ai/admin/community-skills`.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Community catalog (possibly empty, with operator hint)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommunityCatalogResponse'
+        '401':
+          description: Not authenticated
+        '403':
+          description: Authenticated but not an admin
+
+  /api/v1/admin/community-skills/{slug}:
+    get:
+      tags: [admin-community-skills]
+      summary: Full SKILL.md detail for one community skill (DE-263)
+      description: |
+        The install-confirm view — full body markdown + raw frontmatter
+        YAML so the operator reviews the actual work product before
+        installing (transparency principle). `attested_by` is the
+        verbatim frontmatter declaration or null ("none declared");
+        attestation is displayed, never synthesized. Admin-only.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Full community skill detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommunitySkillDetail'
+        '401':
+          description: Not authenticated
+        '403':
+          description: Authenticated but not an admin
+        '404':
+          description: Unknown community skill slug
+        '422':
+          description: SKILL.md exists but is malformed (detail says why)
+
+  /api/v1/admin/community-skills/{slug}/install:
+    post:
+      tags: [admin-community-skills]
+      summary: Install a community skill as an editable user-scope copy (DE-263)
+      description: |
+        Persists a `user_skills` row (ADR 0012 fork semantics) owned by
+        the installing admin, validated through the same bounds as
+        hand-authored user skills (malformed content → the same 422s).
+        Writes `forked_from: "lq-skills:<slug>@<sha>"` where `<sha>` is
+        the submodule HEAD commit resolved by file reads of git
+        plumbing (degrades to `"unknown"`), plus a
+        `community_skill.installed` audit row in the same transaction.
+        The copy does not auto-update when the submodule moves.
+        Admin-only.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '201':
+          description: Installed — the created user-skill row
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSkill'
+        '401':
+          description: Not authenticated
+        '403':
+          description: Authenticated but not an admin
+        '404':
+          description: Unknown community skill slug
+        '409':
+          description: Caller already has a live user skill at this slug
+        '422':
+          description: SKILL.md malformed or violates user-skill bounds
+
+# ============================================================
 # M4-A4-i — Autonomous sessions read/halt API
 # ============================================================
 
@@ -5798,6 +5904,91 @@ components:
         tenant_name: { type: string }
         installer_oid: { type: string }
         installed_at: { type: string, format: date-time }
+
+    CommunityCatalogSource:
+      type: object
+      description: |
+        Where the community catalog came from (DE-263, ADR 0027) —
+        stated so staleness is visible, not hidden. `sha` is the
+        submodule HEAD commit resolved via file reads of git plumbing;
+        null when unresolvable (rendered as "unknown").
+        `operator_hint` is set when the catalog is absent/empty and
+        names the `git submodule update --init` remedy.
+      required:
+        - path
+        - submodule_present
+      properties:
+        path: { type: string }
+        sha: { type: string, nullable: true }
+        submodule_present: { type: boolean }
+        operator_hint: { type: string, nullable: true }
+
+    CommunitySkillSummary:
+      type: object
+      description: |
+        One community catalog entry (DE-263). `attested_by` is the
+        verbatim frontmatter declaration or null — attestation is
+        displayed, never synthesized. `installed` reflects whether the
+        CALLING admin already has a live user-scope row at this slug
+        (the same condition that makes install return 409).
+      required:
+        - slug
+        - title
+        - description
+        - version
+        - installed
+        - body_preview
+      properties:
+        slug: { type: string }
+        title: { type: string }
+        description: { type: string }
+        version: { type: string }
+        author: { type: string, nullable: true }
+        tags:
+          type: array
+          items: { type: string }
+        jurisdiction: { type: string, nullable: true }
+        attested_by: { type: string, nullable: true }
+        installed: { type: boolean }
+        body_preview: { type: string }
+
+    CommunityCatalogResponse:
+      type: object
+      description: |
+        Response for `GET /api/v1/admin/community-skills`. `load_errors`
+        carries per-skill parse failures verbatim so broken corpus
+        entries are visible to the operator rather than silently
+        dropped.
+      required:
+        - items
+        - source
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/CommunitySkillSummary' }
+        source: { $ref: '#/components/schemas/CommunityCatalogSource' }
+        load_errors:
+          type: array
+          items: { type: string }
+
+    CommunitySkillDetail:
+      allOf:
+        - $ref: '#/components/schemas/CommunitySkillSummary'
+        - type: object
+          description: |
+            Full SKILL.md view for the install-confirm surface (DE-263).
+            `install_ref` is the `forked_from` provenance string an
+            install would write now (`lq-skills:<slug>@<sha|unknown>`).
+          required:
+            - content_yaml
+            - content_md
+            - install_ref
+          properties:
+            output_format: { type: string, nullable: true }
+            minimum_inference_tier: { type: integer, nullable: true }
+            content_yaml: { type: string }
+            content_md: { type: string }
+            install_ref: { type: string }
 
     IntakeBridgesList:
       type: object

--- a/web/cypress/e2e/de263-community-skills.cy.ts
+++ b/web/cypress/e2e/de263-community-skills.cy.ts
@@ -1,0 +1,205 @@
+/**
+ * 3.8 / DE-263 — Community skill installer admin UI happy path.
+ *
+ * Covers the operator flow on /lq-ai/admin/community-skills:
+ *
+ *   1. Visit with an admin auth state → catalog list renders with the
+ *      source line (submodule path + short sha) and attestation states
+ *      shown honestly per row.
+ *   2. Search narrows the list.
+ *   3. "Review" opens the detail panel with the FULL SKILL.md
+ *      frontmatter + body (transparency: the work product is reviewed
+ *      before install) and the install provenance ref.
+ *   4. "Install" → confirm dialog → POST install → success banner with
+ *      the provenance ref; the list reloads with installed=true and the
+ *      button flips to a disabled "Installed".
+ *
+ * All API responses are mocked via cy.intercept so the spec runs
+ * against a live SvelteKit dev server without requiring an initialized
+ * skills/community submodule or any particular DB state. Mocked shapes
+ * mirror the wire shapes in `api/app/api/community_skills.py`.
+ *
+ * Run:
+ *   docker compose up -d
+ *   cd web && npx cypress run --spec 'cypress/e2e/de263-community-skills.cy.ts'
+ */
+
+/// <reference types="cypress" />
+
+const SHA = 'abc123def4567890abc123def4567890abc123de';
+
+const mockUser = {
+	id: 'u1',
+	email: 'admin@lq.ai',
+	display_name: 'Admin',
+	is_admin: true,
+	role: 'admin' as const,
+	mfa_enabled: false,
+	must_change_password: false,
+	created_at: '2026-01-01T00:00:00Z'
+};
+
+const leaseReview = {
+	slug: 'lease-review',
+	title: 'Lease Review',
+	description: 'First-pass review of commercial leases.',
+	version: '1.2.0',
+	author: 'Jane Attorney',
+	tags: ['real-estate', 'review'],
+	jurisdiction: 'us',
+	attested_by: 'Jane Attorney, NY Bar #12345',
+	installed: false,
+	body_preview: 'You are reviewing a commercial lease…'
+};
+
+const ndaTriage = {
+	slug: 'nda-triage',
+	title: 'NDA Triage',
+	description: 'Quick triage pass over inbound NDAs.',
+	version: '0.9.0',
+	author: null,
+	tags: ['nda'],
+	jurisdiction: null,
+	attested_by: null,
+	installed: false,
+	body_preview: 'Triage the NDA…'
+};
+
+const catalogBody = (items: unknown[]) => ({
+	items,
+	source: {
+		path: '/app/skills/community/skills',
+		sha: SHA,
+		submodule_present: true,
+		operator_hint: null
+	},
+	load_errors: []
+});
+
+const leaseReviewDetail = {
+	...leaseReview,
+	output_format: 'report',
+	minimum_inference_tier: null,
+	content_yaml: 'name: lease-review\ndescription: First-pass review of commercial leases.',
+	content_md: '# Lease review\n\nYou are reviewing a commercial lease…',
+	install_ref: `lq-skills:lease-review@${SHA}`
+};
+
+const installedRow = {
+	id: 'us-1',
+	scope: 'user',
+	owner_user_id: 'u1',
+	owner_team_id: null,
+	slug: 'lease-review',
+	display_name: 'Lease Review',
+	description: 'First-pass review of commercial leases.',
+	version: '1.2.0',
+	tags: ['real-estate', 'review'],
+	frontmatter_extra: { jurisdiction: 'us', output_format: 'report' },
+	body: '# Lease review\n\nYou are reviewing a commercial lease…',
+	slash_alias: null,
+	forked_from: `lq-skills:lease-review@${SHA}`,
+	archived_at: null,
+	created_at: '2026-07-25T00:00:00Z',
+	updated_at: '2026-07-25T00:00:00Z'
+};
+
+function setAuthStorage(win: Window): void {
+	win.localStorage.setItem(
+		'lq_ai_auth',
+		JSON.stringify({
+			access_token: 'fake-token-de263',
+			refresh_token: null,
+			expires_at: Date.now() + 3600 * 1000,
+			user: mockUser
+		})
+	);
+}
+
+function interceptBaseRequests(): void {
+	cy.intercept('GET', '**/api/v1/users/me', { statusCode: 200, body: mockUser }).as('getMe');
+	cy.intercept('GET', '**/api/v1/admin/bootstrap-status', {
+		statusCode: 200,
+		body: { default_password_active: false, logs_hint: '' }
+	}).as('bootstrapStatus');
+	cy.intercept('GET', '**/api/v1/users/me/preferences', { statusCode: 200, body: {} }).as(
+		'getPreferences'
+	);
+	cy.intercept('GET', '**/api/v1/projects**', { statusCode: 200, body: [] }).as('listProjects');
+	cy.intercept('GET', '**/api/v1/chats**', {
+		statusCode: 200,
+		body: { items: [], next_cursor: null }
+	}).as('listChats');
+	cy.intercept('GET', '**/api/v1/user-skills**', { statusCode: 200, body: [] }).as(
+		'listUserSkills'
+	);
+	cy.intercept('GET', '**/api/v1/saved-prompts**', { statusCode: 200, body: [] }).as(
+		'listSavedPrompts'
+	);
+	cy.intercept('GET', '**/api/v1/teams**', { statusCode: 200, body: [] }).as('listTeams');
+	cy.intercept('GET', '**/api/v1/skills**', { statusCode: 200, body: [] }).as('listSkills');
+}
+
+describe('DE-263 — community skill installer happy path', () => {
+	it('lists, searches, reviews the full SKILL.md, and installs with confirm', () => {
+		interceptBaseRequests();
+
+		// First load: neither skill installed yet.
+		cy.intercept('GET', '**/api/v1/admin/community-skills', {
+			statusCode: 200,
+			body: catalogBody([leaseReview, ndaTriage])
+		}).as('listCatalog');
+
+		cy.visit('/lq-ai/admin/community-skills', {
+			onBeforeLoad: (win) => setAuthStorage(win)
+		});
+		cy.wait('@listCatalog');
+
+		// 1. Catalog renders with source line + honest attestation states.
+		cy.contains('h1', 'Community skills').should('exist');
+		cy.contains('code', SHA.slice(0, 12)).should('exist');
+		cy.contains('td', 'Attested at source repo by: Jane Attorney, NY Bar #12345').should('exist');
+		cy.contains('td', 'No attestation declared in SKILL.md').should('exist');
+
+		// 2. Search narrows the list.
+		cy.get('input[type="search"]').type('lease');
+		cy.contains('.skill-title', 'Lease Review').should('exist');
+		cy.contains('.skill-title', 'NDA Triage').should('not.exist');
+		cy.get('input[type="search"]').clear();
+
+		// 3. Review opens the full SKILL.md detail.
+		cy.intercept('GET', '**/api/v1/admin/community-skills/lease-review', {
+			statusCode: 200,
+			body: leaseReviewDetail
+		}).as('getDetail');
+		cy.contains('tr', 'Lease Review').contains('button', 'Review').click();
+		cy.wait('@getDetail');
+		cy.contains('h3', 'SKILL.md frontmatter').should('exist');
+		cy.contains('pre', 'name: lease-review').should('exist');
+		cy.contains('pre', 'You are reviewing a commercial lease…').should('exist');
+		cy.contains('code', `lq-skills:lease-review@${SHA}`).should('exist');
+
+		// 4. Install with confirm → success banner → installed state.
+		cy.intercept('POST', '**/api/v1/admin/community-skills/lease-review/install', {
+			statusCode: 201,
+			body: installedRow
+		}).as('install');
+		// Reload after install returns the row as installed.
+		cy.intercept('GET', '**/api/v1/admin/community-skills', {
+			statusCode: 200,
+			body: catalogBody([{ ...leaseReview, installed: true }, ndaTriage])
+		}).as('listCatalogAfter');
+
+		cy.on('window:confirm', (message) => {
+			expect(message).to.contain('Install community skill "Lease Review"');
+			expect(message).to.contain(`lq-skills:lease-review@${SHA}`);
+			return true;
+		});
+		cy.contains('button', 'Install').click();
+		cy.wait('@install');
+		cy.wait('@listCatalogAfter');
+
+		cy.contains('[role="status"]', 'Installed "Lease Review"').should('exist');
+		cy.contains('.installed-badge', 'Installed').should('exist');
+	});
+});

--- a/web/src/lib/lq-ai/api/communitySkills.ts
+++ b/web/src/lib/lq-ai/api/communitySkills.ts
@@ -1,0 +1,75 @@
+/**
+ * Admin community-skill installer API client — 3.8 / DE-263 (ADR 0027).
+ *
+ * Surface:
+ *
+ *   - GET  /api/v1/admin/community-skills                — catalog list
+ *   - GET  /api/v1/admin/community-skills/{slug}         — full SKILL.md detail
+ *   - POST /api/v1/admin/community-skills/{slug}/install — install as a
+ *     user-scope copy owned by the installing admin
+ *
+ * The catalog is served FROM THE LOCAL `skills/community` submodule
+ * checkout — never a network fetch (ADR 0027). All endpoints are
+ * admin-gated server-side; non-admin users get 403 which the page
+ * renders inline. `attested_by` is the verbatim frontmatter declaration
+ * or null ("none declared") — attestation is displayed, never
+ * synthesized.
+ */
+import { apiRequest } from './client';
+import type { UserSkill } from '../types';
+
+export interface CommunityCatalogSource {
+	path: string;
+	/** Submodule HEAD commit, or null when unresolvable ("unknown"). */
+	sha: string | null;
+	submodule_present: boolean;
+	/** Set when the catalog is absent/empty — names the git submodule remedy. */
+	operator_hint: string | null;
+}
+
+export interface CommunitySkillSummary {
+	slug: string;
+	title: string;
+	description: string;
+	version: string;
+	author: string | null;
+	tags: string[];
+	jurisdiction: string | null;
+	/** Verbatim frontmatter declaration; null == none declared in SKILL.md. */
+	attested_by: string | null;
+	/** Whether the calling admin already has a live user-scope row at this slug. */
+	installed: boolean;
+	body_preview: string;
+}
+
+export interface CommunityCatalogResponse {
+	items: CommunitySkillSummary[];
+	source: CommunityCatalogSource;
+	/** Per-skill parse failures, verbatim — broken entries stay visible. */
+	load_errors: string[];
+}
+
+export interface CommunitySkillDetail extends CommunitySkillSummary {
+	output_format: string | null;
+	minimum_inference_tier: number | null;
+	content_yaml: string;
+	content_md: string;
+	/** The forked_from provenance string an install would write now. */
+	install_ref: string;
+}
+
+export async function listCommunitySkills(): Promise<CommunityCatalogResponse> {
+	return apiRequest<CommunityCatalogResponse>('/admin/community-skills', { method: 'GET' });
+}
+
+export async function getCommunitySkill(slug: string): Promise<CommunitySkillDetail> {
+	return apiRequest<CommunitySkillDetail>(`/admin/community-skills/${encodeURIComponent(slug)}`, {
+		method: 'GET'
+	});
+}
+
+export async function installCommunitySkill(slug: string): Promise<UserSkill> {
+	return apiRequest<UserSkill>(`/admin/community-skills/${encodeURIComponent(slug)}/install`, {
+		method: 'POST'
+	});
+}

--- a/web/src/lib/lq-ai/api/index.ts
+++ b/web/src/lib/lq-ai/api/index.ts
@@ -20,6 +20,7 @@ export * as modelsApi from './models';
 export * as adminApi from './admin';
 export * as auditLogApi from './auditLog';
 export * as intakeBridgesApi from './intakeBridges';
+export * as communitySkillsApi from './communitySkills';
 export * as savedPromptsApi from './savedPrompts';
 export * as userSkillsApi from './userSkills';
 export * as teamsApi from './teams';

--- a/web/src/routes/lq-ai/admin/+layout.svelte
+++ b/web/src/routes/lq-ai/admin/+layout.svelte
@@ -10,6 +10,7 @@
 		{ href: '/lq-ai/admin/research-sources', label: 'Research sources' },
 		{ href: '/lq-ai/admin/word-addin', label: 'Word add-in' },
 		{ href: '/lq-ai/admin/intake-bridges', label: 'Intake bridges' },
+		{ href: '/lq-ai/admin/community-skills', label: 'Community skills' },
 		{ href: '/lq-ai/admin/developer', label: 'Developer Support' }
 	];
 </script>

--- a/web/src/routes/lq-ai/admin/community-skills/+page.svelte
+++ b/web/src/routes/lq-ai/admin/community-skills/+page.svelte
@@ -1,0 +1,512 @@
+<script lang="ts">
+	/**
+	 * /lq-ai/admin/community-skills — DE-263 community skill installer.
+	 *
+	 * Catalog list (search + attestation state + installed indication) →
+	 * detail panel with the FULL SKILL.md body and raw frontmatter
+	 * (transparency principle: the operator reviews the actual work
+	 * product before installing) → install with confirm dialog.
+	 *
+	 * The catalog is served from the local `skills/community` submodule
+	 * checkout (ADR 0027) — never a network fetch. Refresh path:
+	 * `git submodule update --remote skills/community` on the host.
+	 */
+	import { onMount } from 'svelte';
+
+	import { communitySkillsApi } from '$lib/lq-ai/api';
+	import { LQAIApiError } from '$lib/lq-ai/api/client';
+	import type {
+		CommunityCatalogResponse,
+		CommunitySkillDetail
+	} from '$lib/lq-ai/api/communitySkills';
+	import {
+		attestationLabel,
+		catalogEmptyMessage,
+		filterCatalog,
+		installButtonState,
+		installConfirmMessage,
+		shortSha
+	} from './page-helpers';
+
+	let catalog: CommunityCatalogResponse | null = null;
+	let loading = false;
+	let listError: string | null = null;
+	let actionError: string | null = null;
+	let actionSuccess: string | null = null;
+
+	let query = '';
+	let detail: CommunitySkillDetail | null = null;
+	let detailError: string | null = null;
+	let detailLoadingSlug: string | null = null;
+	let pendingInstallSlug: string | null = null;
+
+	$: visibleItems = catalog ? filterCatalog(catalog.items, query) : [];
+	$: emptyMessage = catalogEmptyMessage(catalog, visibleItems.length, query);
+
+	onMount(load);
+
+	async function load(): Promise<void> {
+		loading = true;
+		listError = null;
+		try {
+			catalog = await communitySkillsApi.listCommunitySkills();
+		} catch (err) {
+			if (err instanceof LQAIApiError && err.status === 403) {
+				listError = 'You need admin access to view the community skill catalog.';
+			} else {
+				listError = err instanceof Error ? err.message : String(err);
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function openDetail(slug: string): Promise<void> {
+		detailLoadingSlug = slug;
+		detailError = null;
+		actionError = null;
+		actionSuccess = null;
+		try {
+			detail = await communitySkillsApi.getCommunitySkill(slug);
+		} catch (err) {
+			detail = null;
+			detailError = err instanceof Error ? err.message : String(err);
+		} finally {
+			detailLoadingSlug = null;
+		}
+	}
+
+	function closeDetail(): void {
+		detail = null;
+		detailError = null;
+	}
+
+	async function install(d: CommunitySkillDetail): Promise<void> {
+		const confirmed = confirm(installConfirmMessage(d));
+		if (!confirmed) return;
+		pendingInstallSlug = d.slug;
+		actionError = null;
+		actionSuccess = null;
+		try {
+			await communitySkillsApi.installCommunitySkill(d.slug);
+			actionSuccess =
+				`Installed "${d.title}" as an editable copy owned by you ` +
+				`(provenance: ${d.install_ref}). Manage it under your skills.`;
+			closeDetail();
+			await load();
+		} catch (err) {
+			actionError = err instanceof Error ? err.message : String(err);
+		} finally {
+			pendingInstallSlug = null;
+		}
+	}
+</script>
+
+<div class="community-skills-page">
+	<header class="page-header">
+		<h1 class="lq-text-page-h">Community skills</h1>
+		<p class="page-intro">
+			Browse and install skills from the community catalog (the local
+			<code>skills/community</code> submodule — served from disk, never fetched over the network; see
+			ADR 0027). Installing creates an editable copy owned by you with its provenance recorded. Community
+			skills are attested at their source repo; this page shows exactly what each SKILL.md declares.
+		</p>
+		{#if catalog}
+			<p class="source-line">
+				Catalog: <code>{catalog.source.path}</code> @ <code>{shortSha(catalog.source.sha)}</code>
+				— refresh with <code>git submodule update --remote skills/community</code>
+			</p>
+		{/if}
+	</header>
+
+	{#if listError}
+		<div class="error-banner" role="alert">{listError}</div>
+	{/if}
+	{#if actionError}
+		<div class="error-banner" role="alert">{actionError}</div>
+	{/if}
+	{#if actionSuccess}
+		<div class="success-banner" role="status">{actionSuccess}</div>
+	{/if}
+
+	{#if catalog && catalog.load_errors.length > 0}
+		<div class="warn-banner" role="alert">
+			<strong
+				>{catalog.load_errors.length} catalog entr{catalog.load_errors.length === 1 ? 'y' : 'ies'} failed
+				to parse and cannot be installed:</strong
+			>
+			<ul class="load-error-list">
+				{#each catalog.load_errors as err}
+					<li><code>{err}</code></li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
+
+	{#if loading && catalog === null}
+		<p class="loading">Loading community catalog…</p>
+	{/if}
+
+	{#if catalog}
+		<div class="search-row">
+			<input
+				type="search"
+				class="search-input"
+				placeholder="Search by slug, title, description, or tag…"
+				aria-label="Search community skills"
+				bind:value={query}
+			/>
+		</div>
+
+		{#if emptyMessage}
+			<p class="empty-state">{emptyMessage}</p>
+		{/if}
+
+		{#if visibleItems.length > 0}
+			<table class="catalog-table">
+				<thead>
+					<tr>
+						<th>Skill</th>
+						<th>Version</th>
+						<th>Tags</th>
+						<th>Attestation</th>
+						<th class="catalog-table-actions">Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each visibleItems as item (item.slug)}
+						<tr>
+							<td>
+								<div class="skill-title">
+									{item.title}
+									{#if item.installed}
+										<span class="installed-badge">Installed</span>
+									{/if}
+								</div>
+								<div class="skill-slug"><code>{item.slug}</code></div>
+								<div class="skill-description">{item.description}</div>
+							</td>
+							<td><code>{item.version}</code></td>
+							<td>
+								{#each item.tags as tag}
+									<span class="tag-chip">{tag}</span>
+								{/each}
+							</td>
+							<td class="attestation-cell" class:attestation-none={!item.attested_by}>
+								{attestationLabel(item.attested_by)}
+							</td>
+							<td class="catalog-table-actions">
+								<button
+									type="button"
+									class="action-button"
+									on:click={() => openDetail(item.slug)}
+									disabled={detailLoadingSlug === item.slug}
+								>
+									{detailLoadingSlug === item.slug ? 'Loading…' : 'Review'}
+								</button>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
+	{/if}
+
+	{#if detailError}
+		<div class="error-banner" role="alert">{detailError}</div>
+	{/if}
+
+	{#if detail}
+		<section class="detail-panel" aria-label="Community skill detail">
+			<div class="detail-head">
+				<div>
+					<h2 class="detail-title">
+						{detail.title}
+						{#if detail.installed}
+							<span class="installed-badge">Installed</span>
+						{/if}
+					</h2>
+					<p class="detail-meta">
+						<code>{detail.slug}</code> · v{detail.version}
+						{#if detail.author}
+							· by {detail.author}{/if}
+						{#if detail.jurisdiction}
+							· jurisdiction: {detail.jurisdiction}{/if}
+					</p>
+					<p class="detail-meta" class:attestation-none={!detail.attested_by}>
+						{attestationLabel(detail.attested_by)}
+					</p>
+					<p class="detail-meta">Install provenance: <code>{detail.install_ref}</code></p>
+				</div>
+				<div class="detail-actions">
+					<button
+						type="button"
+						class="install-button"
+						on:click={() => detail && install(detail)}
+						disabled={installButtonState(detail, pendingInstallSlug).disabled}
+					>
+						{installButtonState(detail, pendingInstallSlug).label}
+					</button>
+					<button type="button" class="action-button" on:click={closeDetail}>Close</button>
+				</div>
+			</div>
+
+			<h3 class="detail-section-title">SKILL.md frontmatter</h3>
+			<pre class="skill-source">{detail.content_yaml}</pre>
+
+			<h3 class="detail-section-title">SKILL.md body</h3>
+			<pre class="skill-source">{detail.content_md}</pre>
+		</section>
+	{/if}
+</div>
+
+<style>
+	.community-skills-page {
+		padding: var(--lq-space-5);
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-4);
+	}
+
+	.page-header {
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-2);
+	}
+
+	.page-intro {
+		color: var(--lq-text-secondary);
+		max-width: 60rem;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	.source-line {
+		color: var(--lq-text-secondary);
+		font-size: 13px;
+	}
+
+	.error-banner {
+		padding: var(--lq-space-3) var(--lq-space-4);
+		background: var(--lq-error-bg, #fee);
+		color: var(--lq-error-text, #800);
+		border-radius: 6px;
+		border: 1px solid var(--lq-error-border, #fbb);
+	}
+
+	.warn-banner {
+		padding: var(--lq-space-3) var(--lq-space-4);
+		background: var(--lq-warning-bg, #fff8e1);
+		color: var(--lq-warning-text, #7a5c00);
+		border-radius: 6px;
+		border: 1px solid var(--lq-warning-border, #f0d78c);
+		font-size: 13px;
+	}
+
+	.load-error-list {
+		margin: var(--lq-space-2) 0 0;
+		padding-left: var(--lq-space-4);
+	}
+
+	.success-banner {
+		padding: var(--lq-space-3) var(--lq-space-4);
+		background: var(--lq-success-bg, #efe);
+		color: var(--lq-success-text, #060);
+		border-radius: 6px;
+		border: 1px solid var(--lq-success-border, #bfb);
+	}
+
+	.loading {
+		color: var(--lq-text-secondary);
+		padding: var(--lq-space-3);
+	}
+
+	.search-row {
+		display: flex;
+	}
+
+	.search-input {
+		flex: 1;
+		max-width: 32rem;
+		padding: var(--lq-space-2) var(--lq-space-3);
+		border: 1px solid var(--lq-border);
+		border-radius: 6px;
+		background: var(--lq-bg, #fff);
+		font-size: 14px;
+	}
+
+	.empty-state {
+		color: var(--lq-text-secondary);
+		font-style: italic;
+		margin: 0;
+	}
+
+	.catalog-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 14px;
+	}
+
+	.catalog-table th,
+	.catalog-table td {
+		text-align: left;
+		padding: var(--lq-space-2) var(--lq-space-3);
+		border-bottom: 1px solid var(--lq-border);
+		vertical-align: top;
+	}
+
+	.catalog-table th {
+		font-weight: 600;
+		color: var(--lq-text-secondary);
+		font-size: 12px;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.catalog-table-actions {
+		text-align: right;
+		width: 1px;
+		white-space: nowrap;
+	}
+
+	.skill-title {
+		font-weight: 600;
+		display: flex;
+		align-items: center;
+		gap: var(--lq-space-2);
+	}
+
+	.skill-slug {
+		font-size: 12px;
+		color: var(--lq-text-secondary);
+	}
+
+	.skill-description {
+		font-size: 13px;
+		color: var(--lq-text-secondary);
+		max-width: 36rem;
+	}
+
+	.tag-chip {
+		display: inline-block;
+		padding: 1px var(--lq-space-2);
+		margin: 1px;
+		border-radius: 999px;
+		border: 1px solid var(--lq-border);
+		font-size: 12px;
+		color: var(--lq-text-secondary);
+	}
+
+	.attestation-cell {
+		font-size: 13px;
+		max-width: 16rem;
+	}
+
+	.attestation-none {
+		color: var(--lq-text-secondary);
+		font-style: italic;
+	}
+
+	.installed-badge {
+		display: inline-block;
+		padding: 1px var(--lq-space-2);
+		border-radius: 999px;
+		background: var(--lq-success-bg, #efe);
+		color: var(--lq-success-text, #060);
+		border: 1px solid var(--lq-success-border, #bfb);
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.action-button {
+		padding: var(--lq-space-1) var(--lq-space-3);
+		border-radius: 6px;
+		font-size: 13px;
+		cursor: pointer;
+		border: 1px solid var(--lq-border);
+		background: transparent;
+		color: var(--lq-text);
+	}
+
+	.action-button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.install-button {
+		padding: var(--lq-space-2) var(--lq-space-4);
+		background: var(--lq-accent);
+		color: white;
+		border: none;
+		border-radius: 6px;
+		font-size: 14px;
+		font-weight: 500;
+		cursor: pointer;
+	}
+
+	.install-button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.detail-panel {
+		display: flex;
+		flex-direction: column;
+		gap: var(--lq-space-3);
+		padding: var(--lq-space-4);
+		border: 1px solid var(--lq-border);
+		border-radius: 8px;
+		background: var(--lq-surface);
+	}
+
+	.detail-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: var(--lq-space-4);
+		flex-wrap: wrap;
+	}
+
+	.detail-title {
+		margin: 0;
+		font-size: 18px;
+		font-weight: 600;
+		display: flex;
+		align-items: center;
+		gap: var(--lq-space-2);
+	}
+
+	.detail-meta {
+		margin: var(--lq-space-1) 0 0;
+		font-size: 13px;
+		color: var(--lq-text-secondary);
+	}
+
+	.detail-actions {
+		display: flex;
+		gap: var(--lq-space-2);
+		align-items: center;
+	}
+
+	.detail-section-title {
+		margin: var(--lq-space-2) 0 0;
+		font-size: 14px;
+		font-weight: 600;
+	}
+
+	.skill-source {
+		margin: 0;
+		padding: var(--lq-space-3);
+		border: 1px solid var(--lq-border);
+		border-radius: 6px;
+		background: var(--lq-bg, #fff);
+		font-size: 12.5px;
+		line-height: 1.5;
+		white-space: pre-wrap;
+		word-break: break-word;
+		max-height: 32rem;
+		overflow: auto;
+	}
+</style>

--- a/web/src/routes/lq-ai/admin/community-skills/__tests__/page-helpers.test.ts
+++ b/web/src/routes/lq-ai/admin/community-skills/__tests__/page-helpers.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Pure-helper tests for the DE-263 admin community-skills page.
+ *
+ * The helpers are extracted into a sibling `page-helpers.ts` so vitest
+ * can exercise them without the svelte transformer (the intake-bridges
+ * convention).
+ */
+import { describe, expect, it } from 'vitest';
+
+import type {
+	CommunityCatalogResponse,
+	CommunitySkillDetail,
+	CommunitySkillSummary
+} from '$lib/lq-ai/api/communitySkills';
+import {
+	attestationLabel,
+	catalogEmptyMessage,
+	filterCatalog,
+	installButtonState,
+	installConfirmMessage,
+	shortSha
+} from '../page-helpers';
+
+function summary(over: Partial<CommunitySkillSummary> = {}): CommunitySkillSummary {
+	return {
+		slug: 'lease-review',
+		title: 'Lease Review',
+		description: 'First-pass review of commercial leases.',
+		version: '1.0.0',
+		author: 'Jane Attorney',
+		tags: ['real-estate', 'review'],
+		jurisdiction: 'us',
+		attested_by: null,
+		installed: false,
+		body_preview: 'You are reviewing a lease…',
+		...over
+	};
+}
+
+function detail(over: Partial<CommunitySkillDetail> = {}): CommunitySkillDetail {
+	return {
+		...summary(),
+		output_format: 'report',
+		minimum_inference_tier: null,
+		content_yaml: 'name: lease-review',
+		content_md: '# Lease review body',
+		install_ref: 'lq-skills:lease-review@abc123def456',
+		...over
+	};
+}
+
+function catalog(
+	items: CommunitySkillSummary[],
+	hint: string | null = null
+): CommunityCatalogResponse {
+	return {
+		items,
+		source: {
+			path: '/repo/skills/community/skills',
+			sha: 'abc123def4567890abc123def4567890abc123de',
+			submodule_present: items.length > 0,
+			operator_hint: hint
+		},
+		load_errors: []
+	};
+}
+
+describe('filterCatalog', () => {
+	const items = [
+		summary(),
+		summary({
+			slug: 'nda-triage',
+			title: 'NDA Triage',
+			description: 'Quick NDA pass',
+			tags: ['nda']
+		})
+	];
+
+	it('returns everything for a blank query', () => {
+		expect(filterCatalog(items, '')).toHaveLength(2);
+		expect(filterCatalog(items, '   ')).toHaveLength(2);
+	});
+
+	it('matches slug, title, description, and tags case-insensitively', () => {
+		expect(filterCatalog(items, 'LEASE').map((i) => i.slug)).toEqual(['lease-review']);
+		expect(filterCatalog(items, 'triage').map((i) => i.slug)).toEqual(['nda-triage']);
+		expect(filterCatalog(items, 'quick nda').map((i) => i.slug)).toEqual(['nda-triage']);
+		expect(filterCatalog(items, 'Quick').map((i) => i.slug)).toEqual(['nda-triage']);
+		expect(filterCatalog(items, 'real-estate').map((i) => i.slug)).toEqual(['lease-review']);
+	});
+
+	it('returns empty on no match', () => {
+		expect(filterCatalog(items, 'zzz-no-such')).toEqual([]);
+	});
+});
+
+describe('attestationLabel', () => {
+	it('renders the declared attestation verbatim', () => {
+		expect(attestationLabel('Jane Attorney, NY Bar #12345')).toBe(
+			'Attested at source repo by: Jane Attorney, NY Bar #12345'
+		);
+	});
+
+	it('states plainly when none is declared — never claims attestation', () => {
+		expect(attestationLabel(null)).toBe('No attestation declared in SKILL.md');
+	});
+});
+
+describe('shortSha', () => {
+	it('truncates a full sha to 12 chars', () => {
+		expect(shortSha('abc123def4567890abc123def4567890abc123de')).toBe('abc123def456');
+	});
+
+	it('degrades to "unknown" when the sha is unresolvable', () => {
+		expect(shortSha(null)).toBe('unknown');
+	});
+});
+
+describe('installConfirmMessage', () => {
+	it('names the skill, the provenance ref, and the attestation state', () => {
+		const msg = installConfirmMessage(detail());
+		expect(msg).toContain('Lease Review');
+		expect(msg).toContain('lq-skills:lease-review@abc123def456');
+		expect(msg).toContain('No attestation declared in SKILL.md');
+		expect(msg).toContain('does not auto-update');
+	});
+
+	it('carries a declared attestation through', () => {
+		const msg = installConfirmMessage(detail({ attested_by: 'Jane Attorney' }));
+		expect(msg).toContain('Attested at source repo by: Jane Attorney');
+	});
+});
+
+describe('catalogEmptyMessage', () => {
+	it('is null before the catalog loads', () => {
+		expect(catalogEmptyMessage(null, 0, '')).toBeNull();
+	});
+
+	it('surfaces the server operator hint for an absent/empty submodule', () => {
+		const hint = 'run `git submodule update --init skills/community`';
+		expect(catalogEmptyMessage(catalog([], hint), 0, '')).toBe(hint);
+	});
+
+	it('falls back to a plain empty message without a hint', () => {
+		expect(catalogEmptyMessage(catalog([], null), 0, '')).toBe('The community catalog is empty.');
+	});
+
+	it('reports a no-match search against a non-empty catalog', () => {
+		expect(catalogEmptyMessage(catalog([summary()]), 0, 'zzz')).toBe(
+			'No community skills match "zzz".'
+		);
+	});
+
+	it('is null when rows are visible', () => {
+		expect(catalogEmptyMessage(catalog([summary()]), 1, '')).toBeNull();
+	});
+});
+
+describe('installButtonState', () => {
+	it('disables with "Installed" for an already-installed skill', () => {
+		expect(installButtonState(summary({ installed: true }), null)).toEqual({
+			label: 'Installed',
+			disabled: true
+		});
+	});
+
+	it('shows progress for the pending slug', () => {
+		expect(installButtonState(summary(), 'lease-review')).toEqual({
+			label: 'Installing…',
+			disabled: true
+		});
+	});
+
+	it('disables other rows while an install is pending', () => {
+		expect(installButtonState(summary(), 'other-slug')).toEqual({
+			label: 'Install',
+			disabled: true
+		});
+	});
+
+	it('is enabled when idle and not installed', () => {
+		expect(installButtonState(summary(), null)).toEqual({ label: 'Install', disabled: false });
+	});
+});

--- a/web/src/routes/lq-ai/admin/community-skills/page-helpers.ts
+++ b/web/src/routes/lq-ai/admin/community-skills/page-helpers.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure helpers for the DE-263 admin community-skills page.
+ *
+ * Extracted out of `+page.svelte` so vitest can exercise them without a
+ * SvelteKit runtime (the intake-bridges page-helpers convention). The
+ * helpers cover:
+ *
+ *   - client-side catalog search across slug / title / description / tags
+ *   - honest attestation labeling (display what the file declares; never
+ *     claim attestation that isn't there — ADR 0027 §5)
+ *   - short-sha rendering with the "unknown" degradation
+ *   - the install-confirm dialog copy (includes the provenance ref that
+ *     will be written to `forked_from`)
+ *   - empty-catalog messaging (absent submodule is a hint, not an error)
+ */
+
+import type {
+	CommunityCatalogResponse,
+	CommunitySkillDetail,
+	CommunitySkillSummary
+} from '$lib/lq-ai/api/communitySkills';
+
+/** Case-insensitive catalog filter across slug, title, description, tags. */
+export function filterCatalog(
+	items: CommunitySkillSummary[],
+	query: string
+): CommunitySkillSummary[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return items;
+	return items.filter(
+		(item) =>
+			item.slug.toLowerCase().includes(q) ||
+			item.title.toLowerCase().includes(q) ||
+			item.description.toLowerCase().includes(q) ||
+			item.tags.some((tag) => tag.toLowerCase().includes(q))
+	);
+}
+
+/**
+ * Honest attestation label. Community skills are attested (or not) at
+ * their source repo; we render exactly what the SKILL.md declares.
+ */
+export function attestationLabel(attestedBy: string | null): string {
+	return attestedBy
+		? `Attested at source repo by: ${attestedBy}`
+		: 'No attestation declared in SKILL.md';
+}
+
+/** Render the submodule sha pin; degrades to "unknown" honestly. */
+export function shortSha(sha: string | null): string {
+	return sha ? sha.slice(0, 12) : 'unknown';
+}
+
+/** Confirm-dialog copy for the install action — names the provenance ref. */
+export function installConfirmMessage(detail: CommunitySkillDetail): string {
+	return (
+		`Install community skill "${detail.title}" (${detail.slug})?\n\n` +
+		`This creates an editable copy owned by you (provenance: ${detail.install_ref}). ` +
+		`The copy does not auto-update when the community catalog moves. ` +
+		attestationLabel(detail.attested_by)
+	);
+}
+
+/**
+ * Empty-state copy for the catalog list. Absent submodule → the
+ * server's operator hint (the `git submodule update --init` remedy);
+ * present-but-filtered → a search message; present-and-empty → hint too.
+ */
+export function catalogEmptyMessage(
+	catalog: CommunityCatalogResponse | null,
+	visibleCount: number,
+	query: string
+): string | null {
+	if (catalog === null) return null;
+	if (catalog.items.length === 0) {
+		return catalog.source.operator_hint ?? 'The community catalog is empty.';
+	}
+	if (visibleCount === 0 && query.trim()) {
+		return `No community skills match "${query.trim()}".`;
+	}
+	return null;
+}
+
+/** Install-button state for one row. */
+export function installButtonState(
+	item: CommunitySkillSummary,
+	pendingSlug: string | null
+): { label: string; disabled: boolean } {
+	if (item.installed) return { label: 'Installed', disabled: true };
+	if (pendingSlug === item.slug) return { label: 'Installing…', disabled: true };
+	return { label: 'Install', disabled: pendingSlug !== null };
+}


### PR DESCRIPTION
## What / why

Roadmap 3.8 (DE-263): admins can browse and install skills from the `skills/community` submodule catalog. Per the sweep's ADR-gated-item rule, **ADR 0027 is self-authored in this PR** — the committee can reject the catalog-source decision at review.

Part of the coordinated roadmap sweep (umbrella issue #321).

## ADR 0027 key decisions

1. **Catalog from the local submodule, re-scanned per request** — never a GitHub fetch from the api. Preserves the transparency invariant (the backend's only outbound client is the gateway; enforced by `test_transparency_invariants.py`, untouched) and air-gap compatibility. `git submodule update --remote` is the operator refresh path.
2. **Provenance:** `forked_from = "lq-skills:<slug>@<sha>"`, sha resolved via pure file reads of git plumbing (gitdir pointer → detached HEAD → loose ref → packed-refs) — no git subprocess at request time; missing plumbing degrades to `"unknown"` honestly.
3. Rejected: api-side GitHub fetch (egress + air-gap), web-side fetch (CSP/supply-chain, unauditable), registry service (overkill).

## Security surfaces (review focus)

- New admin endpoints (`GET /admin/community-skills`, `GET …/{slug}`, `POST …/{slug}/install`) — handler-level admin gate, **403 tested on every endpoint**.
- **Slug validated against the user-skill slug regex before any filesystem join** — path-traversal defense, regression-tested (`test_path_shaped_slug_is_rejected_before_filesystem_join`).
- Install reuses the existing `UserSkillCreate` validation (malformed SKILL.md → 422 naming the problem); audit event rides the insert transaction; 409 while a live row holds the slug (hand-authored rows never clobbered).
- Attestation state is **read from the file and displayed, never synthesized** — the installer can't manufacture attorney attestation.
- Absent/uninitialized submodule (this worktree's state) is first-class: 200 + empty catalog + operator hint.

## Deliberate choices

- Detail GET on a malformed catalog entry returns **422 with the loader's error text** (not 404) — admins see *why* an entry is broken (also surfaced in the list's `load_errors`).
- Catalog path follows the repo's established `skills/community/skills/*` layout (the roadmap sketch said `skills/community/*` — repo convention wins).
- Installed copy is owned by the installing admin (user-scope); an "update available" diff surface is noted in the ADR as a future DE.

## Acceptance evidence

23 api tests (catalog scan incl. malformed + absent-dir, sha plumbing variants, 403 ×3, install happy path with provenance + audit assertions, 409/422/404 paths, traversal rejection, attestation-never-synthesized) + 17 vitest cases + a Cypress spec (added, not run).

Gates run locally:
- api: ruff format/check clean, mypy clean, full suite **2646 passed, 1 skipped, 0 failed** (throwaway pgvector:pg16); route pins 139→142 + OpenAPI conformance + drift guard green
- web: `check:lq-ai` **0 errors**; vitest **754 passed (81 files)**

## Maintainer verification steps

- Initialize the submodule (`git submodule update --init skills/community`), rebuild `web` + `api`, and walk the browse → detail → install → appears-in-my-skills flow; verify the audit row and the 409 on re-install.

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #373** — same head commit (`16f862e50b13`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
