### PR TITLE
Derive ProviderEgressRefused from LQAIError (typed per CONTRIBUTING)

### DIFF
--- a/gateway/app/providers/base_url_policy.py
+++ b/gateway/app/providers/base_url_policy.py
@@ -24,11 +24,31 @@ fails fast at startup.
 from __future__ import annotations
 
 import ipaddress
+from typing import ClassVar
 from urllib.parse import urlparse
 
+from fastapi import status
 
-class ProviderEgressRefused(Exception):
-    """Raised when a provider ``base_url`` violates LLM egress policy."""
+from app.errors import CODE_PROVIDER_UNAVAILABLE, LQAIError
+
+
+class ProviderEgressRefused(LQAIError):
+    """Raised when a provider ``base_url`` violates LLM egress policy.
+
+    Typed per CONTRIBUTING (subsystem errors derive from :class:`LQAIError`,
+    not bare ``Exception``) so a refusal reaching a request path renders the
+    canonical envelope instead of an unhandled 500. It reuses the existing
+    ``provider_unavailable`` code rather than introducing a new wire code:
+    from a caller's point of view a provider whose ``base_url`` is refused has
+    no usable adapter, which is exactly what that code already means.
+
+    Startup behaviour is unchanged — ``lifespan`` runs outside the exception
+    handler, so a refusal there still aborts the gateway, which is the
+    intended fail-closed posture.
+    """
+
+    code: ClassVar[str] = CODE_PROVIDER_UNAVAILABLE
+    http_status: ClassVar[int] = status.HTTP_503_SERVICE_UNAVAILABLE
 
     def __init__(self, reason: str) -> None:
         super().__init__(reason)

--- a/gateway/tests/test_llm_base_url_policy.py
+++ b/gateway/tests/test_llm_base_url_policy.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from fastapi import status
 
 from app.config import ProviderConfig
+from app.errors import CODE_PROVIDER_UNAVAILABLE, LQAIError
 from app.main import build_adapter
 from app.providers.base_url_policy import ProviderEgressRefused, validate_llm_base_url
 
@@ -116,3 +118,20 @@ async def test_lifespan_refuses_to_start_on_refused_base_url(
     with pytest.raises(ProviderEgressRefused):
         async with app.router.lifespan_context(app):
             pass  # pragma: no cover — startup must raise before entry
+
+
+@pytest.mark.unit
+def test_provider_egress_refused_is_typed_lqai_error() -> None:
+    """Regression guard for the LQAIError derivation (CONTRIBUTING: subsystem
+    errors are typed, never bare ``Exception``). A refusal that reaches a
+    request path must render the canonical envelope with the existing
+    ``provider_unavailable`` code and a 503 — not an unhandled 500. Narrowing
+    the class back to bare ``Exception`` fails here before it 500s live.
+    """
+
+    exc = ProviderEgressRefused("cleartext egress to attacker.example")
+    assert isinstance(exc, LQAIError)
+    assert exc.reason == "cleartext egress to attacker.example"
+    assert exc.effective_code == CODE_PROVIDER_UNAVAILABLE
+    assert exc.effective_http_status == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert exc.to_envelope()["error"]["code"] == CODE_PROVIDER_UNAVAILABLE


### PR DESCRIPTION
Follow-up to #400. `ProviderEgressRefused` subclasses bare `Exception`; the two known paths already handle it (lifespan re-raises fatally, the BYOK write maps it to `ProviderKeyMutationError` 409), but any other request path a future refactor routes it through would render an unhandled 500 instead of the canonical envelope.

## What

- `ProviderEgressRefused` now derives from `LQAIError` per CONTRIBUTING (subsystem errors are typed, never bare `Exception`), reusing the existing `provider_unavailable` wire code — to a caller, a provider whose `base_url` is refused has no usable adapter, which is exactly what that code already means. Default `http_status` 503.
- The `.reason` attribute and constructor shape are unchanged, so both existing call sites (which log `exc.reason`) are untouched.
- One regression test pins the contract (derivation, wire code, 503, envelope shape) — narrowing the class back to bare `Exception` fails it.

## What is deliberately unchanged

- Startup: `lifespan` still aborts fatally on a refused `base_url` — pinned by the existing `test_lifespan_refuses_to_start_on_refused_base_url` from #400.
- BYOK: the #400 `ProviderKeyMutationError` 409 mapping is untouched (the specific `except` arm catches the subclass exactly as before).

## Gates

`ruff format` + `ruff check` clean · `mypy --strict` clean (57 files) · gateway suite **795 passed**.

Refs #288

*Prepared and pushed by AlexiOS, Alexios's AI agent, on his instruction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
