### PR TITLE
chore(ci): scope web/ Dependabot to security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,23 +44,31 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
 
-  # web/ shares one package-lock.json, so it serialises exactly as the uv
-  # locks do. The cooldown was previously uv-only; npm now carries the same
-  # 7-day window, which is the posture docs/security/dependencies.md already
-  # describes for the locked ecosystems.
+  # web/ is a vendored OpenWebUI fork pinned by ADR 0001, so its npm pins are
+  # upstream's rather than ours. Routine currency arrives with the quarterly
+  # rebase (#498), which brings upstream's own newer pins with it — a version
+  # bump raised between refreshes is superseded before it can be reviewed.
+  # That is not hypothetical: #459, #460, #473, #474, #475 and #533 all closed
+  # unmerged for exactly this reason.
+  #
+  # `open-pull-requests-limit: 0` disables *version* updates for this ecosystem.
+  # Dependabot **security** updates are unaffected by that limit, so an advisory
+  # against a web/ package still opens a PR — which is the coverage we want, and
+  # matches ADR 0001's "or earlier if an upstream security fix lands that affects
+  # us" clause. The entry is kept rather than deleted so the manifest stays
+  # registered and security PRs keep carrying the `web` label.
+  #
+  # `cooldown` is omitted because it is documented as version-updates-only, and
+  # the `web-minor-patch` group because it was scoped `applies-to:
+  # version-updates`. Neither reached security updates, so dropping them changes
+  # nothing for the one update class this block still produces — and leaving
+  # security bumps ungrouped matches the posture the uv blocks above set out.
   - package-ecosystem: npm
     directory: /web
     schedule:
       interval: weekly
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels: ["dependencies", "web"]
-    groups:
-      web-minor-patch:
-        applies-to: version-updates
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/docs/adr/0001-openwebui-fork-pin.md
+++ b/docs/adr/0001-openwebui-fork-pin.md
@@ -33,6 +33,7 @@ Considerations:
 - Quarterly rebase against the latest upstream stable tag, or earlier if an upstream security fix lands that affects us.
 - Rebase work happens in a `vendor/openwebui-upstream` branch; the rebase result lands in `main` as a single PR titled `chore(web): rebase OpenWebUI fork to vX.Y.Z` with a body listing every upstream commit included and any of our patches that needed rework.
 - Rebase PRs require two maintainer approvals because the merge cost is real and the integration surface is large.
+- `web/`'s npm dependencies are upstream's, not ours, so their currency arrives with the rebase. `.github/dependabot.yml` runs the `/web` npm ecosystem at `open-pull-requests-limit: 0` — **security updates only**. Routine version bumps raised between refreshes are superseded by the next rebase before they can be reviewed; advisories are not, and still open PRs.
 
 **How customizations are organized:**
 

--- a/docs/security/dependencies.md
+++ b/docs/security/dependencies.md
@@ -26,7 +26,7 @@ The `web/` subsystem is out of scope here: its Python side still installs from t
 
 Two layers of automated dependency-vulnerability scanning:
 
-1. **GitHub Advisory Database / Dependabot.** [`.github/dependabot.yml`](../../.github/dependabot.yml) configures weekly scans for `api/` (uv), `gateway/` (uv), `web/` (npm), and `.github/workflows/` (actions). High and critical advisories open PRs automatically. For the uv ecosystems, updates arrive as lock-pinned bumps against `uv.lock` with a 7-day release-age cooldown, not range widenings.
+1. **GitHub Advisory Database / Dependabot.** [`.github/dependabot.yml`](../../.github/dependabot.yml) configures weekly scans for `api/` (uv), `gateway/` (uv), `web/` (npm), and `.github/workflows/` (actions). High and critical advisories open PRs automatically. For the uv ecosystems, updates arrive as lock-pinned bumps against `uv.lock` with a 7-day release-age cooldown, not range widenings. `web/` is **security-updates only** (`open-pull-requests-limit: 0`): it is a vendored OpenWebUI fork pinned by [ADR 0001](../adr/0001-openwebui-fork-pin.md), so routine version currency arrives with the quarterly rebase rather than between refreshes. Advisories against `web/` packages still open PRs — that limit constrains version updates only.
 2. **SBOM scanning.** The SBOM produced by the release workflow (per [docs/security/releases/README.md](releases/README.md)) is in SPDX JSON format and is parseable by any SCA tool. Operators evaluating a specific release can run `grype sbom:./api.spdx.json` (or equivalent) to check the dependency snapshot.
 
 ## Update cadence


### PR DESCRIPTION
Closes the follow-up recorded in #498: scope the `/web` npm block in `.github/dependabot.yml` to **security updates only**.

## Why

`web/` is a vendored OpenWebUI fork pinned by ADR 0001. Its npm pins are upstream's, not ours, and routine currency arrives with the quarterly rebase — which brings upstream's own newer pins with it. A version bump raised between refreshes is therefore superseded before it can be reviewed.

That is not a hypothetical cost. **#459, #460, #473, #474, #475 and #533** were all opened against `web/` and all closed unmerged for exactly this reason. Each one spent a triage cycle. Dependabot also treats a close as "don't reopen this version", so current practice already amounts to hand-simulating this config, one PR at a time.

## What changed

```yaml
  - package-ecosystem: npm
    directory: /web
    schedule:
      interval: weekly
    open-pull-requests-limit: 0
    labels: ["dependencies", "web"]
```

- **`open-pull-requests-limit: 0`** — GitHub documents this as disabling *version* updates for the ecosystem. Security update PRs "are not subject to this limit and do not count toward it", so an advisory against a `web/` package still opens a PR. That is the coverage we want, and it is what ADR 0001's "or earlier if an upstream security fix lands that affects us" clause already assumes.
- **Entry kept, not deleted** — so the manifest stays registered and security PRs keep carrying the `web` label.
- **`cooldown` dropped** — documented as version-updates-only, so it never reached security updates.
- **`web-minor-patch` group dropped** — it was scoped `applies-to: version-updates`. (Groups *can* apply to security updates via `applies-to`; ours did not.) Leaving security bumps ungrouped matches the posture the two uv blocks above already set out.

Both removals are no-ops for the one update class this block still produces.

## Docs

The rule is recorded in two places so an absent `web/` version-update PR reads as intentional rather than as a gap — the exact misreading that cost a review cycle on #516:

- **ADR 0001**, refresh cadence — one bullet, since ADR 0001 is what governs where `web/` currency comes from.
- **`docs/security/dependencies.md`** — the automated-scanning section previously described `web/` (npm) coverage without qualification.

## Verification

- `.github/dependabot.yml` parses (`yaml.safe_load`); the diff touches the `/web` block only — `api`, `gateway`, and `github-actions` entries are byte-identical.
- No CI job validates or consumes `.github/dependabot.yml` (`stack-smoke.yml` only mentions Dependabot in a comment).
- `stack-smoke.yml`'s `paths:` filter matches none of the three changed files, so this PR does not trigger a cold stack build.
- No dangling references to `web-minor-patch` anywhere in the tree.

## Not in scope

- **The repo-level setting.** This config governs whether Dependabot *raises* version updates. Whether security updates run at all is a repository setting (Settings → Code security → Dependabot security updates); the API endpoints that report it need admin scope, so I could not confirm it from here. **Worth eyeballing once before merge** — if that setting is off, this block goes quiet entirely rather than falling back to security-only.
- **The six superseded PRs** (#459, #460, #473, #474, #475, #533) are still open and still need closing by hand. This config stops the *next* one, not the existing ones.

Refs #498
