### PR TITLE
feat(matters): matter membership, share scope, and a people directory

### DIFF
--- a/api/alembic/versions/0067_matter_membership.py
+++ b/api/alembic/versions/0067_matter_membership.py
@@ -1,0 +1,163 @@
+"""project_members + projects.share_scope — matter-scoped collaboration
+
+Revision ID: 0067
+Revises: 0066
+Create Date: 2026-08-20
+
+PRD §3.11 lists ``share_scope`` in the Project data model and names
+``POST /api/v1/projects/{id}/share``; §3.11's M1 status records
+share-with-group as deferred. ADR 0020 D3 pins "matter = project — there
+is no new ``Matter`` model". This migration lands the deferred half:
+a membership table over ``projects`` and the ``share_scope`` column the
+PRD already named.
+
+**project_members** mirrors ``team_members`` (migration 0014) verbatim —
+composite PK, the same CASCADE/RESTRICT split, and the same
+``added_by_user_id`` forensic column so "who let X onto matter Y?"
+survives in audit-log queries that index by actor.
+
+The ``role`` enum extends the team model with one value: ``blocked``.
+A blocked row is a **negative** grant — an ethical screen / conflict
+wall — and the resolver evaluates it before every allow, so it overrides
+firm-wide scope, explicit membership, and operator-admin alike. Storing
+denial as a role value rather than a separate table keeps "who can see
+this matter, and who explicitly cannot" answerable from one indexed
+query.
+
+**share_scope** is the ambient grant:
+
+* ``personal`` — the owner and explicit members only (the pre-migration
+  behaviour, and the default upstream).
+* ``members`` — same as personal today; reserved so a deployment can
+  distinguish "deliberately restricted" from "never shared" in the UI
+  without a second column.
+* ``org`` — every non-blocked user in the deployment gets **read**.
+  Contributing still requires an explicit membership row, so the roster
+  stays a truthful answer to "who worked this matter" — which is the
+  question that matters for privilege and conflicts.
+
+Sandbox matters (``is_sandbox``) are per-user scratch space and are
+constrained to ``personal`` at the DB layer; sharing one would leak a
+colleague's try-it space into the matter list.
+
+**Backfill:** one ``lead`` row per existing project for its owner, so the
+owner path and the membership path are structurally identical from row
+one and the resolver returns exactly the pre-migration answer for every
+existing row. ``projects.owner_id`` is ``ON DELETE RESTRICT`` and
+non-nullable, so every project has a live owner to backfill from.
+
+Reversible: ``downgrade()`` drops the constraint, the column, and the
+table. Membership rows are lost, which is correct — without the table
+there is nothing to express them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic
+revision: str = "0067"
+down_revision: str | None = "0066"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # --- project_members ---------------------------------------------------
+    op.create_table(
+        "project_members",
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "projects.id",
+                ondelete="CASCADE",
+                name="fk_project_members_project",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "users.id",
+                ondelete="CASCADE",
+                name="fk_project_members_user",
+            ),
+            nullable=False,
+        ),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column(
+            "added_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "users.id",
+                ondelete="RESTRICT",
+                name="fk_project_members_added_by",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("project_id", "user_id", name="pk_project_members"),
+        sa.CheckConstraint(
+            "role IN ('lead', 'contributor', 'reader', 'blocked')",
+            name="ck_project_members_role_enum",
+        ),
+    )
+
+    # Drives the "which matters can this user see" list query.
+    op.create_index(
+        "idx_project_members_user",
+        "project_members",
+        ["user_id"],
+    )
+
+    # --- projects.share_scope ----------------------------------------------
+    op.add_column(
+        "projects",
+        sa.Column(
+            "share_scope",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'personal'"),
+        ),
+    )
+    op.create_check_constraint(
+        "chk_projects_share_scope_enum",
+        "projects",
+        "share_scope IN ('personal', 'members', 'org')",
+    )
+    # A sandbox matter is per-user scratch space; sharing one would leak a
+    # colleague's try-it project into the matter list.
+    op.create_check_constraint(
+        "chk_projects_sandbox_personal",
+        "projects",
+        "(is_sandbox = false) OR (share_scope = 'personal')",
+    )
+
+    # --- backfill: every existing project gets its owner as lead -----------
+    op.execute(
+        """
+        INSERT INTO project_members (project_id, user_id, role, added_by_user_id, created_at)
+        SELECT p.id, p.owner_id, 'lead', p.owner_id, p.created_at
+        FROM projects AS p
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("chk_projects_sandbox_personal", "projects", type_="check")
+    op.drop_constraint("chk_projects_share_scope_enum", "projects", type_="check")
+    op.drop_column("projects", "share_scope")
+    op.drop_index("idx_project_members_user", table_name="project_members")
+    op.drop_table("project_members")

