### PR TITLE
Test/gateway env fixture

### DIFF
--- a/deploy/tailnet-ollama/README.md
+++ b/deploy/tailnet-ollama/README.md
@@ -1,0 +1,174 @@
+# Tailnet-Hosted Ollama for the Gateway
+
+[Tailscale](https://tailscale.com/) is a networking platform that connects devices securely into a private network called a **tailnet**. Devices on the same tailnet can communicate without exposing their services directly to the public internet.
+
+[Ollama](https://ollama.com/) is a tool for running large language models locally. It provides an HTTP API that applications such as the LQ.AI inference gateway can use for model inference.
+
+This recipe covers the setup when Ollama runs on a separate GPU host on your tailnet and the LQ.AI gateway runs on another machine.
+
+---
+
+## When to Use This
+
+Use this recipe when:
+
+- Ollama runs on a separate GPU machine from the LQ.AI gateway.
+- Both machines are connected to the same Tailscale tailnet.
+- You want the gateway to reach Ollama over HTTPS without exposing Ollama to the public internet.
+
+### Architecture
+
+```text
+Gateway
+    |
+    | HTTPS
+    v
+https://<host>.<tailnet>.ts.net
+    |
+    | Tailscale Serve
+    v
+127.0.0.1:11434
+    |
+    v
+Ollama on the GPU host
+```
+
+Tailscale Serve terminates HTTPS on the GPU host and forwards requests to Ollama on the host's loopback interface.
+
+---
+
+## Prerequisites
+
+You need:
+
+- A machine running the LQ.AI gateway.
+- A separate GPU host with Ollama installed and running.
+- Tailscale installed and authenticated on the GPU host.
+- Both machines connected to the same tailnet.
+- **MagicDNS** enabled for the tailnet.
+- **HTTPS Certificates** enabled for the tailnet.
+
+> **Note:** MagicDNS provides DNS names for devices on the tailnet. HTTPS Certificates allow Tailscale to provide a publicly trusted certificate for the device's `*.ts.net` hostname.
+> See the Tailscale documentation for [MagicDNS](https://tailscale.com/kb/1081/magicdns) and [HTTPS Certificates](https://tailscale.com/kb/1153/enabling-https).
+
+---
+
+## Quick Start
+
+### 1. Verify Ollama on the GPU Host
+
+Make sure Ollama is installed and running on the GPU host. Verify that its local API responds:
+
+```bash
+curl http://127.0.0.1:11434/api/tags
+```
+
+The response should contain the models available to Ollama.
+
+### 2. Expose Ollama with Tailscale Serve
+
+On the GPU host, run:
+
+```bash
+sudo tailscale serve --bg --https=443 http://127.0.0.1:11434
+```
+
+Check the active configuration:
+
+```bash
+tailscale serve status
+```
+
+The Ollama endpoint is now available over the tailnet at:
+
+```text
+https://<host>.<tailnet>.ts.net
+```
+
+*Example:* `https://gpu-box.example.ts.net` (the exact hostname depends on your Tailscale machine name and tailnet DNS name).
+
+### 3. Configure the Gateway
+
+On the machine running the LQ.AI gateway, set:
+
+```env
+OLLAMA_BASE_URL=https://<host>.<tailnet>.ts.net
+```
+
+*Example:* `OLLAMA_BASE_URL=https://gpu-box.example.ts.net`
+
+Set this in the environment used by the gateway, then recreate or restart the gateway so that it loads the new value.
+
+### 4. Verify the Connection
+
+From the gateway host, verify that the Tailscale HTTPS endpoint is reachable:
+
+```bash
+curl -f https://<host>.<tailnet>.ts.net/api/tags
+```
+
+A successful response confirms that the gateway host can reach the Ollama API through the Tailscale HTTPS endpoint.
+
+---
+
+## Technical Details
+
+### Why HTTPS is Required
+
+The gateway's LLM provider egress policy allows HTTPS destinations without the local-host restriction. Plaintext HTTP is restricted strictly to explicitly local inference targets.
+
+For a remote Ollama host on a tailnet, use:
+
+```env
+OLLAMA_BASE_URL=https://<host>.<tailnet>.ts.net
+```
+
+The Tailscale hostname uses a publicly trusted HTTPS certificate, so the gateway container does not need a custom CA bundle for this connection.
+
+### Why Plain HTTP to a Tailscale IP is Refused
+
+Tailscale addresses use the `100.64.0.0/10` CGNAT range. The gateway's LLM egress policy deliberately does not treat that range as a permitted local target for plaintext HTTP.
+
+Therefore, this configuration is refused:
+
+```env
+OLLAMA_BASE_URL=http://100.x.y.z:11434
+```
+
+The gateway reports an error of this form:
+
+```text
+plaintext http base_url is only permitted for local providers
+(host.docker.internal, localhost, ollama, vllm, or a loopback/private IP);
+host '100.x.y.z' must use https
+```
+
+This refusal is intentional. The egress guard prevents LLM prompts from being sent over plaintext HTTP to a remote host. HTTPS is required for remote destinations, so the supported tailnet configuration uses the Tailscale `*.ts.net` hostname instead.
+
+For egress policy details, see
+[ADR 0014 — Gateway egress boundary](../../docs/adr/0014-gateway-egress-boundary-for-tool-providers.md).
+
+---
+
+## Alternatives to Tailscale Serve
+
+Tailscale Serve is the simplest option when Ollama runs directly on the GPU host. Other HTTPS-capable service patterns can also be used:
+
+- **[Tailscale Services](https://tailscale.com/kb/1573/tailscale-services):** Provides service-level identities and routing within a tailnet.
+- **Caddy or Reverse Proxy:** A reverse proxy can terminate HTTPS and forward requests to Ollama. See [`deploy/caddy-tailscale/README.md`](../caddy-tailscale/README.md) for the general pattern.
+
+Regardless of the mechanism used, a remote Ollama endpoint should always be configured with an HTTPS `OLLAMA_BASE_URL`.
+
+---
+
+## References
+
+- **Tailscale Documentation:**
+  - [What is a tailnet?](https://tailscale.com/kb/1136/tailnet)
+  - [Tailscale Serve](https://tailscale.com/kb/1242/tailscale-serve)
+  - [MagicDNS](https://tailscale.com/kb/1081/magicdns)
+  - [Enabling HTTPS](https://tailscale.com/kb/1153/enabling-https)
+  - **Ollama Documentation:** [ollama.com](https://ollama.com/)
+  - **Internal References:**
+  - [Caddy + Tailscale deployment recipe](../caddy-tailscale/README.md)
+  - [ADR 0014 — Gateway egress boundary](../../docs/adr/0014-gateway-egress-boundary-for-tool-providers.md)

--- a/gateway/tests/test_admin_tool_providers.py
+++ b/gateway/tests/test_admin_tool_providers.py
@@ -54,7 +54,6 @@ async def _run_lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
 
 
-
 @pytest_asyncio.fixture
 async def writable_config(tmp_path: Path) -> Path:
     """Copy the committed example config to a writable temp path."""

--- a/gateway/tests/test_admin_tool_providers.py
+++ b/gateway/tests/test_admin_tool_providers.py
@@ -54,15 +54,6 @@ async def _run_lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
 
 
-def _set_example_env(monkeypatch: pytest.MonkeyPatch, tmp_config: Path) -> None:
-    """Set the ``${VAR}`` placeholders the example config references."""
-
-    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
-    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
-    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
-    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_config))
-
 
 @pytest_asyncio.fixture
 async def writable_config(tmp_path: Path) -> Path:
@@ -93,7 +84,7 @@ async def keyed_app(
 ) -> AsyncIterator[FastAPI]:
     """Gateway app with a fresh master key + writable temp config."""
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", Fernet.generate_key().decode())
     _stub_build_tool_adapter(monkeypatch)
 
@@ -116,7 +107,7 @@ async def no_master_key_app(
 ) -> AsyncIterator[FastAPI]:
     """Gateway app WITHOUT a master key — POST/PATCH with an api_key must 400."""
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     monkeypatch.delenv("LQ_AI_GATEWAY_MASTER_KEY", raising=False)
     _stub_build_tool_adapter(monkeypatch)
 

--- a/gateway/tests/test_config.py
+++ b/gateway/tests/test_config.py
@@ -92,6 +92,7 @@ def example_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
     monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
 
 
 @pytest.mark.unit

--- a/gateway/tests/test_config_holder.py
+++ b/gateway/tests/test_config_holder.py
@@ -39,6 +39,7 @@ def example_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
     monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
 
 
 @pytest.fixture

--- a/gateway/tests/test_provider_keys.py
+++ b/gateway/tests/test_provider_keys.py
@@ -86,8 +86,8 @@ async def keyed_client(keyed_app: FastAPI) -> AsyncIterator[AsyncClient]:
 
 
 @pytest_asyncio.fixture
-async def no_master_key_app(example_env,
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def no_master_key_app(
+    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> AsyncIterator[FastAPI]:
     """Gateway app WITHOUT a master key — POST/PATCH must 400."""
 
@@ -394,7 +394,8 @@ class _FakeState:
 
 
 @pytest.mark.unit
-async def test_rotation_retires_displaced_adapter(example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_rotation_retires_displaced_adapter(
+    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """Rotating an already-keyed provider MOVES the old adapter to retired.
 
@@ -450,7 +451,8 @@ async def test_rotation_retires_displaced_adapter(example_env, monkeypatch: pyte
 
 
 @pytest.mark.unit
-async def test_revoke_retires_live_adapter(example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_revoke_retires_live_adapter(
+    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """revoke_provider_key pops the live adapter into retired_adapters."""
 
@@ -487,7 +489,8 @@ async def test_revoke_retires_live_adapter(example_env, monkeypatch: pytest.Monk
 
 
 @pytest.mark.unit
-async def test_apply_maps_egress_refusal_to_409(example_env,monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_apply_maps_egress_refusal_to_409(
+    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """An egress-refused base_url on the BYOK path is a structured 409.
 

--- a/gateway/tests/test_provider_keys.py
+++ b/gateway/tests/test_provider_keys.py
@@ -54,16 +54,6 @@ async def _run_lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
 
 
-def _set_example_env(monkeypatch: pytest.MonkeyPatch, tmp_config: Path) -> None:
-    """Set the ``${VAR}`` placeholders the example config references."""
-
-    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
-    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
-    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
-    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_config))
-
-
 @pytest_asyncio.fixture
 async def writable_config(tmp_path: Path) -> Path:
     """Copy the committed example config to a writable temp path."""
@@ -79,7 +69,7 @@ async def keyed_app(
 ) -> AsyncIterator[FastAPI]:
     """Gateway app with a fresh master key + writable temp config."""
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", Fernet.generate_key().decode())
 
     from app.main import app
@@ -96,12 +86,12 @@ async def keyed_client(keyed_app: FastAPI) -> AsyncIterator[AsyncClient]:
 
 
 @pytest_asyncio.fixture
-async def no_master_key_app(
+async def no_master_key_app(example_env,
     monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> AsyncIterator[FastAPI]:
     """Gateway app WITHOUT a master key — POST/PATCH must 400."""
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     monkeypatch.delenv("LQ_AI_GATEWAY_MASTER_KEY", raising=False)
 
     from app.main import app
@@ -404,8 +394,7 @@ class _FakeState:
 
 
 @pytest.mark.unit
-async def test_rotation_retires_displaced_adapter(
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_rotation_retires_displaced_adapter(example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """Rotating an already-keyed provider MOVES the old adapter to retired.
 
@@ -414,12 +403,6 @@ async def test_rotation_retires_displaced_adapter(
     provider credentials. Asserts the displaced adapter ends up in
     ``retired_adapters`` exactly once and is not double-held.
     """
-
-    monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", Fernet.generate_key().decode())
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
-    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
-    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
-    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
 
     from app.config_holder import MutableConfigHolder
     from app.config_loader import load_config
@@ -467,8 +450,7 @@ async def test_rotation_retires_displaced_adapter(
 
 
 @pytest.mark.unit
-async def test_revoke_retires_live_adapter(
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_revoke_retires_live_adapter(example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """revoke_provider_key pops the live adapter into retired_adapters."""
 
@@ -505,8 +487,7 @@ async def test_revoke_retires_live_adapter(
 
 
 @pytest.mark.unit
-async def test_apply_maps_egress_refusal_to_409(
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_apply_maps_egress_refusal_to_409(example_env,monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """An egress-refused base_url on the BYOK path is a structured 409.
 
@@ -522,7 +503,7 @@ async def test_apply_maps_egress_refusal_to_409(
     from app.config_writer import ProviderKeyMutationError
     from app.providers.base_url_policy import ProviderEgressRefused
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     master_key = Fernet.generate_key().decode()
     monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", master_key)
 


### PR DESCRIPTION
Consolidates duplicated example-env setup across gateway tests into the shared `example_env` fixture.

- Removed local `_set_example_env` helpers
- Deleted duplicated environment setup blocks
- Replaced with shared fixture usage where appropriate
- Preserved test-specific env overrides (e.g. master key, base_url overrides)

All changes follow the requirements of #493.