### PR TITLE
test(gateway): pin OLLAMA_BASE_URL in the test fixture

### DIFF
--- a/gateway/tests/conftest.py
+++ b/gateway/tests/conftest.py
@@ -38,6 +38,13 @@ def example_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
     monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
+    # Pin the placeholders that have a `:-default` in gateway.yaml.example too,
+    # or the suite silently inherits the developer's shell. `.env.example` tells
+    # operators to export OLLAMA_BASE_URL=http://host.docker.internal:11434, and
+    # a developer who did that would otherwise have the ollama-local provider
+    # point somewhere respx has no mock for — a real failure that reproduces on
+    # one machine and not the next. Tests should not read ambient config.
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama:11434")
 
 
 @asynccontextmanager


### PR DESCRIPTION
## What

`example_env` in `gateway/tests/conftest.py` fills the `${VAR}` placeholders in
`gateway.yaml.example`, but not the ones that carry a `:-default`. `OLLAMA_BASE_URL`
is one of those, so the suite silently inherits whatever the developer has exported.

## Why it matters

`.env.example` explicitly instructs operators to set
`OLLAMA_BASE_URL=http://host.docker.internal:11434` — host Ollama is the documented
default, and `docker-compose.release.yml` has no `ollama` service at all. A developer
who followed that instruction gets the `ollama-local` provider pointing at a host
`respx` has no mock for, so `tests/test_model_discovery.py` fails on their machine and
passes on the next one.

Pinning it to the compose default makes the fixture hermetic. Tests should not read
ambient configuration.

## Verification

```
OLLAMA_BASE_URL=http://host.docker.internal:11434 pytest tests/test_model_discovery.py
```
fails before this change, passes after (29 passed). Full gateway suite unaffected;
`ruff check`, `ruff format --check` clean.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

---

Found while addressing review feedback on #400 — that PR makes the local-provider
guard effective, which is what turns this latent ambient-env dependency into a visible
failure. Split out deliberately so #400 stays scoped to the requested change.