### PR TITLE
DE-284: annotate api/tests + flip CI to mypy app tests (658 → 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,8 @@ jobs:
         run: ruff format --check api scripts
 
       - name: mypy (standard mode)
-        run: mypy app
+        # DE-284 — tests/ are type-checked alongside app/.
+        run: mypy app tests
 
       - name: pytest
         run: pytest -q

--- a/api/tests/autonomous/conftest.py
+++ b/api/tests/autonomous/conftest.py
@@ -373,7 +373,7 @@ async def session_without_target(
     return await _make_session(db_session, user=user, params={})
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 def sample_chunks() -> list[dict[str, Any]]:
     """A small chunks list shaped like ``_handle_retrieve_chunks`` output.
 

--- a/api/tests/autonomous/test_artifacts_endpoint.py
+++ b/api/tests/autonomous/test_artifacts_endpoint.py
@@ -22,7 +22,7 @@ test_findings_endpoint.py. Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -43,7 +43,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/autonomous/test_authority_cache_write.py
+++ b/api/tests/autonomous/test_authority_cache_write.py
@@ -21,7 +21,7 @@ app.citation.authority import point.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
@@ -49,12 +49,12 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.fixture(autouse=True)
-def _reset_cost_cache() -> None:
+def _reset_cost_cache() -> Iterator[None]:
     """Reset the process-level provider tier+cost cache before/after each test."""
     from app.tools.governance import _reset_provider_tier_cache_for_tests
 
     _reset_provider_tier_cache_for_tests()
-    yield  # type: ignore[misc]
+    yield
     _reset_provider_tier_cache_for_tests()
 
 

--- a/api/tests/autonomous/test_autonomous_observability.py
+++ b/api/tests/autonomous/test_autonomous_observability.py
@@ -334,7 +334,9 @@ async def test_retrieve_chunks_no_raw_entities_in_spans_or_audit(
     assert "autonomous.outcome" in attrs
     assert attrs["autonomous.outcome"] == "success"
     assert "autonomous.cost_usd" in attrs
-    assert float(attrs["autonomous.cost_usd"]) == pytest.approx(0.0)
+    cost_val = attrs["autonomous.cost_usd"]
+    assert isinstance(cost_val, float)
+    assert cost_val == pytest.approx(0.0)
 
     # ── Privacy assertion: no synthetic entity in any audit row ─────────────
     audit_rows = (

--- a/api/tests/autonomous/test_evidence_registry.py
+++ b/api/tests/autonomous/test_evidence_registry.py
@@ -3,7 +3,7 @@ from app.autonomous.guard import ToolResult
 from app.autonomous.planner import collect_evidence, summarize_observation
 
 
-def test_caselaw_observation_includes_cluster_id():
+def test_caselaw_observation_includes_cluster_id() -> None:
     result = ToolResult(
         data={
             "results": [
@@ -22,7 +22,7 @@ def test_caselaw_observation_includes_cluster_id():
     assert "42" in s  # cluster_id is shown so the synthesis can cite it
 
 
-def test_collect_evidence_numbers_kb_chunks():
+def test_collect_evidence_numbers_kb_chunks() -> None:
     result = ToolResult(
         data={
             "chunks": [
@@ -42,7 +42,7 @@ def test_collect_evidence_numbers_kb_chunks():
     assert items[0].content == "Confidential Information clause text."
 
 
-def test_collect_evidence_numbers_caselaw():
+def test_collect_evidence_numbers_caselaw() -> None:
     result = ToolResult(
         data={
             "results": [
@@ -60,7 +60,7 @@ def test_collect_evidence_numbers_caselaw():
     assert "held" in items[0].content
 
 
-def test_collect_evidence_empty_on_failure():
+def test_collect_evidence_empty_on_failure() -> None:
     assert (
         collect_evidence(ToolIntent.retrieve_caselaw, ToolResult(data=None, outcome="error"), 1)
         == []

--- a/api/tests/autonomous/test_executor_real_work.py
+++ b/api/tests/autonomous/test_executor_real_work.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -142,7 +143,7 @@ async def test_intake_no_target_returns_empty_chunks(
 async def test_analysis_calls_run_skill_through_chokepoint(
     db_session: AsyncSession,
     running_watch_session_at_analysis: AutonomousSession,
-    mock_gateway_structured_response: object,
+    mock_gateway_structured_response: MagicMock,
 ) -> None:
     """analysis_node assembles messages and makes one guarded run_skill call;
     the structured-output content is stored in state."""
@@ -174,7 +175,7 @@ async def test_analysis_calls_run_skill_through_chokepoint(
 async def test_analysis_first_tick_skips_gateway(
     db_session: AsyncSession,
     running_schedule_session_first_tick: AutonomousSession,
-    mock_gateway: object,
+    mock_gateway: MagicMock,
 ) -> None:
     """If state carries first_tick_no_baseline, analysis_node returns early
     without calling the gateway."""
@@ -194,7 +195,7 @@ async def test_analysis_first_tick_skips_gateway(
 async def test_analysis_no_target_skips_gateway(
     db_session: AsyncSession,
     running_session_without_target: AutonomousSession,
-    mock_gateway: object,
+    mock_gateway: MagicMock,
 ) -> None:
     """A session with no skill_ref + no playbook_id returns early with
     analysis_content=None (no gateway call)."""

--- a/api/tests/autonomous/test_executor_skeleton.py
+++ b/api/tests/autonomous/test_executor_skeleton.py
@@ -366,7 +366,7 @@ async def test_executor_persists_failed_status_on_mid_graph_error(
     # Without this commit, rollback() would wipe the row and the re-fetch in the
     # executor's crash handler would return None, skipping the status update.
     await db_session.commit()
-    executor_mod.make_intake_node = _exploding_intake  # type: ignore[assignment]
+    executor_mod.make_intake_node = _exploding_intake
     try:
         gateway = _StubGateway()
         # Should NOT raise — exception is caught and persisted.
@@ -376,7 +376,7 @@ async def test_executor_persists_failed_status_on_mid_graph_error(
             gateway=gateway,  # type: ignore[arg-type]
         )
     finally:
-        executor_mod.make_intake_node = original_make_intake  # type: ignore[assignment]
+        executor_mod.make_intake_node = original_make_intake
 
     # C1b: rollback() detaches the in-memory row; re-fetch by PK to see the
     # committed failed status.
@@ -417,7 +417,7 @@ async def test_executor_persists_failed_status_on_state_dict_error(
 
         return _node
 
-    executor_mod.make_intake_node = _error_state_intake  # type: ignore[assignment]
+    executor_mod.make_intake_node = _error_state_intake
     try:
         gateway = _StubGateway()
         # Should NOT raise — state-dict errors are handled by the executor.
@@ -427,7 +427,7 @@ async def test_executor_persists_failed_status_on_state_dict_error(
             gateway=gateway,  # type: ignore[arg-type]
         )
     finally:
-        executor_mod.make_intake_node = original_make_intake  # type: ignore[assignment]
+        executor_mod.make_intake_node = original_make_intake
 
     await db_session.refresh(session)
     assert session.status == "failed", (
@@ -482,7 +482,7 @@ async def test_executor_rollback_called_on_mid_graph_error(
     # Commit the row into the outer test transaction so the executor's rollback()
     # (C1b) only removes executor-owned changes (not the session row itself).
     await db_session.commit()
-    executor_mod.make_intake_node = _exploding_intake  # type: ignore[assignment]
+    executor_mod.make_intake_node = _exploding_intake
     try:
         gateway = _StubGateway()
         with patch.object(db_session, "rollback", side_effect=_spy_rollback):
@@ -493,7 +493,7 @@ async def test_executor_rollback_called_on_mid_graph_error(
                 gateway=gateway,  # type: ignore[arg-type]
             )
     finally:
-        executor_mod.make_intake_node = original_make_intake  # type: ignore[assignment]
+        executor_mod.make_intake_node = original_make_intake
 
     assert rollback_call_count >= 1, (
         "C1b: executor must call db.rollback() in the crash handler before committing "

--- a/api/tests/autonomous/test_external_tool_cost.py
+++ b/api/tests/autonomous/test_external_tool_cost.py
@@ -11,6 +11,7 @@ Coverage:
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from decimal import Decimal
 from unittest.mock import AsyncMock
 
@@ -72,10 +73,10 @@ _FREE_PROVIDERS: list[dict] = [
 
 
 @pytest.fixture(autouse=True)
-def _reset_cache() -> None:
+def _reset_cache() -> Iterator[None]:
     """Reset the process-level tier + cost caches before every test."""
     _reset_provider_tier_cache_for_tests()
-    yield  # type: ignore[misc]
+    yield
     _reset_provider_tier_cache_for_tests()
 
 

--- a/api/tests/autonomous/test_findings_endpoint.py
+++ b/api/tests/autonomous/test_findings_endpoint.py
@@ -18,7 +18,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -37,7 +37,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/autonomous/test_guard_external_tool_intents.py
+++ b/api/tests/autonomous/test_guard_external_tool_intents.py
@@ -26,6 +26,7 @@ by this refactor.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Iterator
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
@@ -50,7 +51,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.fixture(autouse=True)
-def _reset_cost_cache() -> None:
+def _reset_cost_cache() -> Iterator[None]:
     """Reset the process-level provider tier+cost cache before/after each test.
 
     Prevents stale cache state from a preceding test (e.g. one that
@@ -60,7 +61,7 @@ def _reset_cost_cache() -> None:
     from app.tools.governance import _reset_provider_tier_cache_for_tests
 
     _reset_provider_tier_cache_for_tests()
-    yield  # type: ignore[misc]
+    yield
     _reset_provider_tier_cache_for_tests()
 
 

--- a/api/tests/autonomous/test_guard_helpers.py
+++ b/api/tests/autonomous/test_guard_helpers.py
@@ -443,7 +443,9 @@ async def test_halted_event_with_details(db_session: AsyncSession) -> None:
         .all()
     )
     assert len(rows) == 1
-    assert rows[0].details["reason"] == "cost_cap_reached"
+    details = rows[0].details
+    assert details is not None
+    assert details["reason"] == "cost_cap_reached"
 
 
 @pytest.mark.integration
@@ -476,6 +478,8 @@ async def test_phases_run_phase_transition_uses_autonomous_audit(
         .all()
     )
     assert len(rows) == 1
-    assert rows[0].details["to_phase"] == str(Phase.analysis)
+    details = rows[0].details
+    assert details is not None
+    assert details["to_phase"] == str(Phase.analysis)
     assert rows[0].resource_type == "autonomous_session"
     assert rows[0].user_id == user.id

--- a/api/tests/autonomous/test_idle_watchdog.py
+++ b/api/tests/autonomous/test_idle_watchdog.py
@@ -389,7 +389,9 @@ async def test_two_sweeps_takes_running_to_halted(db_session: AsyncSession) -> N
         .all()
     )
     assert len(halted_audit) == 1
-    assert halted_audit[0].details["reason"] == "idle_timeout"
+    details = halted_audit[0].details
+    assert details is not None
+    assert details["reason"] == "idle_timeout"
 
 
 @pytest.mark.integration
@@ -439,8 +441,8 @@ def test_cron_registered_in_worker_settings() -> None:
     from app.workers.arq_setup import WorkerSettings
 
     assert hasattr(WorkerSettings, "cron_jobs"), "WorkerSettings must have cron_jobs"
-    cron_jobs: list[CronJob] = WorkerSettings.cron_jobs  # type: ignore[attr-defined]
-    cron_names = [cj.coroutine.__name__ for cj in cron_jobs]
+    cron_jobs: list[CronJob] = WorkerSettings.cron_jobs
+    cron_names = [cj.coroutine.__qualname__ for cj in cron_jobs]
     assert "autonomous_idle_watchdog" in cron_names, (
         f"autonomous_idle_watchdog not in cron_jobs; found: {cron_names}"
     )
@@ -448,7 +450,7 @@ def test_cron_registered_in_worker_settings() -> None:
     # arq stores the scalar value as-is (int 0) when a single value is passed;
     # the cron runner normalises it to a set internally. Check for 0 (int) here.
     watchdog_cron = next(
-        cj for cj in cron_jobs if cj.coroutine.__name__ == "autonomous_idle_watchdog"
+        cj for cj in cron_jobs if cj.coroutine.__qualname__ == "autonomous_idle_watchdog"
     )
     assert watchdog_cron.second in (0, {0}), (
         f"expected second=0 (every-minute schedule), got {watchdog_cron.second!r}"

--- a/api/tests/autonomous/test_ledger_bridge_caselaw.py
+++ b/api/tests/autonomous/test_ledger_bridge_caselaw.py
@@ -63,7 +63,7 @@ async def test_build_caselaw_citations_verifies(db_session: AsyncSession) -> Non
     await db_session.flush()
     msg = await _msg(db_session)
 
-    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:  # type: ignore[type-arg]
+    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:
         return {"text": OPINION_TEXT}
 
     n = await build_caselaw_citations(
@@ -93,7 +93,7 @@ async def test_build_caselaw_citations_unknown_cluster_skipped(
 
     msg = await _msg(db_session)
 
-    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:  # type: ignore[type-arg]
+    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:
         return {"text": OPINION_TEXT}
 
     n = await build_caselaw_citations(
@@ -120,7 +120,7 @@ async def test_build_caselaw_citations_locate_miss_skipped(
     await db_session.flush()
     msg = await _msg(db_session)
 
-    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:  # type: ignore[type-arg]
+    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:
         return {"text": OPINION_TEXT}
 
     n = await build_caselaw_citations(
@@ -147,7 +147,7 @@ async def test_build_caselaw_citations_empty_quote_skipped(
     await db_session.flush()
     msg = await _msg(db_session)
 
-    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:  # type: ignore[type-arg]
+    async def fake_load(db: AsyncSession, *, opinion_id: int) -> dict:
         return {"text": OPINION_TEXT}
 
     n = await build_caselaw_citations(

--- a/api/tests/autonomous/test_memory.py
+++ b/api/tests/autonomous/test_memory.py
@@ -18,7 +18,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -37,7 +37,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/autonomous/test_notifications.py
+++ b/api/tests/autonomous/test_notifications.py
@@ -19,7 +19,8 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
+from typing import Any
 
 import pytest
 import pytest_asyncio
@@ -42,7 +43,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -420,7 +421,7 @@ async def test_notify_handles_missing_user_email_through_handler(
     # Simulate a deleted user: the handler's db.get(User, ...) returns None.
     real_get = db_session.get
 
-    async def _get_none(entity: object, ident: object, *a: object, **k: object):
+    async def _get_none(entity: type[Any], ident: object, *a: Any, **k: Any) -> Any:
         if entity is User:
             return None
         return await real_get(entity, ident, *a, **k)

--- a/api/tests/autonomous/test_observation_summary.py
+++ b/api/tests/autonomous/test_observation_summary.py
@@ -3,7 +3,7 @@ from app.autonomous.guard import ToolResult
 from app.autonomous.planner import summarize_observation
 
 
-def test_caselaw_summary_lists_case_names_not_full_text():
+def test_caselaw_summary_lists_case_names_not_full_text() -> None:
     result = ToolResult(
         data={
             "results": [
@@ -24,7 +24,7 @@ def test_caselaw_summary_lists_case_names_not_full_text():
     assert len(s) < 400
 
 
-def test_chunks_summary_counts_and_files():
+def test_chunks_summary_counts_and_files() -> None:
     result = ToolResult(
         data={
             "chunks": [
@@ -39,13 +39,13 @@ def test_chunks_summary_counts_and_files():
     assert "YYYY" not in s
 
 
-def test_failed_result_is_summarized_not_raised():
+def test_failed_result_is_summarized_not_raised() -> None:
     result = ToolResult(data=None, outcome="gateway_error")
     s = summarize_observation(ToolIntent.retrieve_caselaw, "x", result)
     assert "failed" in s and "gateway_error" in s
 
 
-def test_mcp_tool_summary_emits_keys_not_values():
+def test_mcp_tool_summary_emits_keys_not_values() -> None:
     result = ToolResult(
         data={"status": "ok", "citation": "X" * 500, "tool": "courtlistener"},
         outcome="success",
@@ -55,7 +55,7 @@ def test_mcp_tool_summary_emits_keys_not_values():
     assert "XXXX" not in s  # P3: keys only, never values
 
 
-def test_caselaw_summary_caps_at_five_and_notes_more():
+def test_caselaw_summary_caps_at_five_and_notes_more() -> None:
     result = ToolResult(
         data={
             "results": [

--- a/api/tests/autonomous/test_optin_gate.py
+++ b/api/tests/autonomous/test_optin_gate.py
@@ -9,7 +9,7 @@ Verifies the `AutonomousEnabledUser` gate:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -26,7 +26,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/autonomous/test_plan_intent.py
+++ b/api/tests/autonomous/test_plan_intent.py
@@ -15,7 +15,7 @@ from app.autonomous.enums import PHASE_GRANTS, Phase, ToolIntent
 pytestmark = pytest.mark.asyncio
 
 
-def test_plan_is_a_tool_intent_granted_in_analysis():
+def test_plan_is_a_tool_intent_granted_in_analysis() -> None:
     assert ToolIntent.plan == "plan"
     assert ToolIntent.plan in PHASE_GRANTS[Phase.analysis]
     # not granted elsewhere
@@ -23,11 +23,11 @@ def test_plan_is_a_tool_intent_granted_in_analysis():
     assert ToolIntent.plan not in PHASE_GRANTS[Phase.intake]
 
 
-def test_plan_is_an_inference_intent():
+def test_plan_is_an_inference_intent() -> None:
     assert ToolIntent.plan in _INFERENCE_INTENTS
 
 
-async def test_estimate_tool_cost_treats_plan_as_inference():
+async def test_estimate_tool_cost_treats_plan_as_inference() -> None:
     # db=None → estimator returns its conservative default (non-None Decimal), not 0
     cost = await estimate_tool_cost(ToolIntent.plan, {"model": "fast"}, None)
     from decimal import Decimal

--- a/api/tests/autonomous/test_planner_decision.py
+++ b/api/tests/autonomous/test_planner_decision.py
@@ -12,7 +12,7 @@ from app.autonomous.planner import (
 )
 
 
-def test_allowlist_is_observe_intents_only():
+def test_allowlist_is_observe_intents_only() -> None:
     # WS-E PR1a added retrieve_authority to the closed allowlist.
     assert (
         frozenset(
@@ -27,7 +27,7 @@ def test_allowlist_is_observe_intents_only():
     )
 
 
-def test_prompt_carries_goal_observations_and_allowlist():
+def test_prompt_carries_goal_observations_and_allowlist() -> None:
     msgs = build_planner_messages(
         goal="Is the assignment clause enforceable?",
         observations=["retrieve_caselaw → 2 results: [Smith (9th 2021); Doe (2d 2019)]"],
@@ -41,7 +41,7 @@ def test_prompt_carries_goal_observations_and_allowlist():
         assert intent.value in body  # the allowlist is shown to the planner
 
 
-def test_parse_action_decision():
+def test_parse_action_decision() -> None:
     out = parse_planner_decision(
         json.dumps(
             {
@@ -59,7 +59,7 @@ def test_parse_action_decision():
     )
 
 
-def test_parse_done_decision():
+def test_parse_done_decision() -> None:
     out = parse_planner_decision(
         json.dumps({"done": True, "rationale": "Enough authority gathered."})
     )
@@ -82,7 +82,7 @@ def test_parse_done_decision():
         json.dumps({"args": {}, "rationale": "x"}),  # no next_intent, no done
     ],
 )
-def test_parse_returns_none_on_garbage_or_out_of_set(bad):
+def test_parse_returns_none_on_garbage_or_out_of_set(bad: str | None) -> None:
     assert parse_planner_decision(bad) is None
 
 
@@ -91,12 +91,12 @@ def test_parse_returns_none_on_garbage_or_out_of_set(bad):
 # ---------------------------------------------------------------------------
 
 
-def test_validate_action_args_valid_top_k_passes():
+def test_validate_action_args_valid_top_k_passes() -> None:
     """A positive integer top_k is accepted."""
     validate_action_args(ToolIntent.retrieve_chunks, {"top_k": 5, "query": "x", "kb_id": "k"})
 
 
-def test_validate_action_args_absent_top_k_passes():
+def test_validate_action_args_absent_top_k_passes() -> None:
     """Omitted top_k (None default) is accepted — the handler supplies its own default."""
     validate_action_args(ToolIntent.retrieve_chunks, {"query": "x", "kb_id": "k"})
 
@@ -105,13 +105,13 @@ def test_validate_action_args_absent_top_k_passes():
     "bad_top_k",
     [-1, 0, True, "5"],
 )
-def test_validate_action_args_bad_top_k_raises(bad_top_k):
+def test_validate_action_args_bad_top_k_raises(bad_top_k: int | str) -> None:
     """top_k=-1, 0, bool(True), or str('5') all raise ValueError."""
     with pytest.raises(ValueError, match="top_k"):
         validate_action_args(ToolIntent.retrieve_chunks, {"top_k": bad_top_k, "query": "x"})
 
 
-def test_validate_action_args_valid_embedding_passes():
+def test_validate_action_args_valid_embedding_passes() -> None:
     """A list of floats is accepted."""
     validate_action_args(
         ToolIntent.retrieve_chunks,
@@ -119,7 +119,7 @@ def test_validate_action_args_valid_embedding_passes():
     )
 
 
-def test_validate_action_args_none_embedding_passes():
+def test_validate_action_args_none_embedding_passes() -> None:
     """Explicit None query_embedding is accepted (handler treats it as absent)."""
     validate_action_args(
         ToolIntent.retrieve_chunks,
@@ -131,13 +131,13 @@ def test_validate_action_args_none_embedding_passes():
     "bad_emb",
     ["x", [("a",)]],
 )
-def test_validate_action_args_bad_embedding_raises(bad_emb):
+def test_validate_action_args_bad_embedding_raises(bad_emb: str | list[tuple[str]]) -> None:
     """A string or a list of tuples for query_embedding raises ValueError."""
     with pytest.raises(ValueError, match="query_embedding"):
         validate_action_args(ToolIntent.retrieve_chunks, {"query_embedding": bad_emb, "query": "x"})
 
 
-def test_validate_action_args_non_retrieve_chunks_is_noop():
+def test_validate_action_args_non_retrieve_chunks_is_noop() -> None:
     """Non-retrieve_chunks intents pass unconditionally (no SQL reach)."""
     validate_action_args(ToolIntent.retrieve_caselaw, {"top_k": -999, "query_embedding": "bad"})
     validate_action_args(ToolIntent.call_mcp_tool, {"top_k": -1})

--- a/api/tests/autonomous/test_precedents.py
+++ b/api/tests/autonomous/test_precedents.py
@@ -21,7 +21,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
 
 import pytest
@@ -46,7 +46,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/autonomous/test_project_reassign_ownership.py
+++ b/api/tests/autonomous/test_project_reassign_ownership.py
@@ -24,7 +24,7 @@ and a stubbed enqueue so run-now never touches Redis.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from unittest.mock import AsyncMock
 
 import pytest
@@ -47,7 +47,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/autonomous/test_prompts.py
+++ b/api/tests/autonomous/test_prompts.py
@@ -139,7 +139,9 @@ async def test_artifact_instruction_absent_when_flag_off(
 
 @pytest.mark.asyncio
 async def test_assemble_messages_raises_when_playbook_soft_deleted(
-    db_session: AsyncSession, session_with_playbook_id, sample_chunks
+    db_session: AsyncSession,
+    session_with_playbook_id: AutonomousSession,
+    sample_chunks: list[dict[str, object]],
 ) -> None:
     """Soft-deleted playbooks are refused, not analysed."""
     from datetime import UTC, datetime

--- a/api/tests/autonomous/test_receipt_build_safe.py
+++ b/api/tests/autonomous/test_receipt_build_safe.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.autonomous.nodes import make_delivery_node
 from app.autonomous.receipt import build_receipt, build_receipt_safe
+from app.autonomous.state import AutonomousSessionState
 from app.models.audit import AuditLog
 from app.models.autonomous import AutonomousSession
 
@@ -44,7 +45,10 @@ async def test_delivery_node_survives_build_receipt_failure(
     monkeypatch.setattr("app.autonomous.receipt.build_receipt", _boom)
 
     node = make_delivery_node(db_session, mock_gateway)
-    state = {"session_id": running_session_at_delivery.id, "findings": []}
+    state: AutonomousSessionState = {
+        "session_id": str(running_session_at_delivery.id),
+        "findings": [],
+    }
 
     # Must not raise.
     await node(state)

--- a/api/tests/autonomous/test_retrieve_authority.py
+++ b/api/tests/autonomous/test_retrieve_authority.py
@@ -35,6 +35,7 @@ Coverage
 from __future__ import annotations
 
 import uuid
+from collections.abc import Iterator
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -57,7 +58,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.fixture(autouse=True)
-def _reset_cost_cache() -> None:
+def _reset_cost_cache() -> Iterator[None]:
     """Reset the process-level provider tier+cost cache before/after each test.
 
     Prevents stale cache state from a preceding test (e.g. one that
@@ -67,7 +68,7 @@ def _reset_cost_cache() -> None:
     from app.tools.governance import _reset_provider_tier_cache_for_tests
 
     _reset_provider_tier_cache_for_tests()
-    yield  # type: ignore[misc]
+    yield
     _reset_provider_tier_cache_for_tests()
 
 

--- a/api/tests/autonomous/test_run_now.py
+++ b/api/tests/autonomous/test_run_now.py
@@ -16,7 +16,7 @@ missing Redis never errors.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from decimal import Decimal
 from unittest.mock import AsyncMock
 
@@ -34,7 +34,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/autonomous/test_schedules.py
+++ b/api/tests/autonomous/test_schedules.py
@@ -17,7 +17,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
@@ -38,7 +38,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -544,11 +544,15 @@ async def test_executor_seam_reads_kb_and_query_from_params(
     from app.autonomous.executor import run_autonomous_session
 
     original_build = executor_mod._build_graph
-    executor_mod._build_graph = lambda **_kw: _FakeGraph()  # type: ignore[assignment]
+    executor_mod._build_graph = lambda **_kw: _FakeGraph()
     try:
-        await run_autonomous_session(db_session, session_id=sess.id, gateway=object())
+        await run_autonomous_session(
+            db_session,
+            session_id=sess.id,
+            gateway=object(),  # type: ignore[arg-type]  # dummy; graph is faked so the gateway is never used
+        )
     finally:
-        executor_mod._build_graph = original_build  # type: ignore[assignment]
+        executor_mod._build_graph = original_build
 
     assert captured["kb_id"] == kb_id
     assert captured["query"] == "scan for liability caps"

--- a/api/tests/autonomous/test_session_authority_ledger.py
+++ b/api/tests/autonomous/test_session_authority_ledger.py
@@ -62,7 +62,7 @@ async def _make_session(db: AsyncSession) -> AutonomousSession:
     return sess
 
 
-def _evidence() -> list[dict]:  # type: ignore[type-arg]
+def _evidence() -> list[dict]:
     return [
         {
             "n": 1,
@@ -209,7 +209,7 @@ _EDGAR_BODY = (
 )
 
 
-def _edgar_evidence() -> list[dict]:  # type: ignore[type-arg]
+def _edgar_evidence() -> list[dict]:
     """Mirrors dataclasses.asdict(EvidenceItem(...)) for an EDGAR authority hit:
     source="edgar", content_kind="sec_filing" (both always set by EdgarAdapter,
     per app/research/adapters.py)."""

--- a/api/tests/autonomous/test_session_ledger.py
+++ b/api/tests/autonomous/test_session_ledger.py
@@ -13,6 +13,7 @@ the terminal session status + audit row commiteable.
 
 import json
 import uuid
+from typing import Any
 
 import pytest
 from sqlalchemy import select
@@ -20,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.autonomous.ledger_bridge import build_session_ledger
 from app.autonomous.nodes import make_delivery_node
+from app.autonomous.state import AutonomousSessionState
 from app.models.audit import AuditLog
 from app.models.autonomous import AutonomousSession
 from app.models.chat import Chat
@@ -27,13 +29,14 @@ from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.user import User
 from app.models.work_product_fiduciary_gate import WorkProductFiduciaryGate
 from app.security import hash_password
+from tests.autonomous.conftest import KbOneFile
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
 
 async def test_build_session_ledger_creates_hidden_chat_entries_and_gate(
-    db_session, kb_with_one_indexed_file
-):
+    db_session: AsyncSession, kb_with_one_indexed_file: KbOneFile
+) -> None:
     from app.models.document import DocumentChunk
 
     chunk = (
@@ -106,7 +109,7 @@ async def test_build_session_ledger_creates_hidden_chat_entries_and_gate(
     assert gate.gate_status == verdict["gate_status"]
 
 
-async def test_build_session_ledger_no_citations_returns_none(db_session):
+async def test_build_session_ledger_no_citations_returns_none(db_session: AsyncSession) -> None:
     user = User(
         email="sl2@x.com",
         hashed_password=hash_password("p"),
@@ -162,15 +165,15 @@ async def test_delivery_node_savepoint_isolates_bridge_failure(
     """
 
     async def boom(
-        db,
+        db: AsyncSession,
         *,
-        session,
-        work_product_text,
-        findings,
-        evidence,
-        gateway,
-        judge_model="fast",
-    ):
+        session: AutonomousSession,
+        work_product_text: str,
+        findings: list[dict[str, Any]],
+        evidence: list[dict[str, Any]],
+        gateway: Any,
+        judge_model: str = "fast",
+    ) -> dict[str, Any] | None:
         """Partial write then raise — exercises the SAVEPOINT rollback path."""
         db.add(
             Chat(
@@ -207,8 +210,8 @@ async def test_delivery_node_savepoint_isolates_bridge_failure(
         + "\n```"
     )
 
-    state = {
-        "session_id": running_session_at_delivery.id,
+    state: AutonomousSessionState = {
+        "session_id": str(running_session_at_delivery.id),
         "findings": [],
         "analysis_content": analysis_content,
         "analysis_evidence": [

--- a/api/tests/autonomous/test_session_ledger_endpoint.py
+++ b/api/tests/autonomous/test_session_ledger_endpoint.py
@@ -11,7 +11,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -26,6 +26,7 @@ from app.models.autonomous import AutonomousSession
 from app.models.document import DocumentChunk
 from app.models.user import User
 from app.security import create_access_token, hash_password
+from tests.autonomous.conftest import KbOneFile
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
@@ -35,7 +36,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -103,7 +104,7 @@ def _bearer_for(user: User) -> str:
 
 async def _seed_session_with_ledger(
     db_session: AsyncSession,
-    kb_with_one_indexed_file,
+    kb_with_one_indexed_file: KbOneFile,
     *,
     owner: User,
 ) -> AutonomousSession:
@@ -152,7 +153,7 @@ async def _seed_session_with_ledger(
 async def test_session_ledger_endpoint_returns_entries(
     db_session: AsyncSession,
     client: AsyncClient,
-    kb_with_one_indexed_file,
+    kb_with_one_indexed_file: KbOneFile,
     owner_user: User,
 ) -> None:
     """200 + entries + gate when the session has a built ledger."""
@@ -227,7 +228,7 @@ async def test_session_ledger_endpoint_cross_user_returns_404(
 async def test_session_ledger_endpoint_auditor_cross_user_returns_200_and_audits(
     db_session: AsyncSession,
     client: AsyncClient,
-    kb_with_one_indexed_file,
+    kb_with_one_indexed_file: KbOneFile,
     owner_user: User,
     auditor_user: User,
 ) -> None:
@@ -260,13 +261,14 @@ async def test_session_ledger_endpoint_auditor_cross_user_returns_200_and_audits
     assert row.user_id == auditor_user.id
     assert row.resource_type == "autonomous_session"
     assert row.resource_id == str(sess.id)
+    assert row.details is not None
     assert row.details["viewed_user_id"] == str(owner_user.id)
 
 
 async def test_session_ledger_endpoint_owner_read_not_audited(
     db_session: AsyncSession,
     client: AsyncClient,
-    kb_with_one_indexed_file,
+    kb_with_one_indexed_file: KbOneFile,
     owner_user: User,
 ) -> None:
     """An owner reading their own session ledger writes no audit_log row."""

--- a/api/tests/autonomous/test_sessions_api.py
+++ b/api/tests/autonomous/test_sessions_api.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -33,7 +33,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/autonomous/test_terminal_reason_completed.py
+++ b/api/tests/autonomous/test_terminal_reason_completed.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.autonomous.nodes import make_delivery_node
+from app.autonomous.state import AutonomousSessionState
 from app.models.audit import AuditLog
 from app.models.autonomous import AutonomousSession
 
@@ -30,7 +31,10 @@ async def test_delivery_writes_completed_audit_row_so_receipt_terminal_reason_po
     """delivery_node writes autonomous_session.completed before build_receipt
     so the receipt's terminal_reason is 'completed' (was None — the bug)."""
     node = make_delivery_node(db_session, mock_gateway)
-    state = {"session_id": running_session_at_delivery.id, "findings": []}
+    state: AutonomousSessionState = {
+        "session_id": str(running_session_at_delivery.id),
+        "findings": [],
+    }
     await node(state)
 
     rows = (

--- a/api/tests/autonomous/test_watch_schedule_max_cost_endpoints.py
+++ b/api/tests/autonomous/test_watch_schedule_max_cost_endpoints.py
@@ -24,7 +24,7 @@ this folder has no shared conftest beyond the repo-root ``conftest.py``'s
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from decimal import Decimal
 
 import pytest
@@ -39,7 +39,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/autonomous/test_watches.py
+++ b/api/tests/autonomous/test_watches.py
@@ -19,7 +19,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
@@ -42,7 +42,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/chat/test_tool_loop.py
+++ b/api/tests/chat/test_tool_loop.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -895,11 +896,11 @@ def _authority_spec(op: str) -> ToolSpec:
 
 
 class _FakeGateway:
-    def __init__(self, payload):
+    def __init__(self, payload: dict[str, Any]) -> None:
         self._payload = payload
-        self.calls = []
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
 
-    async def call_tool(self, provider, op, args):
+    async def call_tool(self, provider: str, op: str, args: dict[str, Any]) -> dict[str, Any]:
         self.calls.append((provider, op, args))
         return {"payload": self._payload}
 
@@ -941,8 +942,8 @@ def fake_authority_storage(monkeypatch: pytest.MonkeyPatch) -> dict[str, bytes]:
 
 @pytest.mark.asyncio
 async def test_dispatch_get_authority_writes_cache_and_returns_data(
-    db, fake_authority_storage: dict[str, bytes]
-):
+    db: AsyncSession, fake_authority_storage: dict[str, bytes]
+) -> None:
     payload = {
         "package_id": "USCODE-2022-title17",
         "citation": "17 U.S.C. 107",
@@ -972,7 +973,7 @@ async def test_dispatch_get_authority_writes_cache_and_returns_data(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_search_authority_does_not_write_cache(db):
+async def test_dispatch_search_authority_does_not_write_cache(db: AsyncSession) -> None:
     payload = {
         "results": [
             {"package_id": "USCODE-2022-title17", "title": "Fair use", "dateIssued": "2022-01-01"}
@@ -997,8 +998,10 @@ async def test_dispatch_search_authority_does_not_write_cache(db):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_authority_cache_failure_is_non_fatal(db, monkeypatch):
-    async def _boom(db, *, source_type, external_ref, text):
+async def test_dispatch_authority_cache_failure_is_non_fatal(
+    db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _boom(db: AsyncSession, *, source_type: str, external_ref: str, text: str) -> None:
         raise RuntimeError("storage down")
 
     monkeypatch.setattr("app.citation.authority.store_authority_text", _boom)
@@ -1026,7 +1029,7 @@ async def test_dispatch_authority_cache_failure_is_non_fatal(db, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_collect_tool_sources_authority_branch():
+def test_collect_tool_sources_authority_branch() -> None:
     spec = _authority_spec("get_authority")
     data = {
         "authority": {
@@ -1049,7 +1052,7 @@ def test_collect_tool_sources_authority_branch():
     assert rec.tool == "get_authority"
 
 
-def test_collect_tool_sources_authority_search_also_emits():
+def test_collect_tool_sources_authority_search_also_emits() -> None:
     spec = _authority_spec("search_authority")
     data = {
         "authority": {
@@ -1095,8 +1098,8 @@ def _shared_authority_spec(op: str) -> ToolSpec:
 
 @pytest.mark.asyncio
 async def test_dispatch_authority_uses_registry_adapter_for_edgar(
-    db, fake_authority_storage: dict[str, bytes]
-):
+    db: AsyncSession, fake_authority_storage: dict[str, bytes]
+) -> None:
     """Task 2 review requirement 1: a get_authority call with source='edgar'
     must resolve SOURCE_REGISTRY['edgar'].adapter (EdgarAdapter) — NOT a
     hardcoded GovInfoAdapter(). content_kind must stay 'sec_filing', not be
@@ -1130,7 +1133,7 @@ async def test_dispatch_authority_uses_registry_adapter_for_edgar(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_search_authority_empty_results_does_not_raise(db):
+async def test_dispatch_search_authority_empty_results_does_not_raise(db: AsyncSession) -> None:
     """Task 2 review requirement 2 (empty-search resilience): EdgarAdapter
     (like GovInfoAdapter) raises ValueError on a zero-result search_authority
     payload. execute_tool only catches MCPAuthorizationRequired/
@@ -1156,7 +1159,9 @@ async def test_dispatch_search_authority_empty_results_does_not_raise(db):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_search_authority_empty_results_does_not_raise_govinfo(db):
+async def test_dispatch_search_authority_empty_results_does_not_raise_govinfo(
+    db: AsyncSession,
+) -> None:
     """Same empty-results resilience for the pre-existing GovInfo path (the
     bug pre-dates EDGAR; EDGAR just made it reachable more often given
     full-text search commonly returns zero hits)."""
@@ -1174,7 +1179,7 @@ async def test_dispatch_search_authority_empty_results_does_not_raise_govinfo(db
 
 
 @pytest.mark.asyncio
-async def test_dispatch_authority_unknown_source_does_not_raise(db):
+async def test_dispatch_authority_unknown_source_does_not_raise(db: AsyncSession) -> None:
     """A source not in SOURCE_REGISTRY (or without a registered adapter,
     e.g. courtlistener) must degrade to a failed-but-non-raising observation
     rather than crash the dispatch — defensive belt-and-suspenders mirroring

--- a/api/tests/chat/test_tool_schemas.py
+++ b/api/tests/chat/test_tool_schemas.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.chat.tool_schemas import (
     AUTHORITY_OPS,
@@ -17,7 +18,7 @@ class _FakeGateway:  # only what resolve_available_sources needs
 
 
 @pytest.mark.asyncio
-async def test_research_only_allowlist(db):
+async def test_research_only_allowlist(db: AsyncSession) -> None:
     with (
         patch(
             "app.chat.tool_schemas.get_capabilities",
@@ -36,11 +37,12 @@ async def test_research_only_allowlist(db):
         al = await assemble_allowlist(db, gateway=_FakeGateway())
     assert set(al.specs) >= RESEARCH_OPS
     spec = al.resolve("search_case_law")
+    assert spec is not None
     assert spec.kind == "research" and spec.provider == "cl-prod" and spec.read_only
 
 
 @pytest.mark.asyncio
-async def test_mcp_only_allowlist(db):
+async def test_mcp_only_allowlist(db: AsyncSession) -> None:
     tools = [
         {
             "name": "get_doc",
@@ -83,13 +85,15 @@ async def test_mcp_only_allowlist(db):
     ):
         al = await assemble_allowlist(db, gateway=_FakeGateway())
     assert mcp_function_name("files", "get_doc") in al.specs
-    assert al.resolve(mcp_function_name("files", "delete_doc")).destructive is True
+    delete_spec = al.resolve(mcp_function_name("files", "delete_doc"))
+    assert delete_spec is not None
+    assert delete_spec.destructive is True
     # disabled tools are NOT in the allowlist
     assert mcp_function_name("files", "disabled_tool") not in al.specs
 
 
 @pytest.mark.asyncio
-async def test_empty_allowlist_when_nothing_enabled(db):
+async def test_empty_allowlist_when_nothing_enabled(db: AsyncSession) -> None:
     with (
         patch(
             "app.chat.tool_schemas.get_capabilities",
@@ -102,13 +106,13 @@ async def test_empty_allowlist_when_nothing_enabled(db):
     assert al.function_schemas() == []
 
 
-def test_mcp_name_roundtrip():
+def test_mcp_name_roundtrip() -> None:
     n = mcp_function_name("files", "get_doc")
     assert parse_mcp_function_name(n) == ("files", "get_doc")
     assert parse_mcp_function_name("verify_citations") is None
 
 
-def test_authority_schemas_declare_search_and_get():
+def test_authority_schemas_declare_search_and_get() -> None:
     assert set(AUTHORITY_OPS) == {"search_authority", "get_authority"}
     for op in AUTHORITY_OPS:
         schema = AUTHORITY_TOOL_SCHEMAS[op]
@@ -123,8 +127,10 @@ class _FakeGovInfoSource:
 
 
 @pytest.mark.asyncio
-async def test_assemble_allowlist_adds_authority_when_govinfo_available(db, monkeypatch):
-    async def _fake_resolve(gateway):
+async def test_assemble_allowlist_adds_authority_when_govinfo_available(
+    db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _fake_resolve(gateway: object) -> list[object]:
         return [_FakeGovInfoSource()]
 
     monkeypatch.setattr("app.chat.tool_schemas.resolve_available_sources", _fake_resolve)
@@ -142,8 +148,10 @@ async def test_assemble_allowlist_adds_authority_when_govinfo_available(db, monk
 
 
 @pytest.mark.asyncio
-async def test_assemble_allowlist_no_authority_when_absent(db, monkeypatch):
-    async def _fake_resolve(gateway):
+async def test_assemble_allowlist_no_authority_when_absent(
+    db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _fake_resolve(gateway: object) -> list[object]:
         return []
 
     monkeypatch.setattr("app.chat.tool_schemas.resolve_available_sources", _fake_resolve)
@@ -159,8 +167,10 @@ async def test_assemble_allowlist_no_authority_when_absent(db, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_assemble_allowlist_authority_failure_does_not_kill_other_ops(db, monkeypatch):
-    async def _boom(gateway):
+async def test_assemble_allowlist_authority_failure_does_not_kill_other_ops(
+    db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _boom(gateway: object) -> list[object]:
         raise RuntimeError("registry down")
 
     monkeypatch.setattr("app.chat.tool_schemas.resolve_available_sources", _boom)
@@ -183,7 +193,7 @@ async def test_assemble_allowlist_authority_failure_does_not_kill_other_ops(db, 
 from app.chat.tool_schemas import build_authority_tool_schemas  # noqa: E402
 
 
-def test_authority_source_enum_lists_enabled_sources():
+def test_authority_source_enum_lists_enabled_sources() -> None:
     # both govinfo + edgar enabled → source enum has both
     schemas = build_authority_tool_schemas(enabled_sources=["govinfo", "edgar"])
     search = next(s for s in schemas if s["name"] == "search_authority")
@@ -191,17 +201,17 @@ def test_authority_source_enum_lists_enabled_sources():
     assert set(source_prop["enum"]) == {"govinfo", "edgar"}
 
 
-def test_authority_schemas_empty_when_no_sources():
+def test_authority_schemas_empty_when_no_sources() -> None:
     assert build_authority_tool_schemas(enabled_sources=[]) == []
 
 
-def test_govinfo_only_still_works():
+def test_govinfo_only_still_works() -> None:
     schemas = build_authority_tool_schemas(enabled_sources=["govinfo"])
     search = next(s for s in schemas if s["name"] == "search_authority")
     assert search["parameters"]["properties"]["source"]["enum"] == ["govinfo"]
 
 
-def test_authority_schemas_require_source_and_op_specific_fields():
+def test_authority_schemas_require_source_and_op_specific_fields() -> None:
     schemas = build_authority_tool_schemas(enabled_sources=["govinfo", "edgar"])
     search = next(s for s in schemas if s["name"] == "search_authority")
     get_ = next(s for s in schemas if s["name"] == "get_authority")
@@ -219,8 +229,10 @@ class _FakeEdgarSource:
 
 
 @pytest.mark.asyncio
-async def test_assemble_allowlist_adds_both_sources_when_both_available(db, monkeypatch):
-    async def _fake_resolve(gateway):
+async def test_assemble_allowlist_adds_both_sources_when_both_available(
+    db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _fake_resolve(gateway: object) -> list[object]:
         return [_FakeGovInfoSource(), _FakeEdgarSource()]
 
     monkeypatch.setattr("app.chat.tool_schemas.resolve_available_sources", _fake_resolve)
@@ -237,10 +249,11 @@ async def test_assemble_allowlist_adds_both_sources_when_both_available(db, monk
     assert {s.tool for s in authority_specs} == {"search_authority", "get_authority"}
     assert len(authority_specs) == 2
     search_spec = allowlist.resolve("search_authority")
+    assert search_spec is not None
     assert set(search_spec.parameters["properties"]["source"]["enum"]) == {"govinfo", "edgar"}
 
 
-def test_authority_source_enum_is_per_op():
+def test_authority_source_enum_is_per_op() -> None:
     # govinfo+edgar support both ops; eurlex supports only get_authority.
     schemas = build_authority_tool_schemas(enabled_sources=["govinfo", "edgar", "eurlex"])
     by_name = {s["name"]: s for s in schemas}
@@ -255,7 +268,7 @@ def test_authority_source_enum_is_per_op():
     }
 
 
-def test_authority_search_omitted_when_no_search_source():
+def test_authority_search_omitted_when_no_search_source() -> None:
     # only a get-only source enabled → no search_authority tool at all
     schemas = build_authority_tool_schemas(enabled_sources=["eurlex"])
     assert [s["name"] for s in schemas] == ["get_authority"]

--- a/api/tests/citation/conftest.py
+++ b/api/tests/citation/conftest.py
@@ -14,7 +14,9 @@ from app.models.user import User
 
 
 @pytest.fixture
-async def seeded(db_session: AsyncSession):
+async def seeded(
+    db_session: AsyncSession,
+) -> tuple[uuid.UUID, uuid.UUID, MessageCaselawCitation, CitationLedgerEntry]:
     """Seed: User → Chat → assistant Message → MessageCaselawCitation(cluster_id=2812209)
     → CitationLedgerEntry.  Returns (msg_id, chat_id, cc, entry)."""
     user = User(email=f"t-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")

--- a/api/tests/citation/test_caselaw_verify.py
+++ b/api/tests/citation/test_caselaw_verify.py
@@ -10,21 +10,23 @@ from app.citation.verification import verify
 OPINION = "Before the quote. The implied covenant of good faith applies here. After."
 
 
-def test_locate_passage_found():
+def test_locate_passage_found() -> None:
     loc = locate_passage("The implied covenant of good faith applies here.", OPINION)
     assert loc is not None
     start, end = loc
     assert OPINION[start:end] == "The implied covenant of good faith applies here."
 
 
-def test_locate_passage_absent_returns_none():
+def test_locate_passage_absent_returns_none() -> None:
     assert locate_passage("a sentence that is not in the opinion", OPINION) is None
 
 
 @pytest.mark.asyncio
-async def test_verify_exact_match_against_opinion():
+async def test_verify_exact_match_against_opinion() -> None:
     passage = "The implied covenant of good faith applies here."
-    start, end = locate_passage(passage, OPINION)
+    loc = locate_passage(passage, OPINION)
+    assert loc is not None
+    start, end = loc
     target = opinion_target(opinion_id=777, text=OPINION)
     candidate = _CaselawCandidate(
         source_offset_start=start,
@@ -38,7 +40,7 @@ async def test_verify_exact_match_against_opinion():
 
 
 @pytest.mark.asyncio
-async def test_invented_quote_not_verified():
+async def test_invented_quote_not_verified() -> None:
     target = opinion_target(opinion_id=777, text=OPINION)
     candidate = _CaselawCandidate(
         source_offset_start=0,

--- a/api/tests/citation/test_cost.py
+++ b/api/tests/citation/test_cost.py
@@ -373,7 +373,7 @@ async def test_resolve_ensemble_uses_per_model_calibration(
     # WITHOUT calibration (db=None) the conservative default applies
     # and the request passes the budget.
     result_default = await _resolve_ensemble_config(
-        gateway=_Gw(),
+        gateway=_Gw(),  # type: ignore[arg-type]
         applied_skills=[],
         project_ensemble_verification=True,
         skill_registry=None,
@@ -386,7 +386,7 @@ async def test_resolve_ensemble_uses_per_model_calibration(
     # WITH calibration (real db_session + seeded rows) the per-model
     # average is $0.020/call, so 2 x 3 x 0.020 = $0.12 — falls back.
     result_calibrated = await _resolve_ensemble_config(
-        gateway=_Gw(),
+        gateway=_Gw(),  # type: ignore[arg-type]
         applied_skills=[],
         project_ensemble_verification=True,
         skill_registry=None,

--- a/api/tests/citation/test_edge_cases.py
+++ b/api/tests/citation/test_edge_cases.py
@@ -30,7 +30,7 @@ chat-send pipeline; pure-cascade tests live alongside
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -40,7 +40,7 @@ import pytest
 import pytest_asyncio
 import respx
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.verification import (
@@ -188,7 +188,7 @@ def test_verify_exact_match_offsets_span_chunk_boundary_within_document() -> Non
 pytestmark = pytest.mark.integration
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -600,9 +600,9 @@ async def test_deleted_source_file_handled_gracefully_no_row_written(
         # Mimic the race: doc gets deleted between retrieval and
         # citation persistence.
         await db_session.execute(
-            DocumentChunk.__table__.delete().where(DocumentChunk.document_id == deleted_doc_id)
+            delete(DocumentChunk).where(DocumentChunk.document_id == deleted_doc_id)
         )
-        await db_session.execute(Document.__table__.delete().where(Document.id == deleted_doc_id))
+        await db_session.execute(delete(Document).where(Document.id == deleted_doc_id))
         await db_session.flush()
         return [captured_chunk_data]
 

--- a/api/tests/citation/test_ensemble.py
+++ b/api/tests/citation/test_ensemble.py
@@ -568,10 +568,10 @@ async def test_resolve_activates_on_skill_flag(
     registry = _StubSkillRegistry({"nda-review": _StubSkill(ensemble_verification=True)})
 
     result = await _resolve_ensemble_config(
-        gateway=gw,
+        gateway=gw,  # type: ignore[arg-type]
         applied_skills=["nda-review"],
         project_ensemble_verification=False,
-        skill_registry=registry,
+        skill_registry=registry,  # type: ignore[arg-type]
         n_candidates=2,
         message_id=uuid.uuid4(),
     )
@@ -591,7 +591,7 @@ async def test_resolve_activates_on_project_flag(
     gw = _StubGatewayForActivation(config=_activation_config_off)
 
     result = await _resolve_ensemble_config(
-        gateway=gw,
+        gateway=gw,  # type: ignore[arg-type]
         applied_skills=[],
         project_ensemble_verification=True,
         skill_registry=None,
@@ -618,7 +618,7 @@ async def test_resolve_activates_on_gateway_default() -> None:
     gw = _StubGatewayForActivation(config=cfg)
 
     result = await _resolve_ensemble_config(
-        gateway=gw,
+        gateway=gw,  # type: ignore[arg-type]
         applied_skills=[],
         project_ensemble_verification=False,
         skill_registry=None,
@@ -640,7 +640,7 @@ async def test_resolve_no_activation_returns_none(
     gw = _StubGatewayForActivation(config=_activation_config_off)
 
     result = await _resolve_ensemble_config(
-        gateway=gw,
+        gateway=gw,  # type: ignore[arg-type]
         applied_skills=[],
         project_ensemble_verification=False,
         skill_registry=None,
@@ -678,7 +678,7 @@ async def test_resolve_returns_none_when_gateway_has_no_ensemble_config() -> Non
     gw = _StubGatewayForActivation(config=None)
 
     result = await _resolve_ensemble_config(
-        gateway=gw,
+        gateway=gw,  # type: ignore[arg-type]
         applied_skills=[],
         project_ensemble_verification=True,
         skill_registry=None,
@@ -707,7 +707,7 @@ async def test_resolve_cost_budget_fallback_returns_none() -> None:
     gw = _StubGatewayForActivation(config=cfg)
 
     result = await _resolve_ensemble_config(
-        gateway=gw,
+        gateway=gw,  # type: ignore[arg-type]
         applied_skills=[],
         project_ensemble_verification=False,
         skill_registry=None,
@@ -735,7 +735,7 @@ async def test_resolve_cost_budget_within_cap_activates() -> None:
     gw = _StubGatewayForActivation(config=cfg)
 
     result = await _resolve_ensemble_config(
-        gateway=gw,
+        gateway=gw,  # type: ignore[arg-type]
         applied_skills=[],
         project_ensemble_verification=False,
         skill_registry=None,

--- a/api/tests/citation/test_paraphrase_judge.py
+++ b/api/tests/citation/test_paraphrase_judge.py
@@ -24,7 +24,6 @@ from dataclasses import dataclass
 import pytest
 
 from app.citation.verification import (
-    VerificationResult,
     verify_paraphrase,
 )
 from app.errors import GatewayUnreachable
@@ -151,12 +150,11 @@ async def test_yes_high_returns_verified_with_confidence_0_90() -> None:
 
     result = await verify_paraphrase(cand, doc, gateway=gw, judge_model="fast")
 
-    assert result == VerificationResult(
-        verified=True,
-        method="paraphrase_judge",
-        confidence=pytest.approx(0.90),
-        partial=False,
-    )
+    assert result.verified is True
+    assert result.method == "paraphrase_judge"
+    assert result.confidence == pytest.approx(0.90)
+    assert result.partial is False
+    assert result.tier_envelope is None
 
 
 @pytest.mark.unit

--- a/api/tests/citation/test_treatment_concurrency.py
+++ b/api/tests/citation/test_treatment_concurrency.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy import delete as _real_delete, select
+from sqlalchemy import Delete, delete as _real_delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.treatment import derive_treatment_for_message
@@ -62,7 +62,7 @@ async def _seed_two_cluster_turn(db: AsyncSession) -> uuid.UUID:
     return msg.id
 
 
-async def test_concurrent_insert_conflict_isolates_and_reuses(db_session: AsyncSession):
+async def test_concurrent_insert_conflict_isolates_and_reuses(db_session: AsyncSession) -> None:
     """One cluster's parent INSERT conflicts with a concurrently-inserted row;
     the other cluster still derives + links, and the conflicting cluster reuses
     the winner's row instead of poisoning the session."""
@@ -125,12 +125,16 @@ async def test_concurrent_insert_conflict_isolates_and_reuses(db_session: AsyncS
         .scalars()
         .all()
     }
-    by_cluster = {cc_map[e.message_caselaw_citation_id]: rows[e.treatment_id] for e in entries}
+    by_cluster: dict[int, CitationTreatment] = {}
+    for e in entries:
+        assert e.message_caselaw_citation_id is not None
+        assert e.treatment_id is not None
+        by_cluster[cc_map[e.message_caselaw_citation_id]] = rows[e.treatment_id]
     assert by_cluster[7001].cited_by_count == 99  # reused the winner, did not overwrite
     assert by_cluster[7002].cited_by_count == 5  # derived normally
 
 
-async def test_concurrent_judge_write_last_writer_wins(db_session: AsyncSession):
+async def test_concurrent_judge_write_last_writer_wins(db_session: AsyncSession) -> None:
     """With the in-savepoint DELETE restored, a concurrently-staged winner signal is
     overwritten by last-writer-wins. The committed state must be CONSISTENT: parent
     derived_method='citation_graph+judge', judged_count == len(signals), and
@@ -299,7 +303,7 @@ async def test_judge_write_conflict_skip_restores_parent(
     # `false()` so SQLAlchemy's ORM `evaluate` mode can handle it in Python without
     # falling back to `fetch` mode, which issues a sync SELECT during savepoint
     # teardown and raises MissingGreenlet in the async context.
-    def _noop_delete(model: type) -> object:  # type: ignore[type-arg]
+    def _noop_delete(model: type[CitationTreatmentSignal]) -> Delete:
         return _real_delete(model).where(model.treatment_id.is_(None))
 
     monkeypatch.setattr("app.citation.treatment.delete", _noop_delete)

--- a/api/tests/citation/test_treatment_derivation.py
+++ b/api/tests/citation/test_treatment_derivation.py
@@ -5,10 +5,13 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.treatment import TREATMENT_TTL_DAYS, derive_treatment_for_message
 from app.models.chat import Chat, Message
+from app.models.citation_ledger_entry import CitationLedgerEntry
 from app.models.citation_treatment import CitationTreatment
+from app.models.message_caselaw_citation import MessageCaselawCitation
 from app.models.user import User
 
 pytestmark = pytest.mark.integration
@@ -33,9 +36,12 @@ def _citing(n: int) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_derives_fetches_and_links(db_session, seeded):
+async def test_derives_fetches_and_links(
+    db_session: AsyncSession,
+    seeded: tuple[uuid.UUID, uuid.UUID, MessageCaselawCitation, CitationLedgerEntry],
+) -> None:
     message_id, _chat, _cc, entry = seeded
-    calls = []
+    calls: list[int] = []
 
     async def fake_fetch(opinion_id: int) -> dict:
         calls.append(opinion_id)
@@ -61,7 +67,10 @@ async def test_derives_fetches_and_links(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_reuses_fresh_cache_without_fetch(db_session, seeded):
+async def test_reuses_fresh_cache_without_fetch(
+    db_session: AsyncSession,
+    seeded: tuple[uuid.UUID, uuid.UUID, MessageCaselawCitation, CitationLedgerEntry],
+) -> None:
     message_id, _chat, _cc, entry = seeded
     db_session.add(
         CitationTreatment(
@@ -74,7 +83,7 @@ async def test_reuses_fresh_cache_without_fetch(db_session, seeded):
         )
     )
     await db_session.flush()
-    calls = []
+    calls: list[int] = []
 
     async def fake_fetch(opinion_id: int) -> dict:
         calls.append(opinion_id)
@@ -90,7 +99,10 @@ async def test_reuses_fresh_cache_without_fetch(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_refetches_when_stale(db_session, seeded):
+async def test_refetches_when_stale(
+    db_session: AsyncSession,
+    seeded: tuple[uuid.UUID, uuid.UUID, MessageCaselawCitation, CitationLedgerEntry],
+) -> None:
     message_id, *_ = seeded
     db_session.add(
         CitationTreatment(
@@ -103,7 +115,7 @@ async def test_refetches_when_stale(db_session, seeded):
         )
     )
     await db_session.flush()
-    calls = []
+    calls: list[int] = []
 
     async def fake_fetch(opinion_id: int) -> dict:
         calls.append(opinion_id)
@@ -122,7 +134,10 @@ async def test_refetches_when_stale(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_per_case_fetch_error_is_non_fatal(db_session, seeded):
+async def test_per_case_fetch_error_is_non_fatal(
+    db_session: AsyncSession,
+    seeded: tuple[uuid.UUID, uuid.UUID, MessageCaselawCitation, CitationLedgerEntry],
+) -> None:
     message_id, *_ = seeded
 
     async def boom(opinion_id: int) -> dict:
@@ -137,7 +152,7 @@ async def test_per_case_fetch_error_is_non_fatal(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_no_caselaw_citations_is_noop(db_session):
+async def test_no_caselaw_citations_is_noop(db_session: AsyncSession) -> None:
     # a message with no caselaw citations
     user = User(email=f"t-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
     db_session.add(user)
@@ -148,7 +163,7 @@ async def test_no_caselaw_citations_is_noop(db_session):
     msg = Message(chat_id=chat.id, role="assistant", kind="ai", content="x")
     db_session.add(msg)
     await db_session.flush()
-    called = []
+    called: list[int] = []
 
     async def fake_fetch(opinion_id: int) -> dict:
         called.append(opinion_id)

--- a/api/tests/citation/test_treatment_needed.py
+++ b/api/tests/citation/test_treatment_needed.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.ledger import message_ids_needing_treatment
 from app.models.chat import Chat, Message
@@ -18,7 +19,15 @@ pytestmark = pytest.mark.integration
 _NOW = datetime(2026, 6, 27, tzinfo=UTC)
 
 
-async def _entry(db, chat_id, *, source_kind, treatment_id=None, cc_id=None, user_id=None):
+async def _entry(
+    db: AsyncSession,
+    chat_id: uuid.UUID,
+    *,
+    source_kind: str,
+    treatment_id: uuid.UUID | None = None,
+    cc_id: uuid.UUID | None = None,
+    user_id: uuid.UUID | None = None,
+) -> uuid.UUID:
     from app.models.chat import MessageCitation
 
     msg = Message(chat_id=chat_id, role="assistant", kind="ai", content="x")
@@ -84,7 +93,7 @@ async def _entry(db, chat_id, *, source_kind, treatment_id=None, cc_id=None, use
 
 
 @pytest.fixture
-async def user(db_session):
+async def user(db_session: AsyncSession) -> User:
     u = User(email=f"n-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
     db_session.add(u)
     await db_session.flush()
@@ -92,14 +101,14 @@ async def user(db_session):
 
 
 @pytest.fixture
-async def chat(db_session, user):
+async def chat(db_session: AsyncSession, user: User) -> uuid.UUID:
     c = Chat(owner_id=user.id, title="n")
     db_session.add(c)
     await db_session.flush()
     return c.id
 
 
-async def _treatment(db, *, cluster_id, as_of):
+async def _treatment(db: AsyncSession, *, cluster_id: int, as_of: datetime) -> CitationTreatment:
     t = CitationTreatment(
         cluster_id=cluster_id,
         opinion_id=cluster_id,
@@ -113,33 +122,33 @@ async def _treatment(db, *, cluster_id, as_of):
     return t
 
 
-async def test_null_treatment_caselaw_is_needed(db_session, chat):
+async def test_null_treatment_caselaw_is_needed(db_session: AsyncSession, chat: uuid.UUID) -> None:
     mid = await _entry(db_session, chat, source_kind="caselaw", treatment_id=None)
     out = await message_ids_needing_treatment(db_session, chat_id=chat, message_id=None, now=_NOW)
     assert mid in out
 
 
-async def test_fresh_treatment_not_needed(db_session, chat):
+async def test_fresh_treatment_not_needed(db_session: AsyncSession, chat: uuid.UUID) -> None:
     t = await _treatment(db_session, cluster_id=1, as_of=_NOW)
     mid = await _entry(db_session, chat, source_kind="caselaw", treatment_id=t.id)
     out = await message_ids_needing_treatment(db_session, chat_id=chat, message_id=None, now=_NOW)
     assert mid not in out
 
 
-async def test_stale_treatment_is_needed(db_session, chat):
+async def test_stale_treatment_is_needed(db_session: AsyncSession, chat: uuid.UUID) -> None:
     t = await _treatment(db_session, cluster_id=2, as_of=_NOW - timedelta(days=31))
     mid = await _entry(db_session, chat, source_kind="caselaw", treatment_id=t.id)
     out = await message_ids_needing_treatment(db_session, chat_id=chat, message_id=None, now=_NOW)
     assert mid in out
 
 
-async def test_non_caselaw_excluded(db_session, chat, user):
+async def test_non_caselaw_excluded(db_session: AsyncSession, chat: uuid.UUID, user: User) -> None:
     mid = await _entry(db_session, chat, source_kind="document", treatment_id=None, user_id=user.id)
     out = await message_ids_needing_treatment(db_session, chat_id=chat, message_id=None, now=_NOW)
     assert mid not in out
 
 
-async def test_message_id_scopes(db_session, chat):
+async def test_message_id_scopes(db_session: AsyncSession, chat: uuid.UUID) -> None:
     mid1 = await _entry(db_session, chat, source_kind="caselaw", treatment_id=None)
     mid2 = await _entry(db_session, chat, source_kind="caselaw", treatment_id=None)
     out = await message_ids_needing_treatment(db_session, chat_id=chat, message_id=mid1, now=_NOW)

--- a/api/tests/citation/test_verification_spans.py
+++ b/api/tests/citation/test_verification_spans.py
@@ -15,7 +15,7 @@ from typing import Literal
 
 import pytest
 from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
@@ -130,7 +130,7 @@ def _spans_by_name(exporter: InMemorySpanExporter, name: str) -> list:
     return [s for s in exporter.get_finished_spans() if s.name == name]
 
 
-def _event_names(span) -> list[str]:
+def _event_names(span: ReadableSpan) -> list[str]:
     return [e.name for e in span.events]
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -38,7 +38,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 if TYPE_CHECKING:
-    pass
+    from sqlalchemy.orm import Session, SessionTransaction
 
 API_DIR = Path(__file__).resolve().parent.parent
 
@@ -145,10 +145,11 @@ async def db_session(test_engine: AsyncEngine) -> AsyncIterator[AsyncSession]:
         )
 
         @event.listens_for(session.sync_session, "after_transaction_end")
-        def restart_savepoint(sess, trans):
+        def restart_savepoint(sess: Session, trans: SessionTransaction) -> None:
             # When the inner SAVEPOINT ends (either commit or rollback),
             # immediately start a new one so the session can keep working.
-            if trans.nested and not trans._parent.nested:
+            if trans.nested and trans.parent is not None and not trans.parent.nested:
+                assert conn.sync_connection is not None
                 conn.sync_connection.begin_nested()
 
         try:

--- a/api/tests/integration/test_attached_skills_send.py
+++ b/api/tests/integration/test_attached_skills_send.py
@@ -25,7 +25,7 @@ contract is covered by ``test_skills_send_with_slash_unresolved.py``.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 import httpx
@@ -53,7 +53,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/integration/test_authority_citations.py
+++ b/api/tests/integration/test_authority_citations.py
@@ -233,7 +233,7 @@ def _resp_final(text: str) -> ChatCompletionResponse:
 
 
 @pytest_asyncio.fixture
-async def seeded(db_session: AsyncSession):
+async def seeded(db_session: AsyncSession) -> tuple[User, Chat, uuid.UUID]:
     """Seed a user + chat + assistant message; yield (user, chat, message_id)."""
     user = User(
         email=f"auth-cite-{uuid.uuid4().hex[:8]}@example.com",
@@ -297,7 +297,7 @@ async def _run_loop(
 @pytest.mark.asyncio
 async def test_chat_get_authority_verbatim_quote_verifies_and_gates(
     db_session: AsyncSession,
-    seeded,
+    seeded: tuple[User, Chat, uuid.UUID],
     fake_authority_storage: dict[str, bytes],
 ) -> None:
     user, chat, message_id = seeded
@@ -374,7 +374,7 @@ async def test_chat_get_authority_verbatim_quote_verifies_and_gates(
 @pytest.mark.asyncio
 async def test_chat_fabricated_authority_quote_dropped(
     db_session: AsyncSession,
-    seeded,
+    seeded: tuple[User, Chat, uuid.UUID],
     fake_authority_storage: dict[str, bytes],
 ) -> None:
     user, chat, message_id = seeded

--- a/api/tests/integration/test_caselaw_citations.py
+++ b/api/tests/integration/test_caselaw_citations.py
@@ -102,7 +102,9 @@ def _caselaw_source(cluster_id: int) -> ToolSourceRecord:
 
 
 @pytest.mark.asyncio
-async def test_verbatim_quote_persists_verified_row(db_session, seeded_chat_message):
+async def test_verbatim_quote_persists_verified_row(
+    db_session: AsyncSession, seeded_chat_message: uuid.UUID
+) -> None:
     message_id = seeded_chat_message
     db_session.add(
         ResearchOpinionMetadata(
@@ -115,7 +117,7 @@ async def test_verbatim_quote_persists_verified_row(db_session, seeded_chat_mess
     )
     await db_session.flush()
 
-    async def fake_loader(db, opinion_id):
+    async def fake_loader(db: AsyncSession, opinion_id: int) -> str:
         return _OPINION_TEXT
 
     answer = "**Relevant passage:**\n> The covenant of good faith is implied in every contract.\n"
@@ -146,7 +148,9 @@ async def test_verbatim_quote_persists_verified_row(db_session, seeded_chat_mess
 
 
 @pytest.mark.asyncio
-async def test_invented_quote_persists_nothing(db_session, seeded_chat_message):
+async def test_invented_quote_persists_nothing(
+    db_session: AsyncSession, seeded_chat_message: uuid.UUID
+) -> None:
     message_id = seeded_chat_message
     db_session.add(
         ResearchOpinionMetadata(
@@ -159,7 +163,7 @@ async def test_invented_quote_persists_nothing(db_session, seeded_chat_message):
     )
     await db_session.flush()
 
-    async def fake_loader(db, opinion_id):
+    async def fake_loader(db: AsyncSession, opinion_id: int) -> str:
         return _OPINION_TEXT
 
     answer = "> The court invented a rule that appears in no opinion whatsoever.\n"
@@ -174,7 +178,9 @@ async def test_invented_quote_persists_nothing(db_session, seeded_chat_message):
 
 
 @pytest.mark.asyncio
-async def test_storage_miss_is_skipped_not_fatal(db_session, seeded_chat_message):
+async def test_storage_miss_is_skipped_not_fatal(
+    db_session: AsyncSession, seeded_chat_message: uuid.UUID
+) -> None:
     message_id = seeded_chat_message
     db_session.add(
         ResearchOpinionMetadata(
@@ -183,7 +189,7 @@ async def test_storage_miss_is_skipped_not_fatal(db_session, seeded_chat_message
     )
     await db_session.flush()
 
-    async def boom_loader(db, opinion_id):
+    async def boom_loader(db: AsyncSession, opinion_id: int) -> str:
         raise RuntimeError("object storage unavailable")
 
     answer = "> The covenant of good faith is implied in every contract.\n"

--- a/api/tests/integration/test_caselaw_fail_attribution.py
+++ b/api/tests/integration/test_caselaw_fail_attribution.py
@@ -107,7 +107,7 @@ class _ErroringGateway:
 
 
 @pytest_asyncio.fixture
-async def seeded(db_session: AsyncSession):
+async def seeded(db_session: AsyncSession) -> tuple[uuid.UUID, int, int]:
     user = User(
         email=f"fail-{uuid.uuid4().hex[:8]}@example.com", hashed_password="x", role="member"
     )
@@ -158,7 +158,7 @@ async def _rows(db_session: AsyncSession, message_id: uuid.UUID) -> list[Message
 
 @pytest.mark.asyncio
 async def test_attributed_reject_writes_fail_row_and_flags(
-    db_session: AsyncSession, seeded
+    db_session: AsyncSession, seeded: tuple[uuid.UUID, int, int]
 ) -> None:
     message_id, opinion_id, cluster_id = seeded
     gw = _FakeGateway(json.dumps({"verdict": "no"}))
@@ -191,7 +191,9 @@ async def test_attributed_reject_writes_fail_row_and_flags(
 
 
 @pytest.mark.asyncio
-async def test_attributed_accept_writes_supported_row(db_session: AsyncSession, seeded) -> None:
+async def test_attributed_accept_writes_supported_row(
+    db_session: AsyncSession, seeded: tuple[uuid.UUID, int, int]
+) -> None:
     message_id, _opinion_id, cluster_id = seeded
     gw = _FakeGateway(json.dumps({"verdict": "yes", "confidence": "high"}))
     n = await verify_and_persist_caselaw_citations(
@@ -210,7 +212,9 @@ async def test_attributed_accept_writes_supported_row(db_session: AsyncSession, 
 
 
 @pytest.mark.asyncio
-async def test_unattributed_reject_drops_no_fail(db_session: AsyncSession, seeded) -> None:
+async def test_unattributed_reject_drops_no_fail(
+    db_session: AsyncSession, seeded: tuple[uuid.UUID, int, int]
+) -> None:
     message_id, _opinion_id, cluster_id = seeded
     # H3 names a DIFFERENT case than the consulted cluster -> no attribution.
     answer = "### Totally Different Case, N.Y., 1999\n\n**Relevant passage:**\n> " + _PASSAGE + "\n"
@@ -230,7 +234,7 @@ async def test_unattributed_reject_drops_no_fail(db_session: AsyncSession, seede
 
 @pytest.mark.asyncio
 async def test_attributed_over_budget_writes_unverified_fail(
-    db_session: AsyncSession, seeded, monkeypatch: pytest.MonkeyPatch
+    db_session: AsyncSession, seeded: tuple[uuid.UUID, int, int], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import app.citation.caselaw as caselaw_mod
 
@@ -255,7 +259,9 @@ async def test_attributed_over_budget_writes_unverified_fail(
 
 
 @pytest.mark.asyncio
-async def test_attributed_transient_error_drops(db_session: AsyncSession, seeded) -> None:
+async def test_attributed_transient_error_drops(
+    db_session: AsyncSession, seeded: tuple[uuid.UUID, int, int]
+) -> None:
     message_id, _opinion_id, cluster_id = seeded
     gw = _ErroringGateway()
     n = await verify_and_persist_caselaw_citations(
@@ -273,7 +279,9 @@ async def test_attributed_transient_error_drops(db_session: AsyncSession, seeded
 
 
 @pytest.mark.asyncio
-async def test_attributed_yes_without_confidence_drops(db_session: AsyncSession, seeded) -> None:
+async def test_attributed_yes_without_confidence_drops(
+    db_session: AsyncSession, seeded: tuple[uuid.UUID, int, int]
+) -> None:
     """A 'yes' verdict without a confidence field is non-substantive -> drop, no row.
 
     _parse_judge_response returns _MISS for {"verdict": "yes"} with no confidence.
@@ -296,7 +304,9 @@ async def test_attributed_yes_without_confidence_drops(db_session: AsyncSession,
 
 
 @pytest.mark.asyncio
-async def test_attributed_nonjson_output_drops(db_session: AsyncSession, seeded) -> None:
+async def test_attributed_nonjson_output_drops(
+    db_session: AsyncSession, seeded: tuple[uuid.UUID, int, int]
+) -> None:
     """Truncated / non-JSON judge output is non-substantive -> drop, no row.
 
     The judge caps at max_tokens=400; a verbose justification can truncate the

--- a/api/tests/integration/test_caselaw_paraphrase_judge.py
+++ b/api/tests/integration/test_caselaw_paraphrase_judge.py
@@ -117,7 +117,7 @@ class _FakeGateway:
 
 
 @pytest_asyncio.fixture
-async def seeded_msg(db_session: AsyncSession):
+async def seeded_msg(db_session: AsyncSession) -> tuple[uuid.UUID, uuid.UUID, int, int]:
     """Seed a user + chat + assistant message and a consulted opinion.
 
     Returns (message_id, opinion_id, cluster_id).
@@ -166,7 +166,7 @@ async def _fake_loader(db: AsyncSession, opinion_id: int) -> str:
 @pytest.mark.asyncio
 async def test_accepting_judge_writes_paraphrase_judge_row_and_gate(
     db_session: AsyncSession,
-    seeded_msg,
+    seeded_msg: tuple[uuid.UUID, uuid.UUID, int, int],
 ) -> None:
     """Paraphrased quote + accepting judge -> one paraphrase_judge row.
 
@@ -233,7 +233,7 @@ async def test_accepting_judge_writes_paraphrase_judge_row_and_gate(
 @pytest.mark.asyncio
 async def test_rejecting_judge_writes_no_row(
     db_session: AsyncSession,
-    seeded_msg,
+    seeded_msg: tuple[uuid.UUID, uuid.UUID, int, int],
 ) -> None:
     """Judge rejects all consulted opinions -> no row written, additive-only."""
     message_id, _chat_id, _opinion_id, cluster_id = seeded_msg
@@ -277,7 +277,7 @@ async def test_rejecting_judge_writes_no_row(
 @pytest.mark.asyncio
 async def test_zero_budget_prevents_judge_call(
     db_session: AsyncSession,
-    seeded_msg,
+    seeded_msg: tuple[uuid.UUID, uuid.UUID, int, int],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Budget monkeypatched to Decimal('0') -> judge mock never called, no row."""
@@ -312,7 +312,7 @@ async def test_zero_budget_prevents_judge_call(
 @pytest.mark.asyncio
 async def test_gateway_none_is_verbatim_only(
     db_session: AsyncSession,
-    seeded_msg,
+    seeded_msg: tuple[uuid.UUID, uuid.UUID, int, int],
 ) -> None:
     """gateway=None -> behaves exactly as today: no judge, no paraphrase_judge rows."""
     message_id, _chat_id, _opinion_id, cluster_id = seeded_msg

--- a/api/tests/integration/test_caselaw_paraphrase_method.py
+++ b/api/tests/integration/test_caselaw_paraphrase_method.py
@@ -3,6 +3,7 @@ import uuid
 import pytest
 import pytest_asyncio
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.chat import Chat, Message
 from app.models.message_caselaw_citation import MessageCaselawCitation
@@ -12,7 +13,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest_asyncio.fixture
-async def msg(db_session):
+async def msg(db_session: AsyncSession) -> uuid.UUID:
     u = User(email=f"cm-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
     db_session.add(u)
     await db_session.flush()
@@ -26,7 +27,7 @@ async def msg(db_session):
 
 
 @pytest.mark.asyncio
-async def test_paraphrase_judge_method_accepted(db_session, msg):
+async def test_paraphrase_judge_method_accepted(db_session: AsyncSession, msg: uuid.UUID) -> None:
     db_session.add(
         MessageCaselawCitation(
             message_id=msg,
@@ -45,7 +46,7 @@ async def test_paraphrase_judge_method_accepted(db_session, msg):
 
 
 @pytest.mark.asyncio
-async def test_bogus_method_rejected(db_session, msg):
+async def test_bogus_method_rejected(db_session: AsyncSession, msg: uuid.UUID) -> None:
     db_session.add(
         MessageCaselawCitation(
             message_id=msg,

--- a/api/tests/integration/test_chat_tool_call_resume.py
+++ b/api/tests/integration/test_chat_tool_call_resume.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 import contextlib
 import json as _json
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from typing import Literal
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -52,7 +53,7 @@ _DUMMY_UUID = uuid.UUID("00000000-0000-4000-8000-000000000000")
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -129,7 +130,7 @@ def _parse_sse_frames(body: bytes) -> list[dict]:
 def _make_tool_spec(
     *,
     function_name: str = "mcp__files__delete_doc",
-    kind: str = "mcp",
+    kind: Literal["research", "mcp", "authority"] = "mcp",
     provider: str = "files",
     tool: str = "delete_doc",
     destructive: bool = True,
@@ -288,9 +289,7 @@ async def test_approve_executes_tool_and_streams_loop_final(
     )
 
     # Assert pending row is resolved.
-    await db_session.refresh(
-        await db_session.get(ChatPendingToolCall, pending_id)  # type: ignore[arg-type]
-    )
+    await db_session.refresh(await db_session.get(ChatPendingToolCall, pending_id))
     pending_row = await db_session.get(ChatPendingToolCall, pending_id)
     assert pending_row is not None
     assert pending_row.status == "resolved", f"Expected resolved, got {pending_row.status!r}"

--- a/api/tests/integration/test_chat_tool_loop_send.py
+++ b/api/tests/integration/test_chat_tool_loop_send.py
@@ -26,8 +26,9 @@ from __future__ import annotations
 import contextlib
 import json as _json
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
+from typing import Literal
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -65,7 +66,7 @@ GATEWAY_KEY = "test-gw-key"
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -138,7 +139,7 @@ def _parse_sse_frames(body: bytes) -> list[dict]:
 def _make_tool_spec(
     *,
     function_name: str = "mcp__files__delete_doc",
-    kind: str = "mcp",
+    kind: Literal["research", "mcp", "authority"] = "mcp",
     provider: str = "files",
     tool: str = "delete_doc",
     destructive: bool = True,
@@ -203,7 +204,7 @@ async def test_empty_allowlist_uses_single_shot_stream_path(
         routed_provider="anthropic-prod",
     )
 
-    async def _stream_gen(*_args, **_kwargs):
+    async def _stream_gen(*_args: object, **_kwargs: object) -> AsyncIterator[ChatCompletionChunk]:
         yield chunk
 
     empty_allowlist = ChatToolAllowlist(specs={})

--- a/api/tests/integration/test_citation_ledger.py
+++ b/api/tests/integration/test_citation_ledger.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.ledger import assemble_ledger_entries, resolve_ledger_entries
 from app.models.chat import Chat, Message, MessageCitation
@@ -17,7 +18,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest_asyncio.fixture
-async def seeded_message(db_session):
+async def seeded_message(db_session: AsyncSession) -> uuid.UUID:
     """Seed a user + chat + assistant message; yield the message id."""
     user = User(
         email=f"ledger-{uuid.uuid4().hex[:8]}@example.com",
@@ -36,7 +37,7 @@ async def seeded_message(db_session):
 
 
 @pytest.mark.asyncio
-async def test_ledger_entry_roundtrips(db_session, seeded_message):
+async def test_ledger_entry_roundtrips(db_session: AsyncSession, seeded_message: uuid.UUID) -> None:
     """A single-FK entry referencing a real tool-source row persists and reads back."""
     chat_id = (
         await db_session.execute(select(Message.chat_id).where(Message.id == seeded_message))
@@ -75,7 +76,9 @@ async def test_ledger_entry_roundtrips(db_session, seeded_message):
 
 
 @pytest.mark.asyncio
-async def test_exactly_one_fk_check_rejects_zero_and_two(db_session, seeded_message):
+async def test_exactly_one_fk_check_rejects_zero_and_two(
+    db_session: AsyncSession, seeded_message: uuid.UUID
+) -> None:
     chat_id = (
         await db_session.execute(select(Message.chat_id).where(Message.id == seeded_message))
     ).scalar_one()
@@ -108,7 +111,9 @@ async def test_exactly_one_fk_check_rejects_zero_and_two(db_session, seeded_mess
 
 
 @pytest.mark.asyncio
-async def test_assembles_one_entry_per_source_row(db_session, seeded_message):
+async def test_assembles_one_entry_per_source_row(
+    db_session: AsyncSession, seeded_message: uuid.UUID
+) -> None:
     mid = seeded_message
     # A KB-document citation (verified) — needs a real source_file_id (files row).
     # Reuse the message_tool_sources + caselaw rows that DON'T need a file FK,
@@ -171,13 +176,17 @@ async def test_assembles_one_entry_per_source_row(db_session, seeded_message):
 
 
 @pytest.mark.asyncio
-async def test_no_sources_yields_no_entries(db_session, seeded_message):
+async def test_no_sources_yields_no_entries(
+    db_session: AsyncSession, seeded_message: uuid.UUID
+) -> None:
     n = await assemble_ledger_entries(db_session, message_id=seeded_message)
     assert n == 0
 
 
 @pytest.mark.asyncio
-async def test_resolve_shapes_all_three_source_kinds(db_session, seeded_message):
+async def test_resolve_shapes_all_three_source_kinds(
+    db_session: AsyncSession, seeded_message: uuid.UUID
+) -> None:
     """Each entry resolves to its source block; passages present for quote kinds."""
     mid = seeded_message
     chat_id = (
@@ -258,7 +267,9 @@ async def test_resolve_shapes_all_three_source_kinds(db_session, seeded_message)
 
 
 @pytest.mark.asyncio
-async def test_resolve_message_id_filter_and_empty(db_session, seeded_message):
+async def test_resolve_message_id_filter_and_empty(
+    db_session: AsyncSession, seeded_message: uuid.UUID
+) -> None:
     chat_id = (
         await db_session.execute(select(Message.chat_id).where(Message.id == seeded_message))
     ).scalar_one()
@@ -287,7 +298,9 @@ async def test_resolve_message_id_filter_and_empty(db_session, seeded_message):
 
 
 @pytest.mark.asyncio
-async def test_resolve_skips_dangling_reference(db_session, seeded_message):
+async def test_resolve_skips_dangling_reference(
+    db_session: AsyncSession, seeded_message: uuid.UUID
+) -> None:
     """An entry whose referenced row is absent is skipped, not fatal."""
     _chat_id = (
         await db_session.execute(select(Message.chat_id).where(Message.id == seeded_message))
@@ -304,4 +317,4 @@ async def test_resolve_skips_dangling_reference(db_session, seeded_message):
         message_authority_citation_id = None
         id = uuid.uuid4()
 
-    assert _resolve_source(_E(), {}, {}, {}, {}) is None
+    assert _resolve_source(_E(), {}, {}, {}, {}) is None  # type: ignore[arg-type]  # stub entry

--- a/api/tests/integration/test_fiduciary_gate.py
+++ b/api/tests/integration/test_fiduciary_gate.py
@@ -3,6 +3,7 @@ import uuid
 import pytest
 import pytest_asyncio
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.gate import compute_and_record_gate, resolve_gates
 from app.citation.ledger import assemble_ledger_entries
@@ -18,7 +19,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest_asyncio.fixture
-async def seeded(db_session):
+async def seeded(db_session: AsyncSession) -> tuple[User, Chat, Message]:
     user = User(email=f"g-{uuid.uuid4().hex[:8]}@example.com", hashed_password="x", role="member")
     db_session.add(user)
     await db_session.flush()
@@ -31,7 +32,15 @@ async def seeded(db_session):
     return user, chat, msg
 
 
-async def _seed_entry(db_session, chat, msg, status, conf, *, opinion_id):
+async def _seed_entry(
+    db_session: AsyncSession,
+    chat: Chat,
+    msg: Message,
+    status: str,
+    conf: float | None,
+    *,
+    opinion_id: int,
+) -> None:
     """Create an FK-valid caselaw-citation-backed ledger entry whose
     verification_status is overridden to ``status`` (the entry's status is what
     the gate reads — it need not equal the citation's real method)."""
@@ -62,7 +71,9 @@ async def _seed_entry(db_session, chat, msg, status, conf, *, opinion_id):
 
 
 @pytest.mark.asyncio
-async def test_all_pass_is_fiduciary_grade(db_session, seeded):
+async def test_all_pass_is_fiduciary_grade(
+    db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _user, chat, msg = seeded
     # Seed ledger entries directly via real caselaw-citation rows so FKs resolve.
     for status, conf in [("exact_match", 1.0), ("tolerant_match", 0.95)]:
@@ -98,11 +109,14 @@ async def test_all_pass_is_fiduciary_grade(db_session, seeded):
     assert gate.supported_count == 0
     assert gate.fail_count == 0
     assert gate.total_assertions == 2
+    assert gate.confidence is not None
     assert abs(gate.confidence - 0.975) < 1e-6
 
 
 @pytest.mark.asyncio
-async def test_supported_only_when_paraphrase_no_fail(db_session, seeded):
+async def test_supported_only_when_paraphrase_no_fail(
+    db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _user, chat, msg = seeded
     # one PASS (tolerant_match) + one SUPPORTED (paraphrase_judge), no FAIL
     await _seed_entry(db_session, chat, msg, "tolerant_match", 0.95, opinion_id=101)
@@ -118,7 +132,9 @@ async def test_supported_only_when_paraphrase_no_fail(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_any_fail_is_flagged(db_session, seeded):
+async def test_any_fail_is_flagged(
+    db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _user, chat, msg = seeded
     # one PASS (exact_match, conf=1.0) + one FAIL (unverified, conf=None)
     await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=201)
@@ -136,7 +152,9 @@ async def test_any_fail_is_flagged(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_provenance_excluded(db_session, seeded):
+async def test_provenance_excluded(
+    db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _user, chat, msg = seeded
     # one PASS entry + one provenance entry (via a real MessageToolSource)
     await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=301)
@@ -173,7 +191,9 @@ async def test_provenance_excluded(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_zero_assertions_is_fiduciary_grade(db_session, seeded):
+async def test_zero_assertions_is_fiduciary_grade(
+    db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _user, chat, msg = seeded
     # only a provenance entry — no assertion entries
     ts = MessageToolSource(
@@ -208,7 +228,9 @@ async def test_zero_assertions_is_fiduciary_grade(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_unknown_status_excluded(db_session, seeded):
+async def test_unknown_status_excluded(
+    db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _user, chat, msg = seeded
     # one valid PASS + one entry with unknown status "weird"
     await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=501)
@@ -222,7 +244,9 @@ async def test_unknown_status_excluded(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_upsert_replaces(db_session, seeded):
+async def test_upsert_replaces(
+    db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _user, chat, msg = seeded
     # First call: one exact_match (PASS) → fiduciary_grade
     await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=601)
@@ -252,7 +276,9 @@ async def test_upsert_replaces(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_resolve_gates_shapes(db_session, seeded):
+async def test_resolve_gates_shapes(
+    db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _user, chat, msg = seeded
     await _seed_entry(db_session, chat, msg, "exact_match", 1.0, opinion_id=701)
     await compute_and_record_gate(db_session, message_id=msg.id)
@@ -284,7 +310,9 @@ async def test_resolve_gates_shapes(db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_assembler_marks_unverified_kb_citation(db_session, seeded):
+async def test_assembler_marks_unverified_kb_citation(
+    db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     """Regression: an unverified KB citation must land as 'unverified', not 'verified'."""
     user, _chat, msg = seeded
 

--- a/api/tests/integration/test_ledger_endpoint.py
+++ b/api/tests/integration/test_ledger_endpoint.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.gate import compute_and_record_gate
 from app.citation.ledger import assemble_ledger_entries
@@ -20,15 +22,15 @@ from app.security import create_access_token, hash_password
 pytestmark = pytest.mark.integration
 
 
-def _override_get_db(session):
-    async def _dep():
+def _override_get_db(session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
+    async def _dep() -> AsyncIterator[AsyncSession]:
         yield session
 
     return _dep
 
 
 @pytest_asyncio.fixture
-async def seeded(db_session):
+async def seeded(db_session: AsyncSession) -> tuple[User, Chat, Message]:
     user = User(
         email=f"led-{uuid.uuid4().hex[:8]}@example.com",
         hashed_password=hash_password("pw"),
@@ -71,7 +73,7 @@ async def seeded(db_session):
 
 
 @pytest_asyncio.fixture
-async def client(db_session):
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
     app.dependency_overrides[get_db] = _override_get_db(db_session)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
@@ -79,13 +81,15 @@ async def client(db_session):
     app.dependency_overrides.pop(get_db, None)
 
 
-def _auth(user):
+def _auth(user: User) -> dict[str, str]:
     token = create_access_token(user.id, user.email, is_admin=user.is_admin)
     return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.mark.asyncio
-async def test_ledger_returns_resolved_entries(client, seeded):
+async def test_ledger_returns_resolved_entries(
+    client: AsyncClient, seeded: tuple[User, Chat, Message]
+) -> None:
     user, chat, _msg = seeded
     r = await client.get(f"/api/v1/chats/{chat.id}/ledger", headers=_auth(user))
     assert r.status_code == 200
@@ -99,7 +103,9 @@ async def test_ledger_returns_resolved_entries(client, seeded):
 
 
 @pytest.mark.asyncio
-async def test_ledger_message_id_filter(client, seeded):
+async def test_ledger_message_id_filter(
+    client: AsyncClient, seeded: tuple[User, Chat, Message]
+) -> None:
     user, chat, msg = seeded
     r = await client.get(f"/api/v1/chats/{chat.id}/ledger?message_id={msg.id}", headers=_auth(user))
     assert r.status_code == 200
@@ -111,7 +117,9 @@ async def test_ledger_message_id_filter(client, seeded):
 
 
 @pytest.mark.asyncio
-async def test_ledger_cross_user_404(client, db_session, seeded):
+async def test_ledger_cross_user_404(
+    client: AsyncClient, db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _, chat, _ = seeded
     other = User(
         email=f"other-{uuid.uuid4().hex[:8]}@example.com",
@@ -125,7 +133,9 @@ async def test_ledger_cross_user_404(client, db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_ledger_auditor_can_read_cross_user_and_is_audited(client, db_session, seeded):
+async def test_ledger_auditor_can_read_cross_user_and_is_audited(
+    client: AsyncClient, db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     owner, chat, _msg = seeded
     auditor = User(
         email=f"aud-{uuid.uuid4().hex[:8]}@example.com",
@@ -153,11 +163,14 @@ async def test_ledger_auditor_can_read_cross_user_and_is_audited(client, db_sess
         .one()
     )
     assert row.user_id == auditor.id
+    assert row.details is not None
     assert row.details["viewed_user_id"] == str(owner.id)
 
 
 @pytest.mark.asyncio
-async def test_ledger_member_cross_user_still_404_and_not_audited(client, db_session, seeded):
+async def test_ledger_member_cross_user_still_404_and_not_audited(
+    client: AsyncClient, db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     _owner, chat, _msg = seeded
     other = User(
         email=f"other2-{uuid.uuid4().hex[:8]}@example.com",
@@ -185,7 +198,9 @@ async def test_ledger_member_cross_user_still_404_and_not_audited(client, db_ses
 
 
 @pytest.mark.asyncio
-async def test_ledger_owner_read_not_audited(client, db_session, seeded):
+async def test_ledger_owner_read_not_audited(
+    client: AsyncClient, db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     owner, chat, _msg = seeded
     r = await client.get(f"/api/v1/chats/{chat.id}/ledger", headers=_auth(owner))
     assert r.status_code == 200
@@ -205,7 +220,7 @@ async def test_ledger_owner_read_not_audited(client, db_session, seeded):
 
 
 @pytest.mark.asyncio
-async def test_ledger_non_uuid_400(client, seeded):
+async def test_ledger_non_uuid_400(client: AsyncClient, seeded: tuple[User, Chat, Message]) -> None:
     # _validate_chat_id raises ValidationError (HTTP 400), matching the pattern
     # used by all other chat endpoints (e.g. send_message, get_citations).
     user, _, _ = seeded
@@ -214,7 +229,9 @@ async def test_ledger_non_uuid_400(client, seeded):
 
 
 @pytest.mark.asyncio
-async def test_ledger_includes_gate(client, db_session, seeded):
+async def test_ledger_includes_gate(
+    client: AsyncClient, db_session: AsyncSession, seeded: tuple[User, Chat, Message]
+) -> None:
     user, chat, msg = seeded
     await compute_and_record_gate(db_session, message_id=msg.id)
     await db_session.flush()

--- a/api/tests/integration/test_ledger_lazy_treatment.py
+++ b/api/tests/integration/test_ledger_lazy_treatment.py
@@ -37,7 +37,9 @@ def _fake_request() -> Request:
 
 
 @pytest_asyncio.fixture
-async def seeded_caselaw_null_treatment(db_session: AsyncSession):
+async def seeded_caselaw_null_treatment(
+    db_session: AsyncSession,
+) -> tuple[User, uuid.UUID, uuid.UUID]:
     """Seed: user + chat + assistant message + caselaw citation + ledger entry
     with null treatment_id. Yields (user, chat_id, message_id)."""
     user = User(
@@ -87,9 +89,9 @@ async def seeded_caselaw_null_treatment(db_session: AsyncSession):
 @pytest.mark.asyncio
 async def test_ledger_read_enqueues_for_null_treatment(
     db_session: AsyncSession,
-    seeded_caselaw_null_treatment,
-    monkeypatch,
-):
+    seeded_caselaw_null_treatment: tuple[User, uuid.UUID, uuid.UUID],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """GET /ledger best-effort enqueues derivation for a caselaw turn whose
     treatment is not yet derived; the response shape is unchanged."""
     user, chat_id, message_id = seeded_caselaw_null_treatment
@@ -117,8 +119,8 @@ async def test_ledger_read_enqueues_for_null_treatment(
 @pytest.mark.asyncio
 async def test_ledger_read_skips_enqueue_for_fresh_treatment(
     db_session: AsyncSession,
-    monkeypatch,
-):
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """GET /ledger does NOT enqueue for a caselaw turn with a fresh treatment
     (as_of within the TTL window)."""
     user = User(

--- a/api/tests/integration/test_ledger_treatment_exposure.py
+++ b/api/tests/integration/test_ledger_treatment_exposure.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.asyncio
-async def test_ledger_entry_carries_resolved_treatment(db_session: AsyncSession):
+async def test_ledger_entry_carries_resolved_treatment(db_session: AsyncSession) -> None:
     user = User(email=f"l-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
     db_session.add(user)
     await db_session.flush()
@@ -84,7 +84,7 @@ async def test_ledger_entry_carries_resolved_treatment(db_session: AsyncSession)
 
 
 @pytest.mark.asyncio
-async def test_ledger_exposes_treatment_rollup_and_signals(db_session: AsyncSession):
+async def test_ledger_exposes_treatment_rollup_and_signals(db_session: AsyncSession) -> None:
     """WS-G PR2: treatment dict gains rollup + per-passage signals from judge run."""
     user = User(email=f"trs-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
     db_session.add(user)
@@ -182,7 +182,7 @@ async def test_ledger_exposes_treatment_rollup_and_signals(db_session: AsyncSess
 
 
 @pytest.mark.asyncio
-async def test_ledger_graph_only_treatment_yields_null_rollup(db_session: AsyncSession):
+async def test_ledger_graph_only_treatment_yields_null_rollup(db_session: AsyncSession) -> None:
     """WS-G PR2: graph-only treatment (no signals) yields new keys as null/empty."""
     user = User(email=f"go-{uuid.uuid4().hex[:8]}@e.com", hashed_password="x", role="member")
     db_session.add(user)

--- a/api/tests/integration/test_projects_sandbox_concurrency.py
+++ b/api/tests/integration/test_projects_sandbox_concurrency.py
@@ -37,7 +37,7 @@ FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "skills"
 
 
 @pytest_asyncio.fixture
-async def real_session_factory(test_engine: AsyncEngine):
+async def real_session_factory(test_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
     """Yield a session factory that creates a fresh AsyncSession per call.
 
     Used to override ``get_db`` so each in-flight request gets its own
@@ -83,7 +83,9 @@ async def seeded_user(test_engine: AsyncEngine) -> AsyncIterator[User]:
 
 
 @pytest_asyncio.fixture
-async def client(real_session_factory) -> AsyncIterator[AsyncClient]:
+async def client(
+    real_session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncIterator[AsyncClient]:
     """In-process AsyncClient where each request opens its own DB session."""
 
     async def _override() -> AsyncIterator[AsyncSession]:

--- a/api/tests/integration/test_projects_sandbox_ensure.py
+++ b/api/tests/integration/test_projects_sandbox_ensure.py
@@ -14,7 +14,7 @@ Bearer-token helper.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 import pytest
@@ -32,7 +32,7 @@ from app.skills.registry import MutableSkillRegistry
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/integration/test_skills_autocomplete_endpoint.py
+++ b/api/tests/integration/test_skills_autocomplete_endpoint.py
@@ -23,7 +23,7 @@ helper.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 import pytest
@@ -41,7 +41,7 @@ from app.skills.registry import MutableSkillRegistry
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/integration/test_skills_send_with_slash_unresolved.py
+++ b/api/tests/integration/test_skills_send_with_slash_unresolved.py
@@ -24,7 +24,7 @@ gateway mock so the handler's downstream call succeeds.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 import httpx
@@ -48,7 +48,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/integration/test_treatment_job.py
+++ b/api/tests/integration/test_treatment_job.py
@@ -29,7 +29,9 @@ class _FastGW:
 
 
 @pytest.mark.asyncio
-async def test_run_treatment_derivation_writes_row_and_links(db_session: AsyncSession, monkeypatch):
+async def test_run_treatment_derivation_writes_row_and_links(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # Prevent any outbound HTTP attempt after Task 6 wires in get_gateway_client().
     # The stub returns "fast" (the default) without hitting the network.
     monkeypatch.setattr(treatment_worker, "get_gateway_client", lambda: _FastGW())
@@ -69,7 +71,7 @@ async def test_run_treatment_derivation_writes_row_and_links(db_session: AsyncSe
     # The job's _run helper takes an injected session + fetch so we can test it without Redis/arq.
     from app.workers.treatment_worker import run_treatment_derivation
 
-    async def fake_fetch(opinion_id: int) -> dict:  # type: ignore[type-arg]
+    async def fake_fetch(opinion_id: int) -> dict:
         return {
             "cited_by_count": 7,
             "citing": [
@@ -96,7 +98,9 @@ async def test_run_treatment_derivation_writes_row_and_links(db_session: AsyncSe
 
 
 @pytest.mark.asyncio
-async def test_run_resolves_gateway_and_passes_it(db_session: AsyncSession, monkeypatch):
+async def test_run_resolves_gateway_and_passes_it(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """When a gateway is injected and its judge-model fetch succeeds, derive is
     called with that gateway instance and the returned model name."""
     captured: dict[str, Any] = {}
@@ -131,7 +135,9 @@ async def test_run_resolves_gateway_and_passes_it(db_session: AsyncSession, monk
 
 
 @pytest.mark.asyncio
-async def test_run_degrades_to_graph_only_on_gateway_failure(db_session: AsyncSession, monkeypatch):
+async def test_run_degrades_to_graph_only_on_gateway_failure(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """When the gateway's judge-model fetch raises, the worker degrades to
     graph-only (gateway=None passed to derive)."""
     captured: dict[str, Any] = {}

--- a/api/tests/integration/test_user_skills_create_with_slash_alias.py
+++ b/api/tests/integration/test_user_skills_create_with_slash_alias.py
@@ -18,7 +18,7 @@ its own ``client`` + ``_h(user)`` Bearer-token helper.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 import pytest
@@ -36,7 +36,7 @@ from app.skills.registry import MutableSkillRegistry
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/integration/test_user_skills_versions_endpoint.py
+++ b/api/tests/integration/test_user_skills_versions_endpoint.py
@@ -17,7 +17,7 @@ its own ``client`` + ``_h(user)`` Bearer-token helper and seeds two
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 import pytest
@@ -36,7 +36,7 @@ from app.skills.registry import MutableSkillRegistry
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/integration/test_work_product_fiduciary_gate.py
+++ b/api/tests/integration/test_work_product_fiduciary_gate.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.chat import Chat, Message
 from app.models.user import User
@@ -13,7 +14,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest_asyncio.fixture
-async def seeded_message(db_session):
+async def seeded_message(db_session: AsyncSession) -> tuple[uuid.UUID, uuid.UUID]:
     user = User(
         email=f"gate-{uuid.uuid4().hex[:8]}@example.com",
         hashed_password="x",
@@ -31,7 +32,9 @@ async def seeded_message(db_session):
 
 
 @pytest.mark.asyncio
-async def test_gate_row_roundtrips(db_session, seeded_message):
+async def test_gate_row_roundtrips(
+    db_session: AsyncSession, seeded_message: tuple[uuid.UUID, uuid.UUID]
+) -> None:
     chat_id, mid = seeded_message
     db_session.add(
         WorkProductFiduciaryGate(
@@ -57,7 +60,9 @@ async def test_gate_row_roundtrips(db_session, seeded_message):
 
 
 @pytest.mark.asyncio
-async def test_message_id_unique(db_session, seeded_message):
+async def test_message_id_unique(
+    db_session: AsyncSession, seeded_message: tuple[uuid.UUID, uuid.UUID]
+) -> None:
     chat_id, mid = seeded_message
     for _ in range(2):
         db_session.add(
@@ -78,7 +83,9 @@ async def test_message_id_unique(db_session, seeded_message):
 
 
 @pytest.mark.asyncio
-async def test_confidence_range_check(db_session, seeded_message):
+async def test_confidence_range_check(
+    db_session: AsyncSession, seeded_message: tuple[uuid.UUID, uuid.UUID]
+) -> None:
     chat_id, mid = seeded_message
     db_session.add(
         WorkProductFiduciaryGate(

--- a/api/tests/models/test_autonomous_models.py
+++ b/api/tests/models/test_autonomous_models.py
@@ -119,7 +119,7 @@ async def test_session_custom_brake_knobs_round_trip(db_session: AsyncSession) -
 @pytest.mark.integration
 async def test_session_requires_user_id(db_session: AsyncSession) -> None:
     """user_id is NOT NULL — per-user isolation is enforced at the column."""
-    sess = AutonomousSession(user_id=None, trigger_kind="manual")  # type: ignore[arg-type]
+    sess = AutonomousSession(user_id=None, trigger_kind="manual")
     db_session.add(sess)
     with pytest.raises(IntegrityError):
         await db_session.flush()
@@ -267,7 +267,7 @@ async def test_schedule_round_trip(db_session: AsyncSession) -> None:
 
 @pytest.mark.integration
 async def test_schedule_requires_user_id(db_session: AsyncSession) -> None:
-    sched = AutonomousSchedule(user_id=None, cron_expr="0 2 * * *")  # type: ignore[arg-type]
+    sched = AutonomousSchedule(user_id=None, cron_expr="0 2 * * *")
     db_session.add(sched)
     with pytest.raises(IntegrityError):
         await db_session.flush()
@@ -313,7 +313,7 @@ async def test_watch_round_trip(db_session: AsyncSession) -> None:
 async def test_watch_requires_user_id(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
     kb = await _make_kb(db_session, owner=user)
-    watch = AutonomousWatch(user_id=None, knowledge_base_id=kb.id)  # type: ignore[arg-type]
+    watch = AutonomousWatch(user_id=None, knowledge_base_id=kb.id)
     db_session.add(watch)
     with pytest.raises(IntegrityError):
         await db_session.flush()
@@ -322,7 +322,7 @@ async def test_watch_requires_user_id(db_session: AsyncSession) -> None:
 @pytest.mark.integration
 async def test_watch_requires_knowledge_base_id(db_session: AsyncSession) -> None:
     user = await _make_user(db_session)
-    watch = AutonomousWatch(user_id=user.id, knowledge_base_id=None)  # type: ignore[arg-type]
+    watch = AutonomousWatch(user_id=user.id, knowledge_base_id=None)
     db_session.add(watch)
     with pytest.raises(IntegrityError):
         await db_session.flush()
@@ -388,7 +388,7 @@ async def test_memory_source_session_fk(db_session: AsyncSession) -> None:
 
 @pytest.mark.integration
 async def test_memory_requires_user_id(db_session: AsyncSession) -> None:
-    note = AutonomousMemory(user_id=None, state="proposed", category="x", content="y")  # type: ignore[arg-type]
+    note = AutonomousMemory(user_id=None, state="proposed", category="x", content="y")
     db_session.add(note)
     with pytest.raises(IntegrityError):
         await db_session.flush()
@@ -418,7 +418,7 @@ async def test_precedent_round_trip(db_session: AsyncSession) -> None:
 
 @pytest.mark.integration
 async def test_precedent_requires_user_id(db_session: AsyncSession) -> None:
-    entry = PrecedentEntry(user_id=None, pattern_kind="x", summary="y")  # type: ignore[arg-type]
+    entry = PrecedentEntry(user_id=None, pattern_kind="x", summary="y")
     db_session.add(entry)
     with pytest.raises(IntegrityError):
         await db_session.flush()

--- a/api/tests/models/test_autonomous_notifications.py
+++ b/api/tests/models/test_autonomous_notifications.py
@@ -124,7 +124,7 @@ async def test_notification_requires_user_id(db_session: AsyncSession) -> None:
     sess = await _make_session(db_session, owner=user)
 
     notif = AutonomousNotification(
-        user_id=None,  # type: ignore[arg-type]
+        user_id=None,
         session_id=sess.id,
         title="x",
         body="y",

--- a/api/tests/playbooks/test_executor.py
+++ b/api/tests/playbooks/test_executor.py
@@ -389,6 +389,7 @@ async def test_executor_drafts_redline_for_deviates_verdict(
 
     await db_session.refresh(execution)
     assert execution.status == "completed"
+    assert execution.results is not None
     positions = execution.results["positions"]
     assert positions[0]["verdict"] == "deviates"
     assert positions[0]["redline"] is not None
@@ -445,6 +446,7 @@ async def test_executor_marks_missing_when_keyword_not_in_document(
 
     await db_session.refresh(execution)
     assert execution.status == "completed"
+    assert execution.results is not None
     positions = execution.results["positions"]
     assert positions[0]["verdict"] == "missing"
     assert positions[0]["redline"] is None
@@ -500,6 +502,7 @@ async def test_executor_persists_error_on_gateway_failure(
     # The gateway swallowed the error per-call; the executor still
     # writes a completed row with a 'missing' verdict for the position.
     assert execution.status == "completed"
+    assert execution.results is not None
     positions = execution.results["positions"]
     assert positions[0]["verdict"] == "missing"
     assert positions[0]["confidence"] == 0.5  # low → 0.5

--- a/api/tests/playbooks/test_executor_spans.py
+++ b/api/tests/playbooks/test_executor_spans.py
@@ -228,6 +228,7 @@ async def test_executor_emits_playbook_execute_and_position_spans(
     )
     exec_span = execute_spans[0]
 
+    assert exec_span.attributes is not None
     assert str(exec_span.attributes.get("playbook.id")) == str(playbook.id), (
         f"playbook.id mismatch: {exec_span.attributes.get('playbook.id')!r}"
     )
@@ -248,6 +249,7 @@ async def test_executor_emits_playbook_execute_and_position_spans(
         f"All span names: {span_names}"
     )
     for pos_span in position_spans:
+        assert pos_span.attributes is not None
         assert pos_span.attributes.get("playbook.position.id") is not None, (
             "playbook.position.id attribute missing from position span"
         )

--- a/api/tests/tabular/test_ensemble_verification_integration.py
+++ b/api/tests/tabular/test_ensemble_verification_integration.py
@@ -93,6 +93,7 @@ class _StubGateway:
     async def chat_completion(
         self, request: Any, *, request_id: str | None = None
     ) -> _StubResponse:
+        payload: dict[str, Any]
         if getattr(request, "lq_ai_purpose", None) == "judge_paraphrase":
             self.judge_calls += 1
             payload = _JUDGE_PAYLOAD

--- a/api/tests/tabular/test_executor_spans.py
+++ b/api/tests/tabular/test_executor_spans.py
@@ -218,6 +218,7 @@ async def test_executor_emits_tabular_execute_and_cell_spans(
     )
     exec_span = execute_spans[0]
 
+    assert exec_span.attributes is not None
     assert exec_span.attributes.get("tabular.document_count") == 1, (
         f"tabular.document_count mismatch: {exec_span.attributes.get('tabular.document_count')!r}"
     )
@@ -232,6 +233,7 @@ async def test_executor_emits_tabular_execute_and_cell_spans(
         f"All span names: {span_names}"
     )
     for cell_span in cell_spans:
+        assert cell_span.attributes is not None
         assert cell_span.attributes.get("tabular.document.id") is not None, (
             "tabular.document.id attribute missing from cell span"
         )

--- a/api/tests/tabular/test_export.py
+++ b/api/tests/tabular/test_export.py
@@ -20,7 +20,7 @@ import io
 import uuid
 from decimal import Decimal
 
-from openpyxl import load_workbook
+from openpyxl import load_workbook  # type: ignore[import-untyped]
 
 from app.api.tabular import _build_csv, _build_xlsx
 from app.schemas.tabular import (

--- a/api/tests/test_admin_aliases.py
+++ b/api/tests/test_admin_aliases.py
@@ -13,7 +13,7 @@ tests cover:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import httpx
 import pytest
@@ -32,7 +32,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_admin_bootstrap.py
+++ b/api/tests/test_admin_bootstrap.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -34,7 +34,7 @@ from app.models.user import User, UserSession
 from app.security import hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_admin_intake_bridges.py
+++ b/api/tests/test_admin_intake_bridges.py
@@ -16,7 +16,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
 
 import pytest
@@ -32,7 +32,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_admin_mcp.py
+++ b/api/tests/test_admin_mcp.py
@@ -15,7 +15,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 import pytest
@@ -37,7 +37,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -231,6 +231,7 @@ async def test_refresh_returns_tools_and_writes_audit(
     )
     assert len(audit_rows) == 1
     assert audit_rows[0].resource_type == "mcp_server"
+    assert audit_rows[0].details is not None
     assert audit_rows[0].details["tool_count"] == 1
 
 
@@ -320,6 +321,7 @@ async def test_patch_tool_enabled_flips_and_audits(
     )
     assert len(audit_rows) == 1
     assert audit_rows[0].resource_type == "mcp_tool"
+    assert audit_rows[0].details is not None
     assert audit_rows[0].details["enabled"] is False
 
 
@@ -357,6 +359,7 @@ async def test_patch_tool_enable_writes_enabled_audit(
     )
     assert len(audit_rows) == 1
     assert audit_rows[0].resource_type == "mcp_tool"
+    assert audit_rows[0].details is not None
     assert audit_rows[0].details["enabled"] is True
 
 

--- a/api/tests/test_admin_provider_keys.py
+++ b/api/tests/test_admin_provider_keys.py
@@ -18,7 +18,7 @@ The backend's ``/api/v1/admin/provider-keys*`` proxies the gateway's
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import httpx
 import pytest
@@ -37,7 +37,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_admin_tool_providers.py
+++ b/api/tests/test_admin_tool_providers.py
@@ -26,7 +26,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from unittest.mock import AsyncMock
 
 import pytest
@@ -43,7 +43,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -113,7 +113,7 @@ def fake_gateway() -> AsyncMock:
 @pytest_asyncio.fixture
 async def client(db_session: AsyncSession, fake_gateway: AsyncMock) -> AsyncIterator[AsyncClient]:
     app.dependency_overrides[get_db] = _override_get_db(db_session)
-    set_gateway_client(fake_gateway)  # type: ignore[arg-type]
+    set_gateway_client(fake_gateway)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac

--- a/api/tests/test_admin_users_list.py
+++ b/api/tests/test_admin_users_list.py
@@ -14,7 +14,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
 
 import pytest
@@ -32,7 +32,7 @@ from app.security import create_access_token, hash_password
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_arq_smoke.py
+++ b/api/tests/test_arq_smoke.py
@@ -76,7 +76,8 @@ async def test_on_startup_installs_skill_registry_and_returns_none() -> None:
         return_value=holder,
     ) as mock_install:
         # No exception, no return value.
-        assert await arq_setup.on_startup({}) is None
+        # The return-is-None contract is part of the pinned wiring.
+        assert await arq_setup.on_startup({}) is None  # type: ignore[func-returns-value]
 
     mock_install.assert_called_once()
 

--- a/api/tests/test_audit_log.py
+++ b/api/tests/test_audit_log.py
@@ -15,7 +15,7 @@ follow-on D3-coverage commit.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -31,7 +31,7 @@ from app.models import AuditLog, Project, User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_auditor_audit.py
+++ b/api/tests/test_auditor_audit.py
@@ -12,6 +12,8 @@ Covers:
 from __future__ import annotations
 
 import uuid
+from collections.abc import Awaitable, Callable
+from typing import cast
 
 import pytest
 import pytest_asyncio
@@ -33,7 +35,7 @@ class _FakeUser:
 
 
 @pytest_asyncio.fixture
-async def make_user(db_session: AsyncSession):
+async def make_user(db_session: AsyncSession) -> Callable[..., Awaitable[User]]:
     """Factory fixture mirroring the local ``make_user`` helper pattern used
     elsewhere in this suite (e.g. test_internal_skills.py, test_wave_c.py),
     but parameterized on ``role`` for this task's purposes."""
@@ -55,15 +57,17 @@ async def make_user(db_session: AsyncSession):
     return _make_user
 
 
-def test_is_privileged_reader_truth_table():
-    assert is_privileged_reader(_FakeUser(is_admin=True, role="admin")) is True
-    assert is_privileged_reader(_FakeUser(is_admin=False, role="auditor")) is True
-    assert is_privileged_reader(_FakeUser(is_admin=False, role="member")) is False
-    assert is_privileged_reader(_FakeUser(is_admin=False, role="viewer")) is False
+def test_is_privileged_reader_truth_table() -> None:
+    assert is_privileged_reader(cast(User, _FakeUser(is_admin=True, role="admin"))) is True
+    assert is_privileged_reader(cast(User, _FakeUser(is_admin=False, role="auditor"))) is True
+    assert is_privileged_reader(cast(User, _FakeUser(is_admin=False, role="member"))) is False
+    assert is_privileged_reader(cast(User, _FakeUser(is_admin=False, role="viewer"))) is False
 
 
 @pytest.mark.integration
-async def test_auditor_audit_writes_row(db_session: AsyncSession, make_user) -> None:
+async def test_auditor_audit_writes_row(
+    db_session: AsyncSession, make_user: Callable[..., Awaitable[User]]
+) -> None:
     reader = await make_user(email="r@example.com", role="auditor")
     viewed = uuid.uuid4()
     await auditor_audit(
@@ -85,11 +89,14 @@ async def test_auditor_audit_writes_row(db_session: AsyncSession, make_user) -> 
         .one()
     )
     assert row.user_id == reader.id
+    assert row.details is not None
     assert row.details["viewed_user_id"] == str(viewed)
 
 
 @pytest.mark.integration
-async def test_auditor_audit_rejects_unknown_event(db_session: AsyncSession, make_user) -> None:
+async def test_auditor_audit_rejects_unknown_event(
+    db_session: AsyncSession, make_user: Callable[..., Awaitable[User]]
+) -> None:
     reader = await make_user(email="r2@example.com", role="auditor")
     with pytest.raises(AssertionError):
         await auditor_audit(

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import time
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 
 import jwt as pyjwt
@@ -39,7 +39,7 @@ from app.models.user import User, UserSession
 from app.security import hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     """Build a FastAPI dependency override that yields the test session.
 
     The session has a SAVEPOINT-based join to an outer connection-level

--- a/api/tests/test_authority_substrate.py
+++ b/api/tests/test_authority_substrate.py
@@ -19,6 +19,7 @@ from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.citation.authority import (
     AUTHORITY_TEXT_TTL,
@@ -79,7 +80,9 @@ def test_authority_target_is_deterministic_and_duck_types_document() -> None:
 
 
 @pytest.mark.asyncio
-async def test_store_then_load_round_trips(db_session, fake_storage) -> None:
+async def test_store_then_load_round_trips(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     body = "Every contract, combination ... in restraint of trade ... is declared to be illegal."
     await store_authority_text(
         db_session, source_type="govinfo", external_ref="USCODE-2022-title15", text=body
@@ -91,14 +94,18 @@ async def test_store_then_load_round_trips(db_session, fake_storage) -> None:
 
 
 @pytest.mark.asyncio
-async def test_load_returns_none_when_absent(db_session, fake_storage) -> None:
+async def test_load_returns_none_when_absent(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     assert (
         await load_authority_text(db_session, source_type="govinfo", external_ref="missing") is None
     )
 
 
 @pytest.mark.asyncio
-async def test_load_returns_none_when_stale(db_session, fake_storage) -> None:
+async def test_load_returns_none_when_stale(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     await store_authority_text(
         db_session, source_type="govinfo", external_ref="USCODE-old", text="old body"
     )
@@ -124,7 +131,9 @@ async def test_load_returns_none_when_stale(db_session, fake_storage) -> None:
 
 
 @pytest.mark.asyncio
-async def test_store_rejects_path_traversal_external_ref(db_session, fake_storage) -> None:
+async def test_store_rejects_path_traversal_external_ref(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     """Malicious external_ref containing path-traversal chars raises ValueError.
 
     The resulting storage key must never start with anything outside
@@ -141,7 +150,9 @@ async def test_store_rejects_path_traversal_external_ref(db_session, fake_storag
 
 
 @pytest.mark.asyncio
-async def test_store_rejects_path_traversal_source_type(db_session, fake_storage) -> None:
+async def test_store_rejects_path_traversal_source_type(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     """Malicious source_type also raises ValueError (load path consistent)."""
     with pytest.raises(ValueError, match="source_type"):
         await store_authority_text(
@@ -153,7 +164,9 @@ async def test_store_rejects_path_traversal_source_type(db_session, fake_storage
 
 
 @pytest.mark.asyncio
-async def test_store_second_call_updates_not_raises(db_session, fake_storage) -> None:
+async def test_store_second_call_updates_not_raises(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     """A second store for the same key updates the row, not raises IntegrityError.
 
     Simulates the concurrent-insert scenario by pre-inserting a row (first store)
@@ -173,7 +186,9 @@ async def test_store_second_call_updates_not_raises(db_session, fake_storage) ->
 
 
 @pytest.mark.asyncio
-async def test_verify_exact_match_against_authority_target(db_session, fake_storage) -> None:
+async def test_verify_exact_match_against_authority_target(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     body = "Every contract ... in restraint of trade ... is declared to be illegal."
     target = authority_target("govinfo", "USCODE-2022-title15", body)
     quote = "in restraint of trade"

--- a/api/tests/test_bootstrap_status.py
+++ b/api/tests/test_bootstrap_status.py
@@ -17,7 +17,7 @@ the rest of the API tests (per ``tests/conftest.py``).
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
 
 import pytest
@@ -31,7 +31,7 @@ from app.models.user import User
 from app.security import hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_chat_citations.py
+++ b/api/tests/test_chat_citations.py
@@ -23,7 +23,7 @@ Negative cases:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -58,7 +58,7 @@ GATEWAY_KEY = "test-gw-key"
 # ---------------------------------------------------------------------------
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -1174,6 +1174,7 @@ async def test_get_citations_auditor_can_read_cross_user_and_is_audited(
         .one()
     )
     assert row.user_id == auditor.id
+    assert row.details is not None
     assert row.details["viewed_user_id"] == str(owner_user.id)
 
 

--- a/api/tests/test_chat_pending_tool_call_model.py
+++ b/api/tests/test_chat_pending_tool_call_model.py
@@ -105,7 +105,7 @@ def test_chat_pending_tool_call_columns() -> None:
 @pytest.mark.unit
 def test_chat_pending_tool_call_pk() -> None:
     """PK is 'id' only (single UUID column)."""
-    pk = {c.name for c in ChatPendingToolCall.__table__.primary_key.columns}
+    pk = {c.name for c in ChatPendingToolCall.__table__.primary_key}
     assert pk == {"id"}
 
 

--- a/api/tests/test_chat_rag.py
+++ b/api/tests/test_chat_rag.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import json as _json
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -56,7 +56,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_chat_receipts.py
+++ b/api/tests/test_chat_receipts.py
@@ -10,7 +10,7 @@ gates on owner-or-admin.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -30,7 +30,7 @@ from app.security import create_access_token, hash_password
 pytestmark = pytest.mark.integration
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -277,6 +277,7 @@ async def test_receipts_auditor_can_view_any_chat_and_is_audited(
         .one()
     )
     assert row.user_id == auditor_user.id
+    assert row.details is not None
     assert row.details["viewed_user_id"] == str(owner_user.id)
 
 
@@ -483,6 +484,7 @@ async def test_receipts_export_auditor_can_view_any_chat_and_is_audited(
         .one()
     )
     assert row.user_id == auditor_user.id
+    assert row.details is not None
     assert row.details["viewed_user_id"] == str(owner_user.id)
 
 

--- a/api/tests/test_chats_endpoints.py
+++ b/api/tests/test_chats_endpoints.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 import json as _json
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
+from typing import Any
 
 import httpx
 import pytest
@@ -33,7 +34,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -705,7 +706,7 @@ async def test_streaming_mid_stream_failure_persists_partial_row_with_error_code
         headers={"Authorization": f"Bearer {token}"},
     ) as resp:
         assert resp.status_code == 200
-        events: list[dict[str, object]] = []
+        events: list[dict[str, Any]] = []
         async for line in resp.aiter_lines():
             line = line.strip()
             if not line:

--- a/api/tests/test_chats_send_message.py
+++ b/api/tests/test_chats_send_message.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 
 import json as _json
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
+from typing import Any
 
 import httpx
 import pytest
@@ -44,7 +45,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -567,7 +568,7 @@ async def test_send_message_streaming_happy_path(
     ) as resp:
         assert resp.status_code == 200
         assert resp.headers.get("content-type", "").startswith("text/event-stream")
-        events: list[dict[str, object]] = []
+        events: list[dict[str, Any]] = []
         async for line in resp.aiter_lines():
             line = line.strip()
             if not line:
@@ -612,7 +613,7 @@ async def test_send_message_streaming_mid_stream_error_emits_error_frame(
         headers={"Authorization": f"Bearer {token}"},
     ) as resp:
         assert resp.status_code == 200
-        events: list[dict[str, object]] = []
+        events: list[dict[str, Any]] = []
         async for line in resp.aiter_lines():
             line = line.strip()
             if not line:
@@ -658,7 +659,7 @@ async def test_send_message_streaming_pre_frame_error_emits_error_frame(
     ) as resp:
         # SSE response has 200 status; error is in-band.
         assert resp.status_code == 200
-        events: list[dict[str, object]] = []
+        events: list[dict[str, Any]] = []
         async for line in resp.aiter_lines():
             line = line.strip()
             if not line:

--- a/api/tests/test_chats_tier_floor.py
+++ b/api/tests/test_chats_tier_floor.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import json as _json
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import httpx
 import pytest
@@ -43,7 +43,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_citation_treatment_signal_model.py
+++ b/api/tests/test_citation_treatment_signal_model.py
@@ -1,5 +1,6 @@
 import pytest
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.citation_treatment import CitationTreatment
 from app.models.citation_treatment_signal import CitationTreatmentSignal
@@ -7,7 +8,7 @@ from app.models.citation_treatment_signal import CitationTreatmentSignal
 pytestmark = pytest.mark.asyncio
 
 
-async def _treatment(db) -> CitationTreatment:
+async def _treatment(db: AsyncSession) -> CitationTreatment:
     t = CitationTreatment(
         cluster_id=111,
         opinion_id=222,
@@ -22,7 +23,7 @@ async def _treatment(db) -> CitationTreatment:
     return t
 
 
-async def test_signal_round_trips_and_cascades(db_session) -> None:
+async def test_signal_round_trips_and_cascades(db_session: AsyncSession) -> None:
     t = await _treatment(db_session)
     db_session.add(
         CitationTreatmentSignal(
@@ -51,7 +52,7 @@ async def test_signal_round_trips_and_cascades(db_session) -> None:
     assert remaining == []
 
 
-async def test_bad_classification_rejected(db_session) -> None:
+async def test_bad_classification_rejected(db_session: AsyncSession) -> None:
     from sqlalchemy.exc import IntegrityError
 
     t = await _treatment(db_session)
@@ -68,7 +69,7 @@ async def test_bad_classification_rejected(db_session) -> None:
         await db_session.flush()
 
 
-async def test_parent_allows_graph_plus_judge_method(db_session) -> None:
+async def test_parent_allows_graph_plus_judge_method(db_session: AsyncSession) -> None:
     db_session.add(
         CitationTreatment(
             cluster_id=9,

--- a/api/tests/test_easy_playbook_endpoints.py
+++ b/api/tests/test_easy_playbook_endpoints.py
@@ -14,7 +14,7 @@ worker. Worker-side verification lives in
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -32,7 +32,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_easy_playbook_extractor.py
+++ b/api/tests/test_easy_playbook_extractor.py
@@ -16,10 +16,11 @@ from __future__ import annotations
 import json
 import uuid
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
+from app.models.document import Document
 from app.playbooks.easy.extractor import (
     DEFAULT_CHARACTER_BUDGET,
     SPAN_OVERLAP_CHARACTERS,
@@ -87,8 +88,10 @@ class _StubDocument:
     normalized_content: str
 
 
-def _make_doc(text: str) -> _StubDocument:
-    return _StubDocument(id=uuid.uuid4(), normalized_content=text)
+def _make_doc(text: str) -> Document:
+    # The extractor only reads ``id`` and ``normalized_content``; the stub
+    # duck-types the ORM model, so cast for the type checker.
+    return cast(Document, _StubDocument(id=uuid.uuid4(), normalized_content=text))
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_enhance_prompt.py
+++ b/api/tests/test_enhance_prompt.py
@@ -25,7 +25,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -52,7 +52,7 @@ from app.skills.registry import MutableSkillRegistry
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_errors.py
+++ b/api/tests/test_errors.py
@@ -138,7 +138,9 @@ async def test_handler_renders_canonical_envelope_for_arbitrary_lqai_error() -> 
     # this throwaway app — keeps the test exercising the real handler code.
     from app.main import _lqai_error_handler
 
-    test_app.add_exception_handler(LQAIError, _lqai_error_handler)
+    # Starlette types add_exception_handler as taking a handler of the base
+    # Exception; a narrower LQAIError handler is fine at runtime.
+    test_app.add_exception_handler(LQAIError, _lqai_error_handler)  # type: ignore[arg-type]
 
     @test_app.get("/raise-gateway-unreachable")
     async def _raise_gw() -> None:

--- a/api/tests/test_extract_tool_sources.py
+++ b/api/tests/test_extract_tool_sources.py
@@ -8,7 +8,7 @@ from app.chat.tool_loop import (
 from app.chat.tool_schemas import ToolSpec
 
 
-def test_extract_from_search_case_law():
+def test_extract_from_search_case_law() -> None:
     data = {
         "count": 1,
         "results": [
@@ -34,7 +34,7 @@ def test_extract_from_search_case_law():
     assert r.tool == "search_case_law"
 
 
-def test_extract_from_get_cluster():
+def test_extract_from_get_cluster() -> None:
     data = {
         "cluster": {
             "cluster_id": 7,
@@ -52,7 +52,7 @@ def test_extract_from_get_cluster():
     assert recs[0].url == "https://www.courtlistener.com/opinion/7/"  # already absolute → unchanged
 
 
-def test_extract_non_research_and_empty():
+def test_extract_non_research_and_empty() -> None:
     assert extract_tool_sources("read_opinion", {"opinion_id": 1}) == []
     assert extract_tool_sources("find_in_case", {"matches": []}) == []
     assert extract_tool_sources("some_mcp_tool", {"payload": {}}) == []
@@ -73,7 +73,7 @@ def _spec(kind: str, provider: str, tool: str) -> ToolSpec:
     )
 
 
-def test_mcp_source_from_dict_payload_with_title_and_url():
+def test_mcp_source_from_dict_payload_with_title_and_url() -> None:
     spec = _spec("mcp", "deepwiki", "ask_question")
     data = {"title": "Repo answer", "url": "https://example.com/x", "body": "..."}
     rec = extract_mcp_tool_source(spec, data)
@@ -86,7 +86,7 @@ def test_mcp_source_from_dict_payload_with_title_and_url():
     assert rec.external_ref is None
 
 
-def test_mcp_source_from_text_blocks_falls_back_to_descriptor():
+def test_mcp_source_from_text_blocks_falls_back_to_descriptor() -> None:
     spec = _spec("mcp", "deepwiki", "ask_question")
     data = [{"type": "text", "text": "some answer"}, {"type": "text", "text": "more"}]
     rec = extract_mcp_tool_source(spec, data)
@@ -95,7 +95,7 @@ def test_mcp_source_from_text_blocks_falls_back_to_descriptor():
     assert rec.url is None
 
 
-def test_mcp_source_from_dict_block_inside_list_surfaces_url():
+def test_mcp_source_from_dict_block_inside_list_surfaces_url() -> None:
     spec = _spec("mcp", "srv", "search")
     data = [{"type": "text", "text": "intro"}, {"name": "Result One", "link": "https://e/1"}]
     rec = extract_mcp_tool_source(spec, data)
@@ -104,7 +104,7 @@ def test_mcp_source_from_dict_block_inside_list_surfaces_url():
     assert rec.url == "https://e/1"
 
 
-def test_mcp_source_malformed_payload_never_crashes():
+def test_mcp_source_malformed_payload_never_crashes() -> None:
     spec = _spec("mcp", "srv", "t")
     for data in (None, "a bare string", [1, 2, 3], {"url": 5}):  # url=5 is not a str -> ignored
         rec = extract_mcp_tool_source(spec, data)
@@ -113,17 +113,17 @@ def test_mcp_source_malformed_payload_never_crashes():
         assert rec.url is None
 
 
-def test_extract_mcp_returns_none_for_non_mcp_spec():
+def test_extract_mcp_returns_none_for_non_mcp_spec() -> None:
     assert extract_mcp_tool_source(_spec("research", "courtlistener", "get_cluster"), {}) is None
 
 
-def test_collect_routes_mcp_to_one_record():
+def test_collect_routes_mcp_to_one_record() -> None:
     recs = collect_tool_sources(_spec("mcp", "srv", "t"), {"title": "T"})
     assert len(recs) == 1
     assert recs[0].source_kind == "mcp"
 
 
-def test_collect_routes_research_caselaw_to_existing_path():
+def test_collect_routes_research_caselaw_to_existing_path() -> None:
     data = {
         "cluster": {
             "cluster_id": 7,
@@ -139,7 +139,7 @@ def test_collect_routes_research_caselaw_to_existing_path():
     assert recs[0].external_ref == "7"
 
 
-def test_collect_research_non_caselaw_tool_yields_no_rows():
+def test_collect_research_non_caselaw_tool_yields_no_rows() -> None:
     assert (
         collect_tool_sources(_spec("research", "courtlistener", "read_opinion"), {"text": "..."})
         == []

--- a/api/tests/test_files_endpoints.py
+++ b/api/tests/test_files_endpoints.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import hashlib
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import patch
@@ -51,7 +51,7 @@ from app.security import create_access_token, hash_password
 from tests.test_storage_streaming import FakeS3Client
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_gateway_call_tool.py
+++ b/api/tests/test_gateway_call_tool.py
@@ -5,7 +5,7 @@ import pytest
 import respx
 
 from app.clients.gateway import GatewayClient
-from app.schemas.gateway import ChatCompletionRequest
+from app.schemas.gateway import ChatCompletionMessage, ChatCompletionRequest
 
 GW = "http://gw.test"
 
@@ -69,7 +69,7 @@ async def test_call_tool_maps_gateway_4xx_envelope() -> None:
 def test_api_chat_request_carries_tools() -> None:
     req = ChatCompletionRequest(
         model="smart",
-        messages=[{"role": "user", "content": "hi"}],
+        messages=[ChatCompletionMessage(role="user", content="hi")],
         tools=[{"type": "function", "function": {"name": "x", "parameters": {}}}],
         tool_choice="auto",
     )

--- a/api/tests/test_gateway_client.py
+++ b/api/tests/test_gateway_client.py
@@ -173,7 +173,7 @@ async def test_chat_completion_overrides_stream_flag_to_false(client: GatewayCli
         return_value=httpx.Response(200, json=_success_payload())
     )
     req = _request()
-    req.stream = True  # type: ignore[misc]
+    req.stream = True
 
     await client.chat_completion(req)
 

--- a/api/tests/test_inference_override.py
+++ b/api/tests/test_inference_override.py
@@ -20,7 +20,7 @@ Test cases:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import httpx
 import pytest
@@ -44,7 +44,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_ingest_health.py
+++ b/api/tests/test_ingest_health.py
@@ -16,7 +16,7 @@ the rest of the API tests (per ``tests/conftest.py``).
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -35,7 +35,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_integrations_slack.py
+++ b/api/tests/test_integrations_slack.py
@@ -13,7 +13,7 @@ Covers ``POST /api/v1/integrations/slack/workspaces``:
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
 
 import pytest
@@ -31,7 +31,7 @@ from app.security.encryption import BridgeTokenEncryptor, generate_master_key
 BRIDGE_TOKEN = "bridge-token-fixture-value"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -39,7 +39,7 @@ def _override_get_db(db_session: AsyncSession):
 
 
 @pytest_asyncio.fixture
-async def configured_settings(monkeypatch: pytest.MonkeyPatch) -> str:
+async def configured_settings(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[str]:
     """Set both bridge env vars + clear the Settings cache for the test."""
     master_key = generate_master_key()
     monkeypatch.setenv("LQ_AI_BRIDGE_TOKEN", BRIDGE_TOKEN)

--- a/api/tests/test_integrations_teams.py
+++ b/api/tests/test_integrations_teams.py
@@ -13,7 +13,7 @@ Covers ``POST /api/v1/integrations/teams/tenants``:
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
 
 import pytest
@@ -30,7 +30,7 @@ from app.models.teams_tenant import TeamsTenant
 BRIDGE_TOKEN = "bridge-token-fixture-value"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -38,7 +38,7 @@ def _override_get_db(db_session: AsyncSession):
 
 
 @pytest_asyncio.fixture
-async def configured_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+async def configured_settings(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[None]:
     monkeypatch.setenv("LQ_AI_BRIDGE_TOKEN", BRIDGE_TOKEN)
     get_settings.cache_clear()
     yield

--- a/api/tests/test_internal_skills.py
+++ b/api/tests/test_internal_skills.py
@@ -11,9 +11,10 @@ share fixture machinery.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 import pytest_asyncio
@@ -27,12 +28,16 @@ from app.models.organization_profile import OrganizationProfile
 from app.skills import load_registry
 from app.skills.registry import MutableSkillRegistry
 
+if TYPE_CHECKING:
+    from app.models import User
+    from app.models.team import Team
+
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "skills"
 
 VALID_KEY = "test-gateway-secret-correct-horse"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -513,7 +518,7 @@ async def test_internal_skill_archived_shadow_falls_through(
 # ---------------------------------------------------------------------------
 
 
-async def _team_test_user(db_session: AsyncSession, suffix: str):
+async def _team_test_user(db_session: AsyncSession, suffix: str) -> User:
     """Build a fresh User row inside the internal-skills test context."""
 
     import uuid as _uuid
@@ -534,7 +539,7 @@ async def _team_test_user(db_session: AsyncSession, suffix: str):
     return user
 
 
-async def _team_with_member(db_session: AsyncSession, *, slug: str, member):
+async def _team_with_member(db_session: AsyncSession, *, slug: str, member: User) -> Team:
     """Create a team and add ``member`` as an admin in one shot.
 
     Returns the Team row so callers can populate team-scope skills.

--- a/api/tests/test_kb_retrieval_audit.py
+++ b/api/tests/test_kb_retrieval_audit.py
@@ -15,7 +15,7 @@ on the audit write — the retrieval mechanics themselves are tested in
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -36,7 +36,7 @@ from app.security import create_access_token, hash_password
 pytestmark = pytest.mark.integration
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_knowledge_embed_unit.py
+++ b/api/tests/test_knowledge_embed_unit.py
@@ -7,7 +7,7 @@ functions against a respx-mocked GatewayClient.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -24,6 +24,7 @@ from app.knowledge.embed import (
     request_embedding_vector,
     request_embedding_vectors,
 )
+from app.models.document import DocumentChunk
 
 GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
@@ -99,7 +100,7 @@ def test_batched_groups_within_size_limit() -> None:
 
     # 200 small chunks should batch into multiple groups (default 64
     # per batch).
-    chunks = [_FakeChunk(f"chunk{idx}") for idx in range(200)]
+    chunks = cast("list[DocumentChunk]", [_FakeChunk(f"chunk{idx}") for idx in range(200)])
     batches = list(batched(chunks))
     assert all(len(batch) <= 64 for batch in batches)
     assert sum(len(b) for b in batches) == 200
@@ -110,7 +111,7 @@ def test_batched_respects_char_cap() -> None:
     """C6: a single very-large chunk forces a tighter batch."""
 
     huge_content = "x" * 50_000  # well into the cap
-    chunks = [_FakeChunk(huge_content) for _ in range(3)]
+    chunks = cast("list[DocumentChunk]", [_FakeChunk(huge_content) for _ in range(3)])
     batches = list(batched(chunks))
     # Each big chunk roughly fills its own batch (60K cap).
     assert len(batches) >= 2

--- a/api/tests/test_knowledge_endpoints.py
+++ b/api/tests/test_knowledge_endpoints.py
@@ -14,7 +14,7 @@ the embed-on-write worker job is in test_knowledge_embed_unit.py.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -30,7 +30,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_mcp_models.py
+++ b/api/tests/test_mcp_models.py
@@ -17,5 +17,5 @@ def test_mcp_tool_cache_columns() -> None:
         "enabled",
         "discovered_at",
     }
-    pk = {c.name for c in MCPToolCache.__table__.primary_key.columns}
+    pk = {c.name for c in MCPToolCache.__table__.primary_key}
     assert pk == {"provider_name", "tool_name"}

--- a/api/tests/test_mcp_oauth_endpoints.py
+++ b/api/tests/test_mcp_oauth_endpoints.py
@@ -25,7 +25,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -66,7 +66,7 @@ _TOKEN_ENDPOINT = "https://as.example.com/token"
 _ISSUER = "https://as.example.com"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -271,6 +271,7 @@ async def test_callback_valid_state_returns_200_and_audit(
     )
     assert len(audit_rows) == 1
     assert audit_rows[0].resource_type == "mcp_server"
+    assert audit_rows[0].details is not None
     assert audit_rows[0].details["scope_count"] == 2
 
 

--- a/api/tests/test_mcp_oauth_models.py
+++ b/api/tests/test_mcp_oauth_models.py
@@ -70,7 +70,7 @@ def test_mcp_oauth_token_columns() -> None:
 
 @pytest.mark.unit
 def test_mcp_oauth_token_primary_key() -> None:
-    pk = {c.name for c in MCPOAuthToken.__table__.primary_key.columns}
+    pk = {c.name for c in MCPOAuthToken.__table__.primary_key}
     assert pk == {"user_id", "provider_name"}
 
 
@@ -94,7 +94,7 @@ def test_mcp_oauth_state_columns() -> None:
 
 @pytest.mark.unit
 def test_mcp_oauth_state_primary_key() -> None:
-    pk = {c.name for c in MCPOAuthState.__table__.primary_key.columns}
+    pk = {c.name for c in MCPOAuthState.__table__.primary_key}
     assert pk == {"state"}
 
 

--- a/api/tests/test_mcp_service.py
+++ b/api/tests/test_mcp_service.py
@@ -1,9 +1,11 @@
 import uuid
+from typing import Any
 
 import httpx
 import pytest
 import respx
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.errors import MCPAuthorizationRequired, NotFound
 from app.mcp import service
@@ -43,7 +45,7 @@ _GW_CONFIG_NO_OAUTH = {
 }
 
 
-def _tools_payload(provider, names):
+def _tools_payload(provider: str, names: list[str]) -> dict[str, Any]:
     return {
         "provider": provider,
         "tools": [
@@ -65,7 +67,9 @@ def _tools_payload(provider, names):
 # ---------------------------------------------------------------------------
 
 
-def _make_fake_gateway(*, oauth_names: list[str], tools_payload: dict | None = None):
+def _make_fake_gateway(
+    *, oauth_names: list[str], tools_payload: dict | None = None
+) -> tuple[Any, Any]:
     """Build a minimal fake gateway client for service-layer tests.
 
     ``oauth_names`` — list of provider names that appear in the oauth config.
@@ -77,10 +81,12 @@ def _make_fake_gateway(*, oauth_names: list[str], tools_payload: dict | None = N
     ]
     payload = tools_payload or {"provider": "p", "tools": []}
 
-    async def fake_list_mcp_oauth_config(*, request_id=None):
+    async def fake_list_mcp_oauth_config(*, request_id: str | None = None) -> list[dict[str, str]]:
         return oauth_cfg
 
-    async def fake_discover_tools(provider, *, user_token=None, request_id=None):
+    async def fake_discover_tools(
+        provider: str, *, user_token: str | None = None, request_id: str | None = None
+    ) -> dict:
         # Stash the token for assertion.
         fake_discover_tools.last_user_token = user_token  # type: ignore[attr-defined]
         return payload
@@ -95,7 +101,9 @@ def _make_fake_gateway(*, oauth_names: list[str], tools_payload: dict | None = N
 
 
 @pytest.mark.asyncio
-async def test_refresh_oauth_server_with_valid_token_passes_token(db_session, monkeypatch) -> None:
+async def test_refresh_oauth_server_with_valid_token_passes_token(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """oauth server + get_valid_token returns a token → discover_tools called with it."""
     fake_gw, fake_discover = _make_fake_gateway(
         oauth_names=["oauth-mcp"],
@@ -105,7 +113,9 @@ async def test_refresh_oauth_server_with_valid_token_passes_token(db_session, mo
 
     uid = uuid.uuid4()
 
-    async def _fake_get_valid_token(db, *, user_id, server):
+    async def _fake_get_valid_token(
+        db: AsyncSession, *, user_id: uuid.UUID, server: str
+    ) -> str | None:
         return "secret-token"
 
     monkeypatch.setattr("app.mcp.service.oauth.get_valid_token", _fake_get_valid_token)
@@ -115,14 +125,18 @@ async def test_refresh_oauth_server_with_valid_token_passes_token(db_session, mo
 
 
 @pytest.mark.asyncio
-async def test_refresh_oauth_server_get_valid_token_none_raises(db_session, monkeypatch) -> None:
+async def test_refresh_oauth_server_get_valid_token_none_raises(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """oauth server + get_valid_token returns None → MCPAuthorizationRequired."""
     fake_gw, _fake_discover = _make_fake_gateway(oauth_names=["oauth-mcp"])
     monkeypatch.setattr("app.mcp.service.get_gateway_client", lambda: fake_gw)
 
     uid = uuid.uuid4()
 
-    async def _fake_get_valid_token_none(db, *, user_id, server):
+    async def _fake_get_valid_token_none(
+        db: AsyncSession, *, user_id: uuid.UUID, server: str
+    ) -> None:
         return None
 
     monkeypatch.setattr("app.mcp.service.oauth.get_valid_token", _fake_get_valid_token_none)
@@ -139,7 +153,9 @@ async def test_refresh_oauth_server_get_valid_token_none_raises(db_session, monk
 
 
 @pytest.mark.asyncio
-async def test_refresh_oauth_server_no_user_id_raises(db_session, monkeypatch) -> None:
+async def test_refresh_oauth_server_no_user_id_raises(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """oauth server + user_id=None (admin path) → MCPAuthorizationRequired."""
     fake_gw, _fake_discover = _make_fake_gateway(oauth_names=["oauth-mcp"])
     monkeypatch.setattr("app.mcp.service.get_gateway_client", lambda: fake_gw)
@@ -154,7 +170,9 @@ async def test_refresh_oauth_server_no_user_id_raises(db_session, monkeypatch) -
 
 
 @pytest.mark.asyncio
-async def test_refresh_none_bearer_server_passes_no_token(db_session, monkeypatch) -> None:
+async def test_refresh_none_bearer_server_passes_no_token(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """none/bearer server → discover_tools called with user_token=None (unchanged path)."""
     fake_gw, fake_discover = _make_fake_gateway(
         oauth_names=[],  # acme-mcp is NOT in oauth list
@@ -173,10 +191,10 @@ async def test_refresh_none_bearer_server_passes_no_token(db_session, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_list_servers_filters_mcp(monkeypatch) -> None:
+async def test_list_servers_filters_mcp(monkeypatch: pytest.MonkeyPatch) -> None:
     """list_servers returns only MCP-type providers WITH auth field populated."""
 
-    async def _fake_get_admin_config(*, request_id=None):
+    async def _fake_get_admin_config(*, request_id: str | None = None) -> dict[str, Any]:
         return {
             "tool_providers": [
                 {"name": "acme-mcp", "type": "mcp", "auth": "none"},
@@ -194,7 +212,7 @@ async def test_list_servers_filters_mcp(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_refresh_upserts_and_preserves_enabled(db_session) -> None:
+async def test_refresh_upserts_and_preserves_enabled(db_session: AsyncSession) -> None:
     # seed a disabled tool that will survive refresh + a stale tool that won't
     db_session.add(
         MCPToolCache(
@@ -242,7 +260,7 @@ async def test_refresh_upserts_and_preserves_enabled(db_session) -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_tool_enabled_toggles(db_session) -> None:
+async def test_set_tool_enabled_toggles(db_session: AsyncSession) -> None:
     db_session.add(
         MCPToolCache(
             provider_name="acme-mcp",
@@ -262,13 +280,13 @@ async def test_set_tool_enabled_toggles(db_session) -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_tool_enabled_missing_raises(db_session) -> None:
+async def test_set_tool_enabled_missing_raises(db_session: AsyncSession) -> None:
     with pytest.raises(NotFound):
         await service.set_tool_enabled(db_session, provider="x", tool="y", enabled=True)
 
 
 @pytest.mark.asyncio
-async def test_set_tool_enabled_is_provider_scoped(db_session) -> None:
+async def test_set_tool_enabled_is_provider_scoped(db_session: AsyncSession) -> None:
     """provider_name filter in set_tool_enabled is load-bearing: toggling a tool
     on one provider must not affect a same-named tool on a different provider."""
     db_session.add(
@@ -316,7 +334,7 @@ async def test_set_tool_enabled_is_provider_scoped(db_session) -> None:
 
 
 @pytest.mark.asyncio
-async def test_refresh_is_provider_scoped(db_session) -> None:
+async def test_refresh_is_provider_scoped(db_session: AsyncSession) -> None:
     """refresh_server(provider="acme-mcp") with a narrower tool list must not
     delete cached rows belonging to a different provider."""
     db_session.add(

--- a/api/tests/test_message_tool_sources.py
+++ b/api/tests/test_message_tool_sources.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -23,7 +23,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -70,7 +70,9 @@ async def _assistant_message(db_session: AsyncSession, owner: User) -> tuple[Cha
 
 
 @pytest.mark.asyncio
-async def test_persist_message_tool_sources_writes_rows(db_session: AsyncSession, owner_user: User):
+async def test_persist_message_tool_sources_writes_rows(
+    db_session: AsyncSession, owner_user: User
+) -> None:
     from app.api.chats import _persist_message_tool_sources
     from app.chat.tool_loop import ToolSourceRecord
 
@@ -115,7 +117,7 @@ async def test_persist_message_tool_sources_writes_rows(db_session: AsyncSession
 
 
 @pytest.mark.asyncio
-async def test_message_tool_source_roundtrips(db_session: AsyncSession, owner_user: User):
+async def test_message_tool_source_roundtrips(db_session: AsyncSession, owner_user: User) -> None:
     _chat, msg = await _assistant_message(db_session, owner_user)
     row = MessageToolSource(
         message_id=msg.id,
@@ -143,7 +145,7 @@ async def test_message_tool_source_roundtrips(db_session: AsyncSession, owner_us
 @pytest.mark.asyncio
 async def test_get_sources_endpoint(
     client: AsyncClient, db_session: AsyncSession, owner_user: User
-):
+) -> None:
     chat, msg = await _assistant_message(db_session, owner_user)
     db_session.add(
         MessageToolSource(
@@ -180,7 +182,7 @@ async def test_get_sources_endpoint(
 @pytest.mark.asyncio
 async def test_get_sources_auditor_can_read_cross_user_and_is_audited(
     client: AsyncClient, db_session: AsyncSession, owner_user: User
-):
+) -> None:
     chat, msg = await _assistant_message(db_session, owner_user)
     db_session.add(
         MessageToolSource(
@@ -225,13 +227,14 @@ async def test_get_sources_auditor_can_read_cross_user_and_is_audited(
         .one()
     )
     assert row.user_id == auditor.id
+    assert row.details is not None
     assert row.details["viewed_user_id"] == str(owner_user.id)
 
 
 @pytest.mark.asyncio
 async def test_get_sources_member_cross_user_still_404_and_not_audited(
     client: AsyncClient, db_session: AsyncSession, owner_user: User
-):
+) -> None:
     chat, msg = await _assistant_message(db_session, owner_user)
     db_session.add(
         MessageToolSource(
@@ -280,7 +283,7 @@ async def test_get_sources_member_cross_user_still_404_and_not_audited(
 @pytest.mark.asyncio
 async def test_get_sources_owner_read_not_audited(
     client: AsyncClient, db_session: AsyncSession, owner_user: User
-):
+) -> None:
     chat, msg = await _assistant_message(db_session, owner_user)
     db_session.add(
         MessageToolSource(

--- a/api/tests/test_mfa.py
+++ b/api/tests/test_mfa.py
@@ -16,7 +16,7 @@ per-test access token and exercise the full setup → enable → login
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import jwt as pyjwt
 import pyotp
@@ -32,7 +32,7 @@ from app.models.user import User, UserSession
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_models_endpoints.py
+++ b/api/tests/test_models_endpoints.py
@@ -17,7 +17,7 @@ the database fixture but don't rely on the gateway being live.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import httpx
 import pytest
@@ -36,7 +36,7 @@ GATEWAY_BASE = "http://test-gateway"
 GATEWAY_KEY = "test-gw-key"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_models_project_is_sandbox.py
+++ b/api/tests/test_models_project_is_sandbox.py
@@ -1,7 +1,7 @@
 from app.models.project import Project
 
 
-def test_project_is_sandbox_default_false():
+def test_project_is_sandbox_default_false() -> None:
     col = Project.__table__.c.is_sandbox
     assert col.default.arg is False
     assert col.server_default.arg.text == "false"

--- a/api/tests/test_models_user_skill_new_columns.py
+++ b/api/tests/test_models_user_skill_new_columns.py
@@ -8,7 +8,7 @@ names (``body``, ``display_name``) rather than the plan's draft names
 from app.models.user_skill import UserSkill
 
 
-def test_user_skill_has_slash_alias_and_forked_from_columns():
+def test_user_skill_has_slash_alias_and_forked_from_columns() -> None:
     us = UserSkill(
         scope="user",
         slug="x",

--- a/api/tests/test_observability_helpers.py
+++ b/api/tests/test_observability_helpers.py
@@ -56,6 +56,7 @@ def test_record_attributes_drops_none_and_keeps_values(
     with tracer.start_as_current_span("s") as span:
         record_attributes(span, foo="bar", missing=None, count=5)
     (s,) = span_exporter.get_finished_spans()
+    assert s.attributes is not None
     assert s.attributes["foo"] == "bar"
     assert s.attributes["count"] == 5
     assert "missing" not in s.attributes

--- a/api/tests/test_organization_profile.py
+++ b/api/tests/test_organization_profile.py
@@ -17,7 +17,7 @@ that path will land alongside the gateway integration.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -31,7 +31,7 @@ from app.models import AuditLog, OrganizationProfile, User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_pipeline_parsers.py
+++ b/api/tests/test_pipeline_parsers.py
@@ -17,6 +17,9 @@ canonical text from PyMuPDF.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import NoReturn
+
 import pytest
 
 from app.pipeline.chunker import chunk_document
@@ -212,7 +215,9 @@ def test_parse_pdf_corrupt_input_raises() -> None:
         (_make_two_column_pdf, "two-column"),
     ],
 )
-def test_offset_fidelity_against_fixture_pdfs(fixture_builder, label) -> None:
+def test_offset_fidelity_against_fixture_pdfs(
+    fixture_builder: Callable[[], bytes], label: str
+) -> None:
     """The mandatory contract: every chunk slices back to its content byte-for-byte.
 
     This is the M2 Citation Engine's load-bearing precondition. Run
@@ -263,12 +268,12 @@ def test_parse_pdf_docling_disabled_marks_pymupdf_only() -> None:
 
 
 @pytest.mark.unit
-def test_parse_pdf_docling_failure_falls_through(monkeypatch) -> None:
+def test_parse_pdf_docling_failure_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
     """When Docling raises, the parser falls through to PyMuPDF-only."""
 
     from app.pipeline import parsers
 
-    def _raise(*args, **kwargs):
+    def _raise(*args: object, **kwargs: object) -> NoReturn:
         raise RuntimeError("simulated Docling crash")
 
     monkeypatch.setattr(parsers, "_run_docling", _raise)

--- a/api/tests/test_playbook_crud_endpoints.py
+++ b/api/tests/test_playbook_crud_endpoints.py
@@ -16,7 +16,7 @@ Test fixtures follow the same inline-make-user pattern as
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -31,7 +31,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_playbook_list_endpoints.py
+++ b/api/tests/test_playbook_list_endpoints.py
@@ -19,7 +19,7 @@ created inline and JWTs minted via ``create_access_token``.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -34,7 +34,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_playbooks_endpoints.py
+++ b/api/tests/test_playbooks_endpoints.py
@@ -15,7 +15,7 @@ covered by ``tests/playbooks/test_executor.py``.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 from unittest.mock import patch
 
@@ -34,7 +34,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_project_knowledge_bases.py
+++ b/api/tests/test_project_knowledge_bases.py
@@ -17,7 +17,7 @@ but with the idempotency posture pinned by the Wave D.1 spec:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -43,7 +43,7 @@ from tests.test_storage_streaming import FakeS3Client
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_projects_endpoints.py
+++ b/api/tests/test_projects_endpoints.py
@@ -28,7 +28,7 @@ ASGI in-process client doesn't trigger lifespan), same pattern as
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -51,7 +51,7 @@ from tests.test_storage_streaming import FakeS3Client
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_projects_sandbox_slug_reserved.py
+++ b/api/tests/test_projects_sandbox_slug_reserved.py
@@ -21,7 +21,7 @@ container test tree.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 import pytest
@@ -39,7 +39,7 @@ from app.skills.registry import MutableSkillRegistry
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_projects_unit.py
+++ b/api/tests/test_projects_unit.py
@@ -145,7 +145,7 @@ def test_create_request_privileged_with_tier_accepted() -> None:
 @pytest.mark.unit
 def test_create_request_rejects_invalid_tier() -> None:
     with pytest.raises(PydanticValidationError):
-        ProjectCreateRequest(name="X", privileged=True, minimum_inference_tier=6)
+        ProjectCreateRequest(name="X", privileged=True, minimum_inference_tier=6)  # type: ignore[arg-type]  # intentionally invalid
 
 
 @pytest.mark.unit

--- a/api/tests/test_research_endpoints.py
+++ b/api/tests/test_research_endpoints.py
@@ -85,7 +85,7 @@ async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
 
 
 @pytest.fixture
-def fake_storage(monkeypatch):
+def fake_storage(monkeypatch: pytest.MonkeyPatch) -> dict[str, bytes]:
     """Monkeypatch upload_bytes / stream_download in the research service."""
     store: dict[str, bytes] = {}
 
@@ -96,18 +96,18 @@ def fake_storage(monkeypatch):
         def __init__(self, data: bytes) -> None:
             self._data = data
 
-        async def __aenter__(self):
+        async def __aenter__(self) -> AsyncIterator[bytes]:
             data = self._data
 
-            async def _gen():
+            async def _gen() -> AsyncIterator[bytes]:
                 yield data
 
             return _gen()
 
-        async def __aexit__(self, *a):
+        async def __aexit__(self, *a: object) -> bool:
             return False
 
-    def _download(*, storage_path: str):
+    def _download(*, storage_path: str) -> _Reader:
         return _Reader(store[storage_path])
 
     monkeypatch.setattr("app.research.service.upload_bytes", _upload)
@@ -233,7 +233,7 @@ async def test_search_returns_count_and_results(client: AsyncClient, db_user: Us
 
 @pytest.mark.integration
 async def test_get_cluster_fetches_and_returns(
-    client: AsyncClient, db_user: User, fake_storage
+    client: AsyncClient, db_user: User, fake_storage: dict[str, bytes]
 ) -> None:
     gw_resp = {
         "provider": "courtlistener-prod",
@@ -280,7 +280,7 @@ async def test_get_cluster_fetches_and_returns(
 
 @pytest.mark.integration
 async def test_read_opinion_404_when_not_cached(
-    client: AsyncClient, db_user: User, fake_storage
+    client: AsyncClient, db_user: User, fake_storage: dict[str, bytes]
 ) -> None:
     """GET /opinions/{id} returns 404 when the cluster was never fetched."""
     resp = await client.get(
@@ -292,7 +292,7 @@ async def test_read_opinion_404_when_not_cached(
 
 @pytest.mark.integration
 async def test_read_opinion_200_after_cluster_cached(
-    client: AsyncClient, db_session: AsyncSession, db_user: User, fake_storage
+    client: AsyncClient, db_session: AsyncSession, db_user: User, fake_storage: dict[str, bytes]
 ) -> None:
     """Cache the cluster first (via service), then read the opinion via endpoint."""
     from app.models.research import ResearchOpinionMetadata
@@ -327,7 +327,7 @@ async def test_read_opinion_200_after_cluster_cached(
 
 @pytest.mark.integration
 async def test_find_in_case_returns_matches(
-    client: AsyncClient, db_session: AsyncSession, db_user: User, fake_storage
+    client: AsyncClient, db_session: AsyncSession, db_user: User, fake_storage: dict[str, bytes]
 ) -> None:
     from app.models.research import ResearchOpinionMetadata
 
@@ -358,7 +358,7 @@ async def test_find_in_case_returns_matches(
 
 @pytest.mark.integration
 async def test_find_in_case_404_when_not_cached(
-    client: AsyncClient, db_user: User, fake_storage
+    client: AsyncClient, db_user: User, fake_storage: dict[str, bytes]
 ) -> None:
     resp = await client.post(
         "/api/v1/research/find-in-case",
@@ -381,11 +381,11 @@ async def test_capabilities_unauthenticated_returns_401(client: AsyncClient) -> 
 
 @pytest.mark.integration
 async def test_capabilities_enabled_when_courtlistener_configured(
-    client: AsyncClient, db_user: User, monkeypatch
+    client: AsyncClient, db_user: User, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from app.research import service
 
-    async def _mock_get_capabilities(**_kwargs):
+    async def _mock_get_capabilities(**_kwargs: object) -> dict[str, object]:
         return {
             "enabled": True,
             "providers": [{"name": "courtlistener-prod", "type": "courtlistener"}],
@@ -402,11 +402,11 @@ async def test_capabilities_enabled_when_courtlistener_configured(
 
 @pytest.mark.integration
 async def test_capabilities_disabled_when_not_configured(
-    client: AsyncClient, db_user: User, monkeypatch
+    client: AsyncClient, db_user: User, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from app.research import service
 
-    async def _mock_get_capabilities(**_kwargs):
+    async def _mock_get_capabilities(**_kwargs: object) -> dict[str, object]:
         return {"enabled": False, "providers": []}
 
     monkeypatch.setattr(service, "get_capabilities", _mock_get_capabilities)

--- a/api/tests/test_research_html.py
+++ b/api/tests/test_research_html.py
@@ -12,7 +12,7 @@ from app.research.html import html_to_text
         ("plain text already", "plain text already", "<"),
     ],
 )
-def test_html_to_text(html, expected_contains, expected_excludes) -> None:
+def test_html_to_text(html: str, expected_contains: str, expected_excludes: str) -> None:
     out = html_to_text(html)
     assert expected_contains in out
     assert expected_excludes not in out

--- a/api/tests/test_research_models.py
+++ b/api/tests/test_research_models.py
@@ -22,6 +22,7 @@ from typing import get_args
 
 import pytest
 from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.research import ResearchClusterMetadata, ResearchOpinionMetadata
 from app.schemas.research import (
@@ -35,7 +36,7 @@ from app.schemas.research import (
 )
 
 
-async def test_research_metadata_roundtrips(db_session) -> None:
+async def test_research_metadata_roundtrips(db_session: AsyncSession) -> None:
     cluster = ResearchClusterMetadata(
         cluster_id=2812209,
         case_name="Obergefell v. Hodges",
@@ -78,7 +79,7 @@ def test_verified_citation_roundtrips_adapter_shape() -> None:
             }
         ],
     }
-    resp = VerifyCitationsResponse(citations=[adapter_item])
+    resp = VerifyCitationsResponse.model_validate({"citations": [adapter_item]})
     assert len(resp.citations) == 1
     vc = resp.citations[0]
     assert isinstance(vc, VerifiedCitation)
@@ -103,7 +104,7 @@ def test_verified_citation_not_found_item() -> None:
         "error_message": "not found",
         "clusters": [],
     }
-    resp = VerifyCitationsResponse(citations=[adapter_item])
+    resp = VerifyCitationsResponse.model_validate({"citations": [adapter_item]})
     vc = resp.citations[0]
     assert vc.status == 404
     assert vc.error_message == "not found"
@@ -119,7 +120,7 @@ def test_verified_citation_none_fields_accepted() -> None:
         "error_message": None,
         "clusters": [{"id": None, "case_name": None, "absolute_url": None}],
     }
-    resp = VerifyCitationsResponse(citations=[adapter_item])
+    resp = VerifyCitationsResponse.model_validate({"citations": [adapter_item]})
     vc = resp.citations[0]
     assert vc.citation is None
     assert vc.status is None
@@ -140,14 +141,14 @@ _ALL_TEXT_FIELDS = list(get_args(OpinionTextField))
 
 
 @pytest.mark.parametrize("field", _ALL_TEXT_FIELDS)
-def test_opinion_meta_accepts_all_text_fields(field: str) -> None:
+def test_opinion_meta_accepts_all_text_fields(field: OpinionTextField) -> None:
     """OpinionMeta validates all 7 OpinionTextField values incl xml_harvard."""
     meta = OpinionMeta(opinion_id=1, char_length=100, text_field_used=field)
     assert meta.text_field_used == field
 
 
 @pytest.mark.parametrize("field", _ALL_TEXT_FIELDS)
-def test_opinion_text_accepts_all_text_fields(field: str) -> None:
+def test_opinion_text_accepts_all_text_fields(field: OpinionTextField) -> None:
     """OpinionText validates all 7 OpinionTextField values incl xml_harvard."""
     ot = OpinionText(opinion_id=1, cluster_id=2, text_field_used=field, text="Sample text.")
     assert ot.text_field_used == field
@@ -168,13 +169,13 @@ def test_opinion_text_text_field_used_none() -> None:
 def test_opinion_meta_rejects_invalid_text_field() -> None:
     """OpinionMeta rejects values outside the closed Literal set."""
     with pytest.raises(ValidationError):
-        OpinionMeta(opinion_id=1, char_length=0, text_field_used="raw_text")
+        OpinionMeta(opinion_id=1, char_length=0, text_field_used="raw_text")  # type: ignore[arg-type]  # intentionally invalid
 
 
 def test_opinion_text_rejects_invalid_text_field() -> None:
     """OpinionText rejects values outside the closed Literal set."""
     with pytest.raises(ValidationError):
-        OpinionText(opinion_id=1, cluster_id=2, text_field_used="raw_text", text="x")
+        OpinionText(opinion_id=1, cluster_id=2, text_field_used="raw_text", text="x")  # type: ignore[arg-type]  # intentionally invalid
 
 
 # ---------------------------------------------------------------------------
@@ -212,4 +213,4 @@ def test_search_request_cursor_default_none() -> None:
 def test_search_request_rejects_extra_field() -> None:
     """extra='forbid' is preserved — unknown fields still raise."""
     with pytest.raises(ValidationError):
-        SearchRequest(q="x", unknown_field="y")
+        SearchRequest(q="x", unknown_field="y")  # type: ignore[call-arg]  # intentionally invalid

--- a/api/tests/test_research_service.py
+++ b/api/tests/test_research_service.py
@@ -1,9 +1,10 @@
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 
 import httpx
 import pytest
 import respx
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.errors import ResearchNotConfigured
 from app.models.research import ResearchOpinionMetadata
@@ -30,7 +31,7 @@ def _prime_and_reset_provider_cache() -> Iterator[None]:
 
 
 @pytest.fixture
-def fake_storage(monkeypatch):
+def fake_storage(monkeypatch: pytest.MonkeyPatch) -> dict[str, bytes]:
     store: dict[str, bytes] = {}
 
     async def _upload(*, storage_path: str, body: bytes, content_type: str) -> None:
@@ -40,18 +41,18 @@ def fake_storage(monkeypatch):
         def __init__(self, data: bytes) -> None:
             self._data = data
 
-        async def __aenter__(self):
+        async def __aenter__(self) -> AsyncIterator[bytes]:
             data = self._data
 
-            async def _gen():
+            async def _gen() -> AsyncIterator[bytes]:
                 yield data
 
             return _gen()
 
-        async def __aexit__(self, *a):
+        async def __aexit__(self, *a: object) -> bool:
             return False
 
-    def _download(*, storage_path: str):
+    def _download(*, storage_path: str) -> _Reader:
         return _Reader(store[storage_path])
 
     monkeypatch.setattr("app.research.service.upload_bytes", _upload)
@@ -60,7 +61,9 @@ def fake_storage(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_cluster_fetches_caches_then_serves_from_cache(db_session, fake_storage) -> None:
+async def test_get_cluster_fetches_caches_then_serves_from_cache(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     cluster = {
         "id": 5,
         "case_name": "X v. Y",
@@ -106,7 +109,9 @@ async def test_get_cluster_fetches_caches_then_serves_from_cache(db_session, fak
 
 
 @pytest.mark.asyncio
-async def test_read_opinion_404_when_not_fetched(db_session, fake_storage) -> None:
+async def test_read_opinion_404_when_not_fetched(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     from app.errors import NotFound
 
     with pytest.raises(NotFound):
@@ -114,7 +119,9 @@ async def test_read_opinion_404_when_not_fetched(db_session, fake_storage) -> No
 
 
 @pytest.mark.asyncio
-async def test_find_in_case_returns_matches(db_session, fake_storage) -> None:
+async def test_find_in_case_returns_matches(
+    db_session: AsyncSession, fake_storage: dict[str, bytes]
+) -> None:
     fake_storage["k"] = b"The right to privacy is fundamental. Privacy again here."
     db_session.add(
         ResearchOpinionMetadata(
@@ -128,7 +135,7 @@ async def test_find_in_case_returns_matches(db_session, fake_storage) -> None:
 
 
 @pytest.mark.asyncio
-async def test_verify_citations_passthrough(db_session) -> None:
+async def test_verify_citations_passthrough(db_session: AsyncSession) -> None:
     with respx.mock:
         respx.post(f"{GW}/v1/tools/courtlistener-prod/verify_citations").mock(
             return_value=httpx.Response(

--- a/api/tests/test_research_sources_endpoint.py
+++ b/api/tests/test_research_sources_endpoint.py
@@ -11,7 +11,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from unittest.mock import AsyncMock
 
 import pytest
@@ -89,7 +89,7 @@ def fake_gateway_with_govinfo() -> AsyncMock:
 
 
 @pytest.fixture(autouse=True)
-def _reset_tier_cache() -> None:
+def _reset_tier_cache() -> Iterator[None]:
     """Reset the process-level governance tier cache around every test.
 
     resolve_available_sources now calls resolve_provider_tier (from
@@ -98,7 +98,7 @@ def _reset_tier_cache() -> None:
     tests.
     """
     _reset_provider_tier_cache_for_tests()
-    yield  # type: ignore[misc]
+    yield
     _reset_provider_tier_cache_for_tests()
 
 
@@ -128,7 +128,7 @@ async def test_sources_returns_200_with_govinfo_present(
 
     monkeypatch.setattr("app.tools.governance.get_gateway_client", lambda: _FakeAdminGW())
 
-    set_gateway_client(fake_gateway_with_govinfo)  # type: ignore[arg-type]
+    set_gateway_client(fake_gateway_with_govinfo)
     try:
         resp = await client.get("/api/v1/research/sources", headers=_h(db_user))
     finally:
@@ -164,7 +164,7 @@ async def test_sources_response_never_contains_secrets(
 
     monkeypatch.setattr("app.tools.governance.get_gateway_client", lambda: _FakeAdminGW())
 
-    set_gateway_client(fake_gateway_with_govinfo)  # type: ignore[arg-type]
+    set_gateway_client(fake_gateway_with_govinfo)
     try:
         resp = await client.get("/api/v1/research/sources", headers=_h(db_user))
     finally:
@@ -208,7 +208,7 @@ async def test_sources_egress_tier_resolved_from_admin_config(
 
     monkeypatch.setattr("app.tools.governance.get_gateway_client", lambda: _FakeAdminGW())
 
-    set_gateway_client(fake_gateway_with_govinfo)  # type: ignore[arg-type]
+    set_gateway_client(fake_gateway_with_govinfo)
     try:
         resp = await client.get("/api/v1/research/sources", headers=_h(db_user))
     finally:

--- a/api/tests/test_saved_prompts.py
+++ b/api/tests/test_saved_prompts.py
@@ -15,7 +15,7 @@ Covers the M1-IMPLEMENTATION-ORDER Task D7 backend surface:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC
 
 import pytest
@@ -30,7 +30,7 @@ from app.models import AuditLog, SavedPrompt, User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_session_timeout_mfa_mandatory.py
+++ b/api/tests/test_session_timeout_mfa_mandatory.py
@@ -18,7 +18,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -34,7 +34,7 @@ from app.models.user import User, UserSession
 from app.security import hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -119,6 +119,7 @@ async def test_refresh_rejects_when_absolute_timeout_exceeded(
         select(UserSession).where(UserSession.user_id == seed_user.id)
     )
     session = result.scalars().first()
+    assert session is not None
     session.absolute_expires_at = datetime.now(tz=UTC) - timedelta(minutes=1)
     await db_session.flush()
 
@@ -148,6 +149,7 @@ async def test_refresh_rejects_when_idle_timeout_exceeded(
         select(UserSession).where(UserSession.user_id == seed_user.id)
     )
     session = result.scalars().first()
+    assert session is not None
     session.last_active_at = datetime.now(tz=UTC) - timedelta(
         seconds=settings.session_idle_timeout_seconds + 60
     )
@@ -178,6 +180,7 @@ async def test_refresh_preserves_absolute_expires_at_across_rotation(
         select(UserSession).where(UserSession.user_id == seed_user.id)
     )
     original = result.scalars().first()
+    assert original is not None
     original_absolute = original.absolute_expires_at
 
     # Rotate. The new session should have the SAME absolute_expires_at.
@@ -190,6 +193,7 @@ async def test_refresh_preserves_absolute_expires_at_across_rotation(
         .order_by(UserSession.created_at.desc())
     )
     new = result.scalars().first()
+    assert new is not None
     assert new.absolute_expires_at == original_absolute, (
         "absolute_expires_at must be preserved across rotation"
     )

--- a/api/tests/test_skill_endpoints.py
+++ b/api/tests/test_skill_endpoints.py
@@ -17,7 +17,7 @@ how every integration test in the suite handles process-global state).
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -36,7 +36,7 @@ from app.skills.registry import MutableSkillRegistry
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_skill_loader.py
+++ b/api/tests/test_skill_loader.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import signal
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -60,7 +61,7 @@ def _capture_loader_warnings(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     captured: list[str] = []
     original_warning = loader_mod.log.warning
 
-    def _capture(msg: object, *args: object, **kwargs: object) -> None:
+    def _capture(msg: str, *args: object, **kwargs: Any) -> None:
         # Render the format string with the printf-style args the loader
         # passes, so the test can grep for substrings like "missing-name".
         try:
@@ -510,7 +511,7 @@ def test_install_sighup_reload_handler_swaps_registry(tmp_path: Path) -> None:
         handler = signal.getsignal(signal.SIGHUP)
         assert callable(handler)
         # The handler signature is (signum, frame).
-        handler(signal.SIGHUP, None)  # type: ignore[arg-type, misc]
+        handler(signal.SIGHUP, None)
         new_registry = holder.current()
         assert new_registry is not initial
         assert "alpha-test-skill" in new_registry.names()

--- a/api/tests/test_skill_spans.py
+++ b/api/tests/test_skill_spans.py
@@ -7,14 +7,23 @@ but the helper is pure and importable without any infrastructure.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping
 
 import pytest
 from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util.types import AttributeValue
 
 from app.api.chats import _emit_skill_spans
+
+
+def _attrs(span: ReadableSpan) -> Mapping[str, AttributeValue]:
+    """Narrow ``span.attributes`` from ``Mapping | None`` for type-checking."""
+    assert span.attributes is not None
+    return span.attributes
+
 
 # ---------------------------------------------------------------------------
 # Shared OTel fixtures
@@ -87,13 +96,14 @@ def test_emits_one_span_per_skill(span_exporter: InMemorySpanExporter) -> None:
     assert len(spans) == 2
     assert all(s.name == "skill.execute" for s in spans)
 
-    slugs = {s.attributes["skill.slug"] for s in spans}
+    slugs = {_attrs(s)["skill.slug"] for s in spans}
     assert slugs == {"nda-review", "msa-review-saas"}
 
     for span in spans:
-        assert span.attributes["project.id"] == str(project_id)
-        assert span.attributes["project.privileged"] is False
-        assert span.attributes["chat.id"] == str(chat_id)
+        attrs = _attrs(span)
+        assert attrs["project.id"] == str(project_id)
+        assert attrs["project.privileged"] is False
+        assert attrs["chat.id"] == str(chat_id)
 
 
 @pytest.mark.unit
@@ -118,11 +128,11 @@ def test_span_carries_version_and_author_from_registry(
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-    span = spans[0]
-    assert span.attributes["skill.slug"] == "my-skill"
-    assert span.attributes["skill.version"] == "1.2.0"
-    assert span.attributes["skill.author"] == "Jane"
-    assert span.attributes["project.privileged"] is True
+    attrs = _attrs(spans[0])
+    assert attrs["skill.slug"] == "my-skill"
+    assert attrs["skill.version"] == "1.2.0"
+    assert attrs["skill.author"] == "Jane"
+    assert attrs["project.privileged"] is True
 
 
 @pytest.mark.unit
@@ -148,11 +158,11 @@ def test_unknown_skill_omits_version_author(
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-    span = spans[0]
-    assert span.attributes["skill.slug"] == "unknown-skill"
+    attrs = _attrs(spans[0])
+    assert attrs["skill.slug"] == "unknown-skill"
     # version and author should NOT be in attributes (None → dropped by record_attributes)
-    assert "skill.version" not in span.attributes
-    assert "skill.author" not in span.attributes
+    assert "skill.version" not in attrs
+    assert "skill.author" not in attrs
 
 
 @pytest.mark.unit
@@ -191,12 +201,12 @@ def test_none_registry_emits_span_without_version_author(
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-    span = spans[0]
-    assert span.attributes["skill.slug"] == "nda-review"
-    assert "skill.version" not in span.attributes
-    assert "skill.author" not in span.attributes
-    assert span.attributes["project.id"] == str(project_id)
-    assert span.attributes["chat.id"] == str(chat_id)
+    attrs = _attrs(spans[0])
+    assert attrs["skill.slug"] == "nda-review"
+    assert "skill.version" not in attrs
+    assert "skill.author" not in attrs
+    assert attrs["project.id"] == str(project_id)
+    assert attrs["chat.id"] == str(chat_id)
 
 
 @pytest.mark.unit
@@ -214,4 +224,4 @@ def test_none_project_id_omits_project_id_attribute(
     )
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-    assert "project.id" not in spans[0].attributes
+    assert "project.id" not in _attrs(spans[0])

--- a/api/tests/test_skill_table_mode.py
+++ b/api/tests/test_skill_table_mode.py
@@ -102,12 +102,14 @@ class TestLQAIFrontmatterColumns:
 
         from app.skills.schema import LQAIFrontmatter
 
-        fm = LQAIFrontmatter(
-            output_format="table",
-            columns=[
-                {"name": "Term", "query": "What is the term?"},
-                {"name": "Survival", "query": "What is the survival period?"},
-            ],
+        fm = LQAIFrontmatter.model_validate(
+            {
+                "output_format": "table",
+                "columns": [
+                    {"name": "Term", "query": "What is the term?"},
+                    {"name": "Survival", "query": "What is the survival period?"},
+                ],
+            }
         )
 
         assert fm.output_format == "table"
@@ -122,9 +124,11 @@ class TestLQAIFrontmatterColumns:
 
         from app.skills.schema import LQAIFrontmatter
 
-        fm = LQAIFrontmatter(
-            output_format="report",
-            columns=[{"name": "X", "query": "Y"}],
+        fm = LQAIFrontmatter.model_validate(
+            {
+                "output_format": "report",
+                "columns": [{"name": "X", "query": "Y"}],
+            }
         )
 
         assert fm.output_format == "report"

--- a/api/tests/test_skills_capture_payload.py
+++ b/api/tests/test_skills_capture_payload.py
@@ -17,17 +17,33 @@ draft snippet used ``title`` / ``body_md``.
 
 from __future__ import annotations
 
+from typing import NotRequired, TypedDict
+
 from app.api.user_skills import UserSkillCreate, UserSkillUpdate
 
 
-def _base_payload(**overrides: object) -> dict[str, object]:
-    base: dict[str, object] = {
+class _Payload(TypedDict):
+    slug: str
+    display_name: str
+    description: str
+    body: str
+    source_message_id: NotRequired[str]
+    forked_from: NotRequired[str]
+
+
+def _base_payload(
+    *, source_message_id: str | None = None, forked_from: str | None = None
+) -> _Payload:
+    base: _Payload = {
         "slug": "personal-nda",
         "display_name": "Personal NDA",
         "description": "My NDA workflow",
         "body": "You review NDAs.",
     }
-    base.update(overrides)
+    if source_message_id is not None:
+        base["source_message_id"] = source_message_id
+    if forked_from is not None:
+        base["forked_from"] = forked_from
     return base
 
 

--- a/api/tests/test_skills_tool_usage.py
+++ b/api/tests/test_skills_tool_usage.py
@@ -6,16 +6,16 @@ from app.skills.connectors import resolve_available_connectors, unavailable_tool
 from app.skills.schema import LQAIFrontmatter, SkillFrontmatter, derive_summary
 
 
-def test_frontmatter_parses_tool_usage():
+def test_frontmatter_parses_tool_usage() -> None:
     fm = LQAIFrontmatter.model_validate({"tool_usage": ["courtlistener"]})
     assert fm.tool_usage == ["courtlistener"]
 
 
-def test_frontmatter_tool_usage_absent_is_none():
+def test_frontmatter_tool_usage_absent_is_none() -> None:
     assert LQAIFrontmatter.model_validate({}).tool_usage is None
 
 
-def test_derive_summary_carries_tool_usage():
+def test_derive_summary_carries_tool_usage() -> None:
     front = SkillFrontmatter.model_validate(
         {"name": "x", "description": "d", "lq_ai": {"tool_usage": ["courtlistener"]}}
     )
@@ -23,7 +23,7 @@ def test_derive_summary_carries_tool_usage():
     assert summary.tool_usage == ["courtlistener"]
 
 
-def test_unavailable_pure_function():
+def test_unavailable_pure_function() -> None:
     assert unavailable_tool_usage(None, {"courtlistener"}) == []
     assert unavailable_tool_usage([], {"courtlistener"}) == []
     assert unavailable_tool_usage(["courtlistener"], None) is None  # undeterminable
@@ -33,7 +33,7 @@ def test_unavailable_pure_function():
 
 
 @pytest.mark.asyncio
-async def test_resolve_available_unions_caselaw_and_mcp():
+async def test_resolve_available_unions_caselaw_and_mcp() -> None:
     with (
         patch(
             "app.skills.connectors.get_capabilities",
@@ -49,7 +49,7 @@ async def test_resolve_available_unions_caselaw_and_mcp():
 
 
 @pytest.mark.asyncio
-async def test_resolve_available_none_on_error():
+async def test_resolve_available_none_on_error() -> None:
     with (
         patch(
             "app.skills.connectors.get_capabilities",
@@ -61,7 +61,7 @@ async def test_resolve_available_none_on_error():
 
 
 @pytest.mark.asyncio
-async def test_resolve_available_caselaw_disabled_excludes_courtlistener():
+async def test_resolve_available_caselaw_disabled_excludes_courtlistener() -> None:
     with (
         patch(
             "app.skills.connectors.get_capabilities",

--- a/api/tests/test_source_registry.py
+++ b/api/tests/test_source_registry.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from unittest.mock import AsyncMock
 
 import pytest
@@ -19,9 +20,9 @@ from app.tools.governance import _reset_provider_tier_cache_for_tests
 
 
 @pytest.fixture(autouse=True)
-def _reset_tier_cache() -> None:
+def _reset_tier_cache() -> Iterator[None]:
     _reset_provider_tier_cache_for_tests()
-    yield  # type: ignore[misc]
+    yield
     _reset_provider_tier_cache_for_tests()
 
 
@@ -30,12 +31,12 @@ def _reset_tier_cache() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_registry_has_courtlistener_and_govinfo():
+def test_registry_has_courtlistener_and_govinfo() -> None:
     assert "courtlistener" in SOURCE_REGISTRY and "govinfo" in SOURCE_REGISTRY
     assert "search_authority" in SOURCE_REGISTRY["govinfo"].ops
 
 
-def test_edgar_registered_with_sec_filing_kind():
+def test_edgar_registered_with_sec_filing_kind() -> None:
     spec = SOURCE_REGISTRY["edgar"]
     assert spec.type == "edgar"
     assert spec.content_kinds == ("sec_filing",)
@@ -120,7 +121,7 @@ async def test_resolve_egress_tier_from_governance_cache(
 # ---------------------------------------------------------------------------
 
 
-def test_govinfo_adapter_from_response_get():
+def test_govinfo_adapter_from_response_get() -> None:
     fa = GovInfoAdapter().from_response(
         "get_authority",
         {
@@ -142,15 +143,15 @@ def test_govinfo_adapter_from_response_get():
 # ---------------------------------------------------------------------------
 
 
-def test_content_kind_from_id_uscode_returns_statute():
+def test_content_kind_from_id_uscode_returns_statute() -> None:
     assert _content_kind_from_id("USCODE-2022-title15") == "statute"
 
 
-def test_content_kind_from_id_cfr_returns_regulation():
+def test_content_kind_from_id_cfr_returns_regulation() -> None:
     assert _content_kind_from_id("CFR-2023-title12-vol1") == "regulation"
 
 
-def test_content_kind_from_id_unknown_returns_unknown():
+def test_content_kind_from_id_unknown_returns_unknown() -> None:
     """A non-USCODE/CFR package_id must return 'unknown', not 'statute'.
 
     Returning 'statute' for an unrecognised id would be a confident mislabel
@@ -166,7 +167,7 @@ def test_content_kind_from_id_unknown_returns_unknown():
 # ---------------------------------------------------------------------------
 
 
-def test_edgar_get_authority_maps_to_fetched_authority():
+def test_edgar_get_authority_maps_to_fetched_authority() -> None:
     payload = {
         "external_ref": "1005010_000119312509237465_dex992.htm",
         "title": "dex992.htm",
@@ -182,7 +183,7 @@ def test_edgar_get_authority_maps_to_fetched_authority():
     assert fa.url.endswith("dex992.htm")
 
 
-def test_edgar_search_authority_is_title_only_body():
+def test_edgar_search_authority_is_title_only_body() -> None:
     payload = {
         "results": [
             {
@@ -206,7 +207,7 @@ def test_edgar_search_authority_is_title_only_body():
 # ---------------------------------------------------------------------------
 
 
-def test_eurlex_get_authority_maps_to_fetched_authority():
+def test_eurlex_get_authority_maps_to_fetched_authority() -> None:
     payload = {
         "external_ref": "32016R0679",
         "title": "32016R0679",
@@ -231,7 +232,7 @@ def test_eurlex_unsupported_op_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_eurlex_registered_get_only():
+def test_eurlex_registered_get_only() -> None:
     spec = SOURCE_REGISTRY["eurlex"]
     assert spec.type == "eurlex"
     assert spec.ops == ("get_authority",)

--- a/api/tests/test_storage_streaming.py
+++ b/api/tests/test_storage_streaming.py
@@ -22,7 +22,7 @@ What's covered here:
 from __future__ import annotations
 
 import hashlib
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from typing import Any
 from unittest.mock import patch
 
@@ -194,7 +194,7 @@ def fake_s3() -> FakeS3Client:
 
 
 @pytest.fixture(autouse=True)
-def _patch_s3_client(fake_s3: FakeS3Client):
+def _patch_s3_client(fake_s3: FakeS3Client) -> Iterator[None]:
     """Monkey-patch ``app.storage.s3_client`` to yield the fake."""
 
     from contextlib import asynccontextmanager

--- a/api/tests/test_tabular_endpoints.py
+++ b/api/tests/test_tabular_endpoints.py
@@ -17,7 +17,7 @@ with no migration / backfill / re-run.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 import pytest
@@ -37,7 +37,7 @@ from app.security import create_access_token, hash_password
 from app.tabular import cost as tabular_cost
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_teams.py
+++ b/api/tests/test_teams.py
@@ -18,7 +18,7 @@ Covers the operator-admin-controlled team management surface:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -33,7 +33,7 @@ from app.models import AuditLog, Team, TeamMember, User, UserSkill
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -174,6 +174,7 @@ async def test_update_team_writes_audit_when_changed(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["changed_fields"] == ["name"]
 
 
@@ -269,6 +270,7 @@ async def test_add_member_writes_audit(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["user_email"] == member_user.email
     assert audit.details["role"] == "member"
 
@@ -349,6 +351,7 @@ async def test_role_change_records_before_and_after(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["role_before"] == "member"
     assert audit.details["role_after"] == "admin"
 
@@ -428,6 +431,7 @@ async def test_remove_member_audits_role_at_removal(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["role_at_removal"] == "admin"
 
 

--- a/api/tests/test_tool_call_log_model.py
+++ b/api/tests/test_tool_call_log_model.py
@@ -88,7 +88,7 @@ def test_tool_call_log_columns() -> None:
 @pytest.mark.unit
 def test_tool_call_log_primary_key() -> None:
     """PK is 'id' only (single UUID column)."""
-    pk = {c.name for c in ToolCallLog.__table__.primary_key.columns}
+    pk = {c.name for c in ToolCallLog.__table__.primary_key}
     assert pk == {"id"}
 
 

--- a/api/tests/test_tool_egress_log_model.py
+++ b/api/tests/test_tool_egress_log_model.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 
 import uuid
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.models.tool_egress import ToolEgressLog
 
 
-async def test_tool_egress_log_allows_tier_zero_for_unresolved_provider(db_session) -> None:
+async def test_tool_egress_log_allows_tier_zero_for_unresolved_provider(
+    db_session: AsyncSession,
+) -> None:
     """tier=0 (unknown-provider refusal) must persist — the prod writer
     relies on this so unresolved-provider refusals are actually audited."""
     row = ToolEgressLog(
@@ -30,7 +34,7 @@ async def test_tool_egress_log_allows_tier_zero_for_unresolved_provider(db_sessi
     assert row.refused is True
 
 
-async def test_tool_egress_log_row_roundtrips(db_session) -> None:
+async def test_tool_egress_log_row_roundtrips(db_session: AsyncSession) -> None:
     """A tool_egress_log row persists and reads back with its core fields."""
     row = ToolEgressLog(
         request_id="req_abc",

--- a/api/tests/test_tool_governance.py
+++ b/api/tests/test_tool_governance.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import AsyncIterator
 from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -89,7 +90,7 @@ def _make_span() -> MagicMock:
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clear_tier_cache():
+async def _clear_tier_cache() -> AsyncIterator[None]:
     """Reset the process-level tier cache before every test."""
     _reset_provider_tier_cache_for_tests()
     yield
@@ -102,10 +103,12 @@ async def _clear_tier_cache():
 
 
 @pytest.mark.asyncio
-async def test_resolve_provider_tier_returns_configured_tier(monkeypatch):
+async def test_resolve_provider_tier_returns_configured_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """resolve_provider_tier returns the egress_tier from the gateway config."""
 
-    async def _fake_get_admin_config(*, request_id=None):
+    async def _fake_get_admin_config(*, request_id: str | None = None) -> dict[str, Any]:
         return {
             "tool_providers": [
                 {"name": "courtlistener-prod", "type": "courtlistener", "egress_tier": 4},
@@ -126,10 +129,12 @@ async def test_resolve_provider_tier_returns_configured_tier(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_resolve_provider_tier_fail_safe_for_unknown_provider(monkeypatch):
+async def test_resolve_provider_tier_fail_safe_for_unknown_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """resolve_provider_tier returns _MAX_TIER when the provider is not listed."""
 
-    async def _fake_get_admin_config(*, request_id=None):
+    async def _fake_get_admin_config(*, request_id: str | None = None) -> dict[str, Any]:
         return {"tool_providers": [{"name": "other", "type": "mcp", "egress_tier": 1}]}
 
     class _FakeGW:
@@ -142,10 +147,12 @@ async def test_resolve_provider_tier_fail_safe_for_unknown_provider(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_resolve_provider_tier_fail_safe_on_gateway_error(monkeypatch):
+async def test_resolve_provider_tier_fail_safe_on_gateway_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """resolve_provider_tier returns _MAX_TIER when the gateway is unreachable."""
 
-    async def _fail_get_admin_config(*, request_id=None):
+    async def _fail_get_admin_config(*, request_id: str | None = None) -> dict[str, Any]:
         raise RuntimeError("gateway down")
 
     class _FakeGW:
@@ -158,11 +165,11 @@ async def test_resolve_provider_tier_fail_safe_on_gateway_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_resolve_provider_tier_process_cached(monkeypatch):
+async def test_resolve_provider_tier_process_cached(monkeypatch: pytest.MonkeyPatch) -> None:
     """resolve_provider_tier only calls get_admin_config once per process."""
     call_count = 0
 
-    async def _counting_get_admin_config(*, request_id=None):
+    async def _counting_get_admin_config(*, request_id: str | None = None) -> dict[str, Any]:
         nonlocal call_count
         call_count += 1
         return {"tool_providers": [{"name": "cl", "type": "courtlistener", "egress_tier": 3}]}
@@ -185,7 +192,7 @@ async def test_resolve_provider_tier_process_cached(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_tier_refusal_writes_row_and_raises(db_session: AsyncSession):
+async def test_tier_refusal_writes_row_and_raises(db_session: AsyncSession) -> None:
     """Tier refusal writes a refused_tier row, flushes, and raises ToolTierRefused.
 
     Dispatch must NOT be called.
@@ -231,7 +238,7 @@ async def test_tier_refusal_writes_row_and_raises(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_tier_refusal_no_dispatch_when_no_ceiling(db_session: AsyncSession):
+async def test_tier_refusal_no_dispatch_when_no_ceiling(db_session: AsyncSession) -> None:
     """When max_allowed_tier is None, no tier check is performed."""
     dispatch = _make_dispatch(cost=Decimal("0.05"))
 
@@ -252,7 +259,7 @@ async def test_tier_refusal_no_dispatch_when_no_ceiling(db_session: AsyncSession
 
 
 @pytest.mark.asyncio
-async def test_tier_refusal_no_raise_when_tier_eq_ceiling(db_session: AsyncSession):
+async def test_tier_refusal_no_raise_when_tier_eq_ceiling(db_session: AsyncSession) -> None:
     """provider_tier == max_allowed_tier is allowed (equal is not exceeding)."""
     dispatch = _make_dispatch(cost=Decimal("0.01"))
 
@@ -273,7 +280,7 @@ async def test_tier_refusal_no_raise_when_tier_eq_ceiling(db_session: AsyncSessi
 
 
 @pytest.mark.asyncio
-async def test_tier_refusal_annotates_span(db_session: AsyncSession):
+async def test_tier_refusal_annotates_span(db_session: AsyncSession) -> None:
     """On tier refusal the caller-supplied span is annotated (no raw args)."""
     dispatch = _make_dispatch()
     span = _make_span()
@@ -309,7 +316,7 @@ async def test_tier_refusal_annotates_span(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_happy_path_writes_pending_then_executed(db_session: AsyncSession):
+async def test_happy_path_writes_pending_then_executed(db_session: AsyncSession) -> None:
     """Happy path: pending row written, updated to executed with cost."""
     cost = Decimal("0.0312")
     dispatch = _make_dispatch(cost=cost)
@@ -350,7 +357,7 @@ async def test_happy_path_writes_pending_then_executed(db_session: AsyncSession)
 
 
 @pytest.mark.asyncio
-async def test_happy_path_no_raw_args_in_row(db_session: AsyncSession):
+async def test_happy_path_no_raw_args_in_row(db_session: AsyncSession) -> None:
     """No raw args or result payload must appear in ANY mapped column of the row.
 
     M3 hardening: scans every SQLAlchemy-mapped column value (not just repr,
@@ -397,7 +404,9 @@ async def test_happy_path_no_raw_args_in_row(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_no_sentinel_in_logs(db_session: AsyncSession, caplog: pytest.LogCaptureFixture):
+async def test_no_sentinel_in_logs(
+    db_session: AsyncSession, caplog: pytest.LogCaptureFixture
+) -> None:
     """Sentinel secret must not appear in ANY log record emitted at DEBUG or above.
 
     M4 hardening: drives both the happy path and the error path with the
@@ -456,7 +465,7 @@ async def test_no_sentinel_in_logs(db_session: AsyncSession, caplog: pytest.LogC
 
 
 @pytest.mark.asyncio
-async def test_happy_path_span_annotation(db_session: AsyncSession):
+async def test_happy_path_span_annotation(db_session: AsyncSession) -> None:
     """On success the span receives outcome/tier/cost_usd — no raw payloads."""
     cost = Decimal("0.05")
     dispatch = _make_dispatch(cost=cost)
@@ -490,7 +499,7 @@ async def test_happy_path_span_annotation(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_raises_writes_error_row_and_reraises(db_session: AsyncSession):
+async def test_dispatch_raises_writes_error_row_and_reraises(db_session: AsyncSession) -> None:
     """When dispatch raises, the row is updated to error and the exception re-raised."""
     exc = RuntimeError("tool exploded")
     dispatch = _make_failing_dispatch(exc)
@@ -520,7 +529,7 @@ async def test_dispatch_raises_writes_error_row_and_reraises(db_session: AsyncSe
 
 
 @pytest.mark.asyncio
-async def test_denied_on_matching_exception_writes_denied_row(db_session: AsyncSession):
+async def test_denied_on_matching_exception_writes_denied_row(db_session: AsyncSession) -> None:
     """When dispatch raises an exception listed in denied_on, outcome='denied' (not 'error')."""
 
     class PolicyRefusal(Exception):
@@ -556,7 +565,7 @@ async def test_denied_on_matching_exception_writes_denied_row(db_session: AsyncS
 
 
 @pytest.mark.asyncio
-async def test_denied_on_non_matching_exception_writes_error_row(db_session: AsyncSession):
+async def test_denied_on_non_matching_exception_writes_error_row(db_session: AsyncSession) -> None:
     """When dispatch raises an exception NOT in denied_on, outcome='error' (unchanged)."""
 
     class PolicyRefusal(Exception):
@@ -592,7 +601,7 @@ async def test_denied_on_non_matching_exception_writes_error_row(db_session: Asy
 
 
 @pytest.mark.asyncio
-async def test_dispatch_raises_annotates_span(db_session: AsyncSession):
+async def test_dispatch_raises_annotates_span(db_session: AsyncSession) -> None:
     """On dispatch failure the span is annotated with outcome=error (not the exception)."""
     exc = ValueError("inner error")
     dispatch = _make_failing_dispatch(exc)
@@ -649,7 +658,7 @@ def _make_flush_commit_trackers(
 
 
 @pytest.mark.asyncio
-async def test_flush_not_commit_happy_path(db_session: AsyncSession):
+async def test_flush_not_commit_happy_path(db_session: AsyncSession) -> None:
     """Happy path: flush IS called, commit is NEVER called."""
     flush_calls, commit_calls = _make_flush_commit_trackers(db_session)
 
@@ -673,7 +682,7 @@ async def test_flush_not_commit_happy_path(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_flush_not_commit_tier_refusal(db_session: AsyncSession):
+async def test_flush_not_commit_tier_refusal(db_session: AsyncSession) -> None:
     """Tier-refusal path: flush IS called before the raise, commit is NEVER called."""
     flush_calls, commit_calls = _make_flush_commit_trackers(db_session)
 
@@ -698,7 +707,7 @@ async def test_flush_not_commit_tier_refusal(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_flush_not_commit_dispatch_raises(db_session: AsyncSession):
+async def test_flush_not_commit_dispatch_raises(db_session: AsyncSession) -> None:
     """Dispatch-raises path: flush IS called before the re-raise, commit is NEVER called."""
     flush_calls, commit_calls = _make_flush_commit_trackers(db_session)
 
@@ -741,7 +750,7 @@ def test_governance_module_has_no_estimate_tool_cost() -> None:
 
 
 @pytest.mark.asyncio
-async def test_single_estimate_cost_recorded_verbatim(db_session: AsyncSession):
+async def test_single_estimate_cost_recorded_verbatim(db_session: AsyncSession) -> None:
     """The helper records the caller's estimated_cost verbatim — never recomputes.
 
     Passes a distinctive estimated_cost and verifies the row's cost_usd equals
@@ -786,7 +795,7 @@ async def test_single_estimate_cost_recorded_verbatim(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_optional_ids_stored_in_row(db_session: AsyncSession):
+async def test_optional_ids_stored_in_row(db_session: AsyncSession) -> None:
     """chat_id, message_id, session_id, request_id land on the row."""
     # user_id has a FK to users — create a real user row
     user = User(

--- a/api/tests/test_trace_propagation.py
+++ b/api/tests/test_trace_propagation.py
@@ -26,7 +26,8 @@ See ``docs/architecture.md`` §OBS and
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator
+from collections.abc import Awaitable, Callable, Iterator, MutableMapping
+from typing import Any
 
 import httpx
 import pytest
@@ -121,10 +122,14 @@ async def test_chat_send_produces_single_trace_across_api_and_gateway(
     # --- api half: capture the traceparent the api emits on the wire ---
     wire: dict[str, str] = {}
 
-    async def wire_tap(scope: dict, receive: object, send: object) -> None:  # type: ignore[type-arg]
+    async def wire_tap(
+        scope: MutableMapping[str, Any],
+        receive: Callable[[], Awaitable[MutableMapping[str, Any]]],
+        send: Callable[[MutableMapping[str, Any]], Awaitable[None]],
+    ) -> None:
         wire.update((k.decode(), v.decode()) for k, v in scope["headers"])
-        await send({"type": "http.response.start", "status": 200, "headers": []})  # type: ignore[operator]
-        await send({"type": "http.response.body", "body": b"ok"})  # type: ignore[operator]
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
 
     api_transport = AsyncOpenTelemetryTransport(httpx.ASGITransport(app=wire_tap))
     async with httpx.AsyncClient(transport=api_transport, base_url="http://gateway") as api_client:
@@ -171,17 +176,21 @@ async def test_api_outbound_injects_w3c_traceparent(
 
     captured: dict[str, str] = {}
 
-    async def receiver(scope: dict, receive: object, send: object) -> None:  # type: ignore[type-arg]
+    async def receiver(
+        scope: MutableMapping[str, Any],
+        receive: Callable[[], Awaitable[MutableMapping[str, Any]]],
+        send: Callable[[MutableMapping[str, Any]], Awaitable[None]],
+    ) -> None:
         assert scope["type"] == "http"
         captured.update((k.decode(), v.decode()) for k, v in scope["headers"])
         await send(
-            {  # type: ignore[operator]
+            {
                 "type": "http.response.start",
                 "status": 200,
                 "headers": [(b"content-type", b"text/plain")],
             }
         )
-        await send({"type": "http.response.body", "body": b"ok"})  # type: ignore[operator]
+        await send({"type": "http.response.body", "body": b"ok"})
 
     transport = AsyncOpenTelemetryTransport(httpx.ASGITransport(app=receiver))
     tracer = trace.get_tracer("lq-ai-api-test")

--- a/api/tests/test_treatment_judge.py
+++ b/api/tests/test_treatment_judge.py
@@ -10,22 +10,24 @@ from app.citation.treatment_judge import (
     judge_treatment,
     parse_treatment_response,
 )
+from app.schemas.gateway import ChatCompletionRequest
 
 
-def _resp(content: str):
+def _resp(content: str) -> SimpleNamespace:
     return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
 
 
-def test_prompt_includes_case_and_snippet():
+def test_prompt_includes_case_and_snippet() -> None:
     msgs = build_treatment_judge_prompt(
         cited_case_name="Smith v. Jones", snippet="We overrule Smith."
     )
     assert msgs[0].role == "system" and msgs[1].role == "user"
+    assert msgs[1].content is not None
     assert "Smith v. Jones" in msgs[1].content and "We overrule Smith." in msgs[1].content
 
 
 @pytest.mark.parametrize("cls", TREATMENT_CLASSES)
-def test_parse_accepts_every_class(cls):
+def test_parse_accepts_every_class(cls: str) -> None:
     out = parse_treatment_response(
         _resp(json.dumps({"treatment": cls, "confidence": "high", "justification": "x"}))
     )
@@ -47,18 +49,20 @@ def test_parse_accepts_every_class(cls):
         json.dumps({"treatment": "followed", "confidence": "high"}),  # missing justification
     ],
 )
-def test_parse_returns_none_on_garbage(bad):
+def test_parse_returns_none_on_garbage(bad: str) -> None:
     assert parse_treatment_response(_resp(bad)) is None
 
 
-def test_parse_none_on_no_choices():
+def test_parse_none_on_no_choices() -> None:
     assert parse_treatment_response(SimpleNamespace(choices=[])) is None
 
 
 @pytest.mark.asyncio
-async def test_judge_treatment_swallows_gateway_error():
+async def test_judge_treatment_swallows_gateway_error() -> None:
     class Boom:
-        async def chat_completion(self, request, *, request_id=None):
+        async def chat_completion(
+            self, request: ChatCompletionRequest, *, request_id: str | None = None
+        ) -> SimpleNamespace:
             raise RuntimeError("down")
 
     assert (
@@ -68,11 +72,13 @@ async def test_judge_treatment_swallows_gateway_error():
 
 
 @pytest.mark.asyncio
-async def test_judge_treatment_tags_purpose_and_parses():
-    seen = {}
+async def test_judge_treatment_tags_purpose_and_parses() -> None:
+    seen: dict[str, object] = {}
 
     class GW:
-        async def chat_completion(self, request, *, request_id=None):
+        async def chat_completion(
+            self, request: ChatCompletionRequest, *, request_id: str | None = None
+        ) -> SimpleNamespace:
             seen["purpose"] = request.lq_ai_purpose
             seen["anonymize"] = request.anonymize
             seen["temperature"] = request.temperature

--- a/api/tests/test_treatment_rollup.py
+++ b/api/tests/test_treatment_rollup.py
@@ -2,11 +2,11 @@ from app.citation.treatment_judge import TreatmentJudgment
 from app.citation.treatment_rollup import NEGATIVE_SEVERITY, Rollup, roll_up
 
 
-def _j(cls, conf=0.7):
+def _j(cls: str, conf: float = 0.7) -> TreatmentJudgment:
     return TreatmentJudgment(classification=cls, confidence=conf, justification="x")
 
 
-def test_severity_order_is_fixed():
+def test_severity_order_is_fixed() -> None:
     assert NEGATIVE_SEVERITY == (
         "overruled",
         "superseded",
@@ -16,12 +16,12 @@ def test_severity_order_is_fixed():
     )
 
 
-def test_empty():
+def test_empty() -> None:
     r = roll_up([])
     assert r == Rollup(None, {}, None, 0)
 
 
-def test_all_non_negative_has_no_strongest():
+def test_all_non_negative_has_no_strongest() -> None:
     r = roll_up([_j("followed"), _j("neutral"), _j("followed")])
     assert r.strongest_negative_class is None
     assert r.case_confidence is None
@@ -29,27 +29,30 @@ def test_all_non_negative_has_no_strongest():
     assert r.judged_count == 3
 
 
-def test_picks_most_severe_negative():
+def test_picks_most_severe_negative() -> None:
     r = roll_up([_j("distinguished"), _j("questioned"), _j("overruled"), _j("followed")])
     assert r.strongest_negative_class == "overruled"
     assert r.per_class_counts["distinguished"] == 1
 
 
-def test_corroboration_bumps_confidence():
+def test_corroboration_bumps_confidence() -> None:
     # two "questioned" @0.70 → 0.70 + 0.05*(2-1) = 0.75
     r = roll_up([_j("questioned", 0.70), _j("questioned", 0.70), _j("followed")])
     assert r.strongest_negative_class == "questioned"
+    assert r.case_confidence is not None
     assert abs(r.case_confidence - 0.75) < 1e-9
 
 
-def test_confidence_capped():
+def test_confidence_capped() -> None:
     sig = [_j("criticized", 0.90)] * 6  # 0.90 + 0.05*5 = 1.15 → cap 0.95
     r = roll_up(sig)
+    assert r.case_confidence is not None
     assert abs(r.case_confidence - 0.95) < 1e-9
 
 
-def test_confidence_uses_strongest_class_only():
+def test_confidence_uses_strongest_class_only() -> None:
     # strongest = overruled (one @0.50); the questioned ones don't corroborate it
     r = roll_up([_j("overruled", 0.50), _j("questioned", 0.90), _j("questioned", 0.90)])
     assert r.strongest_negative_class == "overruled"
+    assert r.case_confidence is not None
     assert abs(r.case_confidence - 0.50) < 1e-9

--- a/api/tests/test_user_deletion.py
+++ b/api/tests/test_user_deletion.py
@@ -14,7 +14,7 @@ Hard-delete cascade behavior is covered separately in
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -29,7 +29,7 @@ from app.models import AuditLog, User, UserSession
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 

--- a/api/tests/test_user_export.py
+++ b/api/tests/test_user_export.py
@@ -14,7 +14,7 @@ import io
 import json
 import uuid
 import zipfile
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -30,7 +30,7 @@ from app.security import create_access_token, hash_password
 from app.workers.user_export import build_export_zip_for_test, export_gc_job
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -279,15 +279,15 @@ async def test_export_gc_clears_expired_rows(
 
     # Patch the storage delete and the session factory to use the test
     # session; arq's cron entry point goes through these.
-    from contextlib import asynccontextmanager
+    from contextlib import AbstractAsyncContextManager, asynccontextmanager
 
     monkeypatch.setattr("app.workers.user_export.delete_object", _fake_delete)
 
     @asynccontextmanager
-    async def _factory_cm():
+    async def _factory_cm() -> AsyncIterator[AsyncSession]:
         yield db_session
 
-    def _factory_callable():
+    def _factory_callable() -> AbstractAsyncContextManager[AsyncSession]:
         return _factory_cm()
 
     monkeypatch.setattr("app.workers.user_export.get_session_factory", lambda: _factory_callable)
@@ -298,7 +298,10 @@ async def test_export_gc_clears_expired_rows(
     assert len(deleted) >= 1
 
     # The expired row's storage_key is cleared; the fresh row is untouched.
-    await db_session.refresh(expired := await db_session.get(UserExportJob, expired_id))
-    await db_session.refresh(fresh := await db_session.get(UserExportJob, fresh_id))
-    assert expired.storage_key is None
-    assert fresh.storage_key is not None
+    expired_row = await db_session.get(UserExportJob, expired_id)
+    fresh_row = await db_session.get(UserExportJob, fresh_id)
+    assert expired_row is not None and fresh_row is not None
+    await db_session.refresh(expired_row)
+    await db_session.refresh(fresh_row)
+    assert expired_row.storage_key is None
+    assert fresh_row.storage_key is not None

--- a/api/tests/test_user_preferences.py
+++ b/api/tests/test_user_preferences.py
@@ -15,7 +15,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -29,7 +29,7 @@ from app.models import AuditLog, User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -117,6 +117,7 @@ async def test_patch_preferences_changes_value_and_writes_audit(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     changes = audit.details["changes"]
     assert changes["reasoning_visibility"]["before"] == "disclosure"
     assert changes["reasoning_visibility"]["after"] == "always_show"
@@ -186,7 +187,7 @@ async def test_users_check_constraint_blocks_invalid_value(
 
     from sqlalchemy.exc import IntegrityError
 
-    caller.reasoning_visibility = "invalid_value"
+    caller.reasoning_visibility = "invalid_value"  # type: ignore[assignment]  # intentionally invalid
     with pytest.raises(IntegrityError):
         await db_session.flush()
     await db_session.rollback()
@@ -217,6 +218,7 @@ async def test_patch_preferences_featured_tools_change_writes_audit(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     changes = audit.details["changes"]
     assert changes["featured_tools"]["before"] == "prominent"
     assert changes["featured_tools"]["after"] == "inline"
@@ -242,6 +244,7 @@ async def test_patch_preferences_workspace_layout_change_writes_audit(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     changes = audit.details["changes"]
     assert changes["workspace_layout"]["before"] == "three_pane"
     assert changes["workspace_layout"]["after"] == "two_pane"
@@ -267,6 +270,7 @@ async def test_patch_preferences_trust_pills_change_writes_audit(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     changes = audit.details["changes"]
     assert changes["trust_pills"]["before"] == "labels"
     assert changes["trust_pills"]["after"] == "dots"
@@ -292,6 +296,7 @@ async def test_patch_preferences_provenance_pills_change_writes_audit(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     changes = audit.details["changes"]
     assert changes["provenance_pills"]["before"] == "always"
     assert changes["provenance_pills"]["after"] == "collapsed"
@@ -333,6 +338,7 @@ async def test_patch_preferences_multi_field_change_single_audit_row(
         .all()
     )
     assert len(audits) == 1
+    assert audits[0].details is not None
     changes = audits[0].details["changes"]
     assert set(changes.keys()) == {"featured_tools", "trust_pills", "provenance_pills"}
 
@@ -357,7 +363,7 @@ async def test_users_check_constraint_blocks_invalid_featured_tools_value(
 
     from sqlalchemy.exc import IntegrityError
 
-    caller.featured_tools = "not_a_valid_value"
+    caller.featured_tools = "not_a_valid_value"  # type: ignore[assignment]  # intentionally invalid
     with pytest.raises(IntegrityError):
         await db_session.flush()
     await db_session.rollback()

--- a/api/tests/test_user_profile.py
+++ b/api/tests/test_user_profile.py
@@ -15,7 +15,7 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -30,7 +30,7 @@ from app.models import AuditLog, User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -184,4 +184,5 @@ async def test_patch_me_writes_audit_row(
         )
     ).scalar_one()
     assert audit.resource_type == "user"
+    assert audit.details is not None
     assert audit.details["fields"] == ["display_name"]

--- a/api/tests/test_user_skills.py
+++ b/api/tests/test_user_skills.py
@@ -27,7 +27,7 @@ the skill registry is injected via ``app.state.skill_registry``
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 
 import pytest
@@ -48,7 +48,7 @@ from app.skills.registry import MutableSkillRegistry
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "skills"
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -241,6 +241,7 @@ async def test_patch_partial_update_writes_audit_row(
         .all()
     )
     assert len(audit) == 1
+    assert audit[0].details is not None
     assert audit[0].details["changed_fields"] == ["display_name"]
 
 
@@ -271,6 +272,7 @@ async def test_patch_version_bump_records_before_and_after_in_audit(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["version_before"] == "1.0.0"
     assert audit.details["version_after"] == "1.1.0"
 
@@ -349,6 +351,7 @@ async def test_delete_soft_deletes_and_writes_audit(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["slug"] == "personal-nda"
 
 
@@ -510,7 +513,7 @@ async def test_fork_copies_built_in_into_user_scope(
         .scalars()
         .all()
     )
-    assert any(a.details.get("forked_from") == "alpha-test-skill" for a in audit)
+    assert any((a.details or {}).get("forked_from") == "alpha-test-skill" for a in audit)
 
 
 @pytest.mark.integration
@@ -713,6 +716,7 @@ async def test_create_team_scope_skill_as_team_admin_returns_201(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["scope"] == "team"
     assert audit.details["team_id"] == str(team.id)
     assert audit.details["team_slug"] == "contracts"
@@ -863,6 +867,7 @@ async def test_patch_team_scope_as_team_admin_succeeds(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["scope"] == "team"
     assert audit.details["team_id"] == str(team.id)
 
@@ -917,6 +922,7 @@ async def test_delete_team_scope_as_team_admin_archives_row(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["scope"] == "team"
     assert audit.details["team_id"] == str(team.id)
 

--- a/api/tests/test_user_skills_slash_alias.py
+++ b/api/tests/test_user_skills_slash_alias.py
@@ -14,14 +14,16 @@ Task 1.2 NEEDS_CONTEXT resolution.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
 from app.api.user_skills import UserSkillCreate, UserSkillUpdate
 
 
-def _base_payload(**overrides: object) -> dict[str, object]:
-    base: dict[str, object] = {
+def _base_payload(**overrides: object) -> dict[str, Any]:
+    base: dict[str, Any] = {
         "slug": "personal-nda",
         "display_name": "Personal NDA",
         "description": "My NDA workflow",

--- a/api/tests/test_users_preferences_autonomous.py
+++ b/api/tests/test_users_preferences_autonomous.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
@@ -17,7 +17,7 @@ from app.models import AuditLog, User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -87,6 +87,7 @@ async def test_preferences_patch_opt_in(
             )
         )
     ).scalar_one()
+    assert audit.details is not None
     changes = audit.details["changes"]
     assert changes["autonomous_enabled"]["before"] == "False"
     assert changes["autonomous_enabled"]["after"] == "True"

--- a/api/tests/test_wave_b.py
+++ b/api/tests/test_wave_b.py
@@ -14,7 +14,7 @@ indexes get exercised end-to-end.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock
@@ -34,7 +34,7 @@ from app.models.inference import InferenceRoutingLog
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -248,6 +248,7 @@ async def test_admin_tier_policy_patch_writes_audit(
     audit = (
         await db_session.execute(select(AuditLog).where(AuditLog.action == "tier_policy.updated"))
     ).scalar_one()
+    assert audit.details is not None
     assert audit.details["before"]["default_minimum_tier"] == 4
     assert audit.details["after"]["default_minimum_tier"] == 3
 

--- a/api/tests/test_wave_c.py
+++ b/api/tests/test_wave_c.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 import uuid
 import zipfile
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from io import BytesIO
 
 import pytest
@@ -35,7 +35,7 @@ from app.security import create_access_token, hash_password
 from app.workers.user_export import build_export_zip_for_test
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 
@@ -179,6 +179,7 @@ async def test_update_user_role_admin_to_member_writes_audit(
     )
     # Two updates (promote + demote) → two audit rows.
     assert len(audit) == 2
+    assert audit[-1].details is not None
     assert audit[-1].details["after"]["role"] == "member"
     assert audit[-1].details["before"]["role"] == "admin"
 

--- a/api/tests/test_word_addin_endpoints.py
+++ b/api/tests/test_word_addin_endpoints.py
@@ -16,7 +16,7 @@ before a stale manifest reached an operator's sideload.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from xml.etree import ElementTree
 
@@ -36,7 +36,7 @@ from app.models.user import User
 from app.security import create_access_token, hash_password
 
 
-def _override_get_db(db_session: AsyncSession):
+def _override_get_db(db_session: AsyncSession) -> Callable[[], AsyncIterator[AsyncSession]]:
     async def _override() -> AsyncIterator[AsyncSession]:
         yield db_session
 


### PR DESCRIPTION
## What / why

DE-284 (PRD §9): the api test suite was outside the mypy gate. Measured at start: **658 errors in 163 files** (the count had drifted well past older estimates). This PR takes it to **zero** and flips the CI gate to `mypy app tests` in the same change — no window where the gate is ahead of the code.

Part of the coordinated roadmap sweep (umbrella issue #321).

## Shape of the diff (wide and shallow, by design)

- 163 test files + 3 conftests: `-> None`, fixture/parameter annotations (real types — AsyncSession, AsyncClient, MonkeyPatch), 1003 insertions / 651 deletions.
- **Zero production diffs** — `git diff -- api/app` is empty (verified).
- Non-annotation mechanical fixes, semantics preserved (full suite green): legacy `__table__.delete()` → `sqlalchemy.delete(Model)`; primary-key iteration off `.columns`; OTel span-attribute narrowing; conftest savepoint listener moved off private `trans._parent` to public `trans.parent` with a None-guard; a sync fixture wrongly decorated `@pytest_asyncio.fixture` corrected; arq coroutine access via `__qualname__` per its protocol; dict-coercion Pydantic tests → `model_validate`.
- `type: ignore` hygiene: **21 added** (all precise + commented: structural test stubs vs nominal `GatewayClient`/`SkillRegistry` types per existing repo convention; intentionally-invalid-input tests; three third-party gaps — openpyxl stubs, Starlette handler contravariance, arq returns-None) and **43 stale ignores removed** (net −22). None masks a production bug; no genuine `api/app` type bugs surfaced.

## Evidence

`mypy app tests` → `Success: no issues found in 439 source files` · ruff format/check clean (both local and CI-style root invocations) · full suite **2623 passed, 1 skipped, 0 failed** (throwaway pgvector:pg16) · ci.yml parses.

Merge note: wide-shallow diff — lands cleanest fast; conflicts with in-flight test-touching PRs resolve trivially (annotations only).

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Re-raised after I accidentally deleted my fork, which auto-closed the original PR. **Supersedes #393** — same head commit (`a415757024da`), no content change. GitHub cannot reopen a cross-repo PR once its head repository is gone, hence the new number._

_Any PR numbers referenced in the body above point at the original (now-closed) PRs; the old → new mapping table is on umbrella issue #321._
