### PR TITLE
fix(ci): pick the previous release tag from reachable tags only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,15 @@ jobs:
           # `|| true`: with pipefail, grep exits non-zero when this is the first
           # release and the filtered list is empty, which would abort under `set -e`
           # before the emptiness check below could report it.
-          prev_tag="$(git tag --list 'v*.*.*' --sort=-v:refname \
+          #
+          # --merged HEAD: consider only tags reachable from the commit being
+          # released. web/ is a fork of OpenWebUI, and rebasing it (#541) brought
+          # upstream's own vX.Y.Z tags into this repo (v0.9.2, v0.11.0). They sit
+          # on history that is not an ancestor of main, so without this filter
+          # -v:refname sorts v0.11.0 to the top: the range below would span ~737
+          # unrelated commits, sweep in every historical breaking-change PR, and
+          # fail an otherwise-legitimate patch tag.
+          prev_tag="$(git tag --list 'v*.*.*' --merged HEAD --sort=-v:refname \
                         | grep -v '^desktop-' | grep -vx "$RELEASE_TAG" | head -1 || true)"
 
           if [[ -z "$prev_tag" ]]; then

--- a/docs/BUILD-AND-RELEASE.md
+++ b/docs/BUILD-AND-RELEASE.md
@@ -117,7 +117,12 @@ Milestones are planning tools; they do not decide the version.
 
 ```bash
 # What has landed since the last release?
-git log "$(git tag --sort=-v:refname | grep -v desktop | head -1)"..main --no-merges --oneline
+#   --merged main: web/ is a fork of OpenWebUI, and rebasing it brought upstream's
+#   own vX.Y.Z tags into this repo (v0.9.2, v0.11.0). They are not reachable from
+#   main, and without this filter they sort above the real last release. release.yml's
+#   breaking-change gate applies the same filter.
+git log "$(git tag --list 'v*.*.*' --merged main --sort=-v:refname \
+             | grep -v '^desktop-' | head -1)"..main --no-merges --oneline
 ```
 
 Read that list and ask one question of each entry: **does a working install need a


### PR DESCRIPTION
Both the release runbook and `release.yml` pick the previous release tag with `git tag --sort=-v:refname`, filtered only by name. That ranks every tag present in whatever clone it runs in. `web/` is a fork of open-webui, whose own `vX.Y.Z` tags match the same pattern, and a `git fetch upstream` brings them in — `v0.9.2` and `v0.11.0` are both in my working clone today.

**Scope note, stated plainly: only one half of this is a live bug.** They are shipped together because they are the same mistake in two places.

## The runbook half is a real bug

§3a is the step ADR 0025 leaves to human judgment — read what landed since the last release, ask whether any of it makes an operator touch a working install, and pick the number from that. It hands the maintainer this:

```bash
git log "$(git tag --sort=-v:refname | grep -v desktop | head -1)"..main --no-merges --oneline
```

Run in any clone with the `upstream` remote fetched, that resolves the last release to **`v0.11.0`** and prints **737 commits of OpenWebUI history** in place of the 21 that are ours. The one step the runbook says cannot be automated is fed the wrong list.

## The `release.yml` half is hardening, not a fix

I originally read this as a release blocker for 0.7.1. It is not, and the PR should not be reviewed as one. Those tags are **not on `LegalQuants/lq-ai`** — the highest release tag there is `v0.7.0` — so `actions/checkout` never fetches them and `prev_tag` resolves correctly. Tagging `v0.7.1` against the gate as it stands would pass.

What makes it worth changing anyway is that the tags are one `git push --tags` away from the org repo, from any maintainer's clone. If they land there, the gate compares `v0.7.1` against `v0.11.0`, spans 737 commits, scrapes 231 PR numbers, intersects them with the `breaking-change` label to catch #396, #399 and #400, then reads `0.11` → `0.7` as a downgrade rather than a minor bump and fails a patch release that is entitled to ship. Measured, not predicted — I ran the job's own shell against the local tag namespace.

It fails closed (`build-backend` has `needs: version-consistency`), so nothing would mis-publish. It would just stop a release for a reason with no connection to the release.

## The fix

`--merged HEAD` in the workflow, `--merged main` in the runbook: consider only tags reachable from the commit being released. That is the correct endpoint regardless of upstream tags — an unreachable tag is meaningless as one end of a commit range.

It separates cleanly, and not by coincidence:

| | |
|---|---|
| `v0.2.0` … `v0.7.0` (ours) | reachable from `main` |
| `v0.9.2`, `v0.11.0` (upstream) | not reachable |

Every release we cut is reachable from `main`. Upstream's tags sit on history grafted in as a synthesised merge base by the rebase procedure, so they never become ancestors. After the change, `prev_tag` → `v0.7.0`, range → 21 commits, no `breaking-change` PRs in it, patch allowed.

## What this does not do

No release is cut here, and no version is bumped — `api` and `gateway` remain at `0.7.0`. The two call sites now agree, but nothing enforces that they stay in agreement; a third copy of this idiom would go unnoticed. The unreachable `v0.1.0` tag is also excluded by the new filter, which is harmless — it is the oldest tag either way and never wins the sort.

Neither change is exercised by CI on this PR: `release.yml` only runs on a tag push, so the workflow half is verified by having run its shell by hand, not by a green check here.