--- a/api/app/api/__init__.py
+++ b/api/app/api/__init__.py
@@ -39,6 +39,7 @@ from app.api import (
     integrations_teams,
     internal,
     knowledge_bases,
+    matter_members,
     mcp_oauth,
     models,
     organization_profile,
@@ -94,6 +95,9 @@ api_router.include_router(word_addin.public_router)
 # future real handler in these modules inherits the gate automatically.
 _active = [Depends(get_active_user)]
 api_router.include_router(projects.router, dependencies=_active)
+# Matter roster — mounted on the same /projects prefix so membership reads
+# as part of the matter surface rather than a separate resource.
+api_router.include_router(matter_members.router, dependencies=_active)
 api_router.include_router(chats.router, dependencies=_active)
 api_router.include_router(chat_receipts.router, dependencies=_active)
 api_router.include_router(skills.router, dependencies=_active)

--- a/api/app/api/autonomous.py
+++ b/api/app/api/autonomous.py
@@ -191,26 +191,49 @@ async def _load_owned_project(
     project_id: uuid.UUID,
     user_id: uuid.UUID,
 ) -> Project:
-    """Fetch a Project by id; 404 if missing OR not owned by the caller.
+    """Fetch a matter the caller may act on; 404 if missing OR out of reach.
 
-    Conflates "doesn't exist" and "belongs to someone else" to avoid
-    existence disclosure — same idiom as the autonomous loaders. The
-    autonomous layer never reveals another user's Projects.
+    Conflates "doesn't exist" and "you have no access" to avoid existence
+    disclosure — same idiom as the autonomous loaders. The autonomous layer
+    never reveals a matter the caller cannot reach.
+
+    Access is resolved by :func:`app.authz.matters.require_matter` at
+    ``write``, because everything reached through here *spends* against the
+    matter — spawning a session, scheduling a watch, accepting a context
+    proposal. Reading a shared matter does not entitle a colleague to run
+    autonomous work under it and bill the firm for it.
 
     Raises:
-        HTTPException: 404 if the row is absent or owned by a different user.
+        HTTPException: 404 if the row is absent or unreachable; 403 if the
+        caller can read the matter but not contribute to it.
     """
-    stmt = select(Project).where(
-        Project.id == project_id,
-        Project.owner_id == user_id,
-    )
-    row = (await db.execute(stmt)).scalar_one_or_none()
-    if row is None:
+    from app.authz.matters import require_matter
+    from app.errors import Forbidden as _Forbidden, NotFound as _NotFound
+
+    # The caller is identified by id at several of these call sites, so
+    # re-load the row rather than threading a User object through seven
+    # signatures; it is normally already in the session identity map.
+    user = await db.get(User, user_id)
+    if user is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="project not found",
         )
-    return row
+
+    try:
+        return await require_matter(db, project_id, user, need="write")
+    except _NotFound:
+        # Re-raise in this module's plain shape so the autonomous surface's
+        # error contract does not shift underneath its callers.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="project not found",
+        ) from None
+    except _Forbidden:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="project requires contributor access",
+        ) from None
 
 
 async def _load_owned_proposal(

--- a/api/app/api/chats.py
+++ b/api/app/api/chats.py
@@ -74,6 +74,7 @@ from app.api.dependencies import ActiveUser, is_privileged_reader
 from app.api.skills import _resolve_skill_for_user
 from app.audit import audit_action
 from app.auditor_audit import auditor_audit
+from app.authz.matters import matter_access, require_matter
 from app.autonomous.guard import _args_digest
 from app.chat.tool_loop import (
     LoopConfirmation,
@@ -356,31 +357,66 @@ async def _load_visible_chat(
 async def _load_visible_project_for_chat(
     db: AsyncSession,
     project_id: uuid.UUID,
-    owner_id: uuid.UUID,
+    user: User,
 ) -> Project:
-    """Validate that ``project_id`` is owned by the caller before accepting it
-    as a chat's project association; 404 on miss / cross-user / archived.
+    """Validate the caller may contribute to ``project_id`` before accepting it
+    as a chat's matter association; 404 on miss / no access / archived.
 
-    Mirrors :func:`app.api.knowledge_bases._load_visible_project_for_kb`.
-    Inlined here rather than imported to keep the chat surface free of a
-    reverse dependency on the projects router module — it is a one-statement
-    SELECT. Without this guard a caller can bind a chat to another user's
-    project id and, on ``send_message``, pull that project's attached
+    Without this guard a caller can bind a chat to a matter they cannot
+    reach and, on ``send_message``, pull that matter's attached
     knowledge-base content into the response and out to the LLM provider.
+
+    ``write`` rather than ``read`` deliberately: a firm-wide-readable matter
+    lets a colleague *see* the work, but starting a new thread against it is
+    contributing, and contributing is what the roster is supposed to record.
     """
 
-    stmt = select(Project).where(
-        Project.id == project_id,
-        Project.owner_id == owner_id,
-        Project.archived_at.is_(None),
-    )
+    return await require_matter(db, project_id, user, need="write")
+
+
+async def _load_readable_chat(
+    db: AsyncSession,
+    chat_id: uuid.UUID,
+    user: User,
+    *,
+    include_archived: bool = False,
+) -> Chat:
+    """Load a chat the caller may *read*; 404 otherwise.
+
+    Wider than :func:`_load_visible_chat` by exactly one rule: a chat
+    pinned to a matter is readable by anyone who can read that matter.
+    That is the point of sharing a matter — colleagues can see the work
+    already done on it instead of duplicating it.
+
+    Writing stays owner-only (:func:`_load_visible_chat`). Two lawyers
+    interleaving turns in one thread would make
+    ``work_product_attribution`` ambiguous about who directed which
+    output, which is precisely the record that has to stay unambiguous.
+    A colleague who wants to act on a shared matter starts their own
+    thread in it.
+    """
+    stmt = select(Chat).where(Chat.id == chat_id)
+    if not include_archived:
+        stmt = stmt.where(Chat.archived_at.is_(None))
     row = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
-        raise NotFound(
-            f"Project {project_id} not found.",
-            details={"project_id": str(project_id)},
-        )
-    return row
+        raise NotFound(f"Chat {chat_id} not found.", details={"chat_id": str(chat_id)})
+
+    if row.owner_id == user.id:
+        return row
+
+    if row.project_id is not None:
+        project = (
+            await db.execute(select(Project).where(Project.id == row.project_id))
+        ).scalar_one_or_none()
+        if project is not None:
+            access, _basis = await matter_access(db, project, user)
+            if access != "none":
+                return row
+
+    # Existence-safe: a caller with no path to the chat cannot tell
+    # "exists, not yours" from "does not exist".
+    raise NotFound(f"Chat {chat_id} not found.", details={"chat_id": str(chat_id)})
 
 
 async def _load_chat_for_reader(
@@ -618,7 +654,7 @@ async def create_chat(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ChatResponse:
     if payload.project_id is not None:
-        await _load_visible_project_for_chat(db, payload.project_id, user.id)
+        await _load_visible_project_for_chat(db, payload.project_id, user)
 
     chat = Chat(
         owner_id=user.id,
@@ -804,10 +840,24 @@ async def list_chats(
         Query(ge=1, le=LIST_LIMIT_MAX, description="Page size; capped at 100."),
     ] = LIST_LIMIT_DEFAULT,
 ) -> ChatListResponse:
-    stmt = select(Chat).where(
-        Chat.owner_id == user.id,
-        Chat.autonomous_session_id.is_(None),
-    )
+    # Scoping rule: the unfiltered sidebar stays strictly personal, so a
+    # firm-wide-readable matter never floods a colleague's chat list. Ask
+    # for a specific matter you can read, and you get that matter's threads
+    # — every author's, not just your own. That is the whole point of
+    # sharing a matter: see the work already done rather than repeat it.
+    scope_to_owner = True
+    if project_id is not None:
+        project = (
+            await db.execute(select(Project).where(Project.id == project_id))
+        ).scalar_one_or_none()
+        if project is not None:
+            access, _basis = await matter_access(db, project, user)
+            scope_to_owner = access == "none"
+
+    stmt = select(Chat).where(Chat.autonomous_session_id.is_(None))
+    if scope_to_owner:
+        stmt = stmt.where(Chat.owner_id == user.id)
+
     if archived is True:
         stmt = stmt.where(Chat.archived_at.is_not(None))
     else:
@@ -860,7 +910,7 @@ async def get_chat(
     cid = _validate_chat_id(chat_id)
     # Archived chats are visible via direct GET (so a client can render
     # the archived-detail page); list excludes them by default.
-    chat = await _load_visible_chat(db, cid, user.id, include_archived=True)
+    chat = await _load_readable_chat(db, cid, user, include_archived=True)
     return await _serialize_chat(db, chat)
 
 
@@ -967,7 +1017,7 @@ async def list_messages(
     # The chat must be visible to the caller (404 cross-user). We
     # accept archived chats so a user can read history of an archived
     # conversation.
-    await _load_visible_chat(db, cid, user.id, include_archived=True)
+    await _load_readable_chat(db, cid, user, include_archived=True)
 
     stmt = select(Message).where(Message.chat_id == cid)
 

--- a/api/app/api/files.py
+++ b/api/app/api/files.py
@@ -44,12 +44,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import ActiveUser
 from app.audit import audit_action
+from app.authz.matters import require_matter
 from app.config import get_settings
 from app.db.session import get_db
-from app.errors import NotFound, ValidationError
+from app.errors import Forbidden, NotFound, ValidationError
 from app.models.document import Document
 from app.models.file import File as FileModel
-from app.models.project import Project
 from app.schemas.files import FileMetadata
 from app.storage import (
     StreamUploadResult,
@@ -246,17 +246,19 @@ async def upload_file(
                 details={"project_id": project_id},
             ) from exc
 
-        stmt = select(Project.id).where(
-            Project.id == resolved_project_id,
-            Project.owner_id == user.id,
-            Project.archived_at.is_(None),
-        )
-        result = await db.execute(stmt)
-        if result.scalar_one_or_none() is None:
+        # Uploading into a matter is contributing to it, so ``write`` —
+        # firm-wide read does not entitle a colleague to put documents in
+        # someone's matter file. Both the not-found and the not-permitted
+        # cases fold into the same 422 the create contract already
+        # documents, rather than leaking a 403/404 distinction on what is
+        # request input.
+        try:
+            await require_matter(db, resolved_project_id, user, need="write")
+        except (NotFound, Forbidden) as exc:
             raise ValidationError(
-                "project_id does not reference a project owned by the caller.",
+                "project_id does not reference a matter the caller can contribute to.",
                 details={"project_id": str(resolved_project_id)},
-            )
+            ) from exc
 
     file_id = uuid.uuid4()
     storage_path = str(file_id)

--- a/api/app/api/knowledge_bases.py
+++ b/api/app/api/knowledge_bases.py
@@ -44,6 +44,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import ActiveUser
 from app.audit import audit_action
+from app.authz.matters import require_matter
 from app.clients.gateway import GatewayClient, get_gateway_client
 from app.db.session import get_db
 from app.errors import Conflict, LQAIError, NotFound, ValidationError
@@ -58,6 +59,7 @@ from app.models.file import File as FileModel
 from app.models.knowledge import KnowledgeBase, KnowledgeBaseFile
 from app.models.project import Project
 from app.models.project_knowledge_base import ProjectKnowledgeBase
+from app.models.user import User
 from app.schemas.knowledge import (
     AttachFileRequest,
     KBFileResponse,
@@ -147,24 +149,17 @@ async def _load_visible_file_for_kb(
 async def _load_visible_project_for_kb(
     db: AsyncSession,
     project_id: uuid.UUID,
-    owner_id: uuid.UUID,
+    user: User,
 ) -> Project:
-    """Validate that ``project_id`` is owned by the caller (active) before
-    accepting it as the KB's project association."""
+    """Validate the caller may contribute to ``project_id`` (active) before
+    accepting it as the KB's matter association.
 
-    stmt = select(Project).where(
-        Project.id == project_id,
-        Project.owner_id == owner_id,
-        Project.archived_at.is_(None),
-    )
-    result = await db.execute(stmt)
-    row = result.scalar_one_or_none()
-    if row is None:
-        raise NotFound(
-            f"Project {project_id} not found.",
-            details={"project_id": str(project_id)},
-        )
-    return row
+    ``write``, not ``read``: attaching a knowledge base decides what every
+    chat in the matter retrieves from, so it is a change to the matter, not
+    a use of it.
+    """
+
+    return await require_matter(db, project_id, user, need="write")
 
 
 async def _kb_counts(db: AsyncSession, kb_id: uuid.UUID) -> tuple[int, int]:
@@ -249,7 +244,7 @@ async def create_kb(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> KnowledgeBaseResponse:
     if payload.project_id is not None:
-        await _load_visible_project_for_kb(db, payload.project_id, user.id)
+        await _load_visible_project_for_kb(db, payload.project_id, user)
 
     kb = KnowledgeBase(
         owner_id=user.id,
@@ -379,7 +374,7 @@ async def update_kb(
     if "project_id" in update_fields:
         new_project_id = update_fields["project_id"]
         if new_project_id is not None:
-            await _load_visible_project_for_kb(db, new_project_id, user.id)
+            await _load_visible_project_for_kb(db, new_project_id, user)
         kb.project_id = new_project_id
 
     if "archived" in update_fields:

--- a/api/app/api/matter_members.py
+++ b/api/app/api/matter_members.py
@@ -1,0 +1,407 @@
+"""Matter membership endpoints — who is on a matter, and in what capacity.
+
+A matter is a ``projects`` row (ADR 0020 D3), so this is the roster surface
+for ``project_members`` (migration 0067). PRD §3.11 named
+``POST /api/v1/projects/{id}/share`` and listed ``share_scope`` in the
+Project data model; §3.11's M1 status recorded share-with-group as
+deferred. This module lands that surface, shaped as a roster rather than a
+one-shot share call so the answer to "who was on this matter, and who put
+them there" is a table, not an inference from an event log.
+
+Structurally this mirrors :mod:`app.api.teams` — same response shape, same
+``_list_members`` join, same "audit row in the same transaction as the
+state change" convention. The mirroring is deliberate: a reviewer who
+knows the team surface already knows this one, and a future
+``project_teams`` join slots in without a second vocabulary.
+
+Two differences from teams, both load-bearing:
+
+* **Leads manage their own matters.** Team membership is operator-admin
+  only; matter membership is managed by the matter's leads (and by
+  operator-admins). A firm's partners staff their own matters without
+  filing a ticket.
+* **``blocked`` is a role.** Adding someone at ``blocked`` erects an
+  ethical screen: :func:`app.authz.matters.matter_access` evaluates it
+  before every allow, so it overrides firm-wide scope and operator-admin
+  alike. The endpoints call it *screened* in prose because that is the
+  term of art a lawyer will recognise.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import ActiveUser
+from app.audit import audit_action
+from app.authz.matters import matter_access, require_matter
+from app.db.session import get_db
+from app.models.project import Project
+from app.models.project_member import MEMBER_ROLES, ProjectMember
+from app.models.user import User
+
+router = APIRouter(prefix="/projects", tags=["projects", "matters"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class MatterMemberResponse(BaseModel):
+    """One row of a matter's roster."""
+
+    user_id: uuid.UUID
+    email: str
+    display_name: str | None = None
+    role: str
+    is_owner: bool = False
+    added_by_user_id: uuid.UUID
+    created_at: datetime
+
+
+class MatterMemberAdd(BaseModel):
+    user_id: uuid.UUID
+    role: str = "contributor"
+
+
+class MatterMemberRoleUpdate(BaseModel):
+    role: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_role(role: str) -> str:
+    if role not in MEMBER_ROLES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"role must be one of {sorted(MEMBER_ROLES)}",
+        )
+    return role
+
+
+async def _require_manage(
+    db: AsyncSession,
+    project_id: uuid.UUID,
+    user: User,
+) -> Project:
+    """Load the matter and assert the caller may change its roster.
+
+    Leads manage their own matters; operator-admins manage any matter they
+    are not screened off. ``require_matter(need="lead")`` covers both — an
+    admin who is not a lead resolves to ``read`` and gets the 403, which is
+    correct: staffing a matter is the leads' call, and an operator who
+    needs to intervene can make themselves a lead and leave that act in the
+    audit log rather than acting invisibly.
+    """
+    return await require_matter(db, project_id, user, need="lead", include_archived=True)
+
+
+async def _list_members(db: AsyncSession, project: Project) -> list[MatterMemberResponse]:
+    """Join ``project_members`` → ``users`` so each row carries display info."""
+
+    stmt = (
+        select(ProjectMember, User)
+        .join(User, User.id == ProjectMember.user_id)
+        .where(ProjectMember.project_id == project.id)
+        .order_by(ProjectMember.created_at.asc(), User.email.asc())
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        MatterMemberResponse(
+            user_id=member.id,
+            email=member.email,
+            display_name=member.display_name,
+            role=membership.role,
+            is_owner=member.id == project.owner_id,
+            added_by_user_id=membership.added_by_user_id,
+            created_at=membership.created_at,
+        )
+        for membership, member in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{project_id}/members",
+    response_model=list[MatterMemberResponse],
+    summary="List the people on a matter",
+)
+async def list_members(
+    project_id: uuid.UUID,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> list[MatterMemberResponse]:
+    """Anyone who can read the matter can see who else is on it.
+
+    Withholding the roster from readers would make the collaboration
+    surface unusable — you cannot see who authored the thread you are
+    reading — and it protects nothing, since those people's work product
+    is already visible to the same caller.
+    """
+    project = await require_matter(db, project_id, user, include_archived=True)
+    return await _list_members(db, project)
+
+
+@router.post(
+    "/{project_id}/members",
+    response_model=MatterMemberResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Add someone to a matter (or screen them off it)",
+)
+async def add_member(
+    project_id: uuid.UUID,
+    payload: MatterMemberAdd,
+    request: Request,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> MatterMemberResponse:
+    """Add a roster row. ``role='blocked'`` erects an ethical screen.
+
+    A screen is stored as an ordinary membership row so the roster answers
+    both halves of the question a conflicts check asks: who may see this
+    matter, and who explicitly may not.
+    """
+    project = await _require_manage(db, project_id, user)
+    role = _validate_role(payload.role)
+
+    target = await db.get(User, payload.user_id)
+    if target is None or target.deleted_at is not None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="user not found")
+
+    if target.id == project.owner_id and role != "lead":
+        # The owner's access does not flow from their roster row (the
+        # resolver short-circuits on ownership), so a demotion here would
+        # be a row that lies about who can do what.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="the matter owner is always lead; transfer ownership to change this",
+        )
+
+    membership = ProjectMember(
+        project_id=project.id,
+        user_id=target.id,
+        role=role,
+        added_by_user_id=user.id,
+    )
+    db.add(membership)
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="that person already has a role on this matter",
+        ) from None
+
+    await audit_action(
+        db,
+        user_id=user.id,
+        action="matter.member_added",
+        resource_type="project",
+        resource_id=str(project.id),
+        request=request,
+        project=project,
+        details={
+            "user_id": str(target.id),
+            "user_email": target.email,
+            "role": role,
+        },
+    )
+    await db.commit()
+    await db.refresh(membership)
+
+    return MatterMemberResponse(
+        user_id=target.id,
+        email=target.email,
+        display_name=target.display_name,
+        role=membership.role,
+        is_owner=target.id == project.owner_id,
+        added_by_user_id=membership.added_by_user_id,
+        created_at=membership.created_at,
+    )
+
+
+@router.patch(
+    "/{project_id}/members/{user_id}",
+    response_model=MatterMemberResponse,
+    summary="Change someone's role on a matter",
+)
+async def update_member_role(
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    payload: MatterMemberRoleUpdate,
+    request: Request,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> MatterMemberResponse:
+    """Move a roster row between roles, including to and from ``blocked``.
+
+    The audit row carries before/after so "when was this person screened
+    off, and by whom" is answerable from the log alone — the same
+    before/after convention ``team.member_role_updated`` uses.
+    """
+    project = await _require_manage(db, project_id, user)
+    role = _validate_role(payload.role)
+
+    membership = (
+        await db.execute(
+            select(ProjectMember).where(
+                ProjectMember.project_id == project.id,
+                ProjectMember.user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if membership is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="membership not found")
+
+    target = await db.get(User, user_id)
+    if target is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="user not found")
+
+    if user_id == project.owner_id and role != "lead":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="the matter owner is always lead; transfer ownership to change this",
+        )
+
+    before_role = membership.role
+    if before_role == role:
+        return MatterMemberResponse(
+            user_id=target.id,
+            email=target.email,
+            display_name=target.display_name,
+            role=membership.role,
+            is_owner=target.id == project.owner_id,
+            added_by_user_id=membership.added_by_user_id,
+            created_at=membership.created_at,
+        )
+
+    membership.role = role
+
+    await audit_action(
+        db,
+        user_id=user.id,
+        action="matter.member_role_updated",
+        resource_type="project",
+        resource_id=str(project.id),
+        request=request,
+        project=project,
+        details={
+            "user_id": str(target.id),
+            "user_email": target.email,
+            "before": {"role": before_role},
+            "after": {"role": role},
+        },
+    )
+    await db.commit()
+    await db.refresh(membership)
+
+    return MatterMemberResponse(
+        user_id=target.id,
+        email=target.email,
+        display_name=target.display_name,
+        role=membership.role,
+        is_owner=target.id == project.owner_id,
+        added_by_user_id=membership.added_by_user_id,
+        created_at=membership.created_at,
+    )
+
+
+@router.delete(
+    "/{project_id}/members/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    summary="Remove someone from a matter",
+)
+async def remove_member(
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    request: Request,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Drop a roster row.
+
+    Removing a ``blocked`` row *lifts a screen* — it is the one deletion
+    here that widens access, so the audit row records the role the person
+    held at removal rather than just the fact of it.
+
+    The owner's row cannot be removed: their access does not depend on it,
+    so deleting it would only make the roster lie.
+    """
+    project = await _require_manage(db, project_id, user)
+
+    if user_id == project.owner_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="the matter owner cannot be removed; transfer ownership instead",
+        )
+
+    membership = (
+        await db.execute(
+            select(ProjectMember).where(
+                ProjectMember.project_id == project.id,
+                ProjectMember.user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if membership is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="membership not found")
+
+    role_at_removal = membership.role
+    target = await db.get(User, user_id)
+    await db.delete(membership)
+
+    await audit_action(
+        db,
+        user_id=user.id,
+        action="matter.member_removed",
+        resource_type="project",
+        resource_id=str(project.id),
+        request=request,
+        project=project,
+        details={
+            "user_id": str(user_id),
+            "user_email": target.email if target is not None else None,
+            "role_at_removal": role_at_removal,
+            "lifted_screen": role_at_removal == "blocked",
+        },
+    )
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/{project_id}/access",
+    summary="What the caller may do on this matter, and why",
+)
+async def get_caller_access(
+    project_id: uuid.UUID,
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, str]:
+    """Resolve the caller's own access.
+
+    ``ProjectResponse`` already carries ``caller_access``, so the UI rarely
+    needs this; it exists for clients that hold only a matter id (a
+    deep-link, a bridge) and want to decide what to render before fetching
+    the matter itself.
+    """
+    project = await require_matter(db, project_id, user, include_archived=True)
+    access, basis = await matter_access(db, project, user)
+    return {"project_id": str(project.id), "caller_access": access, "basis": basis}

--- a/api/app/api/projects.py
+++ b/api/app/api/projects.py
@@ -64,12 +64,22 @@ from sqlalchemy.sql import ColumnElement
 
 from app.api.dependencies import ActiveUser
 from app.audit import audit_action
+from app.authz.matters import (
+    MatterAccess,
+    matter_access,
+    matter_access_map,
+    matter_scope_filter,
+    require_matter,
+)
+from app.config import get_settings
 from app.db.session import get_db
-from app.errors import Conflict, NotFound, ValidationError
+from app.errors import Conflict, Forbidden, NotFound, ValidationError
 from app.models.file import File as FileModel
 from app.models.knowledge import KnowledgeBase
 from app.models.project import Project, ProjectFile, ProjectSkill
 from app.models.project_knowledge_base import ProjectKnowledgeBase
+from app.models.project_member import ProjectMember
+from app.models.user import User
 from app.schemas.projects import (
     SLUG_RE,
     ProjectCreateRequest,
@@ -133,33 +143,34 @@ def _validate_project_id(project_id: str) -> uuid.UUID:
 async def _load_visible_project(
     db: AsyncSession,
     project_id: uuid.UUID,
-    owner_id: uuid.UUID,
+    user: User,
     *,
+    need: MatterAccess = "read",
     include_archived: bool = False,
 ) -> Project:
-    """Load a project row scoped to the caller; 404 on miss / cross-user / archived.
+    """Load a matter the caller may act on at ``need``; 404 on miss / no access.
 
-    The cross-user case collapses into 404 deliberately — same posture as
-    C4 (files). Archived projects are also invisible by default; pass
-    ``include_archived=True`` to surface them (used by the unarchive
-    PATCH path so a caller can see and act on their own archived rows).
+    Thin wrapper over :func:`app.authz.matters.require_matter`, kept so the
+    call sites in this module read the way they did when the rule was
+    ``owner_id == caller``. The rule itself now lives in one place, because
+    a matter reaches its members too (migration 0067) and a predicate
+    duplicated across nine handlers is a leak waiting for the one handler
+    that forgets it.
+
+    The no-access case still collapses into 404 deliberately — same posture
+    as C4 (files) — so an id probe cannot distinguish "no such matter" from
+    "not yours". Archived projects stay invisible by default; pass
+    ``include_archived=True`` to surface them (used by the unarchive PATCH
+    path so a caller can see and act on archived rows).
     """
 
-    stmt = select(Project).where(
-        Project.id == project_id,
-        Project.owner_id == owner_id,
+    return await require_matter(
+        db,
+        project_id,
+        user,
+        need=need,
+        include_archived=include_archived,
     )
-    if not include_archived:
-        stmt = stmt.where(Project.archived_at.is_(None))
-
-    result = await db.execute(stmt)
-    row = result.scalar_one_or_none()
-    if row is None:
-        raise NotFound(
-            f"Project {project_id} not found.",
-            details={"project_id": str(project_id)},
-        )
-    return row
 
 
 async def _load_visible_file(
@@ -224,18 +235,31 @@ async def _load_attached_kb_ids(db: AsyncSession, project_id: uuid.UUID) -> list
     return list(result.scalars().all())
 
 
-async def _serialize_project(db: AsyncSession, project: Project) -> ProjectResponse:
+async def _serialize_project(
+    db: AsyncSession,
+    project: Project,
+    user: User,
+    *,
+    access: tuple[MatterAccess, str] | None = None,
+) -> ProjectResponse:
     """Build the ``ProjectResponse`` shape for a row.
 
-    Two extra round-trips: one to fetch attached file ids, one to fetch
-    attached skill names. Cheap on the M1 footprint (a project has a
-    handful of attachments, not hundreds); a future optimisation could
-    JOIN them in if it shows up in production.
+    Extra round-trips: attached file ids, attached skill names, attached KB
+    ids, and the caller's effective access. Cheap on the M1 footprint (a
+    matter has a handful of attachments, not hundreds); a future
+    optimisation could JOIN them in if it shows up in production.
+
+    ``user`` is required rather than defaulted: ``caller_access`` is what
+    the UI gates its affordances on, so a default would be a value that
+    looks authoritative and is not. ``access`` lets a list endpoint hand in
+    a pre-resolved answer from :func:`matter_access_map` so the listing
+    costs one membership query rather than one per row.
     """
 
     file_ids = await _load_attached_file_ids(db, project.id)
     skill_names = await _load_attached_skill_names(db, project.id)
     kb_ids = await _load_attached_kb_ids(db, project.id)
+    resolved_access, basis = access or await matter_access(db, project, user)
     return ProjectResponse(
         id=project.id,
         owner_id=project.owner_id,
@@ -246,6 +270,9 @@ async def _serialize_project(db: AsyncSession, project: Project) -> ProjectRespo
         privileged=project.privileged,
         minimum_inference_tier=project.minimum_inference_tier,
         is_sandbox=project.is_sandbox,
+        share_scope=project.share_scope,
+        caller_access=resolved_access,
+        caller_access_basis=basis,
         attached_file_ids=file_ids,
         attached_skill_names=skill_names,
         attached_knowledge_base_ids=kb_ids,
@@ -363,6 +390,12 @@ async def create_project(
     desired_slug = payload.slug or slugify(payload.name)
     final_slug = await _resolve_unique_slug(db, owner_id=user.id, desired=desired_slug)
 
+    # An unset share_scope takes the deployment default. Upstream ships
+    # ``personal`` (fail-restrictive, ADR 0016 P4); a firm where ambient
+    # visibility is the working assumption sets ``org`` and treats an
+    # ethical screen as the exception.
+    share_scope = payload.share_scope or get_settings().lq_ai_matter_default_share_scope
+
     project = Project(
         owner_id=user.id,
         name=payload.name,
@@ -371,6 +404,7 @@ async def create_project(
         context_md=payload.context_md,
         privileged=payload.privileged,
         minimum_inference_tier=payload.minimum_inference_tier,
+        share_scope=share_scope,
     )
     db.add(project)
     try:
@@ -386,6 +420,19 @@ async def create_project(
             details={"slug": final_slug},
         ) from exc
 
+    # Seed the owner's lead row so the ownership path and the membership
+    # path are identical from row one — the same shape migration 0067's
+    # backfill gives every pre-existing matter.
+    db.add(
+        ProjectMember(
+            project_id=project.id,
+            user_id=user.id,
+            role="lead",
+            added_by_user_id=user.id,
+        )
+    )
+    await db.flush()
+
     await db.commit()
     await db.refresh(project)
 
@@ -400,7 +447,7 @@ async def create_project(
         },
     )
 
-    return await _serialize_project(db, project)
+    return await _serialize_project(db, project, user)
 
 
 @router.get(
@@ -433,7 +480,9 @@ async def list_projects(
         Query(description="Return only sandbox matters."),
     ] = False,
 ) -> list[ProjectResponse]:
-    conditions: list[ColumnElement[bool]] = [Project.owner_id == user.id]
+    # Ownership, explicit membership, and firm-wide scope — minus anything
+    # the caller is screened off. One filter, same rule as the fetch path.
+    conditions: list[ColumnElement[bool]] = [matter_scope_filter(user)]
     if archived is True:
         conditions.append(Project.archived_at.is_not(None))
     else:
@@ -451,7 +500,11 @@ async def list_projects(
 
     result = await db.execute(stmt)
     rows = list(result.scalars().all())
-    return [await _serialize_project(db, row) for row in rows]
+    # One membership query for the whole page rather than one per row.
+    access_by_id = await matter_access_map(db, rows, user)
+    return [
+        await _serialize_project(db, row, user, access=access_by_id.get(row.id)) for row in rows
+    ]
 
 
 @router.get(
@@ -468,8 +521,8 @@ async def get_project(
     # Archived projects are visible to their owner via direct GET so
     # the client can render an "archived" detail page; the list endpoint
     # excludes them by default.
-    project = await _load_visible_project(db, pid, user.id, include_archived=True)
-    return await _serialize_project(db, project)
+    project = await _load_visible_project(db, pid, user, include_archived=True)
+    return await _serialize_project(db, project, user)
 
 
 @router.patch(
@@ -484,9 +537,32 @@ async def update_project(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectResponse:
     pid = _validate_project_id(project_id)
-    project = await _load_visible_project(db, pid, user.id, include_archived=True)
+    project = await _load_visible_project(db, pid, user, need="write", include_archived=True)
 
     update_fields = payload.model_dump(exclude_unset=True)
+
+    # Editing a matter and *governing* one are different acts. A contributor
+    # may rewrite the context and rename the matter; only a lead may change
+    # who can see it (``share_scope``), un-mark it privileged, lower the
+    # inference-tier floor, or archive it out from under the team. Those
+    # four decide where the matter's contents may travel and who may follow
+    # them there.
+    governance_fields = {"privileged", "minimum_inference_tier", "share_scope", "archived"}
+    requested_governance = governance_fields & update_fields.keys()
+    if requested_governance:
+        access, _basis = await matter_access(db, project, user)
+        if access != "lead":
+            raise Forbidden(
+                message=(
+                    "Changing a matter's privilege, tier floor, share scope, or "
+                    "archived state requires lead access to the matter."
+                ),
+                details={
+                    "project_id": str(project.id),
+                    "fields": sorted(requested_governance),
+                    "caller_access": access,
+                },
+            )
 
     if "name" in update_fields:
         project.name = update_fields["name"]
@@ -504,9 +580,12 @@ async def update_project(
                 details={"slug": new_slug},
             )
         if new_slug != project.slug:
+            # Slugs are unique per *owner*, so a contributor renaming a
+            # shared matter must be checked against the owner's namespace,
+            # not their own.
             project.slug = await _resolve_unique_slug(
                 db,
-                owner_id=user.id,
+                owner_id=project.owner_id,
                 desired=new_slug,
                 exclude_project_id=project.id,
             )
@@ -536,6 +615,22 @@ async def update_project(
     if tier_set:
         project.minimum_inference_tier = new_tier
 
+    if "share_scope" in update_fields:
+        new_scope = update_fields["share_scope"]
+        if new_scope is None:
+            raise ValidationError(
+                "share_scope cannot be cleared; supply a value or omit the field.",
+            )
+        # A sandbox matter is per-user scratch space; the DB CHECK refuses
+        # anything but ``personal``, so fail here with a legible message
+        # rather than as an opaque IntegrityError.
+        if project.is_sandbox and new_scope != "personal":
+            raise ValidationError(
+                "A sandbox matter cannot be shared; it is per-user scratch space.",
+                details={"project_id": str(project.id), "share_scope": new_scope},
+            )
+        project.share_scope = new_scope
+
     if "archived" in update_fields:
         # Map the boolean PATCH flag to ``archived_at`` semantics.
         from datetime import UTC, datetime
@@ -548,7 +643,7 @@ async def update_project(
             # already holds the slug. Re-resolve to a free variant.
             project.slug = await _resolve_unique_slug(
                 db,
-                owner_id=user.id,
+                owner_id=project.owner_id,
                 desired=project.slug,
                 exclude_project_id=project.id,
             )
@@ -576,7 +671,7 @@ async def update_project(
         },
     )
 
-    return await _serialize_project(db, project)
+    return await _serialize_project(db, project, user)
 
 
 @router.delete(
@@ -598,7 +693,7 @@ async def delete_project(
     pid = _validate_project_id(project_id)
     # NOT include_archived — already-archived returns 404 (idempotent
     # for clients that retry).
-    project = await _load_visible_project(db, pid, user.id, include_archived=False)
+    project = await _load_visible_project(db, pid, user, need="lead", include_archived=False)
 
     from datetime import UTC, datetime
 
@@ -658,7 +753,7 @@ async def ensure_sandbox(
     )
     if existing is not None:
         response.status_code = status.HTTP_200_OK
-        return await _serialize_project(db, existing)
+        return await _serialize_project(db, existing, user)
 
     # Insert with ON CONFLICT DO NOTHING in case of concurrent ensures.
     # The unique partial index ``idx_projects_slug_owner_active`` on
@@ -716,7 +811,7 @@ async def ensure_sandbox(
             "created": response.status_code == status.HTTP_201_CREATED,
         },
     )
-    return await _serialize_project(db, row)
+    return await _serialize_project(db, row, user)
 
 
 # ---------------------------------------------------------------------------
@@ -742,7 +837,7 @@ async def attach_file(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     pid = _validate_project_id(project_id)
-    project = await _load_visible_project(db, pid, user.id)
+    project = await _load_visible_project(db, pid, user, need="write")
     file_row = await _load_visible_file(db, payload.file_id, user.id)
 
     # Capture as plain UUIDs before the write — these are needed for
@@ -812,7 +907,7 @@ async def detach_file(
     # Verify the project is visible to the caller before peeking at the
     # join — otherwise a cross-user request could distinguish "file
     # exists but not attached" from "project exists but not yours."
-    await _load_visible_project(db, pid, user.id)
+    await _load_visible_project(db, pid, user, need="write")
 
     stmt = select(ProjectFile).where(
         ProjectFile.project_id == pid,
@@ -869,7 +964,7 @@ async def attach_skill(
     request: Request,
 ) -> Response:
     pid = _validate_project_id(project_id)
-    project = await _load_visible_project(db, pid, user.id)
+    project = await _load_visible_project(db, pid, user, need="write")
 
     holder = _registry(request)
     registry = holder.current()
@@ -924,7 +1019,7 @@ async def detach_skill(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     pid = _validate_project_id(project_id)
-    await _load_visible_project(db, pid, user.id)
+    await _load_visible_project(db, pid, user, need="write")
 
     stmt = select(ProjectSkill).where(
         ProjectSkill.project_id == pid,
@@ -1008,7 +1103,7 @@ async def attach_knowledge_base(
     request: Request,
 ) -> ProjectResponse:
     pid = _validate_project_id(project_id)
-    project = await _load_visible_project(db, pid, user.id)
+    project = await _load_visible_project(db, pid, user, need="write")
     kb = await _load_visible_kb(db, payload.knowledge_base_id, user.id)
 
     # Capture as plain UUIDs before any write — see ``attach_file`` for
@@ -1071,7 +1166,7 @@ async def attach_knowledge_base(
             },
         )
 
-    return await _serialize_project(db, project)
+    return await _serialize_project(db, project, user)
 
 
 @router.delete(
@@ -1106,7 +1201,7 @@ async def detach_knowledge_base(
     # Verify the project is visible to the caller before peeking at the
     # join — otherwise cross-user could distinguish "kb exists but not
     # attached" from "project exists but not yours."
-    project = await _load_visible_project(db, pid, user.id)
+    project = await _load_visible_project(db, pid, user, need="write")
 
     stmt = select(ProjectKnowledgeBase).where(
         ProjectKnowledgeBase.project_id == pid,

--- a/api/app/api/users.py
+++ b/api/app/api/users.py
@@ -26,9 +26,9 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel, model_validator
-from sqlalchemy import update
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import UserPublic
@@ -36,7 +36,7 @@ from app.api.dependencies import ActiveUser, CurrentUser, get_active_user
 from app.audit import audit_action
 from app.config import get_settings
 from app.db.session import get_db
-from app.models.user import UserSession
+from app.models.user import User, UserSession
 from app.models.user_export import UserExportJob
 from app.storage import presigned_get_url
 from app.workers.queue import enqueue_user_export_job
@@ -171,6 +171,61 @@ class UserPreferencesResponse(BaseModel):
     provenance_pills: ProvenancePills
     # M4-C2 — Autonomous Layer opt-in (off by default)
     autonomous_enabled: bool
+
+
+# ---------------------------------------------------------------------------
+# /users/directory
+# ---------------------------------------------------------------------------
+
+
+class DirectoryEntry(BaseModel):
+    """One colleague, as the people-pickers need them."""
+
+    id: uuid.UUID
+    email: str
+    display_name: str | None = None
+
+
+@router.get(
+    "/directory",
+    response_model=list[DirectoryEntry],
+    summary="List the people in this deployment (for people-pickers)",
+)
+async def list_directory(
+    user: ActiveUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    q: Annotated[
+        str | None,
+        Query(description="Case-insensitive substring match on email or display name."),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+) -> list[DirectoryEntry]:
+    """GET /api/v1/users/directory — id, email, and display name only.
+
+    Any signed-in user may call this. Sharing a matter is impossible without
+    it: the roster endpoints take a ``user_id``, and a matter lead who is not
+    an operator-admin cannot reach ``GET /admin/users`` to find one. Asking a
+    lawyer to paste a colleague's UUID is not a design.
+
+    Deliberately minimal — no role, no admin flag, no MFA or password state,
+    no last-login. Those stay behind ``GET /admin/users``. A deployment is a
+    single organisation (PRD §2.3), so who else works here is not a secret;
+    *what they can do* still is.
+
+    Soft-deleted users are excluded so a picker cannot re-add someone who has
+    exercised erasure.
+    """
+
+    stmt = select(User).where(User.deleted_at.is_(None))
+    if q is not None and q.strip():
+        needle = f"%{q.strip()}%"
+        # ``email`` is CITEXT so it is already case-insensitive; ``ilike``
+        # adds the substring wildcards and covers display_name too.
+        stmt = stmt.where(or_(User.email.ilike(needle), User.display_name.ilike(needle)))
+
+    stmt = stmt.order_by(User.display_name.asc().nulls_last(), User.email.asc()).limit(limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [DirectoryEntry(id=r.id, email=r.email, display_name=r.display_name) for r in rows]
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/authz/__init__.py
+++ b/api/app/authz/__init__.py
@@ -1,0 +1,31 @@
+"""Authorization policy — one place where "may this caller touch this?" is decided.
+
+Today this package holds matter (project) access control. Before it existed,
+the answer was a ``owner_id == user.id`` predicate copy-pasted into every
+handler that touched a matter-scoped model; a single missed copy is a
+privilege leak that no test names.
+
+Per ADR 0016 P6 ("one governance path, not two"), the policy lives in one
+module and every matter-scoped route goes through it — the human-side
+analogue of the autonomous layer's single ``guarded_tool_call`` chokepoint.
+"""
+
+from app.authz.matters import (
+    MatterAccess,
+    matter_access,
+    matter_access_map,
+    matter_scope_filter,
+    require_matter,
+    resolve_access,
+    visible_project_ids,
+)
+
+__all__ = [
+    "MatterAccess",
+    "matter_access",
+    "matter_access_map",
+    "matter_scope_filter",
+    "require_matter",
+    "resolve_access",
+    "visible_project_ids",
+]

--- a/api/app/authz/matters.py
+++ b/api/app/authz/matters.py
@@ -1,0 +1,250 @@
+"""Matter (project) access control — the single resolver.
+
+A matter is a ``projects`` row (ADR 0020 D3 — no separate ``Matter``
+model). Access to one is decided here and nowhere else.
+
+Evaluation order, most-binding first::
+
+    1. a ``project_members`` row with role='blocked'  -> none  (absolute)
+    2. the caller owns the project                    -> lead
+    3. an explicit ``project_members`` row            -> lead/write/read
+    4. share_scope='org'                              -> read
+    5. otherwise                                      -> none
+
+Four properties of that order are load-bearing:
+
+**Denial is absolute, and it beats ``is_admin``.** An ethical screen an
+operator-admin can walk through is not a screen, and in a small firm the
+operator-admin is usually also a practising lawyer. Step 1 runs before
+every allow.
+
+**There is no operator-admin bypass, and no ``auditor`` branch.** Before
+membership existed, ``is_admin`` did *not* let anyone read another user's
+matter — the matter loaders were plain owner checks. Adding such a branch
+here would be a silent widening of cross-user access smuggled in under a
+collaboration feature, and an unaudited one at that. The deployment-wide
+``auditor`` role (lq-ai #266) keeps working exactly as before on the
+ledger and receipt surfaces, which resolve access their own way through
+``_load_chat_for_reader``. An admin who needs a matter puts themselves on
+its roster, which is an attributed, audited act.
+
+**Org scope grants READ only.** Contributing to a matter always requires
+an explicit membership row, so the roster remains a truthful answer to
+"who worked this matter" — the question that matters for privilege and
+for conflicts, months later, when nobody remembers.
+
+**A denied caller gets 404, not 403.** This preserves the existence-safe
+posture the matter surface already documents (``projects.py``'s
+``_load_visible_project``): a cross-user probe must not be able to
+distinguish "no such matter" from "not yours". 403 is reserved for a
+caller who demonstrably already knows the matter exists because they can
+read it, and is merely asking for more than their role allows.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from typing import Literal
+
+from sqlalchemy import ColumnElement, Select, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.errors import Forbidden, NotFound
+from app.models.project import Project
+from app.models.project_member import ProjectMember
+from app.models.user import User
+
+MatterAccess = Literal["none", "read", "write", "lead"]
+"""Effective access level, ordered by :data:`_ACCESS_RANK`."""
+
+_ACCESS_RANK: dict[str, int] = {"none": 0, "read": 1, "write": 2, "lead": 3}
+
+#: Membership role -> the access level it confers. ``blocked`` is handled
+#: separately (it is a denial, not a level) and so is deliberately absent.
+_ROLE_ACCESS: dict[str, MatterAccess] = {
+    "lead": "lead",
+    "contributor": "write",
+    "reader": "read",
+}
+
+BLOCKED_ROLE = "blocked"
+
+
+def _at_least(have: MatterAccess, need: MatterAccess) -> bool:
+    return _ACCESS_RANK[have] >= _ACCESS_RANK[need]
+
+
+async def matter_access(
+    db: AsyncSession,
+    project: Project,
+    user: User,
+) -> tuple[MatterAccess, str]:
+    """Resolve ``user``'s effective access to ``project``.
+
+    Returns ``(level, basis)`` where ``basis`` names the rule that decided
+    it — ``blocked`` / ``owner`` / ``member`` / ``org`` / ``no_grant``.
+    Callers surface the basis in audit rows and in ``ProjectResponse`` so a
+    reviewer — and the UI — can see *why* access exists, not just that it
+    does.
+    """
+    membership = (
+        await db.execute(
+            select(ProjectMember.role).where(
+                ProjectMember.project_id == project.id,
+                ProjectMember.user_id == user.id,
+            )
+        )
+    ).scalar_one_or_none()
+    return resolve_access(project, user, membership)
+
+
+def resolve_access(
+    project: Project,
+    user: User,
+    membership_role: str | None,
+) -> tuple[MatterAccess, str]:
+    """The rule itself, given a project, a caller, and their roster row.
+
+    Split out so the single-row path (:func:`matter_access`) and the batch
+    path (:func:`matter_access_map`) cannot drift: there is one ordering of
+    the rules and both call it.
+    """
+    # 1. An explicit screen denies before anything else is considered.
+    if membership_role == BLOCKED_ROLE:
+        return "none", "blocked"
+
+    # 2. The owner is always lead. The 0067 backfill also writes an explicit
+    #    lead row, so this is normally belt-and-braces — but it keeps a
+    #    project whose membership row was deleted by hand from becoming
+    #    unreachable by its own owner.
+    if project.owner_id == user.id:
+        return "lead", "owner"
+
+    # 3. An explicit grant.
+    if membership_role is not None:
+        granted = _ROLE_ACCESS.get(membership_role)
+        if granted is not None:
+            return granted, "member"
+
+    # 4. Ambient firm-wide read. Deliberately the last rule: there is no
+    #    operator-admin fallthrough below it.
+    if project.share_scope == "org":
+        return "read", "org"
+
+    return "none", "no_grant"
+
+
+async def matter_access_map(
+    db: AsyncSession,
+    projects: Sequence[Project],
+    user: User,
+) -> dict[uuid.UUID, tuple[MatterAccess, str]]:
+    """Resolve ``user``'s access to many matters in one round-trip.
+
+    :func:`matter_access` issues one membership query per call, which is
+    fine for a fetch and wasteful for a list. Same rules, same order — the
+    ordering lives in :func:`resolve_access` and both paths call it.
+    """
+    if not projects:
+        return {}
+
+    rows = (
+        await db.execute(
+            select(ProjectMember.project_id, ProjectMember.role).where(
+                ProjectMember.project_id.in_([p.id for p in projects]),
+                ProjectMember.user_id == user.id,
+            )
+        )
+    ).all()
+    roles: dict[uuid.UUID, str] = {row.project_id: row.role for row in rows}
+    return {p.id: resolve_access(p, user, roles.get(p.id)) for p in projects}
+
+
+async def require_matter(
+    db: AsyncSession,
+    project_id: uuid.UUID,
+    user: User,
+    *,
+    need: MatterAccess = "read",
+    include_archived: bool = False,
+) -> Project:
+    """Load a matter and assert ``user`` holds at least ``need`` on it.
+
+    Raises :class:`app.errors.NotFound` when the matter does not exist, is
+    archived (unless ``include_archived``), or the caller has no access at
+    all — the three collapse into one 404 so an id probe learns nothing.
+
+    Raises :class:`app.errors.Forbidden` only when the caller *can* read
+    the matter but is asking for more than their role allows. At that
+    point 403 leaks nothing they could not already see, and a bare 404
+    would be actively misleading in the UI.
+    """
+    stmt = select(Project).where(Project.id == project_id)
+    if not include_archived:
+        stmt = stmt.where(Project.archived_at.is_(None))
+
+    project = (await db.execute(stmt)).scalar_one_or_none()
+    if project is None:
+        raise NotFound(
+            f"Project {project_id} not found.",
+            details={"project_id": str(project_id)},
+        )
+
+    level, basis = await matter_access(db, project, user)
+    if level == "none":
+        raise NotFound(
+            f"Project {project_id} not found.",
+            details={"project_id": str(project_id)},
+        )
+    if not _at_least(level, need):
+        raise Forbidden(
+            message=(f"This action requires {need!r} access to the matter; you have {level!r}."),
+            details={
+                "project_id": str(project_id),
+                "required_access": need,
+                "caller_access": level,
+                "basis": basis,
+            },
+        )
+    return project
+
+
+def visible_project_ids(user: User, *, need: MatterAccess = "read") -> Select[tuple[uuid.UUID]]:
+    """Subquery of project ids ``user`` reaches through an explicit grant.
+
+    Ownership and ``share_scope='org'`` are handled by
+    :func:`matter_scope_filter`; this covers only ``project_members`` rows,
+    and never returns a project the caller is blocked on.
+    """
+    roles = [r for r, level in _ROLE_ACCESS.items() if _at_least(level, need)]
+    return select(ProjectMember.project_id).where(
+        ProjectMember.user_id == user.id,
+        ProjectMember.role.in_(roles),
+    )
+
+
+def blocked_project_ids(user: User) -> Select[tuple[uuid.UUID]]:
+    """Subquery of project ids ``user`` is explicitly screened off."""
+    return select(ProjectMember.project_id).where(
+        ProjectMember.user_id == user.id,
+        ProjectMember.role == BLOCKED_ROLE,
+    )
+
+
+def matter_scope_filter(user: User, *, need: MatterAccess = "read") -> ColumnElement[bool]:
+    """WHERE clause selecting the matters ``user`` reaches at ``need``.
+
+    The list-endpoint counterpart to :func:`require_matter`, expressed as
+    SQL so a listing and a fetch cannot drift apart. Blocked matters are
+    subtracted last, mirroring the resolver's rule that denial wins.
+    """
+    reachable: list[ColumnElement[bool]] = [
+        Project.owner_id == user.id,
+        Project.id.in_(visible_project_ids(user, need=need)),
+    ]
+    if need == "read":
+        # Ambient firm-wide scope grants read and nothing more.
+        reachable.append(Project.share_scope == "org")
+
+    return or_(*reachable) & Project.id.not_in(blocked_project_ids(user))

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -176,6 +176,22 @@ class Settings(BaseSettings):
         ),
     )
 
+    # ----- Matter access control (migration 0067) -----
+    lq_ai_matter_default_share_scope: str = Field(
+        default="personal",
+        pattern="^(personal|members|org)$",
+        description=(
+            "Ambient grant applied to a newly created matter when the caller "
+            "does not set one. 'personal' (the default) is fail-restrictive: "
+            "a new matter reaches only its owner until someone is added. "
+            "'org' gives every non-blocked user in the deployment READ on new "
+            "matters, which suits a small firm where ambient visibility is the "
+            "working assumption and an ethical screen is the exception. It "
+            "never widens WRITE, and a 'blocked' membership row overrides it. "
+            "Sandbox matters ignore this and stay 'personal' (DB CHECK)."
+        ),
+    )
+
     # ----- JWT (per ADR 0002 — backend owns auth) -----
     jwt_secret: str = Field(
         default=DEV_JWT_SECRET,

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -39,6 +39,7 @@ from app.models.organization_profile import OrganizationProfile
 from app.models.playbook import Playbook, PlaybookExecution, PlaybookPosition
 from app.models.project import Project, ProjectFile, ProjectSkill
 from app.models.project_knowledge_base import ProjectKnowledgeBase
+from app.models.project_member import ProjectMember
 from app.models.research import ResearchClusterMetadata, ResearchOpinionMetadata
 from app.models.saved_prompt import SavedPrompt
 from app.models.slack_workspace import SlackWorkspace
@@ -88,6 +89,7 @@ __all__ = [
     "Project",
     "ProjectFile",
     "ProjectKnowledgeBase",
+    "ProjectMember",
     "ProjectSkill",
     "ResearchClusterMetadata",
     "ResearchOpinionMetadata",

--- a/api/app/models/project.py
+++ b/api/app/models/project.py
@@ -80,6 +80,14 @@ class Project(Base):
             "char_length(slug) > 0 AND char_length(slug) <= 80",
             name="chk_projects_slug_len",
         ),
+        CheckConstraint(
+            "share_scope IN ('personal', 'members', 'org')",
+            name="chk_projects_share_scope_enum",
+        ),
+        CheckConstraint(
+            "(is_sandbox = false) OR (share_scope = 'personal')",
+            name="chk_projects_sandbox_personal",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -96,6 +104,24 @@ class Project(Base):
     slug: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     context_md: Mapped[str | None] = mapped_column(Text, nullable=True)
+    share_scope: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        server_default=text("'personal'"),
+    )
+    """Ambient grant over this matter (migration 0067).
+
+    ``personal`` — owner + explicit ``project_members`` rows only.
+    ``members``  — same reach as ``personal``; distinguishes "deliberately
+                   restricted" from "never shared" for the UI.
+    ``org``      — every non-blocked user in the deployment gets **read**.
+                   Writing still requires an explicit membership row, so the
+                   roster stays a truthful answer to "who worked this matter".
+
+    A ``blocked`` membership row overrides every value here — see
+    :func:`app.authz.matters.matter_access`.
+    """
+
     privileged: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     minimum_inference_tier: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     is_sandbox: Mapped[bool] = mapped_column(

--- a/api/app/models/project_member.py
+++ b/api/app/models/project_member.py
@@ -1,0 +1,94 @@
+"""ProjectMember ORM model — matter-scoped collaboration.
+
+Backs the ``project_members`` table per migration 0067. A matter is a
+``projects`` row (ADR 0020 D3 — there is no separate ``Matter`` model),
+so membership of a matter is membership of a project.
+
+The shape mirrors ``team_members`` (:mod:`app.models.team`) deliberately:
+composite primary key, CASCADE on both ends so membership never outlives
+its referents, and an ``added_by_user_id`` column with RESTRICT so
+"who let X onto matter Y?" survives in audit-log forensics until the
+membership row itself is gone.
+
+One value has no analogue in the team model: ``blocked``. It is a
+**negative** grant — an ethical screen or conflict wall — and
+:func:`app.authz.matters.matter_access` evaluates it before every allow,
+including operator-admin. A wall an admin can walk through is not a wall,
+and in a small firm the operator-admin is usually also a practising
+lawyer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, PrimaryKeyConstraint, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+MemberRole = Literal["lead", "contributor", "reader", "blocked"]
+
+#: Roles that confer some level of access, most-privileged first. ``blocked``
+#: is deliberately absent — it is a denial, not a grant.
+GRANTING_ROLES: frozenset[str] = frozenset({"lead", "contributor", "reader"})
+
+#: The full closed set, including the negative grant. Mirrors the DB CHECK.
+MEMBER_ROLES: frozenset[str] = GRANTING_ROLES | {"blocked"}
+
+
+class ProjectMember(Base):
+    """Membership of one user in one matter, with role.
+
+    Composite primary key on ``(project_id, user_id)`` — a user holds at
+    most one role on a matter, so a grant and a screen can never coexist
+    and "is this person screened off?" has exactly one answer.
+    """
+
+    __tablename__ = "project_members"
+    __table_args__ = (
+        PrimaryKeyConstraint("project_id", "user_id", name="pk_project_members"),
+        CheckConstraint(
+            "role IN ('lead', 'contributor', 'reader', 'blocked')",
+            name="ck_project_members_role_enum",
+        ),
+    )
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE", name="fk_project_members_project"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE", name="fk_project_members_user"),
+        nullable=False,
+    )
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    """One of ``'lead'`` (manage members, share scope, and matter settings),
+    ``'contributor'`` (read + write the matter and its attachments),
+    ``'reader'`` (read only), or ``'blocked'`` (an ethical screen — denies
+    access that any other rule would otherwise grant)."""
+
+    added_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT", name="fk_project_members_added_by"),
+        nullable=False,
+    )
+    """The user who created this membership row. RESTRICT so the trail
+    survives user deletion until the membership row itself is gone."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ProjectMember project_id={self.project_id} "
+            f"user_id={self.user_id} role={self.role!r}>"
+        )

--- a/api/app/schemas/projects.py
+++ b/api/app/schemas/projects.py
@@ -87,6 +87,18 @@ ProjectDescription = Annotated[
 InferenceTier = Literal[1, 2, 3, 4, 5]
 """Per PRD §1.5.2 the tier spectrum is 1-5 inclusive."""
 
+ShareScope = Literal["personal", "members", "org"]
+"""Ambient grant over a matter (migration 0067).
+
+``personal`` — owner + explicit ``project_members`` rows only.
+``members``  — same reach as ``personal``; marks a matter as deliberately
+               restricted rather than never shared.
+``org``      — every non-blocked user in the deployment gets **read**.
+               Writing still needs an explicit membership row.
+
+A ``blocked`` membership row overrides all three.
+"""
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -154,6 +166,10 @@ class ProjectCreateRequest(BaseModel):
     context_md: str | None = None
     privileged: bool = False
     minimum_inference_tier: InferenceTier | None = None
+    share_scope: ShareScope | None = None
+    """Ambient grant over the new matter. ``None`` (the default) means
+    "use the deployment default" — ``LQ_AI_MATTER_DEFAULT_SHARE_SCOPE``,
+    itself defaulting to ``personal``."""
 
     @model_validator(mode="after")
     def _validate_context_size(self) -> Self:
@@ -204,6 +220,10 @@ class ProjectUpdateRequest(BaseModel):
     OpenAPI sketch has a separate DELETE for soft-delete; this field is
     the non-destructive form (PATCH ``{archived: true}``)."""
 
+    share_scope: ShareScope | None = None
+    """Change the matter's ambient grant. Lead-only — widening who can
+    see a matter is a governance act, not an edit."""
+
     @model_validator(mode="after")
     def _validate_context_size(self) -> Self:
         _validate_context_md_bytes(self.context_md)
@@ -245,6 +265,23 @@ class ProjectResponse(BaseModel):
     # matters created via ``POST /projects``; ``True`` only for the
     # internally-managed row created by ``POST /projects/sandbox/ensure``.
     is_sandbox: bool = False
+    share_scope: str = "personal"
+    """Ambient grant over this matter — ``personal`` / ``members`` / ``org``
+    (migration 0067). Only a matter lead may change it."""
+
+    caller_access: str = "read"
+    """What *this* caller may do here — ``read`` / ``write`` / ``lead``.
+
+    Returned on every project payload so the UI can render the right
+    affordances without a second round-trip; the same trick
+    ``TeamSummary.caller_role`` uses. Never ``none`` — a caller with no
+    access receives 404 rather than a serialized row."""
+
+    caller_access_basis: str = "owner"
+    """Why the caller has that access — ``owner`` / ``member`` / ``org`` /
+    ``privileged_reader``. Lets the matter list distinguish "mine" from
+    "shared with me" without inferring it from ``owner_id``."""
+
     attached_file_ids: list[uuid.UUID] = Field(default_factory=list)
     attached_skill_names: list[str] = Field(default_factory=list)
     attached_knowledge_base_ids: list[uuid.UUID] = Field(default_factory=list)

--- a/api/app/workers/user_deletion.py
+++ b/api/app/workers/user_deletion.py
@@ -35,6 +35,7 @@ from app.models import (
     File,
     KnowledgeBase,
     Project,
+    ProjectMember,
     User,
     UserExportJob,
 )
@@ -111,7 +112,40 @@ async def _hard_delete_user(session: AsyncSession, user: User) -> None:
 
     # Projects — RESTRICT FK on owner; project_files/skills cascade,
     # chats.project_id is SET NULL (already moot since chats are gone).
-    await session.execute(delete(Project).where(Project.owner_id == user.id))
+    #
+    # A matter this user owns but other people work on is NOT theirs alone
+    # to erase: deleting it would destroy colleagues' chats, attachments,
+    # and context along with it. Erasure covers the user's own data, not a
+    # shared matter file. Those rows are left standing and named in the
+    # log; an operator resolves them by transferring ownership before
+    # re-running the deletion, and ``projects.owner_id`` is RESTRICT, so
+    # the FK refuses the user delete below until they do — the job fails
+    # loudly rather than erasing a colleague's work quietly.
+    shared_project_ids = (
+        (
+            await session.execute(
+                select(Project.id)
+                .join(ProjectMember, ProjectMember.project_id == Project.id)
+                .where(Project.owner_id == user.id, ProjectMember.user_id != user.id)
+                .distinct()
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if shared_project_ids:
+        log.warning(
+            "user_deletion: %d matter(s) owned by %s have other members and were "
+            "NOT deleted; transfer ownership before retrying: %s",
+            len(shared_project_ids),
+            user.id,
+            ", ".join(str(pid) for pid in shared_project_ids),
+        )
+
+    stmt = delete(Project).where(Project.owner_id == user.id)
+    if shared_project_ids:
+        stmt = stmt.where(Project.id.not_in(shared_project_ids))
+    await session.execute(stmt)
 
     # User row — sessions + export_jobs CASCADE; audit_log +
     # inference_routing_log SET NULL (PRD §5.3 audit retention).

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -283,6 +283,14 @@ IMPLEMENTED_ROUTES: set[tuple[str, str]] = {
     ("PATCH", "/api/v1/admin/users/{user_id}/role"),
     # Wave B v2 — admin user list for DevRoleManagementCard (PRD §5.2)
     ("GET", "/api/v1/admin/users"),
+    # People-picker directory (id/email/display_name only)
+    ("GET", "/api/v1/users/directory"),
+    # Matter membership — the roster surface over project_members (0067)
+    ("GET", "/api/v1/projects/{project_id}/members"),
+    ("POST", "/api/v1/projects/{project_id}/members"),
+    ("PATCH", "/api/v1/projects/{project_id}/members/{user_id}"),
+    ("DELETE", "/api/v1/projects/{project_id}/members/{user_id}"),
+    ("GET", "/api/v1/projects/{project_id}/access"),
     # Wave D.2 — sandbox ensure, skills autocomplete, user-skill versions, KB files
     ("POST", "/api/v1/projects/sandbox/ensure"),
     ("GET", "/api/v1/skills/autocomplete"),

--- a/api/tests/test_matter_authz.py
+++ b/api/tests/test_matter_authz.py
@@ -1,0 +1,489 @@
+"""The matter access-control matrix — app/authz/matters.py.
+
+This is the file that has to be right. Every rule below is one a firm
+would be asked to demonstrate if a privilege dispute ever reached a
+motion, so each is asserted directly rather than inferred from an
+endpoint's behaviour:
+
+* an explicit screen (``role='blocked'``) beats firm-wide scope, beats an
+  explicit grant, and **beats ``is_admin``**;
+* ``share_scope='org'`` confers read and never write;
+* a caller with no path to a matter gets 404, not 403 — the
+  existence-safe posture the matter surface already documents;
+* a caller who *can* read but is asking for more gets 403, because at
+  that point the 403 leaks nothing they could not already see;
+* sandbox matters cannot be shared (DB CHECK, not just the API);
+* an admin's *listing* stays their own even though they can read a
+  known-id matter cross-user.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.authz.matters import matter_access, matter_scope_filter, require_matter
+from app.errors import Forbidden, NotFound
+from app.models.project import Project
+from app.models.project_member import ProjectMember
+from app.models.user import User
+from app.security import hash_password
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _mk_user(db: AsyncSession, *, is_admin: bool = False, role: str = "member") -> User:
+    user = User(
+        email=f"u-{uuid.uuid4().hex[:10]}@example.com",
+        display_name="Test User",
+        hashed_password=hash_password("s3cr3t-battery-staple"),
+        is_admin=is_admin,
+        role=role,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _mk_project(
+    db: AsyncSession,
+    owner: User,
+    *,
+    share_scope: str = "personal",
+    privileged: bool = False,
+    tier: int | None = None,
+    is_sandbox: bool = False,
+) -> Project:
+    project = Project(
+        owner_id=owner.id,
+        name="Acme MSA renewal",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        share_scope=share_scope,
+        privileged=privileged,
+        minimum_inference_tier=tier,
+        is_sandbox=is_sandbox,
+    )
+    db.add(project)
+    await db.flush()
+    # Mirror what `create_project` and migration 0067's backfill both do.
+    db.add(
+        ProjectMember(
+            project_id=project.id,
+            user_id=owner.id,
+            role="lead",
+            added_by_user_id=owner.id,
+        )
+    )
+    await db.flush()
+    return project
+
+
+async def _grant(db: AsyncSession, project: Project, user: User, role: str) -> ProjectMember:
+    row = ProjectMember(
+        project_id=project.id,
+        user_id=user.id,
+        role=role,
+        added_by_user_id=project.owner_id,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+@pytest_asyncio.fixture
+async def owner(db_session: AsyncSession) -> User:
+    return await _mk_user(db_session)
+
+
+@pytest_asyncio.fixture
+async def colleague(db_session: AsyncSession) -> User:
+    return await _mk_user(db_session)
+
+
+@pytest_asyncio.fixture
+async def stranger(db_session: AsyncSession) -> User:
+    return await _mk_user(db_session)
+
+
+@pytest_asyncio.fixture
+async def admin(db_session: AsyncSession) -> User:
+    return await _mk_user(db_session, is_admin=True, role="admin")
+
+
+@pytest_asyncio.fixture
+async def auditor(db_session: AsyncSession) -> User:
+    return await _mk_user(db_session, role="auditor")
+
+
+# ---------------------------------------------------------------------------
+# The resolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_is_lead(db_session: AsyncSession, owner: User) -> None:
+    project = await _mk_project(db_session, owner)
+    assert await matter_access(db_session, project, owner) == ("lead", "owner")
+
+
+@pytest.mark.asyncio
+async def test_personal_matter_is_invisible_to_a_stranger(
+    db_session: AsyncSession, owner: User, stranger: User
+) -> None:
+    project = await _mk_project(db_session, owner)
+    assert await matter_access(db_session, project, stranger) == ("none", "no_grant")
+
+
+@pytest.mark.parametrize(
+    ("role", "expected"),
+    [("lead", "lead"), ("contributor", "write"), ("reader", "read")],
+)
+@pytest.mark.asyncio
+async def test_explicit_grant_confers_its_level(
+    db_session: AsyncSession, owner: User, colleague: User, role: str, expected: str
+) -> None:
+    project = await _mk_project(db_session, owner)
+    await _grant(db_session, project, colleague, role)
+    level, basis = await matter_access(db_session, project, colleague)
+    assert (level, basis) == (expected, "member")
+
+
+@pytest.mark.asyncio
+async def test_org_scope_grants_read_and_only_read(
+    db_session: AsyncSession, owner: User, stranger: User
+) -> None:
+    project = await _mk_project(db_session, owner, share_scope="org")
+    level, basis = await matter_access(db_session, project, stranger)
+    assert (level, basis) == ("read", "org")
+
+    # Contributing to a firm-wide matter still needs an explicit row, so the
+    # roster stays a truthful answer to "who worked this matter".
+    with pytest.raises(Forbidden):
+        await require_matter(db_session, project.id, stranger, need="write")
+
+
+@pytest.mark.asyncio
+async def test_explicit_grant_beats_org_scope_for_write(
+    db_session: AsyncSession, owner: User, colleague: User
+) -> None:
+    project = await _mk_project(db_session, owner, share_scope="org")
+    await _grant(db_session, project, colleague, "contributor")
+    assert await matter_access(db_session, project, colleague) == ("write", "member")
+
+
+# ---------------------------------------------------------------------------
+# Screens — the rules that must never be "optimised"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_screen_beats_org_scope(
+    db_session: AsyncSession, owner: User, colleague: User
+) -> None:
+    project = await _mk_project(db_session, owner, share_scope="org")
+    await _grant(db_session, project, colleague, "blocked")
+    assert await matter_access(db_session, project, colleague) == ("none", "blocked")
+
+
+@pytest.mark.asyncio
+async def test_screen_beats_is_admin(db_session: AsyncSession, owner: User, admin: User) -> None:
+    """An ethical wall an operator-admin can walk through is not a wall.
+
+    In a small firm the operator-admin is usually also a practising lawyer,
+    so admin bypass would defeat the screen in exactly the deployment that
+    needs it most. The remedy for an admin who must see the matter is to
+    lift the screen — an attributed, audited act — not to ignore it.
+    """
+    project = await _mk_project(db_session, owner, share_scope="org")
+    await _grant(db_session, project, admin, "blocked")
+    assert await matter_access(db_session, project, admin) == ("none", "blocked")
+
+
+@pytest.mark.asyncio
+async def test_screen_beats_auditor(db_session: AsyncSession, owner: User, auditor: User) -> None:
+    project = await _mk_project(db_session, owner, share_scope="org")
+    await _grant(db_session, project, auditor, "blocked")
+    assert await matter_access(db_session, project, auditor) == ("none", "blocked")
+
+
+@pytest.mark.asyncio
+async def test_screened_caller_gets_404_not_403(
+    db_session: AsyncSession, owner: User, admin: User
+) -> None:
+    """A fired screen must be indistinguishable from a missing matter."""
+    project = await _mk_project(db_session, owner, share_scope="org")
+    await _grant(db_session, project, admin, "blocked")
+    with pytest.raises(NotFound):
+        await require_matter(db_session, project.id, admin)
+
+
+@pytest.mark.asyncio
+async def test_screen_is_excluded_from_the_scope_filter(
+    db_session: AsyncSession, owner: User, colleague: User
+) -> None:
+    """The listing and the fetch must agree — a screen hidden on the detail
+    page but leaking through the list is worse than no screen, because it
+    is believed."""
+    from sqlalchemy import select
+
+    visible = await _mk_project(db_session, owner, share_scope="org")
+    screened = await _mk_project(db_session, owner, share_scope="org")
+    await _grant(db_session, screened, colleague, "blocked")
+
+    rows = (
+        (await db_session.execute(select(Project.id).where(matter_scope_filter(colleague))))
+        .scalars()
+        .all()
+    )
+    assert visible.id in rows
+    assert screened.id not in rows
+
+
+# ---------------------------------------------------------------------------
+# No operator-admin bypass
+# ---------------------------------------------------------------------------
+#
+# These three pin the *absence* of a capability, which is the kind of thing
+# that gets reintroduced by a well-meaning patch unless a test names it.
+# Before membership existed, `is_admin` did not let anyone read another
+# user's matter — the loaders were plain owner checks. Membership must not
+# smuggle in a cross-user read under cover of a collaboration feature.
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_read_a_personal_matter(
+    db_session: AsyncSession, owner: User, admin: User
+) -> None:
+    project = await _mk_project(db_session, owner)
+    assert await matter_access(db_session, project, admin) == ("none", "no_grant")
+    with pytest.raises(NotFound):
+        await require_matter(db_session, project.id, admin)
+
+
+@pytest.mark.asyncio
+async def test_auditor_cannot_read_a_personal_matter(
+    db_session: AsyncSession, owner: User, auditor: User
+) -> None:
+    """The deployment-wide auditor role still reaches the ledger and receipt
+    surfaces the way it always did (``_load_chat_for_reader``); it gains no
+    new reach over matters here."""
+    project = await _mk_project(db_session, owner)
+    assert await matter_access(db_session, project, auditor) == ("none", "no_grant")
+
+
+@pytest.mark.asyncio
+async def test_admin_listing_does_not_enumerate_other_peoples_matters(
+    db_session: AsyncSession, owner: User, admin: User
+) -> None:
+    from sqlalchemy import select
+
+    personal = await _mk_project(db_session, owner)
+    rows = (
+        (await db_session.execute(select(Project.id).where(matter_scope_filter(admin))))
+        .scalars()
+        .all()
+    )
+    assert personal.id not in rows
+
+
+@pytest.mark.asyncio
+async def test_admin_reaches_a_firm_wide_matter_like_anyone_else(
+    db_session: AsyncSession, owner: User, admin: User
+) -> None:
+    """An admin's read of a shared matter comes from the same ambient rule
+    every other user gets — read, never write."""
+    project = await _mk_project(db_session, owner, share_scope="org")
+    assert await matter_access(db_session, project, admin) == ("read", "org")
+    with pytest.raises(Forbidden):
+        await require_matter(db_session, project.id, admin, need="write")
+
+
+# ---------------------------------------------------------------------------
+# require_matter status-code contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_matter_is_404(db_session: AsyncSession, owner: User) -> None:
+    with pytest.raises(NotFound):
+        await require_matter(db_session, uuid.uuid4(), owner)
+
+
+@pytest.mark.asyncio
+async def test_archived_matter_hidden_unless_requested(
+    db_session: AsyncSession, owner: User
+) -> None:
+    from datetime import UTC, datetime
+
+    project = await _mk_project(db_session, owner)
+    project.archived_at = datetime.now(tz=UTC)
+    await db_session.flush()
+
+    with pytest.raises(NotFound):
+        await require_matter(db_session, project.id, owner)
+
+    got = await require_matter(db_session, project.id, owner, include_archived=True)
+    assert got.id == project.id
+
+
+@pytest.mark.asyncio
+async def test_reader_asking_for_write_gets_403(
+    db_session: AsyncSession, owner: User, colleague: User
+) -> None:
+    project = await _mk_project(db_session, owner)
+    await _grant(db_session, project, colleague, "reader")
+    with pytest.raises(Forbidden):
+        await require_matter(db_session, project.id, colleague, need="write")
+
+
+@pytest.mark.asyncio
+async def test_contributor_asking_for_lead_gets_403(
+    db_session: AsyncSession, owner: User, colleague: User
+) -> None:
+    project = await _mk_project(db_session, owner)
+    await _grant(db_session, project, colleague, "contributor")
+    with pytest.raises(Forbidden):
+        await require_matter(db_session, project.id, colleague, need="lead")
+
+
+# ---------------------------------------------------------------------------
+# DB-level invariants — defense in depth, not just the API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sandbox_matter_cannot_be_shared(db_session: AsyncSession, owner: User) -> None:
+    with pytest.raises(IntegrityError):
+        await _mk_project(db_session, owner, is_sandbox=True, share_scope="org")
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_share_scope_enum_is_enforced_by_the_db(
+    db_session: AsyncSession, owner: User
+) -> None:
+    with pytest.raises(IntegrityError):
+        await _mk_project(db_session, owner, share_scope="everyone")
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_member_role_enum_is_enforced_by_the_db(
+    db_session: AsyncSession, owner: User, colleague: User
+) -> None:
+    project = await _mk_project(db_session, owner)
+    with pytest.raises(IntegrityError):
+        await _grant(db_session, project, colleague, "partner")
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_one_role_per_person_per_matter(
+    db_session: AsyncSession, owner: User, colleague: User
+) -> None:
+    """The composite PK is what makes "is this person screened?" have
+    exactly one answer — a grant and a screen can never coexist."""
+    project = await _mk_project(db_session, owner)
+    await _grant(db_session, project, colleague, "reader")
+    with pytest.raises(IntegrityError):
+        await _grant(db_session, project, colleague, "blocked")
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_membership_cascades_on_matter_delete(
+    db_session: AsyncSession, owner: User, colleague: User
+) -> None:
+    from sqlalchemy import delete, select
+
+    project = await _mk_project(db_session, owner)
+    await _grant(db_session, project, colleague, "contributor")
+
+    await db_session.execute(delete(Project).where(Project.id == project.id))
+    await db_session.flush()
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(ProjectMember).where(ProjectMember.project_id == project.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_default_share_scope_is_personal(db_session: AsyncSession, owner: User) -> None:
+    """The column default is fail-restrictive (ADR 0016 P4); a deployment
+    opts into ambient visibility via LQ_AI_MATTER_DEFAULT_SHARE_SCOPE."""
+    project = Project(owner_id=owner.id, name="M", slug=f"m-{uuid.uuid4().hex[:8]}")
+    db_session.add(project)
+    await db_session.flush()
+    await db_session.refresh(project)
+    assert project.share_scope == "personal"
+
+
+# ---------------------------------------------------------------------------
+# Migration 0067's backfill invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_reaches_a_matter_with_no_membership_row(
+    db_session: AsyncSession, owner: User
+) -> None:
+    """Ownership short-circuits the roster lookup, so a matter whose lead
+    row was deleted by hand never becomes unreachable by its own owner."""
+    from sqlalchemy import delete
+
+    project = await _mk_project(db_session, owner)
+    await db_session.execute(delete(ProjectMember).where(ProjectMember.project_id == project.id))
+    await db_session.flush()
+    assert await matter_access(db_session, project, owner) == ("lead", "owner")
+
+
+# ---------------------------------------------------------------------------
+# The batch path must agree with the single-row path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batch_resolution_matches_the_single_row_path(
+    db_session: AsyncSession, owner: User, colleague: User, admin: User
+) -> None:
+    """`matter_access_map` exists so a listing costs one membership query
+    instead of one per row. It must never answer differently."""
+    from app.authz.matters import matter_access_map
+
+    owned = await _mk_project(db_session, owner)
+    granted = await _mk_project(db_session, owner)
+    await _grant(db_session, granted, colleague, "contributor")
+    firm_wide = await _mk_project(db_session, owner, share_scope="org")
+    screened = await _mk_project(db_session, owner, share_scope="org")
+    await _grant(db_session, screened, colleague, "blocked")
+    invisible = await _mk_project(db_session, owner)
+
+    projects = [owned, granted, firm_wide, screened, invisible]
+    for caller in (owner, colleague, admin):
+        batch = await matter_access_map(db_session, projects, caller)
+        for project in projects:
+            assert batch[project.id] == await matter_access(db_session, project, caller), (
+                f"{caller.email} on {project.slug}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_batch_resolution_on_an_empty_page(db_session: AsyncSession, owner: User) -> None:
+    from app.authz.matters import matter_access_map
+
+    assert await matter_access_map(db_session, [], owner) == {}

--- a/api/tests/test_matter_members.py
+++ b/api/tests/test_matter_members.py
@@ -1,0 +1,595 @@
+"""Integration tests for the matter roster — /api/v1/projects/{id}/members.
+
+Mirrors ``test_teams.py``'s coverage, because the surface deliberately
+mirrors ``teams.py``: CRUD round-trip, 409 on duplicate, 422 on an unknown
+role, 403 for a non-lead, the users join on the roster, and an audit row on
+every mutation with before/after on a role change.
+
+Adds what teams has no analogue for:
+
+* a screen (``role='blocked'``) hides the matter from someone who could
+  otherwise reach it firm-wide, and the removal that lifts it says so in
+  the audit row;
+* the owner's row is immovable — their access does not flow from it, so a
+  demotion or removal would only make the roster lie;
+* a colleague can read a shared matter's threads but cannot post into one.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.main import app
+from app.models.audit import AuditLog
+from app.models.chat import Chat
+from app.models.project import Project
+from app.models.project_member import ProjectMember
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+def _bearer(user: User) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {create_access_token(user.id, user.email, is_admin=user.is_admin)}"
+    }
+
+
+async def _mk_user(db: AsyncSession, *, is_admin: bool = False, role: str = "member") -> User:
+    user = User(
+        email=f"u-{uuid.uuid4().hex[:10]}@example.com",
+        display_name="Test User",
+        hashed_password=hash_password("s3cr3t-battery-staple"),
+        is_admin=is_admin,
+        role=role,
+        mfa_enabled=False,
+        must_change_password=False,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _mk_project(db: AsyncSession, owner: User, *, share_scope: str = "personal") -> Project:
+    project = Project(
+        owner_id=owner.id,
+        name="Acme MSA renewal",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        share_scope=share_scope,
+    )
+    db.add(project)
+    await db.flush()
+    db.add(
+        ProjectMember(
+            project_id=project.id,
+            user_id=owner.id,
+            role="lead",
+            added_by_user_id=owner.id,
+        )
+    )
+    await db.flush()
+    return project
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def owner(db_session: AsyncSession) -> User:
+    return await _mk_user(db_session)
+
+
+@pytest_asyncio.fixture
+async def colleague(db_session: AsyncSession) -> User:
+    return await _mk_user(db_session)
+
+
+@pytest_asyncio.fixture
+async def stranger(db_session: AsyncSession) -> User:
+    return await _mk_user(db_session)
+
+
+@pytest_asyncio.fixture
+async def matter(db_session: AsyncSession, owner: User) -> Project:
+    return await _mk_project(db_session, owner)
+
+
+# ---------------------------------------------------------------------------
+# Roster CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_matter_lists_its_owner_as_lead(
+    client: AsyncClient, owner: User, matter: Project
+) -> None:
+    resp = await client.get(f"/api/v1/projects/{matter.id}/members", headers=_bearer(owner))
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["user_id"] == str(owner.id)
+    assert rows[0]["role"] == "lead"
+    assert rows[0]["is_owner"] is True
+    assert rows[0]["email"] == owner.email
+
+
+@pytest.mark.asyncio
+async def test_add_member_round_trips(
+    client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    resp = await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "contributor"},
+        headers=_bearer(owner),
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["role"] == "contributor"
+    assert body["added_by_user_id"] == str(owner.id)
+    assert body["is_owner"] is False
+
+    listed = await client.get(f"/api/v1/projects/{matter.id}/members", headers=_bearer(owner))
+    assert {r["user_id"] for r in listed.json()} == {str(owner.id), str(colleague.id)}
+
+
+@pytest.mark.asyncio
+async def test_added_member_sees_the_matter(
+    client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    # Before: invisible.
+    before = await client.get(f"/api/v1/projects/{matter.id}", headers=_bearer(colleague))
+    assert before.status_code == 404
+
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "contributor"},
+        headers=_bearer(owner),
+    )
+
+    after = await client.get(f"/api/v1/projects/{matter.id}", headers=_bearer(colleague))
+    assert after.status_code == 200, after.text
+    assert after.json()["caller_access"] == "write"
+    assert after.json()["caller_access_basis"] == "member"
+
+    listed = await client.get("/api/v1/projects", headers=_bearer(colleague))
+    assert str(matter.id) in {row["id"] for row in listed.json()}
+
+
+@pytest.mark.asyncio
+async def test_add_duplicate_member_409(
+    client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    payload = {"user_id": str(colleague.id), "role": "reader"}
+    first = await client.post(
+        f"/api/v1/projects/{matter.id}/members", json=payload, headers=_bearer(owner)
+    )
+    assert first.status_code == 201
+    second = await client.post(
+        f"/api/v1/projects/{matter.id}/members", json=payload, headers=_bearer(owner)
+    )
+    assert second.status_code == 409, second.text
+
+
+@pytest.mark.asyncio
+async def test_add_member_unknown_role_422(
+    client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    resp = await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "partner"},
+        headers=_bearer(owner),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_add_member_unknown_user_404(
+    client: AsyncClient, owner: User, matter: Project
+) -> None:
+    resp = await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(uuid.uuid4()), "role": "reader"},
+        headers=_bearer(owner),
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_non_lead_cannot_manage_the_roster(
+    client: AsyncClient, owner: User, colleague: User, stranger: User, matter: Project
+) -> None:
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "contributor"},
+        headers=_bearer(owner),
+    )
+    resp = await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(stranger.id), "role": "reader"},
+        headers=_bearer(colleague),
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_stranger_managing_the_roster_gets_404(
+    client: AsyncClient, colleague: User, stranger: User, matter: Project
+) -> None:
+    """Existence-safe: someone with no path to the matter learns nothing."""
+    resp = await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "reader"},
+        headers=_bearer(stranger),
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_role_change_round_trips(
+    client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "reader"},
+        headers=_bearer(owner),
+    )
+    resp = await client.patch(
+        f"/api/v1/projects/{matter.id}/members/{colleague.id}",
+        json={"role": "lead"},
+        headers=_bearer(owner),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["role"] == "lead"
+
+    # A promoted lead can now staff the matter themselves.
+    onward = await client.get(f"/api/v1/projects/{matter.id}/access", headers=_bearer(colleague))
+    assert onward.json()["caller_access"] == "lead"
+
+
+@pytest.mark.asyncio
+async def test_remove_member_revokes_access(
+    client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "contributor"},
+        headers=_bearer(owner),
+    )
+    resp = await client.delete(
+        f"/api/v1/projects/{matter.id}/members/{colleague.id}", headers=_bearer(owner)
+    )
+    assert resp.status_code == 204, resp.text
+    assert resp.content == b""
+
+    gone = await client.get(f"/api/v1/projects/{matter.id}", headers=_bearer(colleague))
+    assert gone.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_owner_row_cannot_be_demoted_or_removed(
+    client: AsyncClient, owner: User, matter: Project
+) -> None:
+    demote = await client.patch(
+        f"/api/v1/projects/{matter.id}/members/{owner.id}",
+        json={"role": "reader"},
+        headers=_bearer(owner),
+    )
+    assert demote.status_code == 409, demote.text
+
+    remove = await client.delete(
+        f"/api/v1/projects/{matter.id}/members/{owner.id}", headers=_bearer(owner)
+    )
+    assert remove.status_code == 409, remove.text
+
+
+# ---------------------------------------------------------------------------
+# Screens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_screen_hides_a_firm_wide_matter(
+    db_session: AsyncSession, client: AsyncClient, owner: User, colleague: User
+) -> None:
+    matter = await _mk_project(db_session, owner, share_scope="org")
+
+    seen = await client.get(f"/api/v1/projects/{matter.id}", headers=_bearer(colleague))
+    assert seen.status_code == 200
+    assert seen.json()["caller_access_basis"] == "org"
+
+    screened = await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "blocked"},
+        headers=_bearer(owner),
+    )
+    assert screened.status_code == 201, screened.text
+
+    hidden = await client.get(f"/api/v1/projects/{matter.id}", headers=_bearer(colleague))
+    assert hidden.status_code == 404
+
+    listed = await client.get("/api/v1/projects", headers=_bearer(colleague))
+    assert str(matter.id) not in {row["id"] for row in listed.json()}
+
+
+@pytest.mark.asyncio
+async def test_lifting_a_screen_is_recorded_as_such(
+    db_session: AsyncSession, client: AsyncClient, owner: User, colleague: User
+) -> None:
+    matter = await _mk_project(db_session, owner, share_scope="org")
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "blocked"},
+        headers=_bearer(owner),
+    )
+    resp = await client.delete(
+        f"/api/v1/projects/{matter.id}/members/{colleague.id}", headers=_bearer(owner)
+    )
+    assert resp.status_code == 204
+
+    entry = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "matter.member_removed",
+                AuditLog.resource_id == str(matter.id),
+            )
+        )
+    ).scalar_one()
+    assert entry.details is not None
+    assert entry.details["role_at_removal"] == "blocked"
+    assert entry.details["lifted_screen"] is True
+
+    back = await client.get(f"/api/v1/projects/{matter.id}", headers=_bearer(colleague))
+    assert back.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_added_writes_an_audit_row(
+    db_session: AsyncSession, client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "contributor"},
+        headers=_bearer(owner),
+    )
+    entry = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "matter.member_added",
+                AuditLog.resource_id == str(matter.id),
+            )
+        )
+    ).scalar_one()
+    assert entry.user_id == owner.id
+    assert entry.resource_type == "project"
+    assert entry.details is not None
+    assert entry.details["user_email"] == colleague.email
+    assert entry.details["role"] == "contributor"
+
+
+@pytest.mark.asyncio
+async def test_role_change_records_before_and_after(
+    db_session: AsyncSession, client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "reader"},
+        headers=_bearer(owner),
+    )
+    await client.patch(
+        f"/api/v1/projects/{matter.id}/members/{colleague.id}",
+        json={"role": "blocked"},
+        headers=_bearer(owner),
+    )
+    entry = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "matter.member_role_updated",
+                AuditLog.resource_id == str(matter.id),
+            )
+        )
+    ).scalar_one()
+    assert entry.details is not None
+    assert entry.details["before"] == {"role": "reader"}
+    assert entry.details["after"] == {"role": "blocked"}
+
+
+@pytest.mark.asyncio
+async def test_idempotent_role_change_writes_no_audit_row(
+    db_session: AsyncSession, client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "reader"},
+        headers=_bearer(owner),
+    )
+    resp = await client.patch(
+        f"/api/v1/projects/{matter.id}/members/{colleague.id}",
+        json={"role": "reader"},
+        headers=_bearer(owner),
+    )
+    assert resp.status_code == 200
+    rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(AuditLog.action == "matter.member_role_updated")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# share_scope is a lead-only lever
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_contributor_cannot_change_share_scope(
+    client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "contributor"},
+        headers=_bearer(owner),
+    )
+    # They can edit the matter...
+    edit = await client.patch(
+        f"/api/v1/projects/{matter.id}",
+        json={"context_md": "counterparty is Acme"},
+        headers=_bearer(colleague),
+    )
+    assert edit.status_code == 200, edit.text
+
+    # ...but not decide who else can see it.
+    widen = await client.patch(
+        f"/api/v1/projects/{matter.id}",
+        json={"share_scope": "org"},
+        headers=_bearer(colleague),
+    )
+    assert widen.status_code == 403, widen.text
+
+
+@pytest.mark.asyncio
+async def test_contributor_cannot_clear_privileged_or_archive(
+    client: AsyncClient, db_session: AsyncSession, owner: User, colleague: User
+) -> None:
+    matter = await _mk_project(db_session, owner)
+    matter.privileged = True
+    matter.minimum_inference_tier = 1
+    await db_session.flush()
+
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "contributor"},
+        headers=_bearer(owner),
+    )
+    for body in ({"privileged": False}, {"minimum_inference_tier": 5}, {"archived": True}):
+        resp = await client.patch(
+            f"/api/v1/projects/{matter.id}", json=body, headers=_bearer(colleague)
+        )
+        assert resp.status_code == 403, f"{body} -> {resp.status_code} {resp.text}"
+
+
+@pytest.mark.asyncio
+async def test_lead_can_widen_share_scope(
+    client: AsyncClient, owner: User, matter: Project
+) -> None:
+    resp = await client.patch(
+        f"/api/v1/projects/{matter.id}",
+        json={"share_scope": "org"},
+        headers=_bearer(owner),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["share_scope"] == "org"
+
+
+# ---------------------------------------------------------------------------
+# Chats: read the matter's threads, but write only your own
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_reads_a_colleagues_thread_but_cannot_post_into_it(
+    db_session: AsyncSession, client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    chat = Chat(owner_id=owner.id, project_id=matter.id, title="Assignment clause")
+    db_session.add(chat)
+    await db_session.flush()
+
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "contributor"},
+        headers=_bearer(owner),
+    )
+
+    # Readable — the whole point of sharing the matter.
+    read = await client.get(f"/api/v1/chats/{chat.id}", headers=_bearer(colleague))
+    assert read.status_code == 200, read.text
+    assert read.json()["owner_id"] == str(owner.id)
+
+    messages = await client.get(f"/api/v1/chats/{chat.id}/messages", headers=_bearer(colleague))
+    assert messages.status_code == 200
+
+    # Not writable — two lawyers interleaving turns in one thread would make
+    # work_product_attribution ambiguous about who directed which output.
+    rename = await client.patch(
+        f"/api/v1/chats/{chat.id}", json={"title": "mine now"}, headers=_bearer(colleague)
+    )
+    assert rename.status_code == 404, rename.text
+
+
+@pytest.mark.asyncio
+async def test_matter_chat_list_shows_every_members_threads(
+    db_session: AsyncSession, client: AsyncClient, owner: User, colleague: User, matter: Project
+) -> None:
+    owner_chat = Chat(owner_id=owner.id, project_id=matter.id, title="Owner thread")
+    db_session.add(owner_chat)
+    await db_session.flush()
+
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "contributor"},
+        headers=_bearer(owner),
+    )
+
+    scoped = await client.get(f"/api/v1/chats?project_id={matter.id}", headers=_bearer(colleague))
+    assert scoped.status_code == 200, scoped.text
+    assert str(owner_chat.id) in {c["id"] for c in scoped.json()["items"]}
+
+    # The unfiltered sidebar stays personal — a shared matter must not flood
+    # a colleague's chat list.
+    unscoped = await client.get("/api/v1/chats", headers=_bearer(colleague))
+    assert str(owner_chat.id) not in {c["id"] for c in unscoped.json()["items"]}
+
+
+@pytest.mark.asyncio
+async def test_screened_member_loses_thread_access(
+    db_session: AsyncSession, client: AsyncClient, owner: User, colleague: User
+) -> None:
+    matter = await _mk_project(db_session, owner, share_scope="org")
+    chat = Chat(owner_id=owner.id, project_id=matter.id, title="Privileged analysis")
+    db_session.add(chat)
+    await db_session.flush()
+
+    before = await client.get(f"/api/v1/chats/{chat.id}", headers=_bearer(colleague))
+    assert before.status_code == 200
+
+    await client.post(
+        f"/api/v1/projects/{matter.id}/members",
+        json={"user_id": str(colleague.id), "role": "blocked"},
+        headers=_bearer(owner),
+    )
+
+    after = await client.get(f"/api/v1/chats/{chat.id}", headers=_bearer(colleague))
+    assert after.status_code == 404, after.text

--- a/api/tests/test_openapi.py
+++ b/api/tests/test_openapi.py
@@ -47,6 +47,10 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         # Wave D.1 T3 — matter <-> KB attach/detach (extends the sketch).
         "/api/v1/projects/{project_id}/knowledge-bases",
         "/api/v1/projects/{project_id}/knowledge-bases/{kb_id}",
+        # Migration 0067 — the matter roster (extends the sketch).
+        "/api/v1/projects/{project_id}/members",
+        "/api/v1/projects/{project_id}/members/{user_id}",
+        "/api/v1/projects/{project_id}/access",
         # chats + messages
         "/api/v1/chats",
         "/api/v1/chats/{chat_id}",
@@ -110,6 +114,10 @@ EXPECTED_PATHS: frozenset[str] = frozenset(
         "/api/v1/admin/users/{user_id}/role",
         # Wave B v2 — admin user list for DevRoleManagementCard
         "/api/v1/admin/users",
+        # User provisioning — reset a user's password (extends the sketch).
+        "/api/v1/admin/users/{user_id}/reset-password",
+        # People-picker source for the matter roster (extends the sketch).
+        "/api/v1/users/directory",
         # admin
         "/api/v1/admin/audit-log",
         "/api/v1/admin/tier-policy",
@@ -255,6 +263,10 @@ async def test_openapi_paths_match_sketch() -> None:
     # /skills/autocomplete, /projects/sandbox/ensure.
     # + M3-0.1's /admin/bootstrap-status.
     # + M3-0.3's /admin/ingest-health.
+    # + matter membership (0067): three /projects/{id}/members|access paths,
+    #   /admin/users/{id}/reset-password, and /users/directory. Note
+    #   POST /admin/users adds a method to an existing path, so it
+    #   contributes 0 new entries here.
     # + M3-A2's two playbook-executor endpoints.
     # + M3-A4's two playbook list/detail endpoints.
     # + M3-A6's Playbook CRUD adds POST/PATCH/DELETE methods on /playbooks +
@@ -342,7 +354,7 @@ async def test_openapi_paths_match_sketch() -> None:
     # Donna #3 adds two new paths (137 -> 139):
     # /api/v1/admin/tool-providers
     # /api/v1/admin/tool-providers/{provider_type}
-    assert len(actual) == 139
+    assert len(actual) == 144
 
 
 @pytest.mark.unit

--- a/api/tests/test_users_directory.py
+++ b/api/tests/test_users_directory.py
@@ -1,0 +1,153 @@
+"""GET /api/v1/users/directory — the people-picker source.
+
+Sharing a matter is impossible without this: the roster endpoints take a
+``user_id``, and a matter lead who is not an operator-admin cannot reach
+``GET /admin/users`` to find one.
+
+What matters here is the *shape*: id, email, display_name, and nothing
+else. Role, admin flag, MFA state, password state, and last-login stay
+behind the admin surface, and a regression that leaks one of them is the
+failure this file is here to catch.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.main import app
+from app.models.user import User
+from app.security import create_access_token, hash_password
+
+
+def _override_get_db(db_session: AsyncSession):
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    return _override
+
+
+def _bearer(user: User) -> dict[str, str]:
+    token = create_access_token(user.id, user.email, is_admin=user.is_admin)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _mk_user(
+    db: AsyncSession,
+    *,
+    email: str | None = None,
+    display_name: str | None = "Test User",
+    is_admin: bool = False,
+    role: str = "member",
+    deleted: bool = False,
+) -> User:
+    from datetime import UTC, datetime
+
+    user = User(
+        email=email or f"u-{uuid.uuid4().hex[:10]}@example.com",
+        display_name=display_name,
+        hashed_password=hash_password("s3cr3t-battery-staple"),
+        is_admin=is_admin,
+        role=role,
+        # Deliberately non-default so a regression that widens the payload
+        # shows up as real state rather than a coincidence of the fixture.
+        mfa_enabled=True,
+        must_change_password=False,
+        deleted_at=datetime.now(tz=UTC) if deleted else None,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    app.dependency_overrides[get_db] = _override_get_db(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.mark.asyncio
+async def test_ordinary_member_can_list_colleagues(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    caller = await _mk_user(db_session)
+    colleague = await _mk_user(db_session)
+
+    resp = await client.get("/api/v1/users/directory", headers=_bearer(caller))
+    assert resp.status_code == 200, resp.text
+    ids = {row["id"] for row in resp.json()}
+    assert str(caller.id) in ids
+    assert str(colleague.id) in ids
+
+
+@pytest.mark.asyncio
+async def test_directory_exposes_only_identity_fields(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Everything else stays behind GET /admin/users."""
+    caller = await _mk_user(db_session, is_admin=True, role="admin")
+
+    resp = await client.get("/api/v1/users/directory", headers=_bearer(caller))
+    assert resp.status_code == 200
+    row = next(r for r in resp.json() if r["id"] == str(caller.id))
+    assert set(row) == {"id", "email", "display_name"}
+
+
+@pytest.mark.asyncio
+async def test_soft_deleted_users_are_hidden(client: AsyncClient, db_session: AsyncSession) -> None:
+    caller = await _mk_user(db_session)
+    erased = await _mk_user(db_session, deleted=True)
+
+    resp = await client.get("/api/v1/users/directory", headers=_bearer(caller))
+    assert str(erased.id) not in {row["id"] for row in resp.json()}
+
+
+@pytest.mark.asyncio
+async def test_query_matches_email_and_display_name(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    caller = await _mk_user(db_session)
+    marker = uuid.uuid4().hex[:8]
+    by_email = await _mk_user(db_session, email=f"{marker}@example.com", display_name=None)
+    by_name = await _mk_user(db_session, display_name=f"Ana {marker}")
+
+    resp = await client.get(f"/api/v1/users/directory?q={marker}", headers=_bearer(caller))
+    assert resp.status_code == 200
+    ids = {row["id"] for row in resp.json()}
+    assert ids == {str(by_email.id), str(by_name.id)}
+
+
+@pytest.mark.asyncio
+async def test_query_is_case_insensitive(client: AsyncClient, db_session: AsyncSession) -> None:
+    caller = await _mk_user(db_session)
+    marker = uuid.uuid4().hex[:8]
+    target = await _mk_user(db_session, email=f"{marker}@example.com", display_name=None)
+
+    resp = await client.get(f"/api/v1/users/directory?q={marker.upper()}", headers=_bearer(caller))
+    assert {row["id"] for row in resp.json()} == {str(target.id)}
+
+
+@pytest.mark.asyncio
+async def test_limit_is_honoured(client: AsyncClient, db_session: AsyncSession) -> None:
+    caller = await _mk_user(db_session)
+    for _ in range(4):
+        await _mk_user(db_session)
+
+    resp = await client.get("/api/v1/users/directory?limit=2", headers=_bearer(caller))
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_requires_authentication(client: AsyncClient) -> None:
+    resp = await client.get("/api/v1/users/directory")
+    assert resp.status_code == 401, resp.text

--- a/docs/adr/0024-matter-scoped-access-control.md
+++ b/docs/adr/0024-matter-scoped-access-control.md
@@ -1,0 +1,140 @@
+# ADR 0024 — Matter-scoped access control (`project_members` + `share_scope`)
+
+**Status:** Accepted — implemented in migration 0067 and `api/app/authz/matters.py`.
+**Date:** 2026-08-21
+**Written after the implementation**, not before, which is a departure from this repo's usual
+order. Recorded that way deliberately rather than back-dated: the shape was settled by building it
+against a running deployment, and this document is the honest account of the decisions that
+survived that.
+**Relates to:** [ADR 0020](0020-governed-agentic-legal-matter-sessions.md) D3 (matter = project),
+[ADR 0016](0016-transparency-and-governance-invariants.md) P4/P5/P6,
+[ADR 0012](0012-db-backed-user-skills.md) (the `teams` model this mirrors),
+[PRD §2.3](../PRD.md#23-data-isolation-model), [PRD §3.11](../PRD.md#311-projects-m1),
+[PRD §5.2](../PRD.md#52-rbac).
+
+## Context
+
+PRD §3.11 lists `share_scope` in the Project data model and names
+`POST /api/v1/projects/{id}/share`; §3.11's M1 status records share-with-group as **deferred**.
+Nothing shipped. The consequence surfaced when the deployment-wide `auditor` role landed
+(lq-ai #266), whose own design note states it plainly:
+
+> We chose a global role, not a per-org/per-matter scope. Grounding found LQ.AI has **no org /
+> membership / project-sharing primitive** today … A scoped auditor would have needed a new
+> membership table — out of scope.
+
+Every resource was single-`owner_id`, and the rule "the caller owns it" was a predicate
+copy-pasted into nine `_load_visible_*` helpers across `api/app/api/`. There was no table capable
+of expressing "attorney B may see matter X", and no way to create a second user at all.
+
+The driving requirement: several lawyers working one matter, each identifiable. Identity is not
+cosmetic here — work-product protection for AI prompts and outputs turns on *who directed the AI*,
+so an unattributed action is a weaker artefact than an attributed one.
+
+## Decision drivers
+
+1. **Privilege attaches at the matter.** Conflicts screening and reasonable-efforts obligations are
+   asked at matter granularity, so that is where the authorization boundary belongs.
+2. **One governance path** (ADR 0016 P6). Nine copies of an access rule is nine places to forget
+   one, and the forgotten one is a leak no test names.
+3. **Fail restrictive** (ADR 0016 P4). A guard that fails open is a bug even when every happy-path
+   test passes.
+4. **The roster must be a stored fact, not a derived aggregate.** "Who could see this matter, and
+   when did that change" has to be answerable from one indexed table, not reconstructed from N
+   per-resource ACLs that drift independently.
+5. **Don't quietly widen anything.** A collaboration feature is an easy place to smuggle in a new
+   cross-user read capability.
+
+## Decisions
+
+### D1 — The matter is the unit of access; `project_members` is the roster
+
+A membership table over `projects`, mirroring `team_members` (migration 0014) deliberately: same
+composite PK, same CASCADE/RESTRICT split, same `added_by_user_id` forensic column. A reviewer who
+knows the team surface knows this one, and a future `project_teams` join slots in without a second
+vocabulary.
+
+Rejected: a generalized per-resource ACL — it makes "who is on this matter" a drifting aggregate.
+Rejected: using `teams` as the scope — a team is a set of *people* and is deployment-global;
+screening someone off one matter by editing team membership would change their access to every
+other matter that team touches, which is exactly the imputation the screen exists to prevent.
+
+### D2 — Denial is a role value, and it is absolute
+
+`role='blocked'` is an ethical screen. The composite PK then guarantees a grant and a screen can
+never coexist, so "is this person screened?" has exactly one answer, and one indexed query answers
+both halves of a conflicts check.
+
+**It beats `is_admin`.** A wall an operator-admin can walk through is not a wall, and in a small
+firm the operator-admin is frequently also a practising lawyer. The remedy for an admin who must
+see the matter is to lift the screen — attributed, audited, permanent in the log — not to bypass
+it. Deliberately no break-glass: break-glass is how walls get breached in practice.
+
+### D3 — Ambient scope grants read, never write
+
+`share_scope ∈ (personal, members, org)`. `org` gives every non-blocked user read. Contributing
+always requires an explicit roster row, so the roster remains a truthful answer to *who worked this
+matter*. The deployment default is `personal`; `org` is an operator choice.
+
+### D4 — No operator-admin bypass and no `auditor` branch on matters
+
+Before this table existed, `is_admin` did not let anyone read another user's matter. Adding such a
+branch here would be a widening of cross-user access introduced under cover of a collaboration
+feature — and unaudited, since matter reads are not logged. The `auditor` role keeps its existing
+reach over the citation-ledger and receipt surfaces, which resolve access their own way.
+
+Three tests pin the *absence* of this capability. Absent capabilities are what a well-meaning
+patch reintroduces.
+
+### D5 — Reads widen; writes do not
+
+A chat pinned to a matter is readable by anyone who can read the matter — that is the point of
+sharing one. Chat *writes* stay owner-only, including for a lead: two lawyers interleaving turns in
+one thread would make `work_product_attribution` ambiguous about who directed which output, which
+is precisely the record that has to stay unambiguous. A colleague acting on a shared matter starts
+their own thread in it.
+
+The unfiltered chat sidebar also stays personal, so a firm-wide-readable matter never floods a
+colleague's chat list; ask for a matter you can read and you get every author's threads in it.
+
+### D6 — 404 for no access, 403 only for insufficient access
+
+No access and "no such matter" are indistinguishable, preserving the existence-safe posture the
+matter surface already documented. 403 is reserved for a caller who demonstrably already knows the
+matter exists because they can read it, and is asking for more than their role allows — at which
+point 403 leaks nothing new and a 404 would mislead the UI.
+
+### D7 — Backfill preserves the pre-migration answer exactly
+
+Migration 0067 writes one `lead` row per existing project for its owner and leaves every existing
+matter at `share_scope='personal'`. The resolver therefore returns exactly the pre-migration answer
+for every pre-existing row; a deployment that upgrades and changes nothing sees no behaviour change.
+
+## Consequences
+
+- One module (`api/app/authz/matters.py`) is now the only place matter access is decided; the nine
+  `_load_visible_*` helpers delegate to it and keep their call-site shape.
+- `matter_access_map` exists so a listing costs one membership query rather than one per row; the
+  ordering itself lives in a single `resolve_access` function that both the single-row and batch
+  paths call, so they cannot drift.
+- The GDPR hard-delete job can no longer erase a matter with other members on it — a correctness
+  fix this ADR forced into view.
+- Slug uniqueness now resolves against the matter's *owner*, not the caller: slugs are unique per
+  owner, and a contributor renaming a shared matter must be checked against the owner's namespace.
+
+## Follow-ups (deliberately not in this ADR)
+
+- `audit_log.project_id`, so a per-matter access log becomes producible; read-event auditing is a
+  separate and larger question (write amplification on a busy privileged matter).
+- Optimistic concurrency on `projects.context_md` — three people editing standing context currently
+  clobber each other silently.
+- Matter ownership transfer, without which a matter can be shared with an identity but not moved to
+  one.
+- `project_teams` grants; making file and KB visibility follow the matter.
+- Client-level screening (`projects.client_ref`), so a lateral hire can be screened from a *client*
+  rather than matter by matter.
+
+## Cross-references
+
+- [`docs/security/matter-access-control.md`](../security/matter-access-control.md) — the operator-facing document, including the limits of the guarantee.
+- [`docs/db-schema.md`](../db-schema.md) — `project_members`, `projects.share_scope`, the backfill.

--- a/docs/api/backend-openapi.generated.yaml
+++ b/docs/api/backend-openapi.generated.yaml
@@ -1872,6 +1872,26 @@ components:
       - grace_period_days
       title: DeleteScheduledResponse
       type: object
+    DirectoryEntry:
+      description: One colleague, as the people-pickers need them.
+      properties:
+        display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Display Name
+        email:
+          title: Email
+          type: string
+        id:
+          format: uuid
+          title: Id
+          type: string
+      required:
+      - id
+      - email
+      title: DirectoryEntry
+      type: object
     EasyPlaybookGeneration:
       description: 'One Easy Playbook generation row.
 
@@ -2987,6 +3007,67 @@ components:
       - enabled
       title: MCPToolView
       type: object
+    MatterMemberAdd:
+      properties:
+        role:
+          default: contributor
+          title: Role
+          type: string
+        user_id:
+          format: uuid
+          title: User Id
+          type: string
+      required:
+      - user_id
+      title: MatterMemberAdd
+      type: object
+    MatterMemberResponse:
+      description: One row of a matter's roster.
+      properties:
+        added_by_user_id:
+          format: uuid
+          title: Added By User Id
+          type: string
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Display Name
+        email:
+          title: Email
+          type: string
+        is_owner:
+          default: false
+          title: Is Owner
+          type: boolean
+        role:
+          title: Role
+          type: string
+        user_id:
+          format: uuid
+          title: User Id
+          type: string
+      required:
+      - user_id
+      - email
+      - role
+      - added_by_user_id
+      - created_at
+      title: MatterMemberResponse
+      type: object
+    MatterMemberRoleUpdate:
+      properties:
+        role:
+          title: Role
+          type: string
+      required:
+      - role
+      title: MatterMemberRoleUpdate
+      type: object
     MemoryKeepRequest:
       description: 'Optional request body for ``POST /autonomous/memory/{id}/keep``.
 
@@ -3999,6 +4080,15 @@ components:
           default: false
           title: Privileged
           type: boolean
+        share_scope:
+          anyOf:
+          - enum:
+            - personal
+            - members
+            - org
+            type: string
+          - type: 'null'
+          title: Share Scope
         slug:
           anyOf:
           - maxLength: 80
@@ -4046,6 +4136,14 @@ components:
             type: string
           title: Attached Skill Names
           type: array
+        caller_access:
+          default: read
+          title: Caller Access
+          type: string
+        caller_access_basis:
+          default: owner
+          title: Caller Access Basis
+          type: string
         context_md:
           anyOf:
           - type: string
@@ -4083,6 +4181,10 @@ components:
         privileged:
           title: Privileged
           type: boolean
+        share_scope:
+          default: personal
+          title: Share Scope
+          type: string
         slug:
           title: Slug
           type: string
@@ -4163,6 +4265,15 @@ components:
           - type: boolean
           - type: 'null'
           title: Privileged
+        share_scope:
+          anyOf:
+          - enum:
+            - personal
+            - members
+            - org
+            type: string
+          - type: 'null'
+          title: Share Scope
         slug:
           anyOf:
           - maxLength: 80
@@ -11996,6 +12107,50 @@ paths:
       summary: Partial update of a project
       tags:
       - projects
+  /api/v1/projects/{project_id}/access:
+    get:
+      description: 'Resolve the caller''s own access.
+
+
+        ``ProjectResponse`` already carries ``caller_access``, so the UI rarely
+
+        needs this; it exists for clients that hold only a matter id (a
+
+        deep-link, a bridge) and want to decide what to render before fetching
+
+        the matter itself.'
+      operationId: get_caller_access_api_v1_projects__project_id__access_get
+      parameters:
+      - in: path
+        name: project_id
+        required: true
+        schema:
+          format: uuid
+          title: Project Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                title: Response Get Caller Access Api V1 Projects  Project Id  Access
+                  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: What the caller may do on this matter, and why
+      tags:
+      - projects
+      - matters
   /api/v1/projects/{project_id}/files:
     post:
       description: 'Body: ``{file_id}``. The caller must own both the project and
@@ -12133,6 +12288,189 @@ paths:
       summary: Detach a knowledge base from a matter
       tags:
       - projects
+  /api/v1/projects/{project_id}/members:
+    get:
+      description: 'Anyone who can read the matter can see who else is on it.
+
+
+        Withholding the roster from readers would make the collaboration
+
+        surface unusable — you cannot see who authored the thread you are
+
+        reading — and it protects nothing, since those people''s work product
+
+        is already visible to the same caller.'
+      operationId: list_members_api_v1_projects__project_id__members_get
+      parameters:
+      - in: path
+        name: project_id
+        required: true
+        schema:
+          format: uuid
+          title: Project Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/MatterMemberResponse'
+                title: Response List Members Api V1 Projects  Project Id  Members
+                  Get
+                type: array
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: List the people on a matter
+      tags:
+      - projects
+      - matters
+    post:
+      description: 'Add a roster row. ``role=''blocked''`` erects an ethical screen.
+
+
+        A screen is stored as an ordinary membership row so the roster answers
+
+        both halves of the question a conflicts check asks: who may see this
+
+        matter, and who explicitly may not.'
+      operationId: add_member_api_v1_projects__project_id__members_post
+      parameters:
+      - in: path
+        name: project_id
+        required: true
+        schema:
+          format: uuid
+          title: Project Id
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MatterMemberAdd'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MatterMemberResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: Add someone to a matter (or screen them off it)
+      tags:
+      - projects
+      - matters
+  /api/v1/projects/{project_id}/members/{user_id}:
+    delete:
+      description: 'Drop a roster row.
+
+
+        Removing a ``blocked`` row *lifts a screen* — it is the one deletion
+
+        here that widens access, so the audit row records the role the person
+
+        held at removal rather than just the fact of it.
+
+
+        The owner''s row cannot be removed: their access does not depend on it,
+
+        so deleting it would only make the roster lie.'
+      operationId: remove_member_api_v1_projects__project_id__members__user_id__delete
+      parameters:
+      - in: path
+        name: project_id
+        required: true
+        schema:
+          format: uuid
+          title: Project Id
+          type: string
+      - in: path
+        name: user_id
+        required: true
+        schema:
+          format: uuid
+          title: User Id
+          type: string
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: Remove someone from a matter
+      tags:
+      - projects
+      - matters
+    patch:
+      description: 'Move a roster row between roles, including to and from ``blocked``.
+
+
+        The audit row carries before/after so "when was this person screened
+
+        off, and by whom" is answerable from the log alone — the same
+
+        before/after convention ``team.member_role_updated`` uses.'
+      operationId: update_member_role_api_v1_projects__project_id__members__user_id__patch
+      parameters:
+      - in: path
+        name: project_id
+        required: true
+        schema:
+          format: uuid
+          title: Project Id
+          type: string
+      - in: path
+        name: user_id
+        required: true
+        schema:
+          format: uuid
+          title: User Id
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MatterMemberRoleUpdate'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MatterMemberResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: Change someone's role on a matter
+      tags:
+      - projects
+      - matters
   /api/v1/projects/{project_id}/skills:
     post:
       description: 'Body: ``{skill_name}``. The skill must exist in the in-memory
@@ -13492,6 +13830,74 @@ paths:
       summary: Audit-log view of edits for this user-skill (Wave D.2)
       tags:
       - user-skills
+  /api/v1/users/directory:
+    get:
+      description: 'GET /api/v1/users/directory — id, email, and display name only.
+
+
+        Any signed-in user may call this. Sharing a matter is impossible without
+
+        it: the roster endpoints take a ``user_id``, and a matter lead who is not
+
+        an operator-admin cannot reach ``GET /admin/users`` to find one. Asking a
+
+        lawyer to paste a colleague''s UUID is not a design.
+
+
+        Deliberately minimal — no role, no admin flag, no MFA or password state,
+
+        no last-login. Those stay behind ``GET /admin/users``. A deployment is a
+
+        single organisation (PRD §2.3), so who else works here is not a secret;
+
+        *what they can do* still is.
+
+
+        Soft-deleted users are excluded so a picker cannot re-add someone who has
+
+        exercised erasure.'
+      operationId: list_directory_api_v1_users_directory_get
+      parameters:
+      - description: Case-insensitive substring match on email or display name.
+        in: query
+        name: q
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Case-insensitive substring match on email or display name.
+          title: Q
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          maximum: 200
+          minimum: 1
+          title: Limit
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/DirectoryEntry'
+                title: Response List Directory Api V1 Users Directory Get
+                type: array
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - OAuth2PasswordBearer: []
+      summary: List the people in this deployment (for people-pickers)
+      tags:
+      - users
   /api/v1/users/me:
     get:
       description: 'GET /api/v1/users/me — return the calling user''s public profile.

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -159,6 +159,7 @@ CREATE TABLE projects (
     privileged               BOOLEAN NOT NULL DEFAULT FALSE,
     minimum_inference_tier   SMALLINT,
     is_sandbox               BOOLEAN NOT NULL DEFAULT FALSE,  -- 0022: system-managed try-it sandbox
+    share_scope              TEXT NOT NULL DEFAULT 'personal',  -- 0067: personal | members | org
     created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
     archived_at              TIMESTAMPTZ,  -- soft-delete; NULL means active
@@ -173,6 +174,15 @@ CREATE TABLE projects (
     ),
     CONSTRAINT chk_projects_slug_len CHECK (
         char_length(slug) > 0 AND char_length(slug) <= 80
+    ),
+    -- Migration 0067.
+    CONSTRAINT chk_projects_share_scope_enum CHECK (
+        share_scope IN ('personal', 'members', 'org')
+    ),
+    -- A sandbox is per-user scratch space; sharing one would leak a
+    -- colleague's try-it project into the matter list.
+    CONSTRAINT chk_projects_sandbox_personal CHECK (
+        (is_sandbox = false) OR (share_scope = 'personal')
     )
 );
 
@@ -202,6 +212,75 @@ CREATE TRIGGER trg_projects_set_updated_at
 | Column | Migration | Notes |
 |---|---|---|
 | `is_sandbox` | 0022 | System-managed flag for the per-user skill try-it sandbox (`slug='__sandbox__'`). `POST /projects/sandbox/ensure` creates or returns the row. Sandbox projects are excluded from the default `GET /projects` list; the `include_sandbox` / `only_sandbox` query params control visibility. |
+| `share_scope` | 0067 | Ambient grant over the matter. `personal` — owner + explicit `project_members` rows only. `members` — same reach; marks a matter as deliberately restricted rather than never shared. `org` — every non-blocked user in the deployment gets **read**; writing still requires an explicit membership row. A `blocked` membership row overrides all three. New matters take `LQ_AI_MATTER_DEFAULT_SHARE_SCOPE` (default `personal`) unless the caller sets one. Only a matter lead may change it. |
+
+### `project_members` (migration 0067)
+
+The matter roster. PRD §3.11 listed `share_scope` in the Project data
+model and named `POST /api/v1/projects/{id}/share`; §3.11's M1 status
+recorded share-with-group as deferred. This is that surface, shaped as a
+roster rather than a one-shot share call so "who was on this matter, and
+who put them there" is a table rather than an inference from an event log.
+
+A matter is a `projects` row (ADR 0020 D3 — there is no separate `Matter`
+model), so matter membership is project membership. The shape mirrors
+`team_members` (0014) deliberately: composite PK, the same
+CASCADE/RESTRICT split, and the same `added_by_user_id` forensic column.
+
+```sql
+CREATE TABLE project_members (
+    project_id       UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    user_id          UUID NOT NULL REFERENCES users(id)    ON DELETE CASCADE,
+    role             TEXT NOT NULL,
+    added_by_user_id UUID NOT NULL REFERENCES users(id)    ON DELETE RESTRICT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT pk_project_members PRIMARY KEY (project_id, user_id),
+    CONSTRAINT ck_project_members_role_enum CHECK (
+        role IN ('lead', 'contributor', 'reader', 'blocked')
+    )
+);
+
+-- Drives the "which matters can this user see" list query.
+CREATE INDEX idx_project_members_user ON project_members (user_id);
+```
+
+**Roles.** `lead` — manage the roster, the share scope, the privilege
+flag, the tier floor, and archiving. `contributor` — read and write the
+matter and its attachments. `reader` — read only. `blocked` — a
+**negative** grant: an ethical screen or conflict wall.
+
+`blocked` is a role value rather than a separate table so the composite
+primary key guarantees "is this person screened?" has exactly one answer
+— a grant and a screen can never coexist on the same matter — and so the
+roster answers both halves of a conflicts check from one indexed query.
+
+**Resolution order** (`app/authz/matters.py`, the only place this is
+decided):
+
+1. a `blocked` row → no access. **Absolute**, and it beats `is_admin`: a
+   wall an operator-admin can walk through is not a wall, and in a small
+   firm the operator-admin is usually also a practising lawyer.
+2. `projects.owner_id == caller` → `lead`. Ownership short-circuits the
+   roster lookup, so a matter whose lead row was deleted by hand never
+   becomes unreachable by its own owner.
+3. an explicit row → `lead` / `write` / `read`.
+4. `share_scope = 'org'` → `read`, never write.
+5. otherwise → no access, surfaced as **404 rather than 403** so an id
+   probe cannot distinguish "no such matter" from "not yours". 403 is
+   reserved for a caller who can already read the matter and is asking
+   for more than their role allows.
+
+There is deliberately **no operator-admin bypass and no `auditor`
+branch**: before this table existed, `is_admin` did not let anyone read
+another user's matter, and adding such a branch here would be a silent,
+unaudited widening of cross-user access smuggled in under a collaboration
+feature. The deployment-wide `auditor` role (migration 0065) keeps
+working exactly as before on the ledger and receipt surfaces.
+
+**Backfill.** 0067 writes one `lead` row per existing project for its
+owner (`added_by_user_id = owner_id`, `created_at = projects.created_at`),
+so the resolver returns exactly the pre-migration answer for every
+existing row.
 
 ### `project_files` and `project_skills`
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -16,6 +16,7 @@ This folder is the home for LQ.AI's security artifacts. The PRD documents the pr
 | **Cryptographic implementations** (`cryptography.md`) | Landed | Documentation of cryptographic primitives used, key lifecycle, and known limitations. |
 | **Network access controls** (`network-access-controls.md`) | M2 (or earlier with [DE-103 IP allowlisting](../PRD.md#de-103--ip-allowlisting-and-geo-restriction)) | IP allowlisting, geo-restriction, outbound proxy configuration. |
 | **Audit logging** (`audit-logging.md`) | Landed | What is logged, retention, integrity protection. |
+| **Matter access control** ([`matter-access-control.md`](matter-access-control.md)) | Landed (ADR 0024) | Who can reach a matter, ethical screens, the share-scope default, and the limits of the guarantee. |
 | **Encrypted-at-rest provider keys** ([`encrypted-keys.md`](encrypted-keys.md)) | Landed (ADR 0011) | Operator workflow for the master-key + Fernet-wrapped `api_key_encrypted` path in `gateway.yaml`. Bootstrap, rotation, recovery. |
 | **Past advisories** (`advisories/`) | As advisories are published | Historical security advisories with reporter credit. |
 

--- a/docs/security/matter-access-control.md
+++ b/docs/security/matter-access-control.md
@@ -1,0 +1,199 @@
+# Matter Access Control
+
+Who can reach a matter, who decides, and what the deployment guarantees.
+
+A **matter** is a `projects` row — there is no separate `Matter` model
+([ADR 0020](../adr/0020-governed-agentic-legal-matter-sessions.md) D3), so matter membership is
+project membership. Everything below is enforced in one module,
+[`api/app/authz/matters.py`](../../api/app/authz/matters.py); nothing else decides matter access.
+
+> **Scope of the guarantee.** This is application-layer authorization, not a cryptographic
+> boundary. Anyone with direct read access to the Postgres database — an operator, a DBA, a
+> restored backup — reads everything regardless of what this document says. A compliance
+> narrative that claims otherwise is overclaiming. What this layer gives you is a truthful,
+> auditable answer to "who could reach this matter through the product, and when did that
+> change."
+
+---
+
+## The model
+
+Two things decide access: a per-matter **roster** (`project_members`) and a per-matter **ambient
+grant** (`projects.share_scope`).
+
+### Roles on the roster
+
+| Role | Can |
+|---|---|
+| `lead` | Everything below, plus manage the roster, the share scope, the privileged flag, the inference-tier floor, and archiving. |
+| `contributor` | Read the matter and add to it: edit standing context, attach files/skills/knowledge bases, start chats in it. |
+| `reader` | Read the matter and everything in it. Change nothing. |
+| `blocked` | **Nothing.** A negative grant — an ethical screen. |
+
+`blocked` is a role value rather than a separate table on purpose: the composite primary key
+`(project_id, user_id)` then guarantees that "is this person screened?" has exactly one answer — a
+grant and a screen can never coexist — and one indexed query answers both halves of a conflicts
+check.
+
+### Share scope
+
+| `share_scope` | Reach |
+|---|---|
+| `personal` | The owner and the explicit roster only. **The default.** |
+| `members` | Identical reach to `personal`; marks a matter as *deliberately restricted* rather than never shared, so the UI can tell the two apart. |
+| `org` | Every non-blocked user in the deployment gets **read**. Writing still requires an explicit roster row. |
+
+`org` grants read and never write. Contributing to a matter always requires a roster row, so the
+roster stays a truthful answer to *who worked this matter* — which is the question that matters for
+privilege and for conflicts, months later, when nobody remembers.
+
+---
+
+## Resolution order
+
+Evaluated top to bottom; the first rule that matches wins.
+
+1. **A `blocked` roster row → no access.** Absolute.
+2. **The caller owns the matter → `lead`.**
+3. **An explicit roster row → its role.**
+4. **`share_scope = 'org'` → `read`.**
+5. **Otherwise → no access.**
+
+Three properties of that order are load-bearing and should not be "optimised" later:
+
+**A screen beats `is_admin`.** An ethical wall an operator-admin can walk through is not a wall,
+and in a small firm the operator-admin is frequently also a practising lawyer. An admin who must
+see a screened matter lifts the screen — an attributed, audited, permanent-in-the-log act — rather
+than bypassing it silently. A test pins this
+(`api/tests/test_matter_authz.py::test_screen_beats_is_admin`).
+
+**There is no operator-admin bypass and no `auditor` branch at all.** Before the roster existed,
+`is_admin` did *not* let anyone read another user's matter — the loaders were plain owner checks.
+Adding such a branch here would be a widening of cross-user access introduced under cover of a
+collaboration feature, and an unaudited one. The deployment-wide `auditor` role
+(migration 0065) is unaffected and still reaches the citation-ledger and receipt surfaces exactly
+as before. Three tests pin the absence of this capability, because absent capabilities are what
+well-meaning patches reintroduce.
+
+**Ownership short-circuits the roster.** A matter whose lead row was deleted by hand never becomes
+unreachable by its own owner.
+
+### Status codes
+
+- **404** — no access at all, *and* for a matter that does not exist. The two are deliberately
+  indistinguishable so an id probe learns nothing. A fired screen is a 404.
+- **403** — the caller *can* read the matter but asked for more than their role allows. At that
+  point 403 leaks nothing they could not already see, and a 404 would actively mislead the UI.
+
+---
+
+## Configuration
+
+| Setting | Default | Effect |
+|---|---|---|
+| `LQ_AI_MATTER_DEFAULT_SHARE_SCOPE` | `personal` | The `share_scope` applied to a new matter when the caller does not specify one. |
+
+The default is `personal` — fail-restrictive, per
+[ADR 0016](../adr/0016-transparency-and-governance-invariants.md) P4. A new matter reaches only its
+owner until someone is added.
+
+Set it to `org` when ambient visibility is the working assumption and an ethical screen is the
+exception — the posture most small firms already run under in their practice-management system. It
+never widens write access, and a `blocked` row still overrides it.
+
+Sandbox matters (`is_sandbox`) are per-user scratch space and are pinned to `personal` by a database
+CHECK constraint; they cannot be shared whatever this setting says.
+
+> **This setting only affects matters created after it is set.** Changing it never retroactively
+> widens an existing matter. Migration 0067's backfill deliberately leaves every pre-existing matter
+> at `personal`.
+
+---
+
+## What an operator should know
+
+**Provisioning.** `POST /api/v1/admin/users` creates a user with a generated one-time password and
+`must_change_password=true`, so the new user is forced through `/auth/change-password` on first
+login. The plaintext is returned once in the response body and is never persisted, logged, or
+written to the audit row. `POST /api/v1/admin/users/{id}/reset-password` re-issues one and revokes
+the target's live refresh sessions.
+
+**The people-picker.** `GET /api/v1/users/directory` returns id, email, and display name for every
+non-deleted user, to any signed-in caller. This exists because the roster endpoints take a
+`user_id`, and a matter lead who is *not* an operator-admin cannot reach `GET /admin/users` to find
+one. A deployment is a single organisation ([PRD §2.3](../PRD.md#23-data-isolation-model)), so who
+else works here is not a secret; *what they can do* still is, and role, admin flag, MFA state and
+password state all stay behind the admin surface.
+
+**Access tokens are stateless.** Revoking a roster row takes effect on the next request, because
+authorization is resolved per request and never cached across requests — a screen erected at 14:03
+bites at 14:03. But an *access token* remains valid until it expires
+(`JWT_ACCESS_TOKEN_TTL_SECONDS`, default 900s). Deployments that raise that TTL widen the window in
+which a just-removed user's in-flight token still authenticates them; the roster check still runs,
+so they lose matter access immediately either way.
+
+**Deleting a user.** The GDPR hard-delete job refuses to delete a matter that has roster members
+other than the owner, and names the blocked matter ids in the worker log. Erasure covers the user's
+own data, not a shared matter file that colleagues are working in. Resolve it by transferring
+ownership first — see *Known limitations*.
+
+---
+
+## Auditing
+
+Every roster change writes an `audit_log` row in the same transaction as the change itself
+(ADR 0016 P5 — no state change without its audit row):
+
+| Action | Recorded |
+|---|---|
+| `matter.member_added` | target user id + email, role granted |
+| `matter.member_role_updated` | before/after role — this is how a screen's erection is recorded |
+| `matter.member_removed` | role held at removal, and `lifted_screen: true` when the removed row was a screen |
+
+Removing a `blocked` row is the one deletion here that *widens* access, which is why it is flagged
+rather than logged as an ordinary removal.
+
+### Known gap
+
+`audit_log` has no `project_id` column, so these rows are queryable by `resource_id` but there is
+no stable foreign key to the matter, and the historical `privilege_basis` string carries the
+matter's *name* — which is mutable. **A per-matter access log is therefore not yet producible**, and
+read events are not logged at all. If your compliance posture depends on answering "who accessed
+this matter", treat that as an open item rather than a solved one.
+
+---
+
+## Known limitations
+
+- **No matter ownership transfer.** A matter can be shared with another identity but not moved to
+  one. The owner is permanently `lead` and cannot be demoted or removed from the roster.
+- **No per-file or per-chat permissions inside a matter.** Access is uniform across the matter's
+  contents. This is deliberate — privilege attaches at the matter, and per-resource drift inside a
+  matter is unauditable — but it means you cannot share a matter while withholding one document in
+  it.
+- **File and knowledge-base *ownership* is still per-user.** A colleague reaching a shared matter
+  reads its attached knowledge bases through the matter, but the standalone file and KB surfaces
+  remain owner-scoped.
+- **Chats in a shared matter are readable by every member but writable only by their author** —
+  including by a lead. Two lawyers interleaving turns in one thread would make
+  `work_product_attribution` ambiguous about who directed which output, which is precisely the
+  record that has to stay unambiguous. A colleague acting on a shared matter starts their own
+  thread in it.
+- **No team-scope grants yet.** `teams` exists and is wired only to skill sharing; a
+  `project_teams` join slots into step 3 of the resolution order when wanted.
+- **No cross-deployment / external-counsel boundary.** See
+  [DE-023](../PRD.md#de-023--external-counsel-collaboration-boundary). External counsel is a user in
+  this deployment with a scoped roster row.
+- **Screens are visible to everyone who can read the matter.** The roster shows screened people to
+  any member. In a small firm that transparency is usually correct; in a larger one, knowing *that*
+  a colleague is screened off a matter may itself be sensitive.
+
+---
+
+## Cross-references
+
+- [`docs/db-schema.md` § `project_members`](../db-schema.md) — table definition, constraints, backfill.
+- [ADR 0024 — Matter-scoped access control](../adr/0024-matter-scoped-access-control.md) — why this shape.
+- [ADR 0020](../adr/0020-governed-agentic-legal-matter-sessions.md) D3 — matter = project.
+- [ADR 0016](../adr/0016-transparency-and-governance-invariants.md) P4, P5, P6 — fail-restrictive, atomic audit, one governance path.
+- [`docs/security/audit-logging.md`](audit-logging.md) — what the audit log holds and how to query it.


### PR DESCRIPTION
PRD §3.11 lists `share_scope` in the Project data model and names
`POST /api/v1/projects/{id}/share`; §3.11's M1 status records share-with-group as **deferred**.
lq-ai #266 (the `auditor` role) records the consequence plainly:

> We chose a global role, not a per-org/per-matter scope. Grounding found LQ.AI has **no org /
> membership / project-sharing primitive** today … a scoped auditor would have needed a new
> membership table — out of scope.

This lands that table. A matter is a `projects` row (ADR 0020 D3 — no new `Matter` model), so
matter membership is project membership.

## Schema (migration 0067)

`project_members` mirrors `team_members` (0014) deliberately: composite PK, the same
CASCADE/RESTRICT split, the same `added_by_user_id` forensic column. A reviewer who knows the team
surface knows this one, and a future `project_teams` join slots in without a second vocabulary.

One value has no analogue there — `blocked`, a **negative** grant (an ethical screen). Storing a
screen as a role rather than a separate table means the composite PK guarantees "is this person
screened?" has exactly one answer — a grant and a screen can never coexist — and one indexed query
answers both halves of a conflicts check.

`projects` gains `share_scope` (`personal` | `members` | `org`), constrained so a sandbox — per-user
scratch space — can never be shared.

**The backfill preserves current behaviour exactly:** one `lead` row per existing project for its
owner, and every existing matter stays `personal`. A deployment that upgrades and changes nothing
sees no behaviour change.

## One resolver

`app/authz/matters.py` is now the only place matter access is decided. Before this, the rule was an
`owner_id == user.id` predicate copy-pasted into nine `_load_visible_*` helpers — nine places to
forget one, and the forgotten one is a leak no test names (ADR 0016 P6, one governance path).

Order: a `blocked` row denies absolutely → owner is lead → explicit grant → `share_scope='org'`
grants **read and never write** → otherwise no access. No access is **404**, preserving the
existence-safe posture the matter surface already documents; **403** is reserved for a caller who
can already read the matter and is asking for more, where it leaks nothing new.

Org scope granting read-only is deliberate: contributing always requires an explicit roster row, so
the roster stays a truthful answer to "who worked this matter" — the question that matters for
privilege and conflicts months later.

## Two decisions I want to flag rather than bury

**`blocked` beats `is_admin`.** An ethical wall an operator-admin can walk through is not a wall,
and in a small firm the operator-admin is frequently also a practising lawyer. The remedy for an
admin who must see a screened matter is to lift the screen — attributed and audited — not to bypass
it. Deliberately no break-glass. Happy to put this behind a deployment flag if you'd rather, but I
didn't want to offer that pre-emptively.

**No operator-admin bypass and no `auditor` branch on matters at all.** Before this table existed,
`is_admin` did not let anyone read another user's matter — the loaders were plain owner checks.
Adding such a branch here would be a widening of cross-user access introduced under cover of a
collaboration feature, and unaudited, since matter reads are not logged. `auditor` keeps its
existing reach over the ledger and receipt surfaces. Three tests pin the *absence* of this
capability, because absent capabilities are what a well-meaning patch reintroduces.

## Reads widen, writes do not

A chat pinned to a matter is readable by anyone who can read the matter — the point of sharing one.
Chat *writes* stay owner-only, including for a lead: two lawyers interleaving turns in one thread
would make `work_product_attribution` ambiguous about who directed which output, which is precisely
the record that has to stay unambiguous. A colleague acting on a shared matter starts their own
thread in it. The unfiltered chat sidebar also stays personal, so a firm-wide matter never floods a
colleague's list.

## `GET /users/directory`

Sharing is impossible without it: the roster endpoints take a `user_id`, and a matter lead who is
not an operator-admin cannot reach `GET /admin/users` to find one. Returns id, email, and display
name only — role, admin flag, MFA and password state stay behind the admin surface. A deployment is
one organisation (PRD §2.3), so who else works here is not a secret; what they can do still is.

## Also fixed here, because sharing makes them bite

- `user_deletion` deleted every project the user owned. With members on them that destroys
  colleagues' work; shared matters are now skipped and named in the log.
- `update_project` resolved slug uniqueness against the *caller's* namespace; slugs are unique per
  owner, so a contributor renaming a shared matter must be checked against the owner's.

## Config

`LQ_AI_MATTER_DEFAULT_SHARE_SCOPE` defaults to `personal` — fail-restrictive per ADR 0016 P4. A new
matter reaches only its owner until someone is added. Deployments where ambient visibility is the
working assumption set `org`.

## Docs

- `docs/security/matter-access-control.md` — operator-facing, including an explicit statement that
  this is application-layer authorization and **not** a cryptographic boundary, plus known
  limitations.
- ADR 0024 — the decision record. It says up front that it was written after the implementation
  rather than before; I'd rather record that honestly than back-date it.
- `docs/db-schema.md` — the table, constraints, and backfill.

## Not in this change

`audit_log.project_id` (so per-matter audit is still not producible — a real gap, worth its own
PR), optimistic concurrency on `context_md`, matter ownership transfer, team-scope grants, and
making file/KB visibility follow the matter.

## Testing

`pytest tests/` — 2709 passed. Two failures remain and **both reproduce on unmodified `main`**; I
ran a clean `origin/main` worktree to confirm rather than assume:

- `test_sighup_reload_in_child_process` segfaults the whole pytest process in a full run (passes
  alone) — a redundant `env=` takes CPython off `posix_spawn`.
- `test_receipt_assembles_phase_transitions_and_tool_calls` is flaky because
  `build_receipt` orders by `audit_log.timestamp`, which is *transaction* time, so same-transaction
  events are indistinguishable.

Happy to file those separately if useful.

New: `tests/test_matter_authz.py` (the access matrix, including the DB-level constraints and the
absent-capability tests), `tests/test_matter_members.py`, `tests/test_users_directory.py`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
