### PR TITLE
feat(gateway-client): make the request timeout configurable

### DIFF
--- a/api/app/clients/gateway.py
+++ b/api/app/clients/gateway.py
@@ -93,9 +93,13 @@ TIER_RESPONSE_HEADER = "X-LQ-AI-Routed-Inference-Tier"
 """Response header set by the gateway (B4) carrying the routed Inference Tier."""
 
 DEFAULT_TIMEOUT_SECONDS = 60.0
-"""Default per-request timeout. Streaming overrides this (the stream is
-expected to take longer than a single API call). Health check overrides
-to a tight value separately."""
+"""Fallback per-request timeout when the caller passes none.
+
+The deployment-wide value is ``LQ_AI_GATEWAY_TIMEOUT_SECONDS`` (see
+:func:`get_gateway_client`); this constant is the library default for
+direct construction, e.g. in tests. Streaming overrides it (a stream is
+expected to outlast a single API call), and the health check overrides to
+a tight value separately."""
 
 
 def _structured_log_extra(**fields: Any) -> dict[str, Any]:
@@ -1568,6 +1572,7 @@ def get_gateway_client() -> GatewayClient:
         _client = GatewayClient(
             base_url=settings.lq_ai_gateway_url,
             gateway_key=settings.lq_ai_gateway_key,
+            timeout=settings.lq_ai_gateway_timeout_seconds,
         )
     return _client
 

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -176,6 +176,20 @@ class Settings(BaseSettings):
         ),
     )
 
+    lq_ai_gateway_timeout_seconds: float = Field(
+        default=60.0,
+        gt=0,
+        description=(
+            "Per-request timeout, in seconds, for backend to Inference Gateway "
+            "calls. 60s suits a hosted provider. A self-hosted deployment "
+            "running a local model on modest hardware needs far longer — a "
+            "single long generation on a fanless laptop can exceed ten minutes "
+            "— and without this the request dies at the wire and surfaces as a "
+            "fake 'upstream error' with no indication that a timeout caused it. "
+            "Operators previously had to patch the constant inside the image."
+        ),
+    )
+
     # ----- JWT (per ADR 0002 — backend owns auth) -----
     jwt_secret: str = Field(
         default=DEV_JWT_SECRET,

--- a/api/tests/test_gateway_timeout_setting.py
+++ b/api/tests/test_gateway_timeout_setting.py
@@ -1,0 +1,62 @@
+"""`LQ_AI_GATEWAY_TIMEOUT_SECONDS` — the deployment-wide gateway timeout.
+
+Before this setting existed, `DEFAULT_TIMEOUT_SECONDS = 60.0` was a module
+constant with no override path. 60s is fine against a hosted provider and far
+too short for a self-hosted deployment running a local model on modest
+hardware, where a single long generation can exceed ten minutes. Operators
+were patching the constant inside the running image — a change lost on every
+container recreate, and one that silently reverts a deployment to a timeout
+that surfaces as a fake "upstream error" with no hint that a timeout caused it.
+
+The default stays 60.0, so this changes nothing for anyone who does not set it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.clients.gateway import (
+    DEFAULT_TIMEOUT_SECONDS,
+    GatewayClient,
+    get_gateway_client,
+    set_gateway_client,
+)
+from app.config import Settings, get_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_client():
+    set_gateway_client(None)
+    get_settings.cache_clear()
+    yield
+    set_gateway_client(None)
+    get_settings.cache_clear()
+
+
+def test_default_is_unchanged() -> None:
+    """A deployment that sets nothing keeps the previous behaviour."""
+    assert Settings().lq_ai_gateway_timeout_seconds == DEFAULT_TIMEOUT_SECONDS == 60.0
+
+
+def test_setting_reaches_the_http_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LQ_AI_GATEWAY_TIMEOUT_SECONDS", "1800")
+    get_settings.cache_clear()
+
+    client = get_gateway_client()
+    # httpx stores the per-request timeout on the client; the connect/read/write
+    # legs all inherit the scalar we passed.
+    assert client.http_client.timeout.read == pytest.approx(1800.0)
+    assert client.http_client.timeout.connect == pytest.approx(1800.0)
+
+
+def test_explicit_construction_still_wins() -> None:
+    client = GatewayClient(base_url="http://gw", gateway_key="k", timeout=12.5)
+    assert client.http_client.timeout.read == pytest.approx(12.5)
+
+
+def test_non_positive_timeout_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A zero or negative timeout would make every gateway call fail instantly;
+    fail at startup with a legible error instead."""
+    monkeypatch.setenv("LQ_AI_GATEWAY_TIMEOUT_SECONDS", "0")
+    with pytest.raises(Exception):
+        Settings()


### PR DESCRIPTION
`DEFAULT_TIMEOUT_SECONDS = 60.0` was a module constant with no override
path. 60s is right against a hosted provider and far too short for a
self-hosted deployment running a local model on modest hardware, where a
single long generation can exceed ten minutes.

The failure mode is what makes this worth fixing rather than tuning: the
request dies at the wire and surfaces as an "upstream error" with no
indication that a timeout caused it, so an operator debugs the model or
the gateway instead of the client.

With no override available, the workaround is to patch the constant
inside the running container — which is lost on every recreate and
repull, silently returning the deployment to a timeout it had already
diagnosed once. Adding `LQ_AI_GATEWAY_TIMEOUT_SECONDS` retires that.

The default stays 60.0, so nothing changes for anyone who does not set
it. The constant remains as the library default for direct construction
(tests, ad-hoc clients); only `get_gateway_client` — the process-global
factory — now reads the setting. `gt=0` so a zero or negative value
fails at startup with a legible error rather than making every gateway
call fail instantly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update 2026-09-13 (maintainer).** Lands with the default raised to **900s** (per #503: the api's timeout must stay looser than the gateway's 600s adapter timeouts or it truncates first), the connect leg capped at 10s (`httpx.Timeout(timeout, connect=min(timeout, 10.0))`), an `.env.example` entry, and a test pinning the settings default to the client constant. Decision recorded in ADR 0027. Refs #503, #504.