### PR TITLE
deps: bump pymdown-extensions to 11.0.2 (clears all open advisories)

### DIFF
--- a/web/backend/requirements.txt
+++ b/web/backend/requirements.txt
@@ -71,7 +71,7 @@ ftfy==6.3.1
 chardet==7.4.3
 pypdf==6.7.5
 fpdf2==2.8.7
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.2
 docx2txt==0.9
 python-pptx==1.0.2
 msoffcrypto-tool==6.0.0

--- a/web/pyproject.toml
+++ b/web/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "chardet==7.4.3",
     "pypdf==6.7.5",
     "fpdf2==2.8.7",
-    "pymdown-extensions==10.21.3",
+    "pymdown-extensions==11.0.2",
     "docx2txt==0.9",
     "python-pptx==1.0.2",
     "msoffcrypto-tool==6.0.0",

--- a/web/uv.lock
+++ b/web/uv.lock
@@ -3231,7 +3231,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pydub", specifier = "==0.25.1" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
-    { name = "pymdown-extensions", specifier = "==10.21.3" },
+    { name = "pymdown-extensions", specifier = "==11.0.2" },
     { name = "pymilvus", marker = "extra == 'all'", specifier = "==2.6.14" },
     { name = "pymongo", marker = "extra == 'all'", specifier = "==4.17.0" },
     { name = "pymysql", specifier = "==1.2.0" },
@@ -4292,15 +4292,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/17/2db4b414de89659144488e0d9c6c0bf0c8395841dc12d81d0532cc6ef310/pymdown_extensions-11.0.2.tar.gz", hash = "sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d", size = 855419, upload-time = "2026-08-22T19:28:47.236139Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/43/9f45ec4d14e596efc32c925a78104934790438b0c0628b70d741016734ad/pymdown_extensions-11.0.2-py3-none-any.whl", hash = "sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5", size = 269929, upload-time = "2026-08-22T19:28:45.389562Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates `pymdown-extensions` from 10.21 to 11.0.2 in `web/pyproject.toml`, `web/backend/requirements.txt` and `web/uv.lock`.

Evidence:
- pins were `pymdown-extensions==10.21`
- 10.21 is affected by GHSA-62q4-447f-wv8h; the minimal fix for that one alone is 10.21.3
- however 10.21.3 still leaves GHSA-9xwg-3r6f-jcx2, GHSA-gm37-52c6-37mw, PYSEC-2026-3609 and PYSEC-2026-3654 open (ReDoS class, same library)
- 11.0.2: OSV reports zero advisories for the package

Compatibility:
- 11.0 drops Python 3.9 only; this project requires >= 3.11
- the one behavior change in 11.0 (B64 relative-link restriction) does not affect this backend
- `uv lock` was updated surgically (pymdown entries only); note the lockfile was already out of sync with the manifest before this change

Scope: dependency/lockfile update only.

Revision note: this PR originally targeted 10.21.3; bumped to 11.0.2 after re-checking the full advisory set. Apologies for the churn. Commit author katsugtgz, unsigned.