### PR TITLE
fix: release image ships an empty skills/community

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ name: CI
 #   - web/    : svelte-check + Vitest
 #   - api/    : ruff + mypy (standard mode) + pytest (with Postgres)
 #   - gateway/: ruff + mypy --strict + pytest
+#   - api/Dockerfile.release: the skills-corpus guard (builds the `skills`
+#     stage only, so no dependency install; see scripts/release-image-check.sh)
 #
 # Out of scope (deferred to future waves):
 #   - Cypress E2E (heavier; needs a stack-up step + LLM provider keys)
@@ -220,3 +222,24 @@ jobs:
 
       - name: pytest
         run: pytest -q
+
+  release-image-checks:
+    name: Release image (skills corpus)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Case 1 of the check needs the real skills/community content, the
+          # same way the release checkout in release.yml requests it.
+          submodules: recursive
+
+      - name: Release image skills-corpus check
+        # The check itself lives in scripts/release-image-check.sh, the single
+        # source of truth, runnable locally. It builds only the `skills` stage
+        # of api/Dockerfile.release (no dependency install), asserts a recursive
+        # checkout bakes the community SKILL.md manifests, and asserts that an
+        # empty submodule, a metadata-only submodule root, and a skills/ tree
+        # without manifests each stop the build at the guard.
+        run: ./scripts/release-image-check.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # api/Dockerfile.release bakes the skills corpus, and half of it lives
+          # in the skills/community submodule. Without this the published image
+          # ships an empty /skills/community.
+          submodules: recursive
 
       - name: Build and push ${{ matrix.service }}
         uses: ./.github/actions/build-push-image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,9 @@ For features not on the deferred-enhancements list, please file an issue describ
    session-scoped disposable database via the conftest fixture, so workers are
    fully isolated); Gateway runs `uv lock --check`, ruff check/format, `mypy
    app`, and `pytest -q`; Web runs `npm run check:lq-ai` and `npm run
-   test:frontend -- --run`. The path-triggered Stack smoke workflow also runs on
+   test:frontend -- --run`; the Release image job runs
+   `scripts/release-image-check.sh` (the skills-corpus guard in
+   `api/Dockerfile.release`). The path-triggered Stack smoke workflow also runs on
    PRs that change the specified API/Gateway/Web dependency manifests and locks,
    Dockerfiles, compose, API migrations, its script, or its workflow. PRs with
    failing CI are not merged.
@@ -208,6 +210,19 @@ and passes after.
   specifically affects provider integration and credentials are available.
 - **End-to-end tests** — browser end-to-end coverage is not part of the current PR workflow.
 - **Fuzzing** — continuous fuzzing is not part of the current PR workflow.
+
+### Release image skills-corpus check
+
+`api/Dockerfile.release` bakes the repo-root `skills/` corpus into the published api image, and half of that corpus is the `skills/community` submodule. The Dockerfile fails the build unless at least one `skills/community/skills/*/SKILL.md` manifest is present, so a checkout without submodules cannot publish an image that is silently missing those skills. CI runs the check on every PR (`release-image-checks` in `.github/workflows/ci.yml`). It builds only the `skills` stage of the Dockerfile, so it needs no dependency install and finishes in seconds.
+
+Run it locally after touching `api/Dockerfile.release`, `.gitmodules`, or the release checkout in `.github/workflows/release.yml` (needs docker and a recursive checkout):
+
+```bash
+git submodule update --init --recursive
+./scripts/release-image-check.sh
+```
+
+It asserts that this checkout bakes the community manifests, and that an empty submodule directory, a submodule root carrying only README and LICENSE, and a `skills/` tree with no manifest each stop the build at the guard. Set `FULL_IMAGE=1` to also build the complete api release image (slow; pulls docling and torch).
 
 ### Stack smoke test (build + boot the whole stack)
 

--- a/api/Dockerfile.release
+++ b/api/Dockerfile.release
@@ -4,6 +4,32 @@
 # bake the repo-root skills corpus (bind-mounted in dev) for the self-contained
 # launcher images; built with repo-root context by .github/workflows/release.yml.
 
+# Skills-corpus stage. Stands alone (no dependency install) so the guard below
+# can be exercised in seconds with `docker build --target skills`, which is
+# what scripts/release-image-check.sh and the CI job built on it do. The final
+# stage copies /skills from here verbatim, so what this stage guarantees, the
+# published image carries.
+FROM python:3.12-slim AS skills
+
+# Bake the skills corpus that the dev stack bind-mounts (./skills:/skills:ro),
+# so the published image is self-contained for the zero-checkout macOS launcher.
+COPY skills /skills
+# COPY of an empty directory succeeds silently, so a build from a checkout
+# without submodules produces an image that starts healthy and is simply
+# missing half the corpus. Fail the build instead.
+#
+# "Non-empty" is not enough: the runtime loads community skills from
+# /skills/community/skills/<slug>/SKILL.md (api/app/config.py,
+# community_skills_dir), so a checkout carrying only the submodule's README
+# and LICENSE would pass an emptiness check with zero loadable skills. Assert
+# that at least one manifest exists. If the glob matches nothing, $1 is the
+# literal pattern and `test -f` fails.
+RUN set -- /skills/community/skills/*/SKILL.md; test -f "$1" || { \
+      echo "ERROR: no community skill manifests found under /skills/community/skills/*/SKILL.md - the skills/community submodule was not checked out." >&2; \
+      echo "Run 'git submodule update --init --recursive' before building this image." >&2; \
+      exit 1; \
+    }
+
 FROM python:3.12-slim AS base
 
 # ADR 0023 — dependencies install from the committed uv.lock so the shipped
