### PR TITLE
test(gateway): consolidate example env setup into shared fixture (#493)

### DIFF
--- a/gateway/tests/test_admin_tool_providers.py
+++ b/gateway/tests/test_admin_tool_providers.py
@@ -54,7 +54,6 @@ async def _run_lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
 
 
-
 @pytest_asyncio.fixture
 async def writable_config(tmp_path: Path) -> Path:
     """Copy the committed example config to a writable temp path."""

--- a/gateway/tests/test_admin_tool_providers.py
+++ b/gateway/tests/test_admin_tool_providers.py
@@ -79,7 +79,7 @@ def _stub_build_tool_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest_asyncio.fixture
 async def keyed_app(
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+    example_env: None, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> AsyncIterator[FastAPI]:
     """Gateway app with a fresh master key + writable temp config."""
 
@@ -102,7 +102,7 @@ async def client(keyed_app: FastAPI) -> AsyncIterator[AsyncClient]:
 
 @pytest_asyncio.fixture
 async def no_master_key_app(
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+    example_env: None, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> AsyncIterator[FastAPI]:
     """Gateway app WITHOUT a master key — POST/PATCH with an api_key must 400."""
 

--- a/gateway/tests/test_admin_tool_providers.py
+++ b/gateway/tests/test_admin_tool_providers.py
@@ -54,15 +54,6 @@ async def _run_lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
 
 
-def _set_example_env(monkeypatch: pytest.MonkeyPatch, tmp_config: Path) -> None:
-    """Set the ``${VAR}`` placeholders the example config references."""
-
-    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
-    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
-    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
-    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_config))
-
 
 @pytest_asyncio.fixture
 async def writable_config(tmp_path: Path) -> Path:
@@ -93,7 +84,7 @@ async def keyed_app(
 ) -> AsyncIterator[FastAPI]:
     """Gateway app with a fresh master key + writable temp config."""
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", Fernet.generate_key().decode())
     _stub_build_tool_adapter(monkeypatch)
 
@@ -116,7 +107,7 @@ async def no_master_key_app(
 ) -> AsyncIterator[FastAPI]:
     """Gateway app WITHOUT a master key — POST/PATCH with an api_key must 400."""
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     monkeypatch.delenv("LQ_AI_GATEWAY_MASTER_KEY", raising=False)
     _stub_build_tool_adapter(monkeypatch)
 

--- a/gateway/tests/test_config.py
+++ b/gateway/tests/test_config.py
@@ -92,6 +92,7 @@ def example_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
     monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
 
 
 @pytest.mark.unit

--- a/gateway/tests/test_config.py
+++ b/gateway/tests/test_config.py
@@ -79,22 +79,6 @@ def test_expand_env_vars_walks_nested_structures(monkeypatch: pytest.MonkeyPatch
 # --- load_config: happy path on the real example -----------------------------
 
 
-@pytest.fixture
-def example_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Set the env vars referenced by ``gateway.yaml.example``.
-
-    The example references several optional ``${VAR:-default}`` placeholders
-    (no env action needed) and one or two required ``${VAR}`` placeholders
-    that we satisfy here so the parse succeeds in tests.
-    """
-
-    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
-    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
-    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
-
-
 @pytest.mark.unit
 def test_load_config_parses_example(example_env: None) -> None:
     config = load_config(EXAMPLE_CONFIG)

--- a/gateway/tests/test_config_holder.py
+++ b/gateway/tests/test_config_holder.py
@@ -32,17 +32,6 @@ EXAMPLE_CONFIG = REPO_ROOT / "gateway.yaml.example"
 
 
 @pytest.fixture
-def example_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Satisfy gateway.yaml.example placeholders for direct loads."""
-
-    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
-    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
-    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
-
-
-@pytest.fixture
 def tmp_config(tmp_path: Path) -> Path:
     """Copy gateway.yaml.example into a tmp dir for safe mutation."""
 

--- a/gateway/tests/test_config_holder.py
+++ b/gateway/tests/test_config_holder.py
@@ -39,6 +39,7 @@ def example_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AWS_REGION", "us-east-1")
     monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
     monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
 
 
 @pytest.fixture

--- a/gateway/tests/test_llm_base_url_policy.py
+++ b/gateway/tests/test_llm_base_url_policy.py
@@ -94,6 +94,7 @@ def test_build_adapter_allows_local_ollama() -> None:
 
 @pytest.mark.unit
 async def test_lifespan_refuses_to_start_on_refused_base_url(
+    example_env: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An egress-policy violation is FATAL at startup, never a silent skip.
@@ -106,10 +107,6 @@ async def test_lifespan_refuses_to_start_on_refused_base_url(
     This reproduces the operator story: a mistyped ``OLLAMA_BASE_URL``.
     """
 
-    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
-    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
-    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
     monkeypatch.setenv("OLLAMA_BASE_URL", "http://attacker.example/v1")
     monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(EXAMPLE_CONFIG))
 

--- a/gateway/tests/test_provider_keys.py
+++ b/gateway/tests/test_provider_keys.py
@@ -65,7 +65,7 @@ async def writable_config(tmp_path: Path) -> Path:
 
 @pytest_asyncio.fixture
 async def keyed_app(
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+    example_env: None, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> AsyncIterator[FastAPI]:
     """Gateway app with a fresh master key + writable temp config."""
 
@@ -87,7 +87,7 @@ async def keyed_client(keyed_app: FastAPI) -> AsyncIterator[AsyncClient]:
 
 @pytest_asyncio.fixture
 async def no_master_key_app(
-    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
+    example_env: None, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> AsyncIterator[FastAPI]:
     """Gateway app WITHOUT a master key — POST/PATCH must 400."""
 
@@ -395,7 +395,7 @@ class _FakeState:
 
 @pytest.mark.unit
 async def test_rotation_retires_displaced_adapter(
-    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
+    example_env: None, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """Rotating an already-keyed provider MOVES the old adapter to retired.
 
@@ -452,7 +452,7 @@ async def test_rotation_retires_displaced_adapter(
 
 @pytest.mark.unit
 async def test_revoke_retires_live_adapter(
-    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
+    example_env: None, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """revoke_provider_key pops the live adapter into retired_adapters."""
 
@@ -490,7 +490,7 @@ async def test_revoke_retires_live_adapter(
 
 @pytest.mark.unit
 async def test_apply_maps_egress_refusal_to_409(
-    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
+    example_env: None, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """An egress-refused base_url on the BYOK path is a structured 409.
 

--- a/gateway/tests/test_provider_keys.py
+++ b/gateway/tests/test_provider_keys.py
@@ -86,8 +86,8 @@ async def keyed_client(keyed_app: FastAPI) -> AsyncIterator[AsyncClient]:
 
 
 @pytest_asyncio.fixture
-async def no_master_key_app(example_env,
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def no_master_key_app(
+    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> AsyncIterator[FastAPI]:
     """Gateway app WITHOUT a master key — POST/PATCH must 400."""
 
@@ -394,7 +394,8 @@ class _FakeState:
 
 
 @pytest.mark.unit
-async def test_rotation_retires_displaced_adapter(example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_rotation_retires_displaced_adapter(
+    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """Rotating an already-keyed provider MOVES the old adapter to retired.
 
@@ -450,7 +451,8 @@ async def test_rotation_retires_displaced_adapter(example_env, monkeypatch: pyte
 
 
 @pytest.mark.unit
-async def test_revoke_retires_live_adapter(example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_revoke_retires_live_adapter(
+    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """revoke_provider_key pops the live adapter into retired_adapters."""
 
@@ -487,7 +489,8 @@ async def test_revoke_retires_live_adapter(example_env, monkeypatch: pytest.Monk
 
 
 @pytest.mark.unit
-async def test_apply_maps_egress_refusal_to_409(example_env,monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_apply_maps_egress_refusal_to_409(
+    example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """An egress-refused base_url on the BYOK path is a structured 409.
 

--- a/gateway/tests/test_provider_keys.py
+++ b/gateway/tests/test_provider_keys.py
@@ -54,16 +54,6 @@ async def _run_lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
 
 
-def _set_example_env(monkeypatch: pytest.MonkeyPatch, tmp_config: Path) -> None:
-    """Set the ``${VAR}`` placeholders the example config references."""
-
-    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
-    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
-    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
-    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_config))
-
-
 @pytest_asyncio.fixture
 async def writable_config(tmp_path: Path) -> Path:
     """Copy the committed example config to a writable temp path."""
@@ -79,7 +69,7 @@ async def keyed_app(
 ) -> AsyncIterator[FastAPI]:
     """Gateway app with a fresh master key + writable temp config."""
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", Fernet.generate_key().decode())
 
     from app.main import app
@@ -96,12 +86,12 @@ async def keyed_client(keyed_app: FastAPI) -> AsyncIterator[AsyncClient]:
 
 
 @pytest_asyncio.fixture
-async def no_master_key_app(
+async def no_master_key_app(example_env,
     monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> AsyncIterator[FastAPI]:
     """Gateway app WITHOUT a master key — POST/PATCH must 400."""
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     monkeypatch.delenv("LQ_AI_GATEWAY_MASTER_KEY", raising=False)
 
     from app.main import app
@@ -404,8 +394,7 @@ class _FakeState:
 
 
 @pytest.mark.unit
-async def test_rotation_retires_displaced_adapter(
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_rotation_retires_displaced_adapter(example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """Rotating an already-keyed provider MOVES the old adapter to retired.
 
@@ -414,12 +403,6 @@ async def test_rotation_retires_displaced_adapter(
     provider credentials. Asserts the displaced adapter ends up in
     ``retired_adapters`` exactly once and is not double-held.
     """
-
-    monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", Fernet.generate_key().decode())
-    monkeypatch.setenv("AWS_REGION", "us-east-1")
-    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
-    monkeypatch.setenv("AZURE_OPENAI_RESOURCE", "test-openai")
-    monkeypatch.setenv("LQ_AI_VERSION", "0.1.0-test")
 
     from app.config_holder import MutableConfigHolder
     from app.config_loader import load_config
@@ -467,8 +450,7 @@ async def test_rotation_retires_displaced_adapter(
 
 
 @pytest.mark.unit
-async def test_revoke_retires_live_adapter(
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_revoke_retires_live_adapter(example_env, monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """revoke_provider_key pops the live adapter into retired_adapters."""
 
@@ -505,8 +487,7 @@ async def test_revoke_retires_live_adapter(
 
 
 @pytest.mark.unit
-async def test_apply_maps_egress_refusal_to_409(
-    monkeypatch: pytest.MonkeyPatch, writable_config: Path
+async def test_apply_maps_egress_refusal_to_409(example_env,monkeypatch: pytest.MonkeyPatch, writable_config: Path
 ) -> None:
     """An egress-refused base_url on the BYOK path is a structured 409.
 
@@ -522,7 +503,7 @@ async def test_apply_maps_egress_refusal_to_409(
     from app.config_writer import ProviderKeyMutationError
     from app.providers.base_url_policy import ProviderEgressRefused
 
-    _set_example_env(monkeypatch, writable_config)
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(writable_config))
     master_key = Fernet.generate_key().decode()
     monkeypatch.setenv("LQ_AI_GATEWAY_MASTER_KEY", master_key)
 


### PR DESCRIPTION
## Summary
Consolidates duplicated environment variable setup into the shared `example_env` fixture across gateway tests.

## Changes
- Removed repeated monkeypatch.setenv blocks
- Added example_env fixture to relevant tests
- Deleted _set_example_env helper where redundant

## Why
Reduces duplication and aligns with issue #493 requirement.
Closes #493

## Notes
No functional changes intended — test cleanup only.