### PR TITLE
4.2: run the deterministic Cypress track nightly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ name: CI
 #   - gateway/: ruff + mypy --strict + pytest
 #
 # Out of scope (deferred to future waves):
-#   - Cypress E2E (heavier; needs a stack-up step + LLM provider keys)
+#   - Cypress E2E: the deterministic track runs nightly in e2e.yml (no
+#     provider keys needed); per-PR promotion waits on buildx caching (#283)
 #   - Coverage gates (no-decrease enforcement)
 #   - Dependency-license check (likely Wave F polish)
 #

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,123 @@
+# Cypress E2E against the full compose stack (roadmap item 4.2).
+#
+# Runs the DETERMINISTIC Cypress track — the spec list is owned by
+# web/cypress.config.ts (single source of truth), not this file. That
+# track needs no provider API keys: specs are either fully
+# cy.intercept-mocked or live-backend-but-LLM-free (login + CRUD). The
+# live-LLM specs stay gated behind CYPRESS_LLM=1 until a mock/echo
+# provider exists; this workflow never sets it because CI holds no
+# provider keys.
+#
+# Stack boot is delegated to scripts/stack-smoke.sh — the same single
+# source of truth stack-smoke.yml uses (build, dummy .env, migrate-on-
+# boot, health-wait). A short soak is enough here; Cypress itself is the
+# real exercise. After boot we seed the reproducible admin fixture the
+# live-backend specs expect (see api/app/cli.py, dev/test posture).
+#
+# Schedule: nightly + manual dispatch only — NOT per-PR yet. A cold
+# compose build is ~20-30 min (docling/torch); promoting this to per-PR
+# waits on buildx layer caching (#283). Revisit once caching lands.
+
+name: E2E (Cypress)
+
+on:
+  schedule:
+    # Nightly, off the top of the hour to dodge GH's peak-load delays.
+    - cron: "37 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cypress:
+    name: Deterministic Cypress track against the compose stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Free runner disk space
+        # Same reclaim as stack-smoke.yml: the api-family image unpacks
+        # to ~12 GB (docling pulls CUDA-enabled torch) and the BuildKit
+        # cache costs about as much again; default runner space is not
+        # enough.
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/lib/jvm /usr/share/swift \
+            /usr/local/.ghcup /usr/local/share/boost /usr/local/lib/node_modules
+          sudo docker image prune -af
+          df -h /
+        # node_modules removal above is the runner's preinstalled global
+        # tree, not the project's — setup-node below restores what we need.
+
+      - name: Build and boot the stack
+        # Reuses the stack-smoke script wholesale (build, dummy .env,
+        # boot to healthy, health probes). SOAK_SECONDS is trimmed: the
+        # 75s crash-loop soak is stack-smoke's job; here the Cypress run
+        # itself holds the stack up far longer than any soak would.
+        run: SOAK_SECONDS=10 ./scripts/stack-smoke.sh
+
+      - name: Seed the Cypress admin fixture
+        # The live-backend deterministic specs (m2-c2, wave-b, wave-c)
+        # log in as admin@lq.ai with this fixed password (the specs'
+        # built-in default). --no-force-change skips the
+        # must-change-password gate that would otherwise trap the login
+        # redirect. admin@lq.ai is the first-run bootstrap admin email
+        # (api/app/admin_bootstrap.py), so the user always exists on a
+        # virgin stack.
+        run: |
+          docker compose exec -T api python -m app.cli reset-admin-password \
+            --email admin@lq.ai --password 'LQ-AI-smoke-test-Pw1!' --no-force-change
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Run Cypress (deterministic track)
+        working-directory: web
+        # Spec selection lives in cypress.config.ts (DETERMINISTIC_SPECS);
+        # the workflow intentionally passes no --spec so local runs and CI
+        # execute the identical list.
+        run: npm run cy:run
+
+      - name: Upload Cypress artifacts
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cypress-artifacts
+          path: |
+            web/cypress/screenshots/
+            web/cypress/videos/
+            web/cypress/downloads/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Collect compose logs
+        if: failure()
+        run: |
+          mkdir -p e2e-compose-logs
+          docker compose ps -a > e2e-compose-logs/ps.txt 2>&1 || true
+          docker compose logs --no-color > e2e-compose-logs/logs.txt 2>&1 || true
+
+      - name: Upload compose logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-compose-logs
+          path: e2e-compose-logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/stack-smoke.yml
+++ b/.github/workflows/stack-smoke.yml
@@ -11,8 +11,8 @@
 # cannot: server boot (uvicorn), real Redis connections (arq workers),
 # lazily-imported heavy deps (docling), and the OpenWebUI-core build that
 # the scoped svelte-check never touches. It proves "builds, migrates,
