### PR TITLE
Map LOCATION and US_BANK_NUMBER spans to their documented pseudonym domains

### DIFF
--- a/docs/security/anonymization.md
+++ b/docs/security/anonymization.md
@@ -155,7 +155,7 @@ If the deployment needs an entity type that isn't in Presidio's vocabulary (e.g.
 
 1. Create the recognizer with `supported_entity="CLIENT_CODE"`.
 2. Register it in `engine.py`.
-3. The new entity type flows through to `PseudonymMapper.assign("CLIENT_CODE", ...)` and gets pseudonyms like `CLIENT_CODE_0001`.
+3. The new entity type flows through to `PseudonymMapper.assign("CLIENT_CODE", ...)` and gets pseudonyms like `CLIENT_CODE_0001`, unless the type appears in the pseudonym-domain remap table (`PSEUDONYM_DOMAINS` in `engine.py`), which today remaps only `LOCATION` → `ADDRESS` and `US_BANK_NUMBER` → `ACCOUNT_NUMBER`.
 
 No further configuration is needed — the pseudonym format is generic per-entity-type.
 
@@ -270,7 +270,7 @@ Pinning tests:
 
 ## Pseudonym format
 
-Every assigned pseudonym follows `{ENTITY_TYPE}_{NNNN}` with a 4-digit zero-padded counter (`PERSON_0001`, `MATTER_NUMBER_0042`). Counters increment per entity type independently within a single request; mappings never persist across requests (the `PseudonymMapper` instance is dropped on response).
+Every assigned pseudonym follows `{ENTITY_TYPE}_{NNNN}` with a 4-digit zero-padded counter (`PERSON_0001`, `MATTER_NUMBER_0042`). The `{ENTITY_TYPE}` prefix is the entity's *pseudonym domain*: Presidio's `LOCATION` and `US_BANK_NUMBER` labels are remapped to `ADDRESS` and `ACCOUNT_NUMBER` at assign time (`PSEUDONYM_DOMAINS` in `engine.py`); every other type uses its recognizer label as-is. Counters increment per entity type independently within a single request; mappings never persist across requests (the `PseudonymMapper` instance is dropped on response).
 
 The format is locked by M2-A3. Operators who need a different format (longer counter, different separator) can fork the `PseudonymMapper.assign` implementation, but the existing format is what M2-B3 middleware + M2-C3 round-trip tests target.
 

--- a/gateway/app/anonymization/engine.py
+++ b/gateway/app/anonymization/engine.py
@@ -74,11 +74,11 @@ class _AnalyzerProtocol(Protocol):
 # * ``EMAIL_ADDRESS`` — counsel email, party email.
 # * ``PHONE_NUMBER`` — contact numbers in correspondence.
 # * ``US_BANK_NUMBER`` — bank account numbers that show up in
-#   settlement statements, escrow docs. Surfaces under Presidio's
-#   built-in ``US_BANK_NUMBER`` entity type.
-# * ``LOCATION`` — addresses, courthouses, jurisdictions. Mapped to
-#   ``ADDRESS`` in the pseudonym domain to match the operator's
-#   mental model.
+#   settlement statements, escrow docs. Remapped to the
+#   ``ACCOUNT_NUMBER`` pseudonym domain via :data:`PSEUDONYM_DOMAINS`.
+# * ``LOCATION`` — addresses, courthouses, jurisdictions. Remapped to
+#   the ``ADDRESS`` pseudonym domain via :data:`PSEUDONYM_DOMAINS` to
+#   match the operator's mental model.
 # * Custom entities from this task — ``CASE_NUMBER``,
 #   ``MATTER_NUMBER``.
 ENABLED_DEFAULT_RECOGNIZERS: tuple[str, ...] = (
@@ -123,6 +123,21 @@ DISABLED_DEFAULT_RECOGNIZERS: tuple[str, ...] = (
     "IpRecognizer",
     "MedicalLicenseRecognizer",
 )
+
+# Presidio's entity-type labels don't always match the pseudonym
+# domain operators are promised in ``docs/security/anonymization.md``:
+# a street address is detected as ``LOCATION`` but must substitute as
+# ``ADDRESS_NNNN``, and a bank account is detected as
+# ``US_BANK_NUMBER`` but must substitute as ``ACCOUNT_NUMBER_NNNN``.
+# The remap happens at assign time in
+# :meth:`Anonymizer.pseudonymize_into` so :class:`PseudonymMapper`
+# stays format-generic (operators may override ``assign`` for a
+# salted format — see DE-274). Types absent from this table pass
+# through unchanged.
+PSEUDONYM_DOMAINS: dict[str, str] = {
+    "LOCATION": "ADDRESS",
+    "US_BANK_NUMBER": "ACCOUNT_NUMBER",
+}
 
 
 _analyzer_singleton: AnalyzerEngine | None = None
@@ -248,8 +263,11 @@ class Anonymizer:
 
         Walks the analyzer's spans, resolves overlapping detections to
         the longer span (ties broken by score), then substitutes
-        right-to-left so earlier offsets stay valid. Calling
-        :meth:`PseudonymMapper.assign` for an already-known
+        right-to-left so earlier offsets stay valid. Each span is
+        assigned under its *pseudonym domain*: :data:`PSEUDONYM_DOMAINS`
+        remaps Presidio labels like ``LOCATION`` to the operator-facing
+        ``ADDRESS`` before ``assign``; unlisted types keep their label.
+        Calling :meth:`PseudonymMapper.assign` for an already-known
         ``(entity_type, original)`` reuses the prior pseudonym, so the
         same name across multiple ``pseudonymize_into`` calls on the
         same mapper resolves to the same pseudonym.
@@ -272,7 +290,14 @@ class Anonymizer:
         # stay valid as the text length changes around each splice.
         ordered = sorted(spans, key=lambda s: s.start)
         pseudonyms: list[tuple[Any, str]] = [
-            (span, mapper.assign(span.entity_type, text[span.start : span.end])) for span in ordered
+            (
+                span,
+                mapper.assign(
+                    PSEUDONYM_DOMAINS.get(span.entity_type, span.entity_type),
+                    text[span.start : span.end],
+                ),
+            )
+            for span in ordered
         ]
 
         out = text

--- a/gateway/app/anonymization/mapper.py
+++ b/gateway/app/anonymization/mapper.py
@@ -56,10 +56,12 @@ class PseudonymMapper:
         previously allocated pseudonym byte-for-byte.
 
         Args:
-            entity_type: Canonical entity-type label, e.g. ``"PERSON"``,
-                ``"ORGANIZATION"``, ``"PHONE_NUMBER"``. Presidio's
-                vocabulary is what M2-B3 wires in; custom recognizers
-                (M2-B2) extend it.
+            entity_type: Pseudonym-domain label, e.g. ``"PERSON"``,
+                ``"ORGANIZATION"``, ``"ADDRESS"``. Usually Presidio's
+                entity type, except where the Anonymizer remaps a
+                label to its documented domain first (see
+                ``PSEUDONYM_DOMAINS`` in ``engine.py``); custom
+                recognizers (M2-B2) extend the vocabulary.
             original: The literal text of the entity as Presidio saw
                 it in the source prompt.
 

--- a/gateway/tests/anonymization/test_anonymizer.py
+++ b/gateway/tests/anonymization/test_anonymizer.py
@@ -319,3 +319,113 @@ def test_pseudonymize_returns_result_with_fresh_mapper() -> None:
 
     assert result.text == "PERSON_0001 signed."
     assert result.mapper.reverse() == {"PERSON_0001": "John Smith"}
+
+
+# ---------------------------------------------------------------------------
+# Pseudonym-domain remapping — LOCATION → ADDRESS, US_BANK_NUMBER →
+# ACCOUNT_NUMBER (``docs/security/anonymization.md``, "Enabled
+# recognizers"). The remap lives in ``PSEUDONYM_DOMAINS`` and applies at
+# assign time in ``pseudonymize_into``; rehydration is token-only so the
+# round-trip must hold unchanged.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_location_maps_to_address_domain() -> None:
+    """A LOCATION span substitutes as ADDRESS_NNNN, never LOCATION_NNNN."""
+
+    text = "Send notice to 123 Main St, New York, NY 10001 before closing."
+    entity = "123 Main St, New York, NY 10001"
+    start = text.index(entity)
+    spans = [_Span("LOCATION", start, start + len(entity))]
+
+    out = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize_into(text, PseudonymMapper())
+
+    assert "ADDRESS_0001" in out
+    assert "LOCATION" not in out
+
+
+@pytest.mark.unit
+def test_pseudonymize_into_us_bank_number_maps_to_account_number_domain() -> None:
+    """A US_BANK_NUMBER span substitutes as ACCOUNT_NUMBER_NNNN."""
+
+    text = "Wire the settlement to account 8529301174 by Friday."
+    entity = "8529301174"
+    start = text.index(entity)
+    spans = [_Span("US_BANK_NUMBER", start, start + len(entity))]
+
+    out = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize_into(text, PseudonymMapper())
+
+    assert "ACCOUNT_NUMBER_0001" in out
+    assert "US_BANK_NUMBER" not in out
+
+
+@pytest.mark.unit
+def test_remapped_domain_round_trips_byte_for_byte() -> None:
+    """Remapping before assign is invisible to rehydration.
+
+    ``PseudonymMapper.reverse()`` discards the entity-type half of the
+    key, so rehydrate only ever matches literal tokens the mapper
+    minted. A LOCATION span pseudonymized under the ADDRESS domain must
+    restore byte-for-byte.
+    """
+
+    text = "The deposition happens at 400 Court Street, Brooklyn tomorrow."
+    entity = "400 Court Street, Brooklyn"
+    start = text.index(entity)
+    spans = [_Span("LOCATION", start, start + len(entity))]
+    anonymizer = Anonymizer(analyzer=_StubAnalyzer(spans))
+    mapper = PseudonymMapper()
+
+    substituted = anonymizer.pseudonymize_into(text, mapper)
+    restored = anonymizer.rehydrate(substituted, mapper)
+
+    assert substituted != text
+    assert restored == text
+
+
+@pytest.mark.unit
+def test_remapped_domains_have_independent_counters() -> None:
+    """ADDRESS and ACCOUNT_NUMBER count independently; raw labels never appear."""
+
+    text = "Refund account 8529301174 and mail notice to 123 Main St, Albany."
+    account = "8529301174"
+    address = "123 Main St, Albany"
+    spans = [
+        _Span("US_BANK_NUMBER", text.index(account), text.index(account) + len(account)),
+        _Span("LOCATION", text.index(address), text.index(address) + len(address)),
+    ]
+    mapper = PseudonymMapper()
+
+    out = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize_into(text, mapper)
+
+    assert "ACCOUNT_NUMBER_0001" in out
+    assert "ADDRESS_0001" in out
+    counts = mapper.entity_counts()
+    assert counts.get("ADDRESS") == 1
+    assert counts.get("ACCOUNT_NUMBER") == 1
+    assert "LOCATION" not in counts
+    assert "US_BANK_NUMBER" not in counts
+
+
+@pytest.mark.unit
+def test_unmapped_entity_types_pass_through_unchanged() -> None:
+    """Types outside the remap table keep their label, custom types included.
+
+    Pins the promise in ``docs/security/anonymization.md`` ("Adding a
+    new entity type"): a custom ``CLIENT_CODE`` recognizer yields
+    ``CLIENT_CODE_0001`` with no further configuration.
+    """
+
+    text = "John Smith opened matter CLIENT-A123 for review."
+    person = "John Smith"
+    code = "CLIENT-A123"
+    spans = [
+        _Span("PERSON", text.index(person), text.index(person) + len(person)),
+        _Span("CLIENT_CODE", text.index(code), text.index(code) + len(code)),
+    ]
+
+    out = Anonymizer(analyzer=_StubAnalyzer(spans)).pseudonymize_into(text, PseudonymMapper())
+
+    assert "PERSON_0001" in out
+    assert "CLIENT_CODE_0001" in out

--- a/gateway/tests/anonymization/test_edge_cases.py
+++ b/gateway/tests/anonymization/test_edge_cases.py
@@ -187,9 +187,9 @@ def test_pre_anonymize_multiline_entity_substitutes_across_newline() -> None:
 
     assert mapper is not None
     assert req.messages[0].content == (
-        "Contract counterparty:\nLOCATION_0001\n\nSignatory: John Doe"
+        "Contract counterparty:\nADDRESS_0001\n\nSignatory: John Doe"
     )
-    assert mapper.reverse()["LOCATION_0001"] == multiline_address
+    assert mapper.reverse()["ADDRESS_0001"] == multiline_address
 
 
 @pytest.mark.unit
@@ -198,9 +198,9 @@ def test_post_anonymize_rehydrates_multiline_entity_with_newlines_preserved() ->
 
     multiline_address = "Acme Corp\n123 Main St\nNew York, NY 10001"
     mapper = PseudonymMapper()
-    mapper.assign("LOCATION", multiline_address)
+    mapper.assign("ADDRESS", multiline_address)
 
-    response = _make_response(content="The counterparty at LOCATION_0001 signed the agreement.")
+    response = _make_response(content="The counterparty at ADDRESS_0001 signed the agreement.")
     post_anonymize_response(
         response=response,
         mapper=mapper,


### PR DESCRIPTION
## What this PR does

Makes pseudonym tokens match the documented pseudonym domains. LOCATION spans now substitute as `ADDRESS_NNNN` and US_BANK_NUMBER spans as `ACCOUNT_NUMBER_NNNN`, which is what `docs/security/anonymization.md` has promised operators since M2.

## Why

The docs, the code, and the tests disagreed three ways. The enabled-recognizers table in `docs/security/anonymization.md` says LOCATION is mapped to the `ADDRESS` pseudonym domain and US_BANK_NUMBER to `ACCOUNT_NUMBER`. The comment above `ENABLED_DEFAULT_RECOGNIZERS` in `engine.py` repeats that promise. But `Anonymizer.pseudonymize_into` passed `span.entity_type` straight through to `PseudonymMapper.assign`, so live tokens were `LOCATION_0001` and `US_BANK_NUMBER_0001`. Two assertions in `test_edge_cases.py` pinned the raw tokens, so the suite enforced the code behavior rather than the documented behavior. The same mapping promise also appears in `docs/M2-IMPLEMENTATION-PLAN.md` and `docs/PRD.md`.

For a product whose operators make confidentiality judgments from these docs, the substituted text an operator inspects should carry the domain labels the security documentation told them to expect.

The change is a two-entry `PSEUDONYM_DOMAINS` table in `engine.py` and a `.get()` remap at the single `assign` call site inside `pseudonymize_into`. Rehydration is unaffected by construction: `PseudonymMapper.reverse()` discards the entity-type half of its key and `rehydrate` replaces literal tokens only, so a remap applied before `assign` is round-trip neutral. The mapper is request-scoped and never persisted, so no stored token can carry an old prefix.

## What this PR does *not* do

- It does not touch `PseudonymMapper.assign`. The mapper stays format-generic so the DE-274 salted-format override path is unchanged.
- It does not remap any other entity type. Types outside the table pass through unchanged, which preserves the documented custom-entity promise (`CLIENT_CODE_0001` with no further configuration).
- It does not touch the ORGANIZATION suppression finding in PR #439. That is a separate issue with a maintainer decision pending.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Documentation update
- [ ] Skill contribution (see attestation below)
- [ ] Refactor (no behavioral change)
- [ ] Test / CI / tooling

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Manually tested against a real deployment (describe scenario below)
- [ ] Acceptance test plan updated (if changing skill behavior)

Five regression tests added to `gateway/tests/anonymization/test_anonymizer.py` using the existing stub-analyzer pattern, so spaCy stays off the fast path: LOCATION emits `ADDRESS_0001`; US_BANK_NUMBER emits `ACCOUNT_NUMBER_0001`; a remapped span round-trips byte for byte; remapped domains keep independent counters with no raw label appearing; unmapped types, including a custom `CLIENT_CODE`, pass through unchanged. The two `test_edge_cases.py` assertions that pinned the raw tokens now assert the documented domains.

Ran locally: `pytest tests/anonymization -q` gives 102 passed, including the real-analyzer round-trip suite. `ruff format --check` and `ruff check` are clean on the four changed Python files. Environment: Python 3.12.13, presidio-analyzer 2.2.364, spaCy en_core_web_lg 3.8.0.

## Documentation

- [ ] PRD updated (if user-facing behavior changes)
- [ ] README updated (if quickstart or capability list changes)
- [ ] Skill-authoring guide updated (if skill conventions change)
- [ ] Deployment cookbook updated (if deployment changes)
- [ ] Compliance documentation updated (if compliance posture changes)
- [ ] OpenAPI schema regenerated (if API endpoints change)

The PRD already states the intended mapping, so this fix makes the code match the PRD rather than the other way around. `docs/security/anonymization.md` is updated in two places so the pseudonym-format section and the custom-entity walkthrough describe the remap table explicitly.

## Transparency & governance invariants

- [x] **Egress (P1):** n/a. No outbound call path changes.
- [x] **Closed set (P2):** n/a. No new capability.
- [x] **No raw payloads (P3):** no new row or log line. The OTel attribute change reports type labels and counts only, never content.
- [x] **Fail restrictive (P4):** n/a. No config surface changes.
- [x] **Atomic audit (P5):** n/a. No state change.
- [x] **One governance path (P6):** n/a.
- [x] **Human gate (P7):** n/a. Nothing destructive.
- [x] **Operator control (P8):** n/a. No new capability; this restores documented behavior rather than adding a toggle.
- [x] **User owns data (P9):** the change strengthens the documented anonymization contract; export, delete, and residency are untouched.
- [x] **Contract is truth (P10):** the remap table is the recorded decision, in code next to the recognizer configuration, and the security doc is updated in the same PR.

## DCO sign-off

- [x] All commits in this PR are signed off per the [DCO](../CONTRIBUTING.md#sign-off-developer-certificate-of-origin)

## Related issues

No existing issue or PR tracks this mismatch; I searched for the mapping terms before opening this. Refs DE-274 for context only: the salted-format override documented there is deliberately unaffected.

## Reviewer notes

One observable side effect for the security review this PR auto-routes to: the OTel span attribute `anonymization.entity_types` now reports `ADDRESS` and `ACCOUNT_NUMBER` instead of `LOCATION` and `US_BANK_NUMBER`. The attribute is fed from the mapper's per-type counters, so the labels follow the domains. A dashboard filtering on the old labels would stop matching. Nothing persists the old labels; the mapper is request-scoped.

Design alternative considered: putting the remap inside `PseudonymMapper.assign`. Rejected because the docs invite operators to override `assign` for salted formats (DE-274), and loading domain policy into that method would put the two on a collision course. The table at the call site keeps the mapper format-generic.
