### PR TITLE
Chore/deps grouping cypress skip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,17 @@ updates:
   # name+version diffs rather than range widenings. The cooldown holds a
   # bump until the release is at least 7 days old — the release-age posture
   # dependency review already applies by hand at the security boundary.
+  #
+  # Grouping is a merge-throughput measure, not a review shortcut. CI gates
+  # lock freshness with `uv lock --check` (ADR 0023), so a lockfile admits
+  # one write at a time: N separate PRs against the same lock must merge
+  # strictly serially, each waiting a full CI cycle after a rebase. One
+  # grouped PR is one lock write.
+  #
+  # Two things stay deliberately ungrouped:
+  #   - security updates — `applies-to: version-updates` scopes the group,
+  #     so an advisory fix is never queued behind routine hygiene;
+  #   - majors — omitted from `update-types`, since each needs its own read.
   - package-ecosystem: uv
     directory: /api
     schedule:
@@ -13,6 +24,11 @@ updates:
       default-days: 7
     open-pull-requests-limit: 5
     labels: ["dependencies", "api"]
+    groups:
+      api-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: uv
     directory: /gateway
@@ -22,16 +38,39 @@ updates:
       default-days: 7
     open-pull-requests-limit: 5
     labels: ["dependencies", "gateway"]
+    groups:
+      gateway-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
+  # web/ shares one package-lock.json, so it serialises exactly as the uv
+  # locks do. The cooldown was previously uv-only; npm now carries the same
+  # 7-day window, which is the posture docs/security/dependencies.md already
+  # describes for the locked ecosystems.
   - package-ecosystem: npm
     directory: /web
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels: ["dependencies", "web"]
+    groups:
+      web-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     labels: ["dependencies", "ci"]
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,13 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
+        # Cypress ships a large binary fetched from download.cypress.io on
+        # postinstall. This job runs svelte-check and Vitest only, and no
+        # workflow in the repo invokes Cypress, so the download is pure
+        # risk: a CDN blip reds a PR that never touched web/. Scoped to
+        # this step so a future Cypress job installs the binary normally.
+        env:
+          CYPRESS_INSTALL_BINARY: "0"
         run: npm ci
 
       - name: svelte-check (typecheck — LQ.AI-owned code)


### PR DESCRIPTION
## What this PR does

Two `.github/` plumbing changes that reduce the cost of dependency PRs:

1. `dependabot.yml` — group routine minor/patch updates per ecosystem into
   one PR each, add the 7-day cooldown to the npm and github-actions
   ecosystems, keep security updates and majors ungrouped.
2. `ci.yml` — skip the Cypress binary download in the Web job.

## Why

**Grouping.** ADR 0023 made CI gate lock freshness with `uv lock --check`.
That is correct, and it has a consequence: every PR touching a given
lockfile invalidates every other open PR against that lockfile. With five
open PRs per lock, merging them means five serial merge→rebase→re-verify
cycles, each waiting on the ~17-minute API job. The current backlog has 19
open Dependabot PRs across four lockfiles; merged one at a time that is
several hours of supervised wall-clock for routine hygiene.

Grouping makes one lock write cover many bumps. Two exclusions are
deliberate: `applies-to: version-updates` keeps advisory-driven updates
arriving individually, so a security fix is never queued behind a linter
bump; and omitting `major` from `update-types` keeps every major on its own,
since those need individual review regardless.

The npm cooldown closes an asymmetry rather than adding a new policy —
`docs/security/dependencies.md` already describes the 7-day release-age
window for the uv ecosystems. npm had none, which is why a 5-day-old
transitive and a 2-day-old major are currently sitting in open PRs.

**Cypress.** The Web job runs `npm ci`, which triggers Cypress's postinstall
binary fetch from `download.cypress.io`. That job runs svelte-check and
Vitest; no workflow in the repo invokes Cypress. The download is a
third-party network dependency on every PR, including PRs that touch no
frontend code — it red-flagged a `gateway/`-only security bump this week.

## What this PR does *not* do