-# boots, and holds" — NOT "features work"; E2E remains a future wave
-# (see ci.yml scope comment).
+# boots, and holds" — NOT "features work"; feature-level E2E is the
+# nightly Cypress run in e2e.yml (which reuses this smoke's boot script).
 #
 # Cold builds are expensive (~20-30 min; the ingest image pulls
 # docling/easyocr/torch), so this runs only where it earns its keep:

--- a/web/cypress.config.ts
+++ b/web/cypress.config.ts
@@ -1,8 +1,68 @@
 import { defineConfig } from 'cypress';
 
+// ---------------------------------------------------------------------------
+// Spec tracks (roadmap 4.2 — Cypress in CI)
+//
+// Specs are classified into explicit tracks so CI can run the deterministic
+// subset against a virgin compose stack with NO provider keys. The track
+// lists live here (single source of truth) rather than in the workflow so
+// `npx cypress run` behaves identically locally and in CI.
+//
+// - DETERMINISTIC_SPECS: no live-LLM dependency. Either fully
+//   cy.intercept-mocked, or live-backend but LLM-free (login + CRUD only).
+//   Live-backend specs require the seeded admin fixture:
+//     docker compose exec api python -m app.cli reset-admin-password \
+//       --email admin@lq.ai --password 'LQ-AI-smoke-test-Pw1!' --no-force-change
+//
+// - LLM_SPECS: perform a real inference round-trip (send a message and wait
+//   for an assistant reply / enhanced prompt / captured skill). They need
+//   configured provider keys, so they are gated behind CYPRESS_LLM=1 until
+//   a mock/echo provider exists (see DE-232 sequencing in docs).
+//
+// - Anything in neither list is quarantined and never runs:
+//     chat.cy.ts          — upstream OpenWebUI; needs an Ollama model + LLM
+//     registration.cy.ts  — upstream OpenWebUI signup flow; LQ.AI stacks
+//                           disable open signup (403) so the flow 404s/fails
+//     settings.cy.ts      — upstream OpenWebUI; depends on the
+//                           admin@example.com bootstrap the LQ.AI stack blocks
+//     wave-a-chrome.cy.ts — stale: asserts Matters opens ComingSoonModal,
+//                           superseded by Wave C (tabs.ts: matters available)
+//     documents.cy.ts     — empty spec (reference comment only)
+//   Un-quarantine by fixing the spec and moving it into a track list.
+// ---------------------------------------------------------------------------
+
+const DETERMINISTIC_SPECS = [
+	// Fully cy.intercept-mocked — no real backend writes, no seeded admin needed.
+	'cypress/e2e/m3-0-fresh-install-login.cy.ts',
+	'cypress/e2e/m3-a4-playbook-execution.cy.ts',
+	'cypress/e2e/m3-a6-easy-playbook-wizard.cy.ts',
+	'cypress/e2e/m3-b2-word-addin-oauth.cy.ts',
+	'cypress/e2e/m3-c-tabular-review.cy.ts',
+	'cypress/e2e/m4-autonomous.cy.ts',
+	// Live-backend but LLM-free — real login as the seeded admin; create
+	// throwaway matters/chats; message/citation payloads are mocked.
+	'cypress/e2e/m2-c2-citation-states.cy.ts',
+	'cypress/e2e/wave-b-surfaces.cy.ts',
+	'cypress/e2e/wave-c-matters.cy.ts'
+];
+
+const LLM_SPECS = [
+	'cypress/e2e/wave-d1-power-features.cy.ts',
+	'cypress/e2e/wave-d2-skill-creator.cy.ts',
+	'cypress/e2e/wave-m1-final-surfaces.cy.ts'
+];
+
+// CYPRESS_LLM=1 widens the run to include the live-LLM specs (requires
+// provider keys in the stack's .env). Default is the deterministic track.
+const specPattern =
+	process.env.CYPRESS_LLM === '1' ? [...DETERMINISTIC_SPECS, ...LLM_SPECS] : DETERMINISTIC_SPECS;
+
 export default defineConfig({
 	e2e: {
-		baseUrl: 'http://localhost:3000'
+		// CYPRESS_BASE_URL env var overrides this natively (Cypress config
+		// resolution) — no extra plumbing needed for CI vs local.
+		baseUrl: 'http://localhost:3000',
+		specPattern
 	},
 	// Desktop-realistic viewport so the matter workspace fits — the chat
 	// shell + matter rail + composer don't fit in Cypress' 1000x660 default

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
 		"format:backend": "ruff format . --exclude .venv --exclude venv",
 		"i18n:parse": "i18next --config i18next-parser.config.ts && prettier --write \"src/lib/i18n/**/*.{js,json}\"",
 		"cy:open": "cypress open",
+		"cy:run": "cypress run",
 		"test:frontend": "vitest --passWithNoTests",
 		"pyodide:fetch": "node scripts/prepare-pyodide.js"
 	},


### PR DESCRIPTION
## What / why

Roadmap 4.2: 17 Cypress spec files exist and none run in CI. This puts the deterministic track on a nightly schedule with honest gating for the rest. Precedes DE-232 (a11y specs are Cypress specs).

Part of the coordinated roadmap sweep (umbrella issue #321).

## Approach

- **`e2e.yml`**: nightly + dispatch (not per-PR yet — compose cold build is heavy; per-PR intention documented, waits on buildx caching). Reuses `scripts/stack-smoke.sh` wholesale, seeds the admin fixture password via the api CLI, runs `npm run cy:run`, uploads screenshots/videos + compose logs on failure. SHA-pinned to the repo's existing action pins; `contents: read`.
- **Config-driven tracks** in `cypress.config.ts` (no spec files modified): default = 9-spec deterministic track; `CYPRESS_LLM=1` adds the 3 LLM-dependent specs; 5 quarantined with per-spec reasons in the config (2 upstream flows broken on LQ.AI stacks by design — signup 403, blocked bootstrap; 1 stale assertion vs current `tabs.ts`; 1 empty shell; 1 upstream chat spec needing a live model). Chosen over workflow `--spec` lists (local/CI divergence) and renaming (spec churn).

## Verification (honest split)

- **Proven locally** against the live dev stack: the 6 fully-mocked specs — **20/20 tests passing in 22s** (they intercept everything including login; nothing real written).
- **Spec-read only:** the 3 live-login specs (running them locally would have required resetting the shared dev stack's admin password). The workflow seeds exactly the password they default to; **their proof is the first CI run** — trigger `workflow_dispatch` after merge.
- Workflow YAML + cypress config parse verified; spec-resolution counts checked per env (9 default / 12 with `CYPRESS_LLM=1`).

## Review points

- `wave-b-surfaces` is the most likely first-run failure (needs built-in skills seeded + tolerates the enhance-error path on a keyless stack); if it fails, demote it to the LLM track rather than patching the workflow.
- Nightly-failure notification routing (schedule failures only ping the workflow author) is worth a follow-up DE.
- Exceeds the ≥6-spec acceptance: 9 in the track, 6 locally proven.

`.github/workflows/**` = security-review routed.

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #377** — same head commit (`18dbbb452d38`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
