### PR TITLE
Stage the release pipeline and add ADR 0025 (release versioning policy)

### DIFF
--- a/.github/actions/build-push-image/action.yml
+++ b/.github/actions/build-push-image/action.yml
@@ -1,0 +1,78 @@
+name: Build and push a release image
+description: >-
+  Builds one multi-arch LQ.AI service image, pushes it to GHCR, and attaches SLSA
+  build provenance. Extracted from release.yml so the backend and frontend release
+  stages (ADR 0025) share one copy of this logic instead of duplicating the
+  build-and-attest steps per stage.
+
+inputs:
+  service:
+    description: Service name; becomes the lq-ai-<service> image name.
+    required: true
+  context:
+    description: Docker build context.
+    required: true
+  file:
+    description: Dockerfile path.
+    required: true
+  build_args:
+    description: Optional newline-separated KEY=VALUE build args.
+    required: false
+    default: ""
+  tag:
+    description: Image tag to publish (e.g. v1.2.3 or dryrun-abc1234).
+    required: true
+  push:
+    description: '"true" to push and attest; "false" for a build-only dry run.'
+    required: true
+  registry:
+    description: Container registry host.
+    required: false
+    default: ghcr.io
+  image_owner:
+    description: Registry namespace.
+    required: false
+    default: legalquants
+
+runs:
+  using: composite
+  steps:
+    - name: Set up QEMU
+      # Enables cross-platform (linux/arm64) builds on the amd64 runner.
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    - name: Login to GHCR
+      if: inputs.push == 'true'
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build and push
+      id: build
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        # Only the web entry sets build_args; for api/gateway/proxy this resolves
+        # to empty (no stray build-arg).
+        build-args: ${{ inputs.build_args }}
+        platforms: linux/amd64,linux/arm64
+        push: ${{ inputs.push == 'true' }}
+        tags: |
+          ${{ inputs.registry }}/${{ inputs.image_owner }}/lq-ai-${{ inputs.service }}:${{ inputs.tag }}
+          ${{ inputs.registry }}/${{ inputs.image_owner }}/lq-ai-${{ inputs.service }}:latest
+        provenance: false   # SLSA provenance is attached below via attest-build-provenance
+        sbom: false         # SBOM is attached by the sbom job via anchore/sbom-action
+
+    - name: Generate SLSA build provenance
+      if: inputs.push == 'true'
+      uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+      with:
+        subject-name: ${{ inputs.registry }}/${{ inputs.image_owner }}/lq-ai-${{ inputs.service }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,21 @@
 name: Release
 
+# Staged per ADR 0025 (release versioning policy and pipeline ordering):
+#
+#   setup → version-consistency → build-backend → build-frontend → sbom → sign
+#
+# The ordering matters. Before ADR 0025 all four services built as one unordered
+# matrix with fail-fast: false, so a failed `api` build did not stop `web` from
+# publishing — and tagging :latest — under the same tag. `build-frontend` now
+# carries `needs: build-backend`, so a backend failure structurally blocks the
+# frontend from publishing.
+#
+# Known limitation (honest scope, see ADR 0025 Consequences): the guarantee is
+# *between* stages, not within one. fail-fast cancels sibling builds in a stage
+# but cannot un-push an image that already pushed. Eliminating intra-stage
+# partial publishes needs a build-then-push-in-a-second-pass design, which
+# ADR 0025 does not decide.
+
 on:
   push:
     tags:
@@ -22,27 +38,233 @@ env:
   IMAGE_OWNER: legalquants
 
 jobs:
-  build-and-push:
+  # Resolve the image tag and the push/dry-run decision once, rather than
+  # repeating the same shell in every downstream job.
+  setup:
+    name: Resolve release parameters
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.cfg.outputs.tag }}
+      push: ${{ steps.cfg.outputs.push }}
+    steps:
+      - name: Resolve tag and push decision
+        id: cfg
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=dryrun-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ "${{ github.event_name }}" == "push" || "${{ inputs.dry_run }}" == "false" ]]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ADR 0025 decision 1: api, gateway, web and proxy share one release version.
+  # Only api and gateway carry a project-owned version string, so those are what
+  # this compares. web/package.json tracks the OpenWebUI fork upstream and is
+  # deliberately NOT checked; proxy has no version string.
+  version-consistency:
+    name: Version consistency
+    needs: setup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # the breaking-change gate below lists merged PRs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the breaking-change gate walks the commit
+          # range back to the previous release tag.
+          fetch-depth: 0
+
+      - name: Check api and gateway versions agree with each other and the tag
+        env:
+          RELEASE_TAG: ${{ needs.setup.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          extract() {
+            sed -n 's/^__version__ = "\(.*\)"$/\1/p' "$1"
+          }
+
+          api_v="$(extract api/app/__init__.py)"
+          gw_v="$(extract gateway/app/__init__.py)"
+
+          if [[ -z "$api_v" || -z "$gw_v" ]]; then
+            echo "::error::Could not read __version__ from api/app/__init__.py and/or gateway/app/__init__.py."
+            exit 1
+          fi
+
+          echo "api     = $api_v"
+          echo "gateway = $gw_v"
+          echo "tag     = $RELEASE_TAG"
+
+          # Escape hatch required by ADR 0025 decision 5: a release may ship with
+          # divergent versions only with justification recorded in the release PR.
+          # Put [allow-version-drift] in the tagged commit's message to take it;
+          # the reason belongs in the PR body, where reviewers will see it.
+          if git log -1 --pretty=%B | grep -qF '[allow-version-drift]'; then
+            echo "::warning::[allow-version-drift] present — version checks downgraded to warnings."
+            allow=1
+          else
+            allow=0
+          fi
+
+          rc=0
+          fail() {
+            if [[ "$allow" == "1" ]]; then
+              echo "::warning::$1"
+            else
+              echo "::error::$1"
+              rc=1
+            fi
+          }
+
+          if [[ "$api_v" != "$gw_v" ]]; then
+            fail "Version drift: api is $api_v but gateway is $gw_v. ADR 0025 requires them to move together."
+          fi
+
+          # Only enforce tag agreement on a real vX.Y.Z tag push; dry runs
+          # resolve to dryrun-<sha> and have nothing to compare against.
+          if [[ "$RELEASE_TAG" == v* ]]; then
+            want="${RELEASE_TAG#v}"
+            if [[ "$api_v" != "$want" ]]; then
+              fail "Tag $RELEASE_TAG does not match api version $api_v (expected $want)."
+            fi
+            if [[ "$gw_v" != "$want" ]]; then
+              fail "Tag $RELEASE_TAG does not match gateway version $gw_v (expected $want)."
+            fi
+          else
+            echo "Not a vX.Y.Z tag push — skipping tag agreement check."
+          fi
+
+          exit "$rc"
+
+      # ADR 0025 decision 3: a patch release never requires operator action.
+      # Changes that do are labelled `breaking-change` on their PR, and force the
+      # next release to a minor bump. This turns that runbook step into a gate.
+      #
+      # The gate is only as good as the labelling: an unlabelled breaking PR is
+      # invisible here. It catches the case where someone remembered at review
+      # time and forgot at release time, which is the common one.
+      - name: Check breaking changes force a minor bump
+        if: startsWith(needs.setup.outputs.tag, 'v')
+        env:
+          RELEASE_TAG: ${{ needs.setup.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # `|| true`: with pipefail, grep exits non-zero when this is the first
+          # release and the filtered list is empty, which would abort under `set -e`
+          # before the emptiness check below could report it.
+          prev_tag="$(git tag --list 'v*.*.*' --sort=-v:refname \
+                        | grep -v '^desktop-' | grep -vx "$RELEASE_TAG" | head -1 || true)"
+
+          if [[ -z "$prev_tag" ]]; then
+            echo "No previous release tag to compare against — skipping."
+            exit 0
+          fi
+          echo "Comparing $prev_tag..$RELEASE_TAG"
+
+          # PR numbers referenced by squash-merge subjects in the range, e.g.
+          # "Require gateway key on inference endpoints (GW-01, Refs #288) (#396)".
+          merged_prs="$(git log "${prev_tag}..HEAD" --no-merges --pretty=%s \
+                          | grep -oE '\(#[0-9]+\)$' | tr -d '(#)' | sort -u || true)"
+
+          labelled="$(gh pr list --repo "$GITHUB_REPOSITORY" \
+                        --label breaking-change --state merged \
+                        --limit 200 --json number -q '.[].number' \
+                        | sort -u || true)"
+
+          breaking="$(comm -12 <(printf '%s\n' "$merged_prs") <(printf '%s\n' "$labelled") || true)"
+
+          if [[ -z "${breaking//[[:space:]]/}" ]]; then
+            echo "No breaking-change PRs in range — a patch release is allowed."
+            exit 0
+          fi
+
+          echo "Breaking-change PRs merged since ${prev_tag}:"
+          for n in $breaking; do echo "  #$n"; done
+
+          IFS=. read -r pmaj pmin _ <<< "${prev_tag#v}"
+          IFS=. read -r cmaj cmin _ <<< "${RELEASE_TAG#v}"
+
+          if (( cmaj > pmaj || cmin > pmin )); then
+            echo "$RELEASE_TAG is a minor-or-greater bump over $prev_tag. OK."
+            exit 0
+          fi
+
+          # Escape hatch, mirroring [allow-version-drift] above. The reason
+          # belongs in the release PR, where reviewers will see it.
+          if git log -1 --pretty=%B | grep -qF '[allow-breaking-in-patch]'; then
+            echo "::warning::[allow-breaking-in-patch] present — downgrading to a warning."
+            exit 0
+          fi
+
+          echo "::error::$RELEASE_TAG is a patch bump over $prev_tag, but breaking-change PRs merged in that range. ADR 0025 requires a minor bump — use v${pmaj}.$((pmin + 1)).0. To override, put [allow-breaking-in-patch] in the tagged commit message and justify it in the release PR."
+          exit 1
+
+  # Stage 1 — backend. api + gateway release images bake repo-root assets (skills
+  # corpus, gateway.yaml.example) so they build from the repo root with a
+  # dedicated *.release Dockerfile.
+  build-backend:
     name: Build ${{ matrix.service }}
+    needs: [setup, version-consistency]
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      # A failed api build should stop the in-flight gateway build rather than
+      # let half a backend publish under the tag. See the limitation note above.
+      fail-fast: true
       matrix:
         include:
-          # api + gateway release images bake repo-root assets (skills corpus,
-          # gateway.yaml.example) so they build from the repo root with a
-          # dedicated *.release Dockerfile. web is self-contained → own subdir
-          # context + default Dockerfile.
           - service: api
-            context: .
             file: api/Dockerfile.release
           - service: gateway
-            context: .
             file: gateway/Dockerfile.release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build and push ${{ matrix.service }}
+        uses: ./.github/actions/build-push-image
+        with:
+          service: ${{ matrix.service }}
+          context: .
+          file: ${{ matrix.file }}
+          tag: ${{ needs.setup.outputs.tag }}
+          push: ${{ needs.setup.outputs.push }}
+          registry: ${{ env.REGISTRY }}
+          image_owner: ${{ env.IMAGE_OWNER }}
+
+  # TODO (ADR 0025 decision 4, deliberately not implemented here): a backend
+  # verification gate between build-backend and build-frontend — migrations plus
+  # admin/RBAC/inference checks run against the *published* images. stack-smoke.yml
+  # is the nearest existing check but builds the compose stack from local sources
+  # and scopes itself to "builds, migrates, boots, and holds", explicitly not
+  # "features work". Extending it to pull published tags is follow-up work; until
+  # it exists, the ordering below gates on build success only.
+
+  # Stage 2 — frontend. Blocked by the backend stage: `needs: build-backend` is
+  # the whole point of this file's structure.
+  build-frontend:
+    name: Build ${{ matrix.service }}
+    needs: [setup, build-backend]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
           # web bakes PUBLIC_LQ_AI_API_BASE_URL=/lq/api/v1 so the LQ.AI client
           # addresses its own /lq-prefixed origin behind the proxy (never
-          # colliding with OpenWebUI's same-origin /api). Other services pass no
-          # build-arg (build_args defaults empty below).
+          # colliding with OpenWebUI's same-origin /api). web is self-contained →
+          # own subdir context + default Dockerfile.
           - service: web
             context: ./web
             file: web/Dockerfile
@@ -57,60 +279,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Resolve image tag
-        id: tag
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=dryrun-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up QEMU
-        # Enables cross-platform (linux/arm64) builds on the amd64 runner.
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Login to GHCR
-        if: ${{ github.event_name == 'push' || !inputs.dry_run }}
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      - name: Build and push ${{ matrix.service }}
+        uses: ./.github/actions/build-push-image
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        id: build
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
-        with:
+          service: ${{ matrix.service }}
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          # Only the web matrix entry sets build_args; for api/gateway/proxy this
-          # resolves to empty (no stray build-arg). docker/build-push-action
-          # accepts a multi-line build-args input (KEY=VALUE per line).
-          build-args: ${{ matrix.build_args }}
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' || !inputs.dry_run }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}:${{ steps.tag.outputs.tag }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}:latest
-          provenance: false   # we attach SLSA provenance via actions/attest-build-provenance in T2
-          sbom: false         # we attach SBOM via anchore/sbom-action in T1
-
-      - name: Generate SLSA build provenance
-        if: ${{ github.event_name == 'push' || !inputs.dry_run }}
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
+          build_args: ${{ matrix.build_args }}
+          tag: ${{ needs.setup.outputs.tag }}
+          push: ${{ needs.setup.outputs.push }}
+          registry: ${{ env.REGISTRY }}
+          image_owner: ${{ env.IMAGE_OWNER }}
 
   sbom:
     name: SBOM ${{ matrix.service }}
-    needs: build-and-push
-    if: ${{ github.event_name == 'push' || !inputs.dry_run }}
+    needs: [setup, build-backend, build-frontend]
+    if: ${{ needs.setup.outputs.push == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -123,20 +307,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Resolve image tag
-        id: tag
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=dryrun-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          fi
-
       # syft pulls the just-pushed image from GHCR, which is private — without
       # an authenticated docker login the pull fails with `UNAUTHORIZED` and the
-      # SBOM step errors out (the build-and-push and sign jobs already log in;
-      # this job was missing the equivalent step). packages:read on this job is
-      # sufficient for the pull.
+      # SBOM step errors out (the build and sign jobs already log in; this job
+      # was missing the equivalent step). packages:read here suffices for the pull.
       - name: Login to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -147,7 +321,7 @@ jobs:
       - name: Generate SBOM (SPDX JSON)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}:${{ steps.tag.outputs.tag }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}:${{ needs.setup.outputs.tag }}
           format: spdx-json
           output-file: ${{ matrix.service }}.spdx.json
           artifact-name: ${{ matrix.service }}.spdx.json
@@ -168,9 +342,9 @@ jobs:
 
   sign:
     name: Cosign ${{ matrix.service }}
-    needs: [build-and-push, sbom]
+    needs: [setup, build-backend, build-frontend, sbom]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || !inputs.dry_run }}
+    if: ${{ needs.setup.outputs.push == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -182,15 +356,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Resolve image tag
-        id: tag
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=dryrun-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -213,11 +378,11 @@ jobs:
       - name: Sign container image (keyless)
         run: |
           cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}:${{ steps.tag.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}:${{ needs.setup.outputs.tag }}
 
       - name: Sign SBOM and attach as attestation
         run: |
           cosign attest --yes \
             --predicate ./sbom/${{ matrix.service }}.spdx.json \
             --type spdxjson \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}:${{ steps.tag.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/lq-ai-${{ matrix.service }}:${{ needs.setup.outputs.tag }}

--- a/docs/BUILD-AND-RELEASE.md
+++ b/docs/BUILD-AND-RELEASE.md
@@ -98,6 +98,71 @@ done
 
 ### 3. Cut the release
 
+> **Versioning policy: [ADR 0025](adr/0025-release-versioning-and-pipeline-ordering.md).**
+> `api`, `gateway`, `web`, and `proxy` share one release version — the `vX.Y.Z` image
+> tag — and are bumped together on every release, including patch releases where only
+> one component substantively changed. Before tagging, set **both**
+> `api/app/__init__.py` and `gateway/app/__init__.py` to `X.Y.Z`; the
+> `version-consistency` job in `release.yml` fails the tag push if they disagree with
+> each other or with the tag. `web/package.json` tracks the OpenWebUI fork upstream and
+> is **not** bumped to match.
+>
+> The desktop launcher versions independently (`desktop-vX.Y.Z`) and records which
+> `vX.Y.Z` image set it ships against — see *Image ↔ launcher relationship* below.
+
+#### 3a. Decide the number first
+
+The number is **computed from what is on `main`**, not chosen from a milestone.
+Milestones are planning tools; they do not decide the version.
+
+```bash
+# What has landed since the last release?
+git log "$(git tag --sort=-v:refname | grep -v desktop | head -1)"..main --no-merges --oneline
+```
+
+Read that list and ask one question of each entry: **does a working install need a
+human to touch it after this upgrade?** A new environment variable, a changed
+config key, a manual migration step, a required header, a removed endpoint — all
+yes. Bug fixes, dependency bumps and output-side hardening — no.
+
+- **Any "yes" in the list → the next release is a minor bump** (`0.6.x` → `0.7.0`).
+- **All "no" → patch** (`0.6.2` → `0.6.3`).
+
+A breaking PR does **not** wait for a `0.7.0` milestone to exist before merging.
+Merging it is what makes the next release `0.7.0`.
+
+Apply the **`breaking-change`** label at review time, so this is a lookup rather
+than an act of memory:
+
+```bash
+gh pr list -R LegalQuants/lq-ai --label breaking-change --state merged --limit 100 \
+  --json number,title,mergedAt
+```
+
+`release.yml`'s `version-consistency` job enforces this on tag push: it walks the
+commit range back to the previous release tag, intersects the PR numbers it finds
+with the `breaking-change` label, and **fails a patch tag** when any turn up. The
+override is `[allow-breaking-in-patch]` in the tagged commit message — justify it
+in the release PR.
+
+> The gate is only as good as the labelling. An unlabelled breaking PR is
+> invisible to it, so the label goes on at review time, not at release time.
+
+> ⚠️ **Once a breaking change is on `main`, you can no longer cut a patch from
+> `main`.** If an urgent fix has to ship *without* also shipping that change,
+> branch from the last release tag, cherry-pick the fix, and cut from there:
+>
+> ```bash
+> git checkout -b release/0.6.x v0.6.1
+> git cherry-pick <fix-sha>
+> # bump api + gateway __version__ to 0.6.2, commit, then tag from this branch
+> ```
+>
+> This is deliberately manual — see ADR 0025 *Cadence* on why a standing
+> release-branch discipline isn't worth its overhead at current capacity.
+
+#### 3b. Tag
+
 ```bash
 # (a) Images first — tag from a ref that CONTAINS the release Dockerfiles + release.yml (main):
 git tag vX.Y.Z && git push origin vX.Y.Z
@@ -121,7 +186,10 @@ git tag desktop-vX.Y.Z && git push origin desktop-vX.Y.Z
 - The launcher renders an `.env` at runtime and runs `docker-compose.release.yml` under its own compose
   project (`lq-ai-desktop`), pulling `ghcr.io/${LQ_AI_IMAGE_NAMESPACE:-legalquants}/lq-ai-<svc>:${LQ_AI_IMAGE_TAG}`.
 - **`LQ_AI_IMAGE_TAG`** pins the image version the launcher runs. The launcher config persists a tag
-  (default the version we ship the app at); a hand-run stack pins it in `.env`
+  — **today the shipped default is `latest`** (`desktop/src/main/index.ts`), so a fresh install floats
+  to the newest published images rather than the set the `.dmg` was verified against. ADR 0025
+  decides that each `desktop-vX.Y.Z` should instead record the `vX.Y.Z` it ships against; changing
+  the default is tracked with that work. A hand-run stack pins it in `.env`
   ([`.env.release.example`](../.env.release.example)). Pin to a released `vX.Y.Z` for reproducibility;
   `latest` follows the newest published images.
 - **`LQ_AI_IMAGE_NAMESPACE`** (default `legalquants`) overrides the GHCR namespace for forks/mirrors

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1754,10 +1754,10 @@ PyMuPDF (AGPL) is used server-side only and not redistributed as a library; the 
 
 ### 7.8 Release Cadence and Supply-Chain Transparency
 
-- Semantic versioning (semver).
+- Semantic versioning (semver). The versioning unit and pre-1.0 semantics are defined in [ADR 0025](adr/0025-release-versioning-and-pipeline-ordering.md): `api`, `gateway`, `web`, and `proxy` share one release version; the desktop launcher versions independently and records the image set it ships against. Pre-1.0 the project promises more than semver requires: **a patch release never requires operator action** — no new environment variable, config change, migration step or client change — and anything that does require it bumps the minor instead. A patch is safe to take unread; a minor means read the release notes.
 - Releases tagged on GitHub with full changelog.
-- Targeted cadence: minor release every 6–8 weeks, patch releases as needed.
-- Long-term-support (LTS) designation for one minor version per year, with security backports for 12 months.
+- Targeted cadence: minor release **every 8–12 weeks**, patch releases as needed. Cadence is **best-effort and capacity-dependent** while the project operates with its current maintainer and signing-identity concentration; revisit once desktop signing moves to an org-owned Apple Developer account and/or a second maintainer holds release authority (see ADR 0025, *Cadence*).
+- Long-term-support (LTS) designation for one minor version per year, with security backports for **6 months**, reflecting current capacity to staff backport work; extend once the bottlenecks above are resolved.
 
 **Supply-chain transparency commitments (M1, per §1.8 and Appendix E).**
 

--- a/docs/adr/0025-release-versioning-and-pipeline-ordering.md
+++ b/docs/adr/0025-release-versioning-and-pipeline-ordering.md
@@ -2,7 +2,7 @@
 
 **Status:** Proposed
 **Date:** 2026-08-02
-**Owner:** Issue #TBD (release pipeline ordering and versioning policy)
+**Owner:** Maintainer team (houfu)
 
 ## Context
 
@@ -274,6 +274,6 @@ supply-chain commitments below them are unchanged):
 `legalquants/main` at `b060ae2f`. Proposed for committee comment by houfu
 (Ang Hou Fu).*
 
-*Numbering note: `0024` is claimed by the in-flight jurisdiction-and-practice-area
-expansion ADR on `docs/expansion-program`; this ADR takes `0025`. It cites
-ADR 0022, which is likewise not yet on `main`.*
+*Numbering note: `0024` is taken by the jurisdiction-and-practice-area expansion
+ADR, merged as PR #313 on 2026-08-09; this ADR takes `0025`. It cites ADR 0022,
+merged as PR #311 on 2026-07-27.*

--- a/docs/adr/0025-release-versioning-and-pipeline-ordering.md
+++ b/docs/adr/0025-release-versioning-and-pipeline-ordering.md
@@ -1,0 +1,279 @@
+# ADR 0025 — Release versioning policy and release-pipeline ordering
+
+**Status:** Proposed
+**Date:** 2026-08-02
+**Owner:** Issue #TBD (release pipeline ordering and versioning policy)
+
+## Context
+
+The project publishes two independent release artifacts — the container image
+set (`v*.*.*` → `release.yml`) and the macOS launcher (`desktop-v*` →
+`desktop-release.yml`) — with no enforced ordering between the components of
+either, and no operational versioning policy tying their version strings
+together.
+
+**The image pipeline is one unordered matrix.** `release.yml` builds `api`,
+`gateway`, `web`, and `proxy` as four parallel entries of a single
+`build-and-push` job. Its `needs:` edges (`sbom` → `sign`) fan in only *after*
+all four have built, so they order the supply-chain steps, not the components.
+With `fail-fast: false`, a failed `api` build does not prevent `web` from
+publishing — and tagging `:latest` — under the same tag.
+
+**Ordering is documented but unenforced.** `docs/BUILD-AND-RELEASE.md` §3
+prescribes cutting images first and the macOS app second, and the BYOK handoff
+below follows that order by hand. What no document covers is ordering *within*
+the image set — nothing says backend must be verified before `web` builds
+against it — and nothing enforces either ordering in CI. The gap is
+enforcement and intra-image sequencing, not a total absence of guidance.
+
+**Version drift is live on `main`.** `api/app/__init__.py` is `0.6.1`,
+`gateway/app/__init__.py` is `0.5.1`, `desktop/package.json` is `0.6.2`. The
+BYOK handoff records api and gateway being bumped *jointly* to `0.5.1`; api
+has moved twice since and gateway has not moved at all. No CI check catches
+the divergence.
+
+**It has already broken a real install.**
+`docs/LQVern/HANDOFF-2026-06-21-byok-recut.md` records `v0.5.0` images and the
+`desktop-v0.5.1` `.dmg` shipping without PR #202's BYOK fix, requiring a manual
+re-cut of both tags (`v0.5.1` / `desktop-v0.5.2`) so that a fresh install would
+work for a stranger.
+
+**No prior decision covers the unit of versioning.** `docs/PRD.md` §7.8
+commits to "Semantic versioning (semver)" in a single line with no operational
+detail. No prior ADR, PRD section, roadmap item, or DE entry decides what is
+versioned as a unit, or what major/minor/patch mean for this project. Nearest
+canon: ADR 0023 (a cross-subsystem decision previously undecided anywhere) and
+CLAUDE.md's decide-once rule.
+
+## Decision
+
+1. **`api`, `gateway`, `web`, and `proxy` share one release version**, bumped
+   together on every `vX.Y.Z` tag — including patch releases where only one
+   component substantively changed. They already build from a single tag; this
+   makes that fact explicit and enforced rather than incidental.
+
+   The shared version is **the image tag itself**. Only `api` and `gateway`
+   carry a project-owned version string (`app/__init__.py`), and those are what
+   the consistency check in decision 5 compares. `web/package.json` is
+   `0.9.2` — inherited from the OpenWebUI fork and tracking upstream, not this
+   project's releases (per ADR 0001's pin-and-monitor posture) — and `proxy`
+   has no version string at all. Neither is retitled to match `vX.Y.Z`.
+
+2. **`desktop` versions independently.** The launcher legitimately ships
+   launcher-only fixes with no backend change (e.g. `desktop-v0.6.2`'s
+   pull-order fix, `05f1cb1e`). Each `desktop-vX.Y.Z` release records which
+   `vX.Y.Z` image set it ships against — explicit and discoverable, rather than
+   implied by whatever `:latest` resolves to at install time.
+
+   The pinning *mechanism* already exists: `LQ_AI_IMAGE_TAG` is rendered into
+   the launcher's runtime `.env` from `cfg.imageTag` (`desktop/src/core/env.ts`).
+   What is missing is a truthful default. `docs/BUILD-AND-RELEASE.md` states the
+   launcher defaults to "the version we ship the app at", but the shipped code
+   defaults to `'latest'` (`desktop/src/main/index.ts:87`) — so today every
+   fresh install floats to whatever `:latest` resolves to, which is the exact
+   failure mode of the BYOK incident. Correcting that default, and recording the
+   pin in a release manifest, is implementation work under this decision.
+
+3. **Pre-1.0, a patch release never requires operator action. Anything that does
+   bumps the minor.** Semver §4 says that below `1.0.0` anything may change at
+   any time. That gives an evaluating security or procurement team no signal at
+   all, so this project promises more than semver requires:
+
+   - **Patch** (`0.6.2` → `0.6.3`) — safe to take without reading anything. No
+     new environment variable, no config change, no migration step, no client
+     change. Upgrade it blind.
+   - **Minor** (`0.6.x` → `0.7.0`) — may require the operator to do something
+     before the upgrade works. Read the release notes first. New features land
+     here too, so a minor bump means "read", not "brace".
+   - **Major** stays unincremented until a `1.0.0` milestone whose criteria this
+     ADR does not decide (see *Explicitly not decided*).
+
+   The test is **"does a working install need a human to touch it?"** — not
+   "did a function signature change?". The former is something an operator can
+   check; the latter is not visible to them.
+
+   **The number is computed from `main`, not chosen in advance.** A release is
+   numbered by what has accumulated since the last tag: if any change requiring
+   operator action has merged, the next release is a minor bump; otherwise it is
+   a patch. A breaking PR therefore does not have to wait for a `0.7.0` to exist
+   before it can merge — **merging it is what makes the next release `0.7.0`**.
+   Milestones are planning tools and do not decide the number.
+
+   Consequence to plan around: once a change requiring operator action sits on
+   `main`, no further *patch* can be cut from `main`. If an urgent fix must ship
+   without also shipping that change, it is cherry-picked onto a branch taken
+   from the last release tag and cut from there. That path is documented in
+   `docs/BUILD-AND-RELEASE.md` and deliberately not automated — with current
+   maintainer capacity (see *Cadence*) a standing release-branch discipline
+   would cost more than it returns.
+
+4. **The image pipeline gates backend before frontend.** `release.yml`'s matrix
+   splits into `build-backend` (api, gateway) and `build-frontend` (web, proxy)
+   with `needs: build-backend`, so a backend failure structurally blocks the
+   frontend from publishing under the same tag. Each stage gates on a real
+   verification step against the published images, not merely a green
+   `docker build`. The `desktop-vX.Y.Z` cut remains the final, separate stage,
+   unchanged, and is sequenced after both image stages are live and verified.
+
+5. **Both rules are enforced in CI, not left to the runbook.** A `vX.Y.Z` tag
+   push fails if `api/app/__init__.py` and `gateway/app/__init__.py` disagree
+   with each other or with the tag. It also fails if the tag is a *patch* bump
+   while any PR labelled `breaking-change` merged since the previous release tag
+   — the gate for decision 3. Each has an explicit override
+   (`[allow-version-drift]`, `[allow-breaking-in-patch]` in the tagged commit
+   message) whose justification belongs in the release PR.
+
+   The breaking-change gate depends on the label being applied at review time; an
+   unlabelled breaking PR is invisible to it. It is a backstop against forgetting
+   at release time, not a substitute for judgement at review time.
+
+6. **Cadence commitments are restated as best-effort and capacity-dependent.**
+   PRD §7.8's "minor release every 6–8 weeks" and "security backports for 12
+   months" predate the committee-governance transition (ADR 0022) and do not
+   reflect current maintainer capacity or process latency. See *Cadence* below.
+
+## Worked examples
+
+Taken from the milestones open at the time of writing, to show where the line
+falls in practice.
+
+| Change | Does a working install need a human to touch it? | Bump |
+|---|---|---|
+| **#399** — refuse to boot when `JWT_SECRET` is still the published dev default | **Yes.** An operator who never set `JWT_SECRET` has a running install today that will refuse to start after upgrading, until they set it (or `LQ_AI_DEV_MODE`). | **minor** |
+| **#396** — require the gateway key on `/v1` inference endpoints | **Yes.** The api client only sends the header when a key is configured; a deployment without one gets `401` on every inference call after upgrading. | **minor** |
+| **#398** — sanitize skill markdown before rendering (XSS) | No. Output-side hardening; nothing to configure. | patch |
+| **#442** — list knowledge bases by join table rather than the legacy column | No. Fixes wrong results; no operator step. | patch |
+| **#485**, **#481**, **#480** — dependency bumps | No. | patch |
+| **#415** — `/lq` slash command for Slack and Teams | No — purely additive. New features are minor because they are new surface, not because they break anything. | **minor** |
+
+**These milestones do not currently follow this rule, and that is the point of
+writing it down.** `v0.6.3` is labelled a patch but contains #399 and #396, both
+of which require operator action; `v0.7.0` is labelled a minor but contains only
+additive work. Under this ADR the two breaking items belong in `v0.7.0`.
+
+**This is already load-bearing, not hypothetical.** #396 and #399 are *both
+merged on `main`* — 29 commits past `v0.6.1`, with nothing tagged since. The next
+image tag cut from `main` must therefore be **`v0.7.0`**; cutting it as `v0.6.2`
+or `v0.6.3` would break this policy on the first release after it is ratified.
+
+## Alternatives considered
+
+- **Fully independent per-component semver** — the status quo. Rejected on the
+  evidence: it produced the BYOK re-cut incident and the drift currently live
+  on `main`. Unenforced, the components do not stay in sync.
+- **One version across all five components, including desktop** — simplest to
+  state, and it would make the desktop→image correspondence automatic. Rejected
+  because it forces a new image tag, and a full image re-publish, every time the
+  launcher needs a zero-backend-change fix.
+- **Calendar versioning (CalVer)** — would sidestep the pre-1.0 ambiguity
+  entirely and honestly describe a project releasing on availability rather
+  than on a compatibility contract. Rejected here because PRD §7.8 already makes
+  a public semver commitment; withdrawing it is a larger decision than this ADR
+  should carry.
+- **Gate the pipeline on build success only, without smoke tests** — cheaper
+  and immediately implementable. Rejected because a green `docker build` is
+  precisely the signal that was already green during the BYOK incident; the
+  images built fine, they just did not contain the fix.
+
+## Cadence
+
+Three factors make the current PRD §7.8 cadence unrealistic to commit to:
+
+- **Contributor concentration.** Of 655 non-merge commits on `main`, roughly
+  642 (~98%) are authored by one person across two identities
+  (`kevin@tucuxi.ai`, `hikevin@gmail.com`). The next-highest human contributor
+  has 6. Five distinct human identities have landed commits on `main`. The
+  project is resourced for what one person's availability allows, not for a
+  committee-wide cadence.
+- **Desktop releases have a hard single point of failure.** The Apple
+  code-signing identity — `Developer ID Application: Tucuxi, Inc.`, team
+  `MC8BT9Z8GD`, per `docs/BUILD-AND-RELEASE.md` §1 — is tied to the founder's
+  own developer account rather than a LegalQuants org account, and
+  `docs/BUILD-AND-RELEASE.md` marks the release checklist "Kevin only". No one
+  else can cut a signed `desktop-vX.Y.Z` release regardless of committee
+  bandwidth.
+- **New process latency is not priced in.** ADR-first review (committee call
+  plus 7-day async ratification, per ADR 0022) and the staged pipeline gating
+  decided above both add real time per release, and both postdate the PRD's
+  cadence commitment.
+
+**Proposed replacement text for PRD §7.8** (the first four bullets; the
+supply-chain commitments below them are unchanged):
+
+> - Semantic versioning (semver), with the versioning unit and pre-1.0
+>   semantics defined in ADR 0025.
+> - Releases tagged on GitHub with full changelog.
+> - Targeted cadence: minor release **every 8–12 weeks**, patch releases as
+>   needed. Cadence is **best-effort and capacity-dependent** while the project
+>   operates with its current maintainer and signing-identity concentration;
+>   revisit once desktop signing moves to an org-owned Apple Developer account
+>   and/or a second maintainer holds release authority.
+> - Long-term-support (LTS) designation for one minor version per year, with
+>   security backports for **6 months** (reduced from 12), reflecting current
+>   capacity to staff backport work; extend once the bottlenecks above are
+>   resolved.
+
+## Consequences
+
+- Every `vX.Y.Z` release republishes all four images, and bumps both
+  project-owned version strings (`api`, `gateway`), whether or not all four
+  components changed. Release notes must therefore distinguish "what changed"
+  from "what was rebuilt", or readers will infer substance from a version bump
+  that carries none.
+- The current drift is resolved as part of the implementing PR: `gateway`
+  moves to match `api`, rather than being quietly papered over by the next
+  release.
+- Splitting the matrix serialises the image build. Backend and frontend no
+  longer build concurrently, so wall-clock release time rises by roughly one
+  build stage — an accepted cost for the ordering guarantee.
+- **The ordering guarantee holds between stages, not within one.** `fail-fast`
+  cancels sibling builds inside a stage, but it cannot un-push an image that has
+  already pushed, so a `gateway` image can still reach the registry under a tag
+  whose `api` build subsequently failed. Closing that gap needs a
+  build-then-push-in-a-second-pass design (build all, load, push only once every
+  build in the stage has succeeded), which is a larger change than this ADR
+  decides and is left as follow-up. Stated here so the guarantee is not read as
+  stronger than it is.
+- The verification gates in decision 4 do not exist yet and must be built.
+  `stack-smoke.yml` is the nearest existing check but is not a drop-in: it
+  builds the compose stack from local sources rather than pulling published
+  images, and its own header scopes it to "builds, migrates, boots, and holds"
+  — explicitly **not** "features work". Cold runs take ~20–30 minutes. Wiring
+  the gates therefore means extending stack-smoke to run against published
+  image tags, and treating `desktop/VERIFICATION.md` Protocol 1 as the manual
+  backstop until an automated equivalent exists.
+- A stricter pre-1.0 reading than semver requires means the project will emit
+  minor bumps that other tooling may treat as safe. This is documented as a
+  deliberate choice, not left for users to discover.
+- `docs/BUILD-AND-RELEASE.md` and `docs/PRD.md` §7.8 are updated to carry the
+  policy and cross-reference this ADR; the release checklist gains the
+  version-consistency and image-pin steps.
+
+## Explicitly not decided
+
+- **What `1.0` means.** This ADR reserves `major` for a `1.0.0` milestone but
+  does not define what that milestone requires, and neither does any other
+  project doc. "GA" appears three times across the docs — two in PRD §9 (a
+  security-doc acceptance criterion and an MCP OAuth timing note) and one in
+  `docs/word-addin.md` (the Word add-in's own GA) — and is never operationally
+  defined at the product level. The roadmap (PRD §8) is structured as
+  milestone-based delivery, each milestone a public release, rather than
+  converging on a single 1.0; `docs/HONEST-STATE.md` frames nothing as a 1.0
+  gate. Defining 1.0/GA criteria is left to a separate, future committee
+  decision — likely its own ADR, once someone is ready to own it. Until then
+  this policy governs minor and patch only.
+- **Migrating the desktop code-signing identity to an org-owned LegalQuants
+  Apple Developer account.** This is the root cause of the desktop
+  single-point-of-failure described under *Cadence*, and directly relevant to
+  it, but it is an infrastructure and access-provisioning change rather than a
+  versioning or pipeline-ordering decision. Tracked separately.
+
+---
+
+*Drafted from the issue decision ledger; every factual claim re-verified against
+`legalquants/main` at `b060ae2f`. Proposed for committee comment by houfu
+(Ang Hou Fu).*
+
+*Numbering note: `0024` is claimed by the in-flight jurisdiction-and-practice-area
+expansion ADR on `docs/expansion-program`; this ADR takes `0025`. It cites
+ADR 0022, which is likewise not yet on `main`.*

--- a/gateway/app/__init__.py
+++ b/gateway/app/__init__.py
@@ -1,3 +1,3 @@
 """LQ.AI Inference Gateway."""
 
-__version__ = "0.5.1"
+__version__ = "0.6.1"


### PR DESCRIPTION
# Stage the release pipeline and add ADR 0025 (release versioning policy)

Branch: `docs/adr-0025-versioning` (off `legalquants/main` @ `b060ae2f`)
Commit: `ba425908`

## Read this first: the next image tag must be `v0.7.0`

`#396` (gateway key required on `/v1` inference) and `#399` (refuses to boot on the default
`JWT_SECRET`) are **both already merged on `main`** — 29 commits past `v0.6.1`, nothing tagged
since. Both require an operator to act before a working install works again.

Under this ADR that makes the next release a **minor** bump. Cutting it as `v0.6.2` or
`v0.6.3` would break the policy on the first release after it is ratified.

## What this does

`release.yml` built `api`, `gateway`, `web` and `proxy` as **one unordered matrix job** with
`fail-fast: false`. Its only `needs:` edges (`sbom` → `sign`) fan in *after* all four have
built, so they sequence the supply-chain steps, not the components — a failed `api` build did
not stop `web` from publishing, and tagging `:latest`, under the same tag.

Nothing enforced that version strings moved together either. `api` and `gateway` were last
bumped **jointly** to `0.5.1`; `api` has since moved to `0.6.1` and `gateway` never followed.
That drift is live on `main` today.

## Changes

| File | Change |
|---|---|
| `docs/adr/0025-release-versioning-and-pipeline-ordering.md` | New. Decision, worked examples, alternatives, consequences, and what is explicitly *not* decided. |
| `.github/workflows/release.yml` | Split into `setup` → `version-consistency` → `build-backend` → `build-frontend` → `sbom` → `sign`; two gates in `version-consistency`. |
| `.github/actions/build-push-image/action.yml` | New composite action; both build stages share one copy of the build-and-attest logic. |
| `gateway/app/__init__.py` | `0.5.1` → `0.6.1`. Fixes the live drift. |
| `docs/PRD.md` §7.8 | Cadence → 8–12 weeks, backports → 6 months, both best-effort and capacity-dependent; states the patch-safety promise. |
| `docs/BUILD-AND-RELEASE.md` | New step **3a** (decide the number) + the cherry-pick path; corrects the launcher-pin claim. |

## The policy (ADR 0025)

1. `api`, `gateway`, `web`, `proxy` share one release version — **the image tag**. Only api and
   gateway carry a project-owned version string, so those are what CI compares.
   `web/package.json` (`0.9.2`) tracks the OpenWebUI fork and is deliberately not bumped.
2. `desktop` versions independently and records which `vX.Y.Z` image set it ships against.
3. **A patch release never requires operator action** — no new env var, config change,
   migration step or client change. Anything that does bumps the **minor**. A patch is safe to
   take unread; a minor means read the notes. **What triggers 1.0 is explicitly left undecided.**
   - The number is **computed from `main`**, not chosen from a milestone. A breaking PR does not
     wait for a `0.7.0` to exist — merging it is what *makes* the next release `0.7.0`.
4. Backend gates frontend in the pipeline.
5. Both rules enforced on tag push: api/gateway version agreement, **and** a patch tag is
   rejected when a `breaking-change`-labelled PR merged since the previous tag. Overrides are
   `[allow-version-drift]` and `[allow-breaking-in-patch]` in the tagged commit message.

## Worked examples — and a milestone correction

The ADR's examples come from the live milestones, which **do not currently follow this rule**:

- **`v0.6.3`** is labelled a patch but carries `#399` and `#396`, both requiring operator action.
- **`v0.7.0`** is labelled a minor but carries only additive work (`#415` `/lq` command,
  `#403` encrypted resume payloads).

Under this ADR the two breaking items belong in `v0.7.0`. **Milestones need re-planning** —
a maintainer action this PR does not take.

## Verification

Both gate scripts were extracted from the workflow and exercised against fixtures before commit.

**Version consistency — 6/6:** aligned + matching tag → pass; **drift (reproducing the current
`main` bug) → fail**; tag disagrees → fail; drift with `[allow-version-drift]` → pass with
warning; dry run skips tag comparison → pass; dry run still catches drift → fail.

**Breaking-change gate — 7/7**, against real fixture git repos with a stubbed `gh`: **patch bump
with a labelled breaking PR → fail**; minor bump with one → pass; patch with nothing labelled →
pass; patch where the breaking PR merged *before* the last tag → pass; patch with
`[allow-breaking-in-patch]` → pass; no previous release tag → pass; major bump → pass.

The fixture run **caught a real bug**: with no previous tag, `grep` exits non-zero and
`pipefail` aborted the script before the emptiness check could report it. Fixed with `|| true`
and a comment explaining why; the "no previous release tag" case only passes because of it.

Job graph verified: `build-frontend` carries `needs: [setup, build-backend]`.

## What is NOT in this PR — please read before approving

- **`#396` and `#399` are not labelled `breaking-change` yet**, so the new gate does **not**
  catch them today. The label exists; applying it is two commands:
  ```bash
  gh pr edit 396 -R LegalQuants/lq-ai --add-label breaking-change
  gh pr edit 399 -R LegalQuants/lq-ai --add-label breaking-change
  ```
  Until then the gate would let a `v0.6.2` through. The gate is a backstop against forgetting at
  release time, not a substitute for judgement at review time.
- **The verification gate on published images (decision 4) is not implemented.** The issue
  assumed `stack-smoke.yml` could be wired in. It can't: it builds from *local sources* rather
  than published images, and its header scopes it to "builds, migrates, boots, and holds",
  explicitly not "features work" (~20–30 min cold). A `TODO` marks the seam.
- **The desktop image-tag pin is not implemented.** The mechanism exists (`LQ_AI_IMAGE_TAG`),
  but the shipped default is `'latest'` (`desktop/src/main/index.ts:87`) while
  `BUILD-AND-RELEASE.md` claimed it pins the shipped version. **I corrected the doc to match the
  code**; changing the default is a launcher behaviour change.
- **Ordering is guaranteed between stages, not within one.** `fail-fast` cannot un-push an image
  that already pushed. Recorded in the ADR rather than glossed.
- **`ruff` was not available locally**, so the one-line `gateway/app/__init__.py` change was not
  format-checked here. CI gates it.
- **Workflow changes cannot be fully validated without a run.** `release.yml` has
  `workflow_dispatch` with `dry_run: true` — suggest a dry-run dispatch before the next tag.
  Note `version-consistency` now checks out with `fetch-depth: 0` and needs `pull-requests: read`.

## Corrections made to the original issue

| Claim | Finding |
|---|---|
| File as ADR **0024** | **0024 is taken** by the in-flight jurisdiction/practice-area ADR. This is **0025**. |
| "11 contributors, one has 664 commits, next human 7" | Doesn't reconcile with `main`. Actual: **655 non-merge commits, ~642 (98%) by one person** across two identities, **next human 6**, five human identities. The capacity argument gets *stronger*. |
| "no doc specifies what they should do instead" | Overstated — `BUILD-AND-RELEASE.md` §3 *does* order images→desktop. The gap is **enforcement + intra-image ordering**. |
| "frontend gate runs the actual e2e stack smoke against published images" | The gate doesn't exist to be wired. |

Verified and unchanged: the version drift, the unordered matrix, the BYOK re-cut incident
(PR #202), PRD §7.8's text, the signing identity (`Developer ID Application: Tucuxi, Inc.`,
team `MC8BT9Z8GD`, checklist marked "Kevin only"), and that "GA" is never operationally defined.

## Note on ADR dependencies

This ADR cites **ADR 0022** (ADR-first workflow), which is not yet on `main` — it's on
`docs/expansion-program` with 0021, 0023 and 0024. Numbering assumes those land.

## Per ADR 0022's ADR-first workflow

The ADR is **Proposed**, not Accepted. The pipeline changes are included so the committee can
see what the policy costs in practice, but they need not merge ahead of ratification — happy to
split the ADR out and hold the CI half.

## Follow-ups (not filed yet)

- **Label `#396` and `#399`**, then **re-plan `v0.6.3` / `v0.7.0`** per the rule above.
- Extend `stack-smoke.yml` to run against published image tags → unblocks decision 4.
- Desktop release manifest + change the `imageTag` default off `latest`.
- Build-then-push-in-a-second-pass to close intra-stage partial publishes.
- Define 1.0/GA criteria — separate committee decision.
- Move desktop signing to an org-owned Apple Developer account.