- Does not change what gets updated, only how updates are batched.
- Does not touch any lockfile or manifest.
- Does not remove Cypress or its specs; the env var is scoped to one step,
  so a future Cypress job installs the binary normally.
- Does not address the open advisories on `starlette` 0.48.0 or
  `cryptography` 44.0.3 — those are separate and tracked.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Skill contribution (see attestation below)
- [ ] Refactor (no behavioral change)
- [x] Test / CI / tooling

## Testing

<!-- How did you verify the change? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Manually tested against a real deployment (describe scenario below)
- [ ] Acceptance test plan updated (if changing skill behavior)
- [x] Manually tested — verified no workflow references Cypress

<details>
<summary>Manual testing notes (if applicable)</summary>
verified no workflow references Cypress
      (`git grep -l cypress .github/workflows/` returns nothing), so the
      Web job's `npm ci` is the only consumer of the download.

Grouping behaviour is observable on the next scheduled run rather than in
CI; the config is validated by Dependabot on push.
<!-- What you ran, against what configuration, and what you observed. -->

</details>

## Documentation

- [ ] PRD updated (if user-facing behavior changes)
- [ ] README updated (if quickstart or capability list changes)
- [ ] Skill-authoring guide updated (if skill conventions change)
- [ ] Deployment cookbook updated (if deployment changes)
- [ ] Compliance documentation updated (if compliance posture changes)
- [ ] OpenAPI schema regenerated (if API endpoints change)

## Transparency & governance invariants

<!-- The posture that *is* the product (ADR 0016). Check each box or mark it
n/a. If you can't, stop and either fix the change or surface the decision to a
maintainer. The cheap-to-check ones are enforced by
api/tests/test_transparency_invariants.py — but the judgment ones are on you. -->

- [x] **Egress (P1):** n/a — no outbound call added; this removes one.
- [ ] **Closed set (P2):** any new model/autonomous-invokable capability is a bounded, operator-controlled allowlist entry, not an open hook.
- [ ] **No raw payloads (P3):** no row or log line I add carries raw content (message bodies, tool args/results, fetched text, keys) — counts, types, ids, digests, outcomes only.
- [ ] **Fail restrictive (P4):** missing/broken config fails closed, and I tested that path, not just the happy path.
- [ ] **Atomic audit (P5):** state changes get an audit row committed in the same transaction (helpers flush, the handler commits).
- [ ] **One governance path (P6):** I reused the shared governance/audit helpers rather than re-deriving tier/cost/audit logic.
- [ ] **Human gate (P7):** anything destructive/irreversible is behind the confirmation gate and excluded from unattended/autonomous execution.
- [ ] **Operator control (P8):** any new capability has an operator enable/disable and appears on an admin surface.
- [ ] **User owns data (P9):** outbound matter context is anonymized; the change respects export/delete and data-residency guarantees.
- [ ] **Contract is truth (P10):** OpenAPI sketch / DB schema doc / relevant ADR updated in this PR; any architectural/authz decision is recorded or surfaced, not made silently.

## DCO sign-off

- [x] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

<!-- Verify with: git log --show-signature -->

## Related issues

<!-- Closes #123, Refs DE-013, etc. -->

---

<!-- ============================================================
SKILL CONTRIBUTION ATTESTATION (uncomment if this PR contributes
or substantively modifies a skill containing legal substance)

## Skill attestation

I have reviewed the substantive legal content of this skill and
certify that, to the best of my knowledge as a [practicing
attorney / legal professional / specific role], the patterns,
severity calibrations, recommended language, and reference
material reflect accurate and reasonable legal practice in
[jurisdiction(s)]. I understand that this skill will be used in
real practice and that errors could affect real legal work; I
have authored this skill with the same care I would apply to my
own client work.

Signed: [your name and any relevant qualifications]

If you are not a practicing attorney, follow the alternative
attestation paths in skills/CONTRIBUTING.md (pair with a
practicing-attorney co-author, or have a practicing attorney
review the skill before submission).
============================================================ -->

## Reviewer notes

<!-- Anything the reviewer should know — areas where you'd specifically
appreciate scrutiny, design decisions you considered alternatives for,
known limitations of this PR. -->
