### PR TITLE
chore(ci): exclude langgraph from the api-minor-patch group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,20 @@ updates:
   # strictly serially, each waiting a full CI cycle after a rebase. One
   # grouped PR is one lock write.
   #
-  # Two things stay deliberately ungrouped:
+  # Three things stay deliberately ungrouped:
   #   - security updates — `applies-to: version-updates` scopes the group,
   #     so an advisory fix is never queued behind routine hygiene;
   #   - majors — omitted from `update-types`, since each needs its own read.
+  #   - langgraph — excluded by name from api-minor-patch. The two above are
+  #     policy classes; this one is a package, and it is here because the
+  #     majors rule cannot reach it. langgraph is pre-1.0, so its breaking
+  #     releases ship as 0.x *minors*: within the group the highest version
+  #     an allowed "minor" reaches is 0.6.x, which re-types StateGraph and
+  #     fails mypy [call-overload] across all three executors. That bump has
+  #     been opened and closed unmerged five times (#68, #176, #482, #520,
+  #     #544) — the fix is in our code, not in the pin. docling and mcp get
+  #     their own read for free by being post-1.0; langgraph needs the
+  #     exclusion to get the same treatment. Lift at DE-319 (#524).
   - package-ecosystem: uv
     directory: /api
     schedule:
@@ -28,6 +38,7 @@ updates:
       api-minor-patch:
         applies-to: version-updates
         patterns: ["*"]
+        exclude-patterns: ["langgraph"]
         update-types: ["minor", "patch"]
 
   - package-ecosystem: uv


### PR DESCRIPTION
Exclude `langgraph` from the `api-minor-patch` group in `.github/dependabot.yml`, so it gets its own PR the way docling and mcp already do.

## Why

The "important dependency gets its own read" posture is already in this file — but it is delivered by exactly one mechanism: **majors are omitted from `update-types`, so they never join a group and always arrive as their own PR.** That is why `docling` (`>=1.16,<2`) and `mcp` (`>=1.28,<2`) behave the way we expect, and why #518 (mcp 1.28.1 → 2.0.0) is sitting on its own right now.

**langgraph is pre-1.0, so that mechanism cannot reach it.** Its breaking release ships as a 0.x *minor*. Inside a group scoped to `update-types: ["minor","patch"]`, the highest version an allowed "minor" reaches is 0.6.x — which re-types `StateGraph` and fails mypy `[call-overload]` across all three executors.

This is not hypothetical churn. The bump has been opened and closed unmerged **five times**: #68, #176, #482, #520, and now #544. The first four were the ungrouped *major* stream working correctly, one PR at a time. #544 is the difference: because the group swallowed it, one unmergeable pin took **eight unrelated updates** down with it (pydantic-settings, starlette, alembic, greenlet, pymupdf, tiktoken, ruff, mypy), and blocked #543 as collateral — the two lift starlette in lockstep and have to land together.

So this closes a blind spot in an existing policy rather than adding a new one.

## What changed

```yaml
      api-minor-patch:
        applies-to: version-updates
        patterns: ["*"]
        exclude-patterns: ["langgraph"]
        update-types: ["minor", "patch"]
```

A dependency matching no group is updated individually, so langgraph now gets the same lane docling and mcp have. The comment block above the `/api` entry grows a third bullet — it already documented its two ungrouped classes, and this one needs its reason on the record precisely because the majors rule cannot see it.

This changes **where the PR lands, not whether it lands**. langgraph currency is not reduced; it stops being bundled with unrelated hygiene.

## What this does not fix

The langgraph PR will still be red. Excluding it does not re-type the executors — that work is **DE-319 (#524)**, which is `help wanted`, unassigned, and already carries the full scope. Until it lands, langgraph's individual PR will keep proposing the widened pin and keep failing the same 12 mypy errors.

That is the intended outcome, not a leftover: an isolated red PR on an important dependency is a standing, visible reminder that #524 is owed, and it now blocks nothing. Deliberately **not** paired with an `ignore` rule, which would hide exactly the thing worth seeing.

## Verification

- `.github/dependabot.yml` parses under `yaml.safe_load`.
- Parsed-tree comparison against `HEAD`: the `github-actions`, `npm /web`, and `uv /gateway` blocks are **identical**; `uv /api` differs by exactly one added key. Nothing else moved.
- No CI job validates or consumes `.github/dependabot.yml` — the only reference across `.github/workflows/` is a comment at `stack-smoke.yml:19`.
- `stack-smoke.yml`'s `paths:` filter covers the two `pyproject.toml`s and two `uv.lock`s only, so this PR triggers no cold stack build.
- No docs change needed: `docs/security/dependencies.md` describes scanning coverage per ecosystem and does not enumerate group membership, so nothing in it becomes inaccurate.

## Follow-up after merge

`@dependabot recreate` on #544. It should return with the other eight updates and go green, which also unblocks #543.

Refs #524
