### PR TITLE
feat(admin): provision users and reset passwords

### DIFF
--- a/api/app/api/admin.py
+++ b/api/app/api/admin.py
@@ -38,8 +38,9 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import ColumnElement, Select, Text, and_, func, select
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from sqlalchemy import ColumnElement, Select, Text, and_, func, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import AdminUser
@@ -1026,6 +1027,235 @@ async def update_user_role(
         email=target.email,
         role=target.role,
         is_admin=target.is_admin,
+    )
+
+
+# ---------------------------------------------------------------------------
+# User provisioning — POST /admin/users, POST /admin/users/{id}/reset-password
+# ---------------------------------------------------------------------------
+# The RBAC surface shipped with a list endpoint and a role-patch endpoint but
+# no way to *create* a user: there is no signup, no invite, and `app/cli.py`
+# exposes only `reset-admin-password`. A deployment's second user therefore
+# required a hand-written bcrypt INSERT. These two handlers close that gap
+# using the machinery the first-run bootstrap already relies on
+# (`app.admin_bootstrap.generate_password` + `must_change_password=True`), so
+# a provisioned user is forced through `/auth/change-password` on first login
+# exactly like the bootstrap admin.
+#
+# The generated password is returned in the response body **once** and is
+# never persisted, logged, or written to the audit row — only its bcrypt hash
+# reaches the database.
+
+
+class AdminUserCreateRequest(BaseModel):
+    """``POST /admin/users`` body."""
+
+    email: EmailStr
+    display_name: str | None = Field(default=None, max_length=200)
+    role: str = Field(
+        default="member",
+        description="One of admin / member / viewer / auditor.",
+    )
+
+
+class AdminUserCreatedResponse(BaseModel):
+    """``POST /admin/users`` response — carries the initial password once.
+
+    ``initial_password`` is the only time the plaintext exists outside the
+    creating admin's screen. It is not recoverable; use
+    ``POST /admin/users/{id}/reset-password`` to mint a new one.
+    """
+
+    user_id: str
+    email: str
+    display_name: str | None
+    role: str
+    is_admin: bool
+    must_change_password: bool
+    initial_password: str
+
+
+class AdminPasswordResetResponse(BaseModel):
+    """``POST /admin/users/{id}/reset-password`` response."""
+
+    user_id: str
+    email: str
+    initial_password: str
+    sessions_revoked: int
+
+
+@router.post(
+    "/users",
+    response_model=AdminUserCreatedResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a user with a generated initial password (admin-only)",
+)
+async def create_user(
+    body: AdminUserCreateRequest,
+    request: Request,
+    admin: AdminUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> AdminUserCreatedResponse:
+    """POST /api/v1/admin/users — provision a user.
+
+    Admin-only. Generates a CSPRNG initial password, stores only its bcrypt
+    hash, and sets ``must_change_password=True`` so the new user is forced to
+    rotate it on first login. ``is_admin`` is derived from ``role`` (True iff
+    ``role='admin'``), keeping the two admin signals in sync exactly as
+    :func:`update_user_role` and the first-run bootstrap do.
+
+    Returns 201 with the plaintext password, which is never stored or logged.
+    Returns 409 if the email is already taken — ``users.email`` is CITEXT, so
+    the collision is case-insensitive.
+    """
+
+    from app.admin_bootstrap import generate_password
+    from app.audit import audit_action
+    from app.errors import Conflict
+    from app.security import hash_password
+
+    if body.role not in _ROLE_ENUM:
+        raise HTTPException(
+            status_code=422,
+            detail=f"role must be one of {sorted(_ROLE_ENUM)}",
+        )
+
+    display_name = (body.display_name or "").strip() or None
+    plaintext = generate_password()
+
+    # Race-safe insert on the unique CITEXT `email` column, mirroring
+    # `ensure_first_run_admin`. A lost race yields no row, which we surface
+    # as the same 409 an up-front existence check would have produced.
+    stmt = (
+        pg_insert(UserORM)
+        .values(
+            email=str(body.email),
+            display_name=display_name,
+            hashed_password=hash_password(plaintext),
+            is_admin=body.role == "admin",
+            role=body.role,
+            mfa_enabled=False,
+            must_change_password=True,
+        )
+        .on_conflict_do_nothing(index_elements=["email"])
+        .returning(UserORM.id)
+    )
+    inserted_id = (await db.execute(stmt)).scalar_one_or_none()
+
+    if inserted_id is None:
+        # Nothing was written (ON CONFLICT DO NOTHING), so there is no dirty
+        # state to roll back — `get_db`'s session context manager discards
+        # the transaction when the error propagates.
+        raise Conflict(
+            message="A user with that email already exists.",
+            details={"email": str(body.email)},
+        )
+
+    # The audit row records who was created, by whom, and with what role —
+    # never the password.
+    await audit_action(
+        db,
+        user_id=admin.id,
+        action="user.created",
+        resource_type="user",
+        resource_id=str(inserted_id),
+        request=request,
+        details={
+            "target_user_email": str(body.email),
+            "role": body.role,
+            "is_admin": body.role == "admin",
+        },
+    )
+    await db.commit()
+
+    return AdminUserCreatedResponse(
+        user_id=str(inserted_id),
+        email=str(body.email),
+        display_name=display_name,
+        role=body.role,
+        is_admin=body.role == "admin",
+        must_change_password=True,
+        initial_password=plaintext,
+    )
+
+
+@router.post(
+    "/users/{user_id}/reset-password",
+    response_model=AdminPasswordResetResponse,
+    summary="Reset a user's password to a generated value (admin-only)",
+)
+async def reset_user_password(
+    user_id: str,
+    request: Request,
+    admin: AdminUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> AdminPasswordResetResponse:
+    """POST /api/v1/admin/users/{user_id}/reset-password — mint a new password.
+
+    Admin-only. Generates a fresh CSPRNG password, sets
+    ``must_change_password=True``, and revokes every active refresh session
+    for the target user so an attacker holding a stolen refresh token cannot
+    outlive the reset. This is the same revocation the self-service
+    ``/auth/change-password`` path performs.
+
+    Note that access tokens are stateless JWTs and remain valid until they
+    expire; deployments that raise ``JWT_ACCESS_TOKEN_TTL_SECONDS`` above the
+    default widen that window.
+    """
+
+    from app.admin_bootstrap import generate_password
+    from app.audit import audit_action
+    from app.errors import NotFound
+    from app.models.user import UserSession
+    from app.security import hash_password
+
+    try:
+        target_uuid = _uuid_mod.UUID(user_id)
+    except (TypeError, ValueError):
+        raise NotFound(message="user not found") from None
+
+    target = await db.get(UserORM, target_uuid)
+    if target is None or target.deleted_at is not None:
+        raise NotFound(message="user not found")
+
+    plaintext = generate_password()
+    target.hashed_password = hash_password(plaintext)
+    target.must_change_password = True
+
+    # RETURNING rather than `rowcount` so the count is typed and portable.
+    revoked_ids = (
+        (
+            await db.execute(
+                update(UserSession)
+                .where(UserSession.user_id == target.id, UserSession.revoked_at.is_(None))
+                .values(revoked_at=func.now())
+                .returning(UserSession.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    sessions_revoked = len(revoked_ids)
+
+    await audit_action(
+        db,
+        user_id=admin.id,
+        action="user.password_reset",
+        resource_type="user",
+        resource_id=str(target.id),
+        request=request,
+        details={
+            "target_user_email": target.email,
+            "sessions_revoked": sessions_revoked,
+        },
+    )
+    await db.commit()
+
+    return AdminPasswordResetResponse(
+        user_id=str(target.id),
+        email=target.email,
+        initial_password=plaintext,
+        sessions_revoked=sessions_revoked,
     )
 
 

--- a/api/tests/test_admin_user_provisioning.py
+++ b/api/tests/test_admin_user_provisioning.py
@@ -1,0 +1,351 @@
+"""Integration tests for user provisioning — POST /api/v1/admin/users and
+POST /api/v1/admin/users/{user_id}/reset-password.
+
+Covers:
+* 201 returns the generated plaintext exactly once; only the bcrypt hash lands
+  in the DB and the plaintext never appears in the audit row.
+* The created user is forced through password rotation (must_change_password).
+* ``is_admin`` is derived from ``role`` (True iff role='admin').
+* 409 on a duplicate email, including a case-variant one (``email`` is CITEXT).
+* 422 on an unknown role; 403 for non-admin callers.
+* Reset mints a new password, re-arms must_change_password, and revokes every
+  active refresh session for the target user.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.main import app
+from app.models.audit import AuditLog
+from app.models.user import User, UserSession
+from app.security import create_access_token, hash_password, verify_password
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+def _bearer(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_user(*, email: str, is_admin: bool = False, role: str = "member") -> User:
+    return User(
+        email=email,
+        display_name=email.split("@")[0].capitalize(),
+        hashed_password=hash_password("s3cr3t-battery-staple"),
+        is_admin=is_admin,
+        role=role,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def admin_user(db_session: AsyncSession) -> User:
+    user = _make_user(
+        email=f"admin-{uuid.uuid4().hex[:8]}@example.com", is_admin=True, role="admin"
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def member_user(db_session: AsyncSession) -> User:
+    user = _make_user(email=f"member-{uuid.uuid4().hex[:8]}@example.com")
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+def _new_email() -> str:
+    return f"attorney-{uuid.uuid4().hex[:8]}@example.com"
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/users
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_user_returns_plaintext_once_and_stores_only_the_hash(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User
+) -> None:
+    email = _new_email()
+    resp = await client.post(
+        "/api/v1/admin/users",
+        json={"email": email, "display_name": "Ana Ruiz", "role": "member"},
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+
+    plaintext = body["initial_password"]
+    assert len(plaintext) == 24
+    assert body["email"] == email
+    assert body["display_name"] == "Ana Ruiz"
+    assert body["role"] == "member"
+    assert body["is_admin"] is False
+    assert body["must_change_password"] is True
+
+    row = (
+        await db_session.execute(select(User).where(User.id == uuid.UUID(body["user_id"])))
+    ).scalar_one()
+    # Only the hash is persisted, and it verifies against the returned plaintext.
+    assert row.hashed_password != plaintext
+    assert verify_password(plaintext, row.hashed_password)
+    assert row.must_change_password is True
+    assert row.mfa_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_create_user_audit_row_never_carries_the_password(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User
+) -> None:
+    email = _new_email()
+    resp = await client.post(
+        "/api/v1/admin/users",
+        json={"email": email, "role": "member"},
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 201
+    plaintext = resp.json()["initial_password"]
+
+    entry = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "user.created",
+                AuditLog.resource_id == resp.json()["user_id"],
+            )
+        )
+    ).scalar_one()
+    assert entry.user_id == admin_user.id
+    assert entry.resource_type == "user"
+    assert entry.details is not None
+    assert entry.details["target_user_email"] == email
+    assert entry.details["role"] == "member"
+    assert plaintext not in str(entry.details)
+
+
+@pytest.mark.asyncio
+async def test_create_admin_role_sets_is_admin(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User
+) -> None:
+    resp = await client.post(
+        "/api/v1/admin/users",
+        json={"email": _new_email(), "role": "admin"},
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["is_admin"] is True
+
+    row = (
+        await db_session.execute(select(User).where(User.id == uuid.UUID(resp.json()["user_id"])))
+    ).scalar_one()
+    assert row.is_admin is True
+    assert row.role == "admin"
+
+
+@pytest.mark.asyncio
+async def test_create_user_rejects_duplicate_email(
+    client: AsyncClient, admin_user: User, member_user: User
+) -> None:
+    resp = await client.post(
+        "/api/v1/admin/users",
+        json={"email": member_user.email, "role": "member"},
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"]["code"] == "conflict"
+
+
+@pytest.mark.asyncio
+async def test_create_user_duplicate_check_is_case_insensitive(
+    client: AsyncClient, admin_user: User, member_user: User
+) -> None:
+    """``users.email`` is CITEXT, so an upper-cased duplicate must still 409."""
+    resp = await client.post(
+        "/api/v1/admin/users",
+        json={"email": member_user.email.upper(), "role": "member"},
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 409, resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_user_rejects_unknown_role(client: AsyncClient, admin_user: User) -> None:
+    resp = await client.post(
+        "/api/v1/admin/users",
+        json={"email": _new_email(), "role": "partner"},
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_user_requires_admin(client: AsyncClient, member_user: User) -> None:
+    resp = await client.post(
+        "/api/v1/admin/users",
+        json={"email": _new_email(), "role": "member"},
+        headers=_bearer(member_user),
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_two_created_users_get_different_passwords(
+    client: AsyncClient, admin_user: User
+) -> None:
+    first = await client.post(
+        "/api/v1/admin/users",
+        json={"email": _new_email(), "role": "member"},
+        headers=_bearer(admin_user),
+    )
+    second = await client.post(
+        "/api/v1/admin/users",
+        json={"email": _new_email(), "role": "member"},
+        headers=_bearer(admin_user),
+    )
+    assert first.status_code == 201 and second.status_code == 201
+    assert first.json()["initial_password"] != second.json()["initial_password"]
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/users/{user_id}/reset-password
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_password_rotates_hash_and_rearms_forced_change(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User, member_user: User
+) -> None:
+    before_hash = member_user.hashed_password
+
+    resp = await client.post(
+        f"/api/v1/admin/users/{member_user.id}/reset-password",
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    row = (await db_session.execute(select(User).where(User.id == member_user.id))).scalar_one()
+    assert row.hashed_password != before_hash
+    assert verify_password(body["initial_password"], row.hashed_password)
+    assert row.must_change_password is True
+
+
+@pytest.mark.asyncio
+async def test_reset_password_revokes_active_sessions(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User, member_user: User
+) -> None:
+    now = datetime.now(UTC)
+    active = UserSession(
+        user_id=member_user.id,
+        refresh_token_hash=hash_password("refresh-token-value"),
+        expires_at=now + timedelta(days=7),
+        absolute_expires_at=now + timedelta(hours=8),
+        last_active_at=now,
+    )
+    already_revoked = UserSession(
+        user_id=member_user.id,
+        refresh_token_hash=hash_password("older-refresh-token"),
+        expires_at=now + timedelta(days=7),
+        absolute_expires_at=now + timedelta(hours=8),
+        last_active_at=now,
+        revoked_at=now - timedelta(hours=1),
+    )
+    db_session.add_all([active, already_revoked])
+    await db_session.flush()
+
+    resp = await client.post(
+        f"/api/v1/admin/users/{member_user.id}/reset-password",
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 200, resp.text
+    # Only the one live session is revoked; the already-revoked row is untouched.
+    assert resp.json()["sessions_revoked"] == 1
+
+    refreshed = (
+        await db_session.execute(select(UserSession).where(UserSession.id == active.id))
+    ).scalar_one()
+    await db_session.refresh(refreshed)
+    assert refreshed.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_reset_password_writes_audit_row(
+    client: AsyncClient, db_session: AsyncSession, admin_user: User, member_user: User
+) -> None:
+    resp = await client.post(
+        f"/api/v1/admin/users/{member_user.id}/reset-password",
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 200
+
+    entry = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "user.password_reset",
+                AuditLog.resource_id == str(member_user.id),
+            )
+        )
+    ).scalar_one()
+    assert entry.user_id == admin_user.id
+    assert entry.details is not None
+    assert entry.details["target_user_email"] == member_user.email
+    assert resp.json()["initial_password"] not in str(entry.details)
+
+
+@pytest.mark.asyncio
+async def test_reset_password_unknown_user_404(client: AsyncClient, admin_user: User) -> None:
+    resp = await client.post(
+        f"/api/v1/admin/users/{uuid.uuid4()}/reset-password",
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_reset_password_malformed_uuid_404(client: AsyncClient, admin_user: User) -> None:
+    resp = await client.post(
+        "/api/v1/admin/users/not-a-uuid/reset-password",
+        headers=_bearer(admin_user),
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_reset_password_requires_admin(client: AsyncClient, member_user: User) -> None:
+    resp = await client.post(
+        f"/api/v1/admin/users/{member_user.id}/reset-password",
+        headers=_bearer(member_user),
+    )
+    assert resp.status_code == 403, resp.text

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -283,6 +283,9 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("PATCH", "/api/v1/admin/users/{user_id}/role"),
     # Wave B v2 — admin user list for DevRoleManagementCard (PRD §5.2)
     ("GET", "/api/v1/admin/users"),
+    # User provisioning — create a user + reset a user's password (admin-only)
+    ("POST", "/api/v1/admin/users"),
+    ("POST", "/api/v1/admin/users/{user_id}/reset-password"),
     # Wave D.2 — sandbox ensure, skills autocomplete, user-skill versions, KB files
     ("POST", "/api/v1/projects/sandbox/ensure"),
     ("GET", "/api/v1/skills/autocomplete"),

--- a/docs/api/backend-openapi.generated.yaml
+++ b/docs/api/backend-openapi.generated.yaml
@@ -1,5 +1,93 @@
 components:
   schemas:
+    AdminPasswordResetResponse:
+      description: '``POST /admin/users/{id}/reset-password`` response.'
+      properties:
+        email:
+          title: Email
+          type: string
+        initial_password:
+          title: Initial Password
+          type: string
+        sessions_revoked:
+          title: Sessions Revoked
+          type: integer
+        user_id:
+          title: User Id
+          type: string
+      required:
+      - user_id
+      - email
+      - initial_password
+      - sessions_revoked
+      title: AdminPasswordResetResponse
+      type: object
+    AdminUserCreateRequest:
+      description: '``POST /admin/users`` body.'
+      properties:
+        display_name:
+          anyOf:
+          - maxLength: 200
+            type: string
+          - type: 'null'
+          title: Display Name
+        email:
+          format: email
+          title: Email
+          type: string
+        role:
+          default: member
+          description: One of admin / member / viewer / auditor.
+          title: Role
+          type: string
+      required:
+      - email
+      title: AdminUserCreateRequest
+      type: object
+    AdminUserCreatedResponse:
+      description: '``POST /admin/users`` response — carries the initial password
+        once.
+
+
+        ``initial_password`` is the only time the plaintext exists outside the
+
+        creating admin''s screen. It is not recoverable; use
+
+        ``POST /admin/users/{id}/reset-password`` to mint a new one.'
+      properties:
+        display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Display Name
+        email:
+          title: Email
+          type: string
+        initial_password:
+          title: Initial Password
+          type: string
+        is_admin:
+          title: Is Admin
+          type: boolean
+        must_change_password:
+          title: Must Change Password
+          type: boolean
+        role:
+          title: Role
+          type: string
+        user_id:
+          title: User Id
+          type: string
+      required:
+      - user_id
+      - email
+      - display_name
+      - role
+      - is_admin
+      - must_change_password
+      - initial_password
+      title: AdminUserCreatedResponse
+      type: object
     AdminUserListResponse:
       description: Paginated user list for ``GET /api/v1/admin/users``.
       properties:
@@ -7725,6 +7813,99 @@ paths:
       security:
       - OAuth2PasswordBearer: []
       summary: List users for RBAC administration (Wave B v2 — PRD §5.2)
+      tags:
+      - admin
+    post:
+      description: 'POST /api/v1/admin/users — provision a user.
+
+
+        Admin-only. Generates a CSPRNG initial password, stores only its bcrypt
+
+        hash, and sets ``must_change_password=True`` so the new user is forced to
+
+        rotate it on first login. ``is_admin`` is derived from ``role`` (True iff
+
+        ``role=''admin''``), keeping the two admin signals in sync exactly as
+
+        :func:`update_user_role` and the first-run bootstrap do.
+
+
+        Returns 201 with the plaintext password, which is never stored or logged.
+
+        Returns 409 if the email is already taken — ``users.email`` is CITEXT, so
+
+        the collision is case-insensitive.'
+      operationId: create_user_api_v1_admin_users_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminUserCreateRequest'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUserCreatedResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: Create a user with a generated initial password (admin-only)
+      tags:
+      - admin
+  /api/v1/admin/users/{user_id}/reset-password:
+    post:
+      description: 'POST /api/v1/admin/users/{user_id}/reset-password — mint a new
+        password.
+
+
+        Admin-only. Generates a fresh CSPRNG password, sets
+
+        ``must_change_password=True``, and revokes every active refresh session
+
+        for the target user so an attacker holding a stolen refresh token cannot
+
+        outlive the reset. This is the same revocation the self-service
+
+        ``/auth/change-password`` path performs.
+
+
+        Note that access tokens are stateless JWTs and remain valid until they
+
+        expire; deployments that raise ``JWT_ACCESS_TOKEN_TTL_SECONDS`` above the
+
+        default widen that window.'
+      operationId: reset_user_password_api_v1_admin_users__user_id__reset_password_post
+      parameters:
+      - in: path
+        name: user_id
+        required: true
+        schema:
+          title: User Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminPasswordResetResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: Reset a user's password to a generated value (admin-only)
       tags:
       - admin
   /api/v1/admin/users/{user_id}/role:

--- a/docs/api/backend-openapi.yaml
+++ b/docs/api/backend-openapi.yaml
@@ -3414,6 +3414,92 @@ paths:
           description: Invalid role filter
         '403':
           description: Caller is not admin
+    post:
+      tags: [admin]
+      summary: Create a user with a generated initial password
+      description: |
+        Admin-only. Provisions a user with a CSPRNG initial password,
+        stores only its bcrypt hash, and sets ``must_change_password``
+        so the new user is forced to rotate it on first login (the same
+        path the first-run bootstrap admin takes).
+
+        ``is_admin`` is derived from ``role`` (True iff role='admin'),
+        keeping the two admin signals in sync exactly as
+        ``PATCH /admin/users/{user_id}/role`` does.
+
+        The plaintext is returned **once** in the 201 body. It is never
+        persisted, logged, or written to the audit row; a lost password
+        is replaced via ``POST /admin/users/{user_id}/reset-password``.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email: {type: string, format: email}
+                display_name: {type: string, maxLength: 200, nullable: true}
+                role:
+                  type: string
+                  enum: [admin, member, viewer, auditor]
+                  default: member
+      responses:
+        '201':
+          description: User created; carries the initial password once
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_id: {type: string, format: uuid}
+                  email: {type: string}
+                  display_name: {type: string, nullable: true}
+                  role: {type: string}
+                  is_admin: {type: boolean}
+                  must_change_password: {type: boolean}
+                  initial_password: {type: string}
+        '403':
+          description: Caller is not admin
+        '409':
+          description: Email already in use (users.email is CITEXT, so case-insensitive)
+        '422':
+          description: Unknown role
+
+  /api/v1/admin/users/{user_id}/reset-password:
+    parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema: {type: string, format: uuid}
+    post:
+      tags: [admin]
+      summary: Reset a user's password to a generated value
+      description: |
+        Admin-only. Mints a fresh CSPRNG password, re-arms
+        ``must_change_password``, and revokes every active refresh
+        session for the target user — the same revocation the
+        self-service ``/auth/change-password`` path performs.
+
+        Access tokens are stateless JWTs and remain valid until they
+        expire; deployments that raise ``JWT_ACCESS_TOKEN_TTL_SECONDS``
+        above the default widen that window.
+      responses:
+        '200':
+          description: Password reset; carries the new password once
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_id: {type: string, format: uuid}
+                  email: {type: string}
+                  initial_password: {type: string}
+                  sessions_revoked: {type: integer}
+        '403':
+          description: Caller is not admin
+        '404':
+          description: No such user
 
   /api/v1/admin/users/{user_id}/role:
     parameters:


### PR DESCRIPTION
The RBAC surface shipped with `GET /admin/users` and
`PATCH /admin/users/{id}/role` but no way to *create* a user. There is no
signup and no invite flow, and `app/cli.py` exposes only
`reset-admin-password`, so a deployment's second user required a
hand-written bcrypt INSERT. Any deployment serving more than one person
is blocked at step zero.

Add two admin-only handlers that reuse the machinery the first-run
bootstrap already relies on:

* `POST /api/v1/admin/users` — generates a CSPRNG initial password via
  `admin_bootstrap.generate_password`, stores only its bcrypt hash, and
  sets `must_change_password=True` so the new user is forced through
  `/auth/change-password` on first login exactly like the bootstrap
  admin. `is_admin` is derived from `role` (True iff role='admin'),
  keeping the two admin signals in sync the same way `update_user_role`
  and `ensure_first_run_admin` do. The insert uses
  `ON CONFLICT DO NOTHING` + `RETURNING`, so a lost race surfaces as the
  same 409 an up-front existence check would have produced. `users.email`
  is CITEXT, so the collision is case-insensitive.

* `POST /api/v1/admin/users/{user_id}/reset-password` — mints a fresh
  password, re-arms `must_change_password`, and revokes every active
  refresh session for the target user, matching the revocation the
  self-service `/auth/change-password` path performs. Without it, a
  locked-out user needs shell access to the container.

The plaintext is returned in the response body once and is never
persisted, logged, or written to the audit row — only the bcrypt hash
reaches the database. Both handlers write audit rows (`user.created`,
`user.password_reset`) recording the actor, the target, and the role.

Access tokens are stateless JWTs and outlive the session revocation
until they expire; the reset handler's docstring says so rather than
implying the revocation is total.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)