### PR TITLE
docs: documentation-site mini-PRD (parent + annexes A–C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ When you need to find something quickly:
 | Frontend dev loop (HMR) | [web/docs/frontend-dev.md](web/docs/frontend-dev.md) |
 | What's already implemented | Existing code in `api/`, `gateway/`, `web/` |
 | What's deferred | [docs/PRD.md §9](docs/PRD.md#9-deferred-enhancements-and-identified-future-work) |
-| Contributor-pickup mini-PRDs | [docs/proposals/](docs/proposals/) |
+| Contributor-pickup mini-PRDs | [docs/contribute/mini-prds/](docs/contribute/mini-prds/) |
 | Security policy | [SECURITY.md](SECURITY.md) |
 | Conduct policy | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
 

--- a/docs/contribute/mini-prds/docsite/README.md
+++ b/docs/contribute/mini-prds/docsite/README.md
@@ -1,0 +1,136 @@
+# A public documentation site for LQ.AI · mini-PRD
+
+| | |
+|---|---|
+| **Status** | **Proposed — pending committee decision.** Carries open forks; see [Decisions the committee must make](#decisions-the-committee-must-make). |
+| **Effort** | **L overall, deliberately divisible** — ~18–20 independently claimable S/M items across six contributor profiles (Annex C). The launch-gating subset is ~25 pages, of which ~15 are curation of existing repo files. |
+| **Contributor profile** | Varies by section: DevOps (operations), compliance/security professional (trust centre), practising lawyer (skills, licensing), technical writer (contribute, orientation), frontend engineer (site infrastructure). Per-item profiles in Annex C. |
+| **Mentor** | Per section — committee to confirm; see decision 5. |
+| **Depends on / relates to** | ADR [0001](../../../adr/0001-openwebui-fork-pin.md) (branding clause — spawned item 1), ADR [0022](../../../adr/0022-committee-governance-and-meeting-records.md), ADR [0024](../../../adr/0024-jurisdiction-and-practice-area-expansion.md) (contribution routing), ADR [0025](../../../adr/0025-release-versioning-and-pipeline-ordering.md) (upgrade classes); the open anonymization item ([2026-07-26 minutes](https://github.com/LegalQuants/lq-ai-community/blob/main/meetings/2026-07-26-weekly/notes.md), PR #439) — **blocks one launch page**; mini-PRDs [#1](../procurement-readiness-pack.md), [#3](../skill-acceptance-tests.md), [#5](../air-gap-install-verification.md), [#7](../reverse-proxy-tls-deployment-recipes.md), [#8](../community-skill-installer-ui.md); DE-386; issues #490, #495, #503. |
+
+**Annexes** (siblings of this file):
+[**A — Quality rules and failure tests**](annex-a-quality-rules.md) *(core rules are community-authored and land under their author's name — see decision 4)* ·
+[**B — User journeys as acceptance criteria**](annex-b-journeys.md) ·
+[**C — Page trees, sizing, and claimable work items**](annex-c-work-plan.md)
+
+---
+
+## What this is
+
+A public documentation site for LQ.AI: an audience-indexed façade over canonical repo files, built with **Astro/Starlight and hosted on GitHub Pages** (maintainer decision, 2026-08-11), with **content living in this repository** and the site building from the same tree — so every page's "checked against" stamp is the file's own git history. Latest-version-only until 1.0, with per-page status badges. It curates and routes; it does not fork content the repo already holds.
+
+## The goal
+
+LQ.AI's promise is that every claim it makes can be checked — read the skill that produced the answer, check the citation against the source, inspect the gap catalogue, verify where data goes. The docs site is how that promise reaches people who have not cloned the repo. Its goal is to grow the four things the project runs on:
+
+- **Deployments** — operators who succeed alone, and whose deployments survive week two.
+- **Approvals** — evaluators who can say yes from their desk, citing stable URLs.
+- **Legal substance** — practising lawyers who become skill authors, the project's canonical value.
+- **Contributors** — humans and their coding agents, for whom a material contribution is a recognised route into LegalQuants membership.
+
+## Who we are building it for
+
+Priority-ordered; the full audience matrix and journeys are in Annexes B–C.
+
+1. **The self-hosting legal team, often a legal function of one (P0).** The same person is operator, author and evaluator across months. What the site gives them: from *"is this for me?"* to a verified running deployment without asking a human — and the week-two pages (backup, upgrade, key rotation) that keep the deployment alive once real matters are in it. Every other audience depends on this reader succeeding.
+2. **The security / procurement evaluator (P0).** Spends 45 minutes, never installs, holds the veto. What the site gives them: a trust centre with stable, citable URLs — the artifacts outside commentators already praise unprompted (threat model, signed releases, HONEST-STATE), organised so an evaluator completes their questionnaire without a meeting. The public framing this earns the project: *procurement delays measured in days, not months*.
+3. **The practising lawyer with substance to encode (P1).** The open-skills thesis made usable: "your prompt files are already skill-shaped", a clear attestation path, and a skill catalogue browsable by **practice area and jurisdiction** — an axis no comparable project's documentation offers and ours can populate today.
+4. **The contributor and their coding agent (P1).** The community's actual onboarding advice, stated publicly, is *point your agent at the repo*. The machine surface (`/llms.txt`, `.md` on every URL) makes the site's most common first reader first-class — and because contribution doubles as the admissions route into LegalQuants, the contributor pages are also the community's front door.
+5. **The builder and the deployment partner (P2, honesty pages first).** Three real products already run on this backend; LQs want to deliver branded deployments to clients — the commercial layer the founder publicly invited. What the site gives them: a documented, supported path (build a frontend or fork the backend; the gateway as an OpenAI drop-in; dual-branding within the upstream licence) instead of folklore — enabling that layer on terms nobody can breach by accident.
+
+## What the project gets
+
+- **Answers become assets instead of favours.** The two costliest questions in the community record — *"why LQ.AI when the open-source alternative exists?"* and *"how do I deploy this on my company's cloud?"* — were each answered once, in chat, by whoever happened to be online, and neither answer is retrievable. The site converts recurring questions from a person's availability into a permanent, versioned answer.
+- **The honesty discipline becomes the public brand.** HONEST-STATE surfaced proudly; every page stamped with the commit it was checked against; every admitted limit ending in a decision. This is the differentiator outsiders already cite — the site makes it the first thing a stranger sees rather than something they excavate.
+- **Contribution scales with the community, not the maintainer.** The site itself ships as ~18–20 claimable S/M items with per-item acceptance tests (Annex C): a lawyer can own the skills pages, a DevOps contributor the operations pages, a compliance professional the trust centre — each mentored, each independently mergeable.
+- **The evaluation and deployment funnel compounds.** Most of the P0 content already exists in the repo — the launch is ~60% curation. The site is the highest-leverage packaging of work already done.
+
+**The gap this closes, in one paragraph.** None of this requires invention — it requires organising what exists, and closing four documented failures on the way: a licence obligation recorded only inside ADR 0001 while the community plans white-label deployments (spawned item 1); a public pseudonymization claim the committee's own [published minutes](https://github.com/LegalQuants/lq-ai-community/blob/main/meetings/2026-07-26-weekly/notes.md) describe as non-functional (decision 1); silent failure modes that have already cost one user a published wrong conclusion ([#503](https://github.com/LegalQuants/lq-ai/issues/503)); and public surfaces drifting out of agreement with the repo and each other (marketing at v0.4.x against a v0.7.0 repo; PRD §1.6 against the decision log on litigation scope). Each is actioned in the decisions and spawned items below rather than argued here. 
+## What we'd ship
+
+**The tree** — nine namespaces, role-based navigation with a goal-based entry hub (full trees, sizing and rationale in Annex C):
+
+```
+/            entry hub: one-sentence definition, data boundary, goal cards, "not for" link
+/start/      orientation — "Is LQ.AI for you?", what it touches, quickstart, routing     (5 pages)
+/operate/    install ×5, hardware sizing, backup/restore, upgrade, key rotation,
+             troubleshooting + recipes/ — an EXTENSIBLE catalogue of short, agent-readable
+             topology guides (Tailscale, Azure, remote Ollama…) behind a supported-shapes
+             index                                                                      (~15+)
+/trust/      TRUST CENTRE — data-flow, threat model, anonymization, audit, supply chain,
+             HONEST-STATE, governance, continuity, disclosure, questionnaires            (~13)
+/skills/     authoring, testing, attestation, playbooks + generated skill catalogue,
+             and a GENERATED coverage index by jurisdiction × practice area: pages
+             listing attested skills, research sources/MCP connectors, scope notes,
+             and coverage gaps                                                          (~10+)
+/build/      choose-your-surface, gateway as OpenAI drop-in, fork/frontend path, SSE,
+             cookbooks                                                                   (~8)
+/deliver/    branding & licensing obligations, theming, branded-deployment guide,
+             multi-deployment ops                                                        (~8)
+/contribute/ two tracks, live board (generated), per-profile on-ramps, dev-env guide     (~9)
+/reference/  GENERATED — config reference, both API references, schemas, ADR index,
+             error vocabulary, stability policy
+/changelog/  one page per release: upgrade class (ADR 0025), operator actions, migrations
++ machine surface: /llms.txt and .md for every page URL — a coding agent is the most
+  common first reader, and this is a build step now or a rewrite later
+```
+
+**The launch (P0):** `/` + `/start/` + the install spine of `/operate/` + the whole of `/trust/` — **~25 pages, ~15 of them curation**. Prioritization: OPS + EVAL launch-gating; AUTHOR + CONTRIB launch-with; DEV + PRODUCT fast-follow with honesty pages up front (decision 2).
+
+**The rules it is built under:** the community-authored twelve ranked rules (from the three-site documentation benchmark), sixteen house-style rules, and two conditions — every page states the commit it was checked against; nothing publishes orphaned — plus three regulated-field additions (silent-failure disclosure, professional-duty language at the point of decision, licence obligations as obligations). All with failure tests, all in Annex A. One cross-surface rule joins them: **every page stating a scope or capability names its canonical artifact and check date — failed when two published surfaces answer the same question differently.**
+
+**Structural commitments:** the `/trust/` subtree carries a URL-stability commitment (procurement memos cite these URLs; GitHub Pages cannot redirect, so stability is a naming discipline plus canonical-stub pages for unavoidable moves). Reference pages are generated, never hand-written — the generators (openapi export, Pydantic config models, skill frontmatter) already exist. The skill catalogue carries **practice area and jurisdiction as first-class axes**, which no comparable project's documentation offers and our skills can populate today.
+
+**Designed to expand.** Two namespaces are catalogues that grow by contribution, not by restructuring:
+
+- **Deployment recipes** (`/operate/recipes/`): short problem-shaped guides in a fixed house format — problem, context, steps, verify, *and the refusal errors explained* (the egress guard refusing plaintext-to-tailnet is a security feature that reads as a wall until a page explains it, issue [#495](https://github.com/LegalQuants/lq-ai/issues/495)). Each recipe is an S-sized claimable item; the Caddy + Tailscale recipe and mini-PRD [#7](../reverse-proxy-tls-deployment-recipes.md) are the precedent. A supported-shapes index fronts the catalogue: one row per topology, marked *recipe published / known to work / not tried*.
+- **The coverage index** (`/skills/coverage/`), by **jurisdiction × practice area**: generated from skill frontmatter and the content-source registry (ADR [0021](../../../adr/0021-content-source-registry-and-free-source-expansion.md)) — a page per jurisdiction and per practice area, listing the attested skills, the research sources and MCP connectors relevant to it, the coverage gaps, and the ADR 0024 route for filling them. Each page carries canon's scope decisions in place (e.g. litigation: research and drafting only), which is the cross-surface rule doing its job. A lawyer browses by practice area within their jurisdiction; both axes are already in skill frontmatter.
+
+Both catalogues are agent-readable page-by-page via the machine surface: **a coding agent should be able to fetch "remote Ollama over Tailscale" or "Singapore law resources" as a single `.md` and act on it.** That is the growth model — the site's most common first reader is an agent, and these are the two page types an agent most often acts on.
+
+## What we would not ship (scope cuts)
+
+- **End-user help.** The in-app Learn surface owns the daily-user audience — it is version-locked to the deployment and present at the moment of the question. Stated as policy, with one deliberate exception: incident procedures with professional-conduct consequences (a wrong citation, evidence reconstruction) belong on the site, because that reader may no longer have deployment access.
+- **Versioned documentation** before 1.0. Latest-only with per-page status badges; revisit at 1.0.
+- **A skill registry.** The catalogue is an index with provenance, not a distribution mechanism; registry ambitions route to mini-PRD #8 and the `lq-skills` repo.
+- **Journeys as navigation.** Journeys (Annex B) are acceptance tests and contribution units. The nav stays role-based; one grouping only — sidebar, address, and index must agree.
+- **A hosted status page.** Acknowledged as an obligation attached to hosted artifacts; deferred with a DE (decision 6).
+
+## How we'd know it's done
+
+The journeys in Annex B each carry a *failed-when* test runnable by someone who did not write the site. **Launch gate:**
+
+1. The four P0 journeys (*Is this for me · Get it running · What leaves my deployment · Hand this to our security team*) pass, run by a non-author; the first and third additionally pass with a **second reader who has not read the source** — until that reader exists they are unverified, not passed.
+2. The twelve community-authored failure tests (Annex A): none fires against the built site.
+3. Machine surface verified: `/llms.txt` present; every page URL serves `.md`; an agent can orient from one fetch.
+4. Accessibility gate in CI (pa11y, WCAG 2.1 AA) passes — including on generated API pages, which is where it fails by default.
+5. Zero orphan pages; every page stamped with the commit it was checked against; the link checker (`docs/audits/check_doc_links.py`) passes.
+
+## Decisions the committee must make
+
+1. **The anonymization layer** (PR #439; open item in the 2026-07-26 minutes). The trust centre's data-flow page — the highest-severity page on the site — cannot be written until this closes. *Recommendation: decide the layer's fate first; whatever the outcome, the page states measured behaviour and ends in a decision ("route privileged matters to Tier 1").*
+2. **Prioritization sign-off**: OPS+EVAL at P0, AUTHOR+CONTRIB at P1, DEV+PRODUCT at P2. *Recommendation: as stated — P0 is ~60% curation; the cost curve favours this order.*
+3. **The deployment-partner framing.** Document persona: "deliver branded client deployments" (dual-branding, threshold-aware), with fork-based multi-tenant SaaS marked unsupported-but-legal on its own page — not "build your own Harvey". *Recommendation: adopt; anything else overpromises against ADR 0001 and single-tenancy.*
+4. **Adopt the quality rules** — the community-authored twelve + sixteen + two conditions as the site's standing gates, credited to and landed by their author (renumbered as they prefer), plus regulated-field rules R-A, R-B, R-C; merging R-D–R-H into the core set is at the author's discretion. *Recommendation: adopt; ask the author for the unposted v2 of the analysis before finalizing.*
+5. **Mentors per section.** Candidate evidence is in Annex C. Note: if any site content ever leaves this repo, CODEOWNERS review-routing for security/compliance/skills paths stops applying — named mentors become load-bearing. *Recommendation: confirm one mentor per P0 section before opening items for claim.*
+6. **Hosted-artifact ownership**: who operates the Pages deployment and DNS, and a DE for the status-page obligation. *Recommendation: LegalQuants org owns both; status page deferred by DE.*
+
+## Spawned, not absorbed
+
+Pre-existing obligations this PRD names as dependencies and refuses to swallow:
+
+1. **Branding-obligations page — ship now, independent of the site** (Effort M). Assigned by ADR 0001 itself; the 50-user threshold appears nowhere else in the repo; the upstream fork refresh (#498) is the natural moment. The single highest-cost gap in the research.
+2. **Status-drift fix**: `GOVERNANCE.md` still says Proposed while ADR 0022 is Accepted; the `lq-ai-community` status notes are frozen at 2026-08-02. Two small human-merged PRs.
+3. **Scoped API tokens**: PRD §5.1 promises them; the code has JWT session auth only. File the DE and the HONEST-STATE row — the one currently unregistered PRD-vs-code divergence.
+4. **Release-notes backfill**: 7 of 12 version tags have no GitHub Release (against PRD §7.8's "full changelog" commitment — second HONEST-STATE row); source material exists for all seven; Effort M. Plus a five-minute edit: v0.4.0's published Release still carries its DRAFT banner.
+5. **API-reference URL stability**: FastAPI auto-generates `operationId` from handler names, so a Python refactor silently changes a published docs URL. Set a `generate_unique_id_function` (plus `tags:`/`servers:` blocks) **before** any API reference publishes. Small; load-bearing.
+6. **The founder loop-in.** The committee already decided it (2026-07-26, decision 4: bring Kevin up to date before any public release). A docs-site launch plausibly triggers it; there are two heavier items to bundle (the Apple signing identity SPOF named in ADR 0025; the standing CallDonna.ai transfer offer). Human task, not an agent's.
+7. **Machine-actionable jurisdiction / practice-area packs (file as a DE).** The coverage index above is *readable* by agents; the further step — a manifest an agent can *apply* ("for Singapore data-protection work: enable these skills, allowlist this MCP connector, set this tier floor") — crosses into product configuration and legal-substance governance (who attests a pack, and what does the attestation cover?). Too consequential to absorb here; the index is designed so a manifest can be generated from it once the DE lands.
+
+## Where this proposal is weak
+
+The journey evidence skews toward the issue tracker — readers who file issues are not typical readers. Two journeys (annual re-review; insurer inquiry) have no evidence because the project is too young for calendars, not because they are wrong. The sizing in Annex C is one researcher's estimate; every contributor who claims a section should re-size it. And the whole plan inherits a single point of external dependence: the quality layer is one community member's work, and the right response to that is to credit and land it, not to rewrite it.
+
+---
+
+*Drafted 2026-08-12 against `main` @ `e9d57763` (v0.7.0).*

--- a/docs/contribute/mini-prds/docsite/annex-a-quality-rules.md
+++ b/docs/contribute/mini-prds/docsite/annex-a-quality-rules.md
@@ -1,0 +1,86 @@
+# Annex A — Quality rules and failure tests
+
+**Status:** Frame only. The core rule set — twelve ranked rules each with a failure test,
+sixteen house-style rules, and two publication conditions — was authored by a community
+member from a three-site comparative review of self-hosted-AI documentation sites, and is
+adopted by reference pending the committee decision in the parent PRD (decision 4). It
+lands here under its author's name, in her own text, when she files it. This annex carries
+only what the parent PRD adds around it.
+
+## The two publication conditions (adopted as stated)
+
+1. Nothing publishes orphaned or stubbed.
+2. Every page states the upstream release or commit it was checked against.
+
+The second condition already runs in production in this project's ecosystem: the
+[`lq-ai-community` decisions log](https://github.com/LegalQuants/lq-ai-community/blob/main/decisions/README.md)
+stamps "status checked <date>" on its records and states that canonical artifacts control
+on any disagreement. The site copies that mechanism; it does not invent one.
+
+## Proposed regulated-field additions
+
+From a benchmark of documentation for open-source software used in regulated fields
+(legal document automation; two medical-records platforms; a core-banking platform
+reviewed and set aside as an anti-pattern). Three rules, in the house format — the rule,
+the reason, the test that says it has been broken — covering ground the core set does not.
+Five further candidates from the same benchmark are held back; the committee can ask for
+them if these three earn their place.
+
+### R-A — Every control whose failure is silent must say so, and say what the reader can observe instead
+
+In an unregulated field the question about a control is "can it fail." In a regulated one
+the question is **"will I know."** This project's own security documentation states the
+finest version of this — for anonymization, a miss is silent, and the lawyer has no in-app
+signal — while the public surface states the control flat. The benchmark found the same
+divergence-without-signal shape in the closest comparable legal project.
+
+> **Failed when:** a page describes a control that protects client-confidential material
+> without stating whether its failure is observable to the user, and — if it is not —
+> what the reader should watch, log, or route differently instead.
+
+### R-B — Name the professional duty at the point of the decision that engages it, in the reader's own professional vocabulary
+
+Across four benchmarked sites in three regulated fields, content addressed to the
+practitioner's own duties totalled two sentences. Our reader *is* the practitioner —
+the solo legal function is operator, author and evaluator in one person. "The gateway logs
+every external call" is an engineering fact; "you can evidence, to your client or your
+regulator, every occasion on which their material left your control" is the same fact
+addressed to the duty it serves.
+
+> **Failed when:** a page describes a technical behaviour that bears on confidentiality,
+> privilege, competence or supervision without naming the duty it touches — or the duty
+> language appears only in a licence, disclaimer, or PRD section rather than beside the
+> decision.
+
+### R-C — Publish the licence obligations the reader can breach as obligations, with the threshold and the compliant pattern
+
+No benchmarked site models this; all three have a licence *link*, which answers "what may
+I do with the code." A deployer is asking "what may I promise my client," and only one of
+those questions currently has an answer anywhere in this project — inside
+[ADR 0001](../../../adr/0001-openwebui-fork-pin.md), which itself assigns the missing page.
+
+> **Failed when:** a reader can plan a rebranded or resold deployment from the deployment
+> documentation without encountering the upstream branding clause, the 50-end-user /
+> 30-day threshold, and the dual-branding pattern — or the constraint lives only in an
+> ADR.
+
+## The cross-surface rule
+
+Added by this PRD on the evidence that two current public surfaces already answer a
+product-scope question differently (PRD §1.6 vs the published decision log, on litigation),
+with the tie-break buried in a register README.
+
+> **Every page that states a scope, capability, or policy names its canonical artifact and
+> the date it was checked against it.**
+>
+> **Failed when:** two published surfaces answer the same scope question differently.
+
+## How the rules are used
+
+- They are **gates, not style advice**: the launch gate (parent PRD, "How we'd know it's
+  done") runs every failure test against the built site, executed by someone who did not
+  write it.
+- The sixteen house-style rules are **authoring guidance, not gates** — reviewers cite
+  them; they do not block merges.
+- A rule without a failure test is a preference, and preferences do not survive the second
+  week. Any rule proposed for this annex must arrive with its test.

--- a/docs/contribute/mini-prds/docsite/annex-b-journeys.md
+++ b/docs/contribute/mini-prds/docsite/annex-b-journeys.md
@@ -1,0 +1,332 @@
+# Annex B — User journeys as acceptance criteria
+
+Twenty-five journeys. Each is a route a real reader takes through the site, and each ends
+in a **failed-when** test that anyone who did not write the site can run against it. The
+journeys are three things and deliberately not a fourth:
+
+- **Acceptance tests** — the launch gate runs the P0 tests; later phases run theirs.
+- **Contribution units** — most journeys are claimable by one person (Annex C maps them).
+- **Entry-point cards** — the site's landing hub routes by these goals, in reader language.
+- **Not navigation.** The nav stays role-based; one grouping only. A journey never becomes
+  a sidebar section.
+
+**Status vocabulary.** *Evidence-derived*: someone took or demanded this path, on the
+record. *Synthetic (likely / plausible)*: extrapolated from evidenced personas and
+contexts; confidence per the evidence pass that adjudicated every synthetic journey
+against the community record, issue tracker, and published minutes. Two journeys found no
+evidence for reasons of project age, are marked so, and should be re-tested once the site
+has lived long enough to produce readers.
+
+**Phase** proposes when the journey's pages ship; committee sign-off is parent decision 2.
+
+| # | Journey | Reader | Status | Phase |
+|---|---|---|---|---|
+| J1 | Am I the person this is for? | anyone; often a legal function of one | evidence | **Launch** |
+| J2 | Get it running | operator | evidence | **Launch** |
+| J3 | What leaves my deployment? | operator, evaluator | evidence | **Launch** ⚠ blocked |
+| J4 | Hand this to our security team | evaluator | evidence | **Launch** |
+| J5 | Point my coding agent at it | a coding agent | evidence | **Launch** (build req.) |
+| J11 | It broke — triage and recover | operator | evidence | **Launch** (min. set) |
+| J20 | Air-gapped install | isolated-network operator | evidence | **Launch** (inventory) |
+| J22 | Which hosting combination is mine? | operator with a fixed topology | evidence | **Launch** (index) |
+| J6 | Week two: back up, upgrade, watch | operator | evidence | Launch-with |
+| J7 | Bring my own workflow in | lawyer-author | evidence | Launch-with |
+| J9 | A provider key leaked, 11pm | operator | synthetic · likely | Launch-with |
+| J10 | The output was wrong — reconstruct | practising lawyer | evidence | Launch-with |
+| J18 | Should I trust this skill? | skill consumer | synthetic · likely | Launch-with |
+| J19 | Will it run on what I have? | resource-constrained reader | synthetic · likely | Launch-with |
+| J21 | Can it do litigation? | disputes practitioner | evidence | Launch-with |
+| J23 | My language, my law — fork or contribute? | non-anglophone practitioner | evidence | Launch-with |
+| J8 | Can it carry our branding? | deployer, firm | evidence | **Ships independently** |
+| J12 | We just crossed fifty users | deployer mid-engagement | synthetic · likely | Fast-follow |
+| J13 | The pilot becomes a programme | prototyper + IT | synthetic · likely | Fast-follow |
+| J15 | Why not just buy it / use the alternative? | budget-holder, contributor | evidence | Fast-follow |
+| J17 | What survives the next release? | fork/frontend builder | evidence | Fast-follow |
+| J24 | I found a security problem | outside reporter | evidence | Fast-follow |
+| J25 | Compare techniques on my matter | benchmarking practitioner | evidence | Fast-follow |
+| J14 | The annual re-review | evaluator, a year on | synthetic · plausible | Post-launch re-test |
+| J16 | The insurer asks what you deployed | accountability reader | synthetic · plausible | Post-launch re-test |
+
+---
+
+## Launch-gating
+
+### J1 — Am I the person this is for?
+The highest-traffic page on the site, and it does not exist. A practitioner inside the
+project's own community deferred engagement for weeks unsure he was an intended user; a
+practising litigator initially dismissed the repo as in-house-only
+([2026-07-19 minutes](https://github.com/LegalQuants/lq-ai-community/blob/main/meetings/2026-07-19-weekly/notes.md)).
+The model is a considerations page with disqualifiers the reader can check themselves
+against — not an audience description.
+> **Failed when:** a reader cannot determine within one page whether the software is
+> intended for them; or discovers only after installing that their use case is out of
+> scope; or can conclude they are in scope when the PRD's non-goals say they are not.
+
+### J2 — Get it running
+The strongest existing journey — the quickstart works. The fixes are ordering (prereqs and
+data boundary before the first command) and recovery inlined rather than on a page the
+stuck reader must find. Day-zero failures on the documented path are on record
+([#92](https://github.com/LegalQuants/lq-ai/issues/92)).
+> **Failed when:** a first-time reader meets a command before the software is defined, its
+> data boundary stated, and prerequisites named — or a stuck reader has no next command
+> and no observable success check.
+
+### J3 — What leaves my deployment, and who sees it?
+The highest-severity journey: this reader's failure mode is a client-confidentiality
+incident. The honest answer exists in [docs/security/anonymization.md](../../../security/anonymization.md)
+and is several clicks deep; the committee's
+[published minutes](https://github.com/LegalQuants/lq-ai-community/blob/main/meetings/2026-07-26-weekly/notes.md)
+record the layer's reliability as an open item. **Blocked** on parent decision 1; whatever
+the outcome, this page states measured behaviour and ends in a decision (route privileged
+matters to Tier 1). No benchmarked site in any regulated field passes this test — it is
+genuinely differentiating.
+> **Failed when:** the answer to "what leaves my deployment" requires more than one page —
+> or a risk paragraph ends without telling the reader to proceed, configure, escalate, or
+> stop.
+
+### J4 — Hand this to our security team
+The richest content in the repo (threat model, audit logging, supply chain, SIG Lite,
+HONEST-STATE) with no information architecture over it. The trust-centre index is the
+deliverable; stable URLs are the commitment; the public governance record
+([lq-ai-community](https://github.com/LegalQuants/lq-ai-community)) is linked as a
+first-class artifact — it is the only public surface that answers "who decides" with dates.
+> **Failed when:** a URL cited externally stops resolving; or an evaluator must read more
+> than the trust-centre index to find any of its artifacts (threat model, data flow, audit
+> and evidence, supply chain, gaps catalogue, governance and continuity, questionnaires).
+
+### J5 — Point my coding agent at it
+The community's publicly stated onboarding route is an agent reading the project. The
+machine surface (`/llms.txt`; `.md` served for every page URL) is a build requirement, not
+a page — cheap specified up front, expensive retrofitted.
+> **Failed when:** any page cannot be retrieved as plain text/markdown, or an agent must
+> scrape rendered HTML to read the docs.
+
+### J11 — It broke — triage and recover *(launch: minimum set)*
+Confirmed five times over, one instance per triage branch: a clean-install failure on the
+documented path ([#92](https://github.com/LegalQuants/lq-ai/issues/92)); three fail-closed
+operator-visible changes in one release (v0.7.0 — #396, #399, #400); a hardening change
+that would have refused the documented default configuration (caught in review); silent
+empty-but-running states ([#503](https://github.com/LegalQuants/lq-ai/issues/503),
+[#207](https://github.com/LegalQuants/lq-ai/issues/207)); an upgrade that silently didn't
+take ([#277](https://github.com/LegalQuants/lq-ai/pull/277)). Launch carries the minimum:
+symptom-first entry, the day-zero branch, and the upgrade branch; full runbooks follow
+with J6.
+> **Failed when:** a reader can find how to upgrade but cannot find whether a release's
+> migrations are reversible, or what to do when one fails halfway — or no page can be
+> reached by searching a symptom rather than a task name.
+
+### J20 — Air-gapped install *(launch: egress inventory)*
+An air-gapped install on the documented path has already failed on an unpublished image
+([#99](https://github.com/LegalQuants/lq-ai/issues/99)), and first boot performs ~30
+undeclared model downloads from an upstream component (DE-353). The egress inventory is a
+test artifact to publish, not a document to write: the air-gap CI records real phone-home
+attempts (#366 / #427). The machine surface doubles as the offline documentation bundle.
+> **Failed when:** an install step assumes network access not named in the egress
+> inventory — or the documentation cannot be read on a machine with no route to the
+> internet.
+
+### J22 — Which of these hosting combinations is mine? *(launch: supported-shapes index)*
+The demand that produced the docs-site idea. Recipes exist or are filed for Caddy +
+Tailscale, reverse-proxy TLS (#370), tailnet Ollama
+([#495](https://github.com/LegalQuants/lq-ai/issues/495) — filed precisely because the
+egress guard refuses the obvious configuration), Windows (#259), Azure (#154–#157, fed
+back by a production deployment's IT team). No index exists, and the guard rails now
+refuse configurations no page explains.
+> **Failed when:** an operator on a common topology — remote inference host, corporate
+> cloud endpoint, Windows, behind a reverse proxy — cannot determine from the site whether
+> it is supported, or hits a fail-closed refusal that no page explains.
+
+---
+
+## Launch-with
+
+### J6 — Week two: back it up, upgrade it, watch it
+No runbooks directory exists; rollback is answered nowhere at any level. The regulated-field
+benchmark reclassified this from "cheap differentiation" to **the floor for the category**
+— sites holding real records document backup and restore.
+> **Failed when:** install is documented and protect/recover is not.
+
+### J7 — Bring my own workflow in
+The best-covered audience in the repo; the missing piece is the entry point — nothing tells
+a reader their existing prompt files are close to skill-shaped — plus the frontmatter
+schema as a table and a skills index.
+> **Failed when:** a reader with working prompt files cannot tell what would have to change
+> to make them a skill.
+
+### J9 — A provider key leaked, and it is 11pm *(synthetic · likely)*
+The trigger is unevidenced (searched; clean negative). The hard half — the blast-radius
+statement and the audit query — already exists in security-audit findings and a measured
+leak-rate PR, in places no operator will look at 11pm. Note: v0.7.0's gateway-key
+requirement (#396) changed the rotation procedure — this page and the per-release surface
+ship together.
+> **Failed when:** a reader searching for how to revoke a leaked credential lands on a page
+> that explains how keys are stored but does not give the revocation command, the
+> blast-radius statement, and the audit query — or gives them across more than one page.
+
+### J10 — The output was wrong — what did the flag promise, and what happened?
+Confirmed in generalised form: a user relied on output, was wrong, and had to reconstruct
+what the system did by hand ([#503](https://github.com/LegalQuants/lq-ai/issues/503) —
+"this defect caused me to publish a wrong conclusion"). The page must state, in the
+negative, what a green citation flag does not assert — including *currency of the law*, a
+limit a committee member independently proposed flagging
+([2026-07-19 minutes](https://github.com/LegalQuants/lq-ai-community/blob/main/meetings/2026-07-19-weekly/notes.md),
+temporal currency flags) — and how to tell "the system broke" from "the analysis is thin."
+Crosses the in-app Learn boundary deliberately: this reader may no longer have deployment
+access.
+> **Failed when:** the page describing citation verification does not state, in the
+> negative, what a verified citation does not assert; or the reader cannot find a
+> documented procedure for retrieving the receipt and ledger entry for a past answer; or
+> the page does not tell the reader how to distinguish a system failure from a poor answer.
+
+### J18 — Should I trust this skill? *(synthetic · likely)*
+A third-party legal-substance skill has been offered to the community and volunteers
+offered to test it — before any index, trust card, or stated attestation meaning exists.
+The trust card states: author, attesting attorney, jurisdiction and practice-area scope,
+version, and what the attestation covers (a maintainer-of-record commitment that decays
+with the law — not a warranty).
+> **Failed when:** a skill can be discovered and installed from the site without its
+> author, attesting attorney, jurisdiction scope, and version visible on the same page —
+> or the attestation's meaning is not stated where a consumer will read it.
+
+### J19 — Will it run on what I have? *(synthetic · likely)*
+Named reference configurations known to work span a very large workstation to a modest
+VPS — a spread wide enough that readers conclude either "server room" or "anything," both
+wrong. For the law-school clinic, legal-aid org, or solo practitioner, this page decides
+whether they try at all.
+> **Failed when:** the site states no minimum hardware, or states a minimum without saying
+> what degrades below the recommended configuration.
+
+### J21 — Can it do litigation?
+Confirmed end-to-end: a practising litigator inferred litigation support from the shipped
+research capability, filed a scope proposal
+([#287](https://github.com/LegalQuants/lq-ai/issues/287), escalated), and the committee
+narrowed the carve-in to research and drafting
+([decision log](https://github.com/LegalQuants/lq-ai-community/blob/main/decisions/README.md))
+— while PRD §1.6 still excludes litigation flatly. Three public surfaces, three answers.
+The failure mode is a *confident wrong answer*, in either direction.
+> **Failed when:** a page presents case-law or research capability without stating on that
+> same page that litigation and e-discovery workflows are v1 non-goals; or the non-goals
+> are listed without telling the reader what to do instead; or two published project
+> surfaces answer the scope question differently.
+
+### J23 — It needs to be in my language and my law — do I fork or contribute?
+In one June fortnight, four community members reached for forks (two language versions, a
+practice-area hard fork, deployment forks) while the routing rule went unstated — the
+record is in [PR #313](https://github.com/LegalQuants/lq-ai/pull/313)'s discussion.
+ADR 0024 has since decided the routes; the coverage map is open
+([#506](https://github.com/LegalQuants/lq-ai/issues/506)). The coverage index (parent PRD,
+"Designed to expand") is this journey's page.
+> **Failed when:** a reader with jurisdiction-specific substance cannot determine where it
+> goes without asking a human — or forks because they could not find out.
+
+---
+
+## Ships independently of the site
+
+### J8 — Can it carry our branding?
+The constraint (alter/remove upstream branding only under 50 end-users per rolling 30
+days, written permission, or an enterprise licence) is recorded in exactly one file —
+[ADR 0001](../../../adr/0001-openwebui-fork-pin.md), which itself assigns the missing
+"Branding obligations" section. Parent PRD spawned item 1; the upstream fork refresh
+(#498) is the natural moment. The page defines "end user," gives a method to determine the
+current count (and states honestly if none exists), and names the three lawful positions
+above the line.
+> **Failed when:** a reader can plan a rebranded deployment without meeting the threshold
+> and the dual-branding requirement.
+
+---
+
+## Fast-follow
+
+### J12 — We just crossed fifty users *(synthetic · likely)*
+J8 is *before you promise*; this is *after you promised and grew* — and the count is
+currently unmonitorable (no end-user definition, no rolling-window count: a product gap
+the page must state honestly).
+> **Failed when:** the branding page states the fifty-user threshold without defining "end
+> user" and without giving a method to determine the current count.
+
+### J13 — The pilot has to become a programme *(synthetic · likely)*
+A prototyper with a live corporate-sandbox opportunity and an ROI condition is on the
+record; the requirements half is a production-readiness matrix with support-tier labels —
+*supported / operator-provided / not yet*, each row linked to its page or DE. The honest
+matrix is mixed, which is exactly why publishing it is credible.
+> **Failed when:** a production requirement an enterprise IT function routinely asks about
+> has no page stating whether it is supported, operator-provided, or not yet built — or a
+> reader cannot find how to extract usage and cost data for a given period.
+
+### J15 — Why not just buy it — or use the open-source alternative?
+Confirmed in the variant that matters: a community member could not say why the project
+should exist alongside the visible open-source alternative, and was resolved only by an
+answer posted in chat — unretrievable. The page includes a "where the commercial products
+win" column and treats the open-source alternative as a first-class comparison, plus the
+test-bench answer to "why not just use Claude directly."
+> **Failed when:** the comparison page names no case in which a commercial product is the
+> better choice — a comparison with no losses is marketing — or the page does not
+> distinguish LQ.AI from the visible open-source alternatives.
+
+### J17 — What can I build on that will survive the next release?
+Confirmed: a fork-builder built against a moving target and had to redo the work, asking
+in as many words when the platform would be "finished." Multiple real builds run on this
+backend; a first-party downstream product broke on an undocumented compose-level contract
+([#278](https://github.com/LegalQuants/lq-ai/pull/278)). The page ranks extension points
+by stability and states plainly what compatibility is and is not promised before 1.0.
+> **Failed when:** the site names an extension point without stating its stability, or a
+> reader cannot find a single statement of what compatibility the project does and does
+> not promise before 1.0.
+
+### J24 — I found a security problem — what do I do with it?
+The project's only full audit to date was disclosed publicly, deliberately, by a reporter
+who read the coordinated-disclosure policy and applied an exploitability test the policy
+does not contain (findings not externally exploitable by default → public review is safer
+and faster). The reasoning is sound and lives in a chat message.
+> **Failed when:** a reporter with findings has to invent the public/private test
+> themselves — or the policy is stated without the exploitability distinction that decides
+> real cases.
+
+### J25 — I want to compare techniques on my own matter
+The test-bench reader, now real: a controlled five-model benchmark run through the full
+stack ([#503](https://github.com/LegalQuants/lq-ai/issues/503)), in which a platform
+default silently zeroed one model's results — a platform failure that would have been
+scored as a model failure. The page documents what the platform's defaults do to results
+and how to read routing metadata so attribution survives.
+> **Failed when:** a reader varying one thing at a time cannot tell from the response
+> whether the platform or the model produced the outcome — or the defaults that shape
+> their results are not documented on the page that invites the comparison.
+
+---
+
+## Post-launch re-test *(no evidence yet — project too young, searched and found clean negatives)*
+
+### J14 — The annual re-review, one year on *(synthetic · plausible)*
+Procurement re-review is a calendar event; the project has not lived a calendar yet. The
+discipline it tests has already failed once in the opposite direction — six files pointed
+at a community channel that was never created
+([#490](https://github.com/LegalQuants/lq-ai/issues/490)). The version-stamp mechanism the
+journey requires already runs in the
+[decisions log](https://github.com/LegalQuants/lq-ai-community/blob/main/decisions/README.md).
+> **Failed when:** any URL published in the trust-centre tree stops resolving, or an
+> evaluator cannot determine from the site what changed between two named releases in the
+> artifacts they relied on.
+
+### J16 — The insurer wants to know what you deployed *(synthetic · plausible)*
+No member has faced an inquiry. The capability is real — signed, provenanced releases
+pinned to a commit; matter-scoped audit and citation records — and a contributor has
+already described the air-gap test's phone-home log as "evidence for procurement
+conversations instead of an assertion." The assembled story (*you can prove what you ran*)
+is a selling point no SaaS competitor can offer a regulated professional.
+> **Failed when:** there is no page a firm can cite that describes what a specific
+> released version did, or no documented query that produces a matter-scoped record of
+> model calls and citation verifications.
+
+---
+
+## Running the tests
+
+- **The launch gate** (parent PRD, "How we'd know it's done"): J1–J4 pass, run by a
+  non-author; J1 and J3 additionally pass with a second reader who has not read the
+  source — until that reader exists they are *unverified*, not passed. J5's machine
+  surface, J11's minimum set, J20's egress inventory, and J22's supported-shapes index are
+  verified as build artifacts.
+- **Each later phase** runs its own journeys' tests on shipping.
+- **A journey's test failing after launch is a bug**, filed like any other, against the
+  page that fails it.

--- a/docs/contribute/mini-prds/docsite/annex-b-journeys.md
+++ b/docs/contribute/mini-prds/docsite/annex-b-journeys.md
@@ -1,14 +1,26 @@
 # Annex B — User journeys as acceptance criteria
 
-Twenty-five journeys. Each is a route a real reader takes through the site, and each ends
-in a **failed-when** test that anyone who did not write the site can run against it. The
-journeys are three things and deliberately not a fourth:
+Twenty-five journeys. Each one is a route a real reader takes through the site, and each
+ends in a **failed-when** test that someone who did not build the site can run against it.
+Read each journey as a person arriving with a worry or a task: it passes when they leave
+with it handled.
+
+The journeys are three things:
 
 - **Acceptance tests** — the launch gate runs the P0 tests; later phases run theirs.
 - **Contribution units** — most journeys are claimable by one person (Annex C maps them).
 - **Entry-point cards** — the site's landing hub routes by these goals, in reader language.
-- **Not navigation.** The nav stays role-based; one grouping only. A journey never becomes
-  a sidebar section.
+
+**How this annex is organised.** By theme first, then by maturity within each theme. Seven
+themes group the journeys by what the reader came to do. Inside each theme, the journeys run
+in maturity order, from launch to later phases, so related journeys sit together instead of
+being spread across phases. J5 sits above the themes: it is not a place a reader goes but a
+rule for how every page is served. See "The two front doors".
+
+**On navigation.** Role still drives the sidebar. Each journey has one page, reached through the reader's role. Theme is a second lens, not a second sidebar: it groups the landing hub's cards and
+the machine index an agent reads. Both point at the same pages, so no page has two homes.
+This relaxes the old rule of one grouping only, and keeps the rule that no journey gets two
+homes.
 
 **Status vocabulary.** *Evidence-derived*: someone took or demanded this path, on the
 record. *Synthetic (likely / plausible)*: extrapolated from evidenced personas and
@@ -19,37 +31,61 @@ has lived long enough to produce readers.
 
 **Phase** proposes when the journey's pages ship; committee sign-off is parent decision 2.
 
-| # | Journey | Reader | Status | Phase |
-|---|---|---|---|---|
-| J1 | Am I the person this is for? | anyone; often a legal function of one | evidence | **Launch** |
-| J2 | Get it running | operator | evidence | **Launch** |
-| J3 | What leaves my deployment? | operator, evaluator | evidence | **Launch** ⚠ blocked |
-| J4 | Hand this to our security team | evaluator | evidence | **Launch** |
-| J5 | Point my coding agent at it | a coding agent | evidence | **Launch** (build req.) |
-| J11 | It broke — triage and recover | operator | evidence | **Launch** (min. set) |
-| J20 | Air-gapped install | isolated-network operator | evidence | **Launch** (inventory) |
-| J22 | Which hosting combination is mine? | operator with a fixed topology | evidence | **Launch** (index) |
-| J6 | Week two: back up, upgrade, watch | operator | evidence | Launch-with |
-| J7 | Bring my own workflow in | lawyer-author | evidence | Launch-with |
-| J9 | A provider key leaked, 11pm | operator | synthetic · likely | Launch-with |
-| J10 | The output was wrong — reconstruct | practising lawyer | evidence | Launch-with |
-| J18 | Should I trust this skill? | skill consumer | synthetic · likely | Launch-with |
-| J19 | Will it run on what I have? | resource-constrained reader | synthetic · likely | Launch-with |
-| J21 | Can it do litigation? | disputes practitioner | evidence | Launch-with |
-| J23 | My language, my law — fork or contribute? | non-anglophone practitioner | evidence | Launch-with |
-| J8 | Can it carry our branding? | deployer, firm | evidence | **Ships independently** |
-| J12 | We just crossed fifty users | deployer mid-engagement | synthetic · likely | Fast-follow |
-| J13 | The pilot becomes a programme | prototyper + IT | synthetic · likely | Fast-follow |
-| J15 | Why not just buy it / use the alternative? | budget-holder, contributor | evidence | Fast-follow |
-| J17 | What survives the next release? | fork/frontend builder | evidence | Fast-follow |
-| J24 | I found a security problem | outside reporter | evidence | Fast-follow |
-| J25 | Compare techniques on my matter | benchmarking practitioner | evidence | Fast-follow |
-| J14 | The annual re-review | evaluator, a year on | synthetic · plausible | Post-launch re-test |
-| J16 | The insurer asks what you deployed | accountability reader | synthetic · plausible | Post-launch re-test |
+| Theme | # | Journey | Reader | Status | Phase |
+|---|---|---|---|---|---|
+| Cross-cutting | J5 | Point my coding agent at it | a coding agent | evidence | **Launch** (build req.) |
+| Is this for me? | J1 | Am I the person this is for? | anyone; often a legal function of one | evidence | **Launch** |
+| Is this for me? | J21 | Can it do litigation? | disputes practitioner | evidence | Launch-with |
+| Is this for me? | J15 | Why not just buy it / use the alternative? | budget-holder, contributor | evidence | Fast-follow |
+| Getting it running | J2 | Get it running | operator | evidence | **Launch** |
+| Getting it running | J20 | Air-gapped install | isolated-network operator | evidence | **Launch** (inventory) |
+| Getting it running | J22 | Which hosting combination is mine? | operator with a fixed topology | evidence | **Launch** (index) |
+| Getting it running | J19 | Will it run on what I have? | resource-constrained reader | synthetic · likely | Launch-with |
+| Keeping data safe | J3 | What leaves my deployment? | operator, evaluator | evidence | **Launch** ⚠ blocked |
+| Keeping data safe | J4 | Hand this to our security team | evaluator | evidence | **Launch** |
+| Keeping data safe | J9 | A provider key leaked, 11pm | operator | synthetic · likely | Launch-with |
+| Keeping data safe | J24 | I found a security problem | outside reporter | evidence | Fast-follow |
+| Running it day to day | J11 | It broke — triage and recover | operator | evidence | **Launch** (min. set) |
+| Running it day to day | J6 | Week two: back up, upgrade, watch | operator | evidence | Launch-with |
+| Proving what happened | J10 | The output was wrong — reconstruct | practising lawyer | evidence | Launch-with |
+| Proving what happened | J25 | Compare techniques on my matter | benchmarking practitioner | evidence | Fast-follow |
+| Proving what happened | J16 | The insurer asks what you deployed | accountability reader | synthetic · plausible | Post-launch re-test |
+| Proving what happened | J14 | The annual re-review | evaluator, a year on | synthetic · plausible | Post-launch re-test |
+| Making it your own | J7 | Bring my own workflow in | lawyer-author | evidence | Launch-with |
+| Making it your own | J18 | Should I trust this skill? | skill consumer | synthetic · likely | Launch-with |
+| Making it your own | J23 | My language, my law — fork or contribute? | non-anglophone practitioner | evidence | Launch-with |
+| Making it your own | J17 | What survives the next release? | fork/frontend builder | evidence | Fast-follow |
+| As you grow | J8 | Can it carry our branding? | deployer, firm | evidence | **Ships independently** |
+| As you grow | J12 | We just crossed fifty users | deployer mid-engagement | synthetic · likely | Fast-follow |
+| As you grow | J13 | The pilot becomes a programme | prototyper + IT | synthetic · likely | Fast-follow |
 
 ---
 
-## Launch-gating
+## The two front doors
+
+Every page has two readers, and they do not want the same thing. A person comes to
+understand the project and judge whether it is safe to proceed: they need to know why it
+matters, what is safe, and what to expect. A coding agent comes because its human pointed it here: it needs the
+exact steps, the rules, and what to do and not do. The community's stated way in is an
+agent reading the project, so this split is live, not hypothetical.
+
+The floor is the same for both: every page retrievable as plain markdown, `/llms.txt`
+present, no scraping of rendered HTML. Above the floor they diverge. The agent does not
+want the human's guided tour through the role sidebar; it wants a flat, complete index of
+goals, served as text. That index is the theme lens. So the theme grouping is not only for
+people: it is the shape the agent needs, and the shape the human hub already uses.
+
+### J5 — Point my coding agent at it
+The community's publicly stated onboarding route is an agent reading the project. The
+machine surface (`/llms.txt`; `.md` served for every page URL) is a build requirement, not
+a page — cheap specified up front, expensive retrofitted.
+> **Failed when:** any page cannot be retrieved as plain text/markdown, or an agent must
+> scrape rendered HTML to read the docs.
+
+---
+
+## Is this for me?
+*Deciding whether to spend any more time here.*
 
 ### J1 — Am I the person this is for?
 The highest-traffic page on the site, and it does not exist. A practitioner inside the
@@ -62,6 +98,34 @@ against — not an audience description.
 > intended for them; or discovers only after installing that their use case is out of
 > scope; or can conclude they are in scope when the PRD's non-goals say they are not.
 
+### J21 — Can it do litigation?
+Confirmed end-to-end: a practising litigator inferred litigation support from the shipped
+research capability, filed a scope proposal
+([#287](https://github.com/LegalQuants/lq-ai/issues/287), escalated), and the committee
+narrowed the carve-in to research and drafting
+([decision log](https://github.com/LegalQuants/lq-ai-community/blob/main/decisions/README.md))
+— while PRD §1.6 still excludes litigation flatly. Three public surfaces, three answers.
+The failure mode is a *confident wrong answer*, in either direction.
+> **Failed when:** a page presents case-law or research capability without stating on that
+> same page that litigation and e-discovery workflows are v1 non-goals; or the non-goals
+> are listed without telling the reader what to do instead; or two published project
+> surfaces answer the scope question differently.
+
+### J15 — Why not just buy it — or use the open-source alternative?
+Confirmed in the variant that matters: a community member could not say why the project
+should exist alongside the visible open-source alternative, and was resolved only by an
+answer posted in chat — unretrievable. The page includes a "where the commercial products
+win" column and treats the open-source alternative as a first-class comparison, plus the
+test-bench answer to "why not just use Claude directly."
+> **Failed when:** the comparison page names no case in which a commercial product is the
+> better choice — a comparison with no losses is marketing — or the page does not
+> distinguish LQ.AI from the visible open-source alternatives.
+
+---
+
+## Getting it running
+*The setup path: mostly day-one work, because readers cannot start without it.*
+
 ### J2 — Get it running
 The strongest existing journey — the quickstart works. The fixes are ordering (prereqs and
 data boundary before the first command) and recovery inlined rather than on a page the
@@ -70,6 +134,40 @@ stuck reader must find. Day-zero failures on the documented path are on record
 > **Failed when:** a first-time reader meets a command before the software is defined, its
 > data boundary stated, and prerequisites named — or a stuck reader has no next command
 > and no observable success check.
+
+### J20 — Air-gapped install *(launch: egress inventory)*
+An air-gapped install on the documented path has already failed on an unpublished image
+([#99](https://github.com/LegalQuants/lq-ai/issues/99)), and first boot performs ~30
+undeclared model downloads from an upstream component (DE-353). The egress inventory is a
+test artifact to publish, not a document to write: the air-gap CI records real phone-home
+attempts (#366 / #427). The machine surface doubles as the offline documentation bundle.
+> **Failed when:** an install step assumes network access not named in the egress
+> inventory — or the documentation cannot be read on a machine with no route to the
+> internet.
+
+### J22 — Which of these hosting combinations is mine? *(launch: supported-shapes index)*
+The demand that produced the docs-site idea. Recipes exist or are filed for Caddy +
+Tailscale, reverse-proxy TLS (#370), tailnet Ollama
+([#495](https://github.com/LegalQuants/lq-ai/issues/495) — filed precisely because the
+egress guard refuses the obvious configuration), Windows (#259), Azure (#154–#157, fed
+back by a production deployment's IT team). No index exists, and the guard rails now
+refuse configurations no page explains.
+> **Failed when:** an operator on a common topology — remote inference host, corporate
+> cloud endpoint, Windows, behind a reverse proxy — cannot determine from the site whether
+> it is supported, or hits a fail-closed refusal that no page explains.
+
+### J19 — Will it run on what I have? *(synthetic · likely)*
+Named reference configurations known to work span a very large workstation to a modest
+VPS — a spread wide enough that readers conclude either "server room" or "anything," both
+wrong. For the law-school clinic, legal-aid org, or solo practitioner, this page decides
+whether they try at all.
+> **Failed when:** the site states no minimum hardware, or states a minimum without saying
+> what degrades below the recommended configuration.
+
+---
+
+## Keeping data safe
+*The risk surface, and who is responsible for it.*
 
 ### J3 — What leaves my deployment, and who sees it?
 The highest-severity journey: this reader's failure mode is a client-confidentiality
@@ -94,12 +192,29 @@ first-class artifact — it is the only public surface that answers "who decides
 > than the trust-centre index to find any of its artifacts (threat model, data flow, audit
 > and evidence, supply chain, gaps catalogue, governance and continuity, questionnaires).
 
-### J5 — Point my coding agent at it
-The community's publicly stated onboarding route is an agent reading the project. The
-machine surface (`/llms.txt`; `.md` served for every page URL) is a build requirement, not
-a page — cheap specified up front, expensive retrofitted.
-> **Failed when:** any page cannot be retrieved as plain text/markdown, or an agent must
-> scrape rendered HTML to read the docs.
+### J9 — A provider key leaked, and it is 11pm *(synthetic · likely)*
+The trigger is unevidenced (searched; clean negative). The hard half — the blast-radius
+statement and the audit query — already exists in security-audit findings and a measured
+leak-rate PR, in places no operator will look at 11pm. Note: v0.7.0's gateway-key
+requirement (#396) changed the rotation procedure — this page and the per-release surface
+ship together.
+> **Failed when:** a reader searching for how to revoke a leaked credential lands on a page
+> that explains how keys are stored but does not give the revocation command, the
+> blast-radius statement, and the audit query — or gives them across more than one page.
+
+### J24 — I found a security problem — what do I do with it?
+The project's only full audit to date was disclosed publicly, deliberately, by a reporter
+who read the coordinated-disclosure policy and applied an exploitability test the policy
+does not contain (findings not externally exploitable by default → public review is safer
+and faster). The reasoning is sound and lives in a chat message.
+> **Failed when:** a reporter with findings has to invent the public/private test
+> themselves — or the policy is stated without the exploitability distinction that decides
+> real cases.
+
+---
+
+## Running it day to day
+*Keep it alive, and fix it when it breaks.*
 
 ### J11 — It broke — triage and recover *(launch: minimum set)*
 Confirmed five times over, one instance per triage branch: a clean-install failure on the
@@ -115,53 +230,17 @@ with J6.
 > migrations are reversible, or what to do when one fails halfway — or no page can be
 > reached by searching a symptom rather than a task name.
 
-### J20 — Air-gapped install *(launch: egress inventory)*
-An air-gapped install on the documented path has already failed on an unpublished image
-([#99](https://github.com/LegalQuants/lq-ai/issues/99)), and first boot performs ~30
-undeclared model downloads from an upstream component (DE-353). The egress inventory is a
-test artifact to publish, not a document to write: the air-gap CI records real phone-home
-attempts (#366 / #427). The machine surface doubles as the offline documentation bundle.
-> **Failed when:** an install step assumes network access not named in the egress
-> inventory — or the documentation cannot be read on a machine with no route to the
-> internet.
-
-### J22 — Which of these hosting combinations is mine? *(launch: supported-shapes index)*
-The demand that produced the docs-site idea. Recipes exist or are filed for Caddy +
-Tailscale, reverse-proxy TLS (#370), tailnet Ollama
-([#495](https://github.com/LegalQuants/lq-ai/issues/495) — filed precisely because the
-egress guard refuses the obvious configuration), Windows (#259), Azure (#154–#157, fed
-back by a production deployment's IT team). No index exists, and the guard rails now
-refuse configurations no page explains.
-> **Failed when:** an operator on a common topology — remote inference host, corporate
-> cloud endpoint, Windows, behind a reverse proxy — cannot determine from the site whether
-> it is supported, or hits a fail-closed refusal that no page explains.
-
----
-
-## Launch-with
-
 ### J6 — Week two: back it up, upgrade it, watch it
 No runbooks directory exists; rollback is answered nowhere at any level. The regulated-field
 benchmark reclassified this from "cheap differentiation" to **the floor for the category**
 — sites holding real records document backup and restore.
 > **Failed when:** install is documented and protect/recover is not.
 
-### J7 — Bring my own workflow in
-The best-covered audience in the repo; the missing piece is the entry point — nothing tells
-a reader their existing prompt files are close to skill-shaped — plus the frontmatter
-schema as a table and a skills index.
-> **Failed when:** a reader with working prompt files cannot tell what would have to change
-> to make them a skill.
+---
 
-### J9 — A provider key leaked, and it is 11pm *(synthetic · likely)*
-The trigger is unevidenced (searched; clean negative). The hard half — the blast-radius
-statement and the audit query — already exists in security-audit findings and a measured
-leak-rate PR, in places no operator will look at 11pm. Note: v0.7.0's gateway-key
-requirement (#396) changed the rotation procedure — this page and the per-release surface
-ship together.
-> **Failed when:** a reader searching for how to revoke a leaked credential lands on a page
-> that explains how keys are stored but does not give the revocation command, the
-> blast-radius statement, and the audit query — or gives them across more than one page.
+## Proving what happened
+*Show your work after the fact. No hosted competitor can offer this to a regulated
+professional.*
 
 ### J10 — The output was wrong — what did the flag promise, and what happened?
 Confirmed in generalised form: a user relied on output, was wrong, and had to reconstruct
@@ -178,6 +257,49 @@ access.
 > documented procedure for retrieving the receipt and ledger entry for a past answer; or
 > the page does not tell the reader how to distinguish a system failure from a poor answer.
 
+### J25 — I want to compare techniques on my own matter
+The test-bench reader, now real: a controlled five-model benchmark run through the full
+stack ([#503](https://github.com/LegalQuants/lq-ai/issues/503)), in which a platform
+default silently zeroed one model's results — a platform failure that would have been
+scored as a model failure. The page documents what the platform's defaults do to results
+and how to read routing metadata so attribution survives.
+> **Failed when:** a reader varying one thing at a time cannot tell from the response
+> whether the platform or the model produced the outcome — or the defaults that shape
+> their results are not documented on the page that invites the comparison.
+
+### J16 — The insurer wants to know what you deployed *(synthetic · plausible)*
+No member has faced an inquiry. The capability is real — signed, provenanced releases
+pinned to a commit; matter-scoped audit and citation records — and a contributor has
+already described the air-gap test's phone-home log as "evidence for procurement
+conversations instead of an assertion." The assembled story (*you can prove what you ran*)
+is a selling point no SaaS competitor can offer a regulated professional.
+> **Failed when:** there is no page a firm can cite that describes what a specific
+> released version did, or no documented query that produces a matter-scoped record of
+> model calls and citation verifications.
+
+### J14 — The annual re-review, one year on *(synthetic · plausible)*
+Procurement re-review is a calendar event; the project has not lived a calendar yet. The
+discipline it tests has already failed once in the opposite direction — six files pointed
+at a community channel that was never created
+([#490](https://github.com/LegalQuants/lq-ai/issues/490)). The version-stamp mechanism the
+journey requires already runs in the
+[decisions log](https://github.com/LegalQuants/lq-ai-community/blob/main/decisions/README.md).
+> **Failed when:** any URL published in the trust-centre tree stops resolving, or an
+> evaluator cannot determine from the site what changed between two named releases in the
+> artifacts they relied on.
+
+---
+
+## Making it your own
+*Adapt it, extend it, and know what to trust.*
+
+### J7 — Bring my own workflow in
+The best-covered audience in the repo; the missing piece is the entry point — nothing tells
+a reader their existing prompt files are close to skill-shaped — plus the frontmatter
+schema as a table and a skills index.
+> **Failed when:** a reader with working prompt files cannot tell what would have to change
+> to make them a skill.
+
 ### J18 — Should I trust this skill? *(synthetic · likely)*
 A third-party legal-substance skill has been offered to the community and volunteers
 offered to test it — before any index, trust card, or stated attestation meaning exists.
@@ -187,27 +309,6 @@ with the law — not a warranty).
 > **Failed when:** a skill can be discovered and installed from the site without its
 > author, attesting attorney, jurisdiction scope, and version visible on the same page —
 > or the attestation's meaning is not stated where a consumer will read it.
-
-### J19 — Will it run on what I have? *(synthetic · likely)*
-Named reference configurations known to work span a very large workstation to a modest
-VPS — a spread wide enough that readers conclude either "server room" or "anything," both
-wrong. For the law-school clinic, legal-aid org, or solo practitioner, this page decides
-whether they try at all.
-> **Failed when:** the site states no minimum hardware, or states a minimum without saying
-> what degrades below the recommended configuration.
-
-### J21 — Can it do litigation?
-Confirmed end-to-end: a practising litigator inferred litigation support from the shipped
-research capability, filed a scope proposal
-([#287](https://github.com/LegalQuants/lq-ai/issues/287), escalated), and the committee
-narrowed the carve-in to research and drafting
-([decision log](https://github.com/LegalQuants/lq-ai-community/blob/main/decisions/README.md))
-— while PRD §1.6 still excludes litigation flatly. Three public surfaces, three answers.
-The failure mode is a *confident wrong answer*, in either direction.
-> **Failed when:** a page presents case-law or research capability without stating on that
-> same page that litigation and e-discovery workflows are v1 non-goals; or the non-goals
-> are listed without telling the reader what to do instead; or two published project
-> surfaces answer the scope question differently.
 
 ### J23 — It needs to be in my language and my law — do I fork or contribute?
 In one June fortnight, four community members reached for forks (two language versions, a
@@ -219,9 +320,20 @@ ADR 0024 has since decided the routes; the coverage map is open
 > **Failed when:** a reader with jurisdiction-specific substance cannot determine where it
 > goes without asking a human — or forks because they could not find out.
 
+### J17 — What can I build on that will survive the next release?
+Confirmed: a fork-builder built against a moving target and had to redo the work, asking
+in as many words when the platform would be "finished." Multiple real builds run on this
+backend; a first-party downstream product broke on an undocumented compose-level contract
+([#278](https://github.com/LegalQuants/lq-ai/pull/278)). The page ranks extension points
+by stability and states plainly what compatibility is and is not promised before 1.0.
+> **Failed when:** the site names an extension point without stating its stability, or a
+> reader cannot find a single statement of what compatibility the project does and does
+> not promise before 1.0.
+
 ---
 
-## Ships independently of the site
+## As you grow
+*The commercial path, from first promise to full programme.*
 
 ### J8 — Can it carry our branding?
 The constraint (alter/remove upstream branding only under 50 end-users per rolling 30
@@ -233,10 +345,6 @@ current count (and states honestly if none exists), and names the three lawful p
 above the line.
 > **Failed when:** a reader can plan a rebranded deployment without meeting the threshold
 > and the dual-branding requirement.
-
----
-
-## Fast-follow
 
 ### J12 — We just crossed fifty users *(synthetic · likely)*
 J8 is *before you promise*; this is *after you promised and grew* — and the count is
@@ -253,70 +361,6 @@ matrix is mixed, which is exactly why publishing it is credible.
 > **Failed when:** a production requirement an enterprise IT function routinely asks about
 > has no page stating whether it is supported, operator-provided, or not yet built — or a
 > reader cannot find how to extract usage and cost data for a given period.
-
-### J15 — Why not just buy it — or use the open-source alternative?
-Confirmed in the variant that matters: a community member could not say why the project
-should exist alongside the visible open-source alternative, and was resolved only by an
-answer posted in chat — unretrievable. The page includes a "where the commercial products
-win" column and treats the open-source alternative as a first-class comparison, plus the
-test-bench answer to "why not just use Claude directly."
-> **Failed when:** the comparison page names no case in which a commercial product is the
-> better choice — a comparison with no losses is marketing — or the page does not
-> distinguish LQ.AI from the visible open-source alternatives.
-
-### J17 — What can I build on that will survive the next release?
-Confirmed: a fork-builder built against a moving target and had to redo the work, asking
-in as many words when the platform would be "finished." Multiple real builds run on this
-backend; a first-party downstream product broke on an undocumented compose-level contract
-([#278](https://github.com/LegalQuants/lq-ai/pull/278)). The page ranks extension points
-by stability and states plainly what compatibility is and is not promised before 1.0.
-> **Failed when:** the site names an extension point without stating its stability, or a
-> reader cannot find a single statement of what compatibility the project does and does
-> not promise before 1.0.
-
-### J24 — I found a security problem — what do I do with it?
-The project's only full audit to date was disclosed publicly, deliberately, by a reporter
-who read the coordinated-disclosure policy and applied an exploitability test the policy
-does not contain (findings not externally exploitable by default → public review is safer
-and faster). The reasoning is sound and lives in a chat message.
-> **Failed when:** a reporter with findings has to invent the public/private test
-> themselves — or the policy is stated without the exploitability distinction that decides
-> real cases.
-
-### J25 — I want to compare techniques on my own matter
-The test-bench reader, now real: a controlled five-model benchmark run through the full
-stack ([#503](https://github.com/LegalQuants/lq-ai/issues/503)), in which a platform
-default silently zeroed one model's results — a platform failure that would have been
-scored as a model failure. The page documents what the platform's defaults do to results
-and how to read routing metadata so attribution survives.
-> **Failed when:** a reader varying one thing at a time cannot tell from the response
-> whether the platform or the model produced the outcome — or the defaults that shape
-> their results are not documented on the page that invites the comparison.
-
----
-
-## Post-launch re-test *(no evidence yet — project too young, searched and found clean negatives)*
-
-### J14 — The annual re-review, one year on *(synthetic · plausible)*
-Procurement re-review is a calendar event; the project has not lived a calendar yet. The
-discipline it tests has already failed once in the opposite direction — six files pointed
-at a community channel that was never created
-([#490](https://github.com/LegalQuants/lq-ai/issues/490)). The version-stamp mechanism the
-journey requires already runs in the
-[decisions log](https://github.com/LegalQuants/lq-ai-community/blob/main/decisions/README.md).
-> **Failed when:** any URL published in the trust-centre tree stops resolving, or an
-> evaluator cannot determine from the site what changed between two named releases in the
-> artifacts they relied on.
-
-### J16 — The insurer wants to know what you deployed *(synthetic · plausible)*
-No member has faced an inquiry. The capability is real — signed, provenanced releases
-pinned to a commit; matter-scoped audit and citation records — and a contributor has
-already described the air-gap test's phone-home log as "evidence for procurement
-conversations instead of an assertion." The assembled story (*you can prove what you ran*)
-is a selling point no SaaS competitor can offer a regulated professional.
-> **Failed when:** there is no page a firm can cite that describes what a specific
-> released version did, or no documented query that produces a matter-scoped record of
-> model calls and citation verifications.
 
 ---
 

--- a/docs/contribute/mini-prds/docsite/annex-c-work-plan.md
+++ b/docs/contribute/mini-prds/docsite/annex-c-work-plan.md
@@ -1,0 +1,209 @@
+# Annex C — Page trees, sizing, and claimable work
+
+**Effort key** (as on the contribution board): **S** = under a day · **M** = a few days ·
+**L** = more than a week. **Kind**: *curation* = an existing repo file becomes a page
+(reorder, retitle, entry sentence, onward links, commit stamp); *new* = written from
+nothing; *generated* = a build step over structured sources, near-zero cost per release
+thereafter.
+
+All numbers are **estimates for planning, not commitments** — a contributor claiming an
+item is expected to re-size it. Nothing here is assigned to anyone; mentors per section
+are a committee decision (parent decision 5).
+
+---
+
+## 1. Page trees per namespace
+
+### `/` + `/start/` — entry hub and orientation · 6 pages · [all audiences · J1, J2]
+
+| Page | Kind | Est. |
+|---|---|---|
+| Entry hub: definition, data boundary, goal cards, "not for" link | new | S |
+| Is LQ.AI for you? *(J1 — considerations page with checkable disqualifiers)* | new | S |
+| What it touches: prerequisites, hardware summary, data-boundary summary | new | S |
+| Quickstart *(reordered; recovery inlined)* | curation | S |
+| Choose your path *(routing by goal, permission to skip)* | new | S |
+| Where end-user help lives *(the in-app Learn boundary, stated as policy)* | new | S |
+
+### `/operate/` — run it · ~16 pages + extensible recipes · [OPS · J2, J6, J9, J11, J19, J20, J22]
+
+| Page | Kind | Est. |
+|---|---|---|
+| Hub | new | S |
+| Install: macOS desktop | curation | S |
+| Install: Docker Compose | curation | S |
+| Install: Helm / Kubernetes *(chart currently has no prose at all)* | new | S–M |
+| Reverse proxy + TLS | curation | S |
+| Air-gapped / local-only + **egress inventory** *(publish what the air-gap CI measures)* | curation + generated | S–M |
+| Hardware sizing: named reference configurations | new | S–M |
+| Architecture explainer | curation | S |
+| Logs & monitoring | curation | S |
+| Backup & restore *(no benchmarked hobbyist site has this; regulated sites treat it as the floor)* | new | M |
+| Upgrade guide *(per-version notes come from `/changelog/`)* | new | M |
+| Rotate a leaked provider key *(runbook: revoke, blast radius, audit query)* | new | S |
+| Symptom index: "something is wrong" *(triage branches: install / upgrade / silent-degrade)* | new | S–M |
+| Move machines / uninstall cleanly | new | S |
+| Troubleshooting & FAQ | new | S–M |
+| Lite / headless profile | new | S — **blocked** (open product question) |
+| **`recipes/`** — supported-shapes index + topology recipes in the house format | new + extensible | index S; each recipe S |
+
+### `/trust/` — trust centre · ~13 pages · [EVAL, PRODUCT · J3, J4, J14, J16] · **URL-stability commitment**
+
+| Page | Kind | Est. |
+|---|---|---|
+| Trust-centre index *(the single missing artifact — this page is the deliverable)* | new | S |
+| What leaves my deployment *(J3; ends in a decision)* | new | M — **blocked** (parent decision 1) |
+| Threat model | curation | S |
+| Anonymization: what it does and does not do | curation | S |
+| Audit & evidence *(incl. the one-query privileged-evidence pattern)* | curation | S |
+| Supply chain: SBOM, provenance, signed releases | curation | S |
+| Published gaps *(HONEST-STATE, surfaced proudly)* | curation | S |
+| Governance & maintainership *(links the public decisions log as a first-class artifact)* | curation | S |
+| Continuity: if we stop maintaining this *(named risks, named mitigations)* | new | S |
+| Security disclosure policy *(+ the public-vs-private exploitability test, J24)* | curation + new | S |
+| Pre-filled questionnaires *(links open items honestly)* | curation | S |
+| Compliance framework mappings index *(scope statements per artifact — what it covers, what remains the operator's)* | curation | S |
+| Verify these claims yourself | new | S |
+
+### `/skills/` — skills & playbooks · ~10 pages + generated indexes · [AUTHOR, PRODUCT · J7, J18, J23]
+
+| Page | Kind | Est. |
+|---|---|---|
+| Hub | new | S |
+| What a skill is | curation | S |
+| Author your first skill | new | S–M |
+| Your prompt files are already skill-shaped *(J7's entry point)* | new | S |
+| Test your skill before sharing *(coordinate with the skill-acceptance-tests mini-PRD)* | new | S–M |
+| Personal / team-shared / upstream — and which upstream *(two-repo routing per ADR 0024)* | curation | S |
+| The attestation bar *(what it is, what it covers, how it decays)* | curation | S |
+| Playbooks | curation | S |
+| **Skill catalogue** *(columns: skill · practice area · jurisdiction · contributor · attested-by · tier; covers first-party and community repos or scopes explicitly)* | generated | M |
+| **`coverage/`** — jurisdiction × practice-area index *(per-page: attested skills, sources/MCP connectors, scope notes from canon, gaps, contribution route)* | generated | M |
+
+### `/build/` — build on it · ~8 pages · [DEV · J17, J25]
+
+| Page | Kind | Est. |
+|---|---|---|
+| Choose your surface *(incl. "you may not need the API")* | new | S |
+| Build a frontend / fork the backend *(the evidenced path; extension points ranked by stability)* | new | M |
+| Gateway as an OpenAI drop-in | new | S–M |
+| Authentication for scripts *(honest interim; names the API-token DE)* | new | S — **blocked-adjacent** |
+| SSE streaming + citation payloads | new | M |
+| Stability: what "finished" means before 1.0 | new | S |
+| Cookbooks: batch tabular review; KB ingest; test-bench comparisons *(J25's defaults documented)* | new | M |
+| Extend instead: MCP, Word add-in, bridges | curation | S |
+
+### `/deliver/` — deliver to a client · ~8 pages · [PRODUCT · J8, J12, J13]
+
+| Page | Kind | Est. |
+|---|---|---|
+| Hub | new | S |
+| **Branding & licensing obligations** *(ships independently — parent spawned item 1)* | new | M |
+| Theming mechanics *(extract the CSS-variable spec from the archived design doc first)* | curation | S |
+| Deliver a branded deployment, end-to-end *(stitched guide across operate/skills/trust)* | new | M |
+| Multi-deployment operations | new | M |
+| Production-readiness matrix *(supported / operator-provided / not-yet, per row)* | new | S–M |
+| What you may and may not claim | curation | S |
+| Fork-based multi-tenant SaaS: unsupported-but-legal | new | S |
+| Hand-off pack for the client's security team *(indexes into `/trust/`)* | curation | S |
+
+### `/contribute/` · ~9 pages · [CONTRIB · J5, J23, J24]
+
+| Page | Kind | Est. |
+|---|---|---|
+| Index: the two tracks *(engineering vs legal substance)* | curation | S |
+| The live board *(build-time read of the existing board file — never forked)* | generated | S–M |
+| On-ramps: lawyer / compliance professional / engineer | new | 3 × S |
+| Coding-agent onboarding | curation | S |
+| Dev environment guide *(api + gateway + web — the one genuine content gap)* | new | M |
+| Contributing is a credential *(the membership route, stated)* | new | S |
+| Code of conduct | curation | S |
+
+### `/reference/` — generated · [OPS, DEV, AUTHOR]
+
+| Artifact | Source | Est. (one-time) |
+|---|---|---|
+| Configuration reference *(env + gateway.yaml + mcp.yaml)* | Pydantic config models | M |
+| Backend API reference | generated OpenAPI spec *(the generated one; the hand-written sketch is retired)* | M — **after** the operationId fix |
+| Gateway API reference | gateway OpenAPI spec | included above |
+| Error vocabulary | specs + code | S |
+| Skill frontmatter schema | loader schema | S |
+| Playbook position schema | playbook docs/schema | S |
+| ADR index *(renders real statuses — which will surface the stale ones)* | `docs/adr/` | S |
+| API stability & versioning statement | ADR 0025 + `/build/` stability page | S |
+
+### `/changelog/` · [OPS, DEV, EVAL · J6, J11, J14]
+
+One page per release, generated from GitHub Releases at build time: upgrade class (patch =
+upgrade blind / minor = read first, per ADR 0025), operator-action list, migration status,
+image tags, link to full notes. Requires a small structured block per release rather than
+prose parsing. Coverage depends on the release-notes backfill (parent spawned item 4);
+until it lands, the page states the gap.
+
+### Machine surface · [J5, J20]
+
+`/llms.txt`, `.md` served per page URL, and a downloadable full-text bundle (which is J20's
+offline artifact for free). Build steps, specified before the first page is written.
+
+---
+
+## 2. Claimable work items
+
+Twenty-two items. Each is claimable by one contributor, sized independently, and carries
+its acceptance test (the journey failed-whens from Annex B plus the Annex A gates).
+**Profiles are roles, not people.** Items marked ⛔ are blocked on a decision, not on
+effort.
+
+| # | Item | Size | Profile | Acceptance / notes |
+|---|---|---|---|---|
+| C1 | Site scaffold: Astro/Starlight, theme, CI build to Pages | M–L | frontend engineer | builds green; a11y + link gates wired |
+| C2 | Content transform: frontmatter injection, link rewriting, commit stamps, archaeology exclusion rules | M | engineer | every page stamped; zero orphans |
+| C3 | Machine surface: llms.txt, .md routes, offline bundle | S–M | engineer | J5, J20 tests |
+| C4 | Entry hub + `/start/` set | M | technical writer | J1, J2 tests; J1 needs a second reader |
+| C5 | Install spine curation (macOS, Compose, TLS, air-gap) | M | DevOps | J2 test |
+| C6 | Helm deployment page | S–M | DevOps | chart deployable from the page alone |
+| C7 | Hardware sizing + reference configurations | S–M | DevOps | J19 test |
+| C8 | Backup & restore | M | DevOps | J6 test (restore actually performed) |
+| C9 | Upgrade guide + symptom index + key-rotation runbook | M | DevOps | J9, J11 tests |
+| C10 | Recipes catalogue: index, house format, first two recipes | M | DevOps | J22 test; each further recipe is its own S item |
+| C11 | Egress inventory page from air-gap CI output | S–M | engineer | J20 test |
+| C12 | Trust-centre index + curation set | M | compliance / security professional | J4 test |
+| C13 | ⛔ Data-flow page ("what leaves my deployment") | M | compliance + engineer | J3 test; blocked on parent decision 1 |
+| C14 | Continuity + verify-yourself + disclosure-test pages | S–M | compliance professional | R-G shape; J24 test |
+| C15 | Skills authoring set | M | practising lawyer | J7 test |
+| C16 | Skill-testing page | S–M | lawyer + engineer | coordinates with skill-acceptance-tests mini-PRD |
+| C17 | Skill catalogue generator + frontmatter/position schema references | M | engineer | catalogue axes render; schemas tabulated |
+| C18 | Coverage index generator (jurisdiction × practice area) | M | engineer, lawyer review | J23 test; scope notes from canon on every page |
+| C19 | Contribute set + live-board wiring + dev-env guide | M–L | technical writer + engineer | agent orients from one fetch (J5) |
+| C20 | Build-on-it set (surfaces, fork path, gateway drop-in, stability, SSE, cookbooks) | L (splittable ×3) | engineer | J17, J25 tests |
+| C21 | Deliver set (theming, stitched guide, multi-deploy, readiness matrix, claims, SaaS page, hand-off) | L (splittable ×2) | DevOps + licence-comfortable lawyer | J8, J12, J13 tests; licensing page ships first and independently |
+| C22 | Reference + changelog generators | M–L | engineer | after operationId fix; changelog states backfill gap honestly |
+
+**Sequencing constraints, not assignments:** C1–C3 precede everything (the infrastructure
+is a prerequisite, and the machine surface is cheap only if specified first). C13 waits on
+decision 1. C22's API half waits on the operationId fix. The branding page inside C21 does
+not wait for anything — it ships as its own item per the parent PRD.
+
+---
+
+## 3. Totals
+
+| Phase | Sections | Narrative pages (curation / new) | Rough single-contributor equivalent |
+|---|---|---|---|
+| **P0 launch** | `/` + `/start/` + install spine + `/trust/` + machine surface + J11/J20/J22 minimums | ~27 (≈15 / ≈12) | ~5–6 weeks |
+| **P1 launch-with** | rest of `/operate/`, `/skills/`, `/contribute/` | ~24 (≈11 / ≈13) | ~3 weeks |
+| **P2 fast-follow** | `/build/`, `/deliver/` | ~16 (≈4 / ≈12) | ~3.5 weeks |
+| **Infrastructure** | scaffold, transform, machine surface, generators | — | ~2–3 weeks |
+| **Total** | | **~67 + generated** | **~14 weeks-equivalent** |
+
+Three honest framings:
+
+1. **"Launch" is ~27 pages, more than half curation.** The single-contributor-weeks number
+   is the wrong way to read this — the point of the item structure is that the same work
+   is 22 claimable items across five profiles.
+2. **The expensive half is the unwritten half, and it is the fast-follow half.** P0 is
+   mostly curation; P2 is mostly new writing. The cost curve supports the priority order.
+3. **Four items are blocked on decisions, not effort** — the data-flow page (decision 1),
+   the lite-profile page (open product question), the API auth page (token DE), and
+   changelog coverage (backfill). The PRD names them as dependencies so no contributor
+   discovers a wall mid-item.


### PR DESCRIPTION
## What this PR does

Adds the mini-PRD for a public LQ.AI documentation site under `docs/contribute/mini-prds/docsite/`: a parent proposal and three annexes. It also fixes the `CLAUDE.md` file-discovery row that pointed "Contributor-pickup mini-PRDs" at `docs/proposals/`.

- **[Parent](docs/contribute/mini-prds/docsite/README.md)** — goal, audiences, the site tree (eight namespaces; content stays in the repo), scope cuts, the launch gate, **four open questions with defaults**, and six spawned dependencies it names but does not absorb.
- **[Annex A](docs/contribute/mini-prds/docsite/annex-a-quality-rules.md)** — the quality-rules frame: the community-authored core set (lands under its author's name), three regulated-field additions, and the cross-surface rule. They serve as the PRD's acceptance tests.
- **[Annex B](docs/contribute/mini-prds/docsite/annex-b-journeys.md)** — 25 user journeys, each with a *failed-when* test a non-author can run.
- **[Annex C](docs/contribute/mini-prds/docsite/annex-c-work-plan.md)** — page trees, sizing (a ~26-page launch, more than half curation; ~60 pages overall), and 22 claimable work items by contributor profile.

## Why

The committee asked for a documentation-site PRD at its 2026-08-09 call. The recurring "is this for me", "how do I deploy it" and "can my security team approve it" questions are answered once in chat and lost; the site turns them into permanent, checkable pages.

## Changes since the draft was opened

- **Scope follows ADR 0031** (headless / API-only use: acknowledged, not supported — #564). `/build/` and the API references are gone. The one allowed page is a headless-boot page under `/operate/`, which J17 now tests. J25 is out of scope.
- **The stack is recorded in ADR 0028** (Astro Starlight on GitHub Pages — #580) instead of as a maintainer decision inside this PRD.
- **The committee accepted ADR 0028 on 2026-09-20.** The anonymization layer (#439), custom domain, preview hosting and deployment-partner framing are open questions, each with the default the site proceeds on. Priority order, quality-rule adoption, mentors and hosting ownership are withdrawn as decisions.
- **Custom domain:** one later move from `github.io` is safe, because GitHub redirects every path; a second move between custom domains is not, so the final domain is chosen once.

## What this PR does *not* do

- Build anything — no site scaffold, workflow, or page content. That can now start with Annex C items C1–C3 following ADR 0028 acceptance.
- Assign work to anyone.
- Reproduce the community author's rule text — that lands in her own PR, credited.
- Quote members-only channel content; all citations are public.

## Type of change

- [x] Documentation update

## Testing

- [x] `python3 docs/audits/check_doc_links.py docs/contribute/mini-prds/docsite/*.md` — 0 dangling links.

## Documentation

Documentation-only proposal; no PRD, README, OpenAPI or compliance changes.

## Transparency & governance invariants

n/a — no code, egress, data or audit paths change. On P10: the structural choice this PRD depends on is recorded in ADR 0028 rather than made inside the PRD.

## DCO sign-off

- [x] All authored commits are signed off. The one exception is `31975ca3`, GitHub's web merge of fork PR #3 into this branch; the commit it merged (`9ba3177f`) is signed off by its author. **Squash-merge** keeps the unsigned merge commit off `main`.

## Related issues

Refs #287, #439, #490, #495, #503, #506, #564

## Reviewer notes

- Annex B's *failed-when* tests are the main review surface — an untestable or wrong test is the most useful feedback.
- Check the four open questions' defaults: each one is what the site does if nobody decides.
- Two spawned items should move regardless of this PRD: the branding-obligations page assigned by ADR 0001, and the `GOVERNANCE.md` / ADR 0022 status fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

