### PR TITLE
chore(deps): lift gateway's starlette cap to <1.5, paired with #513

### DIFF
--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -72,12 +72,15 @@ dependencies = [
     # the official MCP SDK — not reasonably hand-rollable (it implements the
     # full JSON-RPC-over-SSE session + auth handshake). Client-only use here.
     "mcp>=1.28,<2",
-    # mcp pulls sse-starlette, whose latest (3.4.x) requires starlette 1.x —
-    # which conflicts with fastapi 0.116's starlette<0.49 pin. We use only the
-    # MCP *client* (ClientSession + streamablehttp_client), not the server, so
-    # pin starlette to fastapi's supported range; pip then resolves sse-starlette
-    # to a compatible (3.0.x) build. Lift when fastapi supports starlette 1.x.
-    "starlette>=1.3.1,<1.4",
+    # starlette is pinned explicitly rather than left to fastapi's resolver.
+    # History: this cap was originally <1.4 because mcp pulls sse-starlette,
+    # whose 3.4.x line requires starlette 1.x, which conflicted with the
+    # starlette<0.49 pin fastapi carried at 0.116. That conflict is gone —
+    # fastapi 0.141.1 declares starlette with no version specifier, and we
+    # have been running starlette 1.x since 1.3.1. We use only the MCP
+    # *client* (ClientSession + streamablehttp_client), never the server.
+    # Moves in lockstep with api/pyproject.toml's pin — bump both together.
+    "starlette>=1.4.1,<1.5",
 ]
 
 [project.optional-dependencies]

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -843,7 +843,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.1" },
     { name = "spacy", specifier = "~=3.8" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.51,<2.1" },
-    { name = "starlette", specifier = ">=1.3.1,<1.4" },
+    { name = "starlette", specifier = ">=1.4.1,<1.5" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.51.0,<0.52" },
 ]
@@ -2189,15 +2189,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.3.1"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/3c/76d2fd1f1357ed0f0108d8a5aa233dcf16e2946a8559c84912fe08e01ac7/starlette-1.4.1.tar.gz", hash = "sha256:b7332de6e9375593a29ba9eee1e6ecfeb3eb2043e2e19a13b4b71da73ff35540", size = 2709041, upload-time = "2026-08-05T15:17:26.23Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/67e95f21498de41433babf7b1db0eeab449eb58872dfb831b27747a70fd0/starlette-1.4.1-py3-none-any.whl", hash = "sha256:7d078e0fbefae0d2cecfb80a799d6fb84b1c0c6acd4f14ac79d17d0e7ec27f19", size = 74019, upload-time = "2026-08-05T15:17:24.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this PR does

Lifts `gateway/`'s starlette pin from `>=1.3.1,<1.4` to `>=1.4.1,<1.5`, matching
the same move in `api/` (#513), and rewrites the comment above it — its stated
premise no longer describes the tree.

## Why

`api/` and `gateway/` both pin starlette explicitly, and both comments say so:
api's ends *"Mirrors the same explicit pin in gateway/pyproject.toml"*, gateway's
ends *"Lift when fastapi supports starlette 1.x"*. #513 moves api to
`>=1.4.1,<1.5`. Without this PR the two diverge and api's comment becomes false.

The cap turned out to be a leftover rather than a live constraint. Its comment
describes a conflict between sse-starlette's 3.4.x line and the `starlette<0.49`
pin that fastapi carried at 0.116. None of that is current:

- gateway runs **fastapi 0.141.1** (since #500), not 0.116;
- gateway resolves **starlette 1.3.1** today, with green CI — so the `<0.49`
  conflict cannot be occurring;
- fastapi 0.141.1 declares starlette with **no version specifier**
  (`{ name = "starlette" }` in `gateway/uv.lock`).

The comment's own lift condition — *"when fastapi supports starlette 1.x"* — was
therefore already satisfied. This records that rather than repeating a stale
premise.

Refs #513

## What this PR does *not* do

- Does not change any application code. Two files: `gateway/pyproject.toml` and
  the resulting `gateway/uv.lock`.
- Does not touch the MCP client usage. We use `ClientSession` +
  `streamablehttp_client` only, never the MCP server, which is what made the
  original cap tolerable and is unchanged here.
- Does not revisit the `mcp>=1.28,<2` pin.
- Does not change `api/` — #513 owns that side.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Skill contribution (see attestation below)
- [ ] Refactor (no behavioral change)
- [x] Test / CI / tooling — dependency-constraint change

## Testing

- [ ] Unit tests added/updated — n/a, no behavioral change
- [ ] Integration tests added/updated — n/a
- [ ] Manually tested against a real deployment
- [ ] Acceptance test plan updated — n/a

<details>
<summary>Manual testing notes</summary>

CI is the gate here: `Gateway (ruff + mypy --strict + pytest)` plus
`Boot the compose stack and hold` exercise the resolved dependency set. The
relevant evidence to check on the run is that the compose stack still boots and
the gateway suite passes against starlette 1.4.1.

Reviewer: please confirm `sse-starlette`'s resolved version in the lock diff.
It is 3.0.3 on main; if the relock moved it to the 3.4.x line, that is worth a
second look before merge even though we use the MCP client only.

</details>

## Documentation

- [ ] PRD updated — n/a, no user-facing behavior change
- [ ] README updated — n/a
- [ ] Skill-authoring guide updated — n/a
- [ ] Deployment cookbook updated — n/a
- [ ] Compliance documentation updated — n/a
- [ ] OpenAPI schema regenerated — n/a, no API endpoints change

## Transparency & governance invariants

- [x] **Egress (P1):** n/a — no call sites change; no new egress path.
- [x] **Closed set (P2):** n/a — no new model or autonomous-invokable capability.
- [x] **No raw payloads (P3):** n/a — no rows or log lines added.
- [x] **Fail restrictive (P4):** n/a — no config path changes.
- [x] **Atomic audit (P5):** n/a — no state changes.
- [x] **One governance path (P6):** n/a — no governance/audit logic touched.
- [x] **Human gate (P7):** n/a — nothing destructive or irreversible added.
- [x] **Operator control (P8):** n/a — no new capability.
- [x] **User owns data (P9):** n/a — no change to matter context, export, delete,
      or residency.
- [x] **Contract is truth (P10):** no OpenAPI or DB schema change. The decision
      being made — that the `<1.4` cap is retired — is recorded in the rewritten
      comment at the pin itself, which is where the original decision lived. No
      ADR is warranted for a dependency range; if a reviewer disagrees, say so
      and I will file one.

## DCO sign-off

- [x] All commits in this PR are signed off per the DCO

## Related issues

Refs #513