@@ -39,9 +65,8 @@ COPY api/alembic/ ./alembic/
 COPY api/entrypoint.sh /usr/local/bin/lq-ai-entrypoint
 RUN chmod +x /usr/local/bin/lq-ai-entrypoint
 
-# Bake the skills corpus that the dev stack bind-mounts (./skills:/skills:ro),
-# so the published image is self-contained for the zero-checkout macOS launcher.
-COPY skills /skills
+# The guarded skills corpus from the stage above.
+COPY --from=skills /skills /skills
 ENV LQ_AI_SKILLS_DIR=/skills
 
 EXPOSE 8000

--- a/scripts/release-image-check.sh
+++ b/scripts/release-image-check.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Release-image skills-corpus check: the single source of truth for the
+# "Release image (skills corpus)" job in .github/workflows/ci.yml.
+#
+# api/Dockerfile.release bakes the repo-root skills/ corpus into the published
+# api image. Half of that corpus is the skills/community submodule, and a
+# checkout without submodules used to produce an image that built, started
+# healthy, and simply had no community skills. The Dockerfile now guards
+# against that; this script proves the guard works, in both directions:
+#
+#   1. a recursive checkout (this tree) builds, and the image carries
+#      community SKILL.md manifests (and the firm ones);
+#   2. an empty skills/community fails the build;
+#   3. a skills/community carrying only repository metadata (README,
+#      LICENSE) and no skills/ tree also fails the build;
+#   4. a skills/community/skills/ tree with a slug directory but no
+#      SKILL.md inside also fails the build.
+#
+# Only the `skills` stage of the Dockerfile is built (--target skills), so
+# this needs no dependency install and runs in seconds. The final stage
+# copies /skills from that stage verbatim, so what holds here holds for the
+# published image. Set FULL_IMAGE=1 to also build the complete api release
+# image for case 1 (pulls torch via docling; slow, several GB).
+#
+# Requirements: docker with BuildKit; a recursive checkout
+# (git submodule update --init --recursive).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DOCKERFILE=api/Dockerfile.release
+IMAGE_TAG="lq-ai-release-skills-check:local"
+FULL_IMAGE="${FULL_IMAGE:-0}"
+
+# Every negative case builds from a throwaway context that carries only the
+# skills tree (plus the repo-root .dockerignore, which docker reads from the
+# context root). The Dockerfile itself is passed with -f from the real tree.
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() { echo "release-image-check: FAIL: $*" >&2; exit 1; }
+pass() { echo "release-image-check: ok: $*"; }
+
+# The guard message the Dockerfile prints; an expected failure must fail
+# *here*, not somewhere unrelated (a base-image pull, a syntax error).
+GUARD_MARKER="no community skill manifests found"
+
+# expect_guard_failure <case name> <context dir>
+expect_guard_failure() {
+  local name="$1" ctx="$2" log rc
+  log="$TMP_ROOT/$name.log"
+  set +e
+  docker build --progress=plain --target skills -f "$DOCKERFILE" "$ctx" >"$log" 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    fail "$name: build succeeded but should have been stopped by the guard"
+  fi
+  if ! grep -qF "$GUARD_MARKER" "$log"; then
+    echo "--- build log ($name) ---" >&2
+    tail -n 40 "$log" >&2
+    fail "$name: build failed, but not at the skills guard"
+  fi
+  pass "$name: build stopped at the guard"
+}
+
+# new_context <name> -> prints a context dir holding skills/ minus community/
+new_context() {
+  local dir="$TMP_ROOT/$1"
+  mkdir -p "$dir/skills"
+  [ -f .dockerignore ] && cp .dockerignore "$dir/"
+  # Everything under skills/ except the community submodule itself.
+  for entry in skills/*; do
+    [ "$entry" = "skills/community" ] && continue
+    cp -R "$entry" "$dir/skills/"
+  done
+  echo "$dir"
+}
+
+# --- Preconditions --------------------------------------------------------
+
+host_count="$(find skills/community/skills -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$host_count" -eq 0 ]; then
+  fail "no community SKILL.md in this checkout - run 'git submodule update --init --recursive' first"
+fi
+echo "release-image-check: host checkout has $host_count community skill manifests"
+
+# --- Case 1: recursive checkout builds and carries the corpus --------------
+
+docker build --target skills -f "$DOCKERFILE" -t "$IMAGE_TAG" . >"$TMP_ROOT/positive.log" 2>&1 \
+  || { tail -n 40 "$TMP_ROOT/positive.log" >&2; fail "positive: skills stage failed to build"; }
+
+image_community="$(docker run --rm "$IMAGE_TAG" sh -c 'find /skills/community/skills -name SKILL.md | wc -l' | tr -d ' ')"
+image_firm="$(docker run --rm "$IMAGE_TAG" sh -c 'find /skills -path /skills/community -prune -o -name SKILL.md -print | wc -l' | tr -d ' ')"
+[ "$image_community" -ge 1 ] || fail "positive: image has no community SKILL.md"
+[ "$image_firm" -ge 1 ] || fail "positive: image has no firm SKILL.md"
+[ "$image_community" -eq "$host_count" ] \
+  || fail "positive: image carries $image_community community manifests, host checkout has $host_count"
+pass "positive: image carries $image_community community and $image_firm firm skill manifests"
+
+if [ "$FULL_IMAGE" = "1" ]; then
+  docker build -f "$DOCKERFILE" -t "$IMAGE_TAG-full" . \
+    || fail "positive (full image): api release image failed to build"
+  full_count="$(docker run --rm --entrypoint sh "$IMAGE_TAG-full" -c 'find /skills/community/skills -name SKILL.md | wc -l' | tr -d ' ')"
+  [ "$full_count" -eq "$host_count" ] \
+    || fail "positive (full image): image carries $full_count community manifests, host checkout has $host_count"
+  pass "positive (full image): api release image carries $full_count community skill manifests"
+fi
+
+# --- Case 2: empty submodule directory (checkout without submodules) ------
+
+ctx="$(new_context empty-submodule)"
+mkdir -p "$ctx/skills/community"
+expect_guard_failure "empty-submodule" "$ctx"
+
+# --- Case 3: metadata only, no skills/ tree -------------------------------
+
+ctx="$(new_context metadata-only)"
+mkdir -p "$ctx/skills/community"
+find skills/community -maxdepth 1 -type f -exec cp {} "$ctx/skills/community/" \;
+[ -n "$(ls -A "$ctx/skills/community")" ] || fail "metadata-only: fixture is empty; expected README/LICENSE at the submodule root"
+expect_guard_failure "metadata-only" "$ctx"
+
+# --- Case 4: skills/ tree present but no manifest in it ------------------
+
+ctx="$(new_context no-manifest)"
+mkdir -p "$ctx/skills/community/skills/some-skill"
+echo "not a manifest" > "$ctx/skills/community/skills/some-skill/README.md"
+expect_guard_failure "no-manifest" "$ctx"
+
+echo "release-image-check: all cases passed"


### PR DESCRIPTION
`api/Dockerfile.release` does `COPY skills /skills` so the published image is
self-contained. Half that corpus lives in the `skills/community` submodule, but the
`build-backend` checkout does not request submodules, so the directory is empty at
build time.

`COPY` of an empty directory succeeds, so nothing fails: the image builds, starts
healthy, and is simply missing those skills. It only surfaces when someone reaches for
one of them.

**Changes**

- `.github/workflows/release.yml`: request `submodules: recursive` on the
  `build-backend` checkout only. No other checkout is touched.
- `api/Dockerfile.release`: fail the build unless at least one
  `skills/community/skills/*/SKILL.md` manifest is present. The runtime loads community
  skills from that path (`community_skills_dir` in `api/app/config.py`), so an
  emptiness check would pass on a submodule root that carries only README and LICENSE.
  The corpus now lives in its own `skills` build stage that the final stage copies
  from verbatim. The guard is unchanged in effect, but the stage can be built with
  `--target skills` in seconds, without the dependency install (which pulls torch via
  docling).
- `scripts/release-image-check.sh`: regression coverage for the release-packaging
  path, runnable locally. It asserts that a recursive checkout bakes the community
  manifests (count matches the checkout), and that an empty submodule directory, a
  metadata-only submodule root, and a `skills/` tree with no manifest each stop the
  build at the guard (it checks for the guard's own message, not just a non-zero
  exit). `FULL_IMAGE=1` also builds the complete api release image.
- `.github/workflows/ci.yml`: new `release-image-checks` job runs the script on every
  PR with a recursive checkout. Under a minute cold.
- `CONTRIBUTING.md`: document the check next to the stack smoke section.

**Review follow-up**

- Guard strengthened to require an actual `SKILL.md` manifest (inline comment).
- Regression coverage added for the three requested cases, plus a fourth (a slug
  directory without a manifest).
- Commit amended with `--signoff`.

**Verification (locally, on arm64)**

- `./scripts/release-image-check.sh`: all four cases pass in about 50 seconds
  including the base image pull. The `skills` stage carries 44 community and 15 firm
  manifests, matching the checkout.
- `FULL_IMAGE=1 ./scripts/release-image-check.sh`: the complete api release image
  carries the same 44 community manifests.

The guard only affects `api/Dockerfile.release`; `gateway/Dockerfile.release` does not
copy the corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx8YLABGnbDqhznyouzW4s
