### PR TITLE
ci: sweep five Dependabot action bumps into one release.yml write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: web
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         # No dependency cache: setup-python only caches pip's wheel cache,
@@ -152,7 +152,7 @@ jobs:
         working-directory: gateway
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         # No dependency cache: setup-python only caches pip's wheel cache,

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -28,7 +28,7 @@ jobs:
       run:
         working-directory: desktop
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
@@ -56,7 +56,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run dist
       - name: Publish .dmg to the release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: desktop/dist/*.dmg
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
             file: proxy/Dockerfile
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve image tag
         id: tag
@@ -71,11 +71,11 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GHCR
         if: ${{ github.event_name == 'push' || !inputs.dry_run }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -121,7 +121,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve image tag
         id: tag
@@ -138,7 +138,7 @@ jobs:
       # this job was missing the equivalent step). packages:read on this job is
       # sufficient for the pull.
       - name: Login to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -181,7 +181,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve image tag
         id: tag
@@ -193,19 +193,19 @@ jobs:
           fi
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: v2.4.0
 
       - name: Login to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download SBOM artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.service }}.spdx.json
           path: ./sbom

--- a/.github/workflows/stack-smoke.yml
+++ b/.github/workflows/stack-smoke.yml
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Free runner disk space
         # The api-family image unpacks to ~12 GB on its own (docling


### PR DESCRIPTION
Applies the exact SHA pins from #464, #444, #448, #465 and #466:

  actions/checkout            v7.0.0 -> v7.0.1  (ci, release, desktop-release, stack-smoke)
  softprops/action-gh-release v3.0.1 -> v3.0.2  (desktop-release)
  docker/setup-buildx-action  v3     -> v4.2.0  (release)
  docker/login-action         v3     -> v4.4.0  (release, x3)
  sigstore/cosign-installer   v3     -> v4.1.2  (release)
  actions/download-artifact   v4     -> v8.0.1  (release)

All five PRs edit release.yml, so they serialise on textual conflict: five merges cost five rebase-and-wait cycles for what is one file write. Every SHA here is copied from the corresponding PR's diff and is verifiable against it line by line; 15 lines change and all 15 are action pins. The loose `# v3` / `# v4` comments on the four majors are tightened to exact versions.

Verification is partial, and stating so is the point. `workflow_dispatch` with dry_run=true (the default) skips the `sbom` and `sign` jobs entirely via their job-level `if:`, plus the login and attest steps inside `build-and-push`. A dry run therefore exercises only checkout and setup-buildx. cosign-installer, login-action and download-artifact are first exercised by a tag push, so cut the next release as an RC tag (`vX.Y.Z-rc1` matches the `v*.*.*` trigger) and let a break land there rather than on the real release. download-artifact is the one to watch: the sign job reads ./sbom/<service>.spdx.json, an extraction path a four-major jump can plausibly move.

Refs #464, #444, #448, #465, #466


Claude-Session: https://claude.ai/code/session_01CXS1TC1C6Y2EJa36YuUjbk

## What this PR does

<!-- One or two sentences describing the change. Keep this scoped to what
actually changed; the why goes in the next section. -->

## Why

<!-- The motivation. If this PR closes an issue or implements a deferred
enhancement, link it: "Closes #123" or "Refs DE-013". -->

## What this PR does *not* do

<!-- Optional but encouraged for non-trivial PRs. Naming the explicit
non-goals prevents reviewer scope creep and makes follow-up PRs cleaner. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Skill contribution (see attestation below)
- [ ] Refactor (no behavioral change)
- [ ] Test / CI / tooling

## Testing

<!-- How did you verify the change? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Manually tested against a real deployment (describe scenario below)
- [ ] Acceptance test plan updated (if changing skill behavior)

<details>
<summary>Manual testing notes (if applicable)</summary>

<!-- What you ran, against what configuration, and what you observed. -->

</details>

## Documentation

- [ ] PRD updated (if user-facing behavior changes)
- [ ] README updated (if quickstart or capability list changes)
- [ ] Skill-authoring guide updated (if skill conventions change)
- [ ] Deployment cookbook updated (if deployment changes)
- [ ] Compliance documentation updated (if compliance posture changes)
- [ ] OpenAPI schema regenerated (if API endpoints change)

## Transparency & governance invariants

<!-- The posture that *is* the product (ADR 0016). Check each box or mark it
n/a. If you can't, stop and either fix the change or surface the decision to a
maintainer. The cheap-to-check ones are enforced by
api/tests/test_transparency_invariants.py — but the judgment ones are on you. -->

- [ ] **Egress (P1):** any outbound third-party call goes through the gateway only — no direct egress from `api/`.
- [ ] **Closed set (P2):** any new model/autonomous-invokable capability is a bounded, operator-controlled allowlist entry, not an open hook.
- [ ] **No raw payloads (P3):** no row or log line I add carries raw content (message bodies, tool args/results, fetched text, keys) — counts, types, ids, digests, outcomes only.
- [ ] **Fail restrictive (P4):** missing/broken config fails closed, and I tested that path, not just the happy path.
- [ ] **Atomic audit (P5):** state changes get an audit row committed in the same transaction (helpers flush, the handler commits).
- [ ] **One governance path (P6):** I reused the shared governance/audit helpers rather than re-deriving tier/cost/audit logic.
- [ ] **Human gate (P7):** anything destructive/irreversible is behind the confirmation gate and excluded from unattended/autonomous execution.
- [ ] **Operator control (P8):** any new capability has an operator enable/disable and appears on an admin surface.
- [ ] **User owns data (P9):** outbound matter context is anonymized; the change respects export/delete and data-residency guarantees.
- [ ] **Contract is truth (P10):** OpenAPI sketch / DB schema doc / relevant ADR updated in this PR; any architectural/authz decision is recorded or surfaced, not made silently.

## DCO sign-off

- [ ] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

<!-- Verify with: git log --show-signature -->

## Related issues

<!-- Closes #123, Refs DE-013, etc. -->

---

<!-- ============================================================
SKILL CONTRIBUTION ATTESTATION (uncomment if this PR contributes
or substantively modifies a skill containing legal substance)

## Skill attestation

I have reviewed the substantive legal content of this skill and
certify that, to the best of my knowledge as a [practicing
attorney / legal professional / specific role], the patterns,
severity calibrations, recommended language, and reference
material reflect accurate and reasonable legal practice in
[jurisdiction(s)]. I understand that this skill will be used in
real practice and that errors could affect real legal work; I
have authored this skill with the same care I would apply to my
own client work.

Signed: [your name and any relevant qualifications]

If you are not a practicing attorney, follow the alternative
attestation paths in skills/CONTRIBUTING.md (pair with a
practicing-attorney co-author, or have a practicing attorney
review the skill before submission).
============================================================ -->

## Reviewer notes

<!-- Anything the reviewer should know — areas where you'd specifically
appreciate scrutiny, design decisions you considered alternatives for,
known limitations of this PR. -->
