### PR TITLE
build: align contributor workflow with current checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,9 @@ Run this for every non-trivial change — it is battle-tested across M1–M4 and
 2. **Surface the forks** — if the task hides an architectural / product / authz decision, a scope expansion, or a deferral, stop and put the options (with a recommendation) to the maintainer. Don't decide unilaterally.
 3. **Build in reviewed increments** — independent tasks, each: implement → spec-compliance review → code-quality review → fix → re-review. (The `superpowers:subagent-driven-development` skill encodes this.)
 4. **Run the gates yourself** — evidence before claims (see Testing + the collision guards below).
-5. **Ship** — `git commit -s` + the co-author trailer, push **both** remotes (`origin` + `tucuxi`, kept identical on `main`), open the PR, watch CI, merge per the gating rule, report the squash SHA.
+5. **Ship** — external contributors commit with DCO, push the branch only to their own fork,
+   open a PR, and respond to CI and review; they never self-merge. Authorized maintainers
+   handle merges and any upstream/mirror synchronization.
 
 The full step-by-step, including merge-gating and dev-environment rules, is in the [cold-start guide](docs/contribute/coding-agent-onboarding.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,11 @@ Full conventions in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Testing
 
-Coverage target is 80% across `api/` and `gateway/`. CI enforces no-decrease.
+Coverage target is 80% across `api/` and `gateway/`. Current PR CI does not enforce a coverage threshold or no-decrease rule.
 
 - **Unit tests** — fast, no external deps. `pytest` in each subsystem's `tests/` folder.
 - **Integration tests** — run against real Postgres in Docker. Provider integration gated behind `pytest -m provider`.
-- **End-to-end tests** — Playwright against a deployed stack. Runs on every PR.
+- **End-to-end tests** — browser end-to-end coverage is not part of the current PR workflow.
 
 Bug fixes include a regression test. New API endpoints include unit tests for handler logic, integration tests for the endpoint, and OpenAPI schema-conformance tests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,11 +103,14 @@ For features not on the deferred-enhancements list, please file an issue describ
 5. **Sign your commits** per the DCO requirement (see [Sign-off](#sign-off-developer-certificate-of-origin) below). PRs without DCO sign-off cannot be merged.
 6. **Open the PR** with a description that explains what changed, why, and how to verify. Link to any relevant issue or DE-### entry in the PRD.
 7. **Respond to review** — maintainers will review within ~5 business days for most PRs, faster for security or bug fixes. Substantive review feedback usually requires changes; small style nits can be deferred to follow-ups.
-8. **Current PR CI must pass** — API runs `ruff check` and `ruff format --check`
-   for `api/` and `scripts/`, `mypy app`, and `pytest -q` with pgvector Postgres;
-   Gateway runs ruff check/format, `mypy app`, and `pytest -q`; Web runs
-   `npm run check:lq-ai` and `npm run test:frontend -- --run`. PRs with failing
-   CI are not merged.
+8. **Current PR CI must pass** — API runs `uv lock --check`, `ruff check`, and
+   `ruff format --check` for `api/` and `scripts/`, `mypy app`, and `pytest -q`
+   with pgvector Postgres; Gateway runs `uv lock --check`, ruff check/format,
+   `mypy app`, and `pytest -q`; Web runs `npm run check:lq-ai` and `npm run
+   test:frontend -- --run`. The path-triggered Stack smoke workflow also runs on
+   PRs that change the specified API/Gateway/Web dependency manifests and locks,
+   Dockerfiles, compose, API migrations, its script, or its workflow. PRs with
+   failing CI are not merged.
 9. **At least one maintainer approval** is required to merge. For changes affecting multiple subsystems, two approvals are preferred.
 
 Squash-and-merge is the default; merge commits are reserved for cases where the per-commit history meaningfully aids future debugging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,44 +31,46 @@ running the test suite inside a container.
 
 For backend development without Docker, dependencies are managed with
 [uv](https://docs.astral.sh/uv/) (per [ADR 0023](docs/adr/0023-uv-lockfiles-gateway-api.md)):
-`uv sync` creates `.venv/` and installs exactly the committed `uv.lock`. If you
-change dependencies in `pyproject.toml`, run `uv lock` in that directory and
-commit the updated lockfile — CI gates on `uv lock --check`.
+For ordinary reproducible setup, use `uv sync --frozen --extra dev`. It creates
+`.venv/` from the committed `uv.lock` without changing the lockfile. If you
+intentionally change dependencies in `pyproject.toml`, run `uv lock` in that
+subsystem and commit the updated lockfile — CI gates on `uv lock --check`.
+
+Run each subsystem example from the repository root in its own terminal:
 
 ```bash
 # Backend
-cd api
-uv sync --extra dev               # creates .venv from the committed uv.lock
-source .venv/bin/activate
-alembic upgrade head
-uvicorn app.main:app --reload --port 8000
-
-# Inference Gateway (separate service)
-cd gateway
-uv sync --extra dev
-source .venv/bin/activate
-uvicorn app.main:app --reload --port 8001
-
-# Web (OpenWebUI fork)
-cd web
-npm install
-npm run dev
+make install-api
+cd api && .venv/bin/uvicorn app.main:app --reload --port 8000
 ```
+
+```bash
+# Inference Gateway
+make install-gateway
+cd gateway && .venv/bin/uvicorn app.main:app --reload --port 8001
+```
+
+```bash
+# Web (OpenWebUI fork)
+make install-web                    # installs the committed package-lock.json
+cd web && npm run dev
+```
+
+When deliberately changing Web dependencies, use `npm install <package>` (or
+`npm uninstall <package>`) and commit both `web/package.json` and
+`web/package-lock.json`. Use `npm ci` for ordinary setup and verification.
 
 Run the test suite before submitting:
 
 ```bash
-# Python (api/, gateway/)
-pytest                    # unit + integration
-pytest -m "not provider"  # skip provider-integration tests (require API keys)
-ruff check .
-ruff format --check .
-mypy .
+# From the repository root
+make lint          # Python ruff/mypy + Web scoped Svelte check
+make format-check  # Python formatting check
+make test          # Python local-loop suites + Web Vitest
 
-# JavaScript (web/)
-npm test
-npm run lint
-npm run typecheck
+# Web checks can also be run independently
+make web-check     # npm run check:lq-ai
+make web-test      # npm run test:frontend -- --run
 ```
 
 ---
@@ -95,12 +97,17 @@ For features not on the deferred-enhancements list, please file an issue describ
 
 1. **Fork the repository** and create a branch from `main`. Branch names should describe the work: `feat/saved-prompts`, `fix/citation-engine-empty-result`, `docs/clarify-tier-config`.
 2. **Make your changes** following the code style and testing requirements below.
-3. **Add or update tests** covering the change. Pytest coverage target is 80%; PRs that drop coverage materially will be flagged.
+3. **Add or update tests** covering the change. Pytest coverage target is 80%, but
+   current PR CI does not enforce a coverage threshold or no-decrease rule.
 4. **Update documentation** — the PRD, README, skill-authoring guide, or capability docs as relevant. If your change affects user-facing behavior, the docs need to reflect it.
 5. **Sign your commits** per the DCO requirement (see [Sign-off](#sign-off-developer-certificate-of-origin) below). PRs without DCO sign-off cannot be merged.
 6. **Open the PR** with a description that explains what changed, why, and how to verify. Link to any relevant issue or DE-### entry in the PRD.
 7. **Respond to review** — maintainers will review within ~5 business days for most PRs, faster for security or bug fixes. Substantive review feedback usually requires changes; small style nits can be deferred to follow-ups.
-8. **CI must pass** — tests, linting, type checks, container builds, security scans (Trivy, CodeQL). PRs with failing CI are not merged.
+8. **Current PR CI must pass** — API runs `ruff check` and `ruff format --check`
+   for `api/` and `scripts/`, `mypy app`, and `pytest -q` with pgvector Postgres;
+   Gateway runs ruff check/format, `mypy app`, and `pytest -q`; Web runs
+   `npm run check:lq-ai` and `npm run test:frontend -- --run`. PRs with failing
+   CI are not merged.
 9. **At least one maintainer approval** is required to merge. For changes affecting multiple subsystems, two approvals are preferred.
 
 Squash-and-merge is the default; merge commits are reserved for cases where the per-commit history meaningfully aids future debugging.
@@ -123,7 +130,9 @@ This adds a trailer to your commit message:
 Signed-off-by: Your Name <your.email@example.com>
 ```
 
-The `git config user.email` you sign off as must match the email associated with your GitHub account or be in your verified emails list. CI validates DCO sign-off on every commit; PRs with unsigned commits cannot be merged.
+The `git config user.email` you sign off as must match the email associated with
+your GitHub account or be in your verified emails list. Project policy requires
+DCO sign-off on every commit; PRs with unsigned commits cannot be merged.
 
 If you forget to sign off, amend your commits before pushing:
 
@@ -149,8 +158,11 @@ git rebase --signoff main                 # all commits since main diverged
 
 ### JavaScript / TypeScript (`web/`)
 
-- **Formatter:** Prettier with the project's `.prettierrc`. CI rejects unformatted code.
-- **Linter:** ESLint with the project's `.eslintrc`. TypeScript-specific rules enforced for `.ts` files; Svelte rules for `.svelte` files.
+- **Formatter:** Prettier with the project's `.prettierrc`. Run it deliberately on
+  files you change; the current PR workflow does not run a Web formatting gate.
+- **Static check:** `npm run check:lq-ai` runs the scoped Svelte/TypeScript check
+  used by current PR CI. The inherited full-fork `npm run lint` script mutates
+  files and is not the PR static-check contract.
 - **TypeScript:** required for new files; gradual migration of legacy `.js` files welcome but not required for unrelated changes.
 - **Framework:** SvelteKit. The `web/` codebase is a fork of OpenWebUI, which is a SvelteKit app — extensions and customizations stay in Svelte. Do **not** introduce React into `web/`. The Word add-in (`word-addin/`, M3) uses Office.js with React; the `web/` codebase does not.
 - **Component conventions:** match the OpenWebUI conventions for shared components; use the project's design system primitives rather than ad-hoc Tailwind.
@@ -176,15 +188,21 @@ The project takes testing seriously because the substantive correctness of the l
 
 ### Coverage target
 
-Pytest coverage target is **80%** across `api/` and `gateway/`. The CI configuration enforces no-decrease coverage on PRs — your PR cannot drop overall coverage. New code should be covered by tests; bug fixes should include a regression test that fails before the fix and passes after.
+Pytest coverage target is **80%** across `api/` and `gateway/`. Current PR CI does
+not enforce a coverage threshold or no-decrease rule. New code should be covered
+by tests; bug fixes should include a regression test that fails before the fix
+and passes after.
 
 ### Test categories
 
-- **Unit tests** — fast, no external dependencies. Run on every commit. Mock the Inference Gateway, the database, and any provider APIs.
-- **Integration tests** — run against a real Postgres instance (Docker-launched in CI) and the actual Inference Gateway against a mocked provider. These exercise multi-component flows.
-- **Provider-integration tests** — gated behind `pytest -m provider` and require provider API keys configured. CI runs these nightly against a small subset; contributors are not expected to run them locally unless their changes specifically affect provider integration.
-- **End-to-end tests** — Playwright tests covering happy paths in the web UI. Run on every PR.
-- **Fuzzing** — the Inference Gateway's OpenAI compatibility surface is fuzzed continuously in CI against the OpenAI API spec.
+- **Unit tests** — fast, no external dependencies. Mock the Inference Gateway, the database, and any provider APIs.
+- **Integration tests** — API PR tests run with a real pgvector Postgres service.
+  These exercise flows that need database behavior rather than mocks alone.
+- **Provider-integration tests** — marked `provider` and require provider API
+  keys. They are not a separate current PR CI job; run them locally when a change
+  specifically affects provider integration and credentials are available.
+- **End-to-end tests** — browser end-to-end coverage is not part of the current PR workflow.
+- **Fuzzing** — continuous fuzzing is not part of the current PR workflow.
 
 ### Stack smoke test (build + boot the whole stack)
 
@@ -221,24 +239,27 @@ Locked-in choices so new tests don't drift across `api/` and `gateway/`. Changes
 
 ### Test markers
 
-Standard markers — declared in each subsystem's `pyproject.toml` so `pytest --strict-markers` will reject typos:
+Standard markers are declared in each subsystem's `pyproject.toml` where
+applicable, so `pytest --strict-markers` rejects typos:
 
 | Marker | Purpose | Default behavior |
 |---|---|---|
-| `unit` | Pure unit, no I/O | Always run |
-| `integration` | Hits Postgres, Redis, MinIO, or the Gateway | Run on every PR |
-| `provider` | Hits a real LLM provider; requires API key | Skipped unless `-m provider` |
-| `slow` | Takes > 5s; usually integration with realistic data | Run nightly, optional locally |
-| `e2e` | Playwright end-to-end | Run on every PR via the Playwright job |
+| `unit` | Pure unit, no I/O | Included in current PR pytest jobs |
+| `integration` | Hits Postgres, Redis, MinIO, or the Gateway | Included in current PR pytest jobs; API CI supplies pgvector Postgres |
+| `provider` | Hits a real LLM provider; requires API key | Run intentionally with credentials; no dedicated current PR job |
+| `slow` | Takes > 5s; usually integration with realistic data | Skipped by `make test`; current PR pytest has no marker filter |
+| `e2e` | Browser end-to-end (currently declared for API only) | Not run by the current PR workflow |
 
 `pytest -m "not provider and not slow"` is the local-loop default; `make test` runs this.
 
 ### JavaScript/TypeScript tests (`web/`)
 
-The OpenWebUI fork is SvelteKit. New tests use **Vitest** (Svelte's standard) for unit and component tests; Playwright for end-to-end. Don't introduce Jest unless there's a concrete reason — Vitest is closer to SvelteKit's tooling and has fewer ESM-vs-CJS pitfalls.
+The OpenWebUI fork is SvelteKit. New unit and component tests use **Vitest**
+(Svelte's standard). Don't introduce Jest unless there's a concrete reason —
+Vitest is closer to SvelteKit's tooling and has fewer ESM-vs-CJS pitfalls.
 
 - **Component tests:** `@testing-library/svelte` with Vitest.
-- **Type checking in tests:** test files are `.ts` / `.svelte` and pass `npm run typecheck`.
+- **Type checking in tests:** test files are `.ts` / `.svelte` and pass `npm run check:lq-ai`.
 - **Snapshot testing:** discouraged for component output; preferred for stable structured data (e.g., backend-returned shapes).
 
 ### When to write what kind of test
@@ -250,7 +271,7 @@ The OpenWebUI fork is SvelteKit. New tests use **Vitest** (Svelte's standard) fo
 | New provider adapter | Provider-integration tests (gated behind `-m provider`); unit tests with mocked provider responses for the request/response shape |
 | New skill (engineering side; the skill content itself goes through the skills/CONTRIBUTING.md path) | A worked-example test verifying the skill renders and produces structured output of the expected shape |
 | New deployment recipe | Documented steps + a CI verification job that runs the recipe in a clean environment |
-| Documentation only | No new tests; CI lints markdown |
+| Documentation only | No new tests; no current Markdown CI gate |
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 #
 # Conventional targets per CONTRIBUTING.md and M1-IMPLEMENTATION-ORDER A1:
 #   install   — install Python and Node dev dependencies
-#   test      — run unit + integration tests (skips provider-marked)
-#   lint      — ruff check + mypy on Python; eslint on web
-#   format    — ruff format + prettier
+#   test      — run Python tests (skips provider/slow) + Web unit tests
+#   lint      — ruff check + mypy on Python; scoped static checks on web
+#   format    — apply ruff formatting to Python subsystems
 #   migrate   — run Alembic migrations against the configured DB
 #   run-dev   — bring up the dev stack via docker compose
 #   clean     — tear down dev stack and remove caches
@@ -33,10 +33,10 @@ help:
 install: install-api install-gateway install-web ## Install all subsystem dependencies
 
 .PHONY: test
-test: api-test gateway-test ## Run unit + integration tests (skip provider-marked)
+test: api-test gateway-test web-test ## Run Python tests (skip provider/slow) + Web unit tests
 
 .PHONY: lint
-lint: api-lint gateway-lint ## Run ruff + mypy on Python subsystems
+lint: api-lint gateway-lint web-check ## Run Python lint/type checks + Web static checks
 
 .PHONY: format
 format: api-format gateway-format ## Apply ruff format to Python subsystems
@@ -58,8 +58,8 @@ stop-dev: ## Stop the dev stack (preserves volumes)
 	docker compose down
 
 .PHONY: clean
-clean: ## Tear down dev stack, volumes, and caches
-	docker compose down -v
+clean: ## Tear down dev stack and caches (preserves volumes)
+	docker compose down
 	find . -type d -name __pycache__ -prune -exec rm -rf {} +
 	find . -type d -name .pytest_cache -prune -exec rm -rf {} +
 	find . -type d -name .ruff_cache -prune -exec rm -rf {} +
@@ -90,9 +90,7 @@ psql: ## Open a psql shell against the dev database
 
 .PHONY: install-api
 install-api:
-	cd api && python -m venv .venv && \
-		.venv/bin/pip install --upgrade pip && \
-		.venv/bin/pip install -e ".[dev]"
+	cd api && uv sync --frozen --extra dev
 
 .PHONY: api-test
 api-test:
@@ -104,15 +102,16 @@ api-test-all:
 
 .PHONY: api-lint
 api-lint:
-	cd api && .venv/bin/ruff check . && .venv/bin/mypy app
+	api/.venv/bin/ruff check api scripts
+	cd api && .venv/bin/mypy app
 
 .PHONY: api-format
 api-format:
-	cd api && .venv/bin/ruff format .
+	api/.venv/bin/ruff format api scripts
 
 .PHONY: api-format-check
 api-format-check:
-	cd api && .venv/bin/ruff format --check .
+	api/.venv/bin/ruff format --check api scripts
 
 .PHONY: openapi
 openapi: ## Regenerate docs/api/backend-openapi.generated.yaml from the live app (DE-373)
@@ -122,9 +121,7 @@ openapi: ## Regenerate docs/api/backend-openapi.generated.yaml from the live app
 
 .PHONY: install-gateway
 install-gateway:
-	cd gateway && python -m venv .venv && \
-		.venv/bin/pip install --upgrade pip && \
-		.venv/bin/pip install -e ".[dev]"
+	cd gateway && uv sync --frozen --extra dev
 
 .PHONY: gateway-test
 gateway-test:
@@ -136,42 +133,30 @@ gateway-test-all:
 
 .PHONY: gateway-lint
 gateway-lint:
-	cd gateway && .venv/bin/ruff check . && .venv/bin/mypy app
+	gateway/.venv/bin/ruff check gateway
+	cd gateway && .venv/bin/mypy app
 
 .PHONY: gateway-format
 gateway-format:
-	cd gateway && .venv/bin/ruff format .
+	gateway/.venv/bin/ruff format gateway
 
 .PHONY: gateway-format-check
 gateway-format-check:
-	cd gateway && .venv/bin/ruff format --check .
+	gateway/.venv/bin/ruff format --check gateway
 
 # ---------- web/ ----------
-# Lands when OpenWebUI fork is imported in A1.d.
 
 .PHONY: install-web
 install-web:
-	@if [ -f web/package.json ]; then \
-		cd web && npm install; \
-	else \
-		echo "web/ not yet imported (Task A1.d)."; \
-	fi
+	cd web && npm ci
 
 .PHONY: web-test
 web-test:
-	@if [ -f web/package.json ]; then \
-		cd web && npm test; \
-	else \
-		echo "web/ not yet imported (Task A1.d)."; \
-	fi
+	cd web && npm run test:frontend -- --run
 
-.PHONY: web-lint
-web-lint:
-	@if [ -f web/package.json ]; then \
-		cd web && npm run lint; \
-	else \
-		echo "web/ not yet imported (Task A1.d)."; \
-	fi
+.PHONY: web-check
+web-check:
+	cd web && npm run check:lq-ai
 
 # ----------------------------------------------------------------------
 # Release-readiness (Phase E)

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ gateway-format-check:
 
 .PHONY: install-web
 install-web:
-	cd web && npm ci
+	cd web && CYPRESS_INSTALL_BINARY=0 npm ci
 
 .PHONY: web-test
 web-test:

--- a/docs/contribute/coding-agent-onboarding.md
+++ b/docs/contribute/coding-agent-onboarding.md
@@ -113,11 +113,14 @@ make web-test
 Run API tests that need Postgres against the throwaway pgvector database from
 §3; do not claim integration coverage from a run without it.
 
-Current PR CI runs three jobs: **API** (`ruff check api scripts`,
-`ruff format --check api scripts`, `mypy app`, and `pytest -q` with pgvector
-Postgres), **Gateway** (ruff check/format, `mypy app`, and `pytest -q`), and
-**Web** (`npm run check:lq-ai` and `npm run test:frontend -- --run`). It does not
-currently enforce coverage no-decrease or run browser end-to-end tests. A new
+Current PR CI runs three jobs: **API** (`uv lock --check`, `ruff check api
+scripts`, `ruff format --check api scripts`, `mypy app`, and `pytest -q` with
+pgvector Postgres), **Gateway** (`uv lock --check`, ruff check/format, `mypy
+app`, and `pytest -q`), and **Web** (`npm run check:lq-ai` and `npm run
+test:frontend -- --run`). The path-triggered Stack smoke workflow also runs on
+PRs that change the specified API/Gateway/Web dependency manifests and locks,
+Dockerfiles, compose, API migrations, its script, or its workflow. Current PR CI
+does not enforce coverage no-decrease or run browser end-to-end tests. A new
 endpoint needs unit + integration + OpenAPI-conformance tests; a bug fix needs a
 regression test.
 
@@ -141,8 +144,8 @@ These are non-obvious and have each taken down CI at least once:
   open a PR against `LegalQuants/lq-ai`, and respond to CI and maintainer review.
   Do not push maintainer remotes or merge the PR yourself.
 - **Maintainers only:** after merging, an authorized maintainer may synchronize
-  the upstream and `tucuxi` mirror remotes and apply the project's
-  branch-retention policy. These are not contributor steps.
+  upstream and configured mirror remotes and apply the project's branch-retention
+  policy. These are not contributor steps.
 
 ---
 
@@ -156,8 +159,6 @@ receive adversarial vetting per
 Changes to `gateway/**`, authentication, authorization, audit, or cryptography
 require the applicable security review under
 [.github/CODEOWNERS](../../.github/CODEOWNERS) before a maintainer merges them.
-Maintainer-authored internal branches follow the maintainers' own merge policy;
-that is not an external-contributor workflow.
 
 When in doubt, treat it as the stricter row and ask.
 

--- a/docs/contribute/coding-agent-onboarding.md
+++ b/docs/contribute/coding-agent-onboarding.md
@@ -63,8 +63,8 @@ This is how work actually gets shipped here. It is battle-tested across the M1�
    Never report "done" without the command output. See §4.
 
 5. SHIP.
-   Commit with DCO + trailer (§5) → push BOTH remotes → open PR → watch CI
-   → merge per the gating rule (§6) → report the squash SHA.
+   Commit with DCO (§5) → push the branch to your own fork → open a PR
+   → respond to CI and review. A maintainer performs the merge (§6).
 ```
 
 Two honesty rules that sit on top of the loop:
@@ -100,15 +100,26 @@ These have each bitten this codebase. Violating them corrupts the running dev st
 Before claiming a change is complete, run and read the output of:
 
 ```bash
-cd api   # or gateway/
-.venv/bin/ruff format --check app tests
-.venv/bin/ruff check app tests
-.venv/bin/mypy app          # gateway is mypy --strict; api is standard
-# targeted tests for what you touched, then the relevant suites, on a throwaway DB:
-DATABASE_URL=postgresql+asyncpg://test:test@127.0.0.1:55432/lqai_test .venv/bin/pytest <paths> -q
+# From the repository root after `make install`
+make lint          # Python ruff/mypy + Web npm run check:lq-ai
+make format-check  # Python ruff format --check
+make test          # Python local-loop suites + Web Vitest
+
+# Run Web gates independently when iterating on web/
+make web-check
+make web-test
 ```
 
-CI runs three jobs: **API** (ruff + mypy + pytest — the long pole, ~11 min), **Gateway** (ruff + mypy --strict + pytest), **Web** (svelte-check + Vitest). Coverage target is 80% across `api/` and `gateway/`; CI enforces no-decrease. A new endpoint needs unit + integration + OpenAPI-conformance tests; a bug fix needs a regression test.
+Run API tests that need Postgres against the throwaway pgvector database from
+§3; do not claim integration coverage from a run without it.
+
+Current PR CI runs three jobs: **API** (`ruff check api scripts`,
+`ruff format --check api scripts`, `mypy app`, and `pytest -q` with pgvector
+Postgres), **Gateway** (ruff check/format, `mypy app`, and `pytest -q`), and
+**Web** (`npm run check:lq-ai` and `npm run test:frontend -- --run`). It does not
+currently enforce coverage no-decrease or run browser end-to-end tests. A new
+endpoint needs unit + integration + OpenAPI-conformance tests; a bug fix needs a
+regression test.
 
 ### Test-suite collision guards (miss these and the **whole** api suite crashes at collection)
 
@@ -124,20 +135,29 @@ These are non-obvious and have each taken down CI at least once:
 ## 5. Commit & PR mechanics
 
 - **DCO sign-off on every commit:** `git commit -s`. Imperative mood ("Add X", not "Added X"). Reference issues in the body (`Closes #123`, `Refs DE-103`).
-- **Stage files explicitly** — never `git add -A`. There are intentionally-untracked files in the tree (e.g. `docs/lq-ai-skill-inputs-corpus.md`); a blanket add sweeps them in.
-- **Push BOTH remotes** after a merge: `origin` (LegalQuants/lq-ai) and `tucuxi` (Tucuxi-Inc mirror) are kept byte-identical on `main`.
-- **Branch preservation:** merged feature branches are kept on the remotes as a historical record for future contributors — don't delete them.
-- **Co-author trailer:** the project tags AI-assisted commits with a `Co-Authored-By:` trailer. Match the convention already in `git log` rather than inventing one.
+- **Stage files explicitly** — never `git add -A`. Inspect `git status` and add
+  only the paths intended for the contribution.
+- **External contributors:** push the contribution branch only to your own fork,
+  open a PR against `LegalQuants/lq-ai`, and respond to CI and maintainer review.
+  Do not push maintainer remotes or merge the PR yourself.
+- **Maintainers only:** after merging, an authorized maintainer may synchronize
+  the upstream and `tucuxi` mirror remotes and apply the project's
+  branch-retention policy. These are not contributor steps.
 
 ---
 
 ## 6. Merge gating (who merges what)
 
-| Change touches… | Who merges |
-|---|---|
-| `gateway/**`, or **authentication / authorization / audit / crypto** | Maintainer reviews **and** merges (security boundary — see [.github/CODEOWNERS](../../.github/CODEOWNERS)). Offer review-vs-self-merge. |
-| `api/` (non-authz) or docs | Self-merge after CI is green. |
-| **External / community PR** (unknown contributor or fork) | **NEVER** auto- or self-merge. CI green ≠ vetted. Vet adversarially per [docs/security/external-contribution-vetting.md](../security/external-contribution-vetting.md), report, leave the merge to a maintainer. |
+External contributors never auto- or self-merge. CI green is necessary but not
+sufficient: a maintainer reviews and merges the PR. External/community PRs also
+receive adversarial vetting per
+[docs/security/external-contribution-vetting.md](../security/external-contribution-vetting.md).
+
+Changes to `gateway/**`, authentication, authorization, audit, or cryptography
+require the applicable security review under
+[.github/CODEOWNERS](../../.github/CODEOWNERS) before a maintainer merges them.
+Maintainer-authored internal branches follow the maintainers' own merge policy;
+that is not an external-contributor workflow.
 
 When in doubt, treat it as the stricter row and ask.
 
@@ -154,7 +174,7 @@ A worked shape for taking an item from [ROADMAP.md](../ROADMAP.md) / a [mini-PRD
 5. **Build in reviewed increments** (§2 step 3).
 6. **Gates** (§4), including the collision guards and a throwaway-DB migration check if you added one.
 7. **Docs are part of the change** — update the PRD section, OpenAPI yaml, and DB schema doc that your change touches, in the same PR. Reconcile the narrative docs (README, HONEST-STATE, the feature guide) if behavior changed. File new deferrals as **DE-XXX in PRD §9** rather than expanding scope.
-8. **Ship** (§5–§6) and report the squash SHA.
+8. **Ship** (§5–§6): push only to your own fork, open the PR, and respond to CI and review; a maintainer merges it.
 
 ### Special case: skills with legal substance
 


### PR DESCRIPTION
## What this PR does

Aligns the top-level Makefile and contributor documentation with the repository's current tooling:

- uses frozen uv installs for API and Gateway;
- uses `npm ci` and the existing Web test/check scripts;
- includes Web in top-level test and static-check targets; and
- makes `make clean` preserve named volumes.

It also clarifies the fork-to-PR path for external contributors and separates it from maintainer-only merge and mirror operations.

## Why

The repository moved API and Gateway to uv and added the Web application, but the contributor path still used pip, referenced nonexistent Web scripts, omitted Web from aggregate checks, and deleted Docker volumes during cleanup.

## Scope

This does not change application code, dependencies, CI workflows, hooks, schemas, or runtime configuration. It does not address #301, duplicate #431's test-strategy work, or describe #432's pending Cypress checks as current behavior.

## Verification

- Dry-ran the updated install, test, check, and cleanup targets.
- Confirmed documented Web commands exist in `web/package.json`.
- Checked contributor claims against the current CI workflow.
- Validated changed links and ran `git diff --check`.
- Confirmed `make clean` no longer passes `-v`.

The actual subsystem suites were not run locally because this checkout lacks uv, npm, installed dependencies, and a pgvector test database. The existing PR CI will run the repository checks on a clean runner.

## Type of change

- [x] Documentation update
- [x] Test / CI / tooling

## Transparency & governance invariants

P1-P10: n/a - this changes contributor documentation and Make targets only. No application runtime, data, egress, authorization, governance, API, or schema path is changed.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO.

## Related issues

Follow-up to the uv adoption in #441. Issue #301 remains separate.